### PR TITLE
Several raster calculator fixes

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5320,7 +5320,7 @@ void QgisApp::newGeoPackageLayer()
 
 void QgisApp::showRasterCalculator()
 {
-  QgsRasterCalcDialog d( this );
+  QgsRasterCalcDialog d( dynamic_cast<QgsRasterLayer *>( activeLayer() ), this );
   if ( d.exec() == QDialog::Accepted )
   {
     //invoke analysis library

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5331,7 +5331,7 @@ void QgisApp::showRasterCalculator()
     p.setMaximum( 100.0 );
     QgsFeedback feedback;
     connect( &feedback, &QgsFeedback::progressChanged, &p, &QProgressDialog::setValue );
-    connect( &feedback, &QgsFeedback::canceled, &p, &QProgressDialog::cancel );
+    connect( &p, &QProgressDialog::canceled, &feedback, &QgsFeedback::cancel );
     QgsRasterCalculator::Result res = static_cast< QgsRasterCalculator::Result >( rc.processCalculation( &feedback ) );
     switch ( res )
     {

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -21,6 +21,7 @@
 #include "qgsrasterdataprovider.h"
 #include "qgsrasterlayer.h"
 #include "qgssettings.h"
+#include "qgsgui.h"
 
 #include "cpl_string.h"
 #include "gdal.h"
@@ -31,6 +32,8 @@
 QgsRasterCalcDialog::QgsRasterCalcDialog( QWidget *parent, Qt::WindowFlags f ): QDialog( parent, f )
 {
   setupUi( this );
+  QgsGui::instance()->enableAutoGeometryRestore( this );
+
   connect( mOutputLayerPushButton, &QPushButton::clicked, this, &QgsRasterCalcDialog::mOutputLayerPushButton_clicked );
   connect( mRasterBandsListWidget, &QListWidget::itemDoubleClicked, this, &QgsRasterCalcDialog::mRasterBandsListWidget_itemDoubleClicked );
   connect( mButtonBox, &QDialogButtonBox::accepted, this, &QgsRasterCalcDialog::mButtonBox_accepted );
@@ -63,9 +66,6 @@ QgsRasterCalcDialog::QgsRasterCalcDialog( QWidget *parent, Qt::WindowFlags f ): 
   connect( mOrButton, &QPushButton::clicked, this, &QgsRasterCalcDialog::mOrButton_clicked );
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsRasterCalcDialog::showHelp );
 
-  QgsSettings settings;
-  restoreGeometry( settings.value( QStringLiteral( "Windows/RasterCalc/geometry" ) ).toByteArray() );
-
   //add supported output formats
   insertAvailableOutputFormats();
   insertAvailableRasterBands();
@@ -77,12 +77,6 @@ QgsRasterCalcDialog::QgsRasterCalcDialog( QWidget *parent, Qt::WindowFlags f ): 
   }
 
   mExpressionTextEdit->setCurrentFont( QFontDatabase::systemFont( QFontDatabase::FixedFont ) );
-}
-
-QgsRasterCalcDialog::~QgsRasterCalcDialog()
-{
-  QgsSettings settings;
-  settings.setValue( QStringLiteral( "Windows/RasterCalc/geometry" ), saveGeometry() );
 }
 
 QString QgsRasterCalcDialog::formulaString() const

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -26,6 +26,7 @@
 #include "gdal.h"
 
 #include <QFileDialog>
+#include <QFontDatabase>
 
 QgsRasterCalcDialog::QgsRasterCalcDialog( QWidget *parent, Qt::WindowFlags f ): QDialog( parent, f )
 {
@@ -74,6 +75,8 @@ QgsRasterCalcDialog::QgsRasterCalcDialog( QWidget *parent, Qt::WindowFlags f ): 
     //grab default crs from first raster
     mCrsSelector->setCrs( mAvailableRasterBands.at( 0 ).raster->crs() );
   }
+
+  mExpressionTextEdit->setCurrentFont( QFontDatabase::systemFont( QFontDatabase::FixedFont ) );
 }
 
 QgsRasterCalcDialog::~QgsRasterCalcDialog()

--- a/src/app/qgsrastercalcdialog.h
+++ b/src/app/qgsrastercalcdialog.h
@@ -46,12 +46,10 @@ class APP_EXPORT QgsRasterCalcDialog: public QDialog, private Ui::QgsRasterCalcD
     QVector<QgsRasterCalculatorEntry> rasterEntries() const;
 
   private slots:
-    void mOutputLayerPushButton_clicked();
     void mRasterBandsListWidget_itemDoubleClicked( QListWidgetItem *item );
     void mButtonBox_accepted();
     void mCurrentLayerExtentButton_clicked();
     void mExpressionTextEdit_textChanged();
-    void mOutputLayerLineEdit_textChanged( const QString &text );
     //! Enables OK button if calculator expression is valid and output file path exists
     void setAcceptButtonState();
     void showHelp();

--- a/src/app/qgsrastercalcdialog.h
+++ b/src/app/qgsrastercalcdialog.h
@@ -29,7 +29,6 @@ class APP_EXPORT QgsRasterCalcDialog: public QDialog, private Ui::QgsRasterCalcD
     Q_OBJECT
   public:
     QgsRasterCalcDialog( QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
-    ~QgsRasterCalcDialog() override;
 
     QString formulaString() const;
     QString outputFile() const;

--- a/src/app/qgsrastercalcdialog.h
+++ b/src/app/qgsrastercalcdialog.h
@@ -28,7 +28,7 @@ class APP_EXPORT QgsRasterCalcDialog: public QDialog, private Ui::QgsRasterCalcD
 {
     Q_OBJECT
   public:
-    QgsRasterCalcDialog( QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
+    QgsRasterCalcDialog( QgsRasterLayer *rasterLayer = nullptr, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
 
     QString formulaString() const;
     QString outputFile() const;
@@ -83,7 +83,10 @@ class APP_EXPORT QgsRasterCalcDialog: public QDialog, private Ui::QgsRasterCalcD
     void mOrButton_clicked();
 
   private:
-    //insert available GDAL drivers that support the create() option
+    //! Sets the extent and size of the output
+    void setExtentSize( int width, int height, QgsRectangle bbox );
+
+    // Insert available GDAL drivers that support the create() option
     void insertAvailableOutputFormats();
     //! Accesses the available raster layers/bands from the layer registry
     void insertAvailableRasterBands();
@@ -99,6 +102,8 @@ class APP_EXPORT QgsRasterCalcDialog: public QDialog, private Ui::QgsRasterCalcD
     QMap<QString, QString> mDriverExtensionMap;
 
     QList<QgsRasterCalculatorEntry> mAvailableRasterBands;
+
+    bool mExtentSizeSet = false;
 };
 
 #endif // QGSRASTERCALCDIALOG_H

--- a/src/ui/qgsrastercalcdialogbase.ui
+++ b/src/ui/qgsrastercalcdialogbase.ui
@@ -84,7 +84,7 @@
           <item row="1" column="3">
            <widget class="QLabel" name="mXMaxLabel">
             <property name="text">
-             <string>XMax</string>
+             <string>X Max</string>
             </property>
            </widget>
           </item>
@@ -163,8 +163,8 @@
           </item>
          </layout>
         </item>
-        <item row="0" column="1" colspan="2">
-         <widget class="QLineEdit" name="mOutputLayerLineEdit"/>
+        <item row="0" column="1" colspan="3">
+         <widget class="QgsFileWidget" name="mOutputLayer"/>
         </item>
         <item row="1" column="0">
          <widget class="QLabel" name="mOutputFormatLabel">
@@ -176,7 +176,7 @@
         <item row="2" column="0">
          <widget class="QPushButton" name="mCurrentLayerExtentButton">
           <property name="text">
-           <string>Current layer extent</string>
+           <string>Selected layer extent</string>
           </property>
          </widget>
         </item>
@@ -184,28 +184,6 @@
          <widget class="QLabel" name="mOutputLayerLabel">
           <property name="text">
            <string>Output layer</string>
-          </property>
-          <property name="buddy">
-           <cstring>mOutputLayerPushButton</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="3">
-         <widget class="QPushButton" name="mOutputLayerPushButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>20</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>…</string>
           </property>
          </widget>
         </item>
@@ -526,11 +504,15 @@
    <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mRasterBandsListWidget</tabstop>
-  <tabstop>mOutputLayerLineEdit</tabstop>
-  <tabstop>mOutputLayerPushButton</tabstop>
+  <tabstop>mOutputLayer</tabstop>
   <tabstop>mOutputFormatComboBox</tabstop>
   <tabstop>mCurrentLayerExtentButton</tabstop>
   <tabstop>mXMinSpinBox</tabstop>


### PR DESCRIPTION
## Description
I stumbled on a couple of raster calculator issues while working on a project today which this PR fixes:
- The progress dialog's cancel button doesn't cancel the progress, instead the dialog reappears again and again
- I got used to having most processing algorithms rely on the active layer to set its parameters' combo boxes, and for a brief moment, didn't understand why the raster calculator was having memory issues creating the output layer. It was because the extent, width, and height were set to match the first raster layer from an alphabetically sorted list. 

I've also updated the save/restore geometry to use @NathanW2 's new API, and moved the file picker to QgsFileWidget.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
