### PR TITLE
[processing] allow enums values to be used in description files

### DIFF
--- a/python/plugins/processing/algs/grass7/description/i.atcorr.txt
+++ b/python/plugins/processing/algs/grass7/description/i.atcorr.txt
@@ -2,11 +2,11 @@ i.atcorr
 Performs atmospheric correction using the 6S algorithm.
 Imagery (i.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
-QgsProcessingParameterRange|range|Input imagery range [0,255]|0,255|True
+QgsProcessingParameterRange|range|Input imagery range [0,255]|QgsProcessingParameterNumber.Integer|0,255|True
 QgsProcessingParameterRasterLayer|elevation|Input altitude raster map in m (optional)|None|True
 QgsProcessingParameterRasterLayer|visibility|Input visibility raster map in km (optional)|None|True
-QgsProcessingParameterFile|parameters|Name of input text file|False|txt|None|False
-QgsProcessingParameterRange|rescale|Rescale output raster map [0,255]|0,255|True
+QgsProcessingParameterFile|parameters|Name of input text file|QgsProcessingParameterFile.File|txt|None|False
+QgsProcessingParameterRange|rescale|Rescale output raster map [0,255]|QgsProcessingParameterNumber.Integer|0,255|True
 QgsProcessingParameterRasterDestination|output|Atmospheric correction
 *QgsProcessingParameterBoolean|-i|Output raster map as integer|False
 *QgsProcessingParameterBoolean|-r|Input raster map converted to reflectance (default is radiance)|False

--- a/python/plugins/processing/algs/grass7/description/i.cca.txt
+++ b/python/plugins/processing/algs/grass7/description/i.cca.txt
@@ -2,5 +2,5 @@ i.cca
 Canonical components analysis (CCA) program for image processing.
 Imagery (i.*)
 QgsProcessingParameterMultipleLayers|input|Input rasters (2 to 8)|3|None|False
-QgsProcessingParameterFile|signature|File containing spectral signatures|False|txt|None|False
+QgsProcessingParameterFile|signature|File containing spectral signatures|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterFolderDestination|output|Output Directory

--- a/python/plugins/processing/algs/grass7/description/i.cluster.txt
+++ b/python/plugins/processing/algs/grass7/description/i.cluster.txt
@@ -3,7 +3,7 @@ Generates spectral signatures for land cover types in an image using a clusterin
 Imagery (i.*)
 QgsProcessingParameterMultipleLayers|input|Input rasters|3|None|False
 QgsProcessingParameterNumber|classes|Initial number of classes (1-255)|QgsProcessingParameterNumber.Integer|None|False|1|255
-QgsProcessingParameterFile|seed|Name of file containing initial signatures|False|txt|None|True
+QgsProcessingParameterFile|seed|Name of file containing initial signatures|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|sample|Sampling intervals (by row and col)|None|False|True
 QgsProcessingParameterNumber|iterations|Maximum number of iterations|QgsProcessingParameterNumber.Integer|30|True|1|None
 QgsProcessingParameterNumber|convergence|Percent convergence|QgsProcessingParameterNumber.Double|98.0|True|0.0|100.0

--- a/python/plugins/processing/algs/grass7/description/i.in.spotvgt.txt
+++ b/python/plugins/processing/algs/grass7/description/i.in.spotvgt.txt
@@ -1,6 +1,6 @@
 i.in.spotvgt
 Imports SPOT VGT NDVI data into a raster map.
 Imagery (i.*)
-QgsProcessingParameterFile|input|Name of input SPOT VGT NDVI HDF file|False|hdf|None|False
+QgsProcessingParameterFile|input|Name of input SPOT VGT NDVI HDF file|QgsProcessingParameterFile.File|hdf|None|False
 *QgsProcessingParameterBoolean|-a|Also import quality map (SM status map layer) and filter NDVI map|False
 QgsProcessingParameterRasterDestination|output|SPOT NDVI Raster

--- a/python/plugins/processing/algs/grass7/description/i.landsat.toar.txt
+++ b/python/plugins/processing/algs/grass7/description/i.landsat.toar.txt
@@ -2,7 +2,7 @@ i.landsat.toar
 Calculates top-of-atmosphere radiance or reflectance and temperature for Landsat MSS/TM/ETM+/OLI
 Imagery (i.*)
 QgsProcessingParameterMultipleLayers|rasters|Landsat input rasters|3|None|False
-QgsProcessingParameterFile|metfile|Name of Landsat metadata file (.met or MTL.txt)|False|met|None|True
+QgsProcessingParameterFile|metfile|Name of Landsat metadata file (.met or MTL.txt)|QgsProcessingParameterFile.File|met|None|True
 QgsProcessingParameterEnum|sensor|Spacecraft sensor|mss1;mss2;mss3;mss4;mss5;tm4;tm5;tm7;oli8|False|7|True
 QgsProcessingParameterEnum|method|Atmospheric correction method|uncorrected;dos1;dos2;dos2b;dos3;dos4|False|0|True
 QgsProcessingParameterString|date|Image acquisition date (yyyy-mm-dd)|None|False|True

--- a/python/plugins/processing/algs/grass7/description/i.maxlik.txt
+++ b/python/plugins/processing/algs/grass7/description/i.maxlik.txt
@@ -2,6 +2,6 @@ i.maxlik
 Classifies the cell spectral reflectances in imagery data.
 Imagery (i.*)
 QgsProcessingParameterMultipleLayers|input|Input rasters|3|None|False
-QgsProcessingParameterFile|signaturefile|Name of input file containing signatures|False|txt|None|False
+QgsProcessingParameterFile|signaturefile|Name of input file containing signatures|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterRasterDestination|output|Classification|None|False
 QgsProcessingParameterRasterDestination|reject|Reject Threshold|None|True

--- a/python/plugins/processing/algs/grass7/description/i.pca.txt
+++ b/python/plugins/processing/algs/grass7/description/i.pca.txt
@@ -2,7 +2,7 @@ i.pca
 Principal components analysis (PCA) for image processing.
 Imagery (i.*)
 QgsProcessingParameterMultipleLayers|input|Name of two or more input raster maps|3|None|False
-QgsProcessingParameterRange|rescale|Rescaling range for output maps. For no rescaling use 0,0|0,255|True
+QgsProcessingParameterRange|rescale|Rescaling range for output maps. For no rescaling use 0,0|QgsProcessingParameterNumber.Integer|0,255|True
 QgsProcessingParameterNumber|percent|Cumulative percent importance for filtering|QgsProcessingParameterNumber.Integer|99|True|50|99
 *QgsProcessingParameterBoolean|-n|Normalize (center and scale) input maps|False
 *QgsProcessingParameterBoolean|-f|Output will be filtered input bands|False

--- a/python/plugins/processing/algs/grass7/description/i.smap.txt
+++ b/python/plugins/processing/algs/grass7/description/i.smap.txt
@@ -2,7 +2,7 @@ i.smap
 Performs contextual image classification using sequential maximum a posteriori (SMAP) estimation.
 Imagery (i.*)
 QgsProcessingParameterMultipleLayers|input|Input rasters|3|None|False
-QgsProcessingParameterFile|signaturefile|Name of input file containing signatures|False|txt|None|False
+QgsProcessingParameterFile|signaturefile|Name of input file containing signatures|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterNumber|blocksize|Size of submatrix to process at one time|QgsProcessingParameterNumber.Integer|1024|True|1|None
 *QgsProcessingParameterBoolean|-m|Use maximum likelihood estimation (instead of smap)|False
 QgsProcessingParameterRasterDestination|output|Classification|None|False

--- a/python/plugins/processing/algs/grass7/description/m.cogo.txt
+++ b/python/plugins/processing/algs/grass7/description/m.cogo.txt
@@ -1,7 +1,7 @@
 m.cogo
 A simple utility for converting bearing and distance measurements to coordinates and vice versa. It assumes a Cartesian coordinate system
 Miscellaneous (m.*)
-QgsProcessingParameterFile|input|Name of input file|False|txt|None|False
+QgsProcessingParameterFile|input|Name of input file|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterFileDestination|output|Output text file|Txt files (*.txt)|None|False
 QgsProcessingParameterPoint|coordinates|Starting coordinate pair|0.0,0.0
 *QgsProcessingParameterBoolean|-l|Lines are labelled|False

--- a/python/plugins/processing/algs/grass7/description/r.category.txt
+++ b/python/plugins/processing/algs/grass7/description/r.category.txt
@@ -3,7 +3,7 @@ Manages category values and labels associated with user-specified raster map lay
 Raster (r.*)
 QgsProcessingParameterRasterLayer|map|Name of raster map|None|False
 QgsProcessingParameterString|separator|Field separator (Special characters: pipe, comma, space, tab, newline)|tab|False|True
-QgsProcessingParameterFile|rules|File containing category label rules|False|txt|None|True
+QgsProcessingParameterFile|rules|File containing category label rules|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|txtrules|Inline category label rules|None|True|True
 QgsProcessingParameterRasterLayer|raster|Raster map from which to copy category table|None|True
 *QgsProcessingParameterString|format|Default label or format string for dynamic labeling. Used when no explicit label exists for the category|None|False|True

--- a/python/plugins/processing/algs/grass7/description/r.colors.txt
+++ b/python/plugins/processing/algs/grass7/description/r.colors.txt
@@ -4,7 +4,7 @@ Raster (r.*)
 QgsProcessingParameterMultipleLayers|map|Name of raster maps(s)|3|None|False
 QgsProcessingParameterEnum|color|Name of color table|not selected;aspect;aspectcolr;bcyr;bgyr;blues;byg;byr;celsius;corine;curvature;differences;elevation;etopo2;evi;fahrenheit;gdd;greens;grey;grey.eq;grey.log;grey1.0;grey255;gyr;haxby;kelvin;ndvi;ndwi;oranges;population;population_dens;precipitation;precipitation_daily;precipitation_monthly;rainbow;ramp;random;reds;rstcurv;ryb;ryg;sepia;slope;srtm;srtm_plus;terrain;wave|False|0|True
 QgsProcessingParameterString|rules_txt|Color rules|None|True|True
-QgsProcessingParameterFile|rules|Color rules file|False|txt|None|True
+QgsProcessingParameterFile|rules|Color rules file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterLayer|raster|Raster map from which to copy color table|None|True
 QgsProcessingParameterBoolean|-r|Remove existing color table|False
 QgsProcessingParameterBoolean|-w|Only write new color table if it does not already exist|False

--- a/python/plugins/processing/algs/grass7/description/r.in.lidar.info.txt
+++ b/python/plugins/processing/algs/grass7/description/r.in.lidar.info.txt
@@ -1,7 +1,7 @@
 r.in.lidar
 r.in.lidar.info - Extract information from LAS file
 Raster (r.*)
-QgsProcessingParameterFile|input|LAS input file|False|txt|None|False
+QgsProcessingParameterFile|input|LAS input file|QgsProcessingParameterFile.File|txt|None|False
 Hardcoded|-p
 Hardcoded|-g
 Hardcoded|-s

--- a/python/plugins/processing/algs/grass7/description/r.in.lidar.txt
+++ b/python/plugins/processing/algs/grass7/description/r.in.lidar.txt
@@ -1,7 +1,7 @@
 r.in.lidar
 Creates a raster map from LAS LiDAR points using univariate statistics.
 Raster (r.*)
-QgsProcessingParameterFile|input|LAS input file|False|las|None|False
+QgsProcessingParameterFile|input|LAS input file|QgsProcessingParameterFile.File|las|None|False
 QgsProcessingParameterEnum|method|Statistic to use for raster values|n;min;max;range;sum;mean;stddev;variance;coeff_var;median;percentile;skewness;trimmean|False|5|True
 QgsProcessingParameterEnum|type|Storage type for resultant raster map|CELL;FCELL;DCELL|False|1|True
 QgsProcessingParameterRasterLayer|base_raster|Subtract raster values from the Z coordinates|None|True

--- a/python/plugins/processing/algs/grass7/description/r.li.cwed.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.cwed.ascii.txt
@@ -3,6 +3,6 @@ r.li.cwed.ascii - Calculates contrast weighted edge density index on a raster ma
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
-QgsProcessingParameterFile|path|Name of file that contains the weight to calculate the index|False|txt|None|False
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
+QgsProcessingParameterFile|path|Name of file that contains the weight to calculate the index|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterFileDestination|output_txt|CWED|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.cwed.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.cwed.txt
@@ -3,6 +3,6 @@ Calculates contrast weighted edge density index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
-QgsProcessingParameterFile|path|Name of file that contains the weight to calculate the index|False|txt|None|False
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
+QgsProcessingParameterFile|path|Name of file that contains the weight to calculate the index|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterRasterDestination|output|CWED

--- a/python/plugins/processing/algs/grass7/description/r.li.dominance.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.dominance.ascii.txt
@@ -3,5 +3,5 @@ r.li.dominance.ascii - Calculates dominance's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Dominance|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.dominance.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.dominance.txt
@@ -3,5 +3,5 @@ Calculates dominance's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Dominance

--- a/python/plugins/processing/algs/grass7/description/r.li.edgedensity.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.edgedensity.ascii.txt
@@ -3,7 +3,7 @@ r.li.edgedensity.ascii - Calculates edge density index on a raster map, using a 
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|patch_type|The value of the patch type|None|False|True
 QgsProcessingParameterBoolean|-b|Exclude border edges|False
 QgsProcessingParameterFileDestination|output_txt|Edge Density|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.edgedensity.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.edgedensity.txt
@@ -3,7 +3,7 @@ Calculates edge density index on a raster map, using a 4 neighbour algorithm
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|patch_type|The value of the patch type|None|False|True
 QgsProcessingParameterBoolean|-b|Exclude border edges|False
 QgsProcessingParameterRasterDestination|output|Edge Density

--- a/python/plugins/processing/algs/grass7/description/r.li.mpa.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.mpa.ascii.txt
@@ -3,5 +3,5 @@ r.li.mpa.ascii - Calculates mean pixel attribute index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Mean Pixel Attribute|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.mpa.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.mpa.txt
@@ -3,5 +3,5 @@ Calculates mean pixel attribute index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Mean Pixel Attribute

--- a/python/plugins/processing/algs/grass7/description/r.li.mps.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.mps.ascii.txt
@@ -3,5 +3,5 @@ r.li.mps.ascii - Calculates mean patch size index on a raster map, using a 4 nei
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None
 QgsProcessingParameterFileDestination|output_txt|Mean Patch Size|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.mps.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.mps.txt
@@ -3,5 +3,5 @@ Calculates mean patch size index on a raster map, using a 4 neighbour algorithm
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Mean Patch Size

--- a/python/plugins/processing/algs/grass7/description/r.li.padcv.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.padcv.ascii.txt
@@ -3,5 +3,5 @@ r.li.padcv.ascii - Calculates coefficient of variation of patch area on a raster
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|PADCV|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.padcv.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.padcv.txt
@@ -3,5 +3,5 @@ Calculates coefficient of variation of patch area on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|PADCV

--- a/python/plugins/processing/algs/grass7/description/r.li.padrange.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.padrange.ascii.txt
@@ -3,5 +3,5 @@ r.li.padrange.ascii - Calculates range of patch area size on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Pad Range|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.padrange.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.padrange.txt
@@ -3,5 +3,5 @@ Calculates range of patch area size on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Pad Range

--- a/python/plugins/processing/algs/grass7/description/r.li.padsd.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.padsd.ascii.txt
@@ -3,5 +3,5 @@ r.li.padsd.ascii - Calculates standard deviation of patch area a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Patch Area SD|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.padsd.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.padsd.txt
@@ -3,5 +3,5 @@ Calculates standard deviation of patch area a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Patch Area SD

--- a/python/plugins/processing/algs/grass7/description/r.li.patchdensity.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.patchdensity.ascii.txt
@@ -3,5 +3,5 @@ r.li.patchdensity.ascii - Calculates patch density index on a raster map, using 
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Patch Density|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.patchdensity.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.patchdensity.txt
@@ -3,5 +3,5 @@ Calculates patch density index on a raster map, using a 4 neighbour algorithm
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Patch Density

--- a/python/plugins/processing/algs/grass7/description/r.li.patchnum.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.patchnum.ascii.txt
@@ -3,5 +3,5 @@ r.li.patchnum.ascii - Calculates patch number index on a raster map, using a 4 n
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Patch Number|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.patchnum.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.patchnum.txt
@@ -3,5 +3,5 @@ Calculates patch number index on a raster map, using a 4 neighbour algorithm.
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Patch Number

--- a/python/plugins/processing/algs/grass7/description/r.li.pielou.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.pielou.ascii.txt
@@ -1,7 +1,7 @@
 r.li.pielou
-r.li.pielou.ascii - Calculates Pielou's diversity index on a raster map 
+r.li.pielou.ascii - Calculates Pielou's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Pielou|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.pielou.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.pielou.txt
@@ -1,7 +1,7 @@
 r.li.pielou
-Calculates Pielou's diversity index on a raster map 
+Calculates Pielou's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Pielou

--- a/python/plugins/processing/algs/grass7/description/r.li.renyi.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.renyi.ascii.txt
@@ -3,6 +3,6 @@ r.li.renyi.ascii - Calculates Renyi's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|alpha|Alpha value is the order of the generalized entropy|None|False|False
 QgsProcessingParameterFileDestination|output_txt|Renyi|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.renyi.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.renyi.txt
@@ -3,6 +3,6 @@ Calculates Renyi's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|alpha|Alpha value is the order of the generalized entropy|None|False|False
 QgsProcessingParameterRasterDestination|output|Renyi

--- a/python/plugins/processing/algs/grass7/description/r.li.richness.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.richness.ascii.txt
@@ -3,5 +3,5 @@ r.li.richness.ascii - Calculates richness index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Richness|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.richness.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.richness.txt
@@ -3,5 +3,5 @@ Calculates richness index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Richness

--- a/python/plugins/processing/algs/grass7/description/r.li.shannon.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.shannon.ascii.txt
@@ -3,5 +3,5 @@ r.li.shannon.ascii - Calculates Shannon's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Shannon|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.shannon.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.shannon.txt
@@ -3,5 +3,5 @@ Calculates Shannon's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Shannon

--- a/python/plugins/processing/algs/grass7/description/r.li.shape.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.shape.ascii.txt
@@ -1,7 +1,7 @@
 r.li.shape
-r.li.shape.ascii - Calculates shape index on a raster map 
+r.li.shape.ascii - Calculates shape index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Shape|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.shape.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.shape.txt
@@ -1,7 +1,7 @@
 r.li.shape
-Calculates shape index on a raster map 
+Calculates shape index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Shape

--- a/python/plugins/processing/algs/grass7/description/r.li.simpson.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.simpson.ascii.txt
@@ -3,5 +3,5 @@ r.li.simpson.ascii - Calculates Simpson's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterFileDestination|output_txt|Simpson|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.li.simpson.txt
+++ b/python/plugins/processing/algs/grass7/description/r.li.simpson.txt
@@ -3,5 +3,5 @@ Calculates Simpson's diversity index on a raster map
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Name of input raster map|None|False
 QgsProcessingParameterString|config_txt|Landscape structure configuration|None|True|True
-QgsProcessingParameterFile|config|Landscape structure configuration file|False|txt|None|True
+QgsProcessingParameterFile|config|Landscape structure configuration file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Simpson

--- a/python/plugins/processing/algs/grass7/description/r.mapcalc.txt
+++ b/python/plugins/processing/algs/grass7/description/r.mapcalc.txt
@@ -1,9 +1,9 @@
 r.mapcalc
-Raster map calculator. 
+Raster map calculator.
 Raster (r.*)
 QgsProcessingParameterMultipleLayers|maps|Raster maps used in the calculator|3|None|True
 QgsProcessingParameterString|expression|Expression to evaluate. Syntax e.g. `raster_out=raster1+raster2`. Use original filenames, without extension|None|True|True
-QgsProcessingParameterFile|file|File containing expression(s) to evaluate (same rule for raster names than above)|False|txt|None|True
+QgsProcessingParameterFile|file|File containing expression(s) to evaluate (same rule for raster names than above)|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|seed|Integer seed for rand() function|None|False|True
 *QgsProcessingParameterBoolean|-s|Generate random seed (result is non-deterministic)|False
 QgsProcessingParameterFolderDestination|output_dir|Results Directory

--- a/python/plugins/processing/algs/grass7/description/r.mfilter.txt
+++ b/python/plugins/processing/algs/grass7/description/r.mfilter.txt
@@ -2,7 +2,7 @@ r.mfilter
 Performs raster map matrix filter.
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Input layer|None|False
-QgsProcessingParameterFile|filter|Filter file|False|txt|None|False
+QgsProcessingParameterFile|filter|Filter file|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterNumber|repeat|Number of times to repeat the filter|QgsProcessingParameterNumber.Integer|1|True|1|None
 QgsProcessingParameterBoolean|-z|Apply filter only to zero data values|False
 QgsProcessingParameterRasterDestination|output|Filtered

--- a/python/plugins/processing/algs/grass7/description/r.neighbors.txt
+++ b/python/plugins/processing/algs/grass7/description/r.neighbors.txt
@@ -9,5 +9,5 @@ QgsProcessingParameterNumber|gauss|Sigma (in cells) for Gaussian filter|QgsProce
 QgsProcessingParameterString|quantile|Quantile to calculate for method=quantile|None|False|True
 QgsProcessingParameterBoolean|-c|Use circular neighborhood|False
 *QgsProcessingParameterBoolean|-a|Do not align output with the input|False
-*QgsProcessingParameterFile|weight|File containing weights|0|txt|None|True
+*QgsProcessingParameterFile|weight|File containing weights|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterRasterDestination|output|Neighbors

--- a/python/plugins/processing/algs/grass7/description/r.profile.txt
+++ b/python/plugins/processing/algs/grass7/description/r.profile.txt
@@ -5,7 +5,7 @@ QgsProcessingParameterRasterLayer|input|Input raster layer|None|False
 QgsProcessingParameterString|coordinates|Profile coordinate pairs|0,0,1,1|True|True
 QgsProcessingParameterNumber|resolution|Resolution along profile|QgsProcessingParameterNumber.Double|None|True|None|0
 QgsProcessingParameterString|null_value|Character to represent no data cell|*|False|True
-QgsProcessingParameterFile|file|Name of input file containing coordinate pairs|False|txt|None|True
+QgsProcessingParameterFile|file|Name of input file containing coordinate pairs|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterBoolean|-g|Output easting and northing in first two columns of four column output|False
 QgsProcessingParameterBoolean|-c|Output RRR:GGG:BBB color values for each profile point|False
 QgsProcessingParameterFileDestination|output|Profile|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.reclass.txt
+++ b/python/plugins/processing/algs/grass7/description/r.reclass.txt
@@ -2,6 +2,6 @@ r.reclass
 Creates a new map layer whose category values are based upon a reclassification of the categories in an existing raster map layer.
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Input raster layer|None|False
-QgsProcessingParameterFile|rules|File containing reclass rules|False|txt|None|True
+QgsProcessingParameterFile|rules|File containing reclass rules|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|txtrules|Reclass rules text (if rule file not used)|None|True|True
 QgsProcessingParameterRasterDestination|output|Reclassified

--- a/python/plugins/processing/algs/grass7/description/r.recode.txt
+++ b/python/plugins/processing/algs/grass7/description/r.recode.txt
@@ -2,7 +2,7 @@ r.recode
 Recodes categorical raster maps.
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Input layer|None|False
-QgsProcessingParameterFile|rules|File containing recode rules|False|txt|NoneFalse
+QgsProcessingParameterFile|rules|File containing recode rules|QgsProcessingParameterFile.File|txt|NoneFalse
 *QgsProcessingParameterBoolean|-d|Force output to 'double' raster map type (DCELL)|False
 *QgsProcessingParameterBoolean|-a|Align the current region to the input raster map|False
 QgsProcessingParameterRasterDestination|output|Recoded

--- a/python/plugins/processing/algs/grass7/description/r.series.interp.txt
+++ b/python/plugins/processing/algs/grass7/description/r.series.interp.txt
@@ -3,9 +3,9 @@ Interpolates raster maps located (temporal or spatial) in between input raster m
 Raster (r.*)
 QgsProcessingParameterMultipleLayers|input|Input raster layer(s)|3|None|False
 QgsProcessingParameterString|datapos|Data point position for each input map|None|True|True
-QgsProcessingParameterFile|infile|Input file with one input raster map name and data point position per line, field separator between name and sample point is 'pipe'|False|txt|None|True
+QgsProcessingParameterFile|infile|Input file with one input raster map name and data point position per line, field separator between name and sample point is 'pipe'|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|output|Name for output raster map (comma separated list if multiple)|None|False|True
 QgsProcessingParameterString|samplingpos|Sampling point position for each output map (comma separated list)|None|True|True
-QgsProcessingParameterFile|outfile|Input file with one output raster map name and sample point position per line, field separator between name and sample point is 'pipe'|False|txt|None|True
+QgsProcessingParameterFile|outfile|Input file with one output raster map name and sample point position per line, field separator between name and sample point is 'pipe'|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterEnum|method|Interpolation method, currently only linear interpolation is supported|linear|False|0|True
 QgsProcessingParameterFolderDestination|output_dir|Interpolated rasters|None|False

--- a/python/plugins/processing/algs/grass7/description/r.topmodel.txt
+++ b/python/plugins/processing/algs/grass7/description/r.topmodel.txt
@@ -1,9 +1,9 @@
 r.topmodel
 Simulates TOPMODEL which is a physically based hydrologic model.
 Raster (r.*)
-QgsProcessingParameterFile|parameters|Name of TOPMODEL parameters file|False|txt|None|False
-QgsProcessingParameterFile|topidxstats|Name of topographic index statistics file|False|txt|None|False
-QgsProcessingParameterFile|input|Name of rainfall and potential evapotranspiration data file|False|txt|None|False
+QgsProcessingParameterFile|parameters|Name of TOPMODEL parameters file|QgsProcessingParameterFile.File|txt|None|False
+QgsProcessingParameterFile|topidxstats|Name of topographic index statistics file|QgsProcessingParameterFile.File|txt|None|False
+QgsProcessingParameterFile|input|Name of rainfall and potential evapotranspiration data file|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterNumber|timestep|Time step. Generate output for this time step|QgsProcessingParameterNumber.Integer|None|True|0|None
 QgsProcessingParameterNumber|topidxclass|Topographic index class. Generate output for this topographic index class|QgsProcessingParameterNumber.Integer|None|True|0|None
 QgsProcessingParameterFileDestination|output|TOPMODEL output|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/v.edit.txt
+++ b/python/plugins/processing/algs/grass7/description/v.edit.txt
@@ -4,7 +4,7 @@ Vector (v.*)
 QgsProcessingParameterVectorLayer|map|Name of vector layer|-1|None|False
 QgsProcessingParameterEnum|type|Input feature type|point;line;boundary;centroid|True|0,1,2,3|True
 QgsProcessingParameterEnum|tool|Tool|create;add;delete;copy;move;flip;catadd;catdel;merge;break;snap;connect;chtype;vertexadd;vertexdel;vertexmove;areadel;zbulk;select|False|0|False
-QgsProcessingParameterFile|input|ASCII file for add tool|False|txt|None|True
+QgsProcessingParameterFile|input|ASCII file for add tool|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterString|move|Difference in x,y,z direction for moving feature or vertex|None|False|True
 QgsProcessingParameterString|threshold|Threshold distance (coords,snap,query)|None|False|True
 QgsProcessingParameterString|ids|Feature ids|None|False|True

--- a/python/plugins/processing/algs/grass7/description/v.extract.txt
+++ b/python/plugins/processing/algs/grass7/description/v.extract.txt
@@ -4,7 +4,7 @@ Vector (v.*)
 QgsProcessingParameterVectorLayer|input|Vector layer|-1|None|False
 QgsProcessingParameterString|where|WHERE conditions of SQL statement without 'where' keyword|None|True|True
 QgsProcessingParameterEnum|type|Input feature type|point;line;boundary;centroid;area;face|True|0,1,3,4,5,6|True
-QgsProcessingParameterFile|file|Input text file with category numbers/number ranges to be extracted|False|txt|None|True
+QgsProcessingParameterFile|file|Input text file with category numbers/number ranges to be extracted|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterNumber|random|Number of random categories matching vector objects to extract|QgsProcessingParameterNumber.Integer|None|True|0|None
 QgsProcessingParameterNumber|new|Desired new category value (enter -1 to keep original categories)|QgsProcessingParameterNumber.Integer|-1|True|-1|None
 *QgsProcessingParameterBoolean|-d|Dissolve common boundaries|True

--- a/python/plugins/processing/algs/grass7/description/v.in.ascii.txt
+++ b/python/plugins/processing/algs/grass7/description/v.in.ascii.txt
@@ -1,7 +1,7 @@
 v.in.ascii
 Creates a vector map from an ASCII points file or ASCII vector file.
 Vector (v.*)
-QgsProcessingParameterFile|input|ASCII file to be imported|False|txt|None|False
+QgsProcessingParameterFile|input|ASCII file to be imported|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterEnum|format|Input file format|point;standard|False|0|True
 QgsProcessingParameterString|separator|Field separator|pipe|False|True
 QgsProcessingParameterString|text|Text delimiter|None|False|True

--- a/python/plugins/processing/algs/grass7/description/v.in.dxf.txt
+++ b/python/plugins/processing/algs/grass7/description/v.in.dxf.txt
@@ -1,7 +1,7 @@
 v.in.dxf
 Converts files in DXF format to GRASS vector map format.
 Vector (v.*)
-QgsProcessingParameterFile|input|Name of input DXF file|False|dxf|None|False
+QgsProcessingParameterFile|input|Name of input DXF file|QgsProcessingParameterFile.File|dxf|None|False
 QgsProcessingParameterString|layers|List of layers to import|None|False|True
 QgsProcessingParameterBoolean|-e|Ignore the map extent of DXF file|True
 QgsProcessingParameterBoolean|-t|Do not create attribute tables|False

--- a/python/plugins/processing/algs/grass7/description/v.in.e00.txt
+++ b/python/plugins/processing/algs/grass7/description/v.in.e00.txt
@@ -1,6 +1,6 @@
 v.in.e00
 Imports E00 file into a vector map
 Vector (v.*)
-QgsProcessingParameterFile|input|Name of input E00 file|False|e00|None|False
+QgsProcessingParameterFile|input|Name of input E00 file|QgsProcessingParameterFile.File|e00|None|False
 QgsProcessingParameterEnum|type|Input feature type|point;line;area|True|0|True
 QgsProcessingParameterVectorDestination|output|Name of output vector

--- a/python/plugins/processing/algs/grass7/description/v.in.geonames.txt
+++ b/python/plugins/processing/algs/grass7/description/v.in.geonames.txt
@@ -1,5 +1,5 @@
 v.in.geonames
 Imports geonames.org country files into a GRASS vector points map.
 Vector (v.*)
-QgsProcessingParameterFile|input|Uncompressed geonames file from (with .txt extension)|False|txt|None|False
+QgsProcessingParameterFile|input|Uncompressed geonames file from (with .txt extension)|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterVectorDestination|output|Geonames

--- a/python/plugins/processing/algs/grass7/description/v.in.lidar.txt
+++ b/python/plugins/processing/algs/grass7/description/v.in.lidar.txt
@@ -1,7 +1,7 @@
 v.in.lidar
 Converts LAS LiDAR point clouds to a GRASS vector map with libLAS.
 Vector (v.*)
-QgsProcessingParameterFile|input|LiDAR input files in LAS format (*.las or *.laz)|False|las|None|False
+QgsProcessingParameterFile|input|LiDAR input files in LAS format (*.las or *.laz)|QgsProcessingParameterFile.File|las|None|False
 QgsProcessingParameterExtent|spatial|Import subregion only|None|True
 QgsProcessingParameterRange|zrange|Filter range for z data|QgsProcessingParameterNumber.Double|None|True
 QgsProcessingParameterEnum|return_filter|Only import points of selected return type|first;last;mid|True|None|True

--- a/python/plugins/processing/algs/grass7/description/v.in.lines.txt
+++ b/python/plugins/processing/algs/grass7/description/v.in.lines.txt
@@ -1,7 +1,7 @@
 v.in.lines
 Import ASCII x,y[,z] coordinates as a series of lines.
 Vector (v.*)
-QgsProcessingParameterFile|input|ASCII file to be imported|False|txt|None|False
+QgsProcessingParameterFile|input|ASCII file to be imported|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterString|separator|Field separator|pipe|False|True
 *QgsProcessingParameterBoolean|-z|Create 3D vector map|False
 QgsProcessingParameterVectorDestination|output|Lines

--- a/python/plugins/processing/algs/grass7/description/v.in.mapgen.txt
+++ b/python/plugins/processing/algs/grass7/description/v.in.mapgen.txt
@@ -1,7 +1,7 @@
 v.in.mapgen
 Imports Mapgen or Matlab-ASCII vector maps into GRASS.
 Vector (v.*)
-QgsProcessingParameterFile|input|Name of input file in Mapgen/Matlab format|False|txt|None|False
+QgsProcessingParameterFile|input|Name of input file in Mapgen/Matlab format|QgsProcessingParameterFile.File|txt|None|False
 *QgsProcessingParameterBoolean|-z|Create 3D vector map|False
 *QgsProcessingParameterBoolean|-f|Input map is in Matlab format|False
 QgsProcessingParameterVectorDestination|output|Mapgen

--- a/python/plugins/processing/algs/grass7/description/v.net.path.txt
+++ b/python/plugins/processing/algs/grass7/description/v.net.path.txt
@@ -3,7 +3,7 @@ Finds shortest path on vector network
 Vector (v.*)
 QgsProcessingParameterVectorLayer|input|Input vector line layer (arcs)|1|None|False
 QgsProcessingParameterVectorLayer|points|Centers point layer (nodes)|0|None|False
-QgsProcessingParameterFile|file|Name of file containing start and end points|False|txt|None|False
+QgsProcessingParameterFile|file|Name of file containing start and end points|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterNumber|threshold|Threshold for connecting centers to the network (in map unit)|QgsProcessingParameterNumber.Double|50.0|False|0.0|None
 *QgsProcessingParameterEnum|arc_type|Arc type|line;boundary|True|0,1|False
 *QgsProcessingParameterField|arc_column|Arc forward/both direction(s) cost column (number)|None|input|0|False|True

--- a/python/plugins/processing/algs/grass7/description/v.net.txt
+++ b/python/plugins/processing/algs/grass7/description/v.net.txt
@@ -3,7 +3,7 @@ Performs network maintenance
 Vector (v.*)
 QgsProcessingParameterVectorLayer|input|Input vector line layer (arcs)|1|None|True
 QgsProcessingParameterVectorLayer|points|Input vector point layer (nodes)|0|None|True
-QgsProcessingParameterFile|file|Name of input arcs file|False|txt|None|True
+QgsProcessingParameterFile|file|Name of input arcs file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterEnum|operation|Operation to be performed|nodes;connect;arcs|False|0|False
 QgsProcessingParameterNumber|threshold|Threshold for connecting centers to the network (in map unit)|QgsProcessingParameterNumber.Double|50.0|False|0.0|None
 QgsProcessingParameterEnum|arc_type|Arc type|line;boundary|True|0,1|True

--- a/python/plugins/processing/algs/grass7/description/v.reclass.txt
+++ b/python/plugins/processing/algs/grass7/description/v.reclass.txt
@@ -4,5 +4,5 @@ Vector (v.*)
 QgsProcessingParameterVectorLayer|input|Input layer|-1|None|False
 QgsProcessingParameterEnum|type|Input feature type|point;line;boundary;centroid|True|0,1,2,3|True
 QgsProcessingParameterField|column|The name of the column whose values are to be used as new categories|None|input|-1|False|False
-QgsProcessingParameterFile|rules|Reclass rule file|False|txt|None|True
+QgsProcessingParameterFile|rules|Reclass rule file|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterVectorDestination|output|Reclassified

--- a/python/plugins/processing/algs/grass7/description/v.rectify.txt
+++ b/python/plugins/processing/algs/grass7/description/v.rectify.txt
@@ -3,7 +3,7 @@ Rectifies a vector by computing a coordinate transformation for each object in t
 Vector (v.*)
 QgsProcessingParameterVectorLayer|input|Name of input vector map|-1|None|False
 QgsProcessingParameterString|inline_points|Inline control points|None|True|True
-QgsProcessingParameterFile|points|Name of input file with control points|False|txt|None|True
+QgsProcessingParameterFile|points|Name of input file with control points|QgsProcessingParameterFile.File|txt|None|True
 QgsProcessingParameterNumber|order|Rectification polynomial order|QgsProcessingParameterNumber.Integer|1|True|1|3
 QgsProcessingParameterString|separator|Field separator for RMS report|pipe|False|True
 *QgsProcessingParameterBoolean|-3|Perform 3D transformation|False

--- a/python/plugins/processing/algs/grass7/description/v.segment.txt
+++ b/python/plugins/processing/algs/grass7/description/v.segment.txt
@@ -2,5 +2,5 @@ v.segment
 Creates points/segments from input vector lines and positions.
 Vector (v.*)
 QgsProcessingParameterVectorLayer|input|Input lines layer|1|None|False
-QgsProcessingParameterFile|rules|File containing segment rules|False|txt|None|False
+QgsProcessingParameterFile|rules|File containing segment rules|QgsProcessingParameterFile.File|txt|None|False
 QgsProcessingParameterVectorDestination|output|Segments

--- a/python/plugins/processing/algs/saga/description/GridCombination.txt
+++ b/python/plugins/processing/algs/saga/description/GridCombination.txt
@@ -1,7 +1,7 @@
 GridCombination
 sim_rivflow
 QgsProcessingParameterRasterLayer|INPUT|Gelaendemodell (DTM)|None|False
-QgsProcessingParameterFile|Folder1|Pfad WaterGap Raster|False|None|False
+QgsProcessingParameterFile|Folder1|Pfad WaterGap Raster|QgsProcessingParameterFile.File|None|False
 QgsProcessingParameterNumber|sY|Start-Jahr|QgsProcessingParameterNumber.Integer|1990|False| 1906| 2000
 QgsProcessingParameterNumber|eY|End-Jahr|QgsProcessingParameterNumber.Integer|1990|False| 1906| 2000
 QgsProcessingParameterBoolean|DomW|Domestic Water|True

--- a/python/plugins/processing/algs/saga/description/MaximumEntropyPresencePrediction.txt
+++ b/python/plugins/processing/algs/saga/description/MaximumEntropyPresencePrediction.txt
@@ -7,8 +7,8 @@ QgsProcessingParameterRasterDestination|PREDICTION|Presence Prediction
 QgsProcessingParameterRasterDestination|PROBABILITY|Presence Probability
 QgsProcessingParameterNumber|BACKGROUND|Background Sample Density [Percent]|QgsProcessingParameterNumber.Double|1.000000|False| 0.000000| 100.000000
 QgsProcessingParameterEnum|METHOD|Method|[0] Yoshimasa Tsuruoka;[1] Dekang Lin|False|0
-QgsProcessingParameterFile|YT_FILE_LOAD|Load from File...|False|None|False
-QgsProcessingParameterFile|YT_FILE_SAVE|Save to File...|False|None|False
+QgsProcessingParameterFile|YT_FILE_LOAD|Load from File...|QgsProcessingParameterFile.File|None|False
+QgsProcessingParameterFile|YT_FILE_SAVE|Save to File...|QgsProcessingParameterFile.File|None|False
 QgsProcessingParameterEnum|YT_REGUL|Regularization|[0] none;[1] L1;[2] L2|False|1
 QgsProcessingParameterNumber|YT_REGUL_VAL|Regularization Factor|QgsProcessingParameterNumber.Double|1.000000|False| 0.000000|None
 QgsProcessingParameterBoolean|YT_NUMASREAL|Real-valued Numerical Features|True

--- a/python/plugins/processing/algs/saga/description/RandomForestPresencePrediction(ViGrA).txt
+++ b/python/plugins/processing/algs/saga/description/RandomForestPresencePrediction(ViGrA).txt
@@ -10,8 +10,8 @@ QgsProcessingParameterNumber|mRMR_NFEATURES|Number of Features|QgsProcessingPara
 QgsProcessingParameterBoolean|mRMR_DISCRETIZE|Discretization|True
 QgsProcessingParameterNumber|mRMR_THRESHOLD|Discretization Threshold|QgsProcessingParameterNumber.Double|1.000000|False| 0.000000|None
 QgsProcessingParameterEnum|mRMR_METHOD|Selection Method|[0] Mutual Information Difference (MID);[1] Mutual Information Quotient (MIQ)|False|0
-QgsProcessingParameterFile|RF_IMPORT|Import from File|False|None|False
-QgsProcessingParameterFile|RF_EXPORT|Export to File|False|None|False
+QgsProcessingParameterFile|RF_IMPORT|Import from File|QgsProcessingParameterFile.File|None|False
+QgsProcessingParameterFile|RF_EXPORT|Export to File|QgsProcessingParameterFile.File|None|False
 QgsProcessingParameterNumber|RF_TREE_COUNT|Tree Count|QgsProcessingParameterNumber.Integer|32|False| 1|None
 QgsProcessingParameterNumber|RF_TREE_SAMPLES|Samples per Tree|QgsProcessingParameterNumber.Double|1.000000|False| 0.000000| 1.000000
 QgsProcessingParameterBoolean|RF_REPLACE|Sample with Replacement|True

--- a/python/plugins/processing/algs/saga/description/SVMClassification.txt
+++ b/python/plugins/processing/algs/saga/description/SVMClassification.txt
@@ -5,10 +5,10 @@ QgsProcessingParameterRasterDestination|CLASSES|Classification
 QgsProcessingParameterEnum|SCALING|Scaling|[0] none;[1] normalize (0-1);[2] standardize|False|2
 QgsProcessingParameterBoolean|MESSAGE|Verbose Messages|False
 QgsProcessingParameterEnum|MODEL_SRC|Model Source|[0] create from training areas;[1] restore from file|False|0
-QgsProcessingParameterFile|MODEL_LOAD|Restore Model from File|False|None|False
+QgsProcessingParameterFile|MODEL_LOAD|Restore Model from File|QgsProcessingParameterFile.File|None|False
 QgsProcessingParameterFeatureSource|ROI|Training Areas|-1|None|False
 QgsProcessingParameterFeatureSource|ROI_ID|Class Identifier|5|None|False
-QgsProcessingParameterFile|MODEL_SAVE|Store Model to File|False|None|False
+QgsProcessingParameterFile|MODEL_SAVE|Store Model to File|QgsProcessingParameterFile.File|None|False
 QgsProcessingParameterEnum|SVM_TYPE|SVM Type|[0] C-SVC;[1] nu-SVC;[2] one-class SVM;[3] epsilon-SVR;[4] nu-SVR|False|0
 QgsProcessingParameterEnum|KERNEL_TYPE|Kernel Type|[0] linear;[1] polynomial;[2] radial basis function;[3] sigmoid|False|2
 QgsProcessingParameterNumber|DEGREE|Degree|QgsProcessingParameterNumber.Integer|3|False|None|None

--- a/python/plugins/processing/algs/saga/description/SupervisedClassificationforGrids.txt
+++ b/python/plugins/processing/algs/saga/description/SupervisedClassificationforGrids.txt
@@ -6,8 +6,8 @@ QgsProcessingParameterRasterDestination|CLASSES|Classification
 QgsProcessingParameterRasterDestination|QUALITY|Quality
 QgsProcessingParameterFeatureSource|TRAINING|Training Areas|-1|None|True
 QgsProcessingParameterFeatureSource|TRAINING_CLASS|Class Identifier|5|None|False
-QgsProcessingParameterFile|FILE_LOAD|Load Statistics from File...|False|None|False
-QgsProcessingParameterFile|FILE_SAVE|Save Statistics to File...|False|None|False
+QgsProcessingParameterFile|FILE_LOAD|Load Statistics from File...|QgsProcessingParameterFile.File|None|False
+QgsProcessingParameterFile|FILE_SAVE|Save Statistics to File...|QgsProcessingParameterFile.File|None|False
 QgsProcessingParameterEnum|METHOD|Method|[0] Binary Encoding;[1] Parallelepiped;[2] Minimum Distance;[3] Mahalanobis Distance;[4] Maximum Likelihood;[5] Spectral Angle Mapping;[6] Winner Takes All|False|2
 QgsProcessingParameterNumber|THRESHOLD_DIST|Distance Threshold|QgsProcessingParameterNumber.Double|0.000000|False| 0.000000|None
 QgsProcessingParameterNumber|THRESHOLD_ANGLE|Spectral Angle Threshold (Degree)|QgsProcessingParameterNumber.Double|0.000000|False| 0.000000| 90.000000

--- a/python/plugins/processing/algs/saga/description/SupervisedClassificationforShapes.txt
+++ b/python/plugins/processing/algs/saga/description/SupervisedClassificationforShapes.txt
@@ -5,8 +5,8 @@ QgsProcessingParameterVectorDestination|CLASSES|Classification
 QgsProcessingParameterFeatureSource|FEATURES|Features|5|None|False
 QgsProcessingParameterBoolean|NORMALISE|Normalise|False
 QgsProcessingParameterFeatureSource|TRAINING|Training Classes|5|None|False
-QgsProcessingParameterFile|FILE_LOAD|Load Statistics from File...|False|None|False
-QgsProcessingParameterFile|FILE_SAVE|Save Statistics to File...|False|None|False
+QgsProcessingParameterFile|FILE_LOAD|Load Statistics from File...|QgsProcessingParameterFile.File|None|False
+QgsProcessingParameterFile|FILE_SAVE|Save Statistics to File...|QgsProcessingParameterFile.File|None|False
 QgsProcessingParameterEnum|METHOD|Method|[0] Binary Encoding;[1] Parallelepiped;[2] Minimum Distance;[3] Mahalanobis Distance;[4] Maximum Likelihood;[5] Spectral Angle Mapping;[6] Winner Takes All|False|2
 QgsProcessingParameterNumber|THRESHOLD_DIST|Distance Threshold|QgsProcessingParameterNumber.Double|0.000000|False| 0.000000|None
 QgsProcessingParameterNumber|THRESHOLD_ANGLE|Spectral Angle Threshold (Degree)|QgsProcessingParameterNumber.Double|0.000000|False| 0.000000| 90.000000

--- a/python/plugins/processing/algs/saga/description/TopofAtmosphereReflectance.txt
+++ b/python/plugins/processing/algs/saga/description/TopofAtmosphereReflectance.txt
@@ -48,7 +48,7 @@ QgsProcessingParameterRasterDestination|RF_OLI10|Reflectance Band 10
 QgsProcessingParameterRasterDestination|RF_OLI11|Reflectance Band 11
 QgsProcessingParameterRasterLayer|DN_PAN08|DN Band 8|None|True
 QgsProcessingParameterRasterDestination|RF_PAN08|Reflectance Band 8
-QgsProcessingParameterFile|METAFILE|Metadata File|False|None|False
+QgsProcessingParameterFile|METAFILE|Metadata File|QgsProcessingParameterFile.File|None|False
 QgsProcessingParameterEnum|SENSOR|Spacecraft Sensor|[0] Landsat-1 MSS;[1] Landsat-2 MSS;[2] Landsat-3 MSS;[3] Landsat-4 MSS;[4] Landsat-5 MSS;[5] Landsat-4 TM;[6] Landsat-5 TM;[7] Landsat-7 ETM+;[8] Landsat-8 OLI/TIRS|False|7
 QgsProcessingParameterString|DATE_ACQU|Image Acquisition Date
 QgsProcessingParameterString|DATE_PROD|Image Creation Date

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -94,7 +94,10 @@ def getParameterFromString(s):
                     params[3] = True if params[3].lower() == 'true' else False
             elif clazz == QgsProcessingParameterRange:
                 if len(params) > 2:
-                    params[2] = QgsProcessingParameterNumber.Integer if params[2].lower().endswith('integer') else QgsProcessingParameterNumber.Double
+                    try:
+                        params[2] = int(params[2])
+                    except:
+                        params[2] = getattr(QgsProcessingParameterNumber, params[2].split(".")[1])
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False
             elif clazz == QgsProcessingParameterExtent:
@@ -120,7 +123,10 @@ def getParameterFromString(s):
                     params[4] = True if params[4].lower() == 'true' else False
             elif clazz == QgsProcessingParameterMultipleLayers:
                 if len(params) > 2:
-                    params[2] = int(params[2])
+                    try:
+                        params[2] = int(params[2])
+                    except:
+                        params[2] = getattr(QgsProcessing, params[2].split(".")[1])
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False
             elif clazz == QgsProcessingParameterMatrix:
@@ -139,12 +145,18 @@ def getParameterFromString(s):
                     params[6] = True if params[6].lower() == 'true' else False
             elif clazz == QgsProcessingParameterFile:
                 if len(params) > 2:
-                    params[2] = QgsProcessingParameterFile.File if params[2].lower() == 'false' else QgsProcessingParameterFile.Folder
+                    try:
+                        params[2] = int(params[2])
+                    except:
+                        params[2] = getattr(QgsProcessingParameterFile, params[2].split(".")[1])
                 if len(params) > 5:
                     params[5] = True if params[5].lower() == 'true' else False
             elif clazz == QgsProcessingParameterNumber:
                 if len(params) > 2:
-                    params[2] = QgsProcessingParameterNumber.Integer if params[2].lower().endswith('integer') else QgsProcessingParameterNumber.Double
+                    try:
+                        params[2] = int(params[2])
+                    except:
+                        params[2] = getattr(QgsProcessingParameterNumber, params[2].split(".")[1])
                 if len(params) > 3:
                     params[3] = float(params[3].strip()) if params[3] is not None else None
                 if len(params) > 4:
@@ -169,18 +181,10 @@ def getParameterFromString(s):
                     params[3] = True if params[3].lower() == 'true' else False
             elif clazz == QgsProcessingParameterVectorDestination:
                 if len(params) > 2:
-                    if params[2].lower().endswith('point'):
-                        params[2] = QgsProcessing.TypeVectorPoint
-                    elif params[2].lower().endswith('line'):
-                        params[2] = QgsProcessing.TypeVectorLine
-                    elif params[2].lower().endswith('polygon'):
-                        params[2] = QgsProcessing.TypeVectorPolygon
-                    elif params[2].lower().endswith('geometry'):
-                        params[2] = QgsProcessing.TypeVectorAnyGeometry
-                    elif params[2].lower().endswith('vector'):
-                        params[2] = QgsProcessing.TypeVector
-                    elif params[2].lower().endswith('file'):
-                        params[2] = QgsProcessing.TypeFile
+                    try:
+                        params[2] = int(params[2])
+                    except:
+                        params[2] = getattr(QgsProcessing, params[2].split(".")[1])
                 if len(params) > 4:
                     params[4] = True if params[4].lower() == 'true' else False
 


### PR DESCRIPTION
## Description
Allow to use enum values like `QgsProcessingParameterNumber.Integer` in description files instead of corresponding numerical values. This improves readability a bit.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
