### PR TITLE
[processing] Allow providers to return a different helpId() vs their unique id()

### DIFF
--- a/python/analysis/processing/qgsnativealgorithms.sip.in
+++ b/python/analysis/processing/qgsnativealgorithms.sip.in
@@ -33,6 +33,8 @@ Constructor for QgsNativeAlgorithms.
 
     virtual QString id() const;
 
+    virtual QString helpId() const;
+
     virtual QString name() const;
 
     virtual bool supportsNonFileBasedOutput() const;

--- a/python/core/processing/qgsprocessingprovider.sip.in
+++ b/python/core/processing/qgsprocessingprovider.sip.in
@@ -53,6 +53,17 @@ should be a unique, short, character only string, eg "qgis" or "gdal". This
 string should not be localised.
 
 .. seealso:: :py:func:`name`
+
+.. seealso:: :py:func:`helpId`
+%End
+
+    virtual QString helpId() const;
+%Docstring
+Returns the provider help id string, used for creating QgsHelp urls for algorithms
+belong to this provider. By default, this returns the provider's id(). This string
+should not be localised.
+
+.. seealso:: :py:func:`id`
 %End
 
     virtual QString name() const = 0;

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -367,7 +367,7 @@ class ModelerParametersDialog(QDialog):
         algHelp = self._alg.helpUrl()
         if not algHelp:
             algHelp = QgsHelp.helpUrl("processing_algs/{}/{}.html{}".format(
-                self._alg.provider().id(), self._alg.groupId(), self._alg.name())).toString()
+                self._alg.provider().helpId(), self._alg.groupId(), self._alg.name())).toString()
 
         if algHelp not in [None, ""]:
             webbrowser.open(algHelp)

--- a/src/3d/processing/qgs3dalgorithms.cpp
+++ b/src/3d/processing/qgs3dalgorithms.cpp
@@ -40,6 +40,11 @@ QString Qgs3DAlgorithms::id() const
   return QStringLiteral( "3d" );
 }
 
+QString Qgs3DAlgorithms::helpId() const
+{
+  return QStringLiteral( "qgis" );
+}
+
 QString Qgs3DAlgorithms::name() const
 {
   return tr( "QGIS (3D)" );

--- a/src/3d/processing/qgs3dalgorithms.h
+++ b/src/3d/processing/qgs3dalgorithms.h
@@ -42,6 +42,7 @@ class _3D_EXPORT Qgs3DAlgorithms: public QgsProcessingProvider
     QIcon icon() const override;
     QString svgIconPath() const override;
     QString id() const override;
+    QString helpId() const override;
     QString name() const override;
     bool supportsNonFileBasedOutput() const override;
 

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -86,6 +86,11 @@ QString QgsNativeAlgorithms::id() const
   return QStringLiteral( "native" );
 }
 
+QString QgsNativeAlgorithms::helpId() const
+{
+  return QStringLiteral( "qgis" );
+}
+
 QString QgsNativeAlgorithms::name() const
 {
   return tr( "QGIS (native c++)" );

--- a/src/analysis/processing/qgsnativealgorithms.h
+++ b/src/analysis/processing/qgsnativealgorithms.h
@@ -42,6 +42,7 @@ class ANALYSIS_EXPORT QgsNativeAlgorithms: public QgsProcessingProvider
     QIcon icon() const override;
     QString svgIconPath() const override;
     QString id() const override;
+    QString helpId() const override;
     QString name() const override;
     bool supportsNonFileBasedOutput() const override;
 

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -41,6 +41,11 @@ QString QgsProcessingProvider::svgIconPath() const
   return QgsApplication::iconPath( QStringLiteral( "processingAlgorithm.svg" ) );
 }
 
+QString QgsProcessingProvider::helpId() const
+{
+  return id();
+}
+
 QString QgsProcessingProvider::longName() const
 {
   return name();

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -66,8 +66,17 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      * should be a unique, short, character only string, eg "qgis" or "gdal". This
      * string should not be localised.
      * \see name()
+     * \see helpId()
      */
     virtual QString id() const = 0;
+
+    /**
+     * Returns the provider help id string, used for creating QgsHelp urls for algorithms
+     * belong to this provider. By default, this returns the provider's id(). This string
+     * should not be localised.
+     * \see id()
+     */
+    virtual QString helpId() const;
 
     /**
      * Returns the provider name, which is used to describe the provider within the GUI.

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -233,7 +233,7 @@ void QgsProcessingAlgorithmDialogBase::openHelp()
   QUrl algHelp = mAlgorithm->helpUrl();
   if ( algHelp.isEmpty() )
   {
-    algHelp = QgsHelp::helpUrl( QStringLiteral( "processing_algs/%1/%2.html#%3" ).arg( mAlgorithm->provider()->id(), mAlgorithm->groupId(), mAlgorithm->name() ) );
+    algHelp = QgsHelp::helpUrl( QStringLiteral( "processing_algs/%1/%2.html#%3" ).arg( mAlgorithm->provider()->helpId(), mAlgorithm->groupId(), mAlgorithm->name() ) );
   }
 
   if ( !algHelp.isEmpty() )


### PR DESCRIPTION
This is used when generating the QgsHelp url for algorithms attached to the providers.

Implement helpId overrides for the native and 3d providers so that they return 'qgis' helpIds, meaning that all QGIS processing algorithm documentation can be kept within the same url path regardless of which QGIS provider library it sits within.

This also allows us to freely move algorithms from the Python 'qgis' provider to c++ 'native' provider in future releases without breaking the help URLs.

Fixes #17231
