### PR TITLE
Initial workaround for Qt5.10 instability

### DIFF
--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -65,7 +65,11 @@ void QgsCollapsibleGroupBoxBasic::init()
   // TODO set size (as well as margins) depending on theme, in updateStyle()
   mCollapseButton->setIconSize( QSize( 12, 12 ) );
   mCollapseButton->setIcon( mCollapseIcon );
+  // FIXME: This appears to mess up parent-child relationships and causes double-frees of children when destroying in Qt5.10, needs further investigation
+  // See also https://github.com/qgis/QGIS/pull/6301
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
   setFocusProxy( mCollapseButton );
+#endif
   setFocusPolicy( Qt::StrongFocus );
 
   connect( mCollapseButton, &QAbstractButton::clicked, this, &QgsCollapsibleGroupBoxBasic::toggleCollapsed );


### PR DESCRIPTION
After staring at valgrind a bit I noticed that QgsCollapsibleGroupBox was always involved in all those crashes when closing dialogs when compiled against Qt5.10. Gradually expanding from a valilla QGroupBox to the QgsCollapsibleGroupBox revealed that

    setFocusProxy( mCollapseButton );

is somehow responsible for all those crashes when closing dialogs. I'd say for a start we can just comment it out.


@nyalldawson There is a second source of crashes which I believe affects Qt5 in general:

All `QgsLayoutViewTool` are constructed with `QgsLayoutView` as parent, and in their destructor have

    QgsLayoutViewTool::~QgsLayoutViewTool()
    { 
      if ( mView )
        mView->unsetTool( this );
    }

with `mView` being a `QPointer<QgsLayoutView>`. When `QgsLayoutView` is destroyed, all the child `QgsLayoutViewTool` get destroyed as well, as per standard `QObject` behaviour. The problem is that at the time `~QgsLayoutViewTool` is called, the `mView` isn't yet reset to null becase, according to the `QPointer` documentation, starting with Qt5+:

    When using QPointer on a QWidget (or a subclass of QWidget), previously the QPointer would be cleared by the QWidget destructor. Now, the QPointer is cleared by the QObject destructor (since this is when QWeakPointer objects are cleared). Any QPointers tracking a widget will NOT be cleared before the QWidget destructor destroys the children for the widget being tracked.

So this means that in `~QgsLayoutViewTool`, `mView->unsetTool` is called on a half-destroyed `mView`.
