### PR TITLE
Split v.drape command

### DIFF
--- a/python/plugins/processing/algs/grass7/description/v.drape.where.txt
+++ b/python/plugins/processing/algs/grass7/description/v.drape.where.txt
@@ -1,9 +1,10 @@
-v.drape
+v.drape.where
 Converts vector map to 3D by sampling of elevation raster map.
 Vector (v.*)
 ParameterVector|input|Iput vector layer|-1|False
 ParameterRaster|elevation|Elevation raster map for height extraction|False
 ParameterSelection|method|Sampling method|nearest;bilinear;bicubic
 ParameterString|scale|Scale factor for sampled raster values|1.0
+ParameterString|where|WHERE conditions of SQL statement without 'where' keyword|
 ParameterString|null_value|Vector Z value for unknown height|
 OutputVector|output|3D vector


### PR DESCRIPTION
## Description
The ```where``` statement could be pain for basic users, so this PR splits the command in order to be used without ```where``` option

@gioman looks reasonable to you?