### PR TITLE
Fix crash after running GDAL alg from processing (fixes #18004)

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -469,9 +469,12 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri )
   bool supportsBoolean = false;
 
 #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,3,0)
-  const char *pszDataTypes = GDALGetMetadataItem( mOgrOrigLayer->driver(), GDAL_DMD_CREATIONFIELDDATASUBTYPES, nullptr );
-  if ( pszDataTypes && strstr( pszDataTypes, "Boolean" ) )
-    supportsBoolean = true;
+  if ( mOgrOrigLayer )
+  {
+    const char *pszDataTypes = GDALGetMetadataItem( mOgrOrigLayer->driver(), GDAL_DMD_CREATIONFIELDDATASUBTYPES, nullptr );
+    if ( pszDataTypes && strstr( pszDataTypes, "Boolean" ) )
+      supportsBoolean = true;
+  }
 #else
   if ( mGDALDriverName == QLatin1String( "GeoJSON" ) ||
        mGDALDriverName == QLatin1String( "GML" ) ||


### PR DESCRIPTION
This was happening only with GDAL trunk

Processing first tries to load output as a vector, then as a raster and output from raster algs would crash in OGR provider constructor due to null pointer.
