### PR TITLE
 [processing] Add explicit output type for multiple layers

### DIFF
--- a/python/core/processing/qgsprocessingoutputs.sip.in
+++ b/python/core/processing/qgsprocessingoutputs.sip.in
@@ -33,6 +33,8 @@ as generated layers or calculated values.
       sipType = sipType_QgsProcessingOutputRasterLayer;
     else if ( sipCpp->type() == QgsProcessingOutputMapLayer::typeName() )
       sipType = sipType_QgsProcessingOutputMapLayer;
+    else if ( sipCpp->type() == QgsProcessingOutputMultipleLayers::typeName() )
+      sipType = sipType_QgsProcessingOutputMultipleLayers;
     else if ( sipCpp->type() == QgsProcessingOutputHtml::typeName() )
       sipType = sipType_QgsProcessingOutputHtml;
     else if ( sipCpp->type() == QgsProcessingOutputNumber::typeName() )
@@ -187,6 +189,42 @@ A raster layer output for processing algorithms.
     QgsProcessingOutputRasterLayer( const QString &name, const QString &description = QString() );
 %Docstring
 Constructor for QgsProcessingOutputRasterLayer.
+%End
+
+    static QString typeName();
+%Docstring
+Returns the type name for the output class.
+%End
+    virtual QString type() const;
+
+
+};
+
+class QgsProcessingOutputMultipleLayers : QgsProcessingOutputDefinition
+{
+%Docstring
+A multi-layer output for processing algorithms which create map layers, when
+the number and nature of the output layers is not predefined.
+
+.. note::
+
+   Always prefer to explicitly define QgsProcessingOutputVectorLayer,
+   QgsProcessingOutputRasterLayer or QgsProcessingOutputMapLayer where possible. :py:class:`QgsProcessingOutputMultipleLayers`
+   should only ever be used when the number of output layers is not
+   fixed - e.g. as a result of processing all layers in a specified
+   folder.
+
+.. versionadded:: 3.0
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingoutputs.h"
+%End
+  public:
+
+    QgsProcessingOutputMultipleLayers( const QString &name, const QString &description = QString() );
+%Docstring
+Constructor for QgsProcessingOutputMultipleLayers.
 %End
 
     static QString typeName();

--- a/python/plugins/processing/algs/qgis/VectorSplit.py
+++ b/python/plugins/processing/algs/qgis/VectorSplit.py
@@ -33,6 +33,7 @@ from qgis.core import (QgsProcessingUtils,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFolderDestination,
                        QgsProcessingOutputFolder,
+                       QgsProcessingOutputMultipleLayers,
                        QgsExpression,
                        QgsFeatureRequest)
 
@@ -47,6 +48,7 @@ class VectorSplit(QgisAlgorithm):
     INPUT = 'INPUT'
     FIELD = 'FIELD'
     OUTPUT = 'OUTPUT'
+    OUTPUT_LAYERS = 'OUTPUT_LAYERS'
 
     def group(self):
         return self.tr('Vector general')
@@ -66,6 +68,7 @@ class VectorSplit(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterFolderDestination(self.OUTPUT,
                                                                   self.tr('Output directory')))
+        self.addOutput(QgsProcessingOutputMultipleLayers(self.OUTPUT_LAYERS, self.tr('Output layers')))
 
     def name(self):
         return 'splitvectorlayer'
@@ -89,6 +92,7 @@ class VectorSplit(QgisAlgorithm):
         geomType = source.wkbType()
 
         total = 100.0 / len(uniqueValues) if uniqueValues else 1
+        output_layers = []
 
         for current, i in enumerate(uniqueValues):
             if feedback.isCanceled():
@@ -108,8 +112,9 @@ class VectorSplit(QgisAlgorithm):
                 sink.addFeature(f, QgsFeatureSink.FastInsert)
                 count += 1
             feedback.pushInfo(self.tr('Added {} features to layer').format(count))
+            output_layers.append(fName)
             del sink
 
             feedback.setProgress(int(current * total))
 
-        return {self.OUTPUT: directory}
+        return {self.OUTPUT: directory, self.OUTPUT_LAYERS: output_layers}

--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -42,7 +42,8 @@ from qgis.core import (QgsMessageLog,
                        QgsProcessingParameterDefinition,
                        QgsProcessingOutputVectorLayer,
                        QgsProcessingOutputRasterLayer,
-                       QgsProcessingOutputMapLayer)
+                       QgsProcessingOutputMapLayer,
+                       QgsProcessingOutputMultipleLayers)
 
 import processing
 from processing.core.ProcessingConfig import ProcessingConfig
@@ -163,6 +164,22 @@ class Processing(object):
                             layer = context.takeResultLayer(result) # transfer layer ownership out of context
                             if layer:
                                 results[out.name()] = layer # replace layer string ref with actual layer (+ownership)
+                    elif isinstance(out, QgsProcessingOutputMultipleLayers):
+                        result = results[out.name()]
+                        if result:
+                            layers_result = []
+                            for l in result:
+                                if not isinstance(result, QgsMapLayer):
+                                    layer = context.takeResultLayer(l) # transfer layer ownership out of context
+                                    if layer:
+                                        layers_result.append(layer)
+                                    else:
+                                        layers_result.append(l)
+                                else:
+                                    layers_result.append(l)
+
+                            results[out.name()] = layers_result # replace layers strings ref with actual layers (+ownership)
+
         else:
             msg = Processing.tr("There were errors executing the algorithm.")
             feedback.reportError(msg)

--- a/python/plugins/processing/core/outputs.py
+++ b/python/plugins/processing/core/outputs.py
@@ -42,7 +42,8 @@ from qgis.core import (QgsExpressionContext,
                        QgsProcessingOutputHtml,
                        QgsProcessingOutputNumber,
                        QgsProcessingOutputString,
-                       QgsProcessingOutputFolder)
+                       QgsProcessingOutputFolder,
+                       QgsProcessingOutputMultipleLayers)
 
 
 def getOutputFromString(s):
@@ -69,6 +70,8 @@ def getOutputFromString(s):
                 out = QgsProcessingOutputVectorLayer(name, description)
             elif token.lower().strip() == 'outputlayer':
                 out = QgsProcessingOutputMapLayer(name, description)
+            elif token.lower().strip() == 'outputmultilayers':
+                out = QgsProcessingOutputMultipleLayers(name, description)
 #            elif token.lower().strip() == 'vector point':
 #                out = OutputVector(datatype=[dataobjects.TYPE_VECTOR_POINT])
 #            elif token.lower().strip() == 'vector line':

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -608,6 +608,9 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
                     options = QgsProcessingUtils.compatibleRasterLayers(QgsProject.instance(), False)
                 elif self.param.layerType() in (QgsProcessing.TypeVectorAnyGeometry, QgsProcessing.TypeVector):
                     options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [], False)
+                elif self.param.layerType() == QgsProcessing.TypeMapLayer:
+                    options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [], False)
+                    options.extend(QgsProcessingUtils.compatibleRasterLayers(QgsProject.instance(), False))
                 else:
                     options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [self.param.layerType()],
                                                                         False)
@@ -627,6 +630,9 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
                 options = QgsProcessingUtils.compatibleRasterLayers(QgsProject.instance(), False)
             elif self.param.layerType() in (QgsProcessing.TypeVectorAnyGeometry, QgsProcessing.TypeVector):
                 options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [], False)
+            elif self.param.layerType() == QgsProcessing.TypeMapLayer:
+                options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [], False)
+                options.extend(QgsProcessingUtils.compatibleRasterLayers(QgsProject.instance(), False))
             else:
                 options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [self.param.layerType()],
                                                                     False)
@@ -667,6 +673,9 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
                     options = QgsProcessingUtils.compatibleRasterLayers(QgsProject.instance(), False)
                 elif self.param.layerType() in (QgsProcessing.TypeVectorAnyGeometry, QgsProcessing.TypeVector):
                     options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [], False)
+                elif self.param.layerType() == QgsProcessing.TypeMapLayer:
+                    options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [], False)
+                    options.extend(QgsProcessingUtils.compatibleRasterLayers(QgsProject.instance(), False))
                 else:
                     options = QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [self.param.layerType()],
                                                                         False)

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -66,6 +66,7 @@ from qgis.core import (
     QgsProcessingOutputRasterLayer,
     QgsProcessingOutputVectorLayer,
     QgsProcessingOutputMapLayer,
+    QgsProcessingOutputMultipleLayers,
     QgsProcessingOutputFile,
     QgsProcessingOutputString,
     QgsProcessingOutputNumber,
@@ -544,20 +545,23 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
                                                             QgsProcessingParameterVectorLayer,
                                                             QgsProcessingParameterMultipleLayers),
                                                            [QgsProcessingOutputVectorLayer,
-                                                            QgsProcessingOutputMapLayer])
+                                                            QgsProcessingOutputMapLayer,
+                                                            QgsProcessingOutputMultipleLayers])
         elif self.param.layerType() == QgsProcessing.TypeVector:
             options = self.dialog.getAvailableValuesOfType((QgsProcessingParameterFeatureSource,
                                                             QgsProcessingParameterVectorLayer,
                                                             QgsProcessingParameterMultipleLayers),
                                                            [QgsProcessingOutputVectorLayer,
-                                                            QgsProcessingOutputMapLayer],
+                                                            QgsProcessingOutputMapLayer,
+                                                            QgsProcessingOutputMultipleLayers],
                                                            [QgsProcessing.TypeVector])
         elif self.param.layerType() == QgsProcessing.TypeVectorPoint:
             options = self.dialog.getAvailableValuesOfType((QgsProcessingParameterFeatureSource,
                                                             QgsProcessingParameterVectorLayer,
                                                             QgsProcessingParameterMultipleLayers),
                                                            [QgsProcessingOutputVectorLayer,
-                                                            QgsProcessingOutputMapLayer],
+                                                            QgsProcessingOutputMapLayer,
+                                                            QgsProcessingOutputMultipleLayers],
                                                            [QgsProcessing.TypeVectorPoint,
                                                             QgsProcessing.TypeVectorAnyGeometry])
         elif self.param.layerType() == QgsProcessing.TypeVectorLine:
@@ -565,7 +569,8 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
                                                             QgsProcessingParameterVectorLayer,
                                                             QgsProcessingParameterMultipleLayers),
                                                            [QgsProcessingOutputVectorLayer,
-                                                            QgsProcessingOutputMapLayer],
+                                                            QgsProcessingOutputMapLayer,
+                                                            QgsProcessingOutputMultipleLayers],
                                                            [QgsProcessing.TypeVectorLine,
                                                             QgsProcessing.TypeVectorAnyGeometry])
         elif self.param.layerType() == QgsProcessing.TypeVectorPolygon:
@@ -573,18 +578,22 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
                                                             QgsProcessingParameterVectorLayer,
                                                             QgsProcessingParameterMultipleLayers),
                                                            [QgsProcessingOutputVectorLayer,
-                                                            QgsProcessingOutputMapLayer],
+                                                            QgsProcessingOutputMapLayer,
+                                                            QgsProcessingOutputMultipleLayers],
                                                            [QgsProcessing.TypeVectorPolygon,
                                                             QgsProcessing.TypeVectorAnyGeometry])
         elif self.param.layerType() == QgsProcessing.TypeRaster:
             options = self.dialog.getAvailableValuesOfType(
                 (QgsProcessingParameterRasterLayer, QgsProcessingParameterMultipleLayers),
                 [QgsProcessingOutputRasterLayer,
-                 QgsProcessingOutputMapLayer])
+                 QgsProcessingOutputMapLayer,
+                 QgsProcessingOutputMultipleLayers])
         elif self.param.layerType() == QgsProcessing.TypeVector:
             options = self.dialog.getAvailableValuesOfType((QgsProcessingParameterFeatureSource,
                                                             QgsProcessingParameterVectorLayer,
-                                                            QgsProcessingParameterMultipleLayers), QgsProcessingOutputVectorLayer)
+                                                            QgsProcessingParameterMultipleLayers),
+                                                           [QgsProcessingOutputVectorLayer,
+                                                            QgsProcessingOutputMultipleLayers])
         else:
             options = self.dialog.getAvailableValuesOfType(QgsProcessingParameterFile, QgsProcessingOutputFile)
         options = sorted(options, key=lambda opt: self.dialog.resolveValueDescription(opt))

--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -53,6 +53,7 @@ void QgsPackageAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterFileDestination( QStringLiteral( "OUTPUT" ), QObject::tr( "Destination GeoPackage" ), QObject::tr( "GeoPackage files (*.gpkg)" ) ) );
   addParameter( new QgsProcessingParameterBoolean( QStringLiteral( "OVERWRITE" ), QObject::tr( "Overwrite existing GeoPackage" ), false ) );
   addOutput( new QgsProcessingOutputFile( QStringLiteral( "OUTPUT" ), QObject::tr( "GeoPackage" ) ) );
+  addOutput( new QgsProcessingOutputMultipleLayers( QStringLiteral( "OUTPUT_LAYERS" ), QObject::tr( "Layers within new package" ) ) );
 }
 
 QString QgsPackageAlgorithm::shortHelpString() const
@@ -97,6 +98,7 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
 
   QgsProcessingMultiStepFeedback multiStepFeedback( layers.count(), feedback );
 
+  QStringList outputLayers;
   int i = 0;
   for ( QgsMapLayer *layer : layers )
   {
@@ -123,6 +125,8 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
         if ( !packageVectorLayer( qobject_cast< QgsVectorLayer * >( layer ), packagePath,
                                   context, &multiStepFeedback ) )
           errored = true;
+        else
+          outputLayers.append( QStringLiteral( "%1|layername=%2" ).arg( packagePath, layer->name() ) );
         break;
       }
 
@@ -147,6 +151,7 @@ QVariantMap QgsPackageAlgorithm::processAlgorithm( const QVariantMap &parameters
 
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), packagePath );
+  outputs.insert( QStringLiteral( "OUTPUT_LAYERS" ), outputLayers );
   return outputs;
 }
 

--- a/src/core/processing/qgsprocessingoutputs.cpp
+++ b/src/core/processing/qgsprocessingoutputs.cpp
@@ -65,13 +65,18 @@ QgsProcessingOutputFile::QgsProcessingOutputFile( const QString &name, const QSt
 
 QgsProcessingOutputMapLayer::QgsProcessingOutputMapLayer( const QString &name, const QString &description )
   : QgsProcessingOutputDefinition( name, description )
-{
-
-}
-
-
+{}
 
 QString QgsProcessingOutputMapLayer::type() const
+{
+  return typeName();
+}
+
+QgsProcessingOutputMultipleLayers::QgsProcessingOutputMultipleLayers( const QString &name, const QString &description )
+  : QgsProcessingOutputDefinition( name, description )
+{}
+
+QString QgsProcessingOutputMultipleLayers::type() const
 {
   return typeName();
 }

--- a/src/core/processing/qgsprocessingoutputs.h
+++ b/src/core/processing/qgsprocessingoutputs.h
@@ -49,6 +49,8 @@ class CORE_EXPORT QgsProcessingOutputDefinition
       sipType = sipType_QgsProcessingOutputRasterLayer;
     else if ( sipCpp->type() == QgsProcessingOutputMapLayer::typeName() )
       sipType = sipType_QgsProcessingOutputMapLayer;
+    else if ( sipCpp->type() == QgsProcessingOutputMultipleLayers::typeName() )
+      sipType = sipType_QgsProcessingOutputMultipleLayers;
     else if ( sipCpp->type() == QgsProcessingOutputHtml::typeName() )
       sipType = sipType_QgsProcessingOutputHtml;
     else if ( sipCpp->type() == QgsProcessingOutputNumber::typeName() )
@@ -206,6 +208,36 @@ class CORE_EXPORT QgsProcessingOutputRasterLayer : public QgsProcessingOutputDef
     static QString typeName() { return QStringLiteral( "outputRaster" ); }
     QString type() const override { return typeName(); }
 
+
+};
+
+/**
+ * \class QgsProcessingOutputMultipleLayers
+ * \ingroup core
+ * A multi-layer output for processing algorithms which create map layers, when
+ * the number and nature of the output layers is not predefined.
+ *
+ * \note Always prefer to explicitly define QgsProcessingOutputVectorLayer,
+ * QgsProcessingOutputRasterLayer or QgsProcessingOutputMapLayer where possible. QgsProcessingOutputMultipleLayers
+ * should only ever be used when the number of output layers is not
+ * fixed - e.g. as a result of processing all layers in a specified
+ * folder.
+  * \since QGIS 3.0
+ */
+class CORE_EXPORT QgsProcessingOutputMultipleLayers : public QgsProcessingOutputDefinition
+{
+  public:
+
+    /**
+     * Constructor for QgsProcessingOutputMultipleLayers.
+     */
+    QgsProcessingOutputMultipleLayers( const QString &name, const QString &description = QString() );
+
+    /**
+     * Returns the type name for the output class.
+     */
+    static QString typeName() { return QStringLiteral( "outputMultilayer" ); }
+    QString type() const override;
 
 };
 


### PR DESCRIPTION
This was a missing capability in the new processing API - while algorithms could declare multiple layer input parameters, there was no corresponding multi-layer output. This meant that algorithms (such as Package Layers, Vector Split) which create a set of layers which cannot be determined in advance had no way to pass these generated layers on for further model processing steps.

It's also useful for algorithms which operate on a specified folder, processing all layers found there, and allowing these generated outputs to be utilised in other model steps (e.g. packaging all of them, merging them, etc)