### PR TITLE
Don't silently discard requests to set QgsFieldExpressionWidget to an empty expression

### DIFF
--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -173,7 +173,10 @@ void QgsFieldExpressionWidget::setLayer( QgsMapLayer *layer )
 void QgsFieldExpressionWidget::setField( const QString &fieldName )
 {
   if ( fieldName.isEmpty() )
+  {
+    setRow( -1 );
     return;
+  }
 
   QModelIndex idx = mFieldProxyModel->sourceFieldModel()->indexFromName( fieldName );
   if ( !idx.isValid() )

--- a/tests/src/gui/testqgsfieldexpressionwidget.cpp
+++ b/tests/src/gui/testqgsfieldexpressionwidget.cpp
@@ -47,6 +47,7 @@ class TestQgsFieldExpressionWidget : public QObject
     void asExpression();
     void testIsValid();
     void testFilters();
+    void setNull();
 
   private:
     QgsFieldExpressionWidget *mWidget = nullptr;
@@ -265,6 +266,27 @@ void TestQgsFieldExpressionWidget::testFilters()
   widget->setFilters( QgsFieldProxyModel::Time );
   QCOMPARE( widget->mCombo->count(), 1 );
   QCOMPARE( widget->mCombo->itemText( 0 ), QString( "timefld" ) );
+
+  QgsProject::instance()->removeMapLayer( layer );
+}
+
+void TestQgsFieldExpressionWidget::setNull()
+{
+  // test that QgsFieldExpressionWidget can be set to an empty value
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "point?field=fld:int&field=fld2:int&field=fld3:int" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
+  QgsProject::instance()->addMapLayer( layer );
+
+  std::unique_ptr< QgsFieldExpressionWidget > widget( new QgsFieldExpressionWidget() );
+  widget->setLayer( layer );
+
+  widget->setField( QString() );
+  QVERIFY( widget->currentField().isEmpty() );
+
+  widget->setField( QStringLiteral( "fld2" ) );
+  QCOMPARE( widget->currentField(), QStringLiteral( "fld2" ) );
+
+  widget->setField( QString() );
+  QVERIFY( widget->currentField().isEmpty() );
 
   QgsProject::instance()->removeMapLayer( layer );
 }


### PR DESCRIPTION
This causes issues in lots of places - e.g. a field constraint is always set to the first field in a layer, and cannot be removed.

I've looked at all calls to setField and without exception they should accept that setting the field to an empty string results in an empty expression.

Fixes #14325, and supersedes https://github.com/qgis/QGIS/pull/2810
