### PR TITLE
Fix data defined properties in cluster/displacement renderer do not evaluate for isolated features

### DIFF
--- a/src/core/symbology/qgspointdistancerenderer.cpp
+++ b/src/core/symbology/qgspointdistancerenderer.cpp
@@ -459,6 +459,11 @@ QgsExpressionContextScope *QgsPointDistanceRenderer::createGroupScope( const Clu
 
     clusterScope->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_CLUSTER_SIZE, group.size(), true ) );
   }
+  if ( !group.empty() )
+  {
+    // data defined properties may require a feature in the expression context, so just use first feature in group
+    clusterScope->setFeature( group.at( 0 ).feature );
+  }
   return clusterScope;
 }
 


### PR DESCRIPTION
Fixes #18074
