### PR TITLE
[processing] harmonize order of result panel (latest first) and add timestamp

### DIFF
--- a/python/plugins/processing/core/ProcessingResults.py
+++ b/python/plugins/processing/core/ProcessingResults.py
@@ -34,8 +34,8 @@ class ProcessingResults(QObject):
 
     results = []
 
-    def addResult(self, icon, name, result):
-        self.results.append(Result(icon, name, result))
+    def addResult(self, icon, name, timestamp, result):
+        self.results.append(Result(icon, name, timestamp, result))
         self.resultAdded.emit()
 
     def getResults(self):
@@ -44,9 +44,10 @@ class ProcessingResults(QObject):
 
 class Result:
 
-    def __init__(self, icon, name, filename):
+    def __init__(self, icon, name, timestamp, filename):
         self.icon = icon
         self.name = name
+        self.timestamp = timestamp
         self.filename = filename
 
 

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -286,7 +286,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             # add html results to results dock
             for out in self.algorithm().outputDefinitions():
                 if isinstance(out, QgsProcessingOutputHtml) and out.name() in result and result[out.name()]:
-                    resultsList.addResult(icon=self.algorithm().icon(), name=out.description(),
+                    resultsList.addResult(icon=self.algorithm().icon(), name=out.description(), timestamp=time.localtime(),
                                           result=result[out.name()])
 
             if not handleAlgorithmResults(self.algorithm(), context, feedback, not keepOpen):

--- a/python/plugins/processing/gui/ResultsDock.py
+++ b/python/plugins/processing/gui/ResultsDock.py
@@ -26,6 +26,7 @@ __copyright__ = '(C) 2012, Victor Olaya'
 __revision__ = '$Format:%H$'
 
 import os
+import time
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import QUrl
@@ -56,12 +57,12 @@ class ResultsDock(BASE, WIDGET):
         elements = resultsList.getResults()
         for element in elements:
             item = TreeResultItem(element)
-            self.treeResults.addTopLevelItem(item)
+            self.treeResults.insertTopLevelItem(0, item)
         self.treeResults.blockSignals(False)
 
     def updateDescription(self, current, previous):
         if isinstance(current, TreeResultItem):
-            html = '<b>Algorithm</b>: {}<br><b>File path</b>: {}'.format(current.text(0), current.filename)
+            html = '<b>Algorithm</b>: {}<br><b>File path</b>: {}'.format(current.algorithm, current.filename)
             self.txtDescription.setHtml(html)
 
     def openResult(self, item, column):
@@ -73,5 +74,6 @@ class TreeResultItem(QTreeWidgetItem):
     def __init__(self, result):
         QTreeWidgetItem.__init__(self)
         self.setIcon(0, result.icon)
-        self.setText(0, result.name)
+        self.setText(0, '{0} [{1}]'.format(result.name, time.strftime('%I:%M:%S%p', result.timestamp)))
+        self.algorithm = result.name
         self.filename = result.filename


### PR DESCRIPTION
## Description
When an algorithm outputting HTML is executed multiple times in a row, the result viewer panel is confusing. This PR improves the situation by:
- reverting ordering so it matches what we generally use elsewhere (latest first)
- add a timestamp

Here's how it looks:
![screenshot from 2018-02-12 12-16-56](https://user-images.githubusercontent.com/1728657/36084746-b3aca86a-0ff2-11e8-85b3-bbb617976616.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
