### PR TITLE
Make QgsLocator more thread safe

### DIFF
--- a/.ci/travis/linux/blacklist.txt
+++ b/.ci/travis/linux/blacklist.txt
@@ -30,9 +30,6 @@ PyQgsSpatialiteProvider
 # Flaky, see https://travis-ci.org/qgis/QGIS/jobs/297708174
 PyQgsServerAccessControl
 
-# Flaky, see https://dash.orfeo-toolbox.org/testDetails.php?test=61670866&build=297397
-PyQgsLocator
-
 # Need a local postgres installation
 PyQgsAuthManagerPKIPostgresTest
 PyQgsAuthManagerPasswordPostgresTest

--- a/python/core/locator/qgslocatorfilter.sip.in
+++ b/python/core/locator/qgslocatorfilter.sip.in
@@ -134,12 +134,6 @@ tasks are required in order to allow a subsequent search to safely execute
 on a background thread.
 %End
 
-    void executeSearchAndDelete( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback );
-%Docstring
-Executes a search for this filter instance, and then deletes the current instance
-of the filter.
-%End
-
     virtual void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) = 0;
 %Docstring
 Retrieves the filter results for a specified search ``string``. The ``context``
@@ -152,6 +146,9 @@ signal whenever they encounter a matching result.
 Subclasses should periodically check the ``feedback`` object to determine
 whether the query has been canceled. If so, the subclass should return
 from this method as soon as possible.
+
+This will be called from a background thread unless flags() returns the
+QgsLocatorFilter.FlagFast flag.
 %End
 
     virtual void triggerResult( const QgsLocatorResult &result ) = 0;

--- a/python/core/locator/qgslocatorfilter.sip.in
+++ b/python/core/locator/qgslocatorfilter.sip.in
@@ -74,6 +74,12 @@ Abstract base class for filters which collect locator results.
 Constructor for QgsLocatorFilter.
 %End
 
+    virtual QgsLocatorFilter *clone() const = 0 /Factory/;
+%Docstring
+Creates a clone of the filter. New requests are always executed in a
+clone of the original filter.
+%End
+
     virtual QString name() const = 0;
 %Docstring
 Returns the unique name for the filter. This should be an untranslated string identifying the filter.
@@ -106,6 +112,20 @@ results from this filter.
    as these are reserved for core QGIS functions. If a plugin registers
    a filter with a prefix shorter than 3 characters then the prefix will
    be ignored.
+%End
+
+    virtual void prepare( const QString &string, const QgsLocatorContext &context );
+%Docstring
+Prepares the filter instance for an upcoming search for the specified ``string``. This method is always called
+from the main thread, and individual filter subclasses should perform whatever
+tasks are required in order to allow a subsequent search to safely execute
+on a background thread.
+%End
+
+    void executeSearchAndDelete( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback );
+%Docstring
+Executes a search for this filter instance, and then deletes the current instance
+of the filter.
 %End
 
     virtual void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) = 0;
@@ -189,6 +209,8 @@ custom configuration widget.
 %End
 
   signals:
+
+    void finished();
 
     void resultFetched( const QgsLocatorResult &result );
 %Docstring

--- a/python/core/locator/qgslocatorfilter.sip.in
+++ b/python/core/locator/qgslocatorfilter.sip.in
@@ -69,6 +69,13 @@ Abstract base class for filters which collect locator results.
       Lowest
     };
 
+    enum Flag
+    {
+      FlagFast,
+    };
+    typedef QFlags<QgsLocatorFilter::Flag> Flags;
+
+
     QgsLocatorFilter( QObject *parent = 0 );
 %Docstring
 Constructor for QgsLocatorFilter.
@@ -92,6 +99,11 @@ Returns the unique name for the filter. This should be an untranslated string id
 Returns a translated, user-friendly name for the filter.
 
 .. seealso:: :py:func:`name`
+%End
+
+    virtual QgsLocatorFilter::Flags flags() const;
+%Docstring
+Returns flags which specify the filter's behavior.
 %End
 
     virtual Priority priority() const;
@@ -222,6 +234,9 @@ during within their fetchResults() implementation.
 %End
 
 };
+
+QFlags<QgsLocatorFilter::Flag> operator|(QgsLocatorFilter::Flag f1, QFlags<QgsLocatorFilter::Flag> f2);
+
 
 
 

--- a/python/core/locator/qgslocatorfilter.sip.in
+++ b/python/core/locator/qgslocatorfilter.sip.in
@@ -211,6 +211,9 @@ custom configuration widget.
   signals:
 
     void finished();
+%Docstring
+Emitted when the filter finishes fetching results.
+%End
 
     void resultFetched( const QgsLocatorResult &result );
 %Docstring

--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -89,7 +89,7 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
                 dlg.setMessage(message)
                 dlg.exec_()
                 return
-            dlg = alg.createCustomParametersWidget()
+            dlg = alg.createCustomParametersWidget(None)
             if not dlg:
                 dlg = AlgorithmDialog(alg)
             canvas = iface.mapCanvas()

--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -39,7 +39,6 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
 
     def __init__(self, parent=None):
         super(AlgorithmLocatorFilter, self).__init__(parent)
-        self.found_results = []
 
     def clone(self):
         return AlgorithmLocatorFilter()
@@ -56,7 +55,10 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
     def prefix(self):
         return 'a'
 
-    def prepare(self, string, context):
+    def flags(self):
+        return QgsLocatorFilter.FlagFast
+
+    def fetchResults(self, string, context, feedback):
         # collect results in main thread, since this method is inexpensive and
         # accessing the processing registry is not thread safe
         for a in QgsApplication.processingRegistry().algorithms():
@@ -73,11 +75,7 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
                     result.score = float(len(string)) / len(a.displayName())
                 else:
                     result.score = 0
-                self.found_results.append(result)
-
-    def fetchResults(self, string, context, feedback):
-        for result in self.found_results:
-            self.resultFetched.emit(result)
+                self.resultFetched.emit(result)
 
     def triggerResult(self, result):
         alg = QgsApplication.processingRegistry().createAlgorithmById(result.userData)

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -36,10 +36,8 @@ QgsLayerTreeLocatorFilter *QgsLayerTreeLocatorFilter::clone() const
   return new QgsLayerTreeLocatorFilter();
 }
 
-void QgsLayerTreeLocatorFilter::prepare( const QString &string, const QgsLocatorContext & )
+void QgsLayerTreeLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback * )
 {
-  // collect results in main thread, since this method is inexpensive and
-  // accessing the layer tree root is not thread safe
   QgsLayerTree *tree = QgsProject::instance()->layerTreeRoot();
   const QList<QgsLayerTreeLayer *> layers = tree->findLayers();
   for ( QgsLayerTreeLayer *layer : layers )
@@ -51,16 +49,8 @@ void QgsLayerTreeLocatorFilter::prepare( const QString &string, const QgsLocator
       result.userData = layer->layerId();
       result.icon = QgsMapLayerModel::iconForLayer( layer->layer() );
       result.score = static_cast< double >( string.length() ) / layer->layer()->name().length();
-      mResults.append( result );
+      emit resultFetched( result );
     }
-  }
-}
-
-void QgsLayerTreeLocatorFilter::fetchResults( const QString &, const QgsLocatorContext &, QgsFeedback * )
-{
-  for ( const QgsLocatorResult &result : qgis::as_const( mResults ) )
-  {
-    emit resultFetched( result );
   }
 }
 
@@ -84,11 +74,8 @@ QgsLayoutLocatorFilter *QgsLayoutLocatorFilter::clone() const
   return new QgsLayoutLocatorFilter();
 }
 
-void QgsLayoutLocatorFilter::prepare( const QString &string, const QgsLocatorContext & )
+void QgsLayoutLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback * )
 {
-  // collect results in main thread, since this method is inexpensive and
-  // accessing the project layouts is not thread safe
-
   const QList< QgsMasterLayoutInterface * > layouts = QgsProject::instance()->layoutManager()->layouts();
   for ( QgsMasterLayoutInterface *layout : layouts )
   {
@@ -99,16 +86,8 @@ void QgsLayoutLocatorFilter::prepare( const QString &string, const QgsLocatorCon
       result.userData = layout->name();
       //result.icon = QgsMapLayerModel::iconForLayer( layer->layer() );
       result.score = static_cast< double >( string.length() ) / layout->name().length();
-      mResults.append( result );
+      emit resultFetched( result );
     }
-  }
-}
-
-void QgsLayoutLocatorFilter::fetchResults( const QString &, const QgsLocatorContext &, QgsFeedback * )
-{
-  for ( const QgsLocatorResult &result : qgis::as_const( mResults ) )
-  {
-    emit resultFetched( result );
   }
 }
 
@@ -137,7 +116,7 @@ QgsActionLocatorFilter *QgsActionLocatorFilter::clone() const
   return new QgsActionLocatorFilter( mActionParents );
 }
 
-void QgsActionLocatorFilter::prepare( const QString &string, const QgsLocatorContext & )
+void QgsActionLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback * )
 {
   // collect results in main thread, since this method is inexpensive and
   // accessing the gui actions is not thread safe
@@ -147,14 +126,6 @@ void QgsActionLocatorFilter::prepare( const QString &string, const QgsLocatorCon
   for ( QWidget *object : qgis::as_const( mActionParents ) )
   {
     searchActions( string,  object, found );
-  }
-}
-
-void QgsActionLocatorFilter::fetchResults( const QString &, const QgsLocatorContext &, QgsFeedback * )
-{
-  for ( const QgsLocatorResult &result : qgis::as_const( mResults ) )
-  {
-    emit resultFetched( result );
   }
 }
 
@@ -194,7 +165,7 @@ void QgsActionLocatorFilter::searchActions( const QString &string, QWidget *pare
       result.userData = QVariant::fromValue( action );
       result.icon = action->icon();
       result.score = static_cast< double >( string.length() ) / searchText.length();
-      mResults.append( result );
+      emit resultFetched( result );
       found << action;
     }
   }

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -19,6 +19,9 @@
 #define QGSINBUILTLOCATORFILTERS_H
 
 #include "qgslocatorfilter.h"
+#include "qgsexpressioncontext.h"
+#include "qgsfeatureiterator.h"
+
 class QAction;
 
 class QgsLayerTreeLocatorFilter : public QgsLocatorFilter
@@ -28,13 +31,19 @@ class QgsLayerTreeLocatorFilter : public QgsLocatorFilter
   public:
 
     QgsLayerTreeLocatorFilter( QObject *parent = nullptr );
+    QgsLayerTreeLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "layertree" ); }
     QString displayName() const override { return tr( "Project Layers" ); }
     Priority priority() const override { return Highest; }
     QString prefix() const override { return QStringLiteral( "l" ); }
 
+    void prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
+
+  private:
+
+    QVector< QgsLocatorResult > mResults;
 
 };
 
@@ -45,14 +54,19 @@ class QgsLayoutLocatorFilter : public QgsLocatorFilter
   public:
 
     QgsLayoutLocatorFilter( QObject *parent = nullptr );
+    QgsLayoutLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "layouts" ); }
     QString displayName() const override { return tr( "Project Layouts" ); }
     Priority priority() const override { return Highest; }
     QString prefix() const override { return QStringLiteral( "pl" ); }
 
+    void prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
 
+  private:
+
+    QVector< QgsLocatorResult > mResults;
 };
 
 class QgsActionLocatorFilter : public QgsLocatorFilter
@@ -62,16 +76,19 @@ class QgsActionLocatorFilter : public QgsLocatorFilter
   public:
 
     QgsActionLocatorFilter( const QList<QWidget *> &parentObjectsForActions, QObject *parent = nullptr );
+    QgsActionLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "actions" ); }
     QString displayName() const override { return tr( "Actions" ); }
     Priority priority() const override { return Lowest; }
     QString prefix() const override { return QStringLiteral( "." ); }
 
+    void prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
   private:
 
     QList< QWidget * > mActionParents;
+    QVector< QgsLocatorResult > mResults;
 
     void searchActions( const QString &string, QWidget *parent, QList< QAction *> &found );
 
@@ -84,13 +101,23 @@ class QgsActiveLayerFeaturesLocatorFilter : public QgsLocatorFilter
   public:
 
     QgsActiveLayerFeaturesLocatorFilter( QObject *parent = nullptr );
+    QgsActiveLayerFeaturesLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "features" ); }
     QString displayName() const override { return tr( "Active Layer Features" ); }
     Priority priority() const override { return Medium; }
     QString prefix() const override { return QStringLiteral( "f" ); }
 
+    void prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
+
+  private:
+
+    QgsExpression mDispExpression;
+    QgsExpressionContext mContext;
+    QgsFeatureIterator mIterator;
+    QString mLayerId;
+    QIcon mLayerIcon;
 };
 
 

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -36,14 +36,10 @@ class QgsLayerTreeLocatorFilter : public QgsLocatorFilter
     QString displayName() const override { return tr( "Project Layers" ); }
     Priority priority() const override { return Highest; }
     QString prefix() const override { return QStringLiteral( "l" ); }
+    QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
 
-    void prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
-
-  private:
-
-    QVector< QgsLocatorResult > mResults;
 
 };
 
@@ -59,14 +55,11 @@ class QgsLayoutLocatorFilter : public QgsLocatorFilter
     QString displayName() const override { return tr( "Project Layouts" ); }
     Priority priority() const override { return Highest; }
     QString prefix() const override { return QStringLiteral( "pl" ); }
+    QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
 
-    void prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
 
-  private:
-
-    QVector< QgsLocatorResult > mResults;
 };
 
 class QgsActionLocatorFilter : public QgsLocatorFilter
@@ -81,14 +74,13 @@ class QgsActionLocatorFilter : public QgsLocatorFilter
     QString displayName() const override { return tr( "Actions" ); }
     Priority priority() const override { return Lowest; }
     QString prefix() const override { return QStringLiteral( "." ); }
+    QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
 
-    void prepare( const QString &string, const QgsLocatorContext &context ) override;
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
   private:
 
     QList< QWidget * > mActionParents;
-    QVector< QgsLocatorResult > mResults;
 
     void searchActions( const QString &string, QWidget *parent, QList< QAction *> &found );
 

--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -152,12 +152,11 @@ void QgsLocator::fetchResults( const QString &string, const QgsLocatorContext &c
     filter->moveToThread( thread );
     connect( thread, &QThread::started, filter, [filter, searchString, context, feedback]
     {
-      filter->executeSearchAndDelete( searchString, context, feedback );
+      if ( !feedback->isCanceled() )
+        filter->fetchResults( searchString, context, feedback );
+      filter->emit finished();
     }, Qt::QueuedConnection );
-    connect( filter, &QgsLocatorFilter::finished, thread, [thread]
-    {
-      thread->quit();
-    } );
+    connect( filter, &QgsLocatorFilter::finished, thread, &QThread::quit );
     connect( filter, &QgsLocatorFilter::finished, filter, &QgsLocatorFilter::deleteLater );
     connect( thread, &QThread::finished, thread, [this, thread]
     {

--- a/src/core/locator/qgslocator.h
+++ b/src/core/locator/qgslocator.h
@@ -155,10 +155,8 @@ class CORE_EXPORT QgsLocator : public QObject
     std::unique_ptr< QgsFeedback > mOwnedFeedback;
 
     QList< QgsLocatorFilter * > mFilters;
-    QList< QgsLocatorFilter * > mActiveFilters;
     QMap< QString, QgsLocatorFilter *> mPrefixedFilters;
-    QFuture< void > mFuture;
-    QFutureWatcher< void > mFutureWatcher;
+    QList< QThread * > mActiveThreads;
 
     void cancelRunningQuery();
 

--- a/src/core/locator/qgslocatorfilter.cpp
+++ b/src/core/locator/qgslocatorfilter.cpp
@@ -27,6 +27,11 @@ QgsLocatorFilter::QgsLocatorFilter( QObject *parent )
 
 }
 
+QgsLocatorFilter::Flags QgsLocatorFilter::flags() const
+{
+  return nullptr;
+}
+
 void QgsLocatorFilter::executeSearchAndDelete( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback )
 {
   if ( !feedback->isCanceled() )

--- a/src/core/locator/qgslocatorfilter.cpp
+++ b/src/core/locator/qgslocatorfilter.cpp
@@ -32,13 +32,6 @@ QgsLocatorFilter::Flags QgsLocatorFilter::flags() const
   return nullptr;
 }
 
-void QgsLocatorFilter::executeSearchAndDelete( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback )
-{
-  if ( !feedback->isCanceled() )
-    fetchResults( string, context, feedback );
-  emit finished();
-}
-
 bool QgsLocatorFilter::stringMatches( const QString &candidate, const QString &search )
 {
   return candidate.contains( search, Qt::CaseInsensitive );

--- a/src/core/locator/qgslocatorfilter.cpp
+++ b/src/core/locator/qgslocatorfilter.cpp
@@ -18,11 +18,20 @@
 
 #include "qgslocatorfilter.h"
 #include "qgsstringutils.h"
+#include "qgsfeedback.h"
+#include <QThread>
 
 QgsLocatorFilter::QgsLocatorFilter( QObject *parent )
   : QObject( parent )
 {
 
+}
+
+void QgsLocatorFilter::executeSearchAndDelete( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback )
+{
+  if ( !feedback->isCanceled() )
+    fetchResults( string, context, feedback );
+  emit finished();
 }
 
 bool QgsLocatorFilter::stringMatches( const QString &candidate, const QString &search )

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -166,12 +166,6 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
     virtual void prepare( const QString &string, const QgsLocatorContext &context ) { Q_UNUSED( string ); Q_UNUSED( context ); }
 
     /**
-     * Executes a search for this filter instance, and then deletes the current instance
-     * of the filter.
-     */
-    void executeSearchAndDelete( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback );
-
-    /**
      * Retrieves the filter results for a specified search \a string. The \a context
      * argument encapsulates the context relating to the search (such as a map
      * extent to prioritize).
@@ -182,6 +176,9 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
      * Subclasses should periodically check the \a feedback object to determine
      * whether the query has been canceled. If so, the subclass should return
      * from this method as soon as possible.
+     *
+     * This will be called from a background thread unless flags() returns the
+     * QgsLocatorFilter::FlagFast flag.
      */
     virtual void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) = 0;
 

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -106,6 +106,7 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
       Lowest //!< Lowest priority
     };
 
+    //! Flags for locator behavior.
     enum Flag
     {
       FlagFast = 1 << 1, //!< Filter finds results quickly and can be safely run in the main thread

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -106,6 +106,12 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
       Lowest //!< Lowest priority
     };
 
+    enum Flag
+    {
+      FlagFast = 1 << 1, //!< Filter finds results quickly and can be safely run in the main thread
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
     /**
      * Constructor for QgsLocatorFilter.
      */
@@ -128,6 +134,11 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
      * \see name()
      */
     virtual QString displayName() const = 0;
+
+    /**
+     * Returns flags which specify the filter's behavior.
+     */
+    virtual QgsLocatorFilter::Flags flags() const;
 
     /**
      * Returns the priority for the filter, which controls how results are
@@ -253,6 +264,8 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
 };
 
 Q_DECLARE_METATYPE( QgsLocatorResult )
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsLocatorFilter::Flags )
+
 
 #endif // QGSLOCATORFILTER_H
 

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -234,6 +234,9 @@ class CORE_EXPORT QgsLocatorFilter : public QObject
 
   signals:
 
+    /**
+     * Emitted when the filter finishes fetching results.
+     */
     void finished();
 
     /**

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -409,6 +409,11 @@ QgsLocatorFilterFilter *QgsLocatorFilterFilter::clone() const
   return new QgsLocatorFilterFilter( mLocator );
 }
 
+QgsLocatorFilter::Flags QgsLocatorFilterFilter::flags() const
+{
+  return QgsLocatorFilter::FlagFast;
+}
+
 void QgsLocatorFilterFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback *feedback )
 {
   if ( !string.isEmpty() )

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -404,6 +404,11 @@ QgsLocatorFilterFilter::QgsLocatorFilterFilter( QgsLocatorWidget *locator, QObje
   , mLocator( locator )
 {}
 
+QgsLocatorFilterFilter *QgsLocatorFilterFilter::clone() const
+{
+  return new QgsLocatorFilterFilter( mLocator );
+}
+
 void QgsLocatorFilterFilter::fetchResults( const QString &string, const QgsLocatorContext &, QgsFeedback *feedback )
 {
   if ( !string.isEmpty() )
@@ -423,7 +428,6 @@ void QgsLocatorFilterFilter::fetchResults( const QString &string, const QgsLocat
       continue;
 
     QgsLocatorResult result;
-    result.filter = this;
     result.displayString = fIt.key();
     result.description = fIt.value()->displayName();
     result.userData = fIt.key() + ' ';

--- a/src/gui/locator/qgslocatorwidget.h
+++ b/src/gui/locator/qgslocatorwidget.h
@@ -134,6 +134,8 @@ class QgsLocatorFilterFilter : public QgsLocatorFilter
 
     QgsLocatorFilterFilter( QgsLocatorWidget *widget, QObject *parent = nullptr );
 
+    QgsLocatorFilterFilter *clone() const override SIP_FACTORY;
+
     QString name() const override { return QStringLiteral( "filters" );}
     QString displayName() const override { return QString(); }
     Priority priority() const override { return static_cast< QgsLocatorFilter::Priority>( -1 ); /** shh, we cheat!**/ }

--- a/src/gui/locator/qgslocatorwidget.h
+++ b/src/gui/locator/qgslocatorwidget.h
@@ -135,6 +135,7 @@ class QgsLocatorFilterFilter : public QgsLocatorFilter
     QgsLocatorFilterFilter( QgsLocatorWidget *widget, QObject *parent = nullptr );
 
     QgsLocatorFilterFilter *clone() const override SIP_FACTORY;
+    QgsLocatorFilter::Flags flags() const override;
 
     QString name() const override { return QStringLiteral( "filters" );}
     QString displayName() const override { return QString(); }

--- a/tests/src/python/test_qgslocator.py
+++ b/tests/src/python/test_qgslocator.py
@@ -34,6 +34,9 @@ class test_filter(QgsLocatorFilter):
         super().__init__(parent)
         self.prefix = prefix
 
+    def clone(self):
+        return test_filter(self.prefix)
+
     def name(self):
         return 'test'
 
@@ -42,9 +45,9 @@ class test_filter(QgsLocatorFilter):
 
     def fetchResults(self, string, context, feedback):
         for i in range(3):
-            #if feedback.isCanceled():
-            #    return
-            sleep(0.00001)
+            if feedback.isCanceled():
+                return
+            sleep(0.001)
             result = QgsLocatorResult()
             result.displayString = self.prefix + str(i)
             self.resultFetched.emit(result)
@@ -97,6 +100,7 @@ class TestQgsLocator(unittest.TestCase):
         # one filter
         l = QgsLocator()
         filter_a = test_filter('a')
+
         l.registerFilter(filter_a)
 
         l.foundResult.connect(got_hit)


### PR DESCRIPTION
- add a clone() method to filters, and always search using the clone instead of the original filter
- add a prepare() method to filters, which is always run in the main thread and can be used to prepare the filter for safe background execution (e.g. creating feature iterators in advance)
- don't use QtConcurrent to perform searches in background threads, since it is not safe to use with QObjects
- instead manually create threads and ensure that cloned objects are always moved to the thread that they will run in, to ensure that they correctly have thread affinity with the thread in which they are executed
- add a flag to allow certain filters to operate on the main thread (i.e. those which are fast to return results and which it's overkill to run in a separate thread)