### PR TITLE
Find and init qgis_global_settings correctly.

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -1,7 +1,11 @@
-INSTALL(FILES srs.db qgis.db symbology-style.xml spatialite.db customization.xml 2to3migration.txt
+INSTALL(FILES srs.db
+              qgis.db
+              symbology-style.xml
+              spatialite.db
+              customization.xml
+              2to3migration.txt
+              qgis_global_settings.ini
         DESTINATION ${QGIS_DATA_DIR}/resources)
-INSTALL(FILES qgis_global_settings.ini
-        DESTINATION ${QGIS_DATA_DIR})
 INSTALL(DIRECTORY cpt-city-qgis-min DESTINATION ${QGIS_DATA_DIR}/resources)
 INSTALL(DIRECTORY themes DESTINATION ${QGIS_DATA_DIR}/resources)
 INSTALL(DIRECTORY data DESTINATION ${QGIS_DATA_DIR}/resources)

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -798,6 +798,7 @@ int main( int argc, char *argv[] )
   QCoreApplication::setAttribute( Qt::AA_DisableWindowContextHelpButton, true );
 #endif
 
+  QApplication *subapp = new QApplication(argc, argv);
   // SetUp the QgsSettings Global Settings:
   // - use the path specified with --globalsettingsfile path,
   // - use the environment if not found
@@ -809,7 +810,8 @@ int main( int argc, char *argv[] )
 
   if ( globalsettingsfile.isEmpty() )
   {
-    QString default_globalsettingsfile = QgsApplication::pkgDataPath() + "/qgis_global_settings.ini";
+    QString default_globalsettingsfile = QgsApplication::resolvePkgPath() + "/resources/qgis_global_settings.ini";
+    QgsDebugMsg( "GLOABL SETTINGS FILE:" + default_globalsettingsfile );
     if ( QFile::exists( default_globalsettingsfile ) )
     {
       globalsettingsfile = default_globalsettingsfile;
@@ -849,6 +851,9 @@ int main( int argc, char *argv[] )
     }
   }
   delete globalSettings;
+  delete subapp;
+
+  QgsDebugMsg( "CONFIG LOCAL STORAGE:" + configLocalStorageLocation );
 
   QString rootProfileFolder = QgsUserProfileManager::resolveProfilesFolder( configLocalStorageLocation );
   QgsUserProfileManager manager( rootProfileFolder );

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -798,7 +798,8 @@ int main( int argc, char *argv[] )
   QCoreApplication::setAttribute( Qt::AA_DisableWindowContextHelpButton, true );
 #endif
 
-  QApplication *subapp = new QApplication(argc, argv);
+  QgsApplication myApp( argc, argv, myUseGuiFlag );
+
   // SetUp the QgsSettings Global Settings:
   // - use the path specified with --globalsettingsfile path,
   // - use the environment if not found
@@ -851,7 +852,6 @@ int main( int argc, char *argv[] )
     }
   }
   delete globalSettings;
-  delete subapp;
 
   QgsDebugMsg( "CONFIG LOCAL STORAGE:" + configLocalStorageLocation );
 
@@ -872,7 +872,7 @@ int main( int argc, char *argv[] )
   QgsDebugMsg( QString( "\t - %1" ).arg( profileFolder ) );
   QgsDebugMsg( QString( "\t - %1" ).arg( rootProfileFolder ) );
 
-  QgsApplication myApp( argc, argv, myUseGuiFlag, profileFolder );
+  myApp.init( profileFolder );
 
   // Settings migration is only supported on the default profile for now.
   if ( profileName == "default" )

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -577,6 +577,36 @@ void QgsApplication::setThemeName( const QString &themeName )
   ABISYM( mThemeName ) = themeName;
 }
 
+QString QgsApplication::resolvePkgPath()
+{
+#if defined(ANDROID)
+  QString prefixPath( getenv( "QGIS_PREFIX_PATH" ) ? getenv( "QGIS_PREFIX_PATH" ) : QDir::homePath() );
+#else
+  QString prefixPath( getenv( "QGIS_PREFIX_PATH" ) ? getenv( "QGIS_PREFIX_PATH" ) : applicationDirPath() );
+#endif
+  QFile f;
+  // "/../../.." is for Mac bundled app in build directory
+  Q_FOREACH ( const QString &path, QStringList() << "" << "/.." << "/bin" << "/../../.." )
+  {
+    f.setFileName( prefixPath + path + "/qgisbuildpath.txt" );
+    QgsDebugMsg(f.fileName());
+    if ( f.exists() )
+      break;
+  }
+
+  if ( f.exists() && f.open( QIODevice::ReadOnly ) )
+  {
+    return f.readLine().trimmed();
+    QgsDebugMsg("Running from build dir!");
+    return buildSourcePath;
+  }
+  else
+  {
+    return prefixPath + '/' + QStringLiteral( QGIS_DATA_SUBDIR );
+  }
+
+}
+
 QString QgsApplication::themeName()
 {
   return ABISYM( mThemeName );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -596,9 +596,8 @@ QString QgsApplication::resolvePkgPath()
 
   if ( f.exists() && f.open( QIODevice::ReadOnly ) )
   {
-    return f.readLine().trimmed();
     QgsDebugMsg("Running from build dir!");
-    return buildSourcePath;
+    return f.readLine().trimmed();
   }
   else
   {

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -91,9 +91,13 @@ QString ABISYM( QgsApplication::mLibraryPath );
 QString ABISYM( QgsApplication::mLibexecPath );
 QString ABISYM( QgsApplication::mThemeName );
 QString ABISYM( QgsApplication::mUIThemeName );
+QString ABISYM( QgsApplication::mProfilePath );
+
 QStringList ABISYM( QgsApplication::mDefaultSvgPaths );
 QMap<QString, QString> ABISYM( QgsApplication::mSystemEnvVars );
 QString ABISYM( QgsApplication::mConfigPath );
+
+bool ABISYM( QgsApplication::mInitialized ) = false;
 bool ABISYM( QgsApplication::mRunningFromBuildDir ) = false;
 QString ABISYM( QgsApplication::mBuildSourcePath );
 #ifdef _MSC_VER
@@ -121,7 +125,7 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
 
   mApplicationMembers = new ApplicationMembers();
 
-  init( profileFolder ); // init can also be called directly by e.g. unit tests that don't inherit QApplication.
+  ABISYM( mProfilePath ) = profileFolder;
 }
 
 void QgsApplication::init( QString profileFolder )
@@ -145,6 +149,8 @@ void QgsApplication::init( QString profileFolder )
     profileFolder = profile->folder();
     delete profile;
   }
+
+  ABISYM( mProfilePath ) = profileFolder;
 
   qRegisterMetaType<QgsGeometry::Error>( "QgsGeometry::Error" );
   qRegisterMetaType<QgsProcessingFeatureSourceDefinition>( "QgsProcessingFeatureSourceDefinition" );
@@ -259,6 +265,8 @@ void QgsApplication::init( QString profileFolder )
   // this should be read from QgsSettings but we don't know where they are at this point
   // so we read actual value in main.cpp
   ABISYM( mMaxThreads ) = -1;
+
+  ABISYM( mInitialized ) = true;
 }
 
 QgsApplication::~QgsApplication()
@@ -589,14 +597,14 @@ QString QgsApplication::resolvePkgPath()
   Q_FOREACH ( const QString &path, QStringList() << "" << "/.." << "/bin" << "/../../.." )
   {
     f.setFileName( prefixPath + path + "/qgisbuildpath.txt" );
-    QgsDebugMsg(f.fileName());
+    QgsDebugMsg( f.fileName() );
     if ( f.exists() )
       break;
   }
 
   if ( f.exists() && f.open( QIODevice::ReadOnly ) )
   {
-    QgsDebugMsg("Running from build dir!");
+    QgsDebugMsg( "Running from build dir!" );
     return f.readLine().trimmed();
   }
   else
@@ -980,6 +988,11 @@ QgsApplication::endian_t QgsApplication::endian()
 
 void QgsApplication::initQgis()
 {
+  if ( !ABISYM( mInitialized ) )
+  {
+    init( ABISYM( mProfilePath ) );
+  }
+
   // set the provider plugin path (this creates provider registry)
   QgsProviderRegistry::instance( pluginPath() );
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -734,6 +734,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QObject *ABISYM( mFileOpenEventReceiver );
     static QStringList ABISYM( mFileOpenEventList );
 
+    static QString ABISYM( mProfilePath );
     static QString ABISYM( mUIThemeName );
     static QString ABISYM( mPrefixPath );
     static QString ABISYM( mPluginPath );
@@ -745,6 +746,8 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QMap<QString, QString> ABISYM( mSystemEnvVars );
 
     static QString ABISYM( mConfigPath );
+
+    static bool ABISYM( mInitialized );
 
     //! True when running from build directory, i.e. without 'make install'
     static bool ABISYM( mRunningFromBuildDir );

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -184,6 +184,8 @@ class CORE_EXPORT QgsApplication : public QApplication
      */
     static void setThemeName( const QString &themeName );
 
+    static QString resolvePkgPath( );
+
     /**
      * Set the active theme to the specified theme.
      * The theme name should be a single word e.g. 'default','classic'.


### PR DESCRIPTION
So this should hopefully fix the path resolving of QStandardPath and qgis_global_settings.ini (which is now moved in `resources` BTW).  We don't call init(profilePath) any more init so that we can can create the instance first, resolve the paths as needed, and then finally init it later on when we have all the info.    `QgsApplication::init` is also called in `initQgis` if it hasn't already been called.  This should allow applications and scripts keep working without worrying about calling `init` themselves. 