### PR TITLE
[processing] offer hyperlink to file path in the results viewer

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -180,8 +180,6 @@ class ProcessingPlugin:
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.resultsDock)
         self.resultsDock.hide()
 
-        resultsList.resultAdded.connect(self.resultsDock.fillTree)
-
         self.menu = QMenu(self.iface.mainWindow().menuBar())
         self.menu.setObjectName('processing')
         self.menu.setTitle(self.tr('Pro&cessing'))

--- a/python/plugins/processing/gui/ResultsDock.py
+++ b/python/plugins/processing/gui/ResultsDock.py
@@ -32,6 +32,7 @@ from qgis.PyQt import uic
 from qgis.PyQt.QtCore import (QUrl,
                               QFileInfo,
                               QDir)
+from qgis.gui import QgsDockWidget
 from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import QTreeWidgetItem
 
@@ -42,11 +43,13 @@ WIDGET, BASE = uic.loadUiType(
     os.path.join(pluginPath, 'ui', 'resultsdockbase.ui'))
 
 
-class ResultsDock(BASE, WIDGET):
+class ResultsDock(QgsDockWidget, WIDGET):
 
     def __init__(self):
         super(ResultsDock, self).__init__(None)
         self.setupUi(self)
+
+        resultsList.resultAdded.connect(self.addResult)
 
         self.treeResults.currentItemChanged.connect(self.updateDescription)
         self.treeResults.itemDoubleClicked.connect(self.openResult)
@@ -55,6 +58,13 @@ class ResultsDock(BASE, WIDGET):
         self.txtDescription.anchorClicked.connect(self.openLink)
 
         self.fillTree()
+
+    def addResult(self):
+        self.fillTree()
+
+        # Automatically open the panel for users to see output
+        self.setUserVisible(True)
+        self.treeResults.setCurrentItem(self.treeResults.topLevelItem(0))
 
     def fillTree(self):
         self.treeResults.blockSignals(True)

--- a/python/plugins/processing/gui/ResultsDock.py
+++ b/python/plugins/processing/gui/ResultsDock.py
@@ -29,7 +29,9 @@ import os
 import time
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QUrl
+from qgis.PyQt.QtCore import (QUrl,
+                              QFileInfo,
+                              QDir)
 from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import QTreeWidgetItem
 
@@ -49,6 +51,9 @@ class ResultsDock(BASE, WIDGET):
         self.treeResults.currentItemChanged.connect(self.updateDescription)
         self.treeResults.itemDoubleClicked.connect(self.openResult)
 
+        self.txtDescription.setOpenLinks(False)
+        self.txtDescription.anchorClicked.connect(self.openLink)
+
         self.fillTree()
 
     def fillTree(self):
@@ -62,8 +67,11 @@ class ResultsDock(BASE, WIDGET):
 
     def updateDescription(self, current, previous):
         if isinstance(current, TreeResultItem):
-            html = '<b>Algorithm</b>: {}<br><b>File path</b>: {}'.format(current.algorithm, current.filename)
+            html = '<b>Algorithm</b>: {}<br><b>File path</b>: <a href="{}">{}</a>'.format(current.algorithm, QUrl.fromLocalFile(current.filename).toString(), QDir.toNativeSeparators(current.filename))
             self.txtDescription.setHtml(html)
+
+    def openLink(self, url):
+        QDesktopServices.openUrl(url)
 
     def openResult(self, item, column):
         QDesktopServices.openUrl(QUrl.fromLocalFile(item.filename))

--- a/python/plugins/processing/ui/resultsdockbase.ui
+++ b/python/plugins/processing/ui/resultsdockbase.ui
@@ -45,7 +45,7 @@
         </property>
        </column>
       </widget>
-      <widget class="QTextEdit" name="txtDescription"/>
+      <widget class="QTextBrowser" name="txtDescription"/>
      </widget>
     </item>
    </layout>


### PR DESCRIPTION
## Description
Because users don't always get that there is a dbl-click action, against the tree view items, upgrade the file path text to be an hyperlink which opens the HTML file.
![screenshot from 2018-02-12 17-00-11](https://user-images.githubusercontent.com/1728657/36091578-bd009240-1016-11e8-818b-b8067c720d4a.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
