### PR TITLE
 [dxf] use a struct instead of QPair for layers

### DIFF
--- a/python/core/conversions.sip
+++ b/python/core/conversions.sip
@@ -1683,65 +1683,6 @@ template<int, TYPE2*>
 %End
 };
 
-%MappedType QList < QPair< QgsVectorLayer *, int > >
-{
-%TypeHeaderCode
-#include <QPair>
-#include <QList>
-%End
-
-%ConvertFromTypeCode
-//convert map to a python dictionary
-    PyObject *d;
-
-    if ((d = PyList_New( sipCpp->size() )) == NULL)
-      return NULL;
-
-    for ( int i = 0; i<sipCpp->size(); i++ )
-    {
-      PyObject *p;
-      if ((p = PyList_New(2) ) == NULL)
-      {
-	Py_DECREF(d);
-	return NULL;
-      }
-
-      PyObject *t1obj = sipConvertFromNewType(sipCpp->at(i).first, sipType_QgsVectorLayer, sipTransferObj);
-      PyObject *t2obj = PyLong_FromLong( (long) sipCpp->at(i).second );
-      PyList_SetItem( p, 0, t1obj );
-      PyList_SetItem( p, 1, t2obj );
-
-      PyList_SetItem( d, i, p );
-    }
-
-    return d;
-%End
-
-%ConvertToTypeCode
-    Py_ssize_t i = 0;
-
-    QList < QPair< QgsVectorLayer *, int > > *qm = new QList< QPair< QgsVectorLayer *, int > >;
-
-    for ( i = 0; i < PyList_GET_SIZE(sipPy); i++ )
-    {
-	  int state;
-
-      PyObject *sipPair = PyList_GetItem( sipPy, i );
-      PyObject *sipLayer = PyList_GetItem( sipPair, 0 );
-      PyObject *sipIdx = PyList_GetItem( sipPair, 1 );
-
-      QgsVectorLayer *t1 = reinterpret_cast<QgsVectorLayer *>(sipConvertToType(sipLayer, sipType_QgsVectorLayer, sipTransferObj, SIP_NOT_NONE, &state, sipIsErr));
-      int idx = PyLong_AsLongLong(sipIdx);
-      qm->append( qMakePair<QgsVectorLayer *, int>( t1, idx ) );
-      sipReleaseType(t1, sipType_QgsVectorLayer, state);
-    }
-
-    *sipCppPtr = qm;
-
-    return sipGetState(sipTransferObj);
-%End
-};
-
 %MappedType QMap< QPair< QString, QString>, QPair< int, int > >
 {
 %TypeHeaderCode

--- a/python/core/dxf/qgsdxfexport.sip.in
+++ b/python/core/dxf/qgsdxfexport.sip.in
@@ -23,13 +23,19 @@ class QgsDxfExport
 
     struct DxfLayer
     {
-      DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1 );
+        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1 );
 
-      QgsVectorLayer *layer() const;
-      int layerOutputAttributeIndex() const;
+        QgsVectorLayer *layer() const;
+%Docstring
+Return the layer
+%End
 
-      QgsVectorLayer *mLayer;
-      int mLayerOutputAttributeIndex;
+        int layerOutputAttributeIndex() const;
+%Docstring
+Return the attribute index used to split into multiple layers.
+The attribute value is used for layer names.
+%End
+
     };
 
     enum SymbologyExport

--- a/python/core/dxf/qgsdxfexport.sip.in
+++ b/python/core/dxf/qgsdxfexport.sip.in
@@ -20,6 +20,18 @@ class QgsDxfExport
 #include "qgsdxfexport.h"
 %End
   public:
+
+    struct DxfLayer
+    {
+      DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1 );
+
+      QgsVectorLayer *layer() const;
+      int layerOutputAttributeIndex() const;
+
+      QgsVectorLayer *mLayer;
+      int mLayerOutputAttributeIndex;
+    };
+
     enum SymbologyExport
     {
       NoSymbology,
@@ -64,7 +76,7 @@ Returns the export flags.
 .. seealso:: :py:func:`setFlags`
 %End
 
-    void addLayers( const QList< QPair<QgsVectorLayer *, int > > &layers );
+    void addLayers( const QList< QgsDxfExport::DxfLayer > &layers );
 %Docstring
 Add layers to export
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1357,7 +1357,7 @@ int main( int argc, char *argv[] )
     dxfExport.setExtent( dxfExtent );
 
     QStringList layerIds;
-    QList< QPair<QgsVectorLayer *, int > > layers;
+    QList< QgsDxfExport::DxfLayer > layers;
     if ( !dxfMapTheme.isEmpty() )
     {
       Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->mapThemeCollection()->mapThemeVisibleLayers( dxfMapTheme ) )
@@ -1365,7 +1365,7 @@ int main( int argc, char *argv[] )
         QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
         if ( !vl )
           continue;
-        layers << qMakePair<QgsVectorLayer *, int>( vl, -1 );
+        layers << QgsDxfExport::DxfLayer( vl );
         layerIds << vl->id();
       }
     }
@@ -1376,7 +1376,7 @@ int main( int argc, char *argv[] )
         QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
         if ( !vl )
           continue;
-        layers << qMakePair<QgsVectorLayer *, int>( vl, -1 );
+        layers << QgsDxfExport::DxfLayer( vl );
         layerIds << vl->id();
       }
     }

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -276,9 +276,9 @@ bool QgsVectorLayerAndAttributeModel::setData( const QModelIndex &index, const Q
 }
 
 
-QList< QPair<QgsVectorLayer *, int> > QgsVectorLayerAndAttributeModel::layers() const
+QList< QgsDxfExport::DxfLayer > QgsVectorLayerAndAttributeModel::layers() const
 {
-  QList< QPair<QgsVectorLayer *, int> > layers;
+  QList< QgsDxfExport::DxfLayer > layers;
   QHash< QString, int > layerIdx;
 
   Q_FOREACH ( const QModelIndex &idx, mCheckedLeafs )
@@ -293,7 +293,7 @@ QList< QPair<QgsVectorLayer *, int> > QgsVectorLayerAndAttributeModel::layers() 
         if ( !layerIdx.contains( vl->id() ) )
         {
           layerIdx.insert( vl->id(), layers.size() );
-          layers << qMakePair<QgsVectorLayer *, int>( vl, mAttributeIdx.value( vl, -1 ) );
+          layers << QgsDxfExport::DxfLayer( vl, mAttributeIdx.value( vl, -1 ) );
         }
       }
     }
@@ -304,12 +304,12 @@ QList< QPair<QgsVectorLayer *, int> > QgsVectorLayerAndAttributeModel::layers() 
       if ( !layerIdx.contains( vl->id() ) )
       {
         layerIdx.insert( vl->id(), layers.size() );
-        layers << qMakePair<QgsVectorLayer *, int>( vl, mAttributeIdx.value( vl, -1 ) );
+        layers << QgsDxfExport::DxfLayer( vl, mAttributeIdx.value( vl, -1 ) );
       }
     }
   }
 
-  QList< QPair<QgsVectorLayer *, int> > layersInROrder;
+  QList< QgsDxfExport::DxfLayer > layersInROrder;
 
   QList<QgsMapLayer *> layerOrder = mRootNode->layerOrder();
 
@@ -549,7 +549,7 @@ void QgsDxfExportDialog::deSelectAll()
 }
 
 
-QList< QPair<QgsVectorLayer *, int> > QgsDxfExportDialog::layers() const
+QList< QgsDxfExport::DxfLayer > QgsDxfExportDialog::layers() const
 {
   const QgsVectorLayerAndAttributeModel *model = dynamic_cast< const QgsVectorLayerAndAttributeModel *>( mTreeView->model() );
   Q_ASSERT( model );

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -53,7 +53,7 @@ class QgsVectorLayerAndAttributeModel : public QgsLayerTreeModel
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
     bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
 
-    QList< QPair<QgsVectorLayer *, int> > layers() const;
+    QList< QgsDxfExport::DxfLayer > layers() const;
 
     QgsVectorLayer *vectorLayer( const QModelIndex &index ) const;
     int attributeIndex( const QgsVectorLayer *vl ) const;
@@ -79,7 +79,7 @@ class QgsDxfExportDialog : public QDialog, private Ui::QgsDxfExportDialogBase
     QgsDxfExportDialog( QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
     ~QgsDxfExportDialog() override;
 
-    QList< QPair<QgsVectorLayer *, int> > layers() const;
+    QList< QgsDxfExport::DxfLayer > layers() const;
 
     double symbologyScale() const;
     QgsDxfExport::SymbologyExport symbologyMode() const;

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -398,18 +398,18 @@ QgsDxfExport::Flags QgsDxfExport::flags() const
   return mFlags;
 }
 
-void QgsDxfExport::addLayers( const QList< QPair< QgsVectorLayer *, int > > &layers )
+void QgsDxfExport::addLayers( const QList<DxfLayer> &layers )
 {
   QList<QgsMapLayer *> layerList;
 
   mLayerNameAttribute.clear();
 
-  QList< QPair< QgsVectorLayer *, int > >::const_iterator layerIt = layers.constBegin();
+  QList< DxfLayer >::const_iterator layerIt = layers.constBegin();
   for ( ; layerIt != layers.constEnd(); ++layerIt )
   {
-    layerList << layerIt->first;
-    if ( layerIt->second >= 0 )
-      mLayerNameAttribute.insert( layerIt->first->id(), layerIt->second );
+    layerList << layerIt->layer();
+    if ( layerIt->layerOutputAttributeIndex() >= 0 )
+      mLayerNameAttribute.insert( layerIt->layer()->id(), layerIt->layerOutputAttributeIndex() );
   }
 
   mMapSettings.setLayers( layerList );

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -51,6 +51,25 @@ namespace pal SIP_SKIP
 class CORE_EXPORT QgsDxfExport
 {
   public:
+
+    /**
+     * Layers and optional attribute index to split
+     * into multiple layers using attribute value as layer name.
+     */
+    struct DxfLayer
+    {
+      DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1 )
+        : mLayer( vl )
+        , mLayerOutputAttributeIndex( layerOutputAttributeIndex )
+      {}
+
+      QgsVectorLayer *layer() const {return mLayer;}
+      int layerOutputAttributeIndex() const {return mLayerOutputAttributeIndex;}
+
+      QgsVectorLayer *mLayer;
+      int mLayerOutputAttributeIndex;
+    };
+
     enum SymbologyExport
     {
       NoSymbology = 0, //!< Export only data
@@ -97,7 +116,7 @@ class CORE_EXPORT QgsDxfExport
      * \param layers list of layers and corresponding attribute indexes that determine the layer name (-1 for original layer name or title)
      * \see setLayerTitleAsName
      */
-    void addLayers( const QList< QPair<QgsVectorLayer *, int > > &layers );
+    void addLayers( const QList< QgsDxfExport::DxfLayer > &layers );
 
     /**
      * Export to a dxf file in the given encoding

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -58,16 +58,23 @@ class CORE_EXPORT QgsDxfExport
      */
     struct DxfLayer
     {
-      DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1 )
-        : mLayer( vl )
-        , mLayerOutputAttributeIndex( layerOutputAttributeIndex )
-      {}
+        DxfLayer( QgsVectorLayer *vl, int layerOutputAttributeIndex = -1 )
+          : mLayer( vl )
+          , mLayerOutputAttributeIndex( layerOutputAttributeIndex )
+        {}
 
-      QgsVectorLayer *layer() const {return mLayer;}
-      int layerOutputAttributeIndex() const {return mLayerOutputAttributeIndex;}
+        //! Return the layer
+        QgsVectorLayer *layer() const {return mLayer;}
 
-      QgsVectorLayer *mLayer;
-      int mLayerOutputAttributeIndex;
+        /**
+         * Return the attribute index used to split into multiple layers.
+         * The attribute value is used for layer names.
+         */
+        int layerOutputAttributeIndex() const {return mLayerOutputAttributeIndex;}
+
+      private:
+        QgsVectorLayer *mLayer = nullptr;
+        int mLayerOutputAttributeIndex = -1;
     };
 
     enum SymbologyExport

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -767,7 +767,7 @@ namespace QgsWms
     QStringList wfsLayerIds = QgsServerProjectUtils::wfsLayerIds( *mProject );
 
     // get dxf layers
-    QList< QPair<QgsVectorLayer *, int > > dxfLayers;
+    QList< QgsDxfExport::DxfLayer > dxfLayers;
     int layerIdx = -1;
     Q_FOREACH ( QgsMapLayer *layer, layers )
     {
@@ -801,7 +801,7 @@ namespace QgsWms
         layerAttribute = vlayer->fields().indexFromName( layerAttributes.at( layerIdx ) );
       }
 
-      dxfLayers.append( qMakePair( vlayer, layerAttribute ) );
+      dxfLayers.append( QgsDxfExport::DxfLayer( vlayer, layerAttribute ) );
     }
 
     // add layers to dxf

--- a/tests/src/core/testqgsdxfexport.cpp
+++ b/tests/src/core/testqgsdxfexport.cpp
@@ -94,7 +94,7 @@ void TestQgsDxfExport::cleanup()
 void TestQgsDxfExport::testPoints()
 {
   QgsDxfExport d;
-  d.addLayers( QList< QPair< QgsVectorLayer *, int > >() << qMakePair( mPointLayer, -1 ) );
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer ) );
 
   QgsMapSettings mapSettings;
   QSize size( 640, 480 );
@@ -122,7 +122,7 @@ void TestQgsDxfExport::testPoints()
 void TestQgsDxfExport::testLines()
 {
   QgsDxfExport d;
-  d.addLayers( QList< QPair< QgsVectorLayer *, int > >() << qMakePair( mLineLayer, -1 ) );
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mLineLayer ) );
 
   QgsMapSettings mapSettings;
   QSize size( 640, 480 );
@@ -150,7 +150,7 @@ void TestQgsDxfExport::testLines()
 void TestQgsDxfExport::testPolygons()
 {
   QgsDxfExport d;
-  d.addLayers( QList< QPair< QgsVectorLayer *, int > >() << qMakePair( mPolygonLayer, -1 ) );
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPolygonLayer ) );
 
   QgsMapSettings mapSettings;
   QSize size( 640, 480 );
@@ -189,7 +189,7 @@ void TestQgsDxfExport::testMtext()
   mPointLayer->setLabelsEnabled( true );
 
   QgsDxfExport d;
-  d.addLayers( QList< QPair< QgsVectorLayer *, int > >() << qMakePair( mPointLayer, -1 ) );
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer ) );
 
   QgsMapSettings mapSettings;
   QSize size( 640, 480 );
@@ -251,7 +251,7 @@ void TestQgsDxfExport::testText()
   mPointLayer->setLabelsEnabled( true );
 
   QgsDxfExport d;
-  d.addLayers( QList< QPair< QgsVectorLayer *, int > >() << qMakePair( mPointLayer, -1 ) );
+  d.addLayers( QList< QgsDxfExport::DxfLayer >() << QgsDxfExport::DxfLayer( mPointLayer ) );
 
   QgsMapSettings mapSettings;
   QSize size( 640, 480 );


### PR DESCRIPTION
there was a crash in Python in QgsDxfExport.addLayers due to a bad conversion

after discussing it with @nyalldawson, instead of trying to fix sip conversion, the API was improved