### PR TITLE
[processing] harmonize results viewer action behavior

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -211,14 +211,15 @@ class ProcessingPlugin:
         self.menu.addAction(self.historyAction)
         self.toolbox.processingToolbar.addAction(self.historyAction)
 
-        self.resultsAction = self.resultsDock.toggleViewAction()
-        self.resultsAction.setObjectName('resultsAction')
-        self.resultsAction.setIcon(
-            QgsApplication.getThemeIcon("/processingResult.svg"))
-        self.resultsAction.setText(self.tr('&Results Viewer'))
+        self.resultsAction = QAction(
+            QgsApplication.getThemeIcon("/processingResult.svg"),
+            self.tr('&Results Viewer'), self.iface.mainWindow())
+        self.resultsAction.setCheckable(True)
         self.iface.registerMainWindowAction(self.resultsAction, 'Ctrl+Alt+R')
         self.menu.addAction(self.resultsAction)
         self.toolbox.processingToolbar.addAction(self.resultsAction)
+        self.resultsDock.visibilityChanged.connect(self.resultsAction.setChecked)
+        self.resultsAction.toggled.connect(self.resultsDock.setUserVisible)
 
         self.optionsAction = QAction(
             QgsApplication.getThemeIcon("/mActionOptions.svg"),


### PR DESCRIPTION
## Description
@nyalldawson , inspired by your recent action work.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
