### PR TITLE
Fix undo stack does not correctly roll back geometry edits in a granular manner

### DIFF
--- a/src/core/qgsvectorlayerundocommand.cpp
+++ b/src/core/qgsvectorlayerundocommand.cpp
@@ -118,9 +118,7 @@ QgsVectorLayerUndoCommandChangeGeometry::QgsVectorLayerUndoCommandChangeGeometry
   }
   else
   {
-    bool changedAlready = mBuffer->mChangedGeometries.contains( mFid );
-    QgsGeometry geom;
-    mOldGeom = changedAlready ? geom : QgsGeometry();
+    mOldGeom = mBuffer->mChangedGeometries.value( mFid, QgsGeometry() );
   }
 }
 


### PR DESCRIPTION
Fixes #17658
