### PR TITLE
use crs widget picker in db_manager

### DIFF
--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -36,7 +36,7 @@ from qgis.core import (QgsDataSourceUri,
                        QgsVectorLayerExporter,
                        QgsProject,
                        QgsSettings)
-from qgis.gui import QgsMessageViewer, QgsProjectionSelectionWidget
+from qgis.gui import QgsMessageViewer
 from qgis.utils import OverrideCursor
 
 from .ui.ui_DlgImportVector import Ui_DbManagerDlgImportVector as Ui_Dialog
@@ -68,8 +68,8 @@ class DlgImportVector(QDialog, Ui_Dialog):
         # updates of UI
         self.setupWorkingMode(self.mode)
         self.cboSchema.currentIndexChanged.connect(self.populateTables)
-        self.widgetSourceSrid.setOptionVisible(QgsProjectionSelectionWidget.CrsNotSet, True)
-        self.widgetTargetSrid.setOptionVisible(QgsProjectionSelectionWidget.CrsNotSet, True)
+        self.widgetSourceSrid.setCrs(QgsProject.instance().crs())
+        self.widgetTargetSrid.setCrs(QgsProject.instance().crs())
 
     def setupWorkingMode(self, mode):
         """ hide the widget to select a layer/file if the input layer is already set """

--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -273,23 +273,23 @@ class DlgImportVector(QDialog, Ui_Dialog):
 
         # sanity checks
         if self.inLayer is None:
-            QMessageBox.information(self, self.tr("Import to database"), self.tr("Input layer missing or not valid"))
+            QMessageBox.critical(self, self.tr("Import to Database"), self.tr("Input layer missing or not valid."))
             return
 
         if self.cboTable.currentText() == "":
-            QMessageBox.information(self, self.tr("Import to database"), self.tr("Output table name is required"))
+            QMessageBox.critical(self, self.tr("Import to Database"), self.tr("Output table name is required."))
             return
 
         if self.chkSourceSrid.isEnabled() and self.chkSourceSrid.isChecked():
             if not self.widgetSourceSrid.crs().isValid():
-                QMessageBox.critical(self, self.tr("Import to database"),
-                                     self.tr("Invalid source srid: must be a valid crs"))
+                QMessageBox.critical(self, self.tr("Import to Database"),
+                                     self.tr("Invalid source srid: must be a valid crs."))
                 return
 
         if self.chkTargetSrid.isEnabled() and self.chkTargetSrid.isChecked():
             if not self.widgetTargetSrid.crs().isValid():
-                QMessageBox.critical(self, self.tr("Import to database"),
-                                     self.tr("Invalid target srid: must be a valid crs"))
+                QMessageBox.critical(self, self.tr("Import to Database"),
+                                     self.tr("Invalid target srid: must be a valid crs."))
                 return
 
         with OverrideCursor(Qt.WaitCursor):
@@ -369,7 +369,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
 
         if ret != 0:
             output = QgsMessageViewer()
-            output.setTitle(self.tr("Import to database"))
+            output.setTitle(self.tr("Import to Database"))
             output.setMessageAsPlainText(self.tr("Error {0}\n{1}").format(ret, errMsg))
             output.showMessage()
             return
@@ -380,7 +380,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
 
         self.db.connection().reconnect()
         self.db.refresh()
-        QMessageBox.information(self, self.tr("Import to database"), self.tr("Import was successful."))
+        QMessageBox.information(self, self.tr("Import to Database"), self.tr("Import was successful."))
         return QDialog.accept(self)
 
     def closeEvent(self, event):

--- a/python/plugins/db_manager/ui/DlgImportVector.ui
+++ b/python/plugins/db_manager/ui/DlgImportVector.ui
@@ -153,6 +153,13 @@
       <string>Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="5" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkDropTable">
+        <property name="text">
+         <string>Replace destination table (if exists)</string>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
        <widget class="QCheckBox" name="chkPrimaryKey">
         <property name="text">
@@ -181,62 +188,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QCheckBox" name="chkSourceSrid">
-          <property name="text">
-           <string>Source SRID</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="editSourceSrid">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="spacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="chkTargetSrid">
-          <property name="text">
-           <string>Target SRID</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="editTargetSrid">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QCheckBox" name="chkEncoding">
         <property name="text">
          <string>Encoding</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QComboBox" name="cboEncoding">
         <property name="enabled">
          <bool>false</bool>
@@ -246,31 +205,52 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0" colspan="2">
+      <item row="7" column="0" colspan="2">
        <widget class="QCheckBox" name="chkSinglePart">
         <property name="text">
          <string>Create single-part geometries instead of multi-part</string>
         </property>
        </widget>
       </item>
-      <item row="8" column="0" colspan="2">
+      <item row="9" column="0" colspan="2">
        <widget class="QCheckBox" name="chkSpatialIndex">
         <property name="text">
          <string>Create spatial index</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QCheckBox" name="chkDropTable">
-        <property name="text">
-         <string>Replace destination table (if exists)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QCheckBox" name="chkLowercaseFieldNames">
         <property name="text">
          <string>Convert field names to lowercase</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="chkTargetSrid">
+        <property name="text">
+         <string>Target SRID</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QgsProjectionSelectionWidget" name="widgetTargetSrid" native="true">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsProjectionSelectionWidget" name="widgetSourceSrid" native="true">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="chkSourceSrid">
+        <property name="text">
+         <string>Source SRID</string>
         </property>
        </widget>
       </item>
@@ -293,14 +273,33 @@
   <zorder>groupBox_3</zorder>
   <zorder>wdgInput</zorder>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
+  <tabstop>cboInputLayer</tabstop>
+  <tabstop>btnChooseInputFile</tabstop>
+  <tabstop>chkSelectedFeatures</tabstop>
+  <tabstop>btnUpdateInputLayer</tabstop>
+  <tabstop>cboSchema</tabstop>
+  <tabstop>cboTable</tabstop>
+  <tabstop>chkPrimaryKey</tabstop>
+  <tabstop>editPrimaryKey</tabstop>
+  <tabstop>chkGeomColumn</tabstop>
+  <tabstop>editGeomColumn</tabstop>
   <tabstop>chkSourceSrid</tabstop>
-  <tabstop>editSourceSrid</tabstop>
+  <tabstop>chkTargetSrid</tabstop>
   <tabstop>chkEncoding</tabstop>
   <tabstop>cboEncoding</tabstop>
+  <tabstop>chkDropTable</tabstop>
   <tabstop>chkSinglePart</tabstop>
+  <tabstop>chkLowercaseFieldNames</tabstop>
   <tabstop>chkSpatialIndex</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -311,8 +310,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>325</x>
-     <y>518</y>
+     <x>334</x>
+     <y>486</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -327,12 +326,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>108</x>
-     <y>347</y>
+     <x>129</x>
+     <y>239</y>
     </hint>
     <hint type="destinationlabel">
-     <x>207</x>
-     <y>345</y>
+     <x>460</x>
+     <y>239</y>
     </hint>
    </hints>
   </connection>
@@ -343,44 +342,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>120</x>
-     <y>367</y>
+     <x>141</x>
+     <y>265</y>
     </hint>
     <hint type="destinationlabel">
-     <x>188</x>
-     <y>367</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>chkSourceSrid</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>editSourceSrid</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>115</x>
-     <y>390</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>166</x>
-     <y>394</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>chkTargetSrid</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>editTargetSrid</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>360</x>
-     <y>396</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>435</x>
-     <y>394</y>
+     <x>442</x>
+     <y>265</y>
     </hint>
    </hints>
   </connection>
@@ -391,12 +358,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>98</x>
-     <y>415</y>
+     <x>119</x>
+     <y>343</y>
     </hint>
     <hint type="destinationlabel">
-     <x>201</x>
-     <y>414</y>
+     <x>455</x>
+     <y>343</y>
     </hint>
    </hints>
   </connection>
@@ -407,12 +374,44 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>452</x>
-     <y>505</y>
+     <x>461</x>
+     <y>486</y>
     </hint>
     <hint type="destinationlabel">
      <x>508</x>
      <y>243</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chkSourceSrid</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>widgetSourceSrid</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>134</x>
+     <y>281</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>357</x>
+     <y>281</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chkTargetSrid</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>widgetTargetSrid</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>134</x>
+     <y>307</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>357</x>
+     <y>307</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
## Description

* Use CRS widget instead of QLineEdit for CRS in vector import dialog
* Review tab order in this dialog

Before:
![before](https://user-images.githubusercontent.com/12623986/36157315-8fd00ee8-10ea-11e8-94bd-76d8ed857489.png)

After:
![after](https://user-images.githubusercontent.com/12623986/36157319-9311f99a-10ea-11e8-9686-24955f91891e.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
