### PR TITLE
[needs-docs] Rework arrangement of buttons in categories tab in metadata editor

### DIFF
--- a/python/gui/qgsmetadatawidget.sip.in
+++ b/python/gui/qgsmetadatawidget.sip.in
@@ -28,17 +28,17 @@ class QgsMetadataWidget : QWidget
 Constructor for the wizard.
 %End
 
-    void saveMetadata( QgsLayerMetadata &layerMetadata ) const;
+    void saveMetadata( QgsLayerMetadata &layerMetadata );
 %Docstring
 Save all fields in a QgsLayerMetadata object.
 %End
 
-    bool checkMetadata() const;
+    bool checkMetadata();
 %Docstring
 Check if values in the wizard are correct.
 %End
 
-    void crsChanged() const;
+    void crsChanged();
 %Docstring
 If the CRS is updated.
 %End

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -103,19 +103,19 @@ QgsMetadataWidget::QgsMetadataWidget( QWidget *parent, QgsMapLayer *layer )
   connect( btnAddHistory, &QPushButton::clicked, this, &QgsMetadataWidget::addHistory );
   connect( btnRemoveHistory, &QPushButton::clicked, this, &QgsMetadataWidget::removeSelectedHistory );
   connect( btnNewCategory, &QPushButton::clicked, this, &QgsMetadataWidget::addNewCategory );
-  connect( btnAddDefaultCategory, &QPushButton::clicked, this, &QgsMetadataWidget::addDefaultCategory );
-  connect( btnRemoveCategory, &QPushButton::clicked, this, &QgsMetadataWidget::removeSelectedCategory );
+  connect( btnAddDefaultCategory, &QPushButton::clicked, this, &QgsMetadataWidget::addDefaultCategories );
+  connect( btnRemoveCategory, &QPushButton::clicked, this, &QgsMetadataWidget::removeSelectedCategories );
 
   fillComboBox();
   setPropertiesFromLayer();
 }
 
-void QgsMetadataWidget::fillSourceFromLayer() const
+void QgsMetadataWidget::fillSourceFromLayer()
 {
   lineEditIdentifier->setText( mLayer->publicSource() );
 }
 
-void QgsMetadataWidget::addVocabulary() const
+void QgsMetadataWidget::addVocabulary()
 {
   int row = tabKeywords->rowCount();
   tabKeywords->setRowCount( row + 1 );
@@ -130,7 +130,7 @@ void QgsMetadataWidget::addVocabulary() const
   tabKeywords->setItem( row, 1, pCell );
 }
 
-void QgsMetadataWidget::removeSelectedVocabulary() const
+void QgsMetadataWidget::removeSelectedVocabulary()
 {
   QItemSelectionModel *selectionModel = tabKeywords->selectionModel();
   const QModelIndexList selectedRows = selectionModel->selectedRows();
@@ -152,7 +152,7 @@ void QgsMetadataWidget::addLicence()
   }
 }
 
-void QgsMetadataWidget::removeSelectedLicence() const
+void QgsMetadataWidget::removeSelectedLicence()
 {
   QItemSelectionModel *selectionModel = tabLicenses->selectionModel();
   const QModelIndexList selectedRows = selectionModel->selectedRows();
@@ -173,7 +173,7 @@ void QgsMetadataWidget::addRight()
   }
 }
 
-void QgsMetadataWidget::removeSelectedRight() const
+void QgsMetadataWidget::removeSelectedRight()
 {
   QItemSelectionModel *selection = listRights->selectionModel();
   if ( selection->hasSelection() )
@@ -187,20 +187,20 @@ void QgsMetadataWidget::removeSelectedRight() const
   }
 }
 
-void QgsMetadataWidget::addConstraint() const
+void QgsMetadataWidget::addConstraint()
 {
   int row = mConstraintsModel->rowCount();
   mConstraintsModel->setItem( row, 0, new QStandardItem( QString( tr( "undefined %1" ) ).arg( row + 1 ) ) );
   mConstraintsModel->setItem( row, 1, new QStandardItem( QString( tr( "undefined %1" ) ).arg( row + 1 ) ) );
 }
 
-void QgsMetadataWidget::removeSelectedConstraint() const
+void QgsMetadataWidget::removeSelectedConstraint()
 {
   const QModelIndexList selectedRows = tabConstraints->selectionModel()->selectedRows();
   mConstraintsModel->removeRow( selectedRows[0].row() );
 }
 
-void QgsMetadataWidget::crsChanged() const
+void QgsMetadataWidget::crsChanged()
 {
   if ( mCrs.isValid() )
   {
@@ -233,7 +233,7 @@ void QgsMetadataWidget::crsChanged() const
   }
 }
 
-void QgsMetadataWidget::addAddress() const
+void QgsMetadataWidget::addAddress()
 {
   int row = tabAddresses->rowCount();
   tabAddresses->setRowCount( row + 1 );
@@ -259,7 +259,7 @@ void QgsMetadataWidget::addAddress() const
   tabAddresses->setItem( row, 5, new QTableWidgetItem() );
 }
 
-void QgsMetadataWidget::removeSelectedAddress() const
+void QgsMetadataWidget::removeSelectedAddress()
 {
   QItemSelectionModel *selectionModel = tabAddresses->selectionModel();
   const QModelIndexList selectedRows = selectionModel->selectedRows();
@@ -281,7 +281,7 @@ void QgsMetadataWidget::fillCrsFromProvider()
   crsChanged();
 }
 
-void QgsMetadataWidget::addLink() const
+void QgsMetadataWidget::addLink()
 {
   int row = mLinksModel->rowCount();
   mLinksModel->setItem( row, 0, new QStandardItem( QString( tr( "undefined %1" ) ).arg( row + 1 ) ) );
@@ -293,7 +293,7 @@ void QgsMetadataWidget::addLink() const
   mLinksModel->setItem( row, 6, new QStandardItem() );
 }
 
-void QgsMetadataWidget::removeSelectedLink() const
+void QgsMetadataWidget::removeSelectedLink()
 {
   const QModelIndexList selectedRows = tabLinks->selectionModel()->selectedRows();
   mLinksModel->removeRow( selectedRows[0].row() );
@@ -310,7 +310,7 @@ void QgsMetadataWidget::addHistory()
   }
 }
 
-void QgsMetadataWidget::removeSelectedHistory() const
+void QgsMetadataWidget::removeSelectedHistory()
 {
   QItemSelectionModel *selection = listHistory->selectionModel();
   if ( selection->hasSelection() )
@@ -324,7 +324,7 @@ void QgsMetadataWidget::removeSelectedHistory() const
   }
 }
 
-void QgsMetadataWidget::fillComboBox() const
+void QgsMetadataWidget::fillComboBox()
 {
   // Set default values in type combobox
   // It is advised to use the ISO 19115 MD_ScopeCode values. E.g. 'dataset' or 'series'.
@@ -522,7 +522,7 @@ void QgsMetadataWidget::setPropertiesFromLayer()
   mHistoryModel->setStringList( mMetadata.history() );
 }
 
-void QgsMetadataWidget::saveMetadata( QgsLayerMetadata &layerMetadata ) const
+void QgsMetadataWidget::saveMetadata( QgsLayerMetadata &layerMetadata )
 {
   layerMetadata.setParentIdentifier( lineEditParentId->text() );
   layerMetadata.setIdentifier( lineEditIdentifier->text() );
@@ -635,7 +635,7 @@ void QgsMetadataWidget::saveMetadata( QgsLayerMetadata &layerMetadata ) const
   layerMetadata.setHistory( mHistoryModel->stringList() );
 }
 
-bool QgsMetadataWidget::checkMetadata() const
+bool QgsMetadataWidget::checkMetadata()
 {
   QgsLayerMetadata metadata = QgsLayerMetadata();
   saveMetadata( metadata );
@@ -826,7 +826,7 @@ void QgsMetadataWidget::setMetadata( const QgsLayerMetadata &metadata )
   setPropertiesFromLayer();
 }
 
-void QgsMetadataWidget::syncFromCategoriesTabToKeywordsTab() const
+void QgsMetadataWidget::syncFromCategoriesTabToKeywordsTab()
 {
   if ( mCategoriesModel->rowCount() > 0 )
   {
@@ -847,7 +847,7 @@ void QgsMetadataWidget::syncFromCategoriesTabToKeywordsTab() const
   }
 }
 
-void QgsMetadataWidget::updatePanel() const
+void QgsMetadataWidget::updatePanel()
 {
   int index = tabWidget->currentIndex();
   QString currentTabText = tabWidget->widget( index )->objectName();
@@ -896,46 +896,45 @@ void QgsMetadataWidget::addNewCategory()
   }
 }
 
-void QgsMetadataWidget::addDefaultCategory() const
+void QgsMetadataWidget::addDefaultCategories()
 {
-  QItemSelectionModel *selection = listDefaultCategories->selectionModel();
-  if ( selection->hasSelection() )
+  const QModelIndexList selectedIndexes = listDefaultCategories->selectionModel()->selectedIndexes();
+  QStringList defaultCategoriesList = mDefaultCategoriesModel->stringList();
+  QStringList selectedCategories = mCategoriesModel->stringList();
+
+  for ( const QModelIndex &selection : selectedIndexes )
   {
-    QModelIndex indexElementSelectionne = selection->currentIndex();
+    QVariant item = mDefaultCategoriesModel->data( selection, Qt::DisplayRole );
+    defaultCategoriesList.removeOne( item.toString() );
 
-    QVariant item = mDefaultCategoriesModel->data( indexElementSelectionne, Qt::DisplayRole );
-    QStringList list = mDefaultCategoriesModel->stringList();
-    list.removeOne( item.toString() );
-    mDefaultCategoriesModel->setStringList( list );
-
-    list = mCategoriesModel->stringList();
-    list.append( item.toString() );
-    mCategoriesModel->setStringList( list );
-    mCategoriesModel->sort( 0 );
+    selectedCategories.append( item.toString() );
   }
+
+  mDefaultCategoriesModel->setStringList( defaultCategoriesList );
+  mCategoriesModel->setStringList( selectedCategories );
+  mCategoriesModel->sort( 0 );
 }
 
-
-void QgsMetadataWidget::removeSelectedCategory() const
+void QgsMetadataWidget::removeSelectedCategories()
 {
-  QItemSelectionModel *selection = listCategories->selectionModel();
-  if ( selection->hasSelection() )
-  {
-    QModelIndex indexElementSelectionne = listCategories->selectionModel()->currentIndex();
+  const QModelIndexList selectedIndexes = listCategories->selectionModel()->selectedIndexes();
+  QStringList categories = mCategoriesModel->stringList();
+  QStringList defaultList = mDefaultCategoriesModel->stringList();
 
-    QVariant item = mCategoriesModel->data( indexElementSelectionne, Qt::DisplayRole );
-    QStringList list = mCategoriesModel->stringList();
-    list.removeOne( item.toString() );
-    mCategoriesModel->setStringList( list );
+  for ( const QModelIndex &selection : selectedIndexes )
+  {
+    QVariant item = mCategoriesModel->data( selection, Qt::DisplayRole );
+    categories.removeOne( item.toString() );
 
     if ( mDefaultCategories.contains( item.toString() ) )
     {
-      list = mDefaultCategoriesModel->stringList();
-      list.append( item.toString() );
-      mDefaultCategoriesModel->setStringList( list );
-      mDefaultCategoriesModel->sort( 0 );
+      defaultList.append( item.toString() );
     }
   }
+  mCategoriesModel->setStringList( categories );
+
+  mDefaultCategoriesModel->setStringList( defaultList );
+  mDefaultCategoriesModel->sort( 0 );
 }
 
 LinkItemDelegate::LinkItemDelegate( QObject *parent )

--- a/src/gui/qgsmetadatawidget.h
+++ b/src/gui/qgsmetadatawidget.h
@@ -49,17 +49,17 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
     /**
      * Save all fields in a QgsLayerMetadata object.
      */
-    void saveMetadata( QgsLayerMetadata &layerMetadata ) const;
+    void saveMetadata( QgsLayerMetadata &layerMetadata );
 
     /**
      * Check if values in the wizard are correct.
      */
-    bool checkMetadata() const;
+    bool checkMetadata();
 
     /**
      * If the CRS is updated.
      */
-    void crsChanged() const;
+    void crsChanged();
 
     /**
      * Saves the metadata to the layer.
@@ -103,31 +103,34 @@ class GUI_EXPORT QgsMetadataWidget : public QWidget, private Ui::QgsMetadataWidg
      */
     void setMapCanvas( QgsMapCanvas *canvas );
 
-  private:
-    void updatePanel() const;
-    void fillSourceFromLayer() const;
+  private slots:
+    void removeSelectedCategories();
+    void updatePanel();
+    void fillSourceFromLayer();
     void fillCrsFromLayer();
     void fillCrsFromProvider();
-    void addDefaultCategory() const;
+    void addDefaultCategories();
     void addNewCategory();
-    void removeSelectedCategory() const;
-    void addVocabulary() const;
-    void removeSelectedVocabulary() const;
+    void addVocabulary();
+    void removeSelectedVocabulary();
     void addLicence();
-    void removeSelectedLicence() const;
+    void removeSelectedLicence();
     void addRight();
-    void removeSelectedRight() const;
-    void addConstraint() const;
-    void removeSelectedConstraint() const;
-    void addAddress() const;
-    void removeSelectedAddress() const;
-    void addLink() const;
-    void removeSelectedLink() const;
+    void removeSelectedRight();
+    void addConstraint();
+    void removeSelectedConstraint();
+    void addAddress();
+    void removeSelectedAddress();
+    void addLink();
+    void removeSelectedLink();
     void addHistory();
-    void removeSelectedHistory() const;
-    void fillComboBox() const;
+    void removeSelectedHistory();
+
+  private:
+
+    void fillComboBox();
     void setPropertiesFromLayer();
-    void syncFromCategoriesTabToKeywordsTab() const;
+    void syncFromCategoriesTabToKeywordsTab();
     QStringList mDefaultCategories;
     QgsMapLayer *mLayer = nullptr;
     QgsCoordinateReferenceSystem mCrs;

--- a/src/ui/qgsmetadatawidget.ui
+++ b/src/ui/qgsmetadatawidget.ui
@@ -35,7 +35,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabIdentificationDialog">
       <attribute name="title">
@@ -67,8 +67,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>798</width>
-            <height>668</height>
+            <width>800</width>
+            <height>670</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_15">
@@ -318,7 +318,7 @@
             <item>
              <widget class="QLabel" name="label_23">
               <property name="text">
-               <string>Available categories</string>
+               <string>ISO categories</string>
               </property>
              </widget>
             </item>
@@ -329,6 +329,9 @@
               </property>
               <property name="editTriggers">
                <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::ExtendedSelection</enum>
               </property>
              </widget>
             </item>
@@ -350,20 +353,6 @@
              </spacer>
             </item>
             <item>
-             <widget class="QPushButton" name="btnNewCategory">
-              <property name="toolTip">
-               <string>Create a new category</string>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="icon">
-               <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-              </property>
-             </widget>
-            </item>
-            <item>
              <widget class="QPushButton" name="btnAddDefaultCategory">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -372,7 +361,7 @@
                </sizepolicy>
               </property>
               <property name="toolTip">
-               <string>Add category to selection</string>
+               <string>Add selected ISO categories to metadata</string>
               </property>
               <property name="text">
                <string/>
@@ -381,11 +370,19 @@
                <iconset resource="../../images/images.qrc">
                 <normaloff>:/images/themes/default/mActionArrowRight.svg</normaloff>:/images/themes/default/mActionArrowRight.svg</iconset>
               </property>
-              <property name="iconSize">
-               <size>
-                <width>16</width>
-                <height>18</height>
-               </size>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="btnNewCategory">
+              <property name="toolTip">
+               <string>Add a new custom category to the metadata</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="icon">
+               <iconset resource="../../images/images.qrc">
+                <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
               </property>
              </widget>
             </item>
@@ -398,14 +395,14 @@
                </sizepolicy>
               </property>
               <property name="toolTip">
-               <string>Remove category from selection</string>
+               <string>Remove selected categories from metadata</string>
               </property>
               <property name="text">
                <string/>
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionArrowLeft.svg</normaloff>:/images/themes/default/mActionArrowLeft.svg</iconset>
+                <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
               </property>
              </widget>
             </item>
@@ -440,6 +437,9 @@
               </property>
               <property name="editTriggers">
                <set>QAbstractItemView::NoEditTriggers</set>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::ExtendedSelection</enum>
               </property>
              </widget>
             </item>
@@ -574,8 +574,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>798</width>
-            <height>668</height>
+            <width>800</width>
+            <height>670</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -980,8 +980,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>754</width>
-              <height>608</height>
+              <width>778</width>
+              <height>628</height>
              </rect>
             </property>
             <layout class="QGridLayout" name="gridLayout_2">
@@ -1414,7 +1414,91 @@
    <header>qgsdatetimeedit.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>lineEditParentId</tabstop>
+  <tabstop>lineEditIdentifier</tabstop>
+  <tabstop>btnAutoSource</tabstop>
+  <tabstop>lineEditTitle</tabstop>
+  <tabstop>comboType</tabstop>
+  <tabstop>comboLanguage</tabstop>
+  <tabstop>textEditAbstract</tabstop>
+  <tabstop>comboEncoding</tabstop>
+  <tabstop>btnAutoEncoding</tabstop>
+  <tabstop>listDefaultCategories</tabstop>
+  <tabstop>btnAddDefaultCategory</tabstop>
+  <tabstop>btnNewCategory</tabstop>
+  <tabstop>btnRemoveCategory</tabstop>
+  <tabstop>listCategories</tabstop>
+  <tabstop>btnAddVocabulary</tabstop>
+  <tabstop>btnRemoveVocabulary</tabstop>
+  <tabstop>tabKeywords</tabstop>
+  <tabstop>scrollArea_2</tabstop>
+  <tabstop>lineEditFees</tabstop>
+  <tabstop>btnAddLicence</tabstop>
+  <tabstop>btnRemoveLicence</tabstop>
+  <tabstop>tabLicenses</tabstop>
+  <tabstop>btnAddRight</tabstop>
+  <tabstop>btnRemoveRight</tabstop>
+  <tabstop>listRights</tabstop>
+  <tabstop>btnAddConstraint</tabstop>
+  <tabstop>btnRemoveConstraint</tabstop>
+  <tabstop>tabConstraints</tabstop>
+  <tabstop>btnSetCrsFromLayer</tabstop>
+  <tabstop>btnSetCrsFromProvider</tabstop>
+  <tabstop>spinBoxZMaximum</tabstop>
+  <tabstop>spinBoxZMinimum</tabstop>
+  <tabstop>dateTimeFrom</tabstop>
+  <tabstop>dateTimeTo</tabstop>
+  <tabstop>panelDetails</tabstop>
+  <tabstop>lineEditContactPosition</tabstop>
+  <tabstop>lineEditContactName</tabstop>
+  <tabstop>lineEditContactOrganization</tabstop>
+  <tabstop>lineEditContactVoice</tabstop>
+  <tabstop>lineEditContactFax</tabstop>
+  <tabstop>comboContactRole</tabstop>
+  <tabstop>lineEditContactEmail</tabstop>
+  <tabstop>tabAddresses</tabstop>
+  <tabstop>btnAddAddress</tabstop>
+  <tabstop>btnRemoveAddress</tabstop>
+  <tabstop>btnAddLink</tabstop>
+  <tabstop>btnRemoveLink</tabstop>
+  <tabstop>tabLinks</tabstop>
+  <tabstop>btnAddHistory</tabstop>
+  <tabstop>btnRemoveHistory</tabstop>
+  <tabstop>listHistory</tabstop>
+  <tabstop>resultsCheckMetadata</tabstop>
+ </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
Reworks the arrangement of buttons in categories tab in metadata editor to make their operation more self-explanatory for users.

Also add tooltips to the buttons describing their function, and allow the buttons to operate on multiple selected rows at once.

Fixes #18090
