### PR TITLE
[dbmanager] Workaround Python error when vacuuming spatialite table

### DIFF
--- a/python/plugins/db_manager/db_plugins/spatialite/connector.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/connector.py
@@ -555,7 +555,11 @@ class SpatiaLiteDBConnector(DBConnector):
 
     def runVacuum(self):
         """ run vacuum on the db """
-        self._execute_and_commit("VACUUM")
+        # Workaround http://bugs.python.org/issue28518
+        self.connection.isolation_level = None
+        c = self._get_cursor()
+        c.execute('VACUUM')
+        self.connection.isolation_level = '' # reset to default isolation
 
     def addTableColumn(self, table, field_def):
         """ add a column to table """


### PR DESCRIPTION
Workaround https://bugs.python.org/issue28518

Fixes #18079
