### PR TITLE
[processing] In batch dialog, use layer names for input layers

### DIFF
--- a/python/plugins/processing/gui/BatchInputSelectionPanel.py
+++ b/python/plugins/processing/gui/BatchInputSelectionPanel.py
@@ -120,10 +120,19 @@ class BatchInputSelectionPanel(QWidget):
 
         dlg = MultipleInputDialog([layer.name() for layer in layers])
         dlg.exec_()
+
+        def generate_layer_id(layer):
+            # prefer layer name if unique
+            if len([l for l in layers if l.name().lower() == layer.name().lower()]) == 1:
+                return layer.name()
+            else:
+                # otherwise fall back to layer id
+                return layer.id()
+
         if dlg.selectedoptions is not None:
             selected = dlg.selectedoptions
             if len(selected) == 1:
-                self.setValue(layers[selected[0]].id())
+                self.setValue(generate_layer_id(layers[selected[0]]))
             else:
                 if isinstance(self.param, QgsProcessingParameterMultipleLayers):
                     self.text.setText(';'.join(layers[idx].id() for idx in selected))
@@ -133,7 +142,7 @@ class BatchInputSelectionPanel(QWidget):
                         self._panel().addRow()
                     for i, layeridx in enumerate(selected):
                         self._table().cellWidget(i + self.row,
-                                                 self.col).setValue(layers[layeridx].id())
+                                                 self.col).setValue(generate_layer_id(layers[layeridx]))
 
     def showFileSelectionDialog(self):
         settings = QgsSettings()


### PR DESCRIPTION
In batch dialog, use layer names for input layers if they are unique in the current project

Instead of always using the layer id, which is generally gibberish and meaningless for users, instead prefer to use the layer name as an input in the batch processing dialog. This is done only if the name is unique within the current project's loaded layers.

This change makes the dialog more user-friendly, but more importantly it means that autofilling output values based on an input layer parameter generates more meaningful automatic output file names.
