### PR TITLE
[attribute table] fix long UI freeze when resizing columns for large filtered datasets

### DIFF
--- a/python/core/qgsattributetableconfig.sip.in
+++ b/python/core/qgsattributetableconfig.sip.in
@@ -184,7 +184,7 @@ Set the sort order
     bool hasSameColumns( const QgsAttributeTableConfig &other ) const;
 %Docstring
 Compare this configuration's columns name, type, and order to ``other``.
-Other settings (column width and visibility) are not considered.
+The column's width is not considered.
 %End
 
     bool operator!= ( const QgsAttributeTableConfig &other ) const;

--- a/python/core/qgsattributetableconfig.sip.in
+++ b/python/core/qgsattributetableconfig.sip.in
@@ -181,6 +181,11 @@ Set the sort order
 .. versionadded:: 2.16
 %End
 
+    bool sameColumns( const QgsAttributeTableConfig &other ) const;
+%Docstring
+Compare this configuration's columns name and type to other.
+%End
+
     bool operator!= ( const QgsAttributeTableConfig &other ) const;
 
 };

--- a/python/core/qgsattributetableconfig.sip.in
+++ b/python/core/qgsattributetableconfig.sip.in
@@ -181,9 +181,10 @@ Set the sort order
 .. versionadded:: 2.16
 %End
 
-    bool sameColumns( const QgsAttributeTableConfig &other ) const;
+    bool hasSameColumns( const QgsAttributeTableConfig &other ) const;
 %Docstring
-Compare this configuration's columns name and type to other.
+Compare this configuration's columns name, type, and order to ``other``.
+Other settings (column width and visibility) are not considered.
 %End
 
     bool operator!= ( const QgsAttributeTableConfig &other ) const;

--- a/src/core/qgsattributetableconfig.cpp
+++ b/src/core/qgsattributetableconfig.cpp
@@ -283,6 +283,23 @@ void QgsAttributeTableConfig::writeXml( QDomNode &node ) const
   node.appendChild( configElement );
 }
 
+bool QgsAttributeTableConfig::sameColumns( const QgsAttributeTableConfig &other ) const
+{
+  if ( columns().size() == other.columns().size() )
+  {
+    for ( int i = 0; i < columns().size(); i++ )
+    {
+      if ( columns().at( i ).name != other.columns().at( i ).name || columns().at( i ).type != other.columns().at( i ).type )
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
 bool QgsAttributeTableConfig::ColumnConfig::operator== ( const ColumnConfig &other ) const
 {
   return type == other.type && name == other.name && hidden == other.hidden && width == other.width;

--- a/src/core/qgsattributetableconfig.cpp
+++ b/src/core/qgsattributetableconfig.cpp
@@ -283,7 +283,7 @@ void QgsAttributeTableConfig::writeXml( QDomNode &node ) const
   node.appendChild( configElement );
 }
 
-bool QgsAttributeTableConfig::sameColumns( const QgsAttributeTableConfig &other ) const
+bool QgsAttributeTableConfig::hasSameColumns( const QgsAttributeTableConfig &other ) const
 {
   if ( columns().size() == other.columns().size() )
   {

--- a/src/core/qgsattributetableconfig.cpp
+++ b/src/core/qgsattributetableconfig.cpp
@@ -289,7 +289,9 @@ bool QgsAttributeTableConfig::hasSameColumns( const QgsAttributeTableConfig &oth
   {
     for ( int i = 0; i < columns().size(); i++ )
     {
-      if ( columns().at( i ).name != other.columns().at( i ).name || columns().at( i ).type != other.columns().at( i ).type )
+      if ( columns().at( i ).name != other.columns().at( i ).name ||
+           columns().at( i ).type != other.columns().at( i ).type ||
+           columns().at( i ).hidden != other.columns().at( i ).hidden )
       {
         return false;
       }

--- a/src/core/qgsattributetableconfig.h
+++ b/src/core/qgsattributetableconfig.h
@@ -191,6 +191,11 @@ class CORE_EXPORT QgsAttributeTableConfig
     void setSortOrder( Qt::SortOrder sortOrder );
 
     /**
+     * Compare this configuration's columns name and type to other.
+     */
+    bool sameColumns( const QgsAttributeTableConfig &other ) const;
+
+    /**
      * Compare this configuration to other.
      */
     bool operator!= ( const QgsAttributeTableConfig &other ) const;

--- a/src/core/qgsattributetableconfig.h
+++ b/src/core/qgsattributetableconfig.h
@@ -192,7 +192,7 @@ class CORE_EXPORT QgsAttributeTableConfig
 
     /**
      * Compare this configuration's columns name, type, and order to \a other.
-     * Other settings (column width and visibility) are not considered.
+     * The column's width is not considered.
      */
     bool hasSameColumns( const QgsAttributeTableConfig &other ) const;
 

--- a/src/core/qgsattributetableconfig.h
+++ b/src/core/qgsattributetableconfig.h
@@ -191,9 +191,10 @@ class CORE_EXPORT QgsAttributeTableConfig
     void setSortOrder( Qt::SortOrder sortOrder );
 
     /**
-     * Compare this configuration's columns name and type to other.
+     * Compare this configuration's columns name, type, and order to \a other.
+     * Other settings (column width and visibility) are not considered.
      */
-    bool sameColumns( const QgsAttributeTableConfig &other ) const;
+    bool hasSameColumns( const QgsAttributeTableConfig &other ) const;
 
     /**
      * Compare this configuration to other.

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -131,11 +131,16 @@ int QgsAttributeTableFilterModel::columnCount( const QModelIndex &parent ) const
 
 void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTableConfig &config )
 {
+  QgsAttributeTableConfig oldConfig = mConfig;
   mConfig = config;
   mConfig.update( layer()->fields() );
 
-  QVector<int> newColumnMapping;
+  if ( mConfig.sameColumns( oldConfig ) )
+  {
+    return;
+  }
 
+  QVector<int> newColumnMapping;
   Q_FOREACH ( const QgsAttributeTableConfig::ColumnConfig &columnConfig, mConfig.columns() )
   {
     // Hidden? Forget about this column

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -135,7 +135,7 @@ void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTa
   mConfig = config;
   mConfig.update( layer()->fields() );
 
-  if ( mConfig.sameColumns( oldConfig ) )
+  if ( mConfig.hasSameColumns( oldConfig ) )
   {
     return;
   }

--- a/tests/src/python/test_qgsattributetableconfig.py
+++ b/tests/src/python/test_qgsattributetableconfig.py
@@ -109,6 +109,29 @@ class TestQgsAttributeTableConfig(unittest.TestCase):
         self.assertFalse(config.columnHidden(0))
         self.assertTrue(config.columnHidden(1))
 
+    def testSameColumns(self):
+        """ test sameColumns() check """
+
+        config = QgsAttributeTableConfig()
+        c1 = QgsAttributeTableConfig.ColumnConfig()
+        c1.name = 'test'
+        c1.hidden = False
+        c1.width = 100
+        c2 = QgsAttributeTableConfig.ColumnConfig()
+        c2.name = 'test2'
+        c2.hidden = False
+        c2.width = 120
+        config.setColumns([c1, c2])
+
+        config2 = QgsAttributeTableConfig()
+        c1.width = 200
+        config2.setColumns([c1, c2])
+        self.assertTrue(config.sameColumns(config2))
+
+        c2.name = 'test3'
+        config2.setColumns([c1, c2])
+        self.assertFalse(config.sameColumns(config2))
+
     def testMapVisibleColumn(self):
         pass
 

--- a/tests/src/python/test_qgsattributetableconfig.py
+++ b/tests/src/python/test_qgsattributetableconfig.py
@@ -110,7 +110,7 @@ class TestQgsAttributeTableConfig(unittest.TestCase):
         self.assertTrue(config.columnHidden(1))
 
     def testSameColumns(self):
-        """ test sameColumns() check """
+        """ test hasSameColumns() check """
 
         config = QgsAttributeTableConfig()
         c1 = QgsAttributeTableConfig.ColumnConfig()
@@ -122,15 +122,21 @@ class TestQgsAttributeTableConfig(unittest.TestCase):
         c2.hidden = False
         c2.width = 120
         config.setColumns([c1, c2])
-
         config2 = QgsAttributeTableConfig()
+
+        config2.setColumns([c1, c2])
+        self.assertTrue(config.hasSameColumns(config2))
+
         c1.width = 200
         config2.setColumns([c1, c2])
-        self.assertTrue(config.sameColumns(config2))
+        self.assertTrue(config.hasSameColumns(config2))
+
+        config2.setColumns([c2, c1])
+        self.assertFalse(config.hasSameColumns(config2))
 
         c2.name = 'test3'
         config2.setColumns([c1, c2])
-        self.assertFalse(config.sameColumns(config2))
+        self.assertFalse(config.hasSameColumns(config2))
 
     def testMapVisibleColumn(self):
         pass

--- a/tests/src/python/test_qgsattributetableconfig.py
+++ b/tests/src/python/test_qgsattributetableconfig.py
@@ -131,6 +131,10 @@ class TestQgsAttributeTableConfig(unittest.TestCase):
         config2.setColumns([c1, c2])
         self.assertTrue(config.hasSameColumns(config2))
 
+        c1.hidden = True
+        config2.setColumns([c1, c2])
+        self.assertFalse(config.hasSameColumns(config2))
+
         config2.setColumns([c2, c1])
         self.assertFalse(config.hasSameColumns(config2))
 


### PR DESCRIPTION
## Description
@nyalldawson , @m-kuhn , I dissected a UI freeze with the attribute table when resizing columns on large filtered (i.e. setSubsetString(...)). On my machine, a 1.6 million points dataset has my UI freeze for **20+ sec** when trying to resize a column from its attribute table.

The PR fixes the freeze by avoiding costly column-to-field matching code when we only change the width values of a QgsAttributeTableConfig object.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
