### PR TITLE
[processing] Don't throw an exception if an expression cannot be prepared

### DIFF
--- a/python/plugins/processing/algs/qgis/FieldsCalculator.py
+++ b/python/plugins/processing/algs/qgis/FieldsCalculator.py
@@ -123,9 +123,7 @@ class FieldsCalculator(QgisAlgorithm):
         if layer is not None:
             exp_context.appendScope(QgsExpressionContextUtils.layerScope(layer))
 
-        if not expression.prepare(exp_context):
-            raise QgsProcessingException(
-                self.tr('Evaluation error: {0}').format(expression.parserErrorString()))
+        expression.prepare(exp_context)
 
         features = source.getFeatures()
         total = 100.0 / source.featureCount() if source.featureCount() else 0

--- a/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
+++ b/python/plugins/processing/algs/qgis/RandomPointsPolygons.py
@@ -116,9 +116,7 @@ class RandomPointsPolygons(QgisAlgorithm):
             raise QgsProcessingException(expression.parserErrorString())
 
         expressionContext = self.createExpressionContext(parameters, context, source)
-        if not expression.prepare(expressionContext):
-            raise QgsProcessingException(
-                self.tr('Evaluation error: {0}').format(expression.evalErrorString()))
+        expression.prepare(expressionContext)
 
         fields = QgsFields()
         fields.append(QgsField('id', QVariant.Int, '', 10, 0))


### PR DESCRIPTION
There's cases where this happens without reflecting an invalid
expression. So we can try to prepare, but not abort if the
preparation fails.

Fixes #18103
