### PR TITLE
[processing] Don't replace " with ' when handling layer paths

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -295,7 +295,6 @@ QString QgsProcessingUtils::normalizeLayerSource( const QString &source )
 {
   QString normalized = source;
   normalized.replace( '\\', '/' );
-  normalized.replace( '"', QLatin1String( "'" ) );
   return normalized.trimmed();
 }
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -682,7 +682,7 @@ void TestQgsProcessing::compatibleLayers()
 void TestQgsProcessing::normalizeLayerSource()
 {
   QCOMPARE( QgsProcessingUtils::normalizeLayerSource( "data\\layers\\test.shp" ), QString( "data/layers/test.shp" ) );
-  QCOMPARE( QgsProcessingUtils::normalizeLayerSource( "data\\layers \"new\"\\test.shp" ), QString( "data/layers 'new'/test.shp" ) );
+  QCOMPARE( QgsProcessingUtils::normalizeLayerSource( "data\\layers \"new\"\\test.shp" ), QString( "data/layers \"new\"/test.shp" ) );
 }
 
 void TestQgsProcessing::context()


### PR DESCRIPTION
Since netcdf, and possibly other gdal drivers, use layer uris of the format NETCDF:"/tmp/test.nc":var1 we can't safely remove or reformat these quotations.

Without this change it's not possible to re-run a processing algorithm which utilises netcdf files from the history panel, because the layer uris stored in the history log have been altered by changing the " and no longer are valid.

Refs discussion at https://gis.stackexchange.com/questions/271525/how-to-use-context-addlayertoloadoncompletion-with-netcdf-in-a-qgis-3-0-processi

