### PR TITLE
[bugfix] Restore color picker from layer styling panel

### DIFF
--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -231,17 +231,7 @@ void QgsColorButton::mouseMoveEvent( QMouseEvent *e )
 {
   if ( mPickingColor )
   {
-    //currently in color picker mode
-    if ( e->buttons() & Qt::LeftButton )
-    {
-      //if left button depressed, sample color under cursor and temporarily update button color
-      //to give feedback to user
-      QScreen *screen = findScreenAt( e->globalPos() );
-      if ( screen )
-      {
-        setButtonBackground( sampleColor( e->globalPos() ) );
-      }
-    }
+    setButtonBackground( sampleColor( e->globalPos() ) );
     e->accept();
     return;
   }
@@ -294,7 +284,8 @@ void QgsColorButton::stopPicking( QPoint eventPos, bool samplingColor )
 
   if ( !samplingColor )
   {
-    //not sampling color, nothing more to do
+    //not sampling color, restore old color
+    setButtonBackground( mCurrentColor );
     return;
   }
 
@@ -686,6 +677,8 @@ void QgsColorButton::pasteColor()
 void QgsColorButton::activatePicker()
 {
   //activate picker color
+  // Store current color
+  mCurrentColor = mColor;
   QApplication::setOverrideCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::Sampler ) );
   grabMouse();
   grabKeyboard();

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -399,6 +399,9 @@ class GUI_EXPORT QgsColorButton : public QToolButton
 
   private:
 
+
+    QColor sampleColor( QPoint point ) const;
+
     static QScreen *findScreenAt( QPoint pos );
     Behavior mBehavior = QgsColorButton::ShowDialog;
     QString mColorDialogTitle;
@@ -436,10 +439,10 @@ class GUI_EXPORT QgsColorButton : public QToolButton
     /**
      * Ends a color picking operation
      * \param eventPos global position of pixel to sample color from
-     * \param sampleColor set to true to actually sample the color, false to just cancel
+     * \param samplingColor set to true to actually sample the color, false to just cancel
      * the color picking operation
      */
-    void stopPicking( QPointF eventPos, bool sampleColor = true );
+    void stopPicking( QPoint eventPos, bool samplingColor = true );
 
     /**
      * Create a color icon for display in the drop-down menu

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -411,6 +411,10 @@ class GUI_EXPORT QgsColorButton : public QToolButton
     QgsColorSchemeRegistry *mColorSchemeRegistry = nullptr;
 
     QColor mDefaultColor;
+
+    //! Store current color when start picking
+    QColor mCurrentColor;
+
     QString mContext;
     bool mAllowOpacity = false;
     bool mColorSet = false;


### PR DESCRIPTION
Fixes #17721

Successfully tested on Windows 10 and Linux with Qt 5.10

There might be differences on other platforms or with Qt < 5.10