### PR TITLE
[processing] Add easy method to retrieve layers from context

### DIFF
--- a/python/core/processing/qgsprocessingcontext.sip.in
+++ b/python/core/processing/qgsprocessingcontext.sip.in
@@ -275,12 +275,26 @@ This is only safe to call when both this context and the other ``context`` share
 thread() affinity, and that thread is the current thread.
 %End
 
+    QgsMapLayer *getMapLayer( const QString &identifier );
+%Docstring
+Returns a map layer from the context with a matching ``identifier``.
+This method considers layer IDs, names and sources when matching
+the ``identifier`` (see :py:func:`QgsProcessingUtils.mapLayerFromString()`
+for details).
+
+Ownership is not transferred and remains with the context.
+
+.. seealso:: :py:func:`takeResultLayer`
+%End
+
     QgsMapLayer *takeResultLayer( const QString &id ) /TransferBack/;
 %Docstring
 Takes the result map layer with matching ``id`` from the context and
 transfers ownership of it back to the caller. This method can be used
 to remove temporary layers which are not required for further processing
 from a context.
+
+.. seealso:: :py:func:`getMapLayer`
 %End
 
   private:

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -101,6 +101,7 @@ SET(QGIS_CORE_SRCS
 
   processing/qgsprocessingalgorithm.cpp
   processing/qgsprocessingalgrunnertask.cpp
+  processing/qgsprocessingcontext.cpp
   processing/qgsprocessingfeedback.cpp
   processing/qgsprocessingoutputs.cpp
   processing/qgsprocessingparameters.cpp

--- a/src/core/processing/qgsprocessingcontext.cpp
+++ b/src/core/processing/qgsprocessingcontext.cpp
@@ -1,0 +1,73 @@
+/***************************************************************************
+                         qgsprocessingcontext.cpp
+                         ----------------------
+    begin                : April 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessingcontext.h"
+#include "qgsprocessingutils.h"
+
+void QgsProcessingContext::setInvalidGeometryCheck( QgsFeatureRequest::InvalidGeometryCheck check )
+{
+  mInvalidGeometryCheck = check;
+
+  switch ( mInvalidGeometryCheck )
+  {
+    case  QgsFeatureRequest::GeometryAbortOnInvalid:
+    {
+      auto callback = []( const QgsFeature & feature )
+      {
+        throw QgsProcessingException( QObject::tr( "Feature (%1) has invalid geometry. Please fix the geometry or change the Processing setting to the \"Ignore invalid input features\" option." ).arg( feature.id() ) );
+      };
+      mInvalidGeometryCallback = callback;
+      break;
+    }
+
+    case QgsFeatureRequest::GeometrySkipInvalid:
+    {
+      auto callback = [ = ]( const QgsFeature & feature )
+      {
+        if ( mFeedback )
+          mFeedback->reportError( QObject::tr( "Feature (%1) has invalid geometry and has been skipped. Please fix the geometry or change the Processing setting to the \"Ignore invalid input features\" option." ).arg( feature.id() ) );
+      };
+      mInvalidGeometryCallback = callback;
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+void QgsProcessingContext::takeResultsFrom( QgsProcessingContext &context )
+{
+  QMap< QString, LayerDetails > loadOnCompletion = context.layersToLoadOnCompletion();
+  QMap< QString, LayerDetails >::const_iterator llIt = loadOnCompletion.constBegin();
+  for ( ; llIt != loadOnCompletion.constEnd(); ++llIt )
+  {
+    mLayersToLoadOnCompletion.insert( llIt.key(), llIt.value() );
+  }
+  context.setLayersToLoadOnCompletion( QMap< QString, LayerDetails >() );
+  tempLayerStore.transferLayersFromStore( context.temporaryLayerStore() );
+}
+
+QgsMapLayer *QgsProcessingContext::getMapLayer( const QString &identifier )
+{
+  return QgsProcessingUtils::mapLayerFromString( identifier, *this, false );
+}
+
+QgsMapLayer *QgsProcessingContext::takeResultLayer( const QString &id )
+{
+  return tempLayerStore.takeMapLayer( tempLayerStore.mapLayer( id ) );
+}

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -881,36 +881,53 @@ void TestQgsProcessing::mapLayerFromString()
 
   // no project set yet
   QVERIFY( ! QgsProcessingUtils::mapLayerFromString( QString(), c ) );
+  QVERIFY( !c.getMapLayer( QString() ) );
   QVERIFY( ! QgsProcessingUtils::mapLayerFromString( QStringLiteral( "v1" ), c ) );
+  QVERIFY( !c.getMapLayer( QStringLiteral( "v1" ) ) );
 
   c.setProject( &p );
 
   // layers from current project
   QVERIFY( ! QgsProcessingUtils::mapLayerFromString( QString(), c ) );
+  QVERIFY( !c.getMapLayer( QString() ) );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( raster1, c ), r1 );
+  QCOMPARE( c.getMapLayer( raster1 ), r1 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( raster2, c ), r2 );
+  QCOMPARE( c.getMapLayer( raster2 ), r2 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( "R1", c ), r1 );
+  QCOMPARE( c.getMapLayer( "R1" ), r1 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( "ar2", c ), r2 );
+  QCOMPARE( c.getMapLayer( "ar2" ), r2 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( "V4", c ), v1 );
+  QCOMPARE( c.getMapLayer( "V4" ), v1 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( "v1", c ), v2 );
+  QCOMPARE( c.getMapLayer( "v1" ), v2 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( r1->id(), c ), r1 );
+  QCOMPARE( c.getMapLayer( r1->id() ), r1 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( v1->id(), c ), v1 );
+  QCOMPARE( c.getMapLayer( v1->id() ), v1 );
 
   // check that layers in context temporary store are used
   QgsVectorLayer *v5 = new QgsVectorLayer( "Polygon", "V5", "memory" );
   QgsVectorLayer *v6 = new QgsVectorLayer( "Point", "v6", "memory" );
   c.temporaryLayerStore()->addMapLayers( QList<QgsMapLayer *>() << v5 << v6 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( "V5", c ), v5 );
+  QCOMPARE( c.getMapLayer( "V5" ), v5 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( "v6", c ), v6 );
+  QCOMPARE( c.getMapLayer( "v6" ), v6 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( v5->id(), c ), v5 );
+  QCOMPARE( c.getMapLayer( v5->id() ), v5 );
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( v6->id(), c ), v6 );
+  QCOMPARE( c.getMapLayer( v6->id() ), v6 );
   QVERIFY( ! QgsProcessingUtils::mapLayerFromString( "aaaaa", c ) );
+  QVERIFY( !c.getMapLayer( "aaaa" ) );
 
   // if specified, check that layers can be loaded
   QVERIFY( ! QgsProcessingUtils::mapLayerFromString( "aaaaa", c ) );
   QString newRaster = testDataDir + "requires_warped_vrt.tif";
   // don't allow loading
   QVERIFY( ! QgsProcessingUtils::mapLayerFromString( newRaster, c, false ) );
+  QVERIFY( !c.getMapLayer( newRaster ) );
   // allow loading
   QgsMapLayer *loadedLayer = QgsProcessingUtils::mapLayerFromString( newRaster, c, true );
   QVERIFY( loadedLayer->isValid() );
@@ -920,6 +937,7 @@ void TestQgsProcessing::mapLayerFromString()
 
   // since it's now in temporary store, should be accessible even if we deny loading new layers
   QCOMPARE( QgsProcessingUtils::mapLayerFromString( newRaster, c, false ), loadedLayer );
+  QCOMPARE( c.getMapLayer( newRaster ), loadedLayer );
 }
 
 void TestQgsProcessing::algorithm()


### PR DESCRIPTION
Allows python algorithms to call

layer = context.getMapLayer(other_alg_results['OUTPUT'] )

