### PR TITLE
Add provider test for adding features with missing attributes

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -346,11 +346,24 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
   // whether or not to update the layer extent on the fly as we add features
   bool updateExtent = mFeatures.isEmpty() || !mExtent.isEmpty();
 
+  int fieldCount = mFields.count();
+
   // TODO: sanity checks of fields and geometries
   for ( QgsFeatureList::iterator it = flist.begin(); it != flist.end(); ++it )
   {
     it->setId( mNextFeatureId );
     it->setValid( true );
+    if ( it->attributes().count() < fieldCount )
+    {
+      // ensure features have the correct number of attributes by padding
+      // them with null attributes for missing values
+      QgsAttributes attributes = it->attributes();
+      for ( int i = it->attributes().count(); i < mFields.count(); ++i )
+      {
+        attributes.append( QVariant( mFields.at( i ).type() ) );
+      }
+      it->setAttributes( attributes );
+    }
 
     mFeatures.insert( mNextFeatureId, *it );
 

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -463,8 +463,8 @@ class ProviderTestCase(FeatureSourceTestCase):
         f2.setId(added[1].id())
 
         # check result - feature attributes MUST be padded out to required number of fields
-        f1.setAttributes([6, -220, NULL, 'String', NULL])
-        f2.setAttributes([7, 330, NULL, NULL, NULL])
+        f1.setAttributes([6, -220, NULL, 'String', 'NULL'])
+        f2.setAttributes([7, 330, NULL, NULL, 'NULL'])
         self.testGetFeatures(l.dataProvider(), [f1, f2])
 
     def testAddFeaturesUpdateExtent(self):


### PR DESCRIPTION
Add provider test to ensure that features added with missing attributes
are transparently padded out with NULL attributes to the required fields
length

Currently the behavior is inconsistent - some providers reject these
features, others pad them out, and worse -- some add them with
missing attributes (memory provider), causing ALL sorts of flow-on,
difficult to debug issues.
