### PR TITLE
Fix providers handling of features with too many attributes

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -369,8 +369,9 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
     {
       // too many attributes
       pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( fieldCount ).arg( it->attributes().count() ) );
-      result = false;
-      continue;
+      QgsAttributes attributes = it->attributes();
+      attributes.resize( mFields.count() );
+      it->setAttributes( attributes );
     }
 
     if ( it->hasGeometry() && mWkbType == QgsWkbTypes::NoGeometry )

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -343,6 +343,7 @@ QgsCoordinateReferenceSystem QgsMemoryProvider::crs() const
 
 bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
 {
+  bool result = true;
   // whether or not to update the layer extent on the fly as we add features
   bool updateExtent = mFeatures.isEmpty() || !mExtent.isEmpty();
 
@@ -364,6 +365,12 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
       }
       it->setAttributes( attributes );
     }
+    else if ( it->attributes().count() > fieldCount )
+    {
+      // too many attributes
+      result = false;
+      continue;
+    }
 
     mFeatures.insert( mNextFeatureId, *it );
 
@@ -380,7 +387,7 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
     mNextFeatureId++;
   }
 
-  return true;
+  return result;
 }
 
 bool QgsMemoryProvider::deleteFeatures( const QgsFeatureIds &id )

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -349,7 +349,7 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
 
   int fieldCount = mFields.count();
 
-  // TODO: sanity checks of fields and geometries
+  // TODO: sanity checks of fields
   for ( QgsFeatureList::iterator it = flist.begin(); it != flist.end(); ++it )
   {
     it->setId( mNextFeatureId );
@@ -368,6 +368,16 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
     else if ( it->attributes().count() > fieldCount )
     {
       // too many attributes
+      pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( fieldCount ).arg( it->attributes().count() ) );
+      result = false;
+      continue;
+    }
+
+    if ( it->hasGeometry() && QgsWkbTypes::geometryType( it->geometry().wkbType() ) !=
+         QgsWkbTypes::geometryType( mWkbType ) )
+    {
+      pushError( tr( "Could not add feature with geometry type %1 to layer of type %2" ).arg( QgsWkbTypes::displayString( it->geometry().wkbType() ),
+                 QgsWkbTypes::displayString( mWkbType ) ) );
       result = false;
       continue;
     }

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -373,8 +373,12 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
       continue;
     }
 
-    if ( it->hasGeometry() && QgsWkbTypes::geometryType( it->geometry().wkbType() ) !=
-         QgsWkbTypes::geometryType( mWkbType ) )
+    if ( it->hasGeometry() && mWkbType == QgsWkbTypes::NoGeometry )
+    {
+      it->clearGeometry();
+    }
+    else if ( it->hasGeometry() && QgsWkbTypes::geometryType( it->geometry().wkbType() ) !=
+              QgsWkbTypes::geometryType( mWkbType ) )
     {
       pushError( tr( "Could not add feature with geometry type %1 to layer of type %2" ).arg( QgsWkbTypes::displayString( it->geometry().wkbType() ),
                  QgsWkbTypes::displayString( mWkbType ) ) );

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1330,7 +1330,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
     if ( ogrAttId >= fdef.GetFieldCount() )
     {
       pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( fdef.GetFieldCount() ).arg( f.attributes().count() ) );
-      return false;
+      continue;
     }
 
     //if(!s.isEmpty())

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1328,7 +1328,10 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
   {
     // don't try to set field from attribute map if it's not present in layer
     if ( ogrAttId >= fdef.GetFieldCount() )
+    {
+      pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( fdef.GetFieldCount() ).arg( f.attributes().count() ) );
       return false;
+    }
 
     //if(!s.isEmpty())
     // continue;

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1328,7 +1328,7 @@ bool QgsOgrProvider::addFeaturePrivate( QgsFeature &f, Flags flags )
   {
     // don't try to set field from attribute map if it's not present in layer
     if ( ogrAttId >= fdef.GetFieldCount() )
-      continue;
+      return false;
 
     //if(!s.isEmpty())
     // continue;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2150,6 +2150,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
       if ( attrs.count() > mAttributeFields.count() )
       {
+        pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( mAttributeFields.count() ).arg( attrs.count() ) );
         returnvalue = false;
         continue;
       }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2148,13 +2148,6 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     {
       QgsAttributes attrs = features->attributes();
 
-      if ( attrs.count() > mAttributeFields.count() )
-      {
-        pushError( tr( "Feature has too many attributes (expecting %1, received %2)" ).arg( mAttributeFields.count() ).arg( attrs.count() ) );
-        returnvalue = false;
-        continue;
-      }
-
       QStringList params;
       if ( !mGeometryColumn.isNull() )
       {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2148,6 +2148,12 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     {
       QgsAttributes attrs = features->attributes();
 
+      if ( attrs.count() > mAttributeFields.count() )
+      {
+        returnvalue = false;
+        continue;
+      }
+
       QStringList params;
       if ( !mGeometryColumn.isNull() )
       {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2158,7 +2158,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
       for ( int i = 0; i < fieldId.size(); i++ )
       {
         int attrIdx = fieldId[i];
-        QVariant value = attrs.at( attrIdx );
+        QVariant value = attrIdx < attrs.length() ? attrs.at( attrIdx ) : QVariant( QVariant::Int );
 
         QString v;
         if ( value.isNull() )

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -467,6 +467,30 @@ class ProviderTestCase(FeatureSourceTestCase):
         f2.setAttributes([7, 330, NULL, NULL, 'NULL'])
         self.testGetFeatures(l.dataProvider(), [f1, f2])
 
+    def testAddFeatureExtraAttributes(self):
+        if not getattr(self, 'getEditableLayer', None):
+            return
+
+        l = self.getEditableLayer()
+        self.assertTrue(l.isValid())
+
+        if not l.dataProvider().capabilities() & QgsVectorDataProvider.AddFeatures:
+            return
+
+        # test that adding features with too many attributes rejects the feature
+        # we be more tricky and also add a valid feature to stress test the provider
+        f1 = QgsFeature()
+        f1.setAttributes([6, -220, NULL, 'String', '15'])
+        f2 = QgsFeature()
+        f1.setAttributes([7, -230, NULL, 'String', '15', 15, 16, 17])
+
+        result, added = l.dataProvider().addFeatures([f1, f2])
+        self.assertFalse(result, 'Provider returned True to addFeatures with extra attributes. Providers should reject these features.')
+
+        # make sure feature was not added
+        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 7]
+        self.assertFalse(added)
+
     def testAddFeaturesUpdateExtent(self):
         if not getattr(self, 'getEditableLayer', None):
             return

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -488,7 +488,7 @@ class ProviderTestCase(FeatureSourceTestCase):
         self.assertTrue(result,
                         'Provider returned False to addFeatures with extra attributes. Providers should accept these features but truncate the extra attributes.')
 
-        # make sure feature was added correctyl
+        # make sure feature was added correctly
         added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 7][0]
         self.assertEqual(added.attributes(), [7, -230, NULL, 'String', '15'])
 
@@ -506,15 +506,28 @@ class ProviderTestCase(FeatureSourceTestCase):
         # we be more tricky and also add a valid feature to stress test the provider
         f1 = QgsFeature()
         f1.setGeometry(QgsGeometry.fromWkt('LineString (-72.345 71.987, -80 80)'))
+        f1.setAttributes([7])
         f2 = QgsFeature()
         f2.setGeometry(QgsGeometry.fromWkt('Point (-72.345 71.987)'))
+        f2.setAttributes([8])
 
         result, added = l.dataProvider().addFeatures([f1, f2])
         self.assertFalse(result, 'Provider returned True to addFeatures with incorrect geometry type. Providers should reject these features.')
 
         # make sure feature was not added
-        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 7]
-        self.assertFalse(added)
+        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 8]
+        self.assertTrue(added)
+
+        # yet providers MUST always accept null geometries
+        f3 = QgsFeature()
+        f3.setAttributes([9])
+        result, added = l.dataProvider().addFeatures([f3])
+        self.assertTrue(result,
+                        'Provider returned False to addFeatures with null geometry. Providers should always accept these features.')
+
+        # make sure feature was added correctly
+        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 9][0]
+        self.assertFalse(added.hasGeometry())
 
     def testAddFeaturesUpdateExtent(self):
         if not getattr(self, 'getEditableLayer', None):

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -477,7 +477,7 @@ class ProviderTestCase(FeatureSourceTestCase):
         if not l.dataProvider().capabilities() & QgsVectorDataProvider.AddFeatures:
             return
 
-        # test that adding features with too many attributes rejects the feature
+        # test that adding features with too many attributes drops these attributes
         # we be more tricky and also add a valid feature to stress test the provider
         f1 = QgsFeature()
         f1.setAttributes([6, -220, NULL, 'String', '15'])
@@ -485,11 +485,12 @@ class ProviderTestCase(FeatureSourceTestCase):
         f2.setAttributes([7, -230, NULL, 'String', '15', 15, 16, 17])
 
         result, added = l.dataProvider().addFeatures([f1, f2])
-        self.assertFalse(result, 'Provider returned True to addFeatures with extra attributes. Providers should reject these features.')
+        self.assertTrue(result,
+                        'Provider returned False to addFeatures with extra attributes. Providers should accept these features but truncate the extra attributes.')
 
-        # make sure feature was not added
-        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 7]
-        self.assertFalse(added)
+        # make sure feature was added correctyl
+        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 7][0]
+        self.assertEqual(added.attributes(), [7, -230, NULL, 'String', '15'])
 
     def testAddFeatureWrongGeomType(self):
         if not getattr(self, 'getEditableLayer', None):

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -482,10 +482,34 @@ class ProviderTestCase(FeatureSourceTestCase):
         f1 = QgsFeature()
         f1.setAttributes([6, -220, NULL, 'String', '15'])
         f2 = QgsFeature()
-        f1.setAttributes([7, -230, NULL, 'String', '15', 15, 16, 17])
+        f2.setAttributes([7, -230, NULL, 'String', '15', 15, 16, 17])
 
         result, added = l.dataProvider().addFeatures([f1, f2])
         self.assertFalse(result, 'Provider returned True to addFeatures with extra attributes. Providers should reject these features.')
+
+        # make sure feature was not added
+        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 7]
+        self.assertFalse(added)
+
+    def testAddFeatureWrongGeomType(self):
+        if not getattr(self, 'getEditableLayer', None):
+            return
+
+        l = self.getEditableLayer()
+        self.assertTrue(l.isValid())
+
+        if not l.dataProvider().capabilities() & QgsVectorDataProvider.AddFeatures:
+            return
+
+        # test that adding features with incorrect geometry type rejects the feature
+        # we be more tricky and also add a valid feature to stress test the provider
+        f1 = QgsFeature()
+        f1.setGeometry(QgsGeometry.fromWkt('LineString (-72.345 71.987, -80 80)'))
+        f2 = QgsFeature()
+        f2.setGeometry(QgsGeometry.fromWkt('Point (-72.345 71.987)'))
+
+        result, added = l.dataProvider().addFeatures([f1, f2])
+        self.assertFalse(result, 'Provider returned True to addFeatures with incorrect geometry type. Providers should reject these features.')
 
         # make sure feature was not added
         added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 7]

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -515,8 +515,8 @@ class ProviderTestCase(FeatureSourceTestCase):
         self.assertFalse(result, 'Provider returned True to addFeatures with incorrect geometry type. Providers should reject these features.')
 
         # make sure feature was not added
-        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 8]
-        self.assertTrue(added)
+        added = [f for f in l.dataProvider().getFeatures() if f['pk'] == 7]
+        self.assertFalse(added)
 
         # yet providers MUST always accept null geometries
         f3 = QgsFeature()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -468,7 +468,7 @@ class TestQgsGeometry(unittest.TestCase):
                 myFeatures.append(myNewFeature)
 
         myNewMemoryLayer = QgsVectorLayer(
-            ('LineString?crs=epsg:4326&field=name:string(20)&index=yes'),
+            ('Polygon?crs=epsg:4326&field=name:string(20)&index=yes'),
             'clip-out',
             'memory')
         myNewProvider = myNewMemoryLayer.dataProvider()


### PR DESCRIPTION
Add provider test to ensure that adding features to a provider with MORE attributes than expected results in a failure

We need to flag these and not silently discard the extra attributes resulting in loss of information -- if thisi situation occurs there's a deeper bug present which  needs to be addressed.