### PR TITLE
make QgsGeometry a Q_GADGET

### DIFF
--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -269,7 +269,6 @@
 %Include geometry/qgsellipse.sip
 %Include geometry/qgsgeometrycollection.sip
 %Include geometry/qgsgeometryengine.sip
-%Include geometry/qgsgeometry.sip
 %Include geometry/qgsgeometryutils.sip
 %Include geometry/qgslinestring.sip
 %Include geometry/qgsmulticurve.sip
@@ -372,6 +371,7 @@
 %Include raster/qgsrasterdataprovider.sip
 %Include raster/qgsrasterinterface.sip
 %Include geometry/qgspoint.sip
+%Include geometry/qgsgeometry.sip
 %Include geocms/geonode/qgsgeonoderequest.sip
 %Include gps/qgsgpsconnection.sip
 %Include gps/qgsgpsdetector.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -669,6 +669,7 @@ SET(QGIS_CORE_MOC_HDRS
   raster/qgsrasterlayerrenderer.h
 
   geometry/qgspoint.h
+  geometry/qgsgeometry.h
 
   geocms/geonode/qgsgeonoderequest.h
 
@@ -1090,7 +1091,6 @@ SET(QGIS_CORE_HDRS
   geometry/qgsgeometryeditutils.h
   geometry/qgsgeometryengine.h
   geometry/qgsgeometryfactory.h
-  geometry/qgsgeometry.h
   geometry/qgsgeometryutils.h
   geometry/qgsgeos.h
   geometry/qgsinternalgeometryengine.h

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -110,6 +110,7 @@ struct QgsGeometryPrivate;
 
 class CORE_EXPORT QgsGeometry
 {
+    Q_GADGET
   public:
 
     /**
@@ -848,6 +849,7 @@ class CORE_EXPORT QgsGeometry
       SideLeft = 0, //!< Buffer to left of line
       SideRight, //!< Buffer to right of line
     };
+    Q_ENUM( BufferSide );
 
     //! End cap styles for buffers
     enum EndCapStyle
@@ -856,6 +858,7 @@ class CORE_EXPORT QgsGeometry
       CapFlat, //!< Flat cap (in line with start/end of line)
       CapSquare, //!< Square cap (extends past start/end of line by buffer distance)
     };
+    Q_ENUM( EndCapStyle );
 
     //! Join styles for buffers
     enum JoinStyle
@@ -864,6 +867,7 @@ class CORE_EXPORT QgsGeometry
       JoinStyleMiter, //!< Use mitered joins
       JoinStyleBevel, //!< Use beveled joins
     };
+    Q_ENUM( JoinStyle );
 
     /**
      * Returns a buffer region around this geometry having the given width and with a specified number


### PR DESCRIPTION
so Q_ENUM can be used

this is useful using #6364 to get settings value for QgsGeometry::JoinStyle and friends. 