### PR TITLE
 snapToCurrentLayer correctly handles Area type

### DIFF
--- a/python/core/qgspointlocator.sip.in
+++ b/python/core/qgspointlocator.sip.in
@@ -173,6 +173,16 @@ Find nearest edge to the specified point - up to distance specified by tolerance
 Optional filter may discard unwanted matches.
 %End
 
+    Match nearestArea( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0 );
+%Docstring
+Find nearest area to the specified point - up to distance specified by tolerance
+Optional filter may discard unwanted matches.
+This will first perform a pointInPolygon and return first result.
+If no match is found and tolerance is not 0, it will return nearestEdge.
+
+.. versionadded:: 3.0
+%End
+
     MatchList edgesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = 0 );
 %Docstring
 Find edges within a specified recangle

--- a/python/core/qgssnappingutils.sip.in
+++ b/python/core/qgssnappingutils.sip.in
@@ -54,16 +54,9 @@ Snap to map according to the current configuration. Optional filter allows disca
     QgsPointLocator::Match snapToMap( const QgsPointXY &pointMap, QgsPointLocator::MatchFilter *filter = 0 );
 
 
-    QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = 0, double tolerance = 0.0 );
+    QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = 0 );
 %Docstring
- snapToCurrentLayer snap to current layer with given settings
-
-:param point: the point to snap from
-:param type: the matching type (vertex, edge, area)
-:param filter: the matching filter
-:param tolerance: the tolerance in project units. If left to 0, it is calculated from current map settings
-
-:return: the snapping match
+Snap to current layer
 %End
 
 

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -204,7 +204,7 @@ class QgsPointLocator_VisitorArea : public IVisitor
       QgsFeatureId id = d.getIdentifier();
       QgsGeometry *g = mLocator->mGeoms.value( id );
       if ( g->intersects( mGeomPt ) )
-        mList << QgsPointLocator::Match( QgsPointLocator::Area, mLocator->mLayer, id, 0, QgsPointXY() );
+        mList << QgsPointLocator::Match( QgsPointLocator::Area, mLocator->mLayer, id, 0, mGeomPt.asPoint() );
     }
   private:
     QgsPointLocator *mLocator = nullptr;
@@ -908,7 +908,11 @@ QgsPointLocator::Match QgsPointLocator::nearestArea( const QgsPointXY &point, do
     return Match();
 
   // use edges for adding tolerance
-  return nearestEdge( point, tolerance, filter );
+  Match m = nearestEdge( point, tolerance, filter );
+  if ( m.isValid() )
+    return Match( Area, m.layer(), m.featureId(), m.distance(), m.point() );
+  else
+    return Match();
 }
 
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -229,6 +229,15 @@ class CORE_EXPORT QgsPointLocator : public QObject
     Match nearestEdge( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
 
     /**
+     * Find nearest area to the specified point - up to distance specified by tolerance
+     * Optional filter may discard unwanted matches.
+     * This will first perform a pointInPolygon and return first result.
+     * If no match is found and tolerance is not 0, it will return nearestEdge.
+     * \since QGIS 3.0
+     */
+    Match nearestArea( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
+
+    /**
      * Find edges within a specified recangle
      * Optional filter may discard unwanted matches.
      */

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -185,6 +185,13 @@ static void _updateBestMatch( QgsPointLocator::Match &bestMatch, const QgsPointX
   {
     _replaceIfBetter( bestMatch, loc->nearestEdge( pointMap, tolerance, filter ), tolerance );
   }
+  if ( bestMatch.type() != QgsPointLocator::Vertex && bestMatch.type() != QgsPointLocator::Edge && ( type & QgsPointLocator::Area ) )
+  {
+    // if edges were detected, set tolerance to 0 to only do pointInPolygon (and avoid redo nearestEdge)
+    if ( type & QgsPointLocator::Edge )
+      tolerance = 0;
+    _replaceIfBetter( bestMatch, loc->nearestArea( pointMap, tolerance, filter ), tolerance );
+  }
 }
 
 

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -440,14 +440,13 @@ void QgsSnappingUtils::toggleEnabled()
   emit configChanged( mSnappingConfig );
 }
 
-QgsPointLocator::Match QgsSnappingUtils::snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter, double tolerance )
+QgsPointLocator::Match QgsSnappingUtils::snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter )
 {
   if ( !mCurrentLayer )
     return QgsPointLocator::Match();
 
   QgsPointXY pointMap = mMapSettings.mapToPixel().toMapCoordinates( point );
-  if ( tolerance == 0.0 )
-    tolerance = QgsTolerance::vertexSearchRadius( mMapSettings );
+  double tolerance = QgsTolerance::vertexSearchRadius( mMapSettings );
 
   QgsPointLocator *loc = locatorForLayerUsingStrategy( mCurrentLayer, pointMap, tolerance );
   if ( !loc )

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -67,15 +67,8 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     //! Snap to current layer
 
-    /**
-     * \brief snapToCurrentLayer snap to current layer with given settings
-     * \param point the point to snap from
-     * \param type the matching type (vertex, edge, area)
-     * \param filter the matching filter
-     * \param tolerance the tolerance in project units. If left to 0, it is calculated from current map settings
-     * \return the snapping match
-     */
-    QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = nullptr, double tolerance = 0.0 );
+    //! Snap to current layer
+    QgsPointLocator::Match snapToCurrentLayer( QPoint point, QgsPointLocator::Types type, QgsPointLocator::MatchFilter *filter = nullptr );
 
     // environment setup
 

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -144,6 +144,7 @@ class TestQgsPointLocator : public QObject
       QCOMPARE( m2.layer(), mVL );
       QCOMPARE( m2.featureId(), ( QgsFeatureId )1 );
       QCOMPARE( m2.point(), QgsPointXY( 0.9, 0.9 ) );
+      QCOMPARE( m2.distance(), 0 );
 
       QgsPointXY pt3( 1.1, 1.1 );
       QgsPointLocator::Match m3 = loc.nearestArea( pt3, 999 );
@@ -151,7 +152,8 @@ class TestQgsPointLocator : public QObject
       QVERIFY( m3.hasArea() );
       QCOMPARE( m3.layer(), mVL );
       QCOMPARE( m3.featureId(), ( QgsFeatureId )1 );
-      QCOMPARE( m3.point(), QgsPointXY( 1.0, 1 - 0 ) );
+      QCOMPARE( m3.point(), QgsPointXY( 1.0, 1.0 ) );
+      QCOMPARE( m3.distance(), .1 * std::sqrt( 2 ) );
     }
 
     void testPointInPolygon()

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -130,6 +130,30 @@ class TestQgsPointLocator : public QObject
       QCOMPARE( pt2, QgsPointXY( 1, 1 ) );
     }
 
+    void testNearestArea()
+    {
+      QgsPointLocator loc( mVL );
+      QgsPointXY pt1( 1.1, 0.5 );
+      QgsPointLocator::Match m1 = loc.nearestArea( pt1, 0 );
+      QVERIFY( !m1.isValid() );
+
+      QgsPointXY pt2( 0.9, 0.9 );
+      QgsPointLocator::Match m2 = loc.nearestArea( pt2, 0 );
+      QVERIFY( m2.isValid() );
+      QVERIFY( m2.hasArea() );
+      QCOMPARE( m2.layer(), mVL );
+      QCOMPARE( m2.featureId(), ( QgsFeatureId )1 );
+      QCOMPARE( m2.point(), QgsPointXY( 0.9, 0.9 ) );
+
+      QgsPointXY pt3( 1.1, 1.1 );
+      QgsPointLocator::Match m3 = loc.nearestArea( pt3, 999 );
+      QVERIFY( m3.isValid() );
+      QVERIFY( m3.hasArea() );
+      QCOMPARE( m3.layer(), mVL );
+      QCOMPARE( m3.featureId(), ( QgsFeatureId )1 );
+      QCOMPARE( m3.point(), QgsPointXY( 1.0, 1 - 0 ) );
+    }
+
     void testPointInPolygon()
     {
       QgsPointLocator loc( mVL );

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -144,7 +144,7 @@ class TestQgsPointLocator : public QObject
       QCOMPARE( m2.layer(), mVL );
       QCOMPARE( m2.featureId(), ( QgsFeatureId )1 );
       QCOMPARE( m2.point(), QgsPointXY( 0.9, 0.9 ) );
-      QCOMPARE( m2.distance(), 0 );
+      QCOMPARE( m2.distance(), 0.0 );
 
       QgsPointXY pt3( 1.1, 1.1 );
       QgsPointLocator::Match m3 = loc.nearestArea( pt3, 999 );


### PR DESCRIPTION
also  revert adding tolerance to QgsSnappingUtils::snapToCurrentLayer (added by error from a bad rebase)
