### PR TITLE
Remove QgsInterruptionChecker and replace with QgsFeedback

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -287,6 +287,7 @@ should now call QgsCoordinateReferenceSystem::invalidateCache() and QgsCoordinat
 - HalfEdge.
 - QgsHtmlAnnotationItem. Use QgsHtmlAnnotation instead.
 - QgsHttpTransaction. This class was outdated and code should be ported to native Qt or Python implementations.
+- QgsInterruptionChecker. Use QgsFeedback instead.
 - QgsGenericProjectionSelector. Use QgsProjectionSelectionTreeWidget instead.
 - QgsGeometryCache. It got redundant after removal of old snapping classes (QgsSnapper + friends).
 - QgsLabel and QgsLabelAttributes. Replaced by labeling based on PAL library, see QgsLabelingEngine.
@@ -1030,6 +1031,13 @@ None will need to be modified, as the method will return an empty geometry if th
 - setFields( const QgsFields*, bool ) has been removed, use setFields( const QgsFields&, bool ) instead.
 - fields() no longer returns a pointer, but instead a QgsFields value.
 - The duplicate method setFeatureId() was removed. Use setId() instead.
+
+
+QgsFeatureIterator        {#qgis_api_break_3_0_QgsFeatureIterator}
+------------------
+
+- setInterruptionChecker now accepts a QgsFeedback object instead of a QgsInterruptionChecker.
+
 
 QgsFeatureListViewDelegate        {#qgis_api_break_3_0_QgsFeatureListViewDelegate}
 --------------------------

--- a/python/core/qgsfeatureiterator.sip.in
+++ b/python/core/qgsfeatureiterator.sip.in
@@ -8,8 +8,6 @@
 
 
 
-
-
 class QgsAbstractFeatureIterator
 {
 %Docstring

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -637,6 +637,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgsvectorlayerexporter.h
   qgsvectorlayerfeaturecounter.h
   qgsvectorlayerjoinbuffer.h
+  qgsvectorlayerrenderer.h
   qgsvectorlayertools.h
   qgsmapthemecollection.h
   qgswebpage.h
@@ -920,7 +921,6 @@ SET(QGIS_CORE_HDRS
   qgsvectorlayerjoininfo.h
   qgsvectorlayerlabelprovider.h
   qgsvectorlayerlabeling.h
-  qgsvectorlayerrenderer.h
   qgsvectorlayerundocommand.h
   qgsvectorlayerundopassthroughcommand.h
   qgsvectorlayerutils.h

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -211,7 +211,7 @@ bool QgsAbstractFeatureIterator::prepareOrderBy( const QList<QgsFeatureRequest::
   return false;
 }
 
-void QgsAbstractFeatureIterator::setInterruptionChecker( QgsInterruptionChecker * )
+void QgsAbstractFeatureIterator::setInterruptionChecker( QgsFeedback * )
 {
 }
 

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -19,21 +19,7 @@
 #include "qgsfeaturerequest.h"
 #include "qgsindexedfeature.h"
 
-
-
-/**
- * \ingroup core
- * Interface that can be optionally attached to an iterator so its
- * nextFeature() implementaton can check if it must stop as soon as possible.
- * \since QGIS 2.16
- * \note not available in Python bindings
- */
-class CORE_EXPORT QgsInterruptionChecker SIP_SKIP
-{
-  public:
-    //! return true if the iterator must stop as soon as possible
-    virtual bool mustStop() const = 0;
-};
+class QgsFeedback;
 
 /**
  * \ingroup core
@@ -74,7 +60,7 @@ class CORE_EXPORT QgsAbstractFeatureIterator
      * \since QGIS 2.16
      * \note not available in Python bindings
      */
-    virtual void setInterruptionChecker( QgsInterruptionChecker *interruptionChecker ) SIP_SKIP;
+    virtual void setInterruptionChecker( QgsFeedback *interruptionChecker ) SIP_SKIP;
 
     /**
      * Returns the status of expression compilation for filter expression requests.
@@ -329,7 +315,7 @@ class CORE_EXPORT QgsFeatureIterator
      * \since QGIS 2.16
      * \note not available in Python bindings
      */
-    void setInterruptionChecker( QgsInterruptionChecker *interruptionChecker ) SIP_SKIP;
+    void setInterruptionChecker( QgsFeedback *interruptionChecker ) SIP_SKIP;
 
     /**
      * Returns the status of expression compilation for filter expression requests.
@@ -404,7 +390,7 @@ inline bool operator!= ( const QgsFeatureIterator &fi1, const QgsFeatureIterator
   return !( fi1 == fi2 );
 }
 
-inline void QgsFeatureIterator::setInterruptionChecker( QgsInterruptionChecker *interruptionChecker )
+inline void QgsFeatureIterator::setInterruptionChecker( QgsFeedback *interruptionChecker )
 {
   if ( mIter )
     mIter->setInterruptionChecker( interruptionChecker );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -698,46 +698,6 @@ long QgsVectorLayer::featureCount( const QString &legendKey ) const
   return mSymbolFeatureCountMap.value( legendKey );
 }
 
-/**
- * \ingroup core
- * Used by QgsVectorLayer::countSymbolFeatures() to provide an interruption checker
- * \note not available in Python bindings
- */
-class QgsVectorLayerInterruptionCheckerDuringCountSymbolFeatures: public QgsInterruptionChecker
-{
-  public:
-
-    //! Constructor
-    explicit QgsVectorLayerInterruptionCheckerDuringCountSymbolFeatures( QProgressDialog *dialog )
-      : mDialog( dialog )
-    {
-    }
-
-    bool mustStop() const override
-    {
-      if ( mDialog->isVisible() )
-      {
-        // So that we get a chance of hitting the Abort button
-#ifdef Q_OS_LINUX
-        // For some reason on Windows hasPendingEvents() always return true,
-        // but one iteration is actually enough on Windows to get good interactivity
-        // whereas on Linux we must allow for far more iterations.
-        // For safety limit the number of iterations
-        int nIters = 0;
-        while ( QCoreApplication::hasPendingEvents() && ++nIters < 100 )
-#endif
-        {
-          QCoreApplication::processEvents();
-        }
-        return mDialog->wasCanceled();
-      }
-      return false;
-    }
-
-  private:
-    QProgressDialog *mDialog = nullptr;
-};
-
 QgsVectorLayerFeatureCounter *QgsVectorLayer::countSymbolFeatures()
 {
   if ( mSymbolFeatureCounted || mFeatureCounter )

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -402,7 +402,7 @@ bool QgsVectorLayerFeatureIterator::close()
   return true;
 }
 
-void QgsVectorLayerFeatureIterator::setInterruptionChecker( QgsInterruptionChecker *interruptionChecker )
+void QgsVectorLayerFeatureIterator::setInterruptionChecker( QgsFeedback *interruptionChecker )
 {
   mProviderIterator.setInterruptionChecker( interruptionChecker );
   mInterruptionChecker = interruptionChecker;

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -119,7 +119,7 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     //! end of iterating: free the resources / lock
     bool close() override;
 
-    void setInterruptionChecker( QgsInterruptionChecker *interruptionChecker ) override SIP_SKIP;
+    void setInterruptionChecker( QgsFeedback *interruptionChecker ) override SIP_SKIP;
 
     /**
      * Join information prepared for fast attribute id mapping in QgsVectorLayerJoinBuffer::updateFeatureAttributes().
@@ -247,7 +247,7 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
 
     std::unique_ptr<QgsExpressionContext> mExpressionContext;
 
-    QgsInterruptionChecker *mInterruptionChecker = nullptr;
+    QgsFeedback *mInterruptionChecker = nullptr;
 
     QList< int > mPreparedFields;
     QList< int > mFieldsToPrepare;

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -549,10 +549,16 @@ void QgsVectorLayerRenderer::prepareDiagrams( QgsVectorLayer *layer, QSet<QStrin
 QgsVectorLayerRendererInterruptionChecker::QgsVectorLayerRendererInterruptionChecker
 ( const QgsRenderContext &context )
   : mContext( context )
+  , mTimer( new QTimer( this ) )
 {
-}
+  connect( mTimer, &QTimer::timeout, this, [ = ]
+  {
+    if ( mContext.renderingStopped() )
+    {
+      mTimer->stop();
+      cancel();
+    }
+  } );
+  mTimer->start( 50 );
 
-bool QgsVectorLayerRendererInterruptionChecker::mustStop() const
-{
-  return mContext.renderingStopped();
 }

--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -39,6 +39,7 @@ typedef QList<int> QgsAttributeList;
 #include "qgsfeature.h"  // QgsFeatureIds
 #include "qgsfeatureiterator.h"
 #include "qgsvectorsimplifymethod.h"
+#include "qgsfeedback.h"
 
 #include "qgsmaplayerrenderer.h"
 
@@ -50,14 +51,17 @@ class QgsVectorLayerDiagramProvider;
  * Interruption checker used by QgsVectorLayerRenderer::render()
  * \note not available in Python bindings
  */
-class QgsVectorLayerRendererInterruptionChecker: public QgsInterruptionChecker
+class QgsVectorLayerRendererInterruptionChecker: public QgsFeedback
 {
+    Q_OBJECT
+
   public:
     //! Constructor
     explicit QgsVectorLayerRendererInterruptionChecker( const QgsRenderContext &context );
-    bool mustStop() const override;
+
   private:
     const QgsRenderContext &mContext;
+    QTimer *mTimer = nullptr;
 };
 
 /**

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -27,6 +27,7 @@
 #include "qgslogger.h"
 #include "qgssettings.h"
 #include "qgsexception.h"
+#include "qgsfeedback.h"
 
 #include <QDir>
 #include <QProgressDialog>
@@ -965,7 +966,7 @@ void QgsWFSFeatureIterator::endOfDownload( bool )
     mLoop->quit();
 }
 
-void QgsWFSFeatureIterator::setInterruptionChecker( QgsInterruptionChecker *interruptionChecker )
+void QgsWFSFeatureIterator::setInterruptionChecker( QgsFeedback *interruptionChecker )
 {
   mInterruptionChecker = interruptionChecker;
 }
@@ -1018,7 +1019,7 @@ void QgsWFSFeatureIterator::checkInterruption()
 {
   //QgsDebugMsg("QgsWFSFeatureIterator::checkInterruption()");
 
-  if ( mInterruptionChecker && mInterruptionChecker->mustStop() )
+  if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
   {
     mDownloadFinished = true;
     if ( mLoop )
@@ -1037,7 +1038,7 @@ bool QgsWFSFeatureIterator::fetchFeature( QgsFeature &f )
   QgsFeature cachedFeature;
   while ( mCacheIterator.nextFeature( cachedFeature ) )
   {
-    if ( mInterruptionChecker && mInterruptionChecker->mustStop() )
+    if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
       return false;
 
     //QgsDebugMsg(QString("QgsWFSSharedData::fetchFeature() : mCacheIterator.nextFeature(cachedFeature)") );
@@ -1134,7 +1135,7 @@ bool QgsWFSFeatureIterator::fetchFeature( QgsFeature &f )
     {
       while ( !mReaderStream->atEnd() )
       {
-        if ( mInterruptionChecker && mInterruptionChecker->mustStop() )
+        if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
           return false;
 
         QgsFeature feat;
@@ -1186,7 +1187,7 @@ bool QgsWFSFeatureIterator::fetchFeature( QgsFeature &f )
 
     if ( mDownloadFinished )
       return false;
-    if ( mInterruptionChecker && mInterruptionChecker->mustStop() )
+    if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
       return false;
 
     //QgsDebugMsg("fetchFeature before loop");

--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -206,7 +206,7 @@ class QgsWFSFeatureIterator : public QObject,
 
     bool close() override;
 
-    void setInterruptionChecker( QgsInterruptionChecker *interruptionChecker ) override;
+    void setInterruptionChecker( QgsFeedback *interruptionChecker ) override;
 
     //! Used by QgsWFSSharedData::registerToCache()
     void connectSignals( QgsWFSFeatureDownloader *downloader );
@@ -232,7 +232,7 @@ class QgsWFSFeatureIterator : public QObject,
     bool mDownloadFinished;
     QEventLoop *mLoop = nullptr;
     QgsFeatureIterator mCacheIterator;
-    QgsInterruptionChecker *mInterruptionChecker = nullptr;
+    QgsFeedback *mInterruptionChecker = nullptr;
 
     //! this mutex synchronizes the mWriterXXXX variables between featureReceivedSynchronous() and fetchFeature()
     QMutex mMutex;


### PR DESCRIPTION
These two classes have similar use cases, so it makes sense to use only one and QgsFeedback is now used extensively throughout the API.

It also makes sense for the checker to be a QObject, since that facilitates easy cancelation of network requests.