### PR TITLE
Better sort order for browser node

### DIFF
--- a/src/providers/arcgisrest/qgsafsdataitems.h
+++ b/src/providers/arcgisrest/qgsafsdataitems.h
@@ -25,6 +25,9 @@ class QgsAfsRootItem : public QgsDataCollectionItem
   public:
     QgsAfsRootItem( QgsDataItem *parent, const QString &name, const QString &path );
     QVector<QgsDataItem *> createChildren() override;
+
+    QVariant sortKey() const override { return 12; }
+
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;
     QWidget *paramWidget() override;

--- a/src/providers/arcgisrest/qgsafsdataitems.h
+++ b/src/providers/arcgisrest/qgsafsdataitems.h
@@ -26,7 +26,7 @@ class QgsAfsRootItem : public QgsDataCollectionItem
     QgsAfsRootItem( QgsDataItem *parent, const QString &name, const QString &path );
     QVector<QgsDataItem *> createChildren() override;
 
-    QVariant sortKey() const override { return 12; }
+    QVariant sortKey() const override { return 13; }
 
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;

--- a/src/providers/arcgisrest/qgsamsdataitems.h
+++ b/src/providers/arcgisrest/qgsamsdataitems.h
@@ -28,6 +28,9 @@ class QgsAmsRootItem : public QgsDataCollectionItem
     QgsAmsRootItem( QgsDataItem *parent, QString name, QString path );
 
     QVector<QgsDataItem *> createChildren() override;
+
+    QVariant sortKey() const override { return 11; }
+
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;
     QWidget *paramWidget() override;

--- a/src/providers/arcgisrest/qgsamsdataitems.h
+++ b/src/providers/arcgisrest/qgsamsdataitems.h
@@ -29,7 +29,7 @@ class QgsAmsRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
-    QVariant sortKey() const override { return 11; }
+    QVariant sortKey() const override { return 12; }
 
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;

--- a/src/providers/db2/qgsdb2dataitems.h
+++ b/src/providers/db2/qgsdb2dataitems.h
@@ -41,6 +41,8 @@ class QgsDb2RootItem : public QgsDataCollectionItem
      */
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 6; }
+
 #ifdef HAVE_GUI
     QWidget *paramWidget() override;
 

--- a/src/providers/geonode/qgsgeonodedataitems.h
+++ b/src/providers/geonode/qgsgeonodedataitems.h
@@ -69,6 +69,8 @@ class QgsGeoNodeRootItem : public QgsDataCollectionItem
 
     QList<QAction *> actions( QWidget *parent ) override;
 
+    QVariant sortKey() const override { return 13; }
+
   private slots:
     void newConnection();
 };

--- a/src/providers/mssql/qgsmssqldataitems.h
+++ b/src/providers/mssql/qgsmssqldataitems.h
@@ -38,6 +38,8 @@ class QgsMssqlRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 4; }
+
 #ifdef HAVE_GUI
     QWidget *paramWidget() override;
     QList<QAction *> actions( QWidget *parent ) override;

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -136,6 +136,9 @@ class QgsGeoPackageRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 1; }
+
+
 #ifdef HAVE_GUI
     QWidget *paramWidget() override;
     QList<QAction *> actions( QWidget *parent ) override;

--- a/src/providers/oracle/qgsoracledataitems.h
+++ b/src/providers/oracle/qgsoracledataitems.h
@@ -41,6 +41,8 @@ class QgsOracleRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 5; }
+
     virtual QWidget *paramWidget() override;
 
     QList<QAction *> actions( QWidget *parent ) override;

--- a/src/providers/ows/qgsowsdataitems.h
+++ b/src/providers/ows/qgsowsdataitems.h
@@ -48,7 +48,7 @@ class QgsOWSRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
-    QVariant sortKey() const override { return 10; }
+    QVariant sortKey() const override { return 11; }
 
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;

--- a/src/providers/ows/qgsowsdataitems.h
+++ b/src/providers/ows/qgsowsdataitems.h
@@ -48,6 +48,8 @@ class QgsOWSRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 10; }
+
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;
     QWidget *paramWidget() override;

--- a/src/providers/postgres/qgspostgresdataitems.h
+++ b/src/providers/postgres/qgspostgresdataitems.h
@@ -36,6 +36,8 @@ class QgsPGRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 3; }
+
 #ifdef HAVE_GUI
     QWidget *paramWidget() override;
 

--- a/src/providers/spatialite/qgsspatialitedataitems.h
+++ b/src/providers/spatialite/qgsspatialitedataitems.h
@@ -67,6 +67,8 @@ class QgsSLRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 2; }
+
 #ifdef HAVE_GUI
     QWidget *paramWidget() override;
     QList<QAction *> actions( QWidget *parent ) override;

--- a/src/providers/wcs/qgswcsdataitems.h
+++ b/src/providers/wcs/qgswcsdataitems.h
@@ -70,7 +70,7 @@ class QgsWCSRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
-    QVariant sortKey() const override { return 8; }
+    QVariant sortKey() const override { return 9; }
 
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;

--- a/src/providers/wcs/qgswcsdataitems.h
+++ b/src/providers/wcs/qgswcsdataitems.h
@@ -70,6 +70,8 @@ class QgsWCSRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 8; }
+
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;
     QWidget *paramWidget() override;

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -29,6 +29,8 @@ class QgsWfsRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 9; }
+
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;
     QWidget *paramWidget() override;

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -137,6 +137,8 @@ class QgsXyzTileRootItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    QVariant sortKey() const override { return 8; }
+
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;
 #endif

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -33,6 +33,7 @@ class QgsWMSConnectionItem : public QgsDataCollectionItem
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 
+
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;
 #endif
@@ -97,6 +98,8 @@ class QgsWMSRootItem : public QgsDataCollectionItem
     QgsWMSRootItem( QgsDataItem *parent, QString name, QString path );
 
     QVector<QgsDataItem *> createChildren() override;
+
+    QVariant sortKey() const override { return 7; }
 
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;


### PR DESCRIPTION
Makes the browser match the order of the Data Source Manager UI. 

**Before**

![image](https://user-images.githubusercontent.com/381660/36365270-8cd12c5a-1594-11e8-8d03-e399a53a5d11.png)

**After**
![image](https://user-images.githubusercontent.com/381660/36365294-a683c70c-1594-11e8-8e89-181b7dc311d0.png)
