### PR TITLE
Use first feature in layer to generate symbol preview icon in widget

### DIFF
--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -31,6 +31,8 @@
 #include "qgslogger.h"
 #include "qgsapplication.h"
 #include "qgssettings.h"
+#include "qgsfeatureiterator.h"
+#include "qgsvectorlayer.h"
 
 #include <QColorDialog>
 #include <QPainter>
@@ -247,6 +249,19 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
   layersTree->setModel( model );
   layersTree->setHeaderHidden( true );
 
+  //get first feature from layer for previews
+  if ( mVectorLayer )
+  {
+    QgsFeatureIterator it = mVectorLayer->getFeatures( QgsFeatureRequest().setLimit( 1 ) );
+    it.nextFeature( mPreviewFeature );
+    mPreviewExpressionContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mVectorLayer ) );
+    mPreviewExpressionContext.setFeature( mPreviewFeature );
+  }
+  else
+  {
+    mPreviewExpressionContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( nullptr ) );
+  }
+
   QItemSelectionModel *selModel = layersTree->selectionModel();
   connect( selModel, &QItemSelectionModel::currentChanged, this, &QgsSymbolSelectorWidget::layerChanged );
 
@@ -284,6 +299,15 @@ QMenu *QgsSymbolSelectorWidget::advancedMenu()
 void QgsSymbolSelectorWidget::setContext( const QgsSymbolWidgetContext &context )
 {
   mContext = context;
+
+  if ( mContext.expressionContext() )
+  {
+    mPreviewExpressionContext = *mContext.expressionContext();
+    if ( mVectorLayer )
+      mPreviewExpressionContext.appendScope( QgsExpressionContextUtils::layerScope( mVectorLayer ) );
+
+    mPreviewExpressionContext.setFeature( mPreviewFeature );
+  }
 
   QWidget *widget = stackedWidget->currentWidget();
   QgsLayerPropertiesWidget *layerProp = dynamic_cast< QgsLayerPropertiesWidget * >( widget );
@@ -362,7 +386,7 @@ void QgsSymbolSelectorWidget::updateUi()
 
 void QgsSymbolSelectorWidget::updatePreview()
 {
-  QImage preview = mSymbol->bigSymbolPreviewImage( mContext.expressionContext() );
+  QImage preview = mSymbol->bigSymbolPreviewImage( &mPreviewExpressionContext );
   lblPreview->setPixmap( QPixmap::fromImage( preview ) );
   // Hope this is a appropriate place
   emit symbolModified();

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -250,6 +250,9 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
   private:
     std::unique_ptr<DataDefinedRestorer> mDataDefineRestorer;
     QgsSymbolWidgetContext mContext;
+    QgsFeature mPreviewFeature;
+    QgsExpressionContext mPreviewExpressionContext;
+
 };
 
 /**


### PR DESCRIPTION
Uses the first feature found in a layer in order to create a better
preview for the symbol in the symbol selector dialog. This allows
data defined settings to be evaluated correctly (at least, for the
first feature) and avoids missing previews due to missing
attribute values when data defined settings are present.

Fixes #17061
