### PR TITLE
[dbmanager] fix shortcut execute query

### DIFF
--- a/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlLayerWindow.ui
@@ -151,11 +151,14 @@ columns</string>
         <layout class="QHBoxLayout">
          <item>
           <widget class="QPushButton" name="btnExecute">
+           <property name="toolTip">
+            <string>Execute query (Ctrl+R)</string>
+           </property>
            <property name="text">
-            <string>&amp;Execute (F5)</string>
+            <string>Execute</string>
            </property>
            <property name="shortcut">
-            <string>F5</string>
+            <string>Ctrl+R</string>
            </property>
           </widget>
          </item>

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -322,11 +322,14 @@ unique values</string>
         <layout class="QHBoxLayout">
          <item>
           <widget class="QPushButton" name="btnExecute">
+           <property name="toolTip">
+            <string>Execute query (Ctrl+R)</string>
+           </property>
            <property name="text">
-            <string>&amp;Execute (F5)</string>
+            <string>Execute</string>
            </property>
            <property name="shortcut">
-            <string>F5</string>
+            <string>Ctrl+R</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
## Description
F5 is already taken. I changed Ctrl+R to execute the query on db_manager.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
