### PR TITLE
Remove use of deprecated trUtf8 method

### DIFF
--- a/src/analysis/processing/qgsalgorithmextractbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbyattribute.cpp
@@ -50,7 +50,7 @@ void QgsExtractByAttributeAlgorithm::initAlgorithm( const QVariantMap & )
   addParameter( new QgsProcessingParameterField( QStringLiteral( "FIELD" ), QObject::tr( "Selection attribute" ), QVariant(), QStringLiteral( "INPUT" ) ) );
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "OPERATOR" ), QObject::tr( "Operator" ), QStringList()
                 << QObject::tr( "=" )
-                << QObject::trUtf8( "≠" )
+                << QObject::tr( "≠" )
                 << QObject::tr( ">" )
                 << QObject::tr( ">=" )
                 << QObject::tr( "<" )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2852,7 +2852,7 @@ void QgisApp::createStatusBar()
   mRotationEdit->setWrapping( true );
   mRotationEdit->setSingleStep( 5.0 );
   mRotationEdit->setFont( myFont );
-  mRotationEdit->setSuffix( trUtf8( " °" ) );
+  mRotationEdit->setSuffix( tr( " °" ) );
   mRotationEdit->setWhatsThis( tr( "Shows the current map clockwise rotation "
                                    "in degrees. It also allows editing to set "
                                    "the rotation" ) );
@@ -10442,7 +10442,7 @@ bool QgisApp::checkTasksDependOnProject()
     {
       Q_FOREACH ( QgsTask *task, tasks )
       {
-        activeTaskDescriptions.insert( trUtf8( " • %1" ).arg( task->description() ) );
+        activeTaskDescriptions.insert( tr( " • %1" ).arg( task->description() ) );
       }
     }
   }

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -357,7 +357,7 @@ void QgsMapCanvasDockWidget::mapExtentChanged()
 
 void QgsMapCanvasDockWidget::mapCrsChanged()
 {
-  mActionSetCrs->setText( trUtf8( "Change Map CRS (%1)…" ).arg( mMapCanvas->mapSettings().destinationCrs().isValid() ?
+  mActionSetCrs->setText( tr( "Change Map CRS (%1)…" ).arg( mMapCanvas->mapSettings().destinationCrs().isValid() ?
                           mMapCanvas->mapSettings().destinationCrs().authid() :
                           tr( "No projection" ) ) );
 }
@@ -496,7 +496,7 @@ QgsMapSettingsAction::QgsMapSettingsAction( QWidget *parent )
   mRotationWidget->setRange( -180.0, 180.0 );
   mRotationWidget->setWrapping( true );
   mRotationWidget->setSingleStep( 5.0 );
-  mRotationWidget->setSuffix( trUtf8( " °" ) );
+  mRotationWidget->setSuffix( tr( " °" ) );
   mRotationWidget->setToolTip( tr( "Current clockwise map rotation in degrees" ) );
 
   label = new QLabel( tr( "Rotation" ) );
@@ -528,7 +528,7 @@ QgsMapSettingsAction::QgsMapSettingsAction( QWidget *parent )
   gLayout->addWidget( mSyncScaleCheckBox, 4, 0, 1, 2 );
 
   mScaleFactorWidget = new QgsDoubleSpinBox();
-  mScaleFactorWidget->setSuffix( trUtf8( "×" ) );
+  mScaleFactorWidget->setSuffix( tr( "×" ) );
   mScaleFactorWidget->setDecimals( 2 );
   mScaleFactorWidget->setRange( 0.01, 100000 );
   mScaleFactorWidget->setWrapping( false );

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -134,7 +134,7 @@ void QgsMapThemes::replaceTriggered()
     return;
 
   int res = QMessageBox::question( mMenu, tr( "Replace Theme" ),
-                                   trUtf8( "Are you sure you want to replace the existing theme “%1”?" ).arg( actionPreset->text() ),
+                                   tr( "Are you sure you want to replace the existing theme “%1”?" ).arg( actionPreset->text() ),
                                    QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
   if ( res != QMessageBox::Yes )
     return;
@@ -161,7 +161,7 @@ void QgsMapThemes::removeCurrentPreset()
     if ( actionPreset->isChecked() )
     {
       int res = QMessageBox::question( mMenu, tr( "Remove Theme" ),
-                                       trUtf8( "Are you sure you want to remove the existing theme “%1”?" ).arg( actionPreset->text() ),
+                                       tr( "Are you sure you want to remove the existing theme “%1”?" ).arg( actionPreset->text() ),
                                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
       if ( res == QMessageBox::Yes )
         QgsProject::instance()->mapThemeCollection()->removeMapTheme( actionPreset->text() );

--- a/src/app/qgsmaptoolrotatefeature.cpp
+++ b/src/app/qgsmaptoolrotatefeature.cpp
@@ -54,7 +54,7 @@ QgsAngleMagnetWidget::QgsAngleMagnetWidget( const QString &label, QWidget *paren
   mAngleSpinBox = new QgsDoubleSpinBox( this );
   mAngleSpinBox->setMinimum( -360 );
   mAngleSpinBox->setMaximum( 360 );
-  mAngleSpinBox->setSuffix( trUtf8( "°" ) );
+  mAngleSpinBox->setSuffix( tr( "°" ) );
   mAngleSpinBox->setSingleStep( 1 );
   mAngleSpinBox->setValue( 0 );
   mAngleSpinBox->setShowClearButton( false );
@@ -65,7 +65,7 @@ QgsAngleMagnetWidget::QgsAngleMagnetWidget( const QString &label, QWidget *paren
   mMagnetSpinBox->setMinimum( 0 );
   mMagnetSpinBox->setMaximum( 180 );
   mMagnetSpinBox->setPrefix( tr( "Snap to " ) );
-  mMagnetSpinBox->setSuffix( trUtf8( "°" ) );
+  mMagnetSpinBox->setSuffix( tr( "°" ) );
   mMagnetSpinBox->setSingleStep( 15 );
   mMagnetSpinBox->setValue( 0 );
   mMagnetSpinBox->setClearValue( 0, tr( "No snapping" ) );

--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -649,27 +649,27 @@ QString QgsUnitTypes::toAbbreviatedString( QgsUnitTypes::AreaUnit unit )
   switch ( unit )
   {
     case AreaSquareMeters:
-      return QObject::trUtf8( "m²", "area" );
+      return QObject::tr( "m²", "area" );
     case AreaSquareKilometers:
-      return QObject::trUtf8( "km²", "area" );
+      return QObject::tr( "km²", "area" );
     case AreaSquareFeet:
-      return QObject::trUtf8( "ft²", "area" );
+      return QObject::tr( "ft²", "area" );
     case AreaSquareYards:
-      return QObject::trUtf8( "yd²", "area" );
+      return QObject::tr( "yd²", "area" );
     case AreaSquareMiles:
-      return QObject::trUtf8( "mi²", "area" );
+      return QObject::tr( "mi²", "area" );
     case AreaHectares:
-      return QObject::trUtf8( "ha", "area" );
+      return QObject::tr( "ha", "area" );
     case AreaAcres:
-      return QObject::trUtf8( "ac²", "area" );
+      return QObject::tr( "ac²", "area" );
     case AreaSquareNauticalMiles:
-      return QObject::trUtf8( "NM²", "area" );
+      return QObject::tr( "NM²", "area" );
     case AreaSquareDegrees:
-      return QObject::trUtf8( "deg²", "area" );
+      return QObject::tr( "deg²", "area" );
     case AreaSquareCentimeters:
-      return QObject::trUtf8( "cm²", "area" );
+      return QObject::tr( "cm²", "area" );
     case AreaSquareMillimeters:
-      return QObject::trUtf8( "mm²", "area" );
+      return QObject::tr( "mm²", "area" );
     case AreaUnknownUnit:
       return QString();
   }
@@ -1346,22 +1346,22 @@ QString QgsUnitTypes::formatAngle( double angle, int decimals, QgsUnitTypes::Ang
   switch ( unit )
   {
     case AngleDegrees:
-      unitLabel = QObject::trUtf8( "°", "angle" );
+      unitLabel = QObject::tr( "°", "angle" );
       break;
     case AngleRadians:
-      unitLabel = QObject::trUtf8( " rad", "angle" );
+      unitLabel = QObject::tr( " rad", "angle" );
       break;
     case AngleGon:
-      unitLabel = QObject::trUtf8( " gon", "angle" );
+      unitLabel = QObject::tr( " gon", "angle" );
       break;
     case AngleMinutesOfArc:
-      unitLabel = QObject::trUtf8( "′", "angle minutes" );
+      unitLabel = QObject::tr( "′", "angle minutes" );
       break;
     case AngleSecondsOfArc:
-      unitLabel = QObject::trUtf8( "″", "angle seconds" );
+      unitLabel = QObject::tr( "″", "angle seconds" );
       break;
     case AngleTurn:
-      unitLabel = QObject::trUtf8( " tr", "angle turn" );
+      unitLabel = QObject::tr( " tr", "angle turn" );
       break;
     case AngleUnknownUnit:
       break;

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -36,7 +36,7 @@ QgsLocatorWidget::QgsLocatorWidget( QWidget *parent )
 {
   mLineEdit->setShowClearButton( true );
 #ifdef Q_OS_MACX
-  mLineEdit->setPlaceholderText( trUtf8( "Type to locate (⌘K)" ) );
+  mLineEdit->setPlaceholderText( tr( "Type to locate (⌘K)" ) );
 #else
   mLineEdit->setPlaceholderText( tr( "Type to locate (Ctrl+K)" ) );
 #endif
@@ -289,7 +289,7 @@ void QgsLocatorWidget::configMenuAboutToShow()
     mMenu->addAction( action );
   }
   mMenu->addSeparator();
-  QAction *configAction = new QAction( trUtf8( "Configure…" ), mMenu );
+  QAction *configAction = new QAction( tr( "Configure…" ), mMenu );
   connect( configAction, &QAction::triggered, this, &QgsLocatorWidget::configTriggered );
   mMenu->addAction( configAction );
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -110,10 +110,10 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
   QActionGroup *angleButtonGroup = new QActionGroup( menu ); // actions are exclusive for common angles
   mCommonAngleActions = QMap<QAction *, int>();
   QList< QPair< int, QString > > commonAngles;
-  commonAngles << QPair<int, QString>( 0, trUtf8( "Do not snap to common angles" ) );
-  commonAngles << QPair<int, QString>( 30, trUtf8( "Snap to 30° angles" ) );
-  commonAngles << QPair<int, QString>( 45, trUtf8( "Snap to 45° angles" ) );
-  commonAngles << QPair<int, QString>( 90, trUtf8( "Snap to 90° angles" ) );
+  commonAngles << QPair<int, QString>( 0, tr( "Do not snap to common angles" ) );
+  commonAngles << QPair<int, QString>( 30, tr( "Snap to 30° angles" ) );
+  commonAngles << QPair<int, QString>( 45, tr( "Snap to 45° angles" ) );
+  commonAngles << QPair<int, QString>( 90, tr( "Snap to 90° angles" ) );
   for ( QList< QPair< int, QString > >::const_iterator it = commonAngles.constBegin(); it != commonAngles.constEnd(); ++it )
   {
     QAction *action = new QAction( it->second, menu );

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -188,7 +188,7 @@ bool QgsNewHttpConnection::validate()
   if ( ! mAuthSettings->password().isEmpty() &&
        QMessageBox::question( this,
                               tr( "Saving Passwords" ),
-                              trUtf8( "WARNING: You have entered a password. It will be stored in unsecured plain text in your project files and your home directory (Unix-like OS) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't provide a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
+                              tr( "WARNING: You have entered a password. It will be stored in unsecured plain text in your project files and your home directory (Unix-like OS) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't provide a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
     return false;

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -538,12 +538,12 @@ QgsPropertyGenericNumericAssistantWidget::QgsPropertyGenericNumericAssistantWidg
     minOutputSpinBox->setValue( 0.0 );
     minOutputSpinBox->setShowClearButton( true );
     minOutputSpinBox->setClearValue( 0.0 );
-    minOutputSpinBox->setSuffix( trUtf8( " °" ) );
+    minOutputSpinBox->setSuffix( tr( " °" ) );
     maxOutputSpinBox->setMaximum( 360.0 );
     maxOutputSpinBox->setValue( 360.0 );
     maxOutputSpinBox->setShowClearButton( true );
     maxOutputSpinBox->setClearValue( 360.0 );
-    maxOutputSpinBox->setSuffix( trUtf8( " °" ) );
+    maxOutputSpinBox->setSuffix( tr( " °" ) );
     exponentSpinBox->hide();
     mExponentLabel->hide();
     mLabelMinOutput->setText( tr( "Angle from" ) );

--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -48,9 +48,9 @@ QgsPalettedRendererWidget::QgsPalettedRendererWidget( QgsRasterLayer *layer, con
   mAdvancedMenu = new QMenu( tr( "Advanced options" ), this );
   QAction *mLoadFromLayerAction = mAdvancedMenu->addAction( tr( "Load classes from layer" ) );
   connect( mLoadFromLayerAction, &QAction::triggered, this, &QgsPalettedRendererWidget::loadFromLayer );
-  QAction *loadFromFile = mAdvancedMenu->addAction( trUtf8( "Load color map from file…" ) );
+  QAction *loadFromFile = mAdvancedMenu->addAction( tr( "Load color map from file…" ) );
   connect( loadFromFile, &QAction::triggered, this, &QgsPalettedRendererWidget::loadColorTable );
-  QAction *exportToFile = mAdvancedMenu->addAction( trUtf8( "Export color map to file…" ) );
+  QAction *exportToFile = mAdvancedMenu->addAction( tr( "Export color map to file…" ) );
   connect( exportToFile, &QAction::triggered, this, &QgsPalettedRendererWidget::saveColorTable );
 
 

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -64,7 +64,7 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent )
   mSplitter->restoreState( settings.value( QStringLiteral( "Windows/StyleV2Manager/splitter" ) ).toByteArray() );
 
   tabItemType->setDocumentMode( true );
-  searchBox->setPlaceholderText( trUtf8( "Filter symbols…" ) );
+  searchBox->setPlaceholderText( tr( "Filter symbols…" ) );
 
   connect( this, &QDialog::finished, this, &QgsStyleManagerDialog::onFinished );
 
@@ -248,7 +248,7 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
 {
   // when in Color Ramp tab, add menu to add item button and hide "Export symbols as PNG/SVG"
   bool flag = currentItemType() != 3;
-  searchBox->setPlaceholderText( flag ? trUtf8( "Filter symbols…" ) : trUtf8( "Filter color ramps…" ) );
+  searchBox->setPlaceholderText( flag ? tr( "Filter symbols…" ) : tr( "Filter color ramps…" ) );
   btnAddItem->setMenu( flag ? nullptr : mMenuBtnAddItemColorRamp );
   actnExportAsPNG->setVisible( flag );
   actnExportAsSVG->setVisible( flag );

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -115,7 +115,7 @@ void QgsPgNewConnection::accept()
   if ( !hasAuthConfigID && mAuthSettings->storePasswordIsChecked( ) &&
        QMessageBox::question( this,
                               tr( "Saving Passwords" ),
-                              trUtf8( "WARNING: You have opted to save your password. It will be stored in unsecured plain text in your project files and in your home directory (Unix-like OS) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't save a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
+                              tr( "WARNING: You have opted to save your password. It will be stored in unsecured plain text in your project files and in your home directory (Unix-like OS) or user profile (Windows). If you want to avoid this, press Cancel and either:\n\na) Don't save a password in the connection settings — it will be requested interactively when needed;\nb) Use the Configuration tab to add your credentials in an HTTP Basic Authentication method and store them in an encrypted database." ),
                               QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
     return;


### PR DESCRIPTION
This method was deprecated in Qt 5.0 - we need to remove its use so that we can turn off the remaining Qt4 compatibility switches.

Refs https://github.com/qgis/QGIS/pull/6282