### PR TITLE
[Server] Removing method based on non-configurable options

### DIFF
--- a/python/server/qgsserverprojectutils.sip.in
+++ b/python/server/qgsserverprojectutils.sip.in
@@ -161,15 +161,6 @@ Returns if layer ids are used as name in WMS.
 :return: if layer ids are used as name.
 %End
 
-  bool wmsInfoFormatSia2045( const QgsProject &project );
-%Docstring
-Returns if the info format is SIA20145.
-
-:param project: the QGIS project
-
-:return: if the info format is SIA20145.
-%End
-
   bool wmsFeatureInfoAddWktGeometry( const QgsProject &project );
 %Docstring
 Returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
@@ -196,43 +187,6 @@ Returns the geometry precision for GetFeatureInfo request.
 
 :return: the geometry precision for GetFeatureInfo request.
 %End
-
-  QString wmsFeatureInfoDocumentElement( const QgsProject &project );
-%Docstring
-Returns the document element name for XML GetFeatureInfo request.
-
-:param project: the QGIS project
-
-:return: the document element name for XML GetFeatureInfo request.
-%End
-
-  QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
-%Docstring
-Returns the document element namespace for XML GetFeatureInfo request.
-
-:param project: the QGIS project
-
-:return: the document element namespace for XML GetFeatureInfo request.
-%End
-
-  QString wmsFeatureInfoSchema( const QgsProject &project );
-%Docstring
-Returns the schema URL for XML GetFeatureInfo request.
-
-:param project: the QGIS project
-
-:return: the schema URL for XML GetFeatureInfo request.
-%End
-
-  QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
-%Docstring
-Returns the mapping between layer name and wms layer name for GetFeatureInfo request.
-
-:param project: the QGIS project
-
-:return: the mapping between layer name and wms layer name for GetFeatureInfo request.
-%End
-
   bool wmsInspireActivate( const QgsProject &project );
 %Docstring
 Returns if Inspire is activated.

--- a/src/server/qgsserverprojectutils.cpp
+++ b/src/server/qgsserverprojectutils.cpp
@@ -110,14 +110,6 @@ int QgsServerProjectUtils::wmsImageQuality( const QgsProject &project )
   return project.readNumEntry( QStringLiteral( "WMSImageQuality" ), QStringLiteral( "/" ), -1 );
 }
 
-bool QgsServerProjectUtils::wmsInfoFormatSia2045( const QgsProject &project )
-{
-  QString sia2045 = project.readEntry( QStringLiteral( "WMSInfoFormatSIA2045" ), QStringLiteral( "/" ), "" );
-
-  return sia2045.compare( QLatin1String( "enabled" ), Qt::CaseInsensitive ) == 0
-         || sia2045.compare( QLatin1String( "true" ), Qt::CaseInsensitive ) == 0;
-}
-
 bool QgsServerProjectUtils::wmsFeatureInfoAddWktGeometry( const QgsProject &project )
 {
   QString wktGeom = project.readEntry( QStringLiteral( "WMSAddWktGeometry" ), QStringLiteral( "/" ), "" );
@@ -137,48 +129,6 @@ bool QgsServerProjectUtils::wmsFeatureInfoSegmentizeWktGeometry( const QgsProjec
 int QgsServerProjectUtils::wmsFeatureInfoPrecision( const QgsProject &project )
 {
   return project.readNumEntry( QStringLiteral( "WMSPrecision" ), QStringLiteral( "/" ), 6 );
-}
-
-QString QgsServerProjectUtils::wmsFeatureInfoDocumentElement( const QgsProject &project )
-{
-  return project.readEntry( QStringLiteral( "WMSFeatureInfoDocumentElement" ), QStringLiteral( "/" ), "" );
-}
-
-QString QgsServerProjectUtils::wmsFeatureInfoDocumentElementNs( const QgsProject &project )
-{
-  return project.readEntry( QStringLiteral( "WMSFeatureInfoDocumentElementNS" ), QStringLiteral( "/" ), "" );
-}
-
-QString QgsServerProjectUtils::wmsFeatureInfoSchema( const QgsProject &project )
-{
-  return project.readEntry( QStringLiteral( "WMSFeatureInfoSchema" ), QStringLiteral( "/" ), "" );
-}
-
-QHash<QString, QString> QgsServerProjectUtils::wmsFeatureInfoLayerAliasMap( const QgsProject &project )
-{
-  QHash<QString, QString> aliasMap;
-
-  //WMSFeatureInfoAliasLayers
-  QStringList aliasLayerStringList = project.readListEntry( QStringLiteral( "WMSFeatureInfoAliasLayers" ), QStringLiteral( "/value" ), QStringList() );
-  if ( aliasLayerStringList.isEmpty() )
-  {
-    return aliasMap;
-  }
-
-  //WMSFeatureInfoLayerAliases
-  QStringList layerAliasStringList = project.readListEntry( QStringLiteral( "WMSFeatureInfoLayerAliases" ), QStringLiteral( "/value" ), QStringList() );
-  if ( layerAliasStringList.isEmpty() )
-  {
-    return aliasMap;
-  }
-
-  int nMapEntries = std::min( aliasLayerStringList.size(), layerAliasStringList.size() );
-  for ( int i = 0; i < nMapEntries; ++i )
-  {
-    aliasMap.insert( aliasLayerStringList.at( i ), layerAliasStringList.at( i ) );
-  }
-
-  return aliasMap;
 }
 
 bool QgsServerProjectUtils::wmsInspireActivate( const QgsProject &project )

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -150,13 +150,6 @@ namespace QgsServerProjectUtils
   SERVER_EXPORT bool wmsUseLayerIds( const QgsProject &project );
 
   /**
-   * Returns if the info format is SIA20145.
-    * \param project the QGIS project
-    * \returns if the info format is SIA20145.
-    */
-  SERVER_EXPORT bool wmsInfoFormatSia2045( const QgsProject &project );
-
-  /**
    * Returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
     * \param project the QGIS project
     * \returns if the geometry is displayed as Well Known Text in GetFeatureInfo request.
@@ -176,34 +169,6 @@ namespace QgsServerProjectUtils
     * \returns the geometry precision for GetFeatureInfo request.
     */
   SERVER_EXPORT int wmsFeatureInfoPrecision( const QgsProject &project );
-
-  /**
-   * Returns the document element name for XML GetFeatureInfo request.
-    * \param project the QGIS project
-    * \returns the document element name for XML GetFeatureInfo request.
-    */
-  SERVER_EXPORT QString wmsFeatureInfoDocumentElement( const QgsProject &project );
-
-  /**
-   * Returns the document element namespace for XML GetFeatureInfo request.
-    * \param project the QGIS project
-    * \returns the document element namespace for XML GetFeatureInfo request.
-    */
-  SERVER_EXPORT QString wmsFeatureInfoDocumentElementNs( const QgsProject &project );
-
-  /**
-   * Returns the schema URL for XML GetFeatureInfo request.
-    * \param project the QGIS project
-    * \returns the schema URL for XML GetFeatureInfo request.
-    */
-  SERVER_EXPORT QString wmsFeatureInfoSchema( const QgsProject &project );
-
-  /**
-   * Returns the mapping between layer name and wms layer name for GetFeatureInfo request.
-    * \param project the QGIS project
-    * \returns the mapping between layer name and wms layer name for GetFeatureInfo request.
-    */
-  SERVER_EXPORT QHash<QString, QString> wmsFeatureInfoLayerAliasMap( const QgsProject &project );
 
   /**
    * Returns if Inspire is activated.

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -819,7 +819,6 @@ namespace QgsWms
                                     bool projectSettings )
     {
       bool useLayerIds = QgsServerProjectUtils::wmsUseLayerIds( *project );
-      bool siaFormat = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
       QStringList restrictedLayers = QgsServerProjectUtils::wmsRestrictedLayers( *project );
 
       QList< QgsLayerTreeNode * > layerTreeGroupChildren = layerTreeGroup->children();
@@ -961,10 +960,6 @@ namespace QgsWms
               QDomElement keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
               QDomText keywordText = doc.createTextNode( keywordStringList.at( i ).trimmed() );
               keywordElem.appendChild( keywordText );
-              if ( siaFormat )
-              {
-                keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
-              }
               keywordListElem.appendChild( keywordElem );
             }
             layerElem.appendChild( keywordListElem );
@@ -1741,7 +1736,6 @@ namespace QgsWms
 
     void addKeywordListElement( const QgsProject *project, QDomDocument &doc, QDomElement &parent )
     {
-      bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
 
       QDomElement keywordsElem = doc.createElement( QStringLiteral( "KeywordList" ) );
       //add default keyword
@@ -1759,10 +1753,6 @@ namespace QgsWms
           keywordElem = doc.createElement( QStringLiteral( "Keyword" ) );
           keywordText = doc.createTextNode( keyword );
           keywordElem.appendChild( keywordText );
-          if ( sia2045 )
-          {
-            keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
-          }
           keywordsElem.appendChild( keywordElem );
         }
       }

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -135,8 +135,6 @@ namespace QgsWms
       QStringList keywords = QgsServerProjectUtils::owsServiceKeywords( *project );
       if ( !keywords.isEmpty() )
       {
-        bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
-
         QDomElement keywordsElem = doc.createElement( QStringLiteral( "ows:Keywords" ) );
 
         for ( int i = 0; i < keywords.size(); ++i )
@@ -147,10 +145,6 @@ namespace QgsWms
             QDomElement keywordElem = doc.createElement( QStringLiteral( "ows:Keyword" ) );
             QDomText keywordText = doc.createTextNode( keyword );
             keywordElem.appendChild( keywordText );
-            if ( sia2045 )
-            {
-              keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
-            }
             keywordsElem.appendChild( keywordElem );
           }
         }
@@ -355,7 +349,6 @@ namespace QgsWms
           if ( !l->keywordList().isEmpty() )
           {
             QStringList keywordStringList = l->keywordList().split( ',' );
-            bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *project );
 
             QDomElement keywordsElem = doc.createElement( QStringLiteral( "ows:Keywords" ) );
             for ( int i = 0; i < keywordStringList.size(); ++i )
@@ -363,10 +356,6 @@ namespace QgsWms
               QDomElement keywordElem = doc.createElement( QStringLiteral( "ows:Keyword" ) );
               QDomText keywordText = doc.createTextNode( keywordStringList.at( i ).trimmed() );
               keywordElem.appendChild( keywordText );
-              if ( sia2045 )
-              {
-                keywordElem.setAttribute( QStringLiteral( "vocabulary" ), QStringLiteral( "SIA_Geo405" ) );
-              }
               keywordsElem.appendChild( keywordElem );
             }
             layerElem.appendChild( keywordsElem );

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1187,37 +1187,12 @@ namespace QgsWms
     }
     else
     {
-      QString featureInfoElemName = QgsServerProjectUtils::wmsFeatureInfoDocumentElement( *mProject );
-      if ( featureInfoElemName.isEmpty() )
-      {
-        featureInfoElemName = QStringLiteral( "GetFeatureInfoResponse" );
-      }
-      QString featureInfoElemNs = QgsServerProjectUtils::wmsFeatureInfoDocumentElementNs( *mProject );
-      if ( featureInfoElemNs.isEmpty() )
-      {
-        getFeatureInfoElement = result.createElement( featureInfoElemName );
-      }
-      else
-      {
-        getFeatureInfoElement = result.createElementNS( featureInfoElemNs, featureInfoElemName );
-      }
-      //feature info schema
-      QString featureInfoSchema = QgsServerProjectUtils::wmsFeatureInfoSchema( *mProject );
-      if ( !featureInfoSchema.isEmpty() )
-      {
-        getFeatureInfoElement.setAttribute( QStringLiteral( "xmlns:xsi" ), QStringLiteral( "http://www.w3.org/2001/XMLSchema-instance" ) );
-        getFeatureInfoElement.setAttribute( QStringLiteral( "xsi:schemaLocation" ), featureInfoSchema );
-      }
+      getFeatureInfoElement = result.createElement( QStringLiteral( "GetFeatureInfoResponse" ) );
     }
     result.appendChild( getFeatureInfoElement );
 
     //Render context is needed to determine feature visibility for vector layers
     QgsRenderContext renderContext = QgsRenderContext::fromMapSettings( mapSettings );
-
-    bool sia2045 = QgsServerProjectUtils::wmsInfoFormatSia2045( *mProject );
-
-    //layers can have assigned a different name for GetCapabilities
-    QHash<QString, QString> layerAliasMap = QgsServerProjectUtils::wmsFeatureInfoLayerAliasMap( *mProject );
 
     Q_FOREACH ( QString queryLayer, queryLayers )
     {
@@ -1238,19 +1213,8 @@ namespace QgsWms
             layerElement = result.createElement( QStringLiteral( "Layer" ) );
             QString layerName = queryLayer;
 
-            //check if the layer is given a different name for GetFeatureInfo output
-            QHash<QString, QString>::const_iterator layerAliasIt = layerAliasMap.find( layerName );
-            if ( layerAliasIt != layerAliasMap.constEnd() )
-            {
-              layerName = layerAliasIt.value();
-            }
-
             layerElement.setAttribute( QStringLiteral( "name" ), layerName );
             getFeatureInfoElement.appendChild( layerElement );
-            if ( sia2045 ) //the name might not be unique after alias replacement
-            {
-              layerElement.setAttribute( QStringLiteral( "id" ), layer->id() );
-            }
           }
 
           if ( layer->type() == QgsMapLayer::VectorLayer )
@@ -1331,11 +1295,6 @@ namespace QgsWms
         bBoxElem.setAttribute( QStringLiteral( "maxy" ), qgsDoubleToString( featuresRect->yMaximum(), 8 ) );
         getFeatureInfoElement.insertBefore( bBoxElem, QDomNode() ); //insert as first child
       }
-    }
-
-    if ( sia2045 && infoFormat == QgsWmsParameters::Format::XML )
-    {
-      convertFeatureInfoToSia2045( result );
     }
 
     return result;
@@ -1839,121 +1798,6 @@ namespace QgsWms
       return false;
 
     return true;
-  }
-
-  void QgsRenderer::convertFeatureInfoToSia2045( QDomDocument &doc ) const
-  {
-    QDomDocument SIAInfoDoc;
-    QDomElement infoDocElement = doc.documentElement();
-    QDomElement SIAInfoDocElement = SIAInfoDoc.importNode( infoDocElement, false ).toElement();
-    SIAInfoDoc.appendChild( SIAInfoDocElement );
-
-    QString currentAttributeName;
-    QString currentAttributeValue;
-    QDomElement currentAttributeElem;
-    QString currentLayerName;
-    QDomElement currentLayerElem;
-    QDomNodeList layerNodeList = infoDocElement.elementsByTagName( QStringLiteral( "Layer" ) );
-    for ( int i = 0; i < layerNodeList.size(); ++i )
-    {
-      currentLayerElem = layerNodeList.at( i ).toElement();
-      currentLayerName = currentLayerElem.attribute( QStringLiteral( "name" ) );
-
-      QDomElement currentFeatureElem;
-
-      QDomNodeList featureList = currentLayerElem.elementsByTagName( QStringLiteral( "Feature" ) );
-      if ( featureList.isEmpty() )
-      {
-        //raster?
-        QDomNodeList attributeList = currentLayerElem.elementsByTagName( QStringLiteral( "Attribute" ) );
-        QDomElement rasterLayerElem;
-        if ( !attributeList.isEmpty() )
-        {
-          rasterLayerElem = SIAInfoDoc.createElement( currentLayerName );
-        }
-        for ( int j = 0; j < attributeList.size(); ++j )
-        {
-          currentAttributeElem = attributeList.at( j ).toElement();
-          currentAttributeName = currentAttributeElem.attribute( QStringLiteral( "name" ) );
-          currentAttributeValue = currentAttributeElem.attribute( QStringLiteral( "value" ) );
-          QDomElement outAttributeElem = SIAInfoDoc.createElement( currentAttributeName );
-          QDomText outAttributeText = SIAInfoDoc.createTextNode( currentAttributeValue );
-          outAttributeElem.appendChild( outAttributeText );
-          rasterLayerElem.appendChild( outAttributeElem );
-        }
-        if ( !attributeList.isEmpty() )
-        {
-          SIAInfoDocElement.appendChild( rasterLayerElem );
-        }
-      }
-      else //vector
-      {
-        //property attributes
-        QSet<QString> layerPropertyAttributes;
-        QString currentLayerId = currentLayerElem.attribute( QStringLiteral( "id" ) );
-        if ( !currentLayerId.isEmpty() )
-        {
-          QgsMapLayer *currentLayer = mProject->mapLayer( currentLayerId );
-          if ( currentLayer )
-          {
-            QString WMSPropertyAttributesString = currentLayer->customProperty( QStringLiteral( "WMSPropertyAttributes" ) ).toString();
-            if ( !WMSPropertyAttributesString.isEmpty() )
-            {
-              QStringList propertyList = WMSPropertyAttributesString.split( QStringLiteral( "//" ) );
-              for ( auto propertyIt = propertyList.constBegin() ; propertyIt != propertyList.constEnd(); ++propertyIt )
-              {
-                layerPropertyAttributes.insert( *propertyIt );
-              }
-            }
-          }
-        }
-
-        QDomElement propertyRefChild; //child to insert the next property after (or
-        for ( int j = 0; j < featureList.size(); ++j )
-        {
-          QDomElement SIAFeatureElem = SIAInfoDoc.createElement( currentLayerName );
-          currentFeatureElem = featureList.at( j ).toElement();
-          QDomNodeList attributeList = currentFeatureElem.elementsByTagName( QStringLiteral( "Attribute" ) );
-
-          for ( int k = 0; k < attributeList.size(); ++k )
-          {
-            currentAttributeElem = attributeList.at( k ).toElement();
-            currentAttributeName = currentAttributeElem.attribute( QStringLiteral( "name" ) );
-            currentAttributeValue = currentAttributeElem.attribute( QStringLiteral( "value" ) );
-            if ( layerPropertyAttributes.contains( currentAttributeName ) )
-            {
-              QDomElement propertyElem = SIAInfoDoc.createElement( QStringLiteral( "property" ) );
-              QDomElement identifierElem = SIAInfoDoc.createElement( QStringLiteral( "identifier" ) );
-              QDomText identifierText = SIAInfoDoc.createTextNode( currentAttributeName );
-              identifierElem.appendChild( identifierText );
-              QDomElement valueElem = SIAInfoDoc.createElement( QStringLiteral( "value" ) );
-              QDomText valueText = SIAInfoDoc.createTextNode( currentAttributeValue );
-              valueElem.appendChild( valueText );
-              propertyElem.appendChild( identifierElem );
-              propertyElem.appendChild( valueElem );
-              if ( propertyRefChild.isNull() )
-              {
-                SIAFeatureElem.insertBefore( propertyElem, QDomNode() );
-                propertyRefChild = propertyElem;
-              }
-              else
-              {
-                SIAFeatureElem.insertAfter( propertyElem, propertyRefChild );
-              }
-            }
-            else
-            {
-              QDomElement SIAAttributeElem = SIAInfoDoc.createElement( currentAttributeName );
-              QDomText SIAAttributeText = SIAInfoDoc.createTextNode( currentAttributeValue );
-              SIAAttributeElem.appendChild( SIAAttributeText );
-              SIAFeatureElem.appendChild( SIAAttributeElem );
-            }
-          }
-          SIAInfoDocElement.appendChild( SIAFeatureElem );
-        }
-      }
-    }
-    doc = SIAInfoDoc;
   }
 
   QByteArray QgsRenderer::convertFeatureInfoToHtml( const QDomDocument &doc ) const

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -252,9 +252,6 @@ namespace QgsWms
         \returns true if width/height values are okay*/
       bool checkMaximumWidthHeight() const;
 
-      //! Converts a feature info xml document to SIA2045 norm
-      void convertFeatureInfoToSia2045( QDomDocument &doc ) const;
-
       //! Converts a feature info xml document to HTML
       QByteArray convertFeatureInfoToHtml( const QDomDocument &doc ) const;
 


### PR DESCRIPTION
Some options used by the server are not configurable in the QGIS project, so I remove the method and code associated.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
