### PR TITLE
Delim text ui crs

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -203,6 +203,12 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
   // add the layer to the map
   emit addVectorLayer( QString::fromLatin1( url.toEncoded() ), txtLayerName->text() );
+
+  // clear the file and layer name show something has happened, ready for another file
+
+  mFileWidget->setFilePath( QString() );
+  txtLayerName->setText( QString() );
+
   if ( widgetMode() == QgsProviderRegistry::WidgetMode::None )
   {
     accept();

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -154,7 +154,7 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
     url.addQueryItem( QStringLiteral( "xyDms" ), QStringLiteral( "yes" ) );
   }
 
-  bool haveGeom=true;
+  bool haveGeom = true;
   if ( geomTypeXY->isChecked() )
   {
     if ( !cmbXField->currentText().isEmpty() && !cmbYField->currentText().isEmpty() )
@@ -179,15 +179,15 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
   }
   else
   {
-    haveGeom=false;
+    haveGeom = false;
     url.addQueryItem( QStringLiteral( "geomType" ), QStringLiteral( "none" ) );
   }
-  if( haveGeom )
+  if ( haveGeom )
   {
-    QgsCoordinateReferenceSystem crs=crsGeometry->crs();
-    if( crs.isValid() )
+    QgsCoordinateReferenceSystem crs = crsGeometry->crs();
+    if ( crs.isValid() )
     {
-        url.addQueryItem( QStringLiteral( "crs" ), crs.authid() );
+      url.addQueryItem( QStringLiteral( "crs" ), crs.authid() );
     }
 
   }
@@ -299,11 +299,11 @@ void QgsDelimitedTextSourceSelect::loadSettings( const QString &subkey, bool loa
     else geomTypeNone->setChecked( true );
     cbxXyDms->setChecked( settings.value( key + "/xyDms", "false" ) == "true" );
     swGeomType->setCurrentIndex( bgGeomType->checkedId() );
-    QString authid=settings.value(key+"/crs","").toString();
-    QgsCoordinateReferenceSystem crs=QgsCoordinateReferenceSystem::fromOgcWmsCrs(authid);
-    if( crs.isValid() )
+    QString authid = settings.value( key + "/crs", "" ).toString();
+    QgsCoordinateReferenceSystem crs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( authid );
+    if ( crs.isValid() )
     {
-        crsGeometry->setCrs(crs);
+      crsGeometry->setCrs( crs );
     }
   }
 
@@ -342,9 +342,9 @@ void QgsDelimitedTextSourceSelect::saveSettings( const QString &subkey, bool sav
     if ( geomTypeWKT->isChecked() ) geomColumnType = QStringLiteral( "wkt" );
     settings.setValue( key + "/geomColumnType", geomColumnType );
     settings.setValue( key + "/xyDms", cbxXyDms->isChecked() ? "true" : "false" );
-    if( crsGeometry->crs().isValid() )
+    if ( crsGeometry->crs().isValid() )
     {
-        settings.setValue( key + "/crs", crsGeometry->crs().authid());
+      settings.setValue( key + "/crs", crsGeometry->crs().authid() );
     }
   }
 
@@ -732,7 +732,7 @@ bool QgsDelimitedTextSourceSelect::validate()
   {
     message = tr( "The WKT field name must be selected" );
   }
-  else if ( ! geomTypeNone->isChecked() && ! crsGeometry->crs().isValid() ) 
+  else if ( ! geomTypeNone->isChecked() && ! crsGeometry->crs().isValid() )
   {
     message = tr( "The CRS must be selected" );
   }

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -118,19 +118,6 @@
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
          <widget class="QLabel" name="lblEncoding">
           <property name="text">
            <string>Encoding</string>

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -79,7 +79,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QgsFileWidget" name="mFileWidget" native="true"/>
+         <widget class="QgsFileWidget" name="mFileWidget"/>
         </item>
        </layout>
       </item>
@@ -180,8 +180,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>704</width>
-        <height>694</height>
+        <width>714</width>
+        <height>514</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -202,7 +202,7 @@
          <property name="title">
           <string>File format</string>
          </property>
-         <property name="collapsed" stdset="0">
+         <property name="collapsed">
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_8">
@@ -384,6 +384,9 @@
                        <property name="alignment">
                         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                        </property>
+                       <property name="buddy">
+                        <cstring>txtDelimiterOther</cstring>
+                       </property>
                       </widget>
                      </item>
                      <item>
@@ -507,6 +510,9 @@
                      <property name="alignment">
                       <set>Qt::AlignJustify|Qt::AlignVCenter</set>
                      </property>
+                     <property name="buddy">
+                      <cstring>txtQuoteChars</cstring>
+                     </property>
                     </widget>
                    </item>
                    <item>
@@ -560,6 +566,9 @@
                      </property>
                      <property name="alignment">
                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                     </property>
+                     <property name="buddy">
+                      <cstring>txtEscapeChars</cstring>
                      </property>
                     </widget>
                    </item>
@@ -684,7 +693,7 @@
          <property name="title">
           <string>Record and fields options</string>
          </property>
-         <property name="collapsed" stdset="0">
+         <property name="collapsed">
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_7">
@@ -703,6 +712,9 @@
               </property>
               <property name="text">
                <string>Number of header lines to discard</string>
+              </property>
+              <property name="buddy">
+               <cstring>rowCounter</cstring>
               </property>
              </widget>
             </item>
@@ -826,7 +838,7 @@
          <property name="title">
           <string>Geometry definition</string>
          </property>
-         <property name="collapsed" stdset="0">
+         <property name="collapsed">
           <bool>true</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout">
@@ -1004,6 +1016,9 @@
                   <property name="alignment">
                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                   </property>
+                  <property name="buddy">
+                   <cstring>cmbXField</cstring>
+                  </property>
                  </widget>
                 </item>
                 <item row="2" column="0">
@@ -1019,6 +1034,9 @@
                   </property>
                   <property name="text">
                    <string>&lt;p align=&quot;left&quot;&gt;Y field&lt;/p&gt;</string>
+                  </property>
+                  <property name="buddy">
+                   <cstring>cmbYField</cstring>
                   </property>
                  </widget>
                 </item>
@@ -1127,6 +1145,19 @@
             <widget class="QWidget" name="swpGeomNone"/>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="textLabelCrs">
+            <property name="text">
+             <string>Geometry CRS</string>
+            </property>
+            <property name="buddy">
+             <cstring>crsGeometry</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QgsProjectionSelectionWidget" name="crsGeometry"/>
+          </item>
          </layout>
         </widget>
        </item>
@@ -1141,7 +1172,7 @@
          <property name="title">
           <string>Layer settings</string>
          </property>
-         <property name="collapsed" stdset="0">
+         <property name="collapsed">
           <bool>true</bool>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -1289,14 +1320,50 @@
    <extends>QWidget</extends>
    <header>qgsfilewidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>txtLayerName</tabstop>
   <tabstop>cmbEncoding</tabstop>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>fileFormatGroupBox</tabstop>
+  <tabstop>delimiterCSV</tabstop>
+  <tabstop>delimiterRegexp</tabstop>
+  <tabstop>delimiterChars</tabstop>
+  <tabstop>cbxDelimTab</tabstop>
+  <tabstop>cbxDelimColon</tabstop>
+  <tabstop>cbxDelimSpace</tabstop>
+  <tabstop>cbxDelimSemicolon</tabstop>
+  <tabstop>cbxDelimComma</tabstop>
+  <tabstop>txtDelimiterOther</tabstop>
+  <tabstop>txtQuoteChars</tabstop>
+  <tabstop>txtEscapeChars</tabstop>
+  <tabstop>recordOptionsGroupBox</tabstop>
+  <tabstop>rowCounter</tabstop>
+  <tabstop>cbxUseHeader</tabstop>
   <tabstop>cbxPointIsComma</tabstop>
+  <tabstop>cbxTrimFields</tabstop>
+  <tabstop>cbxSkipEmptyFields</tabstop>
+  <tabstop>geometryDefinitionGroupBox</tabstop>
+  <tabstop>geomTypeXY</tabstop>
+  <tabstop>geomTypeWKT</tabstop>
   <tabstop>geomTypeNone</tabstop>
+  <tabstop>cmbXField</tabstop>
+  <tabstop>cmbYField</tabstop>
+  <tabstop>cbxXyDms</tabstop>
+  <tabstop>crsGeometry</tabstop>
+  <tabstop>layeSettingsGroupBox</tabstop>
   <tabstop>cbxSpatialIndex</tabstop>
   <tabstop>cbxSubsetIndex</tabstop>
+  <tabstop>cbxWatchFile</tabstop>
+  <tabstop>tblSample</tabstop>
+  <tabstop>cmbWktField</tabstop>
+  <tabstop>cmbGeometryType</tabstop>
+  <tabstop>txtDelimiterRegexp</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
## Description
Two commits to enhance the source UI for the delimited text provider to improve the user experience

* Added CRS selector to provider widget to improve workflow.  Otherwise adding layer can invoke CRS selection which adds extra dialog and step to process, and is clumsy
* Cleared the selected file after a layer is added (or at least after the addVectorLayer signal is emitted).  This makes it more obvious to the user that something has happened when the layer is added.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] ;Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] N/A New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

Note 1: commit adding CRS selection to delimited text source widget may require small documentation update.  Commit message was written and pushed before seeing request for [needs-docs] in message
Note: built on 16.04 for which astyle.sh does not work using default version of astyle - complains that it needs version 3.0 or greater.