### PR TITLE
Horizontal space at value relation widget at multiple selection

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -27,6 +27,10 @@ QgsValueRelationConfigDlg::QgsValueRelationConfigDlg( QgsVectorLayer *vl, int fi
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, mValueColumn, &QgsFieldComboBox::setLayer );
   connect( mEditExpression, &QAbstractButton::clicked, this, &QgsValueRelationConfigDlg::editExpression );
 
+  mNofColumns->setMinimum( 1 );
+  mNofColumns->setMaximum( 10 );
+  mNofColumns->setValue( 1 );
+
   connect( mLayerName, &QgsMapLayerComboBox::layerChanged, this, &QgsEditorConfigWidget::changed );
   connect( mKeyColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
   connect( mValueColumn, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsEditorConfigWidget::changed );
@@ -35,6 +39,14 @@ QgsValueRelationConfigDlg::QgsValueRelationConfigDlg( QgsVectorLayer *vl, int fi
   connect( mOrderByValue, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
   connect( mFilterExpression, &QTextEdit::textChanged, this, &QgsEditorConfigWidget::changed );
   connect( mUseCompleter, &QAbstractButton::toggled, this, &QgsEditorConfigWidget::changed );
+  connect( mAllowMulti, &QAbstractButton::toggled, this, [ = ]( bool checked )
+  {
+    label_nofColumns->setEnabled( checked );
+    mNofColumns->setEnabled( checked );
+  }
+         );
+
+  connect( mNofColumns, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsEditorConfigWidget::changed );
 }
 
 QVariantMap QgsValueRelationConfigDlg::config()
@@ -45,6 +57,7 @@ QVariantMap QgsValueRelationConfigDlg::config()
   cfg.insert( QStringLiteral( "Key" ), mKeyColumn->currentField() );
   cfg.insert( QStringLiteral( "Value" ), mValueColumn->currentField() );
   cfg.insert( QStringLiteral( "AllowMulti" ), mAllowMulti->isChecked() );
+  cfg.insert( QStringLiteral( "NofColumns" ), mNofColumns->value() );
   cfg.insert( QStringLiteral( "AllowNull" ), mAllowNull->isChecked() );
   cfg.insert( QStringLiteral( "OrderByValue" ), mOrderByValue->isChecked() );
   cfg.insert( QStringLiteral( "FilterExpression" ), mFilterExpression->toPlainText() );
@@ -60,6 +73,12 @@ void QgsValueRelationConfigDlg::setConfig( const QVariantMap &config )
   mKeyColumn->setField( config.value( QStringLiteral( "Key" ) ).toString() );
   mValueColumn->setField( config.value( QStringLiteral( "Value" ) ).toString() );
   mAllowMulti->setChecked( config.value( QStringLiteral( "AllowMulti" ) ).toBool() );
+  mNofColumns->setValue( config.value( QStringLiteral( "NofColumns" ), 1 ).toInt() );
+  if ( !mAllowMulti->isChecked() )
+  {
+    label_nofColumns->setEnabled( false );
+    mNofColumns->setEnabled( false );
+  }
   mAllowNull->setChecked( config.value( QStringLiteral( "AllowNull" ) ).toBool() );
   mOrderByValue->setChecked( config.value( QStringLiteral( "OrderByValue" ) ).toBool() );
   mFilterExpression->setPlainText( config.value( QStringLiteral( "FilterExpression" ) ).toString() );

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -54,19 +54,6 @@ QVariant QgsValueRelationSearchWidgetWrapper::value() const
     }
   }
 
-  if ( mListWidget )
-  {
-    QStringList selection;
-    for ( int i = 0; i < mListWidget->count(); ++i )
-    {
-      QListWidgetItem *item = mListWidget->item( i );
-      if ( item->checkState() == Qt::Checked )
-        selection << item->data( Qt::UserRole ).toString();
-    }
-
-    v = selection.join( QStringLiteral( "," ) ).prepend( '{' ).append( '}' );
-  }
-
   if ( mLineEdit )
   {
     Q_FOREACH ( const QgsValueRelationFieldFormatter::ValueRelationItem &i, mCache )
@@ -141,10 +128,6 @@ void QgsValueRelationSearchWidgetWrapper::clearWidget()
   {
     mComboBox->setCurrentIndex( 0 );
   }
-  if ( mListWidget )
-  {
-    mListWidget->clearSelection();
-  }
   if ( mLineEdit )
   {
     mLineEdit->setText( QString() );
@@ -156,10 +139,6 @@ void QgsValueRelationSearchWidgetWrapper::setEnabled( bool enabled )
   if ( mComboBox )
   {
     mComboBox->setEnabled( enabled );
-  }
-  if ( mListWidget )
-  {
-    mListWidget->setEnabled( enabled );
   }
   if ( mLineEdit )
   {
@@ -231,7 +210,6 @@ void QgsValueRelationSearchWidgetWrapper::initWidget( QWidget *editor )
   mCache = QgsValueRelationFieldFormatter::createCache( config() );
 
   mComboBox = qobject_cast<QComboBox *>( editor );
-  mListWidget = qobject_cast<QListWidget *>( editor );
   mLineEdit = qobject_cast<QLineEdit *>( editor );
 
   if ( mComboBox )
@@ -248,18 +226,6 @@ void QgsValueRelationSearchWidgetWrapper::initWidget( QWidget *editor )
     }
 
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsValueRelationSearchWidgetWrapper::onValueChanged );
-  }
-  else if ( mListWidget )
-  {
-    Q_FOREACH ( const QgsValueRelationFieldFormatter::ValueRelationItem &element, mCache )
-    {
-      QListWidgetItem *item = nullptr;
-      item = new QListWidgetItem( element.value );
-      item->setData( Qt::UserRole, element.key );
-
-      mListWidget->addItem( item );
-    }
-    connect( mListWidget, &QListWidget::itemChanged, this, &QgsValueRelationSearchWidgetWrapper::onValueChanged );
   }
   else if ( mLineEdit )
   {

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.h
@@ -21,7 +21,6 @@
 #include "qgsvaluerelationfieldformatter.h"
 
 #include <QComboBox>
-#include <QListWidget>
 #include <QLineEdit>
 #include "qgis_gui.h"
 
@@ -65,7 +64,6 @@ class GUI_EXPORT QgsValueRelationSearchWidgetWrapper : public QgsSearchWidgetWra
 
   private:
     QComboBox *mComboBox = nullptr;
-    QListWidget *mListWidget = nullptr;
     QLineEdit *mLineEdit = nullptr;
 
     QgsValueRelationFieldFormatter::ValueRelationCache mCache;

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -23,8 +23,11 @@
 #include "qgsfilterlineedit.h"
 #include "qgsfeatureiterator.h"
 #include "qgsvaluerelationfieldformatter.h"
-#include "qgslogger.h"
 
+#include <QHeaderView>
+#include <QComboBox>
+#include <QLineEdit>
+#include <QTableWidget>
 #include <QStringListModel>
 #include <QCompleter>
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -23,6 +23,7 @@
 #include "qgsfilterlineedit.h"
 #include "qgsfeatureiterator.h"
 #include "qgsvaluerelationfieldformatter.h"
+#include "qgslogger.h"
 
 #include <QStringListModel>
 #include <QCompleter>
@@ -46,16 +47,21 @@ QVariant QgsValueRelationWidgetWrapper::value() const
     }
   }
 
-  if ( mListWidget )
+  if ( mTableWidget )
   {
     QStringList selection;
-    for ( int i = 0; i < mListWidget->count(); ++i )
+    for ( int j = 0; j < mTableWidget->rowCount(); j++ )
     {
-      QListWidgetItem *item = mListWidget->item( i );
-      if ( item->checkState() == Qt::Checked )
-        selection << item->data( Qt::UserRole ).toString();
+      for ( int i = 0; i < config( QStringLiteral( "NofColumns" ) ).toInt(); ++i )
+      {
+        QTableWidgetItem *item = mTableWidget->item( j, i );
+        if ( item )
+        {
+        if ( item->checkState() == Qt::Checked )
+          selection << item->data( Qt::UserRole ).toString();
+        }
+      }
     }
-
     v = selection.join( QStringLiteral( "," ) ).prepend( '{' ).append( '}' );
   }
 
@@ -78,7 +84,7 @@ QWidget *QgsValueRelationWidgetWrapper::createWidget( QWidget *parent )
 {
   if ( config( QStringLiteral( "AllowMulti" ) ).toBool() )
   {
-    return new QListWidget( parent );
+    return new QTableWidget( parent );
   }
   else if ( config( QStringLiteral( "UseCompleter" ) ).toBool() )
   {
@@ -94,7 +100,7 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
   mCache = QgsValueRelationFieldFormatter::createCache( config() );
 
   mComboBox = qobject_cast<QComboBox *>( editor );
-  mListWidget = qobject_cast<QListWidget *>( editor );
+  mTableWidget = qobject_cast<QTableWidget *>( editor );
   mLineEdit = qobject_cast<QLineEdit *>( editor );
 
   if ( mComboBox )
@@ -112,17 +118,39 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ),
              this, static_cast<void ( QgsEditorWidgetWrapper::* )()>( &QgsEditorWidgetWrapper::emitValueChanged ) );
   }
-  else if ( mListWidget )
+  else if ( mTableWidget )
   {
-    Q_FOREACH ( const QgsValueRelationFieldFormatter::ValueRelationItem &element, mCache )
-    {
-      QListWidgetItem *item = nullptr;
-      item = new QListWidgetItem( element.value );
-      item->setData( Qt::UserRole, element.key );
+    mTableWidget->horizontalHeader()->setResizeMode( QHeaderView::Stretch );
+    mTableWidget->horizontalHeader()->setVisible( false );
+    mTableWidget->verticalHeader()->setResizeMode( QHeaderView::Stretch );
+    mTableWidget->verticalHeader()->setVisible( false );
+    mTableWidget->setShowGrid( false );
+    mTableWidget->setEditTriggers( QAbstractItemView::NoEditTriggers );
+    mTableWidget->setSelectionMode( QAbstractItemView::NoSelection );
+    if ( mCache.size() > 0 )
+      mTableWidget->setRowCount( ( mCache.size() + config( QStringLiteral( "NofColumns" ) ).toInt() - 1 ) / config( QStringLiteral( "NofColumns" ) ).toInt() );
+    else
+      mTableWidget->setRowCount( 1 );
+    if ( config( QStringLiteral( "NofColumns" ) ).toInt() > 0 )
+      mTableWidget->setColumnCount( config( QStringLiteral( "NofColumns" ) ).toInt() );
+    else
+      mTableWidget->setColumnCount( 1 );
 
-      mListWidget->addItem( item );
+    int row = 0, column = 0;
+    for ( const QgsValueRelationFieldFormatter::ValueRelationItem &element : qgis::as_const( mCache ) )
+    {
+      if ( column == config( QStringLiteral( "NofColumns" ) ).toInt() )
+      {
+        row++;
+        column = 0;
+      }
+      QTableWidgetItem *item = nullptr;
+      item = new QTableWidgetItem( element.value );
+      item->setData( Qt::UserRole, element.key );
+      mTableWidget->setItem( row, column, item );
+      column++;
     }
-    connect( mListWidget, &QListWidget::itemChanged, this, static_cast<void ( QgsEditorWidgetWrapper::* )()>( &QgsEditorWidgetWrapper::emitValueChanged ) );
+    connect( mTableWidget, &QTableWidget::itemChanged, this, static_cast<void ( QgsEditorWidgetWrapper::* )()>( &QgsEditorWidgetWrapper::emitValueChanged ) );
   }
   else if ( mLineEdit )
   {
@@ -144,12 +172,12 @@ void QgsValueRelationWidgetWrapper::initWidget( QWidget *editor )
 
 bool QgsValueRelationWidgetWrapper::valid() const
 {
-  return mListWidget || mLineEdit || mComboBox;
+  return mTableWidget || mLineEdit || mComboBox;
 }
 
 void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
 {
-  if ( mListWidget )
+  if ( mTableWidget )
   {
     QStringList checkList;
     if ( value.type() == QVariant::StringList )
@@ -157,10 +185,16 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
     else if ( value.type() == QVariant::String )
       checkList = value.toString().remove( QChar( '{' ) ).remove( QChar( '}' ) ).split( ',' );
 
-    for ( int i = 0; i < mListWidget->count(); ++i )
+    for ( int j = 0; j < mTableWidget->rowCount(); j++ )
     {
-      QListWidgetItem *item = mListWidget->item( i );
-      item->setCheckState( checkList.contains( item->data( Qt::UserRole ).toString() ) ? Qt::Checked : Qt::Unchecked );
+      for ( int i = 0; i < config( QStringLiteral( "NofColumns" ) ).toInt() ; ++i )
+      {
+        QTableWidgetItem *item = mTableWidget->item( j, i );
+        if ( item )
+        {
+          item->setCheckState( checkList.contains( item->data( Qt::UserRole ).toString() ) ? Qt::Checked : Qt::Unchecked );
+        }
+      }
     }
   }
   else if ( mComboBox )
@@ -182,14 +216,17 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
 
 void QgsValueRelationWidgetWrapper::showIndeterminateState()
 {
-  if ( mListWidget )
+  if ( mTableWidget )
   {
-    mListWidget->blockSignals( true );
-    for ( int i = 0; i < mListWidget->count(); ++i )
+    mTableWidget->blockSignals( true );
+    for ( int j = 0; j < mTableWidget->rowCount(); j++ )
     {
-      mListWidget->item( i )->setCheckState( Qt::PartiallyChecked );
+      for ( int i = 0; i < config( QStringLiteral( "NofColumns" ) ).toInt(); ++i )
+      {
+        mTableWidget->item( j, i )->setCheckState( Qt::PartiallyChecked );
+      }
     }
-    mListWidget->blockSignals( false );
+    mTableWidget->blockSignals( false );
   }
   else if ( mComboBox )
   {
@@ -208,16 +245,21 @@ void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
 
   mEnabled = enabled;
 
-  if ( mListWidget )
+  if ( mTableWidget )
   {
-    for ( int i = 0; i < mListWidget->count(); ++i )
+    for ( int j = 0; j < mTableWidget->rowCount(); j++ )
     {
-      QListWidgetItem *item = mListWidget->item( i );
-
-      if ( enabled )
-        item->setFlags( item->flags() | Qt::ItemIsEnabled );
-      else
-        item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
+      for ( int i = 0; i < mTableWidget->columnCount(); ++i )
+      {
+        QTableWidgetItem *item = mTableWidget->item( j, i );
+        if ( item )
+        {
+          if ( enabled )
+            item->setFlags( item->flags() | Qt::ItemIsEnabled );
+          else
+            item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
+        }
+      }
     }
   }
   else

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -57,8 +57,8 @@ QVariant QgsValueRelationWidgetWrapper::value() const
         QTableWidgetItem *item = mTableWidget->item( j, i );
         if ( item )
         {
-        if ( item->checkState() == Qt::Checked )
-          selection << item->data( Qt::UserRole ).toString();
+          if ( item->checkState() == Qt::Checked )
+            selection << item->data( Qt::UserRole ).toString();
         }
       }
     }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -18,12 +18,11 @@
 
 #include "qgseditorwidgetwrapper.h"
 #include "qgsvaluerelationfieldformatter.h"
-
-#include <QComboBox>
-#include <QTableWidget>
-#include <QHeaderView>
-#include <QLineEdit>
 #include "qgis_gui.h"
+
+class QTableWidget;
+class QComboBox;
+class QLineEdit;
 
 SIP_NO_FILE
 

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -20,7 +20,8 @@
 #include "qgsvaluerelationfieldformatter.h"
 
 #include <QComboBox>
-#include <QListWidget>
+#include <QTableWidget>
+#include <QHeaderView>
 #include <QLineEdit>
 #include "qgis_gui.h"
 
@@ -72,7 +73,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
 
   private:
     QComboBox *mComboBox = nullptr;
-    QListWidget *mListWidget = nullptr;
+    QTableWidget *mTableWidget = nullptr;
     QLineEdit *mLineEdit = nullptr;
 
     QgsValueRelationFieldFormatter::ValueRelationCache mCache;

--- a/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluerelationconfigdlgbase.ui
@@ -13,85 +13,8 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label_8">
-     <property name="text">
-      <string>Select layer, key column and value column</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Layer</string>
-     </property>
-     <property name="buddy">
-      <cstring>mLayerName</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QgsMapLayerComboBox" name="mLayerName"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Key column</string>
-     </property>
-     <property name="buddy">
-      <cstring>mKeyColumn</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QCheckBox" name="mOrderByValue">
-     <property name="text">
-      <string>Order by value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QgsFieldComboBox" name="mKeyColumn"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Value column</string>
-     </property>
-     <property name="buddy">
-      <cstring>mValueColumn</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QgsFieldComboBox" name="mValueColumn"/>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QCheckBox" name="mAllowNull">
-     <property name="text">
-      <string>Allow NULL value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QCheckBox" name="mAllowMulti">
-     <property name="text">
-      <string>Allow multiple selections</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="2">
-    <widget class="QCheckBox" name="mUseCompleter">
-     <property name="text">
-      <string>Use completer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="QTextEdit" name="mFilterExpression"/>
-   </item>
-   <item row="9" column="0" colspan="2">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
+   <item row="12" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="label_19">
@@ -109,7 +32,7 @@
         <enum>Qt::RightToLeft</enum>
        </property>
        <property name="icon">
-        <iconset resource="../../images/images.qrc">
+        <iconset resource="../../../images/images.qrc">
          <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
        </property>
       </widget>
@@ -128,6 +51,93 @@
       </spacer>
      </item>
     </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Layer</string>
+     </property>
+     <property name="buddy">
+      <cstring>mLayerName</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_8">
+     <property name="text">
+      <string>Select layer, key column and value column</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QCheckBox" name="mAllowNull">
+     <property name="text">
+      <string>Allow NULL value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QgsFieldComboBox" name="mKeyColumn"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="QgsFieldComboBox" name="mValueColumn"/>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="QCheckBox" name="mUseCompleter">
+     <property name="text">
+      <string>Use completer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Key column</string>
+     </property>
+     <property name="buddy">
+      <cstring>mKeyColumn</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Value column</string>
+     </property>
+     <property name="buddy">
+      <cstring>mValueColumn</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="mOrderByValue">
+     <property name="text">
+      <string>Order by value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsMapLayerComboBox" name="mLayerName"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="label_nofColumns">
+     <property name="text">
+      <string>Number of columns</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0" colspan="2">
+    <widget class="QTextEdit" name="mFilterExpression"/>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QCheckBox" name="mAllowMulti">
+     <property name="text">
+      <string>Allow multiple selections</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QSpinBox" name="mNofColumns"/>
    </item>
   </layout>
  </widget>
@@ -154,6 +164,8 @@
   <tabstop>mEditExpression</tabstop>
   <tabstop>mFilterExpression</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -23,6 +23,7 @@
 #include <qgsvectorlayer.h>
 #include "qgseditorwidgetwrapper.h"
 #include <editorwidgets/qgsvaluerelationwidgetwrapper.h>
+#include <QTableWidget>
 #include "qgsgui.h"
 
 class TestQgsValueRelationWidgetWrapper : public QObject

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -76,10 +76,11 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
   w.setEnabled( true );
 
   // add an item virtually
-  QListWidgetItem item;
+  QTableWidgetItem item;
   item.setText( QStringLiteral( "MyText" ) );
-  w.mListWidget->addItem( &item );
-  QCOMPARE( w.mListWidget->item( 0 )->text(), QString( "MyText" ) );
+  w.mTableWidget->setItem( 0, 0, &item );
+
+  QCOMPARE( w.mTableWidget->item( 0, 0 )->text(), QString( "MyText" ) );
 
   // when the widget wrapper is enabled, the container should be enabled
   // as well as items
@@ -87,7 +88,7 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
 
   QCOMPARE( w.widget()->isEnabled(), true );
 
-  bool itemEnabled = w.mListWidget->item( 0 )->flags() & Qt::ItemIsEnabled;
+  bool itemEnabled = w.mTableWidget->item( 0, 0 )->flags() & Qt::ItemIsEnabled;
   QCOMPARE( itemEnabled, true );
 
   // when the widget wrapper is disabled, the container should still be enabled
@@ -95,7 +96,7 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
   // edition
   w.setEnabled( false );
 
-  itemEnabled = w.mListWidget->item( 0 )->flags() & Qt::ItemIsEnabled;
+  itemEnabled = w.mTableWidget->item( 0, 0 )->flags() & Qt::ItemIsEnabled;
   QCOMPARE( itemEnabled, false );
 
   QCOMPARE( w.widget()->isEnabled(), true );
@@ -104,7 +105,7 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
   w.setEnabled( true );
 
   QCOMPARE( w.widget()->isEnabled(), true );
-  itemEnabled = w.mListWidget->item( 0 )->flags() & Qt::ItemIsEnabled;
+  itemEnabled = w.mTableWidget->item( 0, 0 )->flags() & Qt::ItemIsEnabled;
   QCOMPARE( itemEnabled, true );
 }
 


### PR DESCRIPTION
## Description
When in the value relation widget allow multiple selection is active, the widget was displayed as QListWidget where you could select the related items. This could have been not very nice when there were a lot of items. It's now a QTableWidged with multiple columns. It's much more comfortable to handle a lot of items and in case there are very few items it can be made very small and we can save some space. The number of columns is configurable.

### Now
![multiselect_is](https://user-images.githubusercontent.com/28384354/34377559-e4eff2c2-eaf1-11e7-86a8-ab33d7fea8d2.gif)
(if only one column it looks the same like before)

### Before
![multiselect_was](https://user-images.githubusercontent.com/28384354/34377491-8562ace6-eaf1-11e7-8d4b-ed76ca51c43a.png)

The listWidget parts are completely replaced by the tableWidget (including tests) and removed from qgsvaluerelationsearchwidgetwrapper where it didn't made sense anyway.

**This is a second pull request to the same improvements like #5954 - what is wrecked because of wrong merging stuff...**