### PR TITLE
Convert mkuidefaults script to python3 and pep8 it

### DIFF
--- a/scripts/mkuidefaults.py
+++ b/scripts/mkuidefaults.py
@@ -48,45 +48,43 @@ s = QSettings(sys.argv[1], QSettings.IniFormat)
 ba = bytes(s.value("/UI/geometry"))
 print
 
-f = open("src/app/ui_defaults.h", "w")
+with open("src/app/ui_defaults.h", "w") as f:
 
-f.write("#ifndef UI_DEFAULTS_H\n#define UI_DEFAULTS_H\n" +
-        "\nstatic const unsigned char defaultUIgeometry[] =\n{\n")
-
-for chunk in chunks(ba, 16):
-    f.write('  {},\n'.format(
-        ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
-
-f.write("};\n\nstatic const unsigned char defaultUIstate[] =\n{\n")
-
-ba = bytes(s.value("/UI/state"))
-
-for chunk in chunks(ba, 16):
-    f.write('  {},\n'.format(
-        ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
-
-try:
-    ba = bytes(s.value("/app/LayoutDesigner/geometry"))
-    f.write("};\n\nstatic const unsigned char " +
-            "defaultLayerDesignerUIgeometry[] =\n{\n")
+    f.write("#ifndef UI_DEFAULTS_H\n#define UI_DEFAULTS_H\n" +
+            "\nstatic const unsigned char defaultUIgeometry[] =\n{\n")
 
     for chunk in chunks(ba, 16):
         f.write('  {},\n'.format(
             ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
-except TypeError as ex:
-    pass
 
-try:
-    ba = bytes(s.value("/app/LayoutDesigner/state"))
-    f.write("};\n\nstatic const unsigned char " +
-            "defaultLayerDesignerUIstate[] =\n{\n")
+    f.write("};\n\nstatic const unsigned char defaultUIstate[] =\n{\n")
+
+    ba = bytes(s.value("/UI/state"))
 
     for chunk in chunks(ba, 16):
         f.write('  {},\n'.format(
             ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
-except TypeError as ex:
-    pass
 
-f.write("};\n\n#endif // UI_DEFAULTS_H\n")
+    try:
+        ba = bytes(s.value("/app/LayoutDesigner/geometry"))
+        f.write("};\n\nstatic const unsigned char " +
+                "defaultLayerDesignerUIgeometry[] =\n{\n")
 
-f.close()
+        for chunk in chunks(ba, 16):
+            f.write('  {},\n'.format(
+                ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
+    except TypeError as ex:
+        pass
+
+    try:
+        ba = bytes(s.value("/app/LayoutDesigner/state"))
+        f.write("};\n\nstatic const unsigned char " +
+                "defaultLayerDesignerUIstate[] =\n{\n")
+
+        for chunk in chunks(ba, 16):
+            f.write('  {},\n'.format(
+                ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
+    except TypeError as ex:
+        pass
+
+    f.write("};\n\n#endif // UI_DEFAULTS_H\n")

--- a/scripts/mkuidefaults.py
+++ b/scripts/mkuidefaults.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -39,7 +40,7 @@ QCoreApplication.setOrganizationDomain("qgis.org")
 QCoreApplication.setApplicationName("QGIS3")
 
 if len(sys.argv) == 1:
-    print "Usage: python ./scripts/mkuidefaults.py \"location_to_ini\""
+    print("Usage: ./scripts/mkuidefaults.py \"location_to_ini\"")
     sys.exit(1)
 
 s = QSettings(sys.argv[1], QSettings.IniFormat)
@@ -49,33 +50,40 @@ print
 
 f = open("src/app/ui_defaults.h", "w")
 
-f.write("#ifndef UI_DEFAULTS_H\n#define UI_DEFAULTS_H\n\nstatic const unsigned char defaultUIgeometry[] =\n{\n")
+f.write("#ifndef UI_DEFAULTS_H\n#define UI_DEFAULTS_H\n" +
+        "\nstatic const unsigned char defaultUIgeometry[] =\n{\n")
 
 for chunk in chunks(ba, 16):
-    f.write('  {},\n'.format(', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
+    f.write('  {},\n'.format(
+        ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
 
 f.write("};\n\nstatic const unsigned char defaultUIstate[] =\n{\n")
 
 ba = bytes(s.value("/UI/state"))
 
 for chunk in chunks(ba, 16):
-    f.write('  {},\n'.format(', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
+    f.write('  {},\n'.format(
+        ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
 
 try:
     ba = bytes(s.value("/app/LayoutDesigner/geometry"))
-    f.write("};\n\nstatic const unsigned char defaultLayerDesignerUIgeometry[] =\n{\n")
+    f.write("};\n\nstatic const unsigned char " +
+            "defaultLayerDesignerUIgeometry[] =\n{\n")
 
     for chunk in chunks(ba, 16):
-        f.write('  {},\n'.format(', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
+        f.write('  {},\n'.format(
+            ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
 except TypeError as ex:
     pass
 
 try:
     ba = bytes(s.value("/app/LayoutDesigner/state"))
-    f.write("};\n\nstatic const unsigned char defaultLayerDesignerUIstate[] =\n{\n")
+    f.write("};\n\nstatic const unsigned char " +
+            "defaultLayerDesignerUIstate[] =\n{\n")
 
     for chunk in chunks(ba, 16):
-        f.write('  {},\n'.format(', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
+        f.write('  {},\n'.format(
+            ', '.join(map(hex, struct.unpack('B' * len(chunk), chunk)))))
 except TypeError as ex:
     pass
 


### PR DESCRIPTION
## Description
A tiny PR to "convert" mkuidefaults script to python3 and pep8 it

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
