### PR TITLE
Is there any reason to be able to put in the WMS capabilities an invalid mime type?

### DIFF
--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -2062,11 +2062,6 @@ p, li { white-space: pre-wrap; }
                         <string notr="true">image/jpeg</string>
                        </property>
                       </item>
-                      <item>
-                       <property name="text">
-                        <string notr="true">image/jpg</string>
-                       </property>
-                      </item>
                      </widget>
                     </item>
                    </layout>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -2261,11 +2261,6 @@ border-radius: 2px;</string>
                         <string>image/jpeg</string>
                        </property>
                       </item>
-                      <item>
-                       <property name="text">
-                        <string>image/jpg</string>
-                       </property>
-                      </item>
                      </widget>
                     </item>
                    </layout>


### PR DESCRIPTION
## Description
Remove the invalid image/jpg mime type

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
