### PR TITLE
Respect selection in layers in vertex tool (fixes #17782)

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -192,6 +192,36 @@ class MatchCollectingFilter : public QgsPointLocator::MatchFilter
     }
 };
 
+
+/**
+ * Keeps the best match from a selected feature so that we can possibly use it with higher priority.
+ * If we do not encounter any selected feature within tolerance, we use the best match as usual.
+ */
+class SelectedMatchFilter : public QgsPointLocator::MatchFilter
+{
+  public:
+    explicit SelectedMatchFilter( double tol )
+      : mTolerance( tol ) {}
+
+    virtual bool acceptMatch( const QgsPointLocator::Match &match )
+    {
+      if ( match.distance() <= mTolerance && match.layer() && match.layer()->selectedFeatureIds().contains( match.featureId() ) )
+      {
+        if ( !mBestSelectedMatch.isValid() || match.distance() < mBestSelectedMatch.distance() )
+          mBestSelectedMatch = match;
+      }
+      return true;
+    }
+
+    bool hasSelectedMatch() const { return mBestSelectedMatch.isValid(); }
+    QgsPointLocator::Match bestSelectedMatch() const { return mBestSelectedMatch; }
+
+  private:
+    double mTolerance;
+    QgsPointLocator::Match mBestSelectedMatch;
+};
+
+
 //
 //
 //
@@ -440,6 +470,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     QgsPointXY pt1 = toMapCoordinates( e->pos() );
     QgsRectangle map_rect( pt0, pt1 );
     QList<Vertex> vertices;
+    QList<Vertex> selectedVertices;
 
     // for each editable layer, select vertices
     const auto layers = canvas()->layers();
@@ -454,15 +485,25 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       QgsFeatureIterator fi = vlayer->getFeatures( QgsFeatureRequest( layerRect ).setSubsetOfAttributes( QgsAttributeList() ) );
       while ( fi.nextFeature( f ) )
       {
+        bool isFeatureSelected = vlayer->selectedFeatureIds().contains( f.id() );
         QgsGeometry g = f.geometry();
         for ( int i = 0; i < g.constGet()->nCoordinates(); ++i )
         {
           QgsPointXY pt = g.vertexAt( i );
           if ( layerRect.contains( pt ) )
+          {
             vertices << Vertex( vlayer, f.id(), i );
+            if ( isFeatureSelected )
+              selectedVertices << Vertex( vlayer, f.id(), i );
+          }
         }
       }
     }
+
+    // If there were any vertices that come from selected features, use just vertices from selected features.
+    // This allows user to select a bunch of features in complex situations to constrain the selection.
+    if ( !selectedVertices.isEmpty() )
+      vertices = selectedVertices;
 
     HighlightMode mode = ModeReset;
     if ( e->modifiers() & Qt::ShiftModifier )
@@ -639,7 +680,15 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
       }
 
       snapUtils->setConfig( config );
-      m = snapUtils->snapToMap( mapPoint );
+      SelectedMatchFilter filter( tol );
+      m = snapUtils->snapToMap( mapPoint, &filter );
+
+      // we give priority to snap matches that are from selected features
+      if ( filter.hasSelectedMatch() )
+      {
+        m = filter.bestSelectedMatch();
+        mLastSnap.reset();
+      }
     }
   }
 
@@ -658,7 +707,15 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
     }
 
     snapUtils->setConfig( config );
-    m = snapUtils->snapToMap( mapPoint );
+    SelectedMatchFilter filter( tol );
+    m = snapUtils->snapToMap( mapPoint, &filter );
+
+    // we give priority to snap matches that are from selected features
+    if ( filter.hasSelectedMatch() )
+    {
+      m = filter.bestSelectedMatch();
+      mLastSnap.reset();
+    }
   }
 
   // try to stay snapped to previously used feature


### PR DESCRIPTION
This fixes issues in situations when there are multiple vertices in one location:

1. when clicking a location, if there are selected features,
   the closest vertex from a selected feature will be used with priority.

2. when dragging a rectangle, if there is a selected feature,
   only vertices from selected features will be used.

If there is selection in any editable layers, but away from the location where
user clicked to pick vertex (or dragged rectangle to pick multiple vertices),
the existing vertex tool behavior is not affected (so it cannot happen that
vertex tool suddenly appears to have stopped working just because there is
selection somewhere possibly outside of the current map view).
