### PR TITLE
[python console] remove 'u' prefixes from strings (fix #18171)

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -18,8 +18,6 @@ email                : lrssvtml (at) gmail (dot) com
  ***************************************************************************/
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
-from builtins import str
-from builtins import range
 import os
 
 from qgis.PyQt.QtCore import Qt, QTimer, QCoreApplication, QSize, QByteArray, QFileInfo, QUrl, QDir

--- a/python/console/console_compile_apis.py
+++ b/python/console/console_compile_apis.py
@@ -64,7 +64,7 @@ class PrepareAPIDialog(QDialog):
         rslt = self.tr("Error")
         if prepd:
             rslt = QCoreApplication.translate("PythonConsole", "Saved")
-        self.ui.label.setText(u'{0} {1}'.format(self.ui.label.text(), rslt))
+        self.ui.label.setText('{0} {1}'.format(self.ui.label.text(), rslt))
         self._api = None
         self.ui.progressBar.setVisible(False)
         self.ui.buttonBox.button(QDialogButtonBox.Cancel).setText(
@@ -73,7 +73,7 @@ class PrepareAPIDialog(QDialog):
 
     def prepareAPI(self):
         # self.ui.textEdit_Qsci.setLexer(0)
-        exec(u'self.qlexer = {0}(self.ui.textEdit_Qsci)'.format(self._api_lexer))
+        exec('self.qlexer = {0}(self.ui.textEdit_Qsci)'.format(self._api_lexer))
         # self.ui.textEdit_Qsci.setLexer(self.qlexer)
         self._api = QsciAPIs(self.qlexer)
         self._api.apiPreparationFinished.connect(self._preparationFinished)

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -432,7 +432,7 @@ class Editor(QsciScintilla):
         getCmd = []
         for strLine in listText:
             getCmd.append(strLine)
-        pasteText = u"\n".join(getCmd)
+        pasteText = "\n".join(getCmd)
         url = 'http://codepad.org'
         values = {'lang': 'Python',
                   'code': pasteText,
@@ -591,7 +591,7 @@ class Editor(QsciScintilla):
                 tmpFile = self.createTempFile()
                 filename = tmpFile
 
-            self.parent.pc.shell.runCommand(u"exec(open(u'{0}'.encode('{1}')).read())"
+            self.parent.pc.shell.runCommand("exec(open('{0}'.encode('{1}')).read())"
                                             .format(filename.replace("\\", "/"), sys.getfilesystemencoding()))
 
     def runSelectedCode(self):  # spellok
@@ -626,9 +626,9 @@ class Editor(QsciScintilla):
             if not filename:
                 filename = self.parent.tw.currentWidget().path
             # source = open(filename, 'r').read() + '\n'
-            if isinstance(source, type(u"")):
+            if isinstance(source, type("")):
                 source = source.encode('utf-8')
-            if isinstance(filename, type(u"")):
+            if isinstance(filename, type("")):
                 filename = filename.encode('utf-8')
             if filename:
                 compile(source, filename, 'exec')

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -18,8 +18,6 @@ email                : lrssvtml (at) gmail (dot) com
  ***************************************************************************/
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
-from builtins import range
-from builtins import object
 
 from qgis.PyQt.QtCore import Qt, QCoreApplication
 from qgis.PyQt.QtGui import QColor, QFont, QKeySequence, QFontDatabase

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -18,8 +18,6 @@ email                : lrssvtml (at) gmail (dot) com
  ***************************************************************************/
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
-from builtins import bytes
-from builtins import range
 
 from qgis.PyQt.QtCore import Qt, QByteArray, QCoreApplication, QFile, QSize
 from qgis.PyQt.QtWidgets import QDialog, QMenu, QShortcut, QApplication
@@ -600,7 +598,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
             more = False
         else:
             self.buffer.append(cmd)
-            src = u"\n".join(self.buffer)
+            src = "\n".join(self.buffer)
             more = self.runsource(src)
             if not more:
                 self.buffer = []
@@ -627,7 +625,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         hook = sys.excepthook
         try:
             def excepthook(etype, value, tb):
-                self.write(u"".join(traceback.format_exception(etype, value, tb)))
+                self.write("".join(traceback.format_exception(etype, value, tb)))
 
             sys.excepthook = excepthook
 

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -18,15 +18,15 @@ email                : lrssvtml (at) gmail (dot) com
  ***************************************************************************/
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
-from builtins import range
 
 from qgis.PyQt.QtCore import QCoreApplication, QSize, Qt
 from qgis.PyQt.QtWidgets import QDialog, QFileDialog, QMessageBox, QTableWidgetItem
 from qgis.PyQt.QtGui import QIcon, QFont, QColor, QFontDatabase
-from .console_compile_apis import PrepareAPIDialog
 
-from .ui_console_settings import Ui_SettingsDialogPythonConsole
 from qgis.core import QgsSettings
+
+from .console_compile_apis import PrepareAPIDialog
+from .ui_console_settings import Ui_SettingsDialogPythonConsole
 
 
 class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):


### PR DESCRIPTION
## Description
Removes `u""` prefixes from strings as well as not needed Python compatibility imports. Fixes https://issues.qgis.org/issues/18171

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
