### PR TITLE
Do not auto-close vertex editor on any mouse click (ref #17243)

### DIFF
--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -387,6 +387,13 @@ void QgsVertexEditor::keyPressEvent( QKeyEvent *e )
   }
 }
 
+void QgsVertexEditor::closeEvent( QCloseEvent *event )
+{
+  QgsDockWidget::closeEvent( event );
+
+  emit editorClosed();
+}
+
 //
 // CoordinateItemDelegate
 //

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -83,9 +83,11 @@ class QgsVertexEditor : public QgsDockWidget
 
   signals:
     void deleteSelectedRequested();
+    void editorClosed();
 
   protected:
     void keyPressEvent( QKeyEvent *event ) override;
+    void closeEvent( QCloseEvent *event ) override;
 
   private slots:
     void updateTableSelection();

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -374,8 +374,6 @@ void QgsVertexTool::cadCanvasPressEvent( QgsMapMouseEvent *e )
     return;
   }
 
-  cleanupVertexEditor();
-
   if ( !mDraggingVertex && !mSelectedVertices.isEmpty() && !( e->modifiers() & Qt::ShiftModifier ) && !( e->modifiers() & Qt::ControlModifier ) )
   {
     // only remove highlight if not clicked on one of highlighted vertices
@@ -1041,6 +1039,7 @@ void QgsVertexTool::showVertexEditor()  //#spellok
   mVertexEditor.reset( new QgsVertexEditor( m.layer(), mSelectedFeature.get(), mCanvas ) );
   QgisApp::instance()->addDockWidget( Qt::LeftDockWidgetArea, mVertexEditor.get() );
   connect( mVertexEditor.get(), &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
+  connect( mVertexEditor.get(), &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
   connect( mSelectedFeature.get()->vlayer(), &QgsVectorLayer::featureDeleted, this, &QgsVertexTool::cleanEditor );
 }
 

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -119,6 +119,8 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
     void removeTemporaryRubberBands();
 
+    void cleanupVertexEditor();
+
     /**
      * Temporarily override snapping config and snap to vertices and edges
      of any editable vector layer, to allow selection of vertex for editing
@@ -201,8 +203,6 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
      * center of the edge and whether we are close enough to the center
      */
     bool matchEdgeCenterTest( const QgsPointLocator::Match &m, const QgsPointXY &mapPoint, QgsPointXY *edgeCenterPtr = nullptr );
-
-    void cleanupVertexEditor();
 
     //! Run validation on a geometry (in a background thread)
     void validateGeometry( QgsVectorLayer *layer, QgsFeatureId featureId );


### PR DESCRIPTION
This is a partial fix for #17243 to improve usability of vertex editor panel.
Until now the vertex editor would get closed on any mouse click in mouse canvas,
making it quite annoying to work with it.

With this change, the vertex editor stays open until it is explicitly closed.

cc @andreasneumann