### PR TITLE
[processing] Fix model docks are not removed when closing modeler

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -82,7 +82,9 @@ class ModelerDialog(BASE, WIDGET):
     update_model = pyqtSignal()
 
     def __init__(self, model=None):
-        super(ModelerDialog, self).__init__(None)
+        super().__init__(None)
+        self.setAttribute(Qt.WA_DeleteOnClose)
+
         self.setupUi(self)
 
         self.bar = QgsMessageBar()


### PR DESCRIPTION
Actually caused by the modeler dialog never being deleted correctly.

Fixes #18213
