### PR TITLE
Add dependency on qgis_gui target to fix parallel build.

### DIFF
--- a/src/providers/wms/CMakeLists.txt
+++ b/src/providers/wms/CMakeLists.txt
@@ -46,6 +46,8 @@ INCLUDE_DIRECTORIES(SYSTEM
 ADD_LIBRARY(wmsprovider_a STATIC ${WMS_SRCS} ${WMS_MOC_SRCS})
 ADD_LIBRARY(wmsprovider MODULE ${WMS_SRCS} ${WMS_MOC_SRCS})
 
+ADD_DEPENDENCIES(wmsprovider qgis_gui)
+
 TARGET_LINK_LIBRARIES(wmsprovider
   qgis_core
   qgis_gui


### PR DESCRIPTION
QGIS 2.18.17 failed to build on [s390x](https://buildd.debian.org/status/fetch.php?pkg=qgis&arch=s390x&ver=2.18.17%2Bdfsg-1%7Eexp2&stamp=1519643202&raw=0) due to a missing dependency:
```
 /<<BUILDDIR>>/qgis-2.18.17+dfsg/src/providers/wms/../../gui/qgsgenericprojectionselector.h:20:10: fatal error: ui_qgsgenericprojectionselectorbase.h: No such file or directory
  #include <ui_qgsgenericprojectionselectorbase.h>
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

`qgis_gui` already depends on the `ui` target to ensure it's built before, the `wmsprovider` has no such dependency.


