### PR TITLE
[bugfix] Add a link to the Georef Transform settings help button 

### DIFF
--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -688,11 +688,9 @@ void QgsGeorefPluginGui::localHistogramStretch()
 }
 
 // Info slots
-void QgsGeorefPluginGui::contextHelp()
+void QgsGeorefPluginGui::showHelp()
 {
-  QgsGeorefDescriptionDialog dlg( this );
-  dlg.exec();
-}
+ QgsHelp::openHelp( QStringLiteral( "plugins/plugins_georeferencer.html#defining-the-transformation-settings" ) );}
 
 // Comfort slots
 void QgsGeorefPluginGui::jumpToGCP( uint theGCPIndex )
@@ -914,7 +912,7 @@ void QgsGeorefPluginGui::createActions()
 
   // Help actions
   mActionHelp = new QAction( tr( "Help" ), this );
-  connect( mActionHelp, &QAction::triggered, this, &QgsGeorefPluginGui::contextHelp );
+  connect( mActionHelp, &QAction::triggered, this, &QgsGeorefPluginGui::showHelp );
 
   mActionQuit->setIcon( getThemeIcon( QStringLiteral( "/mActionQuit.png" ) ) );
   mActionQuit->setShortcuts( QList<QKeySequence>() << QKeySequence( Qt::CTRL + Qt::Key_Q )

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -690,7 +690,8 @@ void QgsGeorefPluginGui::localHistogramStretch()
 // Info slots
 void QgsGeorefPluginGui::showHelp()
 {
- QgsHelp::openHelp( QStringLiteral( "plugins/plugins_georeferencer.html#defining-the-transformation-settings" ) );}
+ QgsHelp::openHelp( QStringLiteral( "plugins/plugins_georeferencer.html#defining-the-transformation-settings" ) );
+}
 
 // Comfort slots
 void QgsGeorefPluginGui::jumpToGCP( uint theGCPIndex )

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -690,7 +690,7 @@ void QgsGeorefPluginGui::localHistogramStretch()
 // Info slots
 void QgsGeorefPluginGui::showHelp()
 {
- QgsHelp::openHelp( QStringLiteral( "plugins/plugins_georeferencer.html#defining-the-transformation-settings" ) );
+  QgsHelp::openHelp( QStringLiteral( "plugins/plugins_georeferencer.html#defining-the-transformation-settings" ) );
 }
 
 // Comfort slots

--- a/src/plugins/georeferencer/qgsgeorefplugingui.h
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.h
@@ -104,7 +104,7 @@ class QgsGeorefPluginGui : public QMainWindow, private Ui::QgsGeorefPluginGuiBas
     void showGeorefConfigDialog();
 
     // plugin info
-    void contextHelp();
+    void showHelp();
 
     // comfort
     void jumpToGCP( uint theGCPIndex );


### PR DESCRIPTION
The context help has been removed but no link put in replacement. 

In a wider perspective, the georeferencer dialog does not have a help button; it has menus, toolbars, panels but nothing that would lead to its whole chapter in docs. What could be a solution:
* add a Help menu and toolbar (but both will be with single item)
* simply add the toolbar with its button or the menu with its sub-menu
* a help item in an existing menu/toolbar: which one
* it's ok how it's now
*...?

