### PR TITLE
Fix crash when using the identify tool on a categorized render

### DIFF
--- a/python/core/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -45,7 +45,22 @@ copy constructor
     void setLabel( const QString &label );
 
     bool renderState() const;
+%Docstring
+Returns true if the category is currently enabled and should be rendered.
+
+.. seealso:: :py:func:`setRenderState`
+
+.. versionadded:: 2.5
+%End
+
     void setRenderState( bool render );
+%Docstring
+Sets whether the category is currently enabled and should be rendered.
+
+.. seealso:: :py:func:`renderState`
+
+.. versionadded:: 2.5
+%End
 
     QString dump() const;
 
@@ -252,9 +267,36 @@ Will return null if the functionality is disabled.
 hashtable for faster access to symbols
 %End
 
-    QgsSymbol *skipRender();
+ QgsSymbol *skipRender() /Deprecated/;
+%Docstring
 
-    QgsSymbol *symbolForValue( const QVariant &value );
+.. deprecated:: No longer used, will be removed in QGIS 4.0
+%End
+
+ QgsSymbol *symbolForValue( const QVariant &value ) /Deprecated/;
+%Docstring
+Returns the matching symbol corresponding to an attribute ``value``.
+
+.. deprecated:: use variant which takes a second bool argument instead.
+%End
+
+
+    QgsSymbol *symbolForValue( const QVariant &value, bool &foundMatchingSymbol /Out/ ) /PyName=symbolForValue2/;
+%Docstring
+Returns the matching symbol corresponding to an attribute ``value``.
+
+Will return None if no matching symbol was found for ``value``, or
+if the category corresponding to ``value`` is currently disabled (see QgsRendererCategory.renderState()).
+
+If ``foundMatchingSymbol`` is specified then it will be set to true if
+a matching category was found. This can be used to differentiate between
+a None returned as a result of no matching category vs a None as a result
+of disabled categories.
+
+.. note::
+
+   available in Python bindings as symbolForValue2
+%End
 
   private:
     QgsCategorizedSymbolRenderer( const QgsCategorizedSymbolRenderer & );

--- a/python/gui/qgisinterface.sip.in
+++ b/python/gui/qgisinterface.sip.in
@@ -849,6 +849,7 @@ Unregister a previously registered custom drop ``handler`` for layout windows.
 %End
 
 
+
     virtual void openURL( const QString &url, bool useQgisDocDirectory = true ) = 0 /Deprecated/;
 %Docstring
 Open a url in the users browser. By default the QGIS doc directory is used

--- a/python/server/qgsmapserviceexception.sip.in
+++ b/python/server/qgsmapserviceexception.sip.in
@@ -16,7 +16,7 @@ class QgsMapServiceException : QgsOgcServiceException
 %Docstring
  Exception class for WMS service exceptions (for compatibility only).
 
-\deprecated Use QsgServerException
+.. deprecated:: Use QsgServerException
 
 The most important codes are:
 * "InvalidFormat"

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -192,6 +192,9 @@ sub processDoxygenLine {
     if ( $line =~ m/\\since .*?([\d\.]+)/i ) {
         return "\n.. versionadded:: $1\n";
     }
+    if ( $line =~ m/\\deprecated (.*)/i ) {
+        return "\n.. deprecated:: $1\n";
+    }
 
     # create links in see also
     if ( $line =~ m/\\see +(\w+(\.\w+)*)(\([^()]*\))?/ ) {
@@ -596,7 +599,7 @@ while ($LINE_IDX < $LINE_COUNT){
         next;
     }
     # Skip Q_OBJECT, Q_PROPERTY, Q_ENUM, Q_GADGET etc.
-    if ($LINE =~ m/^\s*Q_(OBJECT|ENUMS|ENUM|FLAG|PROPERTY|GADGET|DECLARE_METATYPE|DECLARE_TYPEINFO|DECL_DEPRECATED|NOWARN_DEPRECATED_(PUSH|POP))\b.*?$/){
+    if ($LINE =~ m/^\s*Q_(OBJECT|ENUMS|ENUM|FLAG|PROPERTY|GADGET|DECLARE_METATYPE|DECLARE_TYPEINFO|NOWARN_DEPRECATED_(PUSH|POP))\b.*?$/){
         next;
     }
 
@@ -848,7 +851,8 @@ while ($LINE_IDX < $LINE_COUNT){
         $LINE =~ s/\s*\boverride\b//;
         $LINE =~ s/\s*\bextern \b//;
         $LINE =~ s/\s*\bMAYBE_UNUSED \b//;
-        $LINE =~ s/\s*\bNODISCARD \b//;   
+        $LINE =~ s/\s*\bNODISCARD \b//;
+        $LINE =~ s/\s*\bQ_DECL_DEPRECATED\b//;
         $LINE =~ s/^(\s*)?(const )?(virtual |static )?inline /$1$2$3/;
         $LINE =~ s/\bconstexpr\b/const/;
         $LINE =~ s/\bnullptr\b/0/g;

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -56,8 +56,18 @@ class CORE_EXPORT QgsRendererCategory
     void setSymbol( QgsSymbol *s SIP_TRANSFER );
     void setLabel( const QString &label );
 
-    // \since QGIS 2.5
+    /**
+     * Returns true if the category is currently enabled and should be rendered.
+     * \see setRenderState()
+     * \since QGIS 2.5
+     */
     bool renderState() const;
+
+    /**
+     * Sets whether the category is currently enabled and should be rendered.
+     * \see renderState()
+     * \since QGIS 2.5
+     */
     void setRenderState( bool render );
 
     // debugging
@@ -233,9 +243,33 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
 
     void rebuildHash();
 
-    QgsSymbol *skipRender();
+    /**
+     * \deprecated No longer used, will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED QgsSymbol *skipRender() SIP_DEPRECATED;
 
-    QgsSymbol *symbolForValue( const QVariant &value );
+    /**
+     * Returns the matching symbol corresponding to an attribute \a value.
+     * \deprecated use variant which takes a second bool argument instead.
+     */
+    Q_DECL_DEPRECATED QgsSymbol *symbolForValue( const QVariant &value ) SIP_DEPRECATED;
+
+    // TODO QGIS 4.0 - rename Python method to symbolForValue
+
+    /**
+     * Returns the matching symbol corresponding to an attribute \a value.
+     *
+     * Will return nullptr if no matching symbol was found for \a value, or
+     * if the category corresponding to \a value is currently disabled (see QgsRendererCategory::renderState()).
+     *
+     * If \a foundMatchingSymbol is specified then it will be set to true if
+     * a matching category was found. This can be used to differentiate between
+     * a nullptr returned as a result of no matching category vs a nullptr as a result
+     * of disabled categories.
+     *
+     * \note available in Python bindings as symbolForValue2
+     */
+    QgsSymbol *symbolForValue( const QVariant &value, bool &foundMatchingSymbol SIP_OUT ) SIP_PYNAME( symbolForValue2 );
 
   private:
 #ifdef SIP_RUN


### PR DESCRIPTION
with an unchecked category corresponding to the feature at the clicked point

Also fix count of default category symbols