### PR TITLE
[processing] Support dynamic properties for all native c++ algorithms

### DIFF
--- a/python/plugins/processing/gui/HistoryDialog.py
+++ b/python/plugins/processing/gui/HistoryDialog.py
@@ -112,7 +112,7 @@ class HistoryDialog(BASE, WIDGET):
         if isinstance(item, TreeLogEntryItem):
             if item.isAlg:
                 script = 'import processing\n'
-                script += 'from qgis.core import QgsProcessingOutputLayerDefinition, QgsProcessingFeatureSourceDefinition\n'
+                script += 'from qgis.core import QgsProcessingOutputLayerDefinition, QgsProcessingFeatureSourceDefinition, QgsProperty\n'
                 script += item.entry.text.replace('processing.run(', 'processing.execAlgorithmDialog(')
                 self.close()
                 exec(script)

--- a/src/analysis/processing/qgsalgorithmremoveduplicatevertices.h
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatevertices.h
@@ -51,8 +51,12 @@ class QgsAlgorithmRemoveDuplicateVertices : public QgsProcessingFeatureBasedAlgo
   private:
 
     double mTolerance = 1.0;
-    bool mUseZValues = false;
+    bool mDynamicTolerance = false;
+    QgsProperty mToleranceProperty;
 
+    bool mUseZValues = false;
+    bool mDynamicUseZ = false;
+    QgsProperty mUseZProperty;
 };
 
 

--- a/src/analysis/processing/qgsalgorithmsimplify.cpp
+++ b/src/analysis/processing/qgsalgorithmsimplify.cpp
@@ -78,14 +78,22 @@ void QgsSimplifyAlgorithm::initParameters( const QVariantMap & )
                   QStringLiteral( "METHOD" ),
                   QObject::tr( "Simplification method" ),
                   methods, false, 0 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "TOLERANCE" ),
-                QObject::tr( "Tolerance" ), QgsProcessingParameterNumber::Double,
-                1.0, false, 0, 10000000.0 ) );
+  std::unique_ptr< QgsProcessingParameterNumber > tolerance = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "TOLERANCE" ),
+      QObject::tr( "Tolerance" ), QgsProcessingParameterNumber::Double,
+      1.0, false, 0, 10000000.0 );
+  tolerance->setIsDynamic( true );
+  tolerance->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "Tolerance" ), QObject::tr( "Tolerance distance" ), QgsPropertyDefinition::DoublePositive ) );
+  tolerance->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( tolerance.release() );
 }
 
 bool QgsSimplifyAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   mTolerance = parameterAsDouble( parameters, QStringLiteral( "TOLERANCE" ), context );
+  mDynamicTolerance = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "TOLERANCE" ) );
+  if ( mDynamicTolerance )
+    mToleranceProperty = parameters.value( QStringLiteral( "TOLERANCE" ) ).value< QgsProperty >();
+
   mMethod = static_cast< QgsMapToPixelSimplifier::SimplifyAlgorithm >( parameterAsEnum( parameters, QStringLiteral( "METHOD" ), context ) );
   if ( mMethod != QgsMapToPixelSimplifier::Distance )
     mSimplifier.reset( new QgsMapToPixelSimplifier( QgsMapToPixelSimplifier::SimplifyGeometry, mTolerance, mMethod ) );
@@ -93,7 +101,7 @@ bool QgsSimplifyAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsP
   return true;
 }
 
-QgsFeatureList QgsSimplifyAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
+QgsFeatureList QgsSimplifyAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )
@@ -102,11 +110,23 @@ QgsFeatureList QgsSimplifyAlgorithm::processFeature( const QgsFeature &feature, 
     QgsGeometry outputGeometry;
     if ( mMethod == QgsMapToPixelSimplifier::Distance )
     {
-      outputGeometry = inputGeometry.simplify( mTolerance );
+      double tolerance = mTolerance;
+      if ( mDynamicTolerance )
+        tolerance = mToleranceProperty.valueAsDouble( context.expressionContext(), tolerance );
+      outputGeometry = inputGeometry.simplify( tolerance );
     }
     else
     {
-      outputGeometry = mSimplifier->simplify( inputGeometry );
+      if ( !mDynamicTolerance )
+      {
+        outputGeometry = mSimplifier->simplify( inputGeometry );
+      }
+      else
+      {
+        double tolerance = mToleranceProperty.valueAsDouble( context.expressionContext(), mTolerance );
+        QgsMapToPixelSimplifier simplifier( QgsMapToPixelSimplifier::SimplifyGeometry, tolerance, mMethod );
+        outputGeometry = simplifier.simplify( inputGeometry );
+      }
     }
     f.setGeometry( outputGeometry );
   }

--- a/src/analysis/processing/qgsalgorithmsimplify.h
+++ b/src/analysis/processing/qgsalgorithmsimplify.h
@@ -53,6 +53,8 @@ class QgsSimplifyAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   private:
 
     double mTolerance = 1.0;
+    bool mDynamicTolerance = false;
+    QgsProperty mToleranceProperty;
     QgsMapToPixelSimplifier::SimplifyAlgorithm mMethod = QgsMapToPixelSimplifier::Distance;
     std::unique_ptr< QgsMapToPixelSimplifier > mSimplifier;
 

--- a/src/analysis/processing/qgsalgorithmsmooth.cpp
+++ b/src/analysis/processing/qgsalgorithmsmooth.cpp
@@ -82,31 +82,69 @@ QList<int> QgsSmoothAlgorithm::inputLayerTypes() const
 
 void QgsSmoothAlgorithm::initParameters( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "ITERATIONS" ),
-                QObject::tr( "Iterations" ), QgsProcessingParameterNumber::Integer,
-                1, false, 1, 10 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "OFFSET" ),
-                QObject::tr( "Offset" ), QgsProcessingParameterNumber::Double,
-                0.25, false, 0.0, 0.5 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MAX_ANGLE" ),
-                QObject::tr( "Maximum node angle to smooth" ), QgsProcessingParameterNumber::Double,
-                180.0, false, 0.0, 180.0 ) );
+  std::unique_ptr< QgsProcessingParameterNumber > iterations = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ITERATIONS" ),
+      QObject::tr( "Iterations" ), QgsProcessingParameterNumber::Integer,
+      1, false, 1, 10 );
+  iterations->setIsDynamic( true );
+  iterations->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "ITERATIONS" ), QObject::tr( "Iterations" ), QgsPropertyDefinition::IntegerPositiveGreaterZero ) );
+  iterations->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( iterations.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > offset = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "OFFSET" ),
+      QObject::tr( "Offset" ), QgsProcessingParameterNumber::Double,
+      0.25, false, 0.0, 0.5 );
+  offset->setIsDynamic( true );
+  offset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "OFFSET" ), QObject::tr( "Offset" ), QgsPropertyDefinition::Double0To1 ) );
+  offset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( offset.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > maxAngle = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "MAX_ANGLE" ),
+      QObject::tr( "Maximum node angle to smooth" ), QgsProcessingParameterNumber::Double,
+      180.0, false, 0.0, 180.0 );
+  maxAngle->setIsDynamic( true );
+  maxAngle->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "MAX_ANGLE" ), QObject::tr( "Maximum node angle to smooth" ), QgsPropertyDefinition::Rotation ) );
+  maxAngle->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( maxAngle.release() );
 }
 
 bool QgsSmoothAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   mIterations = parameterAsInt( parameters, QStringLiteral( "ITERATIONS" ), context );
+  mDynamicIterations = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "ITERATIONS" ) );
+  if ( mDynamicIterations )
+    mIterationsProperty = parameters.value( QStringLiteral( "ITERATIONS" ) ).value< QgsProperty >();
+
   mOffset = parameterAsDouble( parameters, QStringLiteral( "OFFSET" ), context );
+  mDynamicOffset = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "OFFSET" ) );
+  if ( mDynamicOffset )
+    mOffsetProperty = parameters.value( QStringLiteral( "OFFSET" ) ).value< QgsProperty >();
+
   mMaxAngle = parameterAsDouble( parameters, QStringLiteral( "MAX_ANGLE" ), context );
+  mDynamicMaxAngle = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "MAX_ANGLE" ) );
+  if ( mDynamicMaxAngle )
+    mMaxAngleProperty = parameters.value( QStringLiteral( "MAX_ANGLE" ) ).value< QgsProperty >();
+
   return true;
 }
 
-QgsFeatureList QgsSmoothAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
+QgsFeatureList QgsSmoothAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {
-    QgsGeometry outputGeometry = f.geometry().smooth( mIterations, mOffset, -1, mMaxAngle );
+    int iterations = mIterations;
+    if ( mDynamicIterations )
+      iterations = mIterationsProperty.valueAsInt( context.expressionContext(), iterations );
+
+    double offset = mOffset;
+    if ( mDynamicOffset )
+      offset = mOffsetProperty.valueAsDouble( context.expressionContext(), offset );
+
+    double maxAngle = mMaxAngle;
+    if ( mDynamicMaxAngle )
+      maxAngle = mMaxAngleProperty.valueAsDouble( context.expressionContext(), maxAngle );
+
+    QgsGeometry outputGeometry = f.geometry().smooth( iterations, offset, -1, maxAngle );
     if ( !outputGeometry )
     {
       feedback->reportError( QObject::tr( "Error smoothing geometry %1" ).arg( feature.id() ) );

--- a/src/analysis/processing/qgsalgorithmsmooth.h
+++ b/src/analysis/processing/qgsalgorithmsmooth.h
@@ -52,8 +52,16 @@ class QgsSmoothAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
   private:
     int mIterations = 1;
+    bool mDynamicIterations = false;
+    QgsProperty mIterationsProperty;
+
     double mOffset = 0.25;
+    bool mDynamicOffset = false;
+    QgsProperty mOffsetProperty;
+
     double mMaxAngle = 0;
+    bool mDynamicMaxAngle = false;
+    QgsProperty mMaxAngleProperty;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
@@ -67,35 +67,86 @@ QgsSnapToGridAlgorithm *QgsSnapToGridAlgorithm::createInstance() const
 
 void QgsSnapToGridAlgorithm::initParameters( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "HSPACING" ),
-                QObject::tr( "X Grid Spacing" ), QgsProcessingParameterNumber::Double,
-                1, false, 0 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "VSPACING" ),
-                QObject::tr( "Y Grid Spacing" ), QgsProcessingParameterNumber::Double,
-                1, false, 0 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "ZSPACING" ),
-                QObject::tr( "Z Grid Spacing" ), QgsProcessingParameterNumber::Double,
-                0, false, 0 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MSPACING" ),
-                QObject::tr( "M Grid Spacing" ), QgsProcessingParameterNumber::Double,
-                0, false, 0 ) );
+  std::unique_ptr< QgsProcessingParameterNumber> hSpacing = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "HSPACING" ),
+      QObject::tr( "X Grid Spacing" ), QgsProcessingParameterNumber::Double,
+      1, false, 0 );
+  hSpacing->setIsDynamic( true );
+  hSpacing->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "HSPACING" ), QObject::tr( "X Grid Spacing" ), QgsPropertyDefinition::DoublePositive ) );
+  hSpacing->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( hSpacing.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber> vSpacing = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "VSPACING" ),
+      QObject::tr( "Y Grid Spacing" ), QgsProcessingParameterNumber::Double,
+      1, false, 0 );
+  vSpacing->setIsDynamic( true );
+  vSpacing->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "VSPACING" ), QObject::tr( "Y Grid Spacing" ), QgsPropertyDefinition::DoublePositive ) );
+  vSpacing->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( vSpacing.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > zSpacing = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ZSPACING" ),
+      QObject::tr( "Z Grid Spacing" ), QgsProcessingParameterNumber::Double,
+      0, false, 0 );
+  zSpacing->setIsDynamic( true );
+  zSpacing->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "ZSPACING" ), QObject::tr( "Z Grid Spacing" ), QgsPropertyDefinition::DoublePositive ) );
+  zSpacing->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( zSpacing.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > mSpacing = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "MSPACING" ),
+      QObject::tr( "M Grid Spacing" ), QgsProcessingParameterNumber::Double,
+      0, false, 0 );
+  mSpacing->setIsDynamic( true );
+  mSpacing->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "MSPACING" ), QObject::tr( "M Grid Spacing" ), QgsPropertyDefinition::DoublePositive ) );
+  mSpacing->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( mSpacing.release() );
 }
 
 bool QgsSnapToGridAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   mIntervalX = parameterAsDouble( parameters, QStringLiteral( "HSPACING" ), context );
+  mDynamicIntervalX = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "HSPACING" ) );
+  if ( mDynamicIntervalX )
+    mIntervalXProperty = parameters.value( QStringLiteral( "HSPACING" ) ).value< QgsProperty >();
+
   mIntervalY = parameterAsDouble( parameters, QStringLiteral( "VSPACING" ), context );
+  mDynamicIntervalY = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "VSPACING" ) );
+  if ( mDynamicIntervalY )
+    mIntervalYProperty = parameters.value( QStringLiteral( "VSPACING" ) ).value< QgsProperty >();
+
   mIntervalZ = parameterAsDouble( parameters, QStringLiteral( "ZSPACING" ), context );
+  mDynamicIntervalZ = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "ZSPACING" ) );
+  if ( mDynamicIntervalZ )
+    mIntervalZProperty = parameters.value( QStringLiteral( "ZSPACING" ) ).value< QgsProperty >();
+
   mIntervalM = parameterAsDouble( parameters, QStringLiteral( "MSPACING" ), context );
+  mDynamicIntervalM = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "MSPACING" ) );
+  if ( mDynamicIntervalM )
+    mIntervalMProperty = parameters.value( QStringLiteral( "MSPACING" ) ).value< QgsProperty >();
+
   return true;
 }
 
-QgsFeatureList QgsSnapToGridAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback *feedback )
+QgsFeatureList QgsSnapToGridAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {
-    QgsGeometry outputGeometry = f.geometry().snappedToGrid( mIntervalX, mIntervalY, mIntervalZ, mIntervalM );
+    double intervalX = mIntervalX;
+    if ( mDynamicIntervalX )
+      intervalX = mIntervalXProperty.valueAsDouble( context.expressionContext(), intervalX );
+
+    double intervalY = mIntervalY;
+    if ( mDynamicIntervalY )
+      intervalY = mIntervalYProperty.valueAsDouble( context.expressionContext(), intervalY );
+
+    double intervalZ = mIntervalZ;
+    if ( mDynamicIntervalZ )
+      intervalZ = mIntervalZProperty.valueAsDouble( context.expressionContext(), intervalZ );
+
+    double intervalM = mIntervalM;
+    if ( mDynamicIntervalM )
+      intervalM = mIntervalMProperty.valueAsDouble( context.expressionContext(), intervalM );
+
+    QgsGeometry outputGeometry = f.geometry().snappedToGrid( intervalX, intervalY, intervalZ, intervalM );
     if ( !outputGeometry )
     {
       feedback->reportError( QObject::tr( "Error snapping geometry %1" ).arg( feature.id() ) );

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.h
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.h
@@ -50,9 +50,21 @@ class QgsSnapToGridAlgorithm : public QgsProcessingFeatureBasedAlgorithm
 
   private:
     double mIntervalX = 0.0;
+    bool mDynamicIntervalX = false;
+    QgsProperty mIntervalXProperty;
+
     double mIntervalY = 0.0;
+    bool mDynamicIntervalY = false;
+    QgsProperty mIntervalYProperty;
+
     double mIntervalZ = 0.0;
+    bool mDynamicIntervalZ = false;
+    QgsProperty mIntervalZProperty;
+
     double mIntervalM = 0.0;
+    bool mDynamicIntervalM = false;
+    QgsProperty mIntervalMProperty;
+
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -21,8 +21,13 @@
 
 void QgsSubdivideAlgorithm::initParameters( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "MAX_NODES" ), QObject::tr( "Maximum nodes in parts" ), QgsProcessingParameterNumber::Integer,
-                256, false, 8, 100000 ) );
+  std::unique_ptr< QgsProcessingParameterNumber> nodes = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "MAX_NODES" ), QObject::tr( "Maximum nodes in parts" ), QgsProcessingParameterNumber::Integer,
+      256, false, 8, 100000 );
+  nodes->setIsDynamic( true );
+  nodes->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "MAX_NODES" ), QObject::tr( "Maximum nodes in parts" ), QgsPropertyDefinition::Integer ) );
+  nodes->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+
+  addParameter( nodes.release() );
 }
 
 QString QgsSubdivideAlgorithm::name() const
@@ -75,12 +80,16 @@ QgsWkbTypes::Type QgsSubdivideAlgorithm::outputWkbType( QgsWkbTypes::Type inputW
   return QgsWkbTypes::multiType( inputWkbType );
 }
 
-QgsFeatureList QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &, QgsProcessingFeedback *feedback )
+QgsFeatureList QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
   QgsFeature feature = f;
   if ( feature.hasGeometry() )
   {
-    feature.setGeometry( feature.geometry().subdivide( mMaxNodes ) );
+    int maxNodes = mMaxNodes;
+    if ( mDynamicMaxNodes )
+      maxNodes = mMaxNodesProperty.valueAsDouble( context.expressionContext(), maxNodes );
+
+    feature.setGeometry( feature.geometry().subdivide( maxNodes ) );
     if ( !feature.geometry() )
     {
       feedback->reportError( QObject::tr( "Error calculating subdivision for feature %1" ).arg( feature.id() ) );
@@ -92,6 +101,10 @@ QgsFeatureList QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsPr
 bool QgsSubdivideAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   mMaxNodes = parameterAsInt( parameters, QStringLiteral( "MAX_NODES" ), context );
+  mDynamicMaxNodes = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "MAX_NODES" ) );
+  if ( mDynamicMaxNodes )
+    mMaxNodesProperty = parameters.value( QStringLiteral( "MAX_NODES" ) ).value< QgsProperty >();
+
   return true;
 }
 

--- a/src/analysis/processing/qgsalgorithmsubdivide.h
+++ b/src/analysis/processing/qgsalgorithmsubdivide.h
@@ -54,7 +54,8 @@ class QgsSubdivideAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   private:
 
     int mMaxNodes = -1;
-
+    bool mDynamicMaxNodes = false;
+    QgsProperty mMaxNodesProperty;
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/processing/qgsalgorithmtransect.cpp
+++ b/src/analysis/processing/qgsalgorithmtransect.cpp
@@ -50,10 +50,20 @@ void QgsTransectAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ),
                 QObject::tr( "Input layer" ), QList< int >() << QgsProcessing::TypeVectorLine ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "LENGTH" ), QObject::tr( "Length of the transect " ), QgsProcessingParameterNumber::Double,
-                5.0, false, 0 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "ANGLE" ), QObject::tr( "Angle in degrees from the original line at the vertices" ), QgsProcessingParameterNumber::Double,
-                90.0, false, 0, 360 ) );
+  std::unique_ptr< QgsProcessingParameterNumber > length = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "LENGTH" ), QObject::tr( "Length of the transect" ), QgsProcessingParameterNumber::Double,
+      5.0, false, 0 );
+  length->setIsDynamic( true );
+  length->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "LENGTH" ), QObject::tr( "Length of the transect" ), QgsPropertyDefinition::DoublePositive ) );
+  length->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( length.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > angle = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "ANGLE" ), QObject::tr( "Angle in degrees from the original line at the vertices" ), QgsProcessingParameterNumber::Double,
+      90.0, false, 0, 360 );
+  angle->setIsDynamic( true );
+  angle->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "ANGLE" ), QObject::tr( "Angle in degrees" ), QgsPropertyDefinition::Double ) );
+  angle->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( angle.release() );
+
   addParameter( new QgsProcessingParameterEnum( QStringLiteral( "SIDE" ), QObject::tr( "Side to create the transects" ), QStringList() << QObject::tr( "Left" ) << QObject::tr( "Right" ) << QObject::tr( "Both" ), false ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Transect" ), QgsProcessing::TypeVectorLine ) );
 
@@ -84,7 +94,16 @@ QVariantMap QgsTransectAlgorithm::processAlgorithm( const QVariantMap &parameter
 {
   Side orientation = static_cast< QgsTransectAlgorithm::Side >( parameterAsInt( parameters, QStringLiteral( "SIDE" ), context ) );
   double angle = fabs( parameterAsDouble( parameters, QStringLiteral( "ANGLE" ), context ) );
+  bool dynamicAngle = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "ANGLE" ) );
+  QgsProperty angleProperty;
+  if ( dynamicAngle )
+    angleProperty = parameters.value( QStringLiteral( "ANGLE" ) ).value< QgsProperty >();
+
   double length = parameterAsDouble( parameters, QStringLiteral( "LENGTH" ), context );
+  bool dynamicLength = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "LENGTH" ) );
+  QgsProperty lengthProperty;
+  if ( dynamicLength )
+    lengthProperty = parameters.value( QStringLiteral( "LENGTH" ) ).value< QgsProperty >();
 
   if ( orientation == QgsTransectAlgorithm::Both )
     length /= 2.0;
@@ -92,6 +111,8 @@ QVariantMap QgsTransectAlgorithm::processAlgorithm( const QVariantMap &parameter
   std::unique_ptr< QgsFeatureSource > source( parameterAsSource( parameters, QStringLiteral( "INPUT" ), context ) );
   if ( !source )
     return QVariantMap();
+
+  QgsExpressionContext expressionContext = createExpressionContext( parameters, context, dynamic_cast< QgsProcessingFeatureSource * >( source.get() ) );
 
   QgsFields fields = source->fields();
 
@@ -136,6 +157,18 @@ QVariantMap QgsTransectAlgorithm::processAlgorithm( const QVariantMap &parameter
 
     QgsGeometry inputGeometry = feat.geometry();
 
+    if ( dynamicLength || dynamicAngle )
+    {
+      expressionContext.setFeature( feat );
+    }
+
+    double evaluatedLength = length;
+    if ( dynamicLength )
+      evaluatedLength = lengthProperty.valueAsDouble( context.expressionContext(), length );
+    double evaluatedAngle = angle;
+    if ( dynamicAngle )
+      evaluatedAngle = angleProperty.valueAsDouble( context.expressionContext(), angle );
+
     inputGeometry.convertToMultiType();
     const QgsMultiLineString *multiLine = static_cast< const QgsMultiLineString *  >( inputGeometry.constGet() );
     for ( int id = 0; id < multiLine->numGeometries(); ++id )
@@ -148,12 +181,12 @@ QVariantMap QgsTransectAlgorithm::processAlgorithm( const QVariantMap &parameter
         int i = vertexId.vertex;
         QgsFeature outFeat;
         QgsAttributes attrs = feat.attributes();
-        attrs << current << number << i + 1 << angle <<
-              ( ( orientation == QgsTransectAlgorithm::Both ) ? length * 2 : length ) <<
+        attrs << current << number << i + 1 << evaluatedAngle <<
+              ( ( orientation == QgsTransectAlgorithm::Both ) ? evaluatedLength * 2 : evaluatedLength ) <<
               orientation;
         outFeat.setAttributes( attrs );
         double angleAtVertex = line->vertexAngle( vertexId );
-        outFeat.setGeometry( calcTransect( *it, angleAtVertex, length, orientation, angle ) );
+        outFeat.setGeometry( calcTransect( *it, angleAtVertex, evaluatedLength, orientation, evaluatedAngle ) );
         sink->addFeature( outFeat, QgsFeatureSink::FastInsert );
         number++;
         it++;

--- a/src/analysis/processing/qgsalgorithmtranslate.cpp
+++ b/src/analysis/processing/qgsalgorithmtranslate.cpp
@@ -63,42 +63,90 @@ QgsTranslateAlgorithm *QgsTranslateAlgorithm::createInstance() const
 
 void QgsTranslateAlgorithm::initParameters( const QVariantMap & )
 {
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "DELTA_X" ),
-                QObject::tr( "Offset distance (x-axis)" ), QgsProcessingParameterNumber::Double,
-                0.0 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "DELTA_Y" ),
-                QObject::tr( "Offset distance (y-axis)" ), QgsProcessingParameterNumber::Double,
-                0.0 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "DELTA_Z" ),
-                QObject::tr( "Offset distance (z-axis)" ), QgsProcessingParameterNumber::Double,
-                0.0 ) );
-  addParameter( new QgsProcessingParameterNumber( QStringLiteral( "DELTA_M" ),
-                QObject::tr( "Offset distance (m values)" ), QgsProcessingParameterNumber::Double,
-                0.0 ) );
+  std::unique_ptr< QgsProcessingParameterNumber > xOffset = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DELTA_X" ),
+      QObject::tr( "Offset distance (x-axis)" ), QgsProcessingParameterNumber::Double,
+      0.0 );
+  xOffset->setIsDynamic( true );
+  xOffset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DELTA_X" ), QObject::tr( "Offset distance (x-axis)" ), QgsPropertyDefinition::Double ) );
+  xOffset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( xOffset.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > yOffset = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DELTA_Y" ),
+      QObject::tr( "Offset distance (y-axis)" ), QgsProcessingParameterNumber::Double,
+      0.0 );
+  yOffset->setIsDynamic( true );
+  yOffset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DELTA_Y" ), QObject::tr( "Offset distance (y-axis)" ), QgsPropertyDefinition::Double ) );
+  yOffset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( yOffset.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > zOffset = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DELTA_Z" ),
+      QObject::tr( "Offset distance (z-axis)" ), QgsProcessingParameterNumber::Double,
+      0.0 );
+  zOffset->setIsDynamic( true );
+  zOffset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DELTA_Z" ), QObject::tr( "Offset distance (z-axis)" ), QgsPropertyDefinition::Double ) );
+  zOffset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( zOffset.release() );
+
+  std::unique_ptr< QgsProcessingParameterNumber > mOffset = qgis::make_unique< QgsProcessingParameterNumber >( QStringLiteral( "DELTA_M" ),
+      QObject::tr( "Offset distance (m values)" ), QgsProcessingParameterNumber::Double,
+      0.0 );
+  mOffset->setIsDynamic( true );
+  mOffset->setDynamicPropertyDefinition( QgsPropertyDefinition( QStringLiteral( "DELTA_M" ), QObject::tr( "Offset distance (m values)" ), QgsPropertyDefinition::Double ) );
+  mOffset->setDynamicLayerParameterName( QStringLiteral( "INPUT" ) );
+  addParameter( mOffset.release() );
 }
 
 bool QgsTranslateAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   mDeltaX = parameterAsDouble( parameters, QStringLiteral( "DELTA_X" ), context );
+  mDynamicDeltaX = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DELTA_X" ) );
+  if ( mDynamicDeltaX )
+    mDeltaXProperty = parameters.value( QStringLiteral( "DELTA_X" ) ).value< QgsProperty >();
+
   mDeltaY = parameterAsDouble( parameters, QStringLiteral( "DELTA_Y" ), context );
+  mDynamicDeltaY = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DELTA_Y" ) );
+  if ( mDynamicDeltaY )
+    mDeltaYProperty = parameters.value( QStringLiteral( "DELTA_Y" ) ).value< QgsProperty >();
+
   mDeltaZ = parameterAsDouble( parameters, QStringLiteral( "DELTA_Z" ), context );
+  mDynamicDeltaZ = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DELTA_Z" ) );
+  if ( mDynamicDeltaZ )
+    mDeltaZProperty = parameters.value( QStringLiteral( "DELTA_Z" ) ).value< QgsProperty >();
+
   mDeltaM = parameterAsDouble( parameters, QStringLiteral( "DELTA_M" ), context );
+  mDynamicDeltaM = QgsProcessingParameters::isDynamic( parameters, QStringLiteral( "DELTA_M" ) );
+  if ( mDynamicDeltaM )
+    mDeltaMProperty = parameters.value( QStringLiteral( "DELTA_M" ) ).value< QgsProperty >();
 
   return true;
 }
 
-QgsFeatureList QgsTranslateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &, QgsProcessingFeedback * )
+QgsFeatureList QgsTranslateAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   QgsFeature f = feature;
   if ( f.hasGeometry() )
   {
     QgsGeometry geometry = f.geometry();
-    if ( mDeltaZ != 0 && !geometry.constGet()->is3D() )
+
+    double deltaX = mDeltaX;
+    if ( mDynamicDeltaX )
+      deltaX = mDeltaXProperty.valueAsDouble( context.expressionContext(), deltaX );
+    double deltaY = mDeltaY;
+    if ( mDynamicDeltaY )
+      deltaY = mDeltaYProperty.valueAsDouble( context.expressionContext(), deltaY );
+    double deltaZ = mDeltaZ;
+    if ( mDynamicDeltaZ )
+      deltaZ = mDeltaZProperty.valueAsDouble( context.expressionContext(), deltaZ );
+    double deltaM = mDeltaM;
+    if ( mDynamicDeltaM )
+      deltaM = mDeltaMProperty.valueAsDouble( context.expressionContext(), deltaM );
+
+    if ( deltaZ != 0 && !geometry.constGet()->is3D() )
       geometry.get()->addZValue( 0 );
-    if ( mDeltaM != 0 && !geometry.constGet()->isMeasure() )
+    if ( deltaM != 0 && !geometry.constGet()->isMeasure() )
       geometry.get()->addMValue( 0 );
 
-    geometry.translate( mDeltaX, mDeltaY, mDeltaZ, mDeltaM );
+    geometry.translate( deltaX, deltaY, deltaZ, deltaM );
     f.setGeometry( geometry );
   }
   return QgsFeatureList() << f;

--- a/src/analysis/processing/qgsalgorithmtranslate.h
+++ b/src/analysis/processing/qgsalgorithmtranslate.h
@@ -52,9 +52,20 @@ class QgsTranslateAlgorithm : public QgsProcessingFeatureBasedAlgorithm
   private:
 
     double mDeltaX = 0.0;
+    bool mDynamicDeltaX = false;
+    QgsProperty mDeltaXProperty;
+
     double mDeltaY = 0.0;
+    bool mDynamicDeltaY = false;
+    QgsProperty mDeltaYProperty;
+
     double mDeltaZ = 0.0;
+    bool mDynamicDeltaZ = false;
+    QgsProperty mDeltaZProperty;
+
     double mDeltaM = 0.0;
+    bool mDynamicDeltaM = false;
+    QgsProperty mDeltaMProperty;
 
 };
 


### PR DESCRIPTION
Make all sensible input parameters support dynamic parameters for the native c++ algorithms.

I'd like us to make this "mostly-mandatory" for new algorithms now, and require dynamic parameter support for any future algorithms ported from python -> c++.

(Eventually we should have support for dynamic parameters in all QGIS algorithms.)