### PR TITLE
[processing] fix QgsProcessingParameterFileDestination handling in models

### DIFF
--- a/python/plugins/processing/algs/gdal/gdal2xyz.py
+++ b/python/plugins/processing/algs/gdal/gdal2xyz.py
@@ -29,8 +29,8 @@ from qgis.core import (QgsProcessing,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterBand,
                        QgsProcessingParameterBoolean,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputFile)
+                       QgsProcessingParameterFileDestination
+                       )
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 from processing.algs.gdal.GdalUtils import GdalUtils
 from processing.tools.system import isWindows
@@ -58,7 +58,6 @@ class gdal2xyz(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT,
                                                                 self.tr('XYZ ASCII file'),
                                                                 self.tr('CSV files (*.csv)')))
-        self.addOutput(QgsProcessingOutputFile(self.OUTPUT, self.tr('XYZ ASCII file')))
 
     def name(self):
         return 'gdal2xyz'

--- a/python/plugins/processing/algs/gdal/gdalinfo.py
+++ b/python/plugins/processing/algs/gdal/gdalinfo.py
@@ -30,8 +30,7 @@ import os
 from qgis.PyQt.QtGui import QIcon
 from qgis.core import (QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterBoolean,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 from processing.algs.gdal.GdalUtils import GdalUtils
 
@@ -69,7 +68,6 @@ class gdalinfo(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT,
                                                                 self.tr('Layer information'),
                                                                 self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Layer information')))
 
     def name(self):
         return 'gdalinfo'

--- a/python/plugins/processing/algs/gdal/ogrinfo.py
+++ b/python/plugins/processing/algs/gdal/ogrinfo.py
@@ -28,8 +28,7 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterBoolean,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 from processing.algs.gdal.GdalUtils import GdalUtils
 
@@ -57,7 +56,6 @@ class ogrinfo(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT,
                                                                 self.tr('Layer information'),
                                                                 self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Layer information')))
 
     def name(self):
         return 'ogrinfo'

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -59,10 +59,6 @@ from qgis.core import (Qgis,
                        QgsProcessingParameterFileDestination,
                        QgsProcessingParameterFile,
                        QgsProcessingParameterFolderDestination,
-                       QgsProcessingOutputFolder,
-                       QgsProcessingOutputVectorLayer,
-                       QgsProcessingOutputRasterLayer,
-                       QgsProcessingOutputHtml,
                        QgsProcessingUtils)
 from qgis.utils import iface
 
@@ -178,10 +174,6 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
         for p in self.params:
             # We use createOutput argument for automatic output creation
             res = self.addParameter(p, True)
-            # File destinations are not automatically added as outputs
-            if (isinstance(p, QgsProcessingParameterFileDestination)
-                    and p.defaultFileExtension().lower() == 'html'):
-                self.addOutput(QgsProcessingOutputHtml(p.name(), p.description()))
 
     def defineCharacteristicsFromFile(self):
         """

--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -31,8 +31,7 @@ import plotly.graph_objs as go
 
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import vector
 
@@ -64,8 +63,6 @@ class BarPlot(QgisAlgorithm):
                                                       None, self.INPUT, QgsProcessingParameterField.Numeric))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Bar plot'), self.tr('HTML files (*.html)')))
-
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Bar plot')))
 
     def name(self):
         return 'barplot'

--- a/python/plugins/processing/algs/qgis/BasicStatistics.py
+++ b/python/plugins/processing/algs/qgis/BasicStatistics.py
@@ -38,7 +38,6 @@ from qgis.core import (QgsStatisticalSummary,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml,
                        QgsProcessingOutputNumber)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
@@ -98,7 +97,6 @@ class BasicStatisticsForField(QgisAlgorithm):
                                                       None, self.INPUT_LAYER, QgsProcessingParameterField.Any))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT_HTML_FILE, self.tr('Statistics'), self.tr('HTML files (*.html)'), None, True))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT_HTML_FILE, self.tr('Statistics')))
 
         self.addOutput(QgsProcessingOutputNumber(self.COUNT, self.tr('Count')))
         self.addOutput(QgsProcessingOutputNumber(self.UNIQUE, self.tr('Number of unique values')))

--- a/python/plugins/processing/algs/qgis/BoxPlot.py
+++ b/python/plugins/processing/algs/qgis/BoxPlot.py
@@ -32,7 +32,6 @@ from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml,
                        QgsFeatureRequest)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import vector
@@ -76,7 +75,6 @@ class BoxPlot(QgisAlgorithm):
             options=msd, defaultValue=0))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Box plot'), self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Box plot')))
 
     def name(self):
         return 'boxplot'

--- a/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
+++ b/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
@@ -31,8 +31,7 @@ import plotly.graph_objs as go
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingUtils,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
 from processing.tools import vector
@@ -64,7 +63,6 @@ class MeanAndStdDevPlot(QgisAlgorithm):
                                                       self.tr('Value field'), parentLayerParameterName=self.INPUT))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Plot'), self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Plot')))
 
     def name(self):
         return 'meanandstandarddeviationplot'

--- a/python/plugins/processing/algs/qgis/NearestNeighbourAnalysis.py
+++ b/python/plugins/processing/algs/qgis/NearestNeighbourAnalysis.py
@@ -37,7 +37,6 @@ from qgis.core import (QgsFeatureRequest,
                        QgsProcessing,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml,
                        QgsProcessingOutputNumber,
                        QgsSpatialIndex)
 
@@ -73,7 +72,6 @@ class NearestNeighbourAnalysis(QgisAlgorithm):
                                                               self.tr('Input layer'), [QgsProcessing.TypeVectorPoint]))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT_HTML_FILE, self.tr('Nearest neighbour'), self.tr('HTML files (*.html)'), None, True))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT_HTML_FILE, self.tr('Nearest neighbour')))
 
         self.addOutput(QgsProcessingOutputNumber(self.OBSERVED_MD,
                                                  self.tr('Observed mean distance')))

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -31,8 +31,7 @@ import numpy as np
 
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import vector
 
@@ -62,7 +61,6 @@ class PolarPlot(QgisAlgorithm):
                                                       self.tr('Value field'), parentLayerParameterName=self.INPUT))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Polar plot'), self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Polar plot')))
 
     def name(self):
         return 'polarplot'

--- a/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
@@ -31,8 +31,7 @@ import plotly.graph_objs as go
 from qgis.core import (QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterBand,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import raster
 
@@ -64,7 +63,6 @@ class RasterLayerHistogram(QgisAlgorithm):
                                                        self.tr('number of bins'), minValue=2, defaultValue=10))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Histogram'), self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Histogram')))
 
     def name(self):
         return 'rasterlayerhistogram'

--- a/python/plugins/processing/algs/qgis/RasterLayerStatistics.py
+++ b/python/plugins/processing/algs/qgis/RasterLayerStatistics.py
@@ -32,7 +32,6 @@ from qgis.core import (QgsRectangle,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterBand,
                        QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml,
                        QgsProcessingOutputNumber)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -68,7 +67,6 @@ class RasterLayerStatistics(QgisAlgorithm):
                                                      1,
                                                      self.INPUT))
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT_HTML_FILE, self.tr('Statistics'), self.tr('HTML files (*.html)'), None, True))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT_HTML_FILE, self.tr('Statistics')))
 
         self.addOutput(QgsProcessingOutputNumber(self.MIN, self.tr('Minimum value')))
         self.addOutput(QgsProcessingOutputNumber(self.MAX, self.tr('Maximum value')))

--- a/python/plugins/processing/algs/qgis/UniqueValues.py
+++ b/python/plugins/processing/algs/qgis/UniqueValues.py
@@ -42,8 +42,7 @@ from qgis.core import (QgsCoordinateReferenceSystem,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingOutputNumber,
                        QgsProcessingOutputString,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -81,7 +80,6 @@ class UniqueValues(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Unique values'), optional=True, defaultValue=''))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT_HTML_FILE, self.tr('HTML report'), self.tr('HTML files (*.html)'), None, True))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT_HTML_FILE, self.tr('HTML report')))
         self.addOutput(QgsProcessingOutputNumber(self.TOTAL_VALUES, self.tr('Total unique values')))
         self.addOutput(QgsProcessingOutputString(self.UNIQUE_VALUES, self.tr('Unique values')))
 

--- a/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
@@ -31,8 +31,7 @@ import plotly.graph_objs as go
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingParameterNumber,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import vector
 
@@ -63,7 +62,6 @@ class VectorLayerHistogram(QgisAlgorithm):
                                                        self.tr('number of bins'), minValue=2, defaultValue=10))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Histogram'), self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Histogram')))
 
     def name(self):
         return 'vectorlayerhistogram'

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -31,8 +31,7 @@ import plotly.graph_objs as go
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingUtils,
-                       QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml)
+                       QgsProcessingParameterFileDestination)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 from processing.tools import vector
 
@@ -66,7 +65,6 @@ class VectorLayerScatterplot(QgisAlgorithm):
                                                       type=QgsProcessingParameterField.Numeric))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Scatterplot'), self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Scatterplot')))
 
     def name(self):
         return 'vectorlayerscatterplot'

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot3D.py
@@ -31,7 +31,6 @@ import plotly.graph_objs as go
 from qgis.core import (QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFileDestination,
-                       QgsProcessingOutputHtml,
                        QgsProcessingUtils)
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
 
@@ -72,7 +71,6 @@ class VectorLayerScatterplot3D(QgisAlgorithm):
                                                       type=QgsProcessingParameterField.Numeric))
 
         self.addParameter(QgsProcessingParameterFileDestination(self.OUTPUT, self.tr('Histogram'), self.tr('HTML files (*.html)')))
-        self.addOutput(QgsProcessingOutputHtml(self.OUTPUT, self.tr('Histogram')))
 
     def name(self):
         return 'scatter3dplot'

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -3402,7 +3402,14 @@ QString QgsProcessingParameterFileDestination::valueAsPythonString( const QVaria
 
 QgsProcessingOutputDefinition *QgsProcessingParameterFileDestination::toOutputDefinition() const
 {
-  return new QgsProcessingOutputFile( name(), description() );
+  if ( !mFileFilter.isEmpty() and mFileFilter.contains( QStringLiteral( "html" ), Qt::CaseInsensitive ) )
+  {
+    return new QgsProcessingOutputHtml( name(), description() );
+  }
+  else
+  {
+    return new QgsProcessingOutputFile( name(), description() );
+  }
 }
 
 QString QgsProcessingParameterFileDestination::defaultFileExtension() const

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -3402,7 +3402,7 @@ QString QgsProcessingParameterFileDestination::valueAsPythonString( const QVaria
 
 QgsProcessingOutputDefinition *QgsProcessingParameterFileDestination::toOutputDefinition() const
 {
-  return nullptr;
+  return new QgsProcessingOutputFile( name(), description() );
 }
 
 QString QgsProcessingParameterFileDestination::defaultFileExtension() const

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -3402,7 +3402,7 @@ QString QgsProcessingParameterFileDestination::valueAsPythonString( const QVaria
 
 QgsProcessingOutputDefinition *QgsProcessingParameterFileDestination::toOutputDefinition() const
 {
-  if ( !mFileFilter.isEmpty() and mFileFilter.contains( QStringLiteral( "html" ), Qt::CaseInsensitive ) )
+  if ( !mFileFilter.isEmpty() && mFileFilter.contains( QStringLiteral( "htm" ), Qt::CaseInsensitive ) )
   {
     return new QgsProcessingOutputHtml( name(), description() );
   }

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -4398,6 +4398,16 @@ void TestQgsProcessing::parameterFileOut()
   QCOMPARE( fromCode->description(), QStringLiteral( "optional" ) );
   QCOMPARE( fromCode->flags(), def->flags() );
   QCOMPARE( fromCode->defaultValue(), def->defaultValue() );
+
+  // outputs definitio test
+  def.reset( new QgsProcessingParameterFileDestination( "html", QString(), QString( "HTML files" ), QString(), false ) );
+  QVERIFY( dynamic_cast< QgsProcessingOutputHtml *>( def->toOutputDefinition() ) );
+  def.reset( new QgsProcessingParameterFileDestination( "html", QString(), QString( "Text files (*.htm)" ), QString(), false ) );
+  QVERIFY( dynamic_cast< QgsProcessingOutputHtml *>( def->toOutputDefinition() ) );
+  def.reset( new QgsProcessingParameterFileDestination( "file", QString(), QString( "Text files (*.txt)" ), QString(), false ) );
+  QVERIFY( dynamic_cast< QgsProcessingOutputFile *>( def->toOutputDefinition() ) );
+  def.reset( new QgsProcessingParameterFileDestination( "file", QString(), QString(), QString(), false ) );
+  QVERIFY( dynamic_cast< QgsProcessingOutputFile *>( def->toOutputDefinition() ) );
 }
 
 void TestQgsProcessing::parameterFolderOut()


### PR DESCRIPTION
## Description
`QgsProcessingParameterFileDestination` lacks `toOutputDefinition()` conversion. As result using file outputs in models is not possible, because they are not recognized.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
