### PR TITLE
[labeling] Fix broken data defined shape radius setting

### DIFF
--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2186,6 +2186,17 @@ bool QgsPalLayerSettings::dataDefinedValEval( DataDefinedValueType valType,
         }
         return false;
       }
+      case DDSizeF:
+      {
+        QString ptstr = exprVal.toString().trimmed();
+
+        if ( !ptstr.isEmpty() )
+        {
+          dataDefinedValues.insert( p, QVariant( QgsSymbolLayerUtils::decodeSize( ptstr ) ) );
+          return true;
+        }
+        return false;
+      }
     }
   }
   return false;
@@ -2671,7 +2682,7 @@ void QgsPalLayerSettings::parseShapeBackground( QgsRenderContext &context )
   dataDefinedValEval( DDUnits, QgsPalLayerSettings::ShapeOffsetUnits, exprVal, context.expressionContext() );
 
   // data defined shape radii?
-  dataDefinedValEval( DDPointF, QgsPalLayerSettings::ShapeRadii, exprVal, context.expressionContext(), QgsSymbolLayerUtils::encodeSize( background.radii() ) );
+  dataDefinedValEval( DDSizeF, QgsPalLayerSettings::ShapeRadii, exprVal, context.expressionContext(), QgsSymbolLayerUtils::encodeSize( background.radii() ) );
 
   // data defined shape radii units?
   dataDefinedValEval( DDUnits, QgsPalLayerSettings::ShapeRadiiUnits, exprVal, context.expressionContext() );

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -847,7 +847,8 @@ class CORE_EXPORT QgsPalLayerSettings
       DDColor,
       DDJoinStyle,
       DDBlendMode,
-      DDPointF
+      DDPointF,
+      DDSizeF, //!< Data defined size
     };
 
     // convenience data defined evaluation function


### PR DESCRIPTION
Reported in https://gis.stackexchange.com/questions/272966/how-to-specify-data-defined-rounded-background-corners-for-labels-in-qgis-3