### PR TITLE
 Allow QgsVectorDataProviders to create QgsFeatureRenderers 

### DIFF
--- a/python/core/qgsvectordataprovider.sip.in
+++ b/python/core/qgsvectordataprovider.sip.in
@@ -51,6 +51,7 @@ of feature and attribute information from a spatial datasource.
       ReadLayerMetadata,
       WriteLayerMetadata,
       CancelSupport,
+      CreateRenderer,
     };
 
     typedef QFlags<QgsVectorDataProvider::Capability> Capabilities;
@@ -477,6 +478,23 @@ Must be implemented by providers that support saving and loading styles to db re
 %Docstring
 It returns false by default.
 Must be implemented by providers that support delete styles from db returning true
+%End
+
+    virtual QgsFeatureRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const;
+%Docstring
+Creates a new vector layer feature renderer, using provider backend specific information.
+
+The ``configuration`` map can be used to pass provider-specific configuration maps to the provider to
+allow customisation of the returned renderer. Support and format of ``configuration`` varies by provider.
+
+When called with an empty ``configuration`` map the provider's default renderer will be returned.
+
+This method returns a new renderer and the caller takes ownership of the returned object.
+
+Only providers which report the CreateRenderer capability will return a feature renderer. Other
+providers will return None.
+
+.. versionadded:: 3.2
 %End
 
     static QVariant convertValue( QVariant::Type type, const QString &value );

--- a/python/core/qgsvectorlayer.sip.in
+++ b/python/core/qgsvectorlayer.sip.in
@@ -936,6 +936,9 @@ data source
 .. versionadded:: 2.10
 %End
 
+    virtual QString loadDefaultStyle( bool &resultFlag /Out/ );
+
+
     QgsVectorLayerFeatureCounter *countSymbolFeatures();
 %Docstring
 Count features for symbols.

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -681,6 +681,11 @@ bool QgsVectorDataProvider::isDeleteStyleFromDatabaseSupported() const
   return false;
 }
 
+QgsFeatureRenderer *QgsVectorDataProvider::createRenderer( const QVariantMap & ) const SIP_FACTORY
+{
+  return nullptr;
+}
+
 void QgsVectorDataProvider::pushError( const QString &msg ) const
 {
   QgsDebugMsg( msg );

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -40,6 +40,7 @@ typedef QHash<int, QString> QgsAttrPalIndexNameHash;
 class QgsFeatureIterator;
 class QgsTransaction;
 class QgsFeedback;
+class QgsFeatureRenderer;
 
 #include "qgsfeaturerequest.h"
 
@@ -91,6 +92,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
       ReadLayerMetadata = 1 << 21, //!< Provider can read layer metadata from data store. Since QGIS 3.0. See QgsDataProvider::layerMetadata()
       WriteLayerMetadata = 1 << 22, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
       CancelSupport = 1 << 23, //!< Supports interruption of pending queries from a separated thread. Since QGIS 3.2
+      CreateRenderer = 1 << 24, //!< Provider can create feature renderers using backend-specific formatting information. Since QGIS 3.2. See QgsVectorDataProvider::createRenderer().
     };
 
     Q_DECLARE_FLAGS( Capabilities, Capability )
@@ -478,6 +480,23 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * Must be implemented by providers that support delete styles from db returning true
      */
     virtual bool isDeleteStyleFromDatabaseSupported() const;
+
+    /**
+     * Creates a new vector layer feature renderer, using provider backend specific information.
+     *
+     * The \a configuration map can be used to pass provider-specific configuration maps to the provider to
+     * allow customisation of the returned renderer. Support and format of \a configuration varies by provider.
+     *
+     * When called with an empty \a configuration map the provider's default renderer will be returned.
+     *
+     * This method returns a new renderer and the caller takes ownership of the returned object.
+     *
+     * Only providers which report the CreateRenderer capability will return a feature renderer. Other
+     * providers will return nullptr.
+     *
+     * \since QGIS 3.2
+     */
+    virtual QgsFeatureRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const;
 
     static QVariant convertValue( QVariant::Type type, const QString &value );
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -930,6 +930,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false );
 
+    QString loadDefaultStyle( bool &resultFlag SIP_OUT ) override;
+
     /**
      * Count features for symbols.
      * The method will return the feature counter task. You will need to

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -53,14 +53,22 @@ ENDIF ()
 
 QT5_WRAP_CPP (AFS_MOC_SRCS ${AFS_MOC_HDRS})
 
+ADD_LIBRARY (arcgisfeatureserverprovider_a STATIC ${AFS_SRCS} ${AFS_MOC_SRCS})
 ADD_LIBRARY(arcgisfeatureserverprovider MODULE ${AFS_SRCS} ${AFS_MOC_SRCS})
 
 TARGET_LINK_LIBRARIES(arcgisfeatureserverprovider
   qgis_core
 )
 
+TARGET_LINK_LIBRARIES (arcgisfeatureserverprovider_a
+  qgis_core
+)
+
 IF (WITH_GUI)
   TARGET_LINK_LIBRARIES(arcgisfeatureserverprovider
+    qgis_gui
+  )
+  TARGET_LINK_LIBRARIES(arcgisfeatureserverprovider_a
     qgis_gui
   )
 ENDIF ()

--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -5,6 +5,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/raster
   ${CMAKE_SOURCE_DIR}/src/core/metadata
+  ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/gui
   ${CMAKE_SOURCE_DIR}/src/gui/auth
   ${CMAKE_BINARY_DIR}/src/ui

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -28,9 +28,6 @@
 #include "qgssourceselectprovider.h"
 #endif
 
-#include "qgssinglesymbolrenderer.h"
-#include "qgscategorizedsymbolrenderer.h"
-
 #include <QEventLoop>
 #include <QMessageBox>
 #include <QNetworkRequest>
@@ -295,61 +292,7 @@ void QgsAfsProvider::reloadData()
 
 QgsFeatureRenderer *QgsAfsProvider::createRenderer( const QVariantMap & ) const
 {
-  const QString type = mRendererDataMap.value( QStringLiteral( "type" ) ).toString();
-  if ( type == QLatin1String( "simple" ) )
-  {
-    const QVariantMap symbolProps = mRendererDataMap.value( QStringLiteral( "symbol" ) ).toMap();
-    std::unique_ptr< QgsSymbol > symbol = QgsArcGisRestUtils::parseEsriSymbolJson( symbolProps );
-    if ( symbol )
-      return new QgsSingleSymbolRenderer( symbol.release() );
-    else
-      return nullptr;
-  }
-  else if ( type == QLatin1String( "uniqueValue" ) )
-  {
-    const QString attribute = mRendererDataMap.value( QStringLiteral( "field1" ) ).toString();
-    // TODO - handle field2, field3
-    const QVariantList categories = mRendererDataMap.value( QStringLiteral( "uniqueValueInfos" ) ).toList();
-    QgsCategoryList categoryList;
-    for ( const QVariant &category : categories )
-    {
-      const QVariantMap categoryData = category.toMap();
-      const QString value = categoryData.value( QStringLiteral( "value" ) ).toString();
-      const QString label = categoryData.value( QStringLiteral( "label" ) ).toString();
-      std::unique_ptr< QgsSymbol > symbol = QgsArcGisRestUtils::parseEsriSymbolJson( categoryData.value( QStringLiteral( "symbol" ) ).toMap() );
-      if ( symbol )
-      {
-        categoryList.append( QgsRendererCategory( value, symbol.release(), label ) );
-      }
-    }
-
-    std::unique_ptr< QgsSymbol > defaultSymbol = QgsArcGisRestUtils::parseEsriSymbolJson( mRendererDataMap.value( QStringLiteral( "defaultSymbol" ) ).toMap() );
-    if ( defaultSymbol )
-    {
-      categoryList.append( QgsRendererCategory( QVariant(), defaultSymbol.release(), mRendererDataMap.value( QStringLiteral( "defaultLabel" ) ).toString() ) );
-    }
-
-    if ( categoryList.empty() )
-      return nullptr;
-
-    return new QgsCategorizedSymbolRenderer( attribute, categoryList );
-  }
-  else if ( type == QLatin1String( "classBreaks" ) )
-  {
-// currently unsupported
-    return nullptr;
-  }
-  else if ( type == QLatin1String( "heatmap" ) )
-  {
-// currently unsupported
-    return nullptr;
-  }
-  else if ( type == QLatin1String( "vectorField" ) )
-  {
-// currently unsupported
-    return nullptr;
-  }
-  return nullptr;
+  return QgsArcGisRestUtils::parseEsriRenderer( mRendererDataMap );
 }
 
 

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -70,6 +70,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QString description() const override;
     QString dataComment() const override;
     void reloadData() override;
+    QgsFeatureRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const override;
 
   private:
     bool mValid;
@@ -78,6 +79,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QString mLayerName;
     QString mLayerDescription;
     QgsLayerMetadata mLayerMetadata;
+    QVariantMap mRendererDataMap;
 };
 
 #endif // QGSAFSPROVIDER_H

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -27,6 +27,10 @@ class QgsRectangle;
 class QgsAbstractGeometry;
 class QgsCoordinateReferenceSystem;
 class QgsFeedback;
+class QgsSymbol;
+class QgsLineSymbol;
+class QgsFillSymbol;
+class QgsMarkerSymbol;
 
 class QgsArcGisRestUtils
 {
@@ -45,6 +49,15 @@ class QgsArcGisRestUtils
     static QList<quint32> getObjectIdsByExtent( const QString &layerurl, const QString &objectIdField, const QgsRectangle &filterRect, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
     static QByteArray queryService( const QUrl &url, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
     static QVariantMap queryServiceJSON( const QUrl &url, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
+
+    static std::unique_ptr< QgsSymbol > parseEsriSymbolJson( const QVariantMap &symbolData );
+    static std::unique_ptr< QgsLineSymbol > parseEsriLineSymbolJson( const QVariantMap &symbolData );
+    static std::unique_ptr< QgsFillSymbol > parseEsriFillSymbolJson( const QVariantMap &symbolData );
+    static std::unique_ptr< QgsMarkerSymbol > parseEsriMarkerSymbolJson( const QVariantMap &symbolData );
+
+    static QColor parseEsriColorJson( const QVariant &colorData );
+    static Qt::PenStyle parseEsriLineStyle( const QString &style );
+    static Qt::BrushStyle parseEsriFillStyle( const QString &style );
 
     static QUrl parseUrl( const QUrl &url );
 };

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -31,6 +31,7 @@ class QgsSymbol;
 class QgsLineSymbol;
 class QgsFillSymbol;
 class QgsMarkerSymbol;
+class QgsFeatureRenderer;
 
 class QgsArcGisRestUtils
 {
@@ -54,6 +55,7 @@ class QgsArcGisRestUtils
     static std::unique_ptr< QgsLineSymbol > parseEsriLineSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsFillSymbol > parseEsriFillSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsMarkerSymbol > parseEsriMarkerSymbolJson( const QVariantMap &symbolData );
+    static QgsFeatureRenderer *parseEsriRenderer( const QVariantMap &rendererData );
 
     static QColor parseEsriColorJson( const QVariant &colorData );
     static Qt::PenStyle parseEsriLineStyle( const QString &style );

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -11,8 +11,10 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_SOURCE_DIR}/src/core/geometry
   ${CMAKE_SOURCE_DIR}/src/core/metadata
   ${CMAKE_SOURCE_DIR}/src/core/raster
+  ${CMAKE_SOURCE_DIR}/src/core/symbology
   ${CMAKE_SOURCE_DIR}/src/providers/wms
   ${CMAKE_SOURCE_DIR}/src/providers/postgres
+  ${CMAKE_SOURCE_DIR}/src/providers/arcgisrest
   ${CMAKE_SOURCE_DIR}/src/test
   ${CMAKE_BINARY_DIR}/src/core
 )
@@ -63,6 +65,9 @@ SET(TEST_SERVER_URL "http://wcs.qgis.org/1.9.0")
 SET_TARGET_PROPERTIES(qgis_wcsprovidertest PROPERTIES
   COMPILE_FLAGS "-DTEST_SERVER_URL=\\\"${TEST_SERVER_URL}\\\""
 )
+
+ADD_QGIS_TEST(arcgisrestutilstest testqgsarcgisrestutils.cpp)
+TARGET_LINK_LIBRARIES(qgis_arcgisrestutilstest arcgisfeatureserverprovider_a)
 
 ADD_QGIS_TEST(gdalprovidertest testqgsgdalprovider.cpp)
 

--- a/tests/src/providers/testqgsarcgisrestutils.cpp
+++ b/tests/src/providers/testqgsarcgisrestutils.cpp
@@ -1,0 +1,381 @@
+/***************************************************************************
+  testqgsarcgisrestutils.cpp
+
+ ---------------------
+ begin                : March 2018
+ copyright            : (C) 2018 by Nyall Dawson
+ email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+#include "qgis.h"
+#include "qgsarcgisrestutils.h"
+#include "qgssymbol.h"
+#include "qgssymbollayer.h"
+#include "qgslinesymbollayer.h"
+#include "qgsfillsymbollayer.h"
+#include "qgsmarkersymbollayer.h"
+#include "qgssinglesymbolrenderer.h"
+#include "qgscategorizedsymbolrenderer.h"
+#include <QObject>
+
+class TestQgsArcGisRestUtils : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {}// will be called before each testfunction is executed.
+    void cleanup() {}// will be called after every testfunction.
+    void testMapEsriFieldType();
+    void testMapEsriGeometryType();
+    void testParseEsriFillStyle();
+    void testParseEsriLineStyle();
+    void testParseEsriColorJson();
+    void testParseMarkerSymbol();
+    void testParseLineSymbol();
+    void testParseFillSymbol();
+    void testParseRendererSimple();
+    void testParseRendererCategorized();
+
+  private:
+
+    QVariantMap jsonStringToMap( const QString &string ) const;
+
+};
+
+
+
+//runs before all tests
+void TestQgsArcGisRestUtils::initTestCase()
+{
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+//runs after all tests
+void TestQgsArcGisRestUtils::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsArcGisRestUtils::testMapEsriFieldType()
+{
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeInteger" ) ), QVariant::LongLong );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeSmallInteger" ) ), QVariant::Int );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeDouble" ) ), QVariant::Double );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeSingle" ) ), QVariant::Double );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeString" ) ), QVariant::String );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeDate" ) ), QVariant::Date );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeOID" ) ), QVariant::LongLong );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeBlob" ) ), QVariant::ByteArray );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeGlobalID" ) ), QVariant::String );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeRaster" ) ), QVariant::ByteArray );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeGUID" ) ), QVariant::String );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeXML" ) ), QVariant::String );
+
+  // not valid fields
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeGeometry" ) ), QVariant::Invalid );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "xxx" ) ), QVariant::Invalid );
+}
+
+void TestQgsArcGisRestUtils::testMapEsriGeometryType()
+{
+  QCOMPARE( QgsArcGisRestUtils::mapEsriGeometryType( QStringLiteral( "esriGeometryNull" ) ), QgsWkbTypes::Unknown );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriGeometryType( QStringLiteral( "esriGeometryPoint" ) ), QgsWkbTypes::Point );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriGeometryType( QStringLiteral( "esriGeometryMultipoint" ) ), QgsWkbTypes::MultiPoint );
+  //unsure why this maps to multicurve and not multilinestring
+  //QCOMPARE( QgsArcGisRestUtils::mapEsriGeometryType( QStringLiteral("esriGeometryPolyline") ),QgsWkbTypes::MultiCurve );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriGeometryType( QStringLiteral( "esriGeometryPolygon" ) ), QgsWkbTypes::Polygon );
+  QCOMPARE( QgsArcGisRestUtils::mapEsriGeometryType( QStringLiteral( "esriGeometryEnvelope" ) ), QgsWkbTypes::Polygon );
+
+  QCOMPARE( QgsArcGisRestUtils::mapEsriGeometryType( QStringLiteral( "xxx" ) ), QgsWkbTypes::Unknown );
+}
+
+void TestQgsArcGisRestUtils::testParseEsriFillStyle()
+{
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "esriSFSBackwardDiagonal" ) ), Qt::BDiagPattern );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "esriSFSCross" ) ), Qt::CrossPattern );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "esriSFSDiagonalCross" ) ), Qt::DiagCrossPattern );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "esriSFSForwardDiagonal" ) ), Qt::FDiagPattern );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "esriSFSHorizontal" ) ), Qt::HorPattern );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "esriSFSNull" ) ), Qt::NoBrush );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "esriSFSSolid" ) ), Qt::SolidPattern );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "esriSFSVertical" ) ), Qt::VerPattern );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriFillStyle( QStringLiteral( "xxx" ) ), Qt::SolidPattern );
+}
+
+void TestQgsArcGisRestUtils::testParseEsriLineStyle()
+{
+  QCOMPARE( QgsArcGisRestUtils::parseEsriLineStyle( QStringLiteral( "esriSLSSolid" ) ), Qt::SolidLine );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriLineStyle( QStringLiteral( "esriSLSDash" ) ), Qt::DashLine );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriLineStyle( QStringLiteral( "esriSLSDashDot" ) ), Qt::DashDotLine );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriLineStyle( QStringLiteral( "esriSLSDashDotDot" ) ), Qt::DashDotDotLine );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriLineStyle( QStringLiteral( "esriSLSDot" ) ), Qt::DotLine );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriLineStyle( QStringLiteral( "esriSLSNull" ) ), Qt::NoPen );
+  QCOMPARE( QgsArcGisRestUtils::parseEsriLineStyle( QStringLiteral( "xxx" ) ), Qt::SolidLine );
+}
+
+void TestQgsArcGisRestUtils::testParseEsriColorJson()
+{
+  QVERIFY( !QgsArcGisRestUtils::parseEsriColorJson( QString( "x" ) ).isValid() );
+  QVERIFY( !QgsArcGisRestUtils::parseEsriColorJson( QVariantList() ).isValid() );
+  QVERIFY( !QgsArcGisRestUtils::parseEsriColorJson( QVariantList() << 1 ).isValid() );
+  QVERIFY( !QgsArcGisRestUtils::parseEsriColorJson( QVariantList() << 10 << 20 ).isValid() );
+  QVERIFY( !QgsArcGisRestUtils::parseEsriColorJson( QVariantList() << 10 << 20 << 30 ).isValid() );
+  QColor res = QgsArcGisRestUtils::parseEsriColorJson( QVariantList() << 10 << 20 << 30 << 40 );
+  QCOMPARE( res.red(), 10 );
+  QCOMPARE( res.green(), 20 );
+  QCOMPARE( res.blue(), 30 );
+  QCOMPARE( res.alpha(), 40 );
+}
+
+void TestQgsArcGisRestUtils::testParseMarkerSymbol()
+{
+  QVariantMap map = jsonStringToMap( "{"
+                                     "\"type\": \"esriSMS\","
+                                     "\"style\": \"esriSMSSquare\","
+                                     "\"color\": ["
+                                     "76,"
+                                     "115,"
+                                     "10,"
+                                     "200"
+                                     "],"
+                                     "\"size\": 8,"
+                                     "\"angle\": 10,"
+                                     "\"xoffset\": 7,"
+                                     "\"yoffset\": 17,"
+                                     "\"outline\": {"
+                                     "\"color\": ["
+                                     "152,"
+                                     "230,"
+                                     "17,"
+                                     "176"
+                                     "],"
+                                     "\"width\": 5"
+                                     "}"
+                                     "}" );
+  std::unique_ptr<QgsSymbol> symbol = QgsArcGisRestUtils::parseEsriSymbolJson( map );
+  QgsMarkerSymbol *marker = dynamic_cast< QgsMarkerSymbol * >( symbol.get() );
+  QVERIFY( marker );
+  QCOMPARE( marker->symbolLayerCount(), 1 );
+  QgsSimpleMarkerSymbolLayer *markerLayer = dynamic_cast< QgsSimpleMarkerSymbolLayer * >( marker->symbolLayer( 0 ) );
+  QVERIFY( markerLayer );
+  QCOMPARE( markerLayer->fillColor(), QColor( 76, 115, 10, 200 ) );
+  QCOMPARE( markerLayer->shape(), QgsSimpleMarkerSymbolLayerBase::Square );
+  QCOMPARE( markerLayer->size(), 8.0 );
+  QCOMPARE( markerLayer->sizeUnit(), QgsUnitTypes::RenderPoints );
+  QCOMPARE( markerLayer->angle(), -10.0 ); // opposite direction to esri spec!
+  QCOMPARE( markerLayer->offset(), QPointF( 7, 17 ) );
+  QCOMPARE( markerLayer->offsetUnit(), QgsUnitTypes::RenderPoints );
+  QCOMPARE( markerLayer->strokeColor(), QColor( 152, 230, 17, 176 ) );
+  QCOMPARE( markerLayer->strokeWidth(), 5.0 );
+  QCOMPARE( markerLayer->strokeWidthUnit(), QgsUnitTypes::RenderPoints );
+
+  // invalid json
+  symbol = QgsArcGisRestUtils::parseEsriMarkerSymbolJson( QVariantMap() );
+  QVERIFY( !symbol );
+}
+
+void TestQgsArcGisRestUtils::testParseLineSymbol()
+{
+  QVariantMap map = jsonStringToMap( "{"
+                                     "\"type\": \"esriSLS\","
+                                     "\"style\": \"esriSLSDot\","
+                                     "\"color\": ["
+                                     "115,"
+                                     "76,"
+                                     "10,"
+                                     "212"
+                                     "],"
+                                     "\"width\": 7"
+                                     "}" );
+  std::unique_ptr<QgsSymbol> symbol = QgsArcGisRestUtils::parseEsriSymbolJson( map );
+  QgsLineSymbol *line = dynamic_cast< QgsLineSymbol * >( symbol.get() );
+  QVERIFY( line );
+  QCOMPARE( line->symbolLayerCount(), 1 );
+  QgsSimpleLineSymbolLayer *lineLayer = dynamic_cast< QgsSimpleLineSymbolLayer * >( line->symbolLayer( 0 ) );
+  QVERIFY( lineLayer );
+  QCOMPARE( lineLayer->color(), QColor( 115, 76, 10, 212 ) );
+  QCOMPARE( lineLayer->width(), 7.0 );
+  QCOMPARE( lineLayer->widthUnit(), QgsUnitTypes::RenderPoints );
+  QCOMPARE( lineLayer->penStyle(), Qt::DotLine );
+
+  // invalid json
+  symbol = QgsArcGisRestUtils::parseEsriLineSymbolJson( QVariantMap() );
+  QVERIFY( !symbol );
+}
+
+void TestQgsArcGisRestUtils::testParseFillSymbol()
+{
+  QVariantMap map = jsonStringToMap( "{"
+                                     "\"type\": \"esriSFS\","
+                                     "\"style\": \"esriSFSHorizontal\","
+                                     "\"color\": ["
+                                     "115,"
+                                     "76,"
+                                     "10,"
+                                     "200"
+                                     "],"
+                                     "\"outline\": {"
+                                     "\"type\": \"esriSLS\","
+                                     "\"style\": \"esriSLSDashDot\","
+                                     "\"color\": ["
+                                     "110,"
+                                     "120,"
+                                     "130,"
+                                     "215"
+                                     "],"
+                                     "\"width\": 5"
+                                     "}"
+                                     "}" );
+  std::unique_ptr<QgsSymbol> symbol = QgsArcGisRestUtils::parseEsriSymbolJson( map );
+  QgsFillSymbol *fill = dynamic_cast< QgsFillSymbol * >( symbol.get() );
+  QVERIFY( fill );
+  QCOMPARE( fill->symbolLayerCount(), 1 );
+  QgsSimpleFillSymbolLayer *fillLayer = dynamic_cast< QgsSimpleFillSymbolLayer * >( fill->symbolLayer( 0 ) );
+  QVERIFY( fillLayer );
+  QCOMPARE( fillLayer->fillColor(), QColor( 115, 76, 10, 200 ) );
+  QCOMPARE( fillLayer->brushStyle(), Qt::HorPattern );
+  QCOMPARE( fillLayer->strokeColor(), QColor( 110, 120, 130, 215 ) );
+  QCOMPARE( fillLayer->strokeWidth(), 5.0 );
+  QCOMPARE( fillLayer->strokeWidthUnit(), QgsUnitTypes::RenderPoints );
+  QCOMPARE( fillLayer->strokeStyle(), Qt::DashDotLine );
+}
+
+void TestQgsArcGisRestUtils::testParseRendererSimple()
+{
+  QVariantMap map = jsonStringToMap( "{"
+                                     "\"type\": \"simple\","
+                                     "\"symbol\": {"
+                                     "\"color\": ["
+                                     "0,"
+                                     "0,"
+                                     "128,"
+                                     "128"
+                                     "],"
+                                     "\"size\": 15,"
+                                     "\"angle\": 0,"
+                                     "\"xoffset\": 0,"
+                                     "\"yoffset\": 0,"
+                                     "\"type\": \"esriSMS\","
+                                     "\"style\": \"esriSMSCircle\","
+                                     "\"outline\": {"
+                                     "\"color\": ["
+                                     "0,"
+                                     "0,"
+                                     "128,"
+                                     "255"
+                                     "],"
+                                     "\"width\": 0.99975,"
+                                     "\"type\": \"esriSLS\","
+                                     "\"style\": \"esriSLSSolid\""
+                                     "}"
+                                     "}"
+                                     "}" );
+  std::unique_ptr< QgsFeatureRenderer > renderer( QgsArcGisRestUtils::parseEsriRenderer( map ) );
+  QgsSingleSymbolRenderer *ssRenderer = dynamic_cast< QgsSingleSymbolRenderer *>( renderer.get() );
+  QVERIFY( ssRenderer );
+  QVERIFY( ssRenderer->symbol() );
+}
+
+void TestQgsArcGisRestUtils::testParseRendererCategorized()
+{
+  QVariantMap map = jsonStringToMap( "{"
+                                     "\"type\": \"uniqueValue\","
+                                     "\"field1\": \"COUNTRY\","
+                                     "\"uniqueValueInfos\": ["
+                                     "{"
+                                     "\"value\": \"US\","
+                                     "\"symbol\": {"
+                                     "\"color\": ["
+                                     "253,"
+                                     "127,"
+                                     "111,"
+                                     "255"
+                                     "],"
+                                     "\"size\": 12.75,"
+                                     "\"angle\": 0,"
+                                     "\"xoffset\": 0,"
+                                     "\"yoffset\": 0,"
+                                     "\"type\": \"esriSMS\","
+                                     "\"style\": \"esriSMSCircle\","
+                                     "\"outline\": {"
+                                     "\"color\": ["
+                                     "26,"
+                                     "26,"
+                                     "26,"
+                                     "255"
+                                     "],"
+                                     "\"width\": 0.75,"
+                                     "\"type\": \"esriSLS\","
+                                     "\"style\": \"esriSLSSolid\""
+                                     "}"
+                                     "},"
+                                     "\"label\": \"United States\""
+                                     "},"
+                                     "{"
+                                     "\"value\": \"Canada\","
+                                     "\"symbol\": {"
+                                     "\"color\": ["
+                                     "126,"
+                                     "176,"
+                                     "213,"
+                                     "255"
+                                     "],"
+                                     "\"size\": 12.75,"
+                                     "\"angle\": 0,"
+                                     "\"xoffset\": 0,"
+                                     "\"yoffset\": 0,"
+                                     "\"type\": \"esriSMS\","
+                                     "\"style\": \"esriSMSCircle\","
+                                     "\"outline\": {"
+                                     "\"color\": ["
+                                     "26,"
+                                     "26,"
+                                     "26,"
+                                     "255"
+                                     "],"
+                                     "\"width\": 0.75,"
+                                     "\"type\": \"esriSLS\","
+                                     "\"style\": \"esriSLSSolid\""
+                                     "}"
+                                     "},"
+                                     "\"label\": \"Canada\""
+                                     "}"
+                                     "]"
+                                     "}" );
+  std::unique_ptr< QgsFeatureRenderer > renderer( QgsArcGisRestUtils::parseEsriRenderer( map ) );
+  QgsCategorizedSymbolRenderer *catRenderer = dynamic_cast< QgsCategorizedSymbolRenderer *>( renderer.get() );
+  QVERIFY( catRenderer );
+  QCOMPARE( catRenderer->categories().count(), 2 );
+  QCOMPARE( catRenderer->categories().at( 0 ).value().toString(), QStringLiteral( "US" ) );
+  QCOMPARE( catRenderer->categories().at( 0 ).label(), QStringLiteral( "United States" ) );
+  QVERIFY( catRenderer->categories().at( 0 ).symbol() );
+  QCOMPARE( catRenderer->categories().at( 1 ).value().toString(), QStringLiteral( "Canada" ) );
+  QCOMPARE( catRenderer->categories().at( 1 ).label(), QStringLiteral( "Canada" ) );
+  QVERIFY( catRenderer->categories().at( 1 ).symbol() );
+}
+
+QVariantMap TestQgsArcGisRestUtils::jsonStringToMap( const QString &string ) const
+{
+  QJsonDocument doc = QJsonDocument::fromJson( string.toUtf8() );
+  if ( doc.isNull() )
+  {
+    return QVariantMap();
+  }
+  return doc.object().toVariantMap();
+}
+
+QGSTEST_MAIN( TestQgsArcGisRestUtils )
+#include "testqgsarcgisrestutils.moc"


### PR DESCRIPTION
Implements https://github.com/qgis/QGIS-Enhancement-Proposals/issues/111

Adds support to QgsVectorDataProvider to create vector layer renderers using provider-specific backend information.

Additionally implements default styles for layers loaded from the AFS data provider.  (Means that when an AFS layer is loaded into QGIS, it will automatically have the same style applied as has been created
for that layer, matching the appearance of the layer when it is loaded into ArcGIS.)



