### PR TITLE
[bugfix][server] Fix prefix path for server

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -220,7 +220,7 @@ void QgsApplication::init( QString profileFolder )
       setPrefixPath( myPrefix, true );
 #else
       QDir myDir( applicationDirPath() );
-      // Fix for server wich is one level deeper in /usr/lib/cgi-bin
+      // Fix for server which is one level deeper in /usr/lib/cgi-bin
       if ( applicationDirPath().contains( QStringLiteral( "cgi-bin" ) ) )
       {
         myDir.cdUp();

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -220,7 +220,12 @@ void QgsApplication::init( QString profileFolder )
       setPrefixPath( myPrefix, true );
 #else
       QDir myDir( applicationDirPath() );
-      myDir.cdUp();
+      // Fix for server wich is one level deeper in /usr/lib/cgi-bin
+      if ( applicationDirPath().contains( QStringLiteral( "cgi-bin" ) ) )
+      {
+        myDir.cdUp();
+      }
+      myDir.cdUp(); // Go from /usr/bin or /usr/lib (for server) to /usr
       QString myPrefix = myDir.absolutePath();
       setPrefixPath( myPrefix, true );
 #endif


### PR DESCRIPTION
Fixes #18230 - service configuration error (service unknown or unsupported)

I thought about placing the fix into the server code, but I believe
that it's much more cleaner here: otherwise we'd need to adjust all
other paths *after* they have been uncorrectly set by the application
init() code.

Note that it is always possible to override the path with an environment variable.
