### PR TITLE
More processing parameters in modeller

### DIFF
--- a/python/core/processing/qgsprocessingprovider.sip.in
+++ b/python/core/processing/qgsprocessingprovider.sip.in
@@ -206,6 +206,17 @@ algorithm is contained by this provider.
 .. seealso:: :py:func:`algorithms`
 %End
 
+    virtual QgsProcessingParameterDefinition *createParameter( const QString &type, const QString &name ) /Factory/;
+%Docstring
+Returns a new parameter from of the given type and name.
+This should be reimplemented by providers that implement custom types.
+If the provider does not implement the parameter with ``type``, a None will be returned.
+
+By default, this returns a None.
+
+.. versionadded:: 3.2
+%End
+
   signals:
 
     void algorithmsLoaded();

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -54,49 +54,8 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
         return self.tr('attributes,table').split(',')
 
     def initParameters(self, config=None):
-
-        class ParameterFieldsMapping(QgsProcessingParameterDefinition):
-
-            def __init__(self, name, description, parentLayerParameterName='INPUT'):
-                super().__init__(name, description)
-                self._parentLayerParameter = parentLayerParameterName
-
-            def clone(self):
-                copy = ParameterFieldsMapping(self.name(), self.description(), self._parentLayerParameter)
-                return copy
-
-            def type(self):
-                return 'fields_mapping'
-
-            def checkValueIsAcceptable(self, value, context=None):
-                if not isinstance(value, list):
-                    return False
-                for field_def in value:
-                    if not isinstance(field_def, dict):
-                        return False
-                    if 'name' not in field_def.keys():
-                        return False
-                    if 'type' not in field_def.keys():
-                        return False
-                    if 'expression' not in field_def.keys():
-                        return False
-                return True
-
-            def valueAsPythonString(self, value, context):
-                return str(value)
-
-            def asScriptCode(self):
-                raise NotImplementedError()
-
-            @classmethod
-            def fromScriptCode(cls, name, description, isOptional, definition):
-                raise NotImplementedError()
-
-            def parentLayerParameter(self):
-                return self._parentLayerParameter
-
-        fields_mapping = ParameterFieldsMapping(self.FIELDS_MAPPING,
-                                                description=self.tr('Fields mapping'))
+        fields_mapping = FieldsMapper.ParameterFieldsMapping(self.FIELDS_MAPPING,
+                                                             description=self.tr('Fields mapping'))
         fields_mapping.setMetadata({
             'widget_wrapper': 'processing.algs.qgis.ui.FieldsMappingPanel.FieldsMappingWidgetWrapper'
         })
@@ -181,3 +140,47 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
         feature.setAttributes(attributes)
         self._row_number += 1
         return [feature]
+
+    class ParameterFieldsMapping(QgsProcessingParameterDefinition):
+
+        def __init__(self, name, description='', parentLayerParameterName='INPUT'):
+            super().__init__(name, description)
+            self._parentLayerParameter = parentLayerParameterName
+
+        def clone(self):
+            copy = FieldsMapper.ParameterFieldsMapping(self.name(), self.description(), self._parentLayerParameter)
+            return copy
+
+        def type(self):
+            return self.typeName()
+
+        @staticmethod
+        def typeName():
+            return 'fields_mapping'
+
+        def checkValueIsAcceptable(self, value, context=None):
+            if not isinstance(value, list):
+                return False
+            for field_def in value:
+                if not isinstance(field_def, dict):
+                    return False
+                if 'name' not in field_def.keys():
+                    return False
+                if 'type' not in field_def.keys():
+                    return False
+                if 'expression' not in field_def.keys():
+                    return False
+            return True
+
+        def valueAsPythonString(self, value, context):
+            return str(value)
+
+        def asScriptCode(self):
+            raise NotImplementedError()
+
+        @classmethod
+        def fromScriptCode(cls, name, description, isOptional, definition):
+            raise NotImplementedError()
+
+        def parentLayerParameter(self):
+            return self._parentLayerParameter

--- a/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QgisAlgorithmProvider.py
@@ -36,6 +36,8 @@ except:
 from qgis.core import (QgsApplication,
                        QgsProcessingProvider)
 
+from PyQt5.QtCore import QCoreApplication
+
 from processing.script import ScriptUtils
 
 from .QgisAlgorithm import QgisAlgorithm
@@ -154,6 +156,7 @@ pluginPath = os.path.normpath(os.path.join(
 
 
 class QgisAlgorithmProvider(QgsProcessingProvider):
+    fieldMappingParameterName = QCoreApplication.translate('Processing', 'Fields Mapper')
 
     def __init__(self):
         super().__init__()
@@ -316,6 +319,30 @@ class QgisAlgorithmProvider(QgsProcessingProvider):
             self.addAlgorithm(a)
         for a in self.externalAlgs:
             self.addAlgorithm(a)
+
+    def load(self):
+        success = super().load()
+
+        from processing.core.Processing import Processing
+
+        if success:
+            Processing.registerParameter(
+                'Fields Mapper',
+                self.fieldMappingParameterName,
+                parameter=FieldsMapper.ParameterFieldsMapping,
+                metadata={'widget_wrapper': 'processing.algs.qgis.ui.FieldsMappingPanel.FieldsMappingWidgetWrapper'}
+            )
+
+        return success
+
+    def unload(self):
+        super().unload()
+        from processing.core.Processing import Processing
+        Processing.unregisterParameter(self.fieldMappingParameterName)
+
+    def createParameter(self, type, name):
+        if type == 'fields_mapping':
+            return FieldsMapper.ParameterFieldsMapping(name)
 
     def supportsNonFileBasedOutput(self):
         return True

--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -36,6 +36,7 @@ from qgis.PyQt.QtCore import (
     QVariant,
     Qt,
     pyqtSlot,
+    QCoreApplication
 )
 from qgis.PyQt.QtWidgets import (
     QComboBox,
@@ -45,6 +46,8 @@ from qgis.PyQt.QtWidgets import (
     QMessageBox,
     QSpinBox,
     QStyledItemDelegate,
+    QWidget,
+    QVBoxLayout
 )
 
 from qgis.core import (
@@ -58,8 +61,9 @@ from qgis.core import (
 )
 from qgis.gui import QgsFieldExpressionWidget
 
-from processing.gui.wrappers import WidgetWrapper, DIALOG_STANDARD, DIALOG_MODELER
+from processing.gui.wrappers import WidgetWrapper, DIALOG_STANDARD, DIALOG_MODELER, DIALOG_BATCH
 from processing.tools import dataobjects
+from processing.algs.qgis.FieldsMapper import FieldsMapper
 
 
 pluginPath = os.path.dirname(__file__)
@@ -141,7 +145,10 @@ class FieldsMappingModel(QAbstractTableModel):
     def rowCount(self, parent=QModelIndex()):
         if parent.isValid():
             return 0
-        return self._mapping.__len__()
+        try:
+            return len(self._mapping)
+        except TypeError:
+            return 0
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         if role == Qt.DisplayRole:
@@ -473,9 +480,31 @@ class FieldsMappingWidgetWrapper(WidgetWrapper):
         self._layer = None
 
     def createWidget(self):
-        panel = FieldsMappingPanel()
-        panel.dialogType = self.dialogType
-        return panel
+        self.panel = FieldsMappingPanel()
+        self.panel.dialogType = self.dialogType
+
+        if self.dialogType == DIALOG_MODELER:
+            self.combobox = QComboBox()
+            self.combobox.addItem(QCoreApplication.translate('Processing', '[Preconfigure]'), None)
+            fieldsMappingInputs = self.dialog.getAvailableValuesOfType(FieldsMapper.ParameterFieldsMapping)
+            for input in fieldsMappingInputs:
+                self.combobox.addItem(self.dialog.resolveValueDescription(input), input)
+
+            def updatePanelEnabledState():
+                if self.combobox.currentData() is None:
+                    self.panel.setEnabled(True)
+                else:
+                    self.panel.setEnabled(False)
+
+            self.combobox.currentIndexChanged.connect(updatePanelEnabledState)
+
+            widget = QWidget()
+            widget.setLayout(QVBoxLayout())
+            widget.layout().addWidget(self.combobox)
+            widget.layout().addWidget(self.panel)
+            return widget
+        else:
+            return self.panel
 
     def postInitialize(self, wrappers):
         for wrapper in wrappers:
@@ -506,10 +535,16 @@ class FieldsMappingWidgetWrapper(WidgetWrapper):
         if not isinstance(layer, QgsVectorLayer):
             layer = None
         self._layer = layer
-        self.widget.setLayer(self._layer)
+        self.panel.setLayer(self._layer)
 
     def setValue(self, value):
-        self.widget.setValue(value)
+        self.panel.setValue(value)
 
     def value(self):
-        return self.widget.value()
+        if self.dialogType == DIALOG_MODELER:
+            if self.combobox.currentData() is None:
+                return self.panel.value()
+            else:
+                return self.comboValue(combobox=self.combobox)
+        else:
+            return self.panel.value()

--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -135,8 +135,14 @@ class Processing(object):
 
     @staticmethod
     def registeredParameters():
-        """Returns a set of registered parameters.
-        Each entry is a tuple consisting of a human readable name and the class.
+        """Returns a dict of registered parameters. The key of the dict is the id of the parameter.
+        Each entry is itself a dict with the keys
+
+          - name: The human readable name of the parameter
+          - parameter: The class of the parameter
+          - metadata: Additional metadata for the parameter, mainly used for widget wrappers
+          - description: A longer description for the parameter, suitable for tooltips etc
+          - exposeToModeller: A boolean indicating if the parameter is available as model parameter input
         """
         return Processing.REGISTERED_PARAMETERS
 

--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -114,7 +114,7 @@ class Processing(object):
         Processing.REGISTERED_PARAMETERS = dict()
 
     @staticmethod
-    def registerParameter(id, name, parameter, metadata=dict(), description=None):
+    def registerParameter(id, name, parameter, metadata=dict(), description=None, exposeToModeller=True):
         """Register a new parameter.
         The ``name`` is a human readable translated string, the ``parameter`` is a class type with the base class ``qgis.core.QgsProcessingParameterDefinition``,
         the ``metadata`` is a dictionary with additional metadata, mainly used for widget wrappers.
@@ -123,7 +123,8 @@ class Processing(object):
             'name': name,
             'parameter': parameter,
             'metadata': metadata,
-            'description': description
+            'description': description,
+            'exposeToModeller': exposeToModeller
         }
 
     @staticmethod

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -262,7 +262,7 @@ def initializeParameters():
     Processing.registerParameter(PARAMETER_RANGE, QCoreApplication.translate('Processing', 'Range'), QgsProcessingParameterRange)
     Processing.registerParameter(PARAMETER_POINT, QCoreApplication.translate('Processing', 'Point'), QgsProcessingParameterPoint,
                                  description=QCoreApplication.translate('Processing', 'A geographic point parameter.'))
-    Processing.registerParameter(PARAMETER_ENUM, QCoreApplication.translate('Processing', 'Enum'), QgsProcessingParameterEnum)
+    Processing.registerParameter(PARAMETER_ENUM, QCoreApplication.translate('Processing', 'Enum'), QgsProcessingParameterEnum, exposeToModeller=False)
     Processing.registerParameter(PARAMETER_EXTENT, QCoreApplication.translate('Processing', 'Extent'), QgsProcessingParameterExtent,
                                  description=QCoreApplication.translate('Processing', 'A map extent parameter.'))
     Processing.registerParameter(PARAMETER_MATRIX, QCoreApplication.translate('Processing', 'Matrix'), QgsProcessingParameterMatrix)
@@ -270,10 +270,10 @@ def initializeParameters():
                                  description=QCoreApplication.translate('Processing', 'A file parameter, for use with non-map layer file sources.'))
     Processing.registerParameter(PARAMETER_TABLE_FIELD, QCoreApplication.translate('Processing', 'Field'), QgsProcessingParameterField,
                                  description=QCoreApplication.translate('Processing', 'A vector field parameter, for selecting an existing field from a vector source.'))
-    Processing.registerParameter(PARAMETER_VECTOR_DESTINATION, QCoreApplication.translate('Processing', 'Vector Destination'), QgsProcessingParameterVectorDestination)
-    Processing.registerParameter(PARAMETER_FILE_DESTINATION, QCoreApplication.translate('Processing', 'File Destination'), QgsProcessingParameterFileDestination)
-    Processing.registerParameter(PARAMETER_FOLDER_DESTINATION, QCoreApplication.translate('Processing', 'Folder Destination'), QgsProcessingParameterFolderDestination)
-    Processing.registerParameter(PARAMETER_RASTER_DESTINATION, QCoreApplication.translate('Processing', 'Raster Destination'), QgsProcessingParameterRasterDestination)
+    Processing.registerParameter(PARAMETER_VECTOR_DESTINATION, QCoreApplication.translate('Processing', 'Vector Destination'), QgsProcessingParameterVectorDestination, exposeToModeller=False)
+    Processing.registerParameter(PARAMETER_FILE_DESTINATION, QCoreApplication.translate('Processing', 'File Destination'), QgsProcessingParameterFileDestination, exposeToModeller=False)
+    Processing.registerParameter(PARAMETER_FOLDER_DESTINATION, QCoreApplication.translate('Processing', 'Folder Destination'), QgsProcessingParameterFolderDestination, exposeToModeller=False)
+    Processing.registerParameter(PARAMETER_RASTER_DESTINATION, QCoreApplication.translate('Processing', 'Raster Destination'), QgsProcessingParameterRasterDestination, exposeToModeller=False)
     Processing.registerParameter(PARAMETER_STRING, QCoreApplication.translate('Processing', 'String'), QgsProcessingParameterString,
                                  description=QCoreApplication.translate('Processing', 'A freeform string parameter.'))
     Processing.registerParameter(PARAMETER_MULTIPLE, QCoreApplication.translate('Processing', 'Multiple Layers'), QgsProcessingParameterMultipleLayers,

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -41,12 +41,14 @@ from qgis.core import (QgsRasterLayer,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterVectorLayer,
+                       QgsProcessingParameterBand,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterCrs,
                        QgsProcessingParameterRange,
                        QgsProcessingParameterPoint,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterExtent,
+                       QgsProcessingParameterExpression,
                        QgsProcessingParameterMatrix,
                        QgsProcessingParameterFile,
                        QgsProcessingParameterField,
@@ -55,9 +57,35 @@ from qgis.core import (QgsRasterLayer,
                        QgsProcessingParameterFolderDestination,
                        QgsProcessingParameterRasterDestination,
                        QgsProcessingParameterString,
+                       QgsProcessingParameterMapLayer,
                        QgsProcessingParameterMultipleLayers,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterNumber)
+
+from PyQt5.QtCore import QCoreApplication
+
+PARAMETER_NUMBER = 'Number'
+PARAMETER_RASTER = 'Raster Layer'
+PARAMETER_TABLE = 'Vector Layer'
+PARAMETER_VECTOR = 'Vector Features'
+PARAMETER_STRING = 'String'
+PARAMETER_EXPRESSION = 'Expression'
+PARAMETER_BOOLEAN = 'Boolean'
+PARAMETER_TABLE_FIELD = 'Vector Field'
+PARAMETER_EXTENT = 'Extent'
+PARAMETER_FILE = 'File'
+PARAMETER_POINT = 'Point'
+PARAMETER_CRS = 'CRS'
+PARAMETER_MULTIPLE = 'Multiple Input'
+PARAMETER_BAND = 'Raster Band'
+PARAMETER_MAP_LAYER = 'Map Layer'
+PARAMETER_RANGE = 'Range'
+PARAMETER_ENUM = 'Enum'
+PARAMETER_MATRIX = 'Matrix'
+PARAMETER_VECTOR_DESTINATION = 'Vector Destination'
+PARAMETER_FILE_DESTINATION = 'File Destination'
+PARAMETER_FOLDER_DESTINATION = 'Folder Destination'
+PARAMETER_RASTER_DESTINATION = 'Raster Destination'
 
 
 def getParameterFromString(s):
@@ -209,3 +237,53 @@ def getParameterFromString(s):
         param = QgsProcessingParameters.parameterFromScriptCode(s)
         if param:
             return param
+
+
+def initializeParameters():
+    from processing.core.Processing import Processing
+
+    """
+    ModelerParameterDefinitionDialog.PARAMETER_TABLE: QCoreApplication.translate('Processing',
+                                                                                 'A vector layer parameter, e.g. for algorithms which change layer styles, edit layers in place, or other operations which affect an entire layer.'),
+    """
+
+    Processing.registerParameter(PARAMETER_MAP_LAYER, QCoreApplication.translate('Processing', 'Map Layer'),
+                                 QgsProcessingParameterMapLayer,
+                                 description=QCoreApplication.translate('Processing', 'A generic map layer parameter, which accepts either vector or raster layers.'))
+    Processing.registerParameter(PARAMETER_BAND, QCoreApplication.translate('Processing', 'Raster Band'),
+                                 QgsProcessingParameterBand,
+                                 description=QCoreApplication.translate('Processing', 'A raster band parameter, for selecting an existing band from a raster source.'))
+    Processing.registerParameter(PARAMETER_EXPRESSION, QCoreApplication.translate('Processing', 'Expression'),
+                                 QgsProcessingParameterExpression,
+                                 description=QCoreApplication.translate('Processing', 'A QGIS expression parameter, which presents an expression builder widget to users.'))
+    Processing.registerParameter(PARAMETER_RASTER, QCoreApplication.translate('Processing', 'Raster Layer'), QgsProcessingParameterRasterLayer,
+                                 description=QCoreApplication.translate('Processing', 'A raster layer parameter.'))
+    Processing.registerParameter(PARAMETER_TABLE, QCoreApplication.translate('Processing', 'Vector Layer'), QgsProcessingParameterVectorLayer,
+                                 description=QCoreApplication.translate('Processing', 'A vector feature parameter, e.g. for algorithms which operate on the features within a layer.'))
+    Processing.registerParameter(PARAMETER_BOOLEAN, QCoreApplication.translate('Processing', 'Boolean'), QgsProcessingParameterBoolean,
+                                 description=QCoreApplication.translate('Processing', 'A boolean parameter, for true/false values.'))
+    Processing.registerParameter(PARAMETER_CRS, QCoreApplication.translate('Processing', 'CRS'), QgsProcessingParameterCrs,
+                                 description=QCoreApplication.translate('Processing', 'A coordinate reference system (CRS) input parameter.'))
+    Processing.registerParameter(PARAMETER_RANGE, QCoreApplication.translate('Processing', 'Range'), QgsProcessingParameterRange)
+    Processing.registerParameter(PARAMETER_POINT, QCoreApplication.translate('Processing', 'Point'), QgsProcessingParameterPoint,
+                                 description=QCoreApplication.translate('Processing', 'A geographic point parameter.'))
+    Processing.registerParameter(PARAMETER_ENUM, QCoreApplication.translate('Processing', 'Enum'), QgsProcessingParameterEnum)
+    Processing.registerParameter(PARAMETER_EXTENT, QCoreApplication.translate('Processing', 'Extent'), QgsProcessingParameterExtent,
+                                 description=QCoreApplication.translate('Processing', 'A map extent parameter.'))
+    Processing.registerParameter(PARAMETER_MATRIX, QCoreApplication.translate('Processing', 'Matrix'), QgsProcessingParameterMatrix)
+    Processing.registerParameter(PARAMETER_FILE, QCoreApplication.translate('Processing', 'File'), QgsProcessingParameterFile,
+                                 description=QCoreApplication.translate('Processing', 'A file parameter, for use with non-map layer file sources.'))
+    Processing.registerParameter(PARAMETER_TABLE_FIELD, QCoreApplication.translate('Processing', 'Field'), QgsProcessingParameterField,
+                                 description=QCoreApplication.translate('Processing', 'A vector field parameter, for selecting an existing field from a vector source.'))
+    Processing.registerParameter(PARAMETER_VECTOR_DESTINATION, QCoreApplication.translate('Processing', 'Vector Destination'), QgsProcessingParameterVectorDestination)
+    Processing.registerParameter(PARAMETER_FILE_DESTINATION, QCoreApplication.translate('Processing', 'File Destination'), QgsProcessingParameterFileDestination)
+    Processing.registerParameter(PARAMETER_FOLDER_DESTINATION, QCoreApplication.translate('Processing', 'Folder Destination'), QgsProcessingParameterFolderDestination)
+    Processing.registerParameter(PARAMETER_RASTER_DESTINATION, QCoreApplication.translate('Processing', 'Raster Destination'), QgsProcessingParameterRasterDestination)
+    Processing.registerParameter(PARAMETER_STRING, QCoreApplication.translate('Processing', 'String'), QgsProcessingParameterString,
+                                 description=QCoreApplication.translate('Processing', 'A freeform string parameter.'))
+    Processing.registerParameter(PARAMETER_MULTIPLE, QCoreApplication.translate('Processing', 'Multiple Layers'), QgsProcessingParameterMultipleLayers,
+                                 description=QCoreApplication.translate('Processing', 'An input allowing selection of multiple sources, including multiple map layers or file sources.'))
+    Processing.registerParameter(PARAMETER_VECTOR, QCoreApplication.translate('Processing', 'Feature Source'), QgsProcessingParameterFeatureSource)
+    Processing.registerParameter(PARAMETER_NUMBER, QCoreApplication.translate('Processing', 'Number'), QgsProcessingParameterNumber,
+                                 description=QCoreApplication.translate('Processing', 'A numeric parameter, including float or integer values.'))
+    Processing.registeredParameters()

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -242,11 +242,6 @@ def getParameterFromString(s):
 def initializeParameters():
     from processing.core.Processing import Processing
 
-    """
-    ModelerParameterDefinitionDialog.PARAMETER_TABLE: QCoreApplication.translate('Processing',
-                                                                                 'A vector layer parameter, e.g. for algorithms which change layer styles, edit layers in place, or other operations which affect an entire layer.'),
-    """
-
     Processing.registerParameter(PARAMETER_MAP_LAYER, QCoreApplication.translate('Processing', 'Map Layer'),
                                  QgsProcessingParameterMapLayer,
                                  description=QCoreApplication.translate('Processing', 'A generic map layer parameter, which accepts either vector or raster layers.'))

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -227,7 +227,7 @@ class ModelerDialog(BASE, WIDGET):
 
         def _mimeDataInput(items):
             mimeData = QMimeData()
-            text = items[0].text(0)
+            text = items[0].data(0, Qt.UserRole)
             mimeData.setText(text)
             return mimeData
 
@@ -629,8 +629,8 @@ class ModelerDialog(BASE, WIDGET):
         sortedParams = sorted(Processing.registeredParameters().items())
         for param in sortedParams:
             paramItem = QTreeWidgetItem()
-            paramItem.setText(0, param[0])
-            paramItem.setData(0, Qt.UserRole, param[1]['parameter'])
+            paramItem.setText(0, param[1]['name'])
+            paramItem.setData(0, Qt.UserRole, param[0])
             paramItem.setIcon(0, icon)
             paramItem.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDragEnabled)
             paramItem.setToolTip(0, param[1]['description'])

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -628,13 +628,14 @@ class ModelerDialog(BASE, WIDGET):
         parametersItem.setText(0, self.tr('Parameters'))
         sortedParams = sorted(Processing.registeredParameters().items())
         for param in sortedParams:
-            paramItem = QTreeWidgetItem()
-            paramItem.setText(0, param[1]['name'])
-            paramItem.setData(0, Qt.UserRole, param[0])
-            paramItem.setIcon(0, icon)
-            paramItem.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDragEnabled)
-            paramItem.setToolTip(0, param[1]['description'])
-            parametersItem.addChild(paramItem)
+            if param[1]['exposeToModeller']:
+                paramItem = QTreeWidgetItem()
+                paramItem.setText(0, param[1]['name'])
+                paramItem.setData(0, Qt.UserRole, param[0])
+                paramItem.setIcon(0, icon)
+                paramItem.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDragEnabled)
+                paramItem.setToolTip(0, param[1]['description'])
+                parametersItem.addChild(paramItem)
         self.inputsTree.addTopLevelItem(parametersItem)
         parametersItem.setExpanded(True)
 

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -204,12 +204,11 @@ class ModelerGraphicItem(QGraphicsItem):
                 self.scene.dialog.repaintModel()
         elif isinstance(self.element, QgsProcessingModelChildAlgorithm):
             dlg = None
-            try:
-                dlg = self.element.algorithm().getCustomModelerParametersDialog(self.model, self.element.childId())
-            except:
-                pass
+            elemAlg = self.element.algorithm()
+            if hasattr(elemAlg, 'getCustomModelerParametersDialog'):
+                dlg = elemAlg.getCustomModelerParametersDialog(self.model, self.element.childId())
             if not dlg:
-                dlg = ModelerParametersDialog(self.element.algorithm(), self.model, self.element.childId())
+                dlg = ModelerParametersDialog(elemAlg, self.model, self.element.childId())
             if dlg.exec_():
                 alg = dlg.createAlgorithm()
                 alg.setChildId(self.element.childId())

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -62,41 +62,10 @@ from qgis.PyQt.QtWidgets import (QDialog,
                                  QDialogButtonBox,
                                  QMessageBox)
 
+from processing.core import parameters
+
 
 class ModelerParameterDefinitionDialog(QDialog):
-    PARAMETER_NUMBER = 'Number'
-    PARAMETER_RASTER = 'Raster Layer'
-    PARAMETER_TABLE = 'Vector Layer'
-    PARAMETER_VECTOR = 'Vector Features'
-    PARAMETER_STRING = 'String'
-    PARAMETER_EXPRESSION = 'Expression'
-    PARAMETER_BOOLEAN = 'Boolean'
-    PARAMETER_TABLE_FIELD = 'Vector Field'
-    PARAMETER_EXTENT = 'Extent'
-    PARAMETER_FILE = 'File'
-    PARAMETER_POINT = 'Point'
-    PARAMETER_CRS = 'CRS'
-    PARAMETER_MULTIPLE = 'Multiple Input'
-    PARAMETER_BAND = 'Raster Band'
-    PARAMETER_MAP_LAYER = 'Map Layer'
-
-    paramTypes = [
-        PARAMETER_BOOLEAN,
-        PARAMETER_EXTENT,
-        PARAMETER_FILE,
-        PARAMETER_NUMBER,
-        PARAMETER_RASTER,
-        PARAMETER_STRING,
-        PARAMETER_EXPRESSION,
-        PARAMETER_MAP_LAYER,
-        PARAMETER_TABLE,
-        PARAMETER_TABLE_FIELD,
-        PARAMETER_VECTOR,
-        PARAMETER_POINT,
-        PARAMETER_CRS,
-        PARAMETER_MULTIPLE,
-        PARAMETER_BAND
-    ]
 
     def __init__(self, alg, paramType=None, param=None):
         self.alg = alg
@@ -128,7 +97,7 @@ class ModelerParameterDefinitionDialog(QDialog):
         if isinstance(self.param, QgsProcessingParameterDefinition):
             self.nameTextBox.setText(self.param.description())
 
-        if self.paramType == ModelerParameterDefinitionDialog.PARAMETER_BOOLEAN or \
+        if self.paramType == parameters.PARAMETER_BOOLEAN or \
                 isinstance(self.param, QgsProcessingParameterBoolean):
             self.state = QCheckBox()
             self.state.setText(self.tr('Checked'))
@@ -136,7 +105,7 @@ class ModelerParameterDefinitionDialog(QDialog):
             if self.param is not None:
                 self.state.setChecked(bool(self.param.defaultValue()))
             self.verticalLayout.addWidget(self.state)
-        elif self.paramType == ModelerParameterDefinitionDialog.PARAMETER_TABLE_FIELD or \
+        elif self.paramType == parameters.PARAMETER_TABLE_FIELD or \
                 isinstance(self.param, QgsProcessingParameterField):
             self.verticalLayout.addWidget(QLabel(self.tr('Parent layer')))
             self.parentCombo = QComboBox()
@@ -183,7 +152,7 @@ class ModelerParameterDefinitionDialog(QDialog):
                     self.defaultTextBox.setText(str(default))
             self.verticalLayout.addWidget(self.defaultTextBox)
 
-        elif self.paramType == ModelerParameterDefinitionDialog.PARAMETER_BAND or \
+        elif self.paramType == parameters.PARAMETER_BAND or \
                 isinstance(self.param, QgsProcessingParameterBand):
             self.verticalLayout.addWidget(QLabel(self.tr('Parent layer')))
             self.parentCombo = QComboBox()
@@ -198,7 +167,7 @@ class ModelerParameterDefinitionDialog(QDialog):
                     idx += 1
             self.verticalLayout.addWidget(self.parentCombo)
         elif (self.paramType in (
-                ModelerParameterDefinitionDialog.PARAMETER_VECTOR, ModelerParameterDefinitionDialog.PARAMETER_TABLE) or
+                parameters.PARAMETER_VECTOR, parameters.PARAMETER_TABLE) or
                 isinstance(self.param, (QgsProcessingParameterFeatureSource, QgsProcessingParameterVectorLayer))):
             self.verticalLayout.addWidget(QLabel(self.tr('Geometry type')))
             self.shapetypeCombo = QComboBox()
@@ -210,7 +179,7 @@ class ModelerParameterDefinitionDialog(QDialog):
             if self.param is not None:
                 self.shapetypeCombo.setCurrentIndex(self.shapetypeCombo.findData(self.param.dataTypes()[0]))
             self.verticalLayout.addWidget(self.shapetypeCombo)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_MULTIPLE or
+        elif (self.paramType == parameters.PARAMETER_MULTIPLE or
               isinstance(self.param, QgsProcessingParameterMultipleLayers)):
             self.verticalLayout.addWidget(QLabel(self.tr('Data type')))
             self.datatypeCombo = QComboBox()
@@ -225,7 +194,7 @@ class ModelerParameterDefinitionDialog(QDialog):
             if self.param is not None:
                 self.datatypeCombo.setCurrentIndex(self.datatypeCombo.findData(self.param.layerType()))
             self.verticalLayout.addWidget(self.datatypeCombo)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_NUMBER or
+        elif (self.paramType == parameters.PARAMETER_NUMBER or
               isinstance(self.param, QgsProcessingParameterNumber)):
             self.verticalLayout.addWidget(QLabel(self.tr('Min value')))
             self.minTextBox = QLineEdit()
@@ -246,7 +215,7 @@ class ModelerParameterDefinitionDialog(QDialog):
                 if default:
                     self.defaultTextBox.setText(str(default))
             self.verticalLayout.addWidget(self.defaultTextBox)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_EXPRESSION or
+        elif (self.paramType == parameters.PARAMETER_EXPRESSION or
               isinstance(self.param, QgsProcessingParameterExpression)):
             self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
             self.defaultEdit = QgsExpressionLineEdit()
@@ -267,14 +236,14 @@ class ModelerParameterDefinitionDialog(QDialog):
                             self.parentCombo.setCurrentIndex(idx)
                     idx += 1
             self.verticalLayout.addWidget(self.parentCombo)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_STRING or
+        elif (self.paramType == parameters.PARAMETER_STRING or
               isinstance(self.param, QgsProcessingParameterString)):
             self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
             self.defaultTextBox = QLineEdit()
             if self.param is not None:
                 self.defaultTextBox.setText(self.param.defaultValue())
             self.verticalLayout.addWidget(self.defaultTextBox)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_FILE or
+        elif (self.paramType == parameters.PARAMETER_FILE or
               isinstance(self.param, QgsProcessingParameterFile)):
             self.verticalLayout.addWidget(QLabel(self.tr('Type')))
             self.fileFolderCombo = QComboBox()
@@ -284,14 +253,14 @@ class ModelerParameterDefinitionDialog(QDialog):
                 self.fileFolderCombo.setCurrentIndex(
                     1 if self.param.behavior() == QgsProcessingParameterFile.Folder else 0)
             self.verticalLayout.addWidget(self.fileFolderCombo)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_POINT or
+        elif (self.paramType == parameters.PARAMETER_POINT or
               isinstance(self.param, QgsProcessingParameterPoint)):
             self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
             self.defaultTextBox = QLineEdit()
             if self.param is not None:
                 self.defaultTextBox.setText(self.param.defaultValue())
             self.verticalLayout.addWidget(self.defaultTextBox)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_CRS or
+        elif (self.paramType == parameters.PARAMETER_CRS or
               isinstance(self.param, QgsProcessingParameterCrs)):
             self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
             self.selector = QgsProjectionSelectionWidget()
@@ -339,10 +308,10 @@ class ModelerParameterDefinitionDialog(QDialog):
                 i += 1
         else:
             name = self.param.name()
-        if (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_BOOLEAN or
+        if (self.paramType == parameters.PARAMETER_BOOLEAN or
                 isinstance(self.param, QgsProcessingParameterBoolean)):
             self.param = QgsProcessingParameterBoolean(name, description, self.state.isChecked())
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_TABLE_FIELD or
+        elif (self.paramType == parameters.PARAMETER_TABLE_FIELD or
               isinstance(self.param, QgsProcessingParameterField)):
             if self.parentCombo.currentIndex() < 0:
                 QMessageBox.warning(self, self.tr('Unable to define parameter'),
@@ -356,7 +325,7 @@ class ModelerParameterDefinitionDialog(QDialog):
             self.param = QgsProcessingParameterField(name, description, defaultValue=default,
                                                      parentLayerParameterName=parent, type=datatype,
                                                      allowMultiple=self.multipleCheck.isChecked())
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_BAND or
+        elif (self.paramType == parameters.PARAMETER_BAND or
               isinstance(self.param, QgsProcessingParameterBand)):
             if self.parentCombo.currentIndex() < 0:
                 QMessageBox.warning(self, self.tr('Unable to define parameter'),
@@ -364,30 +333,30 @@ class ModelerParameterDefinitionDialog(QDialog):
                 return
             parent = self.parentCombo.currentData()
             self.param = QgsProcessingParameterBand(name, description, None, parent)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_MAP_LAYER or
+        elif (self.paramType == parameters.PARAMETER_MAP_LAYER or
               isinstance(self.param, QgsProcessingParameterMapLayer)):
             self.param = QgsProcessingParameterMapLayer(
                 name, description)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_RASTER or
+        elif (self.paramType == parameters.PARAMETER_RASTER or
               isinstance(self.param, QgsProcessingParameterRasterLayer)):
             self.param = QgsProcessingParameterRasterLayer(
                 name, description)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_TABLE or
+        elif (self.paramType == parameters.PARAMETER_TABLE or
               isinstance(self.param, QgsProcessingParameterVectorLayer)):
             self.param = QgsProcessingParameterVectorLayer(
                 name, description,
                 [self.shapetypeCombo.currentData()])
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_VECTOR or
+        elif (self.paramType == parameters.PARAMETER_VECTOR or
               isinstance(self.param, QgsProcessingParameterFeatureSource)):
             self.param = QgsProcessingParameterFeatureSource(
                 name, description,
                 [self.shapetypeCombo.currentData()])
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_MULTIPLE or
+        elif (self.paramType == parameters.PARAMETER_MULTIPLE or
               isinstance(self.param, QgsProcessingParameterMultipleLayers)):
             self.param = QgsProcessingParameterMultipleLayers(
                 name, description,
                 self.datatypeCombo.currentData())
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_NUMBER or
+        elif (self.paramType == parameters.PARAMETER_NUMBER or
               isinstance(self.param, QgsProcessingParameterNumber)):
             try:
                 self.param = QgsProcessingParameterNumber(name, description, QgsProcessingParameterNumber.Double,
@@ -402,31 +371,39 @@ class ModelerParameterDefinitionDialog(QDialog):
                 QMessageBox.warning(self, self.tr('Unable to define parameter'),
                                     self.tr('Wrong or missing parameter values'))
                 return
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_EXPRESSION or
+        elif (self.paramType == parameters.PARAMETER_EXPRESSION or
               isinstance(self.param, QgsProcessingParameterExpression)):
             parent = self.parentCombo.currentData()
             self.param = QgsProcessingParameterExpression(name, description,
                                                           str(self.defaultEdit.expression()),
                                                           parent)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_STRING or
+        elif (self.paramType == parameters.PARAMETER_STRING or
               isinstance(self.param, QgsProcessingParameterString)):
             self.param = QgsProcessingParameterString(name, description,
                                                       str(self.defaultTextBox.text()))
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_EXTENT or
+        elif (self.paramType == parameters.PARAMETER_EXTENT or
               isinstance(self.param, QgsProcessingParameterExtent)):
             self.param = QgsProcessingParameterExtent(name, description)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_FILE or
+        elif (self.paramType == parameters.PARAMETER_FILE or
               isinstance(self.param, QgsProcessingParameterFile)):
             isFolder = self.fileFolderCombo.currentIndex() == 1
             self.param = QgsProcessingParameterFile(name, description,
                                                     QgsProcessingParameterFile.Folder if isFolder else QgsProcessingParameterFile.File)
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_POINT or
+        elif (self.paramType == parameters.PARAMETER_POINT or
               isinstance(self.param, QgsProcessingParameterPoint)):
             self.param = QgsProcessingParameterPoint(name, description,
                                                      str(self.defaultTextBox.text()))
-        elif (self.paramType == ModelerParameterDefinitionDialog.PARAMETER_CRS or
+        elif (self.paramType == parameters.PARAMETER_CRS or
               isinstance(self.param, QgsProcessingParameterCrs)):
             self.param = QgsProcessingParameterCrs(name, description, self.selector.crs().authid())
+        else:
+            from processing.core.Processing import Processing
+
+            param = Processing.registeredParameters()[self.paramType]
+
+            self.param = param['parameter'](name, description, None)
+            self.param.setMetadata(param['metadata'])
+
         if not self.requiredCheck.isChecked():
             self.param.setFlags(self.param.flags() | QgsProcessingParameterDefinition.FlagOptional)
 
@@ -442,24 +419,3 @@ class ModelerParameterDefinitionDialog(QDialog):
         settings.setValue("/Processing/modelParametersDefinitionDialogGeometry", self.saveGeometry())
 
         QDialog.reject(self)
-
-    @staticmethod
-    def inputTooltip(input_type):
-        tooltips = {
-            ModelerParameterDefinitionDialog.PARAMETER_NUMBER: QCoreApplication.translate('Processing', 'A numeric parameter, including float or integer values.'),
-            ModelerParameterDefinitionDialog.PARAMETER_RASTER: QCoreApplication.translate('Processing', 'A raster layer parameter.'),
-            ModelerParameterDefinitionDialog.PARAMETER_TABLE: QCoreApplication.translate('Processing', 'A vector layer parameter, e.g. for algorithms which change layer styles, edit layers in place, or other operations which affect an entire layer.'),
-            ModelerParameterDefinitionDialog.PARAMETER_VECTOR: QCoreApplication.translate('Processing', 'A vector feature parameter, e.g. for algorithms which operate on the features within a layer.'),
-            ModelerParameterDefinitionDialog.PARAMETER_STRING: QCoreApplication.translate('Processing', 'A freeform string parameter.'),
-            ModelerParameterDefinitionDialog.PARAMETER_EXPRESSION: QCoreApplication.translate('Processing', 'A QGIS expression parameter, which presents an expression builder widget to users.'),
-            ModelerParameterDefinitionDialog.PARAMETER_BOOLEAN: QCoreApplication.translate('Processing', 'A boolean parameter, for true/false values.'),
-            ModelerParameterDefinitionDialog.PARAMETER_TABLE_FIELD: QCoreApplication.translate('Processing', 'A vector field parameter, for selecting an existing field from a vector source.'),
-            ModelerParameterDefinitionDialog.PARAMETER_EXTENT: QCoreApplication.translate('Processing', 'A map extent parameter.'),
-            ModelerParameterDefinitionDialog.PARAMETER_FILE: QCoreApplication.translate('Processing', 'A file parameter, for use with non-map layer file sources.'),
-            ModelerParameterDefinitionDialog.PARAMETER_POINT: QCoreApplication.translate('Processing', 'A geographic point parameter.'),
-            ModelerParameterDefinitionDialog.PARAMETER_CRS: QCoreApplication.translate('Processing', 'A coordinate reference system (CRS) input parameter.'),
-            ModelerParameterDefinitionDialog.PARAMETER_MULTIPLE: QCoreApplication.translate('Processing', 'An input allowing selection of multiple sources, including multiple map layers or file sources.'),
-            ModelerParameterDefinitionDialog.PARAMETER_BAND: QCoreApplication.translate('Processing', 'A raster band parameter, for selecting an existing band from a raster source.'),
-            ModelerParameterDefinitionDialog.PARAMETER_MAP_LAYER: QCoreApplication.translate('Processing', 'A generic map layer parameter, which accepts either vector or raster layers.')
-        }
-        return tooltips[input_type]

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -25,6 +25,7 @@
 #include "qgssettings.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsreferencedgeometry.h"
+#include "qgsprocessingregistry.h"
 #include <functional>
 
 bool QgsProcessingParameters::isDynamic( const QVariantMap &parameters, const QString &name )
@@ -1079,6 +1080,21 @@ QgsProcessingParameterDefinition *QgsProcessingParameters::parameterFromVariantM
     def.reset( new QgsProcessingParameterFolderDestination( name ) );
   else if ( type == QgsProcessingParameterBand::typeName() )
     def.reset( new QgsProcessingParameterBand( name ) );
+  else
+  {
+    const QList<QgsProcessingProvider *> providers = QgsApplication::instance()->processingRegistry()->providers();
+
+    for ( QgsProcessingProvider *provider : providers )
+    {
+      QgsProcessingParameterDefinition *param = provider->createParameter( type, name );
+
+      if ( param )
+      {
+        def.reset( param );
+        break;
+      }
+    }
+  }
 
   if ( !def )
     return nullptr;

--- a/src/core/processing/qgsprocessingprovider.cpp
+++ b/src/core/processing/qgsprocessingprovider.cpp
@@ -74,6 +74,13 @@ const QgsProcessingAlgorithm *QgsProcessingProvider::algorithm( const QString &n
   return mAlgorithms.value( name );
 }
 
+QgsProcessingParameterDefinition *QgsProcessingProvider::createParameter( const QString &type, const QString &name )
+{
+  Q_UNUSED( type )
+  Q_UNUSED( name )
+  return nullptr;
+}
+
 bool QgsProcessingProvider::addAlgorithm( QgsProcessingAlgorithm *algorithm )
 {
   if ( !algorithm )

--- a/src/core/processing/qgsprocessingprovider.h
+++ b/src/core/processing/qgsprocessingprovider.h
@@ -203,6 +203,17 @@ class CORE_EXPORT QgsProcessingProvider : public QObject
      */
     const QgsProcessingAlgorithm *algorithm( const QString &name ) const;
 
+    /**
+     * Returns a new parameter from of the given type and name.
+     * This should be reimplemented by providers that implement custom types.
+     * If the provider does not implement the parameter with \a type, a nullptr will be returned.
+     *
+     * By default, this returns a nullptr.
+     *
+     * \since QGIS 3.2
+     */
+    virtual QgsProcessingParameterDefinition *createParameter( const QString &type, const QString &name ) SIP_FACTORY;
+
   signals:
 
     /**


### PR DESCRIPTION
Opens up the processing parameter system more. Instead of having hardcoded lists of parameters in various places, there is a registry of available parameters and an API for plugins to expose their own parameters.

This makes the fields mapping parameter for refactor fields available in the modeller.

![screenshot from 2018-03-01 08-18-32](https://user-images.githubusercontent.com/588407/36846560-295ea552-1d29-11e8-9d6d-561a646a5432.png)

As a nice side effect, the list of available parameters in the modeller dialog is now also translatable.

At the current state, all available parameters are exposed to the modeller. Many of them are not prepared (i.e. they don't have a combobox to select from available input parameter definitions inside an algorithm, so cannot be connected). I'll probably disable those for now, they can then incrementally be added later on.