### PR TITLE
Fix Integer range widget with allowNull

### DIFF
--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -128,24 +128,27 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
       mDoubleSpinBox->setSuffix( config( QStringLiteral( "Suffix" ) ).toString() );
 
     connect( mDoubleSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ),
-    this, [ = ]( double value ) { emit valueChanged( value ); } );
+    this, [ = ]( double ) { emitValueChanged(); } );
   }
   else if ( mIntSpinBox )
   {
     QgsSpinBox *qgsWidget = qobject_cast<QgsSpinBox *>( mIntSpinBox );
     if ( qgsWidget )
       qgsWidget->setShowClearButton( allowNull );
+    int minval = min.toInt();
     if ( allowNull )
     {
-      int minval = min.toInt();
       int stepval = step.toInt();
       minval -= stepval;
       mIntSpinBox->setValue( minval );
       mIntSpinBox->setSpecialValueText( QgsApplication::nullRepresentation() );
     }
-    setupIntEditor( min, max, step, mIntSpinBox, this );
+    setupIntEditor( minval, max, step, mIntSpinBox, this );
     if ( config( QStringLiteral( "Suffix" ) ).isValid() )
       mIntSpinBox->setSuffix( config( QStringLiteral( "Suffix" ) ).toString() );
+
+    connect( mIntSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ),
+    this, [ = ]( int ) { emitValueChanged(); } );
   }
   else
   {

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -98,7 +98,7 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
 
     mDoubleSpinBox->setDecimals( precisionval );
 
-    QgsDoubleSpinBox *qgsWidget = dynamic_cast<QgsDoubleSpinBox *>( mDoubleSpinBox );
+    QgsDoubleSpinBox *qgsWidget = qobject_cast<QgsDoubleSpinBox *>( mDoubleSpinBox );
 
 
     if ( qgsWidget )
@@ -132,7 +132,7 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
   }
   else if ( mIntSpinBox )
   {
-    QgsSpinBox *qgsWidget = dynamic_cast<QgsSpinBox *>( mIntSpinBox );
+    QgsSpinBox *qgsWidget = qobject_cast<QgsSpinBox *>( mIntSpinBox );
     if ( qgsWidget )
       qgsWidget->setShowClearButton( allowNull );
     if ( allowNull )

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -146,9 +146,6 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
     setupIntEditor( minval, max, step, mIntSpinBox, this );
     if ( config( QStringLiteral( "Suffix" ) ).isValid() )
       mIntSpinBox->setSuffix( config( QStringLiteral( "Suffix" ) ).toString() );
-
-    connect( mIntSpinBox, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ),
-    this, [ = ]( int ) { emitValueChanged(); } );
   }
   else
   {

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -466,7 +466,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         # check new values
         self.assertTrue(vl.getFeatures('id=1').nextFeature(f))
-        self.assertEqual(f.attributes(), [1, 1, 0])
+        self.assertEqual(f.attributes(), [1, 1, NULL])
 
     def testTransactionTuple(self):
         # create a vector layer based on postgres

--- a/tests/src/python/test_qgsrangewidgets.py
+++ b/tests/src/python/test_qgsrangewidgets.py
@@ -45,6 +45,7 @@ class TestQgsRangeWidget(unittest.TestCase):
         reg = QgsGui.editorWidgetRegistry()
         configWdg = reg.createConfigWidget('Range', self.layer, 1, None)
         config = configWdg.config()
+        config["Min"] = 0
 
         # if null shall be allowed
         if allownull:
@@ -84,10 +85,13 @@ class TestQgsRangeWidget(unittest.TestCase):
         rangewidget = self.__createRangeWidget(True)
 
         rangewidget.setValue(NULL)
-        assert rangewidget.value() == NULL
+        self.assertEqual(rangewidget.value(), NULL)
 
         rangewidget.setValue(None)
-        assert rangewidget.value() == NULL
+        self.assertEqual(rangewidget.value(), NULL)
+
+        rangewidget.setValue(0)
+        self.assertEqual(rangewidget.value(), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Steps to reproduce:

    Take an integer field
    Configure a range widget with * min 0 * max 10 * step 1 * allow null True

Try to enter a value of 0

Observed behavior:

NULL appears

Expected behavior:

0 appears

See https://issues.qgis.org/issues/18297