### PR TITLE
Non-spatial layers shoudn't have a coordinate transform

### DIFF
--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -380,7 +380,7 @@ void QgsMapSettings::setTransformContext( const QgsCoordinateTransformContext &c
 
 QgsCoordinateTransform QgsMapSettings::layerTransform( const QgsMapLayer *layer ) const
 {
-  if ( !layer )
+  if ( !layer || !layer->isSpatial() )
     return QgsCoordinateTransform();
 
   return QgsCoordinateTransform( layer->crs(), mDestCRS, mTransformContext );


### PR DESCRIPTION
## Description
Resolves a freeze for me when it tries to render non-spatial layers. 

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
