### PR TITLE
[oracle] Fix provider when feature id maps are required

### DIFF
--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -341,7 +341,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
       case PktRowId:
       case PktFidMap:
       {
-        QList<QVariant> primaryKeyVals;
+        QVariantList primaryKeyVals;
 
         if ( mSource->mPrimaryKeyType == PktFidMap )
         {
@@ -365,7 +365,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
           primaryKeyVals << mQry.value( col++ );
         }
 
-        fid = mSource->mShared->lookupFid( QVariant( primaryKeyVals ) );
+        fid = mSource->mShared->lookupFid( primaryKeyVals );
       }
       break;
 

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -1374,14 +1374,14 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist, QgsFeatureSink::Flag
           }
           else
           {
-            QList<QVariant> primaryKeyVals;
+            QVariantList primaryKeyVals;
 
             Q_FOREACH ( int idx, mPrimaryKeyAttrs )
             {
               primaryKeyVals << attributevec[ idx ];
             }
 
-            features->setId( mShared->lookupFid( QVariant( primaryKeyVals ) ) );
+            features->setId( mShared->lookupFid( primaryKeyVals ) );
           }
           QgsDebugMsgLevel( QString( "new fid=%1" ).arg( features->id() ), 4 );
         }
@@ -3193,11 +3193,11 @@ QgsOracleSharedData::QgsOracleSharedData()
 {
 }
 
-QgsFeatureId QgsOracleSharedData::lookupFid( const QVariant &v )
+QgsFeatureId QgsOracleSharedData::lookupFid( const QVariantList &v )
 {
   QMutexLocker locker( &mMutex );
 
-  QMap<QVariant, QgsFeatureId>::const_iterator it = mKeyToFid.find( v );
+  QMap<QVariantList, QgsFeatureId>::const_iterator it = mKeyToFid.constFind( v );
 
   if ( it != mKeyToFid.constEnd() )
   {
@@ -3214,13 +3214,13 @@ QVariant QgsOracleSharedData::removeFid( QgsFeatureId fid )
 {
   QMutexLocker locker( &mMutex );
 
-  QVariant v = mFidToKey[ fid ];
+  QVariantList v = mFidToKey[ fid ];
   mFidToKey.remove( fid );
   mKeyToFid.remove( v );
   return v;
 }
 
-void QgsOracleSharedData::insertFid( QgsFeatureId fid, const QVariant &k )
+void QgsOracleSharedData::insertFid( QgsFeatureId fid, const QVariantList &k )
 {
   QMutexLocker locker( &mMutex );
 
@@ -3228,14 +3228,14 @@ void QgsOracleSharedData::insertFid( QgsFeatureId fid, const QVariant &k )
   mKeyToFid.insert( k, fid );
 }
 
-QVariant QgsOracleSharedData::lookupKey( QgsFeatureId featureId )
+QVariantList QgsOracleSharedData::lookupKey( QgsFeatureId featureId )
 {
   QMutexLocker locker( &mMutex );
 
-  QMap<QgsFeatureId, QVariant>::const_iterator it = mFidToKey.find( featureId );
+  QMap<QgsFeatureId, QVariantList>::const_iterator it = mFidToKey.find( featureId );
   if ( it != mFidToKey.constEnd() )
     return it.value();
-  return QVariant();
+  return QVariantList();
 }
 
 QGISEXTERN bool saveStyle( const QString &uri,

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -344,17 +344,17 @@ class QgsOracleSharedData
     QgsOracleSharedData();
 
     // FID lookups
-    QgsFeatureId lookupFid( const QVariant &v ); // lookup existing mapping or add a new one
+    QgsFeatureId lookupFid( const QVariantList &v ); // lookup existing mapping or add a new one
     QVariant removeFid( QgsFeatureId fid );
-    void insertFid( QgsFeatureId fid, const QVariant &k );
-    QVariant lookupKey( QgsFeatureId featureId );
+    void insertFid( QgsFeatureId fid, const QVariantList &k );
+    QVariantList lookupKey( QgsFeatureId featureId );
 
   protected:
     QMutex mMutex; //!< Access to all data members is guarded by the mutex
 
     QgsFeatureId mFidCounter;                    // next feature id if map is used
-    QMap<QVariant, QgsFeatureId> mKeyToFid;      // map key values to feature id
-    QMap<QgsFeatureId, QVariant> mFidToKey;      // map feature back to fea
+    QMap<QVariantList, QgsFeatureId> mKeyToFid;      // map key values to feature id
+    QMap<QgsFeatureId, QVariantList> mFidToKey;      // map feature back to fea
 };
 
 


### PR DESCRIPTION
The oracle provider is quite broken on 3.0 for tables which require a feature id map.

This is due to QMap<QVariant,..> not working correctly when the keys are QVariantLists on Qt5. We had a similar issue with the postgres provider which was resolved by changing the map to always use QVariantLists.

Apply the same fix to oracle.

Fixes #18289, #16869, #17738
