### PR TITLE
[bugfix][server] Fix temporary path permission issue

### DIFF
--- a/python/server/qgsserviceregistry.sip.in
+++ b/python/server/qgsserviceregistry.sip.in
@@ -59,7 +59,7 @@ services. A module may register multiple services.
 
 The registry gain ownership of services and will call 'delete' on cleanup
 
-:param service: a QgsServerResponse to be registered
+:param service: a QgsService to be registered
 %End
 
     int unregisterService( const QString &name, const QString &version = QString() );

--- a/src/server/qgsserviceregistry.h
+++ b/src/server/qgsserviceregistry.h
@@ -73,7 +73,7 @@ class SERVER_EXPORT QgsServiceRegistry
      *
      * The registry gain ownership of services and will call 'delete' on cleanup
      *
-     * \param service a QgsServerResponse to be registered
+     * \param service a QgsService to be registered
      */
     void registerService( QgsService *service SIP_TRANSFER );
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -68,6 +68,7 @@
 #include "qgsdxfexport.h"
 #include "qgssymbollayerutils.h"
 #include "qgslayoutitemlegend.h"
+#include "qgsserverexception.h"
 
 #include <QImage>
 #include <QPainter>
@@ -379,11 +380,11 @@ namespace QgsWms
     configurePrintLayout( layout.get(), mapSettings );
 
     // Get the temporary output file
-    QTemporaryFile tempOutputFile( QStringLiteral( "XXXXXX.%1" ).arg( formatString.toLower() ) );
+    QTemporaryFile tempOutputFile( QDir::tempPath() +  '/' + QStringLiteral( "XXXXXX.%1" ).arg( formatString.toLower() ) );
     if ( !tempOutputFile.open() )
     {
-      // let the caller handle this
-      return nullptr;
+      throw QgsServerException( QStringLiteral( "Could not open temporary file for the GetPrint request." ) );
+
     }
 
     if ( formatString.compare( QLatin1String( "svg" ), Qt::CaseInsensitive ) == 0 )


### PR DESCRIPTION
If I don't misread the docs, if a template is given, the file
is created in the current directory instead of the temporary
directory reported by QDir::tempPath()

Furthermore it cannot be set by env TMPDIR.

This issue drove me crazy (and no exceptions and no logs!)
until when I switched the server user to root (that is
of course not what we want).

As a temporary workaround, the server can be configured to
use /tmp or another www-data writeable directory as a working
directory.

btw, the template in this case was completely useless so
we don't risk anything.
