### PR TITLE
Fallback to feature id if pk attribute is not there

### DIFF
--- a/src/server/qgsowsserver.cpp
+++ b/src/server/qgsowsserver.cpp
@@ -85,7 +85,13 @@ QString QgsOWSServer::featureGmlId( const QgsFeature* f, const QgsAttributeList&
     {
       pkId.append( pkSeparator() );
     }
-    pkId.append( f->attribute( *it ).toString() );
+
+    QVariant pkAttribute = f->attribute( *it );
+    if ( !pkAttribute.isValid() )
+    {
+      return QString::number( f->id() );
+    }
+    pkId.append( pkAttribute.toString() );
   }
   return pkId;
 }


### PR DESCRIPTION
Fallback to feature id if primary key is not there. Fixes https://issues.qgis.org/issues/18247
