### PR TITLE
With ctrl-tab ALSO hide statusbar, toolbars and menubar

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6193,9 +6193,11 @@ void QgisApp::togglePanelsVisibility()
 
   QStringList docksTitle = settings.value( QStringLiteral( "UI/hiddenDocksTitle" ), QStringList() ).toStringList();
   QStringList docksActive = settings.value( QStringLiteral( "UI/hiddenDocksActive" ), QStringList() ).toStringList();
+  QStringList toolBarsActive = settings.value( QStringLiteral( "UI/hiddenToolBarsActive" ), QStringList() ).toStringList();
 
   QList<QDockWidget *> docks = findChildren<QDockWidget *>();
   QList<QTabBar *> tabBars = findChildren<QTabBar *>();
+  QList<QToolBar *> toolBars = findChildren<QToolBar *>();
 
   if ( docksTitle.isEmpty() )
   {
@@ -6214,8 +6216,20 @@ void QgisApp::togglePanelsVisibility()
       docksActive << tabBar->tabText( tabBar->currentIndex() );
     }
 
+    Q_FOREACH ( QToolBar *toolBar, toolBars )
+    {
+      if ( toolBar->isVisible() && !toolBar->isFloating() )
+      {
+        toolBarsActive << toolBar->windowTitle();
+        toolBar->setVisible( false );
+      }
+    }
+
+    this->menuBar()->setVisible( false );
+    this->statusBar()->setVisible( false );
     settings.setValue( QStringLiteral( "UI/hiddenDocksTitle" ), docksTitle );
     settings.setValue( QStringLiteral( "UI/hiddenDocksActive" ), docksActive );
+    settings.setValue( QStringLiteral( "UI/hiddenToolBarsActive" ), toolBarsActive );
   }
   else
   {
@@ -6238,8 +6252,18 @@ void QgisApp::togglePanelsVisibility()
       }
     }
 
+    Q_FOREACH ( QToolBar *toolBar, toolBars )
+    {
+      if ( toolBarsActive.contains( toolBar->windowTitle() ) )
+      {
+        toolBar->setVisible( true );
+      }
+    }
+    this->menuBar()->setVisible( true ); // not working as no QMenuBar visible?
+    this->statusBar()->setVisible( true );
     settings.setValue( QStringLiteral( "UI/hiddenDocksTitle" ), QStringList() );
     settings.setValue( QStringLiteral( "UI/hiddenDocksActive" ), QStringList() );
+    settings.setValue( QStringLiteral( "UI/hiddenToolBarsActive" ), QStringList() );
   }
 }
 


### PR DESCRIPTION
## Description

This PR is more of a work in progress/discussion then a true PR.
I really like full screen maps on monitors/beamers and touchscreens!
So I'm really happy with @nirvn's work on using ctrl-tab to hide all docks/tabs.

Because I always have A LOT of toolbars, I added code to also hide all toolbars temporarily (as you can still use mouse and key board to fly around).
But, then I also wanted to remove the statusbar and then the menubar.
So current PR is a PR which on Ctrl-tab hides everything. When you FIRST use F11 to full screen and then Ctrl-tab you have a full screen map (no sign of QGIS anymore).
Drawback: in this state you cannot Ctrl-tab or F11 back anymore. My theory is that all actions are disabled as the menu is not visible, but I'm not sure of that. So you have to Quit (Alt-F4) to stop QGIS. Upon startup you will be non full screen again.

I reckon this has to discussed first:
- I think this is actually TOO much, while nice for something like a 'Kiosk'-mode, for general use it is probably too much.
- @nirvn what was the reasoning to let the toolbars/statusbar stay?
- we could also have a Ctrl-tab-shift to hide all (or all but the menubar)?
- in current state we could do somethink like OpenLayers 'full screen mode', that is IF you are in true full screen, add a small button (on a tiny floating toolbar) with an X to go back to normal view again.

What do others think?

Happy to redo this or even withdraw this PR if others think it is too much...

Image: full screen QGIS (without F11) looking at Amsterdam.

![qgis 0a6024b506_322](https://user-images.githubusercontent.com/731673/36944898-542af29e-1fa5-11e8-8e3e-52c70b6e8d6c.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ X ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
