### PR TITLE
Fixes a wrong dpi resolution in images exported from composer (2.18.x)

### DIFF
--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -3058,8 +3058,8 @@ QImage QgsComposition::printPageAsRaster( int page, QSize imageSize, int dpi )
   {
     //output size in pixels specified, calculate resolution using average of
     //derived x/y dpi
-    resolution = ( imageSize.width() / mPageWidth
-                   + imageSize.height() / mPageHeight ) / 2.0 * 25.4;
+    resolution = qRound(( imageSize.width() / mPageWidth
+                          + imageSize.height() / mPageHeight ) / 2.0 * 25.4 );
   }
   else if ( dpi > 0 )
   {
@@ -3092,8 +3092,8 @@ QImage QgsComposition::renderRectAsRaster( const QRectF& rect, QSize imageSize, 
   {
     //output size in pixels specified, calculate resolution using average of
     //derived x/y dpi
-    resolution = ( imageSize.width() / rect.width()
-                   + imageSize.height() / rect.height() ) / 2.0 * 25.4;
+    resolution = qRound(( imageSize.width() / rect.width()
+                          + imageSize.height() / rect.height() ) / 2.0 * 25.4 );
   }
   else if ( dpi > 0 )
   {


### PR DESCRIPTION
## Description
In order to avoid wrong dpi resolution in images exported from composer we need to round the dpi resolution calculated "using average of derived x/y dpi" instead of truncate it to int.

Using "Export as Image..." tool from map / print composer, with, for example:
**"Page size" = A4 (210x297mm)**, **"Export resolution" = 150 dpi**, the "Image export options" window is automatically filled with: **"Export resolution" = 150 dpi**, "Page width" = 1240 px, "Page eight" = 1753 px

but the exported image (BMP/PNG/JPEG/JPG/TIF/TIFF formats) will be 1240x1753 px with the **wrong resolution set to 149 dpi**; so it will be of the **incorrect size of 211,38x298,83 mm**.
The same for, e.g., 300 dpi: the exported image will have the wrong resolution of 299 dpi.

The problem lies in how dpi resolution in calculated in QgsComposition::printPageAsRaster and QgsComposition::renderRectAsRaster.

For the above example:
( imageSize.width() / rect.width() + imageSize.height() / rect.height() ) / 2.0 * 25.4 = (1240/210 + 1753/297)/2 *25.4 = 149,95...
now: resolution = 149 (that is wrong)
with the patch using qRound: resolution = 150 (as expected).

Fixes https://issues.qgis.org/issues/18132

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
