### PR TITLE
 [pal] Fix invalid candidates created for parallel line labeling for small, closed linestrings

### DIFF
--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -856,11 +856,16 @@ int FeaturePart::createCandidatesAlongLineNearMidpoint( QList<LabelPosition *> &
   {
     lineStepDistance = std::min( std::min( labelHeight, labelWidth ), lineStepDistance / mLF->layer()->pal->line_p );
   }
-  else // line length < label width => centering label position
+  else if ( !line->isClosed() ) // line length < label width => centering label position
   {
     currentDistanceAlongLine = - ( labelWidth - totalLineLength ) / 2.0;
     lineStepDistance = -1;
     totalLineLength = labelWidth;
+  }
+  else
+  {
+    // closed line, not long enough for label => no candidates!
+    currentDistanceAlongLine = std::numeric_limits< double >::max();
   }
 
   double candidateLength;

--- a/src/core/pal/pointset.cpp
+++ b/src/core/pal/pointset.cpp
@@ -846,3 +846,8 @@ double PointSet::length() const
     return -1;
   }
 }
+
+bool PointSet::isClosed() const
+{
+  return qgsDoubleNear( x[0], x[nbPoints - 1] ) && qgsDoubleNear( y[0], y[nbPoints - 1] );
+}

--- a/src/core/pal/pointset.h
+++ b/src/core/pal/pointset.h
@@ -156,13 +156,18 @@ namespace pal
        */
       double length() const;
 
+      /**
+       * Returns true if pointset is closed.
+       */
+      bool isClosed() const;
+
     protected:
       mutable GEOSGeometry *mGeos = nullptr;
       mutable bool mOwnsGeom = false;
 
       int nbPoints;
       double *x = nullptr;
-      double *y;   // points order is counterclockwise
+      double *y = nullptr;   // points order is counterclockwise
 
       int *cHull = nullptr;
       int cHullSize;

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -50,6 +50,7 @@ class TestQgsLabelingEngine : public QObject
     void testParticipatingLayers();
     void testRegisterFeatureUnprojectible();
     void testRotateHidePartial();
+    void testParallelLabelSmallFeature();
 
   private:
     QgsVectorLayer *vl = nullptr;
@@ -694,6 +695,77 @@ void TestQgsLabelingEngine::testRotateHidePartial()
   engine.removeProvider( provider );
 
   QVERIFY( imageCheck( "label_rotate_hide_partial", img, 20 ) );
+}
+
+void TestQgsLabelingEngine::testParallelLabelSmallFeature()
+{
+  // Test rendering a small, closed linestring using parallel labeling
+  // This test assumes that NO label is drawn in this situation. In future we may want
+  // to revisit this and e.g. draw a centered horizontal label over the feature -- in which
+  // case the reference image here should be freely revised. But for now, we just don't
+  // want a hang/crash such as described in https://issues.qgis.org/issues/18283
+
+  QgsPalLayerSettings settings;
+  setDefaultLabelParams( settings );
+
+  QgsTextFormat format = settings.format();
+  format.setSize( 20 );
+  format.setColor( QColor( 0, 0, 0 ) );
+  settings.setFormat( format );
+
+  settings.fieldName = QStringLiteral( "'long label which doesn\\'t fit'" );
+  settings.isExpression = true;
+  settings.placement = QgsPalLayerSettings::Line;
+
+  std::unique_ptr< QgsVectorLayer> vl2( new QgsVectorLayer( QStringLiteral( "linestring?crs=epsg:3148&field=id:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+  vl2->setRenderer( new QgsNullSymbolRenderer() );
+
+  QgsVectorLayerLabelProvider *provider = new QgsVectorLayerLabelProvider( vl2.get(), QStringLiteral( "test" ), true, &settings );
+  QgsFeature f( vl2->fields(), 1 );
+
+  f.setGeometry( QgsGeometry().fromWkt( QStringLiteral( "MultiLineString ((491176.796876200591214 1277565.39028006233274937, 491172.03128372476203367 1277562.45040752924978733, 491167.67935446038609371 1277557.28786265244707465, 491165.36599104333436117 1277550.97473702346906066, 491165.35308923490811139 1277544.24074512091465294, 491166.8345245998352766 1277539.49665334494784474, 491169.47186020453227684 1277535.27191955596208572, 491173.11253597546601668 1277531.85408334922976792, 491179.02124191814800724 1277528.94421873707324266, 491185.57387020520400256 1277528.15719766705296934, 491192.01811734877992421 1277529.57064539520069957, 491197.62341773137450218 1277533.02997340611182153, 491201.74636711279163137 1277538.15941766835749149, 491203.92884904221864417 1277544.35095247370190918, 491203.9633954341406934 1277550.5652371181640774, 491202.02436481812037528 1277556.4815535971429199, 491198.296930403157603 1277561.48062952468171716, 491193.17346247035311535 1277565.0647635399363935, 491187.82046439842088148 1277566.747082503978163, 491182.21622701874002814 1277566.85931688314303756, 491176.796876200591214 1277565.39028006233274937))" ) ) );
+  vl2->dataProvider()->addFeature( f );
+
+  vl2->setLabeling( new QgsVectorLayerSimpleLabeling( settings ) );  // TODO: this should not be necessary!
+  vl2->setLabelsEnabled( true );
+
+  // make a fake render context
+  QSize size( 640, 480 );
+  QgsMapSettings mapSettings;
+  QgsCoordinateReferenceSystem tgtCrs;
+  tgtCrs.createFromString( QStringLiteral( "EPSG:3148" ) );
+  mapSettings.setDestinationCrs( tgtCrs );
+
+  mapSettings.setOutputSize( size );
+  mapSettings.setExtent( QgsRectangle( 490359.7, 1276862.1, 492587.8, 1278500.0 ) );
+  mapSettings.setLayers( QList<QgsMapLayer *>() << vl2.get() );
+  mapSettings.setOutputDpi( 96 );
+
+  QgsLabelingEngineSettings engineSettings = mapSettings.labelingEngineSettings();
+  engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, false );
+  engineSettings.setFlag( QgsLabelingEngineSettings::DrawLabelRectOnly, true );
+  mapSettings.setLabelingEngineSettings( engineSettings );
+
+  QgsMapRendererSequentialJob job( mapSettings );
+  job.start();
+  job.waitForFinished();
+
+  QImage img = job.renderedImage();
+
+  QPainter p( &img );
+  QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
+  context.setPainter( &p );
+
+  QgsLabelingEngine engine;
+  engine.setMapSettings( mapSettings );
+  engine.addProvider( provider );
+
+  engine.run( context );
+  p.end();
+  engine.removeProvider( provider );
+
+  // no need to actually check the result here -- we were just testing that no hang/crash occurred
+  //  QVERIFY( imageCheck( "label_rotate_hide_partial", img, 20 ) );
 }
 
 QGSTEST_MAIN( TestQgsLabelingEngine )


### PR DESCRIPTION
Fixes the hang described in https://issues.qgis.org/issues/18283