### PR TITLE
[needs-doc] Add stable id, save id, save count to project spec

### DIFF
--- a/python/core/qgsproject.sip.in
+++ b/python/core/qgsproject.sip.in
@@ -64,6 +64,33 @@ Returns the project's title.
 .. seealso:: :py:func:`setTitle`
 %End
 
+    QString id() const;
+%Docstring
+Returns the project's stable id.
+%End
+
+    QString saveId() const;
+%Docstring
+Returns the project's current save id. This value is changed on after each save.
+Use :py:func:`id` if you need a stable id for the project.
+%End
+
+    int saveCounter() const;
+%Docstring
+Returns the save counter for the project. Like a car odometer but better because it's QGIS.
+This will change with each save like :py:func:`saveId`
+%End
+
+    QString saveUser() const;
+%Docstring
+Returns the user name that did the last save.
+%End
+
+    QString saveUserFullname() const;
+%Docstring
+Returns the full user name that did the last save.
+%End
+
     bool isDirty() const;
 %Docstring
 Returns true if the project has been modified since the last write()

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -917,12 +917,6 @@ bool QgsProject::readProjectFile( const QString &filename )
 
 
   QgsDebugMsg( "Opened document " + projectFile.fileName() );
-  QgsDebugMsg( "Project title: " + mTitle );
-  QgsDebugMsg( "Project id: " + mId );
-  QgsDebugMsg( "Project save id: " + mSaveId );
-  QgsDebugMsg( QString( "Project save counter: %1" ).arg( mSaveCounter ) );
-  QgsDebugMsg( QString( "Project save user: %1" ).arg( mSaveUser ) );
-  QgsDebugMsg( QString( "Project save user: %1" ).arg( mSaveUserFull ) );
 
   // get project version string, if any
   QgsProjectVersion fileVersion = getVersion( *doc );
@@ -1150,6 +1144,13 @@ bool QgsProject::readProjectFile( const QString &filename )
     setDirty( false );
 
   emit nonIdentifiableLayersChanged( nonIdentifiableLayers() );
+
+  QgsDebugMsg( "Project title: " + mTitle );
+  QgsDebugMsg( "Project id: " + mId );
+  QgsDebugMsg( "Project save id: " + mSaveId );
+  QgsDebugMsg( QString( "Project save counter: %1" ).arg( mSaveCounter ) );
+  QgsDebugMsg( QString( "Project save user: %1" ).arg( mSaveUser ) );
+  QgsDebugMsg( QString( "Project save user: %1" ).arg( mSaveUserFull ) );
 
   return true;
 }

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -66,6 +66,12 @@
 #include <utime.h>
 #endif
 
+static QString generateUuid()
+{
+  QString uuid = QUuid::createUuid().toString();
+  return uuid.mid( 1, uuid.length() - 3 );
+}
+
 // canonical project instance
 QgsProject *QgsProject::sProject = nullptr;
 
@@ -405,6 +411,31 @@ QString QgsProject::title() const
   return mTitle;
 }
 
+QString QgsProject::id() const
+{
+  return mId;
+}
+
+QString QgsProject::saveId() const
+{
+  return mSaveId;
+}
+
+int QgsProject::saveCounter() const
+{
+  return mSaveCounter;
+}
+
+QString QgsProject::saveUser() const
+{
+  return mSaveUser;
+}
+
+QString QgsProject::saveUserFullname() const
+{
+  return mSaveUserFull;
+}
+
 
 bool QgsProject::isDirty() const
 {
@@ -487,6 +518,11 @@ void QgsProject::clear()
   mFile.setFileName( QString() );
   mProperties.clearKeys();
   mTitle.clear();
+  mId.clear();
+  mSaveId.clear();
+  mSaveCounter = 0;
+  mSaveUser.clear();
+  mSaveUserFull.clear();
   mAutoTransaction = false;
   mEvaluateDefaultValues = false;
   mDirty = false;
@@ -630,6 +666,32 @@ static void _getTitle( const QDomDocument &doc, QString &title )
   title = titleText.data();
 
 }
+
+static void getProjectMetadata( const QDomDocument &doc, QString &stableId,
+                                QString &saveId, int &saveCounter, QString &lastUser, QString &lastUserFull )
+{
+  QDomNodeList nl = doc.elementsByTagName( QStringLiteral( "qgis" ) );
+
+  if ( !nl.count() )
+  {
+    QgsDebugMsg( "unable to find qgis element" );
+    return;
+  }
+
+  QDomNode qgisNode = nl.item( 0 );  // there should only be one, so zeroth element OK
+
+  QDomElement qgisElement = qgisNode.toElement(); // qgis node should be element
+  QString uuid = generateUuid();
+  stableId = qgisElement.attribute( QStringLiteral( "id" ), uuid );
+  if ( stableId.isEmpty() )
+    stableId = uuid;
+
+  saveId = qgisElement.attribute( QStringLiteral( "save-id" ), QString() );
+  saveCounter = qgisElement.attribute( QStringLiteral( "save-counter" ), 0 ).toInt();
+  lastUser = qgisElement.attribute( QStringLiteral( "save-user" ), QString() );
+  lastUserFull = qgisElement.attribute( QStringLiteral( "save-user-full" ), QString() );
+}
+
 
 QgsProjectVersion getVersion( const QDomDocument &doc )
 {
@@ -856,6 +918,11 @@ bool QgsProject::readProjectFile( const QString &filename )
 
   QgsDebugMsg( "Opened document " + projectFile.fileName() );
   QgsDebugMsg( "Project title: " + mTitle );
+  QgsDebugMsg( "Project id: " + mId );
+  QgsDebugMsg( "Project save id: " + mSaveId );
+  QgsDebugMsg( QString( "Project save counter: %1" ).arg( mSaveCounter ) );
+  QgsDebugMsg( QString( "Project save user: %1" ).arg( mSaveUser ) );
+  QgsDebugMsg( QString( "Project save user: %1" ).arg( mSaveUserFull ) );
 
   // get project version string, if any
   QgsProjectVersion fileVersion = getVersion( *doc );
@@ -893,6 +960,8 @@ bool QgsProject::readProjectFile( const QString &filename )
 
   // now get project title
   _getTitle( *doc, mTitle );
+
+  getProjectMetadata( *doc, mId, mSaveId, mSaveCounter, mSaveUser, mSaveUserFull );
 
   QgsReadWriteContext context;
   context.setPathResolver( pathResolver() );
@@ -1366,6 +1435,15 @@ bool QgsProject::writeProjectFile( const QString &filename )
   QDomElement qgisNode = doc->createElement( QStringLiteral( "qgis" ) );
   qgisNode.setAttribute( QStringLiteral( "projectname" ), title() );
   qgisNode.setAttribute( QStringLiteral( "version" ), QStringLiteral( "%1" ).arg( Qgis::QGIS_VERSION ) );
+  qgisNode.setAttribute( QStringLiteral( "id" ), id() );
+  QString newSaveId = generateUuid();
+  int newSaveCounter = saveCounter() + 1;
+  QString newSaveUser = QgsApplication::userLoginName();
+  QString newSaveUserFull = QgsApplication::userFullName();
+  qgisNode.setAttribute( QStringLiteral( "save-id" ), newSaveId );
+  qgisNode.setAttribute( QStringLiteral( "save-counter" ), newSaveCounter );
+  qgisNode.setAttribute( QStringLiteral( "save-user" ), newSaveUser );
+  qgisNode.setAttribute( QStringLiteral( "save-user-full" ), newSaveUserFull );
 
   doc->appendChild( qgisNode );
 
@@ -1562,6 +1640,11 @@ bool QgsProject::writeProjectFile( const QString &filename )
   setDirty( false );               // reset to pristine state
 
   emit projectSaved();
+
+  mSaveId = newSaveId;
+  mSaveCounter = newSaveCounter;
+  mSaveUser = newSaveUser;
+  mSaveUserFull = newSaveUserFull;
 
   return true;
 }

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -121,6 +121,33 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QString title() const;
 
     /**
+     * Returns the project's stable id.
+    */
+    QString id() const;
+
+    /**
+     * Returns the project's current save id. This value is changed on after each save.
+     * Use \see id() if you need a stable id for the project.
+    */
+    QString saveId() const;
+
+    /**
+     * Returns the save counter for the project. Like a car odometer but better because it's QGIS.
+     * This will change with each save like \see saveId()
+    */
+    int saveCounter() const;
+
+    /**
+     * Returns the user name that did the last save.
+    */
+    QString saveUser() const;
+
+    /**
+     * Returns the full user name that did the last save.
+    */
+    QString saveUserFullname() const;
+
+    /**
      * Returns true if the project has been modified since the last write()
      */
     bool isDirty() const;
@@ -1207,6 +1234,11 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QFile mFile;                 // current physical project file
     mutable QgsProjectPropertyKey mProperties;  // property hierarchy, TODO: this shouldn't be mutable
     QString mTitle;              // project title
+    QString mId;              // project id
+    QString mSaveId;              // changing id for each save.
+    QString mSaveUser;              // last saved user.
+    QString mSaveUserFull;              // last saved user.
+    int mSaveCounter;              // increasing save counter
     bool mAutoTransaction = false;       // transaction grouped editing
     bool mEvaluateDefaultValues = false; // evaluate default values immediately
     QgsCoordinateReferenceSystem mCrs;

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -1238,7 +1238,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QString mSaveId;              // changing id for each save.
     QString mSaveUser;              // last saved user.
     QString mSaveUserFull;              // last saved user.
-    int mSaveCounter;              // increasing save counter
+    int mSaveCounter = 0;              // increasing save counter
     bool mAutoTransaction = false;       // transaction grouped editing
     bool mEvaluateDefaultValues = false; // evaluate default values immediately
     QgsCoordinateReferenceSystem mCrs;


### PR DESCRIPTION
Adds some new metadata about the project itself for future use.

```
<qgis version="2.99.0-Master" save-counter="7" projectname="" save-user-full="Nathan" id="3ed6e416-b659-455d-a870-99971197890" save-id="64e96782-d2aa-4350-b2f6-7e77f31eece" save-user="nathan">
```
Adds the following information:

- id() -> Stable ID that never changes (can be used to track the project even if the file name changes)
- saveId() -> Changes on each save to give you a ID number for that version
- saveCounter() -> A int with a counter how many times this project has been saved. Same kind of deal as saveId() but we will have both anyway
- saveUser() -> Last saved user
- saveUserFull -> Last saved user full name.

**NOTE:** I was considering backporting this into 3.0 so that we can start getting projects including those ids for future release. If you save with a older version of QGIS it will nuke these values.