### PR TITLE
[FEATURE][layouts] Data defined table source for attribute table items 

### DIFF
--- a/python/core/layout/qgslayoutitemattributetable.sip.in
+++ b/python/core/layout/qgslayoutitemattributetable.sip.in
@@ -295,6 +295,9 @@ be replaced by a line break.
     virtual void finalizeRestoreFromXml();
 
 
+    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+
+
   protected:
 
     virtual bool writePropertiesToElement( QDomElement &elem, QDomDocument &doc, const QgsReadWriteContext &context ) const;

--- a/python/core/layout/qgslayoutobject.sip.in
+++ b/python/core/layout/qgslayoutobject.sip.in
@@ -71,6 +71,8 @@ A base class for objects which belong to a layout.
       ScalebarFillColor2,
       ScalebarLineColor,
       ScalebarLineWidth,
+      //table
+      AttributeTableSourceLayer,
     };
 
     enum PropertyValueType

--- a/python/core/layout/qgslayoututils.sip.in
+++ b/python/core/layout/qgslayoututils.sip.in
@@ -225,6 +225,17 @@ If the string was correctly decoded, ``ok`` will be set to true.
 Extracts the scale factor from an item ``style``.
 %End
 
+    static QgsMapLayer *mapLayerFromString( const QString &string, QgsProject *project );
+%Docstring
+Resolves a ``string`` into a map layer from a given ``project``. Attempts different
+forms of layer matching such as matching by layer id or layer name.
+
+Layer names are matched using a case-insensitive check, ONLY if an exact case
+match was not found.
+
+.. versionadded:: 3.2
+%End
+
 };
 
 /************************************************************************

--- a/src/app/layout/qgslayoutattributetablewidget.cpp
+++ b/src/app/layout/qgslayoutattributetablewidget.cpp
@@ -131,7 +131,11 @@ QgsLayoutAttributeTableWidget::QgsLayoutAttributeTableWidget( QgsLayoutFrame *fr
     {
       connect( atlas, &QgsLayoutAtlas::toggled, this, &QgsLayoutAttributeTableWidget::atlasToggled );
     }
+
+    mLayerSourceDDBtn->registerExpressionContextGenerator( mTable );
   }
+
+  registerDataDefinedButton( mLayerSourceDDBtn, QgsLayoutObject::AttributeTableSourceLayer );
 
   //embed widget for general options
   if ( mFrame )
@@ -925,6 +929,7 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
     case QgsLayoutItemAttributeTable::LayerAttributes:
       mLayerComboBox->setEnabled( true );
       mLayerComboBox->setVisible( true );
+      mLayerSourceDDBtn->setVisible( true );
       mLayerLabel->setVisible( true );
       mRelationsComboBox->setEnabled( false );
       mRelationsComboBox->setVisible( false );
@@ -938,6 +943,7 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
     case QgsLayoutItemAttributeTable::AtlasFeature:
       mLayerComboBox->setEnabled( false );
       mLayerComboBox->setVisible( false );
+      mLayerSourceDDBtn->setVisible( false );
       mLayerLabel->setVisible( false );
       mRelationsComboBox->setEnabled( false );
       mRelationsComboBox->setVisible( false );
@@ -952,6 +958,7 @@ void QgsLayoutAttributeTableWidget::toggleSourceControls()
       mLayerComboBox->setEnabled( false );
       mLayerComboBox->setVisible( false );
       mLayerLabel->setVisible( false );
+      mLayerSourceDDBtn->setVisible( false );
       mRelationsComboBox->setEnabled( true );
       mRelationsComboBox->setVisible( true );
       mRelationLabel->setVisible( true );

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -292,6 +292,8 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
     QgsExpressionContext createExpressionContext() const override;
     void finalizeRestoreFromXml() override;
 
+    void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
+
   protected:
 
     bool writePropertiesToElement( QDomElement &elem, QDomDocument &doc, const QgsReadWriteContext &context ) const override;
@@ -303,6 +305,10 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
     ContentSource mSource = LayerAttributes;
     //! Associated vector layer
     QgsVectorLayerRef mVectorLayer;
+
+    //! Data defined vector layer - only
+    QPointer< QgsVectorLayer > mDataDefinedVectorLayer;
+
     //! Relation id, if in relation children mode
     QString mRelationId;
 

--- a/src/core/layout/qgslayoutobject.cpp
+++ b/src/core/layout/qgslayoutobject.cpp
@@ -76,6 +76,7 @@ void QgsLayoutObject::initPropertyDefinitions()
     { QgsLayoutObject::ScalebarFillColor2, QgsPropertyDefinition( "dataDefinedScalebarFill2", QObject::tr( "Secondary fill color" ), QgsPropertyDefinition::ColorWithAlpha ) },
     { QgsLayoutObject::ScalebarLineColor, QgsPropertyDefinition( "dataDefinedScalebarLineColor", QObject::tr( "Line color" ), QgsPropertyDefinition::ColorWithAlpha ) },
     { QgsLayoutObject::ScalebarLineWidth, QgsPropertyDefinition( "dataDefinedScalebarLineWidth", QObject::tr( "Line width" ), QgsPropertyDefinition::StrokeWidth ) },
+    { QgsLayoutObject::AttributeTableSourceLayer, QgsPropertyDefinition( "dataDefinedAttributeTableSourceLayer", QObject::tr( "Table source layer" ), QgsPropertyDefinition::String ) },
   };
 }
 

--- a/src/core/layout/qgslayoutobject.h
+++ b/src/core/layout/qgslayoutobject.h
@@ -92,7 +92,9 @@ class CORE_EXPORT QgsLayoutObject: public QObject, public QgsExpressionContextGe
       ScalebarFillColor, //!< Scalebar fill color
       ScalebarFillColor2, //!< Scalebar secondary fill color
       ScalebarLineColor, //!< Scalebar line color
-      ScalebarLineWidth, //!< Scalebar line width
+      ScalebarLineWidth, //!< Scalebar line width,
+      //table item
+      AttributeTableSourceLayer, //!< Attribute table source layer
     };
 
     /**

--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -196,6 +196,7 @@ QSizeF QgsLayoutTable::totalSize() const
 
 void QgsLayoutTable::refresh()
 {
+  QgsLayoutMultiFrame::refresh();
   refreshAttributes();
 }
 

--- a/src/core/layout/qgslayoututils.cpp
+++ b/src/core/layout/qgslayoututils.cpp
@@ -395,6 +395,27 @@ double QgsLayoutUtils::scaleFactorFromItemStyle( const QStyleOptionGraphicsItem 
   return !qgsDoubleNear( style->matrix.m11(), 0.0 ) ? style->matrix.m11() : style->matrix.m12();
 }
 
+QgsMapLayer *QgsLayoutUtils::mapLayerFromString( const QString &string, QgsProject *project )
+{
+  // Maybe it's a layer id?
+  if ( QgsMapLayer *ml = project->mapLayer( string ) )
+    return ml;
+
+  // Still nothing? Check for layer name
+  if ( QgsMapLayer *ml = project->mapLayersByName( string ).value( 0 ) )
+    return ml;
+
+  // Still nothing? Check for layer name, case-insensitive
+  const auto layers = project->mapLayers();
+  for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )
+  {
+    if ( it.value()->name().compare( string, Qt::CaseInsensitive ) == 0 )
+      return it.value();
+  }
+
+  return nullptr;
+}
+
 double QgsLayoutUtils::pointsToMM( const double pointSize )
 {
   //conversion to mm based on 1 point = 1/72 inch

--- a/src/core/layout/qgslayoututils.h
+++ b/src/core/layout/qgslayoututils.h
@@ -211,6 +211,17 @@ class CORE_EXPORT QgsLayoutUtils
      */
     static double scaleFactorFromItemStyle( const QStyleOptionGraphicsItem *style );
 
+    /**
+     * Resolves a \a string into a map layer from a given \a project. Attempts different
+     * forms of layer matching such as matching by layer id or layer name.
+     *
+     * Layer names are matched using a case-insensitive check, ONLY if an exact case
+     * match was not found.
+     *
+     * \since QGIS 3.2
+     */
+    static QgsMapLayer *mapLayerFromString( const QString &string, QgsProject *project );
+
   private:
 
     //! Scale factor for upscaling fontsize and downscaling painter

--- a/src/ui/layout/qgslayoutattributetablewidgetbase.ui
+++ b/src/ui/layout/qgslayoutattributetablewidgetbase.ui
@@ -55,8 +55,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>689</width>
-        <height>2574</height>
+        <width>394</width>
+        <height>1487</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -85,6 +85,30 @@
           <item row="0" column="1">
            <widget class="QComboBox" name="mSourceComboBox"/>
           </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="mRelationLabel">
+            <property name="text">
+             <string>Relation</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="mRelationsComboBox"/>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QPushButton" name="mRefreshPushButton">
+            <property name="text">
+             <string>Refresh table data</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0" colspan="2">
+           <widget class="QPushButton" name="mAttributesPushButton">
+            <property name="text">
+             <string>Attributes...</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="mLayerLabel">
             <property name="text">
@@ -96,38 +120,25 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QgsMapLayerComboBox" name="mLayerComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="mRelationLabel">
-            <property name="text">
-             <string>Relation</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="mRelationsComboBox"/>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <widget class="QPushButton" name="mRefreshPushButton">
-            <property name="text">
-             <string>Refresh table data</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QPushButton" name="mAttributesPushButton">
-            <property name="text">
-             <string>Attributes...</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QgsMapLayerComboBox" name="mLayerComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsPropertyOverrideButton" name="mLayerSourceDDBtn">
+              <property name="text">
+               <string>…</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -832,12 +843,18 @@
    <extends>QComboBox</extends>
    <header>qgslayoutitemcombobox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>groupBox</tabstop>
   <tabstop>mSourceComboBox</tabstop>
   <tabstop>mLayerComboBox</tabstop>
+  <tabstop>mLayerSourceDDBtn</tabstop>
   <tabstop>mRelationsComboBox</tabstop>
   <tabstop>mRefreshPushButton</tabstop>
   <tabstop>mAttributesPushButton</tabstop>
@@ -878,6 +895,8 @@
   <tabstop>mHideEmptyBgCheckBox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>

--- a/tests/src/core/testqgslayoututils.cpp
+++ b/tests/src/core/testqgslayoututils.cpp
@@ -54,6 +54,7 @@ class TestQgsLayoutUtils: public QObject
     void largestRotatedRect(); //test largest rotated rect helper function
     void decodePaperOrientation();
     void scaleFactorFromItemStyle();
+    void mapLayerFromString();
 
   private:
 
@@ -636,6 +637,28 @@ void TestQgsLayoutUtils::scaleFactorFromItemStyle()
   QCOMPARE( QgsLayoutUtils::scaleFactorFromItemStyle( &style ), 2.0 );
   style.matrix = QMatrix( 0, 2, 0, 0, 0, 0 );
   QCOMPARE( QgsLayoutUtils::scaleFactorFromItemStyle( &style ), 2.0 );
+}
+
+void TestQgsLayoutUtils::mapLayerFromString()
+{
+  // add some layers to a project
+  QgsVectorLayer *l1 = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer&field=col2:integer&field=col3:integer" ), QStringLiteral( "layer 1" ), QStringLiteral( "memory" ) );
+  QgsVectorLayer *l2 = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer&field=col2:integer&field=col3:integer" ), QStringLiteral( "layer 2" ), QStringLiteral( "memory" ) );
+  QgsVectorLayer *l2a = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer&field=col2:integer&field=col3:integer" ), QStringLiteral( "LAYER 2" ), QStringLiteral( "memory" ) );
+  QgsProject p;
+  p.addMapLayer( l1 );
+  p.addMapLayer( l2 );
+  p.addMapLayer( l2a );
+
+  QCOMPARE( QgsLayoutUtils::mapLayerFromString( "layer 1", &p ), l1 );
+  QCOMPARE( QgsLayoutUtils::mapLayerFromString( "LAYER 1", &p ), l1 );
+  QCOMPARE( QgsLayoutUtils::mapLayerFromString( "layer 2", &p ), l2 );
+  QCOMPARE( QgsLayoutUtils::mapLayerFromString( "LAYER 2", &p ), l2a );
+  QCOMPARE( QgsLayoutUtils::mapLayerFromString( l1->id(), &p ), l1 );
+  QCOMPARE( QgsLayoutUtils::mapLayerFromString( l2->id(), &p ), l2 );
+  QCOMPARE( QgsLayoutUtils::mapLayerFromString( l2a->id(), &p ), l2a );
+  QVERIFY( !QgsLayoutUtils::mapLayerFromString( "none", &p ) );
+
 }
 
 bool TestQgsLayoutUtils::renderCheck( const QString &testName, QImage &image, int mismatchCount )


### PR DESCRIPTION
When an attribute table is set to a "Layer features" source, this allows the underlying vector layer from which to source features to be data defined.

(All existing table attributes (column settings) are left intact, so setting a data defined table to a layer with different fields will result in empty columns in the table.)

Sponsored by Kartoza/Inasafe