### PR TITLE
Ensure FILTER_GEOM is transformed to layer CRS in GetFeatureInfo

### DIFF
--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -193,10 +193,19 @@ class TestQgsServerWMS(QgsServerTestBase):
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&' +
                                  'INFO_FORMAT=text%2Fxml&' +
-                                 'width=600&height=400&srs=EPSG%3A3857&' +
+                                 'width=600&height=400&srs=EPSG%3A4326&' +
                                  'query_layers=testlayer%20%C3%A8%C3%A9&' +
                                  'FEATURE_COUNT=10&FILTER_GEOM=POLYGON((8.2035381 44.901459,8.2035562 44.901459,8.2035562 44.901418,8.2035381 44.901418,8.2035381 44.901459))',
                                  'wms_getfeatureinfo_geometry_filter')
+
+        # Test feature info request with filter geometry in non-layer CRS
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=text%2Fxml&' +
+                                 'width=600&height=400&srs=EPSG%3A3857&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&FILTER_GEOM=POLYGON ((913213.6839952 5606021.5399693, 913215.6988780 5606021.5399693, 913215.6988780 5606015.09643322, 913213.6839952 5606015.0964332, 913213.6839952 5606021.5399693))',
+                                 'wms_getfeatureinfo_geometry_filter_3857')
 
         # Test feature info request with invalid query_layer
         self.wms_request_compare('GetFeatureInfo',

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter_3857.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_geometry_filter_3857.txt
@@ -7,7 +7,7 @@ Content-Type: text/xml; charset=utf-8
    <Attribute name="id" value="2"/>
    <Attribute name="name" value="two"/>
    <Attribute name="utf8nameè" value="two àò"/>
-   <BoundingBox CRS="EPSG:4326" minx="8.2035" maxx="8.2035" miny="44.9014" maxy="44.9014"/>
+   <BoundingBox CRS="EPSG:3857" minx="913214.6741" maxx="913214.6741" miny="5606017.8743" maxy="5606017.8743"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>


### PR DESCRIPTION
Currently the geometry passed as FILTER_GEOM in WMS GetFeatureInfo is not transformed, hence it will only work as expected if the layer CRS is the same as the request CRS.