### PR TITLE
Avoid freezing attribute form with recursion

### DIFF
--- a/python/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip.in
+++ b/python/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.sip.in
@@ -42,6 +42,7 @@ Constructor
 
     virtual void setExpression( const QString &value );
 
+    virtual bool eventFilter( QObject *watched, QEvent *event );
 
 };
 

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.cpp
@@ -61,10 +61,9 @@ QWidget *QgsRelationAggregateSearchWidgetWrapper::createWidget( QWidget *parent 
   }
   else
   {
-    QgsAttributeEditorContext subContext = QgsAttributeEditorContext( context(), mWrapper->relation(), QgsAttributeEditorContext::Multiple, QgsAttributeEditorContext::Embed );
-    mAttributeForm = new QgsAttributeForm( mWrapper->relation().referencingLayer(), QgsFeature(), subContext, parent );
-    mAttributeForm->setMode( QgsAttributeForm::AggregateSearchMode );
-    widget = mAttributeForm;
+    mContainerWidget = new QWidget( parent );
+    widget = mContainerWidget;
+    widget->installEventFilter( this );
   }
 
   groupBox->setLayout( new QGridLayout() );
@@ -82,4 +81,20 @@ void QgsRelationAggregateSearchWidgetWrapper::setExpression( const QString &valu
 {
   Q_UNUSED( value )
   QgsDebugMsg( "Not supported" );
+}
+
+bool QgsRelationAggregateSearchWidgetWrapper::eventFilter( QObject *watched, QEvent *event )
+{
+  bool rv = QgsSearchWidgetWrapper::eventFilter( watched, event );
+  if ( event->type() == QEvent::Show && !mAttributeForm )
+  {
+    QgsAttributeEditorContext subContext = QgsAttributeEditorContext( context(), mWrapper->relation(), QgsAttributeEditorContext::Multiple, QgsAttributeEditorContext::Embed );
+    mAttributeForm = new QgsAttributeForm( mWrapper->relation().referencingLayer(), QgsFeature(), subContext, mContainerWidget );
+    mAttributeForm->setMode( QgsAttributeForm::AggregateSearchMode );
+    QGridLayout *glayout = new QGridLayout();
+    mContainerWidget->setLayout( glayout );
+    glayout->setMargin( 0 );
+    glayout->addWidget( mAttributeForm );
+  }
+  return rv;
 }

--- a/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationaggregatesearchwidgetwrapper.h
@@ -49,10 +49,12 @@ class GUI_EXPORT QgsRelationAggregateSearchWidgetWrapper : public QgsSearchWidge
     QWidget *createWidget( QWidget *parent ) override;
     bool applyDirectly() override;
     void setExpression( const QString &value ) override;
+    virtual bool eventFilter( QObject *watched, QEvent *event ) override;
 
   private:
     QgsRelationWidgetWrapper *mWrapper = nullptr;
     QgsAttributeForm *mAttributeForm = nullptr;
+    QWidget *mContainerWidget = nullptr;
 };
 
 #endif // QGSRELATIONAGGREGATESEARCHWIDGETWRAPPER_H

--- a/src/gui/qgsattributeformrelationeditorwidget.cpp
+++ b/src/gui/qgsattributeformrelationeditorwidget.cpp
@@ -28,10 +28,13 @@ QgsAttributeFormRelationEditorWidget::QgsAttributeFormRelationEditorWidget( QgsR
 
 void QgsAttributeFormRelationEditorWidget::createSearchWidgetWrappers( const QgsAttributeEditorContext &context )
 {
-  Q_UNUSED( context )
-  mSearchWidget = new QgsRelationAggregateSearchWidgetWrapper( layer(), mWrapper, form() );
+  if ( context.parentContext() )
+  {
+    mSearchWidget = new QgsRelationAggregateSearchWidgetWrapper( layer(), mWrapper, form() );
+    mSearchWidget->setContext( context );
 
-  setSearchWidgetWrapper( mSearchWidget );
+    setSearchWidgetWrapper( mSearchWidget );
+  }
 }
 
 QString QgsAttributeFormRelationEditorWidget::currentFilterExpression() const


### PR DESCRIPTION
The search widget wrappers for relations have two issues

* They recursively load whatever relations are defined. With self-referencing this leads to 💀
  This is addressed by only loading one level of relations in search widgets.

* They would load even when hidden, leading to long load times on attribute table opening.
  We now only actually load the form on the show event

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
