### PR TITLE
fix size for menu indicator in data defined button

### DIFF
--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -43,7 +43,12 @@ QgsPropertyOverrideButton::QgsPropertyOverrideButton( QWidget *parent,
 
   // button width is 1.25 * icon size, height 1.1 * icon size. But we round to ensure even pixel sizes for equal margins
   setFixedSize( 2 * static_cast< int >( 1.25 * iconSize / 2.0 ), 2 * static_cast< int >( iconSize * 1.1 / 2.0 ) );
-  setStyleSheet( QStringLiteral( "QToolButton{ background: none; border: 1px solid rgba(0, 0, 0, 0%);} QToolButton:focus { border: 1px solid palette(highlight); }" ) );
+  QString ss;
+  ss += QStringLiteral( "QToolButton{ background: none; border: 1px solid rgba(0, 0, 0, 0%); } QToolButton:focus { border: 1px solid palette(highlight); }" );
+#ifdef Q_OS_MACX
+  ss += QStringLiteral( "QToolButton::menu-indicator{ width: 5px; }" );
+#endif
+  setStyleSheet( ss );
 
   setIconSize( QSize( iconSize, iconSize ) );
   setPopupMode( QToolButton::InstantPopup );


### PR DESCRIPTION
## Description
menu indicator of data defined button looks too big, this is happening on macos with retina display.
Please, anyone could test this PR on others platform?

<img width="136" alt="schermata 2018-03-05 alle 23 03 09" src="https://user-images.githubusercontent.com/1374682/37002484-2ea000c0-20ca-11e8-8df1-59309f7f849a.png"><img width="145" alt="schermata 2018-03-05 alle 23 02 48" src="https://user-images.githubusercontent.com/1374682/37002490-34f2bc9c-20ca-11e8-861d-5092bf65c1f6.png">


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
