### PR TITLE
fix spacing between label and icon in widget layer properties

### DIFF
--- a/src/gui/effects/qgseffectstackpropertieswidget.cpp
+++ b/src/gui/effects/qgseffectstackpropertieswidget.cpp
@@ -390,7 +390,7 @@ QgsEffectStackCompactWidget::QgsEffectStackCompactWidget( QWidget *parent, QgsPa
 {
   QHBoxLayout *layout = new QHBoxLayout();
   layout->setContentsMargins( 0, 0, 0, 0 );
-  layout->setSpacing( 0 );
+  layout->setSpacing( 6 );
   setLayout( layout );
 
   mEnabledCheckBox = new QCheckBox( this );

--- a/src/ui/symbollayer/widget_layerproperties.ui
+++ b/src/ui/symbollayer/widget_layerproperties.ui
@@ -71,7 +71,7 @@
    <item row="3" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <property name="spacing">
-      <number>0</number>
+      <number>6</number>
      </property>
      <property name="bottomMargin">
       <number>0</number>


### PR DESCRIPTION
## Description
This PR adjusts spacing between labels and icons for Enable layer and Draw effects checkboxes.

before:
<img width="332" alt="schermata 2018-03-06 alle 00 11 05" src="https://user-images.githubusercontent.com/1374682/37005203-89ae2434-20d3-11e8-9373-048bf2ec278c.png">
after:
<img width="356" alt="schermata 2018-03-06 alle 00 10 48" src="https://user-images.githubusercontent.com/1374682/37005208-9063ef02-20d3-11e8-8a7d-1c9b90432b94.png">


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
