### PR TITLE
Correctly set base style for QgsLayerTreeViewProxyStyle

### DIFF
--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -177,6 +177,7 @@
 %Include qgsprojectionselectiontreewidget.sip
 %Include qgspropertyassistantwidget.sip
 %Include qgspropertyoverridebutton.sip
+%Include qgsproxystyle.sip
 %Include qgsquerybuilder.sip
 %Include qgsrasterformatsaveoptionswidget.sip
 %Include qgsrasterlayersaveasdialog.sip

--- a/python/gui/qgsproxystyle.sip.in
+++ b/python/gui/qgsproxystyle.sip.in
@@ -1,0 +1,40 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsproxystyle.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsProxyStyle : QProxyStyle
+{
+%Docstring
+A QProxyStyle subclass which correctly sets the base style to match
+the QGIS application style, and handles object lifetime by correctly
+parenting to a parent widget.
+
+.. versionadded:: 3.2
+%End
+
+%TypeHeaderCode
+#include "qgsproxystyle.h"
+%End
+  public:
+
+    explicit QgsProxyStyle( QWidget *parent /Transfer/ );
+%Docstring
+Constructor for QgsProxyStyle. Ownership is transferred to the ``parent`` widget.
+
+The base style for the QProxyStyle will be set to match the current QGIS application style.
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsproxystyle.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/symbology/qgscategorizedsymbolrendererwidget.sip.in
+++ b/python/gui/symbology/qgscategorizedsymbolrendererwidget.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsCategorizedSymbolRendererWidget : QgsRendererWidget
 {
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -332,6 +332,7 @@ SET(QGIS_GUI_SRCS
   qgsprojectionselectiontreewidget.cpp
   qgspropertyassistantwidget.cpp
   qgspropertyoverridebutton.cpp
+  qgsproxystyle.cpp
   qgsquerybuilder.cpp
   qgsrasterformatsaveoptionswidget.cpp
   qgsrasterlayersaveasdialog.cpp
@@ -500,6 +501,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsprojectionselectiontreewidget.h
   qgspropertyassistantwidget.h
   qgspropertyoverridebutton.h
+  qgsproxystyle.h
   qgsquerybuilder.h
   qgsrasterformatsaveoptionswidget.h
   qgsrasterlayersaveasdialog.h

--- a/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
+++ b/src/gui/layertree/qgslayertreeviewitemdelegate.cpp
@@ -25,9 +25,9 @@
 /// @cond PRIVATE
 
 QgsLayerTreeViewProxyStyle::QgsLayerTreeViewProxyStyle( QgsLayerTreeView *treeView )
-  : mLayerTreeView( treeView )
+  : QgsProxyStyle( treeView )
+  , mLayerTreeView( treeView )
 {
-  setParent( treeView );
 }
 
 

--- a/src/gui/layertree/qgslayertreeviewitemdelegate.h
+++ b/src/gui/layertree/qgslayertreeviewitemdelegate.h
@@ -33,13 +33,13 @@ SIP_NO_FILE
 
 class QgsLayerTreeView;
 
-#include <QProxyStyle>
+#include "qgsproxystyle.h"
 #include <QStyledItemDelegate>
 
 /**
  * Proxy style to make the item text rect shorter so that indicators fit in without colliding with text
  */
-class QgsLayerTreeViewProxyStyle : public QProxyStyle
+class QgsLayerTreeViewProxyStyle : public QgsProxyStyle
 {
   public:
     explicit QgsLayerTreeViewProxyStyle( QgsLayerTreeView *treeView );

--- a/src/gui/qgsproxystyle.cpp
+++ b/src/gui/qgsproxystyle.cpp
@@ -1,0 +1,34 @@
+/***************************************************************************
+  qgsproxystyle.cpp
+  -----------------
+  Date                 : March 2018
+  Copyright            : (C) 2018 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsproxystyle.h"
+#include <QStyleFactory>
+#include <QStyle>
+#include <QApplication>
+
+QgsProxyStyle::QgsProxyStyle( QWidget *parent )
+  : QProxyStyle( nullptr ) // no base style yet - it transfer ownership, so we need a NEW QStyle object for the base style
+{
+  // get application style
+  QString appStyle = QApplication::style()->objectName();
+  if ( !appStyle.isEmpty() )
+  {
+    if ( QStyle *style = QStyleFactory::create( appStyle ) )
+      setBaseStyle( style );
+  }
+
+  // set lifetime to match parent widget's
+  setParent( parent );
+}

--- a/src/gui/qgsproxystyle.h
+++ b/src/gui/qgsproxystyle.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+  qgsproxystyle.h
+  ---------------
+  Date                 : March 2018
+  Copyright            : (C) 2018 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROXYSTYLE_H
+#define QGSPROXYSTYLE_H
+
+#include "qgis_sip.h"
+#include "qgsgui.h"
+#include <QProxyStyle>
+
+/**
+ * A QProxyStyle subclass which correctly sets the base style to match
+ * the QGIS application style, and handles object lifetime by correctly
+ * parenting to a parent widget.
+ * \since QGIS 3.2
+ * \ingroup gui
+ */
+class GUI_EXPORT QgsProxyStyle : public QProxyStyle
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProxyStyle. Ownership is transferred to the \a parent widget.
+     *
+     * The base style for the QProxyStyle will be set to match the current QGIS application style.
+     */
+    explicit QgsProxyStyle( QWidget *parent SIP_TRANSFER );
+};
+
+#endif // QGSPROXYSTYLE_H

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -364,8 +364,8 @@ void QgsCategorizedSymbolRendererModel::updateSymbology()
 }
 
 // ------------------------------ View style --------------------------------
-QgsCategorizedSymbolRendererViewStyle::QgsCategorizedSymbolRendererViewStyle( QStyle *style )
-  : QProxyStyle( style )
+QgsCategorizedSymbolRendererViewStyle::QgsCategorizedSymbolRendererViewStyle( QWidget *parent )
+  : QgsProxyStyle( parent )
 {}
 
 void QgsCategorizedSymbolRendererViewStyle::drawPrimitive( PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget ) const
@@ -443,7 +443,7 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
   viewCategories->resizeColumnToContents( 1 );
   viewCategories->resizeColumnToContents( 2 );
 
-  viewCategories->setStyle( new QgsCategorizedSymbolRendererViewStyle( viewCategories->style() ) );
+  viewCategories->setStyle( new QgsCategorizedSymbolRendererViewStyle( viewCategories ) );
 
   connect( mModel, &QgsCategorizedSymbolRendererModel::rowsMoved, this, &QgsCategorizedSymbolRendererWidget::rowsMoved );
   connect( mModel, &QAbstractItemModel::dataChanged, this, &QgsPanelWidget::widgetChanged );

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -18,8 +18,9 @@
 #include "qgscategorizedsymbolrenderer.h"
 #include "qgis.h"
 #include "qgsrendererwidget.h"
+#include "qgsproxystyle.h"
 #include <QStandardItem>
-#include <QProxyStyle>
+
 
 class QgsCategorizedSymbolRenderer;
 class QgsRendererCategory;
@@ -70,12 +71,12 @@ class GUI_EXPORT QgsCategorizedSymbolRendererModel : public QAbstractItemModel
  * \ingroup gui
  * View style which shows drop indicator line between items
  */
-class QgsCategorizedSymbolRendererViewStyle: public QProxyStyle
+class QgsCategorizedSymbolRendererViewStyle: public QgsProxyStyle
 {
     Q_OBJECT
 
   public:
-    explicit QgsCategorizedSymbolRendererViewStyle( QStyle *style = nullptr );
+    explicit QgsCategorizedSymbolRendererViewStyle( QWidget *parent );
 
     void drawPrimitive( PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr ) const override;
 };

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -377,8 +377,8 @@ void QgsGraduatedSymbolRendererModel::updateLabels()
 }
 
 // ------------------------------ View style --------------------------------
-QgsGraduatedSymbolRendererViewStyle::QgsGraduatedSymbolRendererViewStyle( QStyle *style )
-  : QProxyStyle( style )
+QgsGraduatedSymbolRendererViewStyle::QgsGraduatedSymbolRendererViewStyle( QWidget *parent )
+  : QgsProxyStyle( parent )
 {}
 
 void QgsGraduatedSymbolRendererViewStyle::drawPrimitive( PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget ) const
@@ -483,7 +483,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   }
 
 
-  viewGraduated->setStyle( new QgsGraduatedSymbolRendererViewStyle( viewGraduated->style() ) );
+  viewGraduated->setStyle( new QgsGraduatedSymbolRendererViewStyle( viewGraduated ) );
 
   mGraduatedSymbol = QgsSymbol::defaultSymbol( mLayer->geometryType() );
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -19,8 +19,8 @@
 #include "qgsgraduatedsymbolrenderer.h"
 #include "qgis.h"
 #include "qgsrendererwidget.h"
+#include "qgsproxystyle.h"
 #include <QStandardItem>
-#include <QProxyStyle>
 
 #include "ui_qgsgraduatedsymbolrendererv2widget.h"
 #include "qgis_gui.h"
@@ -66,12 +66,12 @@ class GUI_EXPORT QgsGraduatedSymbolRendererModel : public QAbstractItemModel
 };
 
 // View style which shows drop indicator line between items
-class QgsGraduatedSymbolRendererViewStyle: public QProxyStyle
+class QgsGraduatedSymbolRendererViewStyle: public QgsProxyStyle
 {
     Q_OBJECT
 
   public:
-    explicit QgsGraduatedSymbolRendererViewStyle( QStyle *style = nullptr );
+    explicit QgsGraduatedSymbolRendererViewStyle( QWidget *parent );
 
     void drawPrimitive( PrimitiveElement element, const QStyleOption *option, QPainter *painter, const QWidget *widget = nullptr ) const override;
 };


### PR DESCRIPTION
Creates a new QgsProxyStyle subclass of QProxyStyle which automatically sets the base style to match the current application style (creating a new QStyle object, since setting the base style takes ownership). Additionally, QgsProxyStyle correctly parents the style to a parent widget, avoiding leaks since calling QWidget::setStyle doesn't transfer ownership.

Fixes incorrect theme used for layer tree view since addition of indicator icons.
