### PR TITLE
Manage relative path if it's a link. Fixes #18337

### DIFF
--- a/src/core/qgspathresolver.cpp
+++ b/src/core/qgspathresolver.cpp
@@ -207,8 +207,29 @@ QString QgsPathResolver::writePath( const QString &src ) const
 
   if ( n == 0 )
   {
-    // no common parts; might not even by a file
-    return src;
+    // can be that projPath and srcPath belongs to a linked path
+    // try to normalize also projPath
+    projPath = pfi.canonicalFilePath();
+    projElems = projPath.split( '/', QString::SkipEmptyParts );
+    projElems.removeLast();
+    projElems.removeAll( QStringLiteral( "." ) );
+
+    // remove common part
+    n = 0;
+    while ( !srcElems.isEmpty() &&
+            !projElems.isEmpty() &&
+            srcElems[0].compare( projElems[0], cs ) == 0 )
+    {
+      srcElems.removeFirst();
+      projElems.removeFirst();
+      n++;
+    }
+
+    if ( n == 0 )
+    {
+      // no common parts; might not even by a file
+      return src;
+    }
   }
 
   if ( !projElems.isEmpty() )


### PR DESCRIPTION
## Description
fix should affect Linux and OSX

the construction of relative path is done here:
https://github.com/qgis/QGIS/blob/master/src/core/qgspathresolver.cpp#L199

but the project path is absolute without resolving the linked path, whilst the datasource have the linked path resolved probably here:
https://github.com/qgis/QGIS/blob/master/src/core/qgspathresolver.cpp#L158

the patch sould fix https://issues.qgis.org/issues/18337

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
