### PR TITLE
allows to add default XYZ Tiles Servers

### DIFF
--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -146,6 +146,7 @@ class QgsXyzTileRootItem : public QgsDataCollectionItem
   private slots:
 #ifdef HAVE_GUI
     void newConnection();
+    void addDefaultXYZServers();
 #endif
 };
 


### PR DESCRIPTION
## Description
This PR adds an action which allows adding some default XYZ servers [0] from Browser Panel. I wondering if this could be useful for users which feel lost without QMS plugin :-)

![default_xyz_servers](https://user-images.githubusercontent.com/1374682/37056126-c6c0678c-2183-11e8-9ef8-be4dccb8a988.gif)

[0] - https://www.spatialbias.com/2018/02/qgis-3.0-xyz-tile-layers/

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
