### PR TITLE
color_grayscale() and color_mix_rgb() expression functions

### DIFF
--- a/resources/function_help/json/color_grayscale_average
+++ b/resources/function_help/json/color_grayscale_average
@@ -1,0 +1,9 @@
+{
+  "name": "color_grayscale_average",
+  "type": "function",
+  "description": "Applies a grayscale filter and returns a string representation from a provided color.",
+  "arguments": [
+               {"arg":"color", "description":"a color string"}
+	          ],
+  "examples": [ { "expression":"color_grayscale_average('255,100,50')", "returns":"127,127,127,255"}]
+}

--- a/resources/function_help/json/color_mix_rgb
+++ b/resources/function_help/json/color_mix_rgb
@@ -1,0 +1,11 @@
+{
+  "name": "color_mix_rgb",
+  "type": "function",
+  "description": "Returns a string representing a color mixing the reg, green, blue, and alpha values of two provided colors based on a given ratio.",
+  "arguments": [
+               {"arg":"color1", "description":"a color string"},
+               {"arg":"color2", "description":"a color string"},
+               {"arg":"ratio", "description":"a ratio"}
+	          ],
+  "examples": [ { "expression":"color_mix_rgb('0,0,0','255,255,255',0.5)", "returns":"127,127,127,255"}]
+}

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2998,7 +2998,7 @@ static QVariant fcnFormatDate( const QVariantList &values, const QgsExpressionCo
   return dt.toString( format );
 }
 
-static QVariant fcnColorGrayscale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
+static QVariant fcnColorGrayscaleAverage( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
   int avg = ( color.red() + color.green() + color.blue() ) / 3;
@@ -4133,7 +4133,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "format" ), -1, fcnFormatString, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "format_number" ), 2, fcnFormatNumber, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "format_date" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "date" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "format" ) ), fcnFormatDate, QStringList() << QStringLiteral( "String" ) << QStringLiteral( "Date and Time" ) )
-        << new QgsStaticExpressionFunction( QStringLiteral( "color_grayscale" ), 1, fcnColorGrayscale, QStringLiteral( "Color" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "color_grayscale_average" ), 1, fcnColorGrayscaleAverage, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_mix_rgb" ), 3, fcnColorMixRgb, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_rgb" ), 3, fcnColorRgb, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_rgba" ), 4, fncColorRgba, QStringLiteral( "Color" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2998,6 +2998,17 @@ static QVariant fcnFormatDate( const QVariantList &values, const QgsExpressionCo
   return dt.toString( format );
 }
 
+static QVariant fcnColorGrayscale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
+  int avg = ( color.red() + color.green() + color.blue() ) / 3;
+  int alpha = color.alpha();
+
+  color.setRgb( avg, avg, avg, alpha );
+
+  return QgsSymbolLayerUtils::encodeColor( color );
+}
+
 static QVariant fcnColorRgb( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   int red = QgsExpressionUtils::getIntValue( values.at( 0 ), parent );
@@ -4098,6 +4109,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "format" ), -1, fcnFormatString, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "format_number" ), 2, fcnFormatNumber, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "format_date" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "date" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "format" ) ), fcnFormatDate, QStringList() << QStringLiteral( "String" ) << QStringLiteral( "Date and Time" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "color_grayscale" ), 1, fcnColorGrayscale, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_rgb" ), 3, fcnColorRgb, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_rgba" ), 4, fncColorRgba, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "ramp_color" ), 2, fcnRampColor, QStringLiteral( "Color" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -2998,7 +2998,7 @@ static QVariant fcnFormatDate( const QVariantList &values, const QgsExpressionCo
   return dt.toString( format );
 }
 
-static QVariant fcnColorGrayscale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnColorGrayscale( const QVariantList &values, const QgsExpressionContext *, QgsExpression *, const QgsExpressionNodeFunction * )
 {
   QColor color = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
   int avg = ( color.red() + color.green() + color.blue() ) / 3;
@@ -3007,6 +3007,30 @@ static QVariant fcnColorGrayscale( const QVariantList &values, const QgsExpressi
   color.setRgb( avg, avg, avg, alpha );
 
   return QgsSymbolLayerUtils::encodeColor( color );
+}
+
+static QVariant fcnColorMixRgb( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QColor color1 = QgsSymbolLayerUtils::decodeColor( values.at( 0 ).toString() );
+  QColor color2 = QgsSymbolLayerUtils::decodeColor( values.at( 1 ).toString() );
+  double ratio = QgsExpressionUtils::getDoubleValue( values.at( 2 ), parent );
+  if ( ratio > 1 )
+  {
+    ratio = 1;
+  }
+  else if ( ratio < 0 )
+  {
+    ratio = 0;
+  }
+
+  int red = color1.red() * ( 1 - ratio ) + color2.red() * ratio;
+  int green = color1.green() * ( 1 - ratio ) + color2.green() * ratio;
+  int blue = color1.blue() * ( 1 - ratio ) + color2.blue() * ratio;
+  int alpha = color1.alpha() * ( 1 - ratio ) + color2.alpha() * ratio;
+
+  QColor newColor( red, green, blue, alpha );
+
+  return QgsSymbolLayerUtils::encodeColor( newColor );
 }
 
 static QVariant fcnColorRgb( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
@@ -4110,6 +4134,7 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "format_number" ), 2, fcnFormatNumber, QStringLiteral( "String" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "format_date" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "date" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "format" ) ), fcnFormatDate, QStringList() << QStringLiteral( "String" ) << QStringLiteral( "Date and Time" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_grayscale" ), 1, fcnColorGrayscale, QStringLiteral( "Color" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "color_mix_rgb" ), 3, fcnColorMixRgb, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_rgb" ), 3, fcnColorRgb, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "color_rgba" ), 4, fncColorRgba, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "ramp_color" ), 2, fcnRampColor, QStringLiteral( "Color" ) )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1109,7 +1109,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color hsva" ) << "color_hsva(40,100,100,200)" << false << QVariant( "255,170,0,200" );
       QTest::newRow( "color cmyk" ) << "color_cmyk(100,50,33,10)" << false << QVariant( "0,115,154" );
       QTest::newRow( "color cmyka" ) << "color_cmyka(50,25,90,60,200)" << false << QVariant( "51,76,10,200" );
-      QTest::newRow( "color grayscale" ) << "color_grayscale('255,100,50')" << false << QVariant( "135,135,135,255" );
+      QTest::newRow( "color grayscale average" ) << "color_grayscale_average('255,100,50')" << false << QVariant( "135,135,135,255" );
       QTest::newRow( "color mix rgb" ) << "color_mix_rgb('0,0,0,100','255,255,255',0.5)" << false << QVariant( "127,127,127,177" );
 
       QTest::newRow( "color part bad color" ) << "color_part('notacolor','red')" << true << QVariant();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1109,6 +1109,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color hsva" ) << "color_hsva(40,100,100,200)" << false << QVariant( "255,170,0,200" );
       QTest::newRow( "color cmyk" ) << "color_cmyk(100,50,33,10)" << false << QVariant( "0,115,154" );
       QTest::newRow( "color cmyka" ) << "color_cmyka(50,25,90,60,200)" << false << QVariant( "51,76,10,200" );
+      QTest::newRow( "color grayscale" ) << "color_grayscale('255,100,50')" << false << QVariant( "135,135,135,255" );
 
       QTest::newRow( "color part bad color" ) << "color_part('notacolor','red')" << true << QVariant();
       QTest::newRow( "color part bad part" ) << "color_part(color_rgb(255,127,0),'bad')" << true << QVariant();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1110,6 +1110,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "color cmyk" ) << "color_cmyk(100,50,33,10)" << false << QVariant( "0,115,154" );
       QTest::newRow( "color cmyka" ) << "color_cmyka(50,25,90,60,200)" << false << QVariant( "51,76,10,200" );
       QTest::newRow( "color grayscale" ) << "color_grayscale('255,100,50')" << false << QVariant( "135,135,135,255" );
+      QTest::newRow( "color mix rgb" ) << "color_mix_rgb('0,0,0,100','255,255,255',0.5)" << false << QVariant( "127,127,127,177" );
 
       QTest::newRow( "color part bad color" ) << "color_part('notacolor','red')" << true << QVariant();
       QTest::newRow( "color part bad part" ) << "color_part(color_rgb(255,127,0),'bad')" << true << QVariant();


### PR DESCRIPTION
## Description
This PR adds two color functions to the expression engine: `color_grayscale_average( color )` and `color_mix_rgb( color, color, ratio )`.

@nyalldawson , tests included; all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
