### PR TITLE
[FEATURE] Allow overwriting the project home path

### DIFF
--- a/python/core/qgsproject.sip.in
+++ b/python/core/qgsproject.sip.in
@@ -442,9 +442,34 @@ Sets the default area measurement units for the project.
 
     QString homePath() const;
 %Docstring
-Return project's home path
+Returns the project's home path. This will either be a manually set home path
+(see presetHomePath()) or the path containing the project file itself.
 
-:return: home path of project (or null QString if not set) *
+This method always returns the absolute path to the project's home. See
+presetHomePath() to retrieve any manual project home path override (e.g.
+relative home paths).
+
+.. seealso:: :py:func:`setPresetHomePath`
+
+.. seealso:: :py:func:`presetHomePath`
+
+.. seealso:: :py:func:`homePathChanged`
+%End
+
+    QString presetHomePath() const;
+%Docstring
+Returns any manual project home path setting, or an empty string if not set.
+
+This path may be a relative path. See homePath() to retrieve a path which is always
+an absolute path.
+
+.. seealso:: :py:func:`homePath`
+
+.. seealso:: :py:func:`setPresetHomePath`
+
+.. seealso:: :py:func:`homePathChanged`
+
+.. versionadded:: 3.2
 %End
 
     QgsRelationManager *relationManager() const;
@@ -937,7 +962,13 @@ Emitted when the file name of the project changes
 
     void homePathChanged();
 %Docstring
-Emitted when the home path of the project changes
+Emitted when the home path of the project changes.
+
+.. seealso:: :py:func:`setPresetHomePath`
+
+.. seealso:: :py:func:`homePath`
+
+.. seealso:: :py:func:`presetHomePath`
 %End
 
     void snappingConfigChanged( const QgsSnappingConfig &config );
@@ -1168,6 +1199,20 @@ be asked to save changes to the project before closing the current project.
 .. note::
 
    promoted to public slot in 2.16
+%End
+
+    void setPresetHomePath( const QString &path );
+%Docstring
+Sets the project's home ``path``. If an empty path is specified than the
+home path will be automatically determined from the project's file path.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`presetHomePath`
+
+.. seealso:: :py:func:`homePath`
+
+.. seealso:: :py:func:`homePathChanged`
 %End
 
 };

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -637,6 +637,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "project_path" ), QCoreApplication::translate( "variable_help", "Full path (including file name) of current project." ) );
   sVariableHelpTexts.insert( QStringLiteral( "project_folder" ), QCoreApplication::translate( "variable_help", "Folder for current project." ) );
   sVariableHelpTexts.insert( QStringLiteral( "project_filename" ), QCoreApplication::translate( "variable_help", "Filename of current project." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "project_home" ), QCoreApplication::translate( "variable_help", "Home path of current project." ) );
   sVariableHelpTexts.insert( QStringLiteral( "project_crs" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of project (e.g., 'EPSG:4326')." ) );
   sVariableHelpTexts.insert( QStringLiteral( "project_crs_definition" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of project (full definition)." ) );
 

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -177,7 +177,8 @@ void QgsBrowserModel::initialize()
   if ( ! mInitialized )
   {
     connect( QgsProject::instance(), &QgsProject::readProject, this, &QgsBrowserModel::updateProjectHome );
-    connect( QgsProject::instance(), &QgsProject::writeProject, this, &QgsBrowserModel::updateProjectHome );
+    connect( QgsProject::instance(), &QgsProject::projectSaved, this, &QgsBrowserModel::updateProjectHome );
+    connect( QgsProject::instance(), &QgsProject::homePathChanged, this, &QgsBrowserModel::updateProjectHome );
     addRootItems();
     mInitialized = true;
   }

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -28,6 +28,7 @@
 #include <QVector>
 #include <QStyle>
 #include <QDesktopServices>
+#include <QFileDialog>
 
 #include "qgis.h"
 #include "qgsdataitem.h"
@@ -40,6 +41,7 @@
 #include "qgsconfig.h"
 #include "qgssettings.h"
 #include "qgsanimatedicon.h"
+#include "qgsproject.h"
 
 // use GDAL VSI mechanism
 #define CPL_SUPRESS_CPLUSPLUS  //#spellok
@@ -1612,6 +1614,28 @@ QIcon QgsProjectHomeItem::icon()
 QVariant QgsProjectHomeItem::sortKey() const
 {
   return QStringLiteral( " 1" );
+}
+
+QList<QAction *> QgsProjectHomeItem::actions( QWidget *parent )
+{
+  QList<QAction *> lst = QgsDirectoryItem::actions( parent );
+  QAction *separator = new QAction( parent );
+  separator->setSeparator( true );
+  lst.append( separator );
+
+  QAction *setHome = new QAction( tr( "Set Project Home…" ), parent );
+  connect( setHome, &QAction::triggered, this, [ = ]
+  {
+    QString oldHome = QgsProject::instance()->homePath();
+    QString newPath = QFileDialog::getExistingDirectory( parent, tr( "Select Project Home Directory" ), oldHome );
+    if ( !newPath.isEmpty() )
+    {
+      QgsProject::instance()->setPresetHomePath( newPath );
+    }
+  } );
+  lst << setHome;
+
+  return lst;
 }
 
 QgsFavoriteItem::QgsFavoriteItem( QgsFavoritesItem *parent, const QString &name, const QString &dirPath, const QString &path )

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -745,6 +745,9 @@ class CORE_EXPORT QgsProjectHomeItem : public QgsDirectoryItem
     QIcon icon() override;
     QVariant sortKey() const override;
 
+    QList<QAction *> actions( QWidget *parent ) override;
+
+
 };
 
 /**

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -783,6 +783,7 @@ QgsExpressionContextScope *QgsExpressionContextUtils::projectScope( const QgsPro
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_path" ), QDir::toNativeSeparators( project->fileInfo().filePath() ), true, true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_folder" ), QDir::toNativeSeparators( project->fileInfo().dir().path() ), true, true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_filename" ), project->fileInfo().fileName(), true, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_home" ), QDir::toNativeSeparators( project->homePath() ), true, true ) );
   QgsCoordinateReferenceSystem projectCrs = project->crs();
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs" ), projectCrs.authid(), true, true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "project_crs_definition" ), projectCrs.toProj4(), true, true ) );

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -85,7 +85,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     Q_OBJECT
     Q_PROPERTY( QStringList nonIdentifiableLayers READ nonIdentifiableLayers WRITE setNonIdentifiableLayers NOTIFY nonIdentifiableLayersChanged )
     Q_PROPERTY( QString fileName READ fileName WRITE setFileName NOTIFY fileNameChanged )
-    Q_PROPERTY( QString homePath READ homePath NOTIFY homePathChanged )
+    Q_PROPERTY( QString homePath READ homePath WRITE setPresetHomePath NOTIFY homePathChanged )
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
     Q_PROPERTY( QString ellipsoid READ ellipsoid WRITE setEllipsoid NOTIFY ellipsoidChanged )
     Q_PROPERTY( QgsMapThemeCollection *mapThemeCollection READ mapThemeCollection NOTIFY mapThemeCollectionChanged )
@@ -423,9 +423,32 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     void setAreaUnits( QgsUnitTypes::AreaUnit unit );
 
     /**
-     * Return project's home path
-      \returns home path of project (or null QString if not set) */
+     * Returns the project's home path. This will either be a manually set home path
+     * (see presetHomePath()) or the path containing the project file itself.
+     *
+     * This method always returns the absolute path to the project's home. See
+     * presetHomePath() to retrieve any manual project home path override (e.g.
+     * relative home paths).
+     *
+     * \see setPresetHomePath()
+     * \see presetHomePath()
+     * \see homePathChanged()
+    */
     QString homePath() const;
+
+    /**
+     * Returns any manual project home path setting, or an empty string if not set.
+     *
+     * This path may be a relative path. See homePath() to retrieve a path which is always
+     * an absolute path.
+     *
+     * \see homePath()
+     * \see setPresetHomePath()
+     * \see homePathChanged()
+     *
+     * \since QGIS 3.2
+    */
+    QString presetHomePath() const;
 
     QgsRelationManager *relationManager() const;
 
@@ -905,7 +928,12 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     //! Emitted when the file name of the project changes
     void fileNameChanged();
 
-    //! Emitted when the home path of the project changes
+    /**
+     * Emitted when the home path of the project changes.
+     * \see setPresetHomePath()
+     * \see homePath()
+     * \see presetHomePath()
+     */
     void homePathChanged();
 
     //! emitted whenever the configuration for snapping has changed
@@ -1117,6 +1145,16 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     void setDirty( bool b = true );
 
+    /**
+     * Sets the project's home \a path. If an empty path is specified than the
+     * home path will be automatically determined from the project's file path.
+     * \since QGIS 3.2
+     * \see presetHomePath()
+     * \see homePath()
+     * \see homePathChanged()
+    */
+    void setPresetHomePath( const QString &path );
+
   private slots:
     void onMapLayersAdded( const QList<QgsMapLayer *> &layers );
     void onMapLayersRemoved( const QList<QgsMapLayer *> &layers );
@@ -1212,6 +1250,12 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     std::unique_ptr<QgsAuxiliaryStorage> mAuxiliaryStorage;
 
     QFile mFile;                 // current physical project file
+
+    /**
+     * Manual override for project home path - if empty, home path is automatically
+     * created based on file name.
+     */
+    QString mHomePath;
     mutable QgsProjectPropertyKey mProperties;  // property hierarchy, TODO: this shouldn't be mutable
     QString mTitle;              // project title
     bool mAutoTransaction = false;       // transaction grouped editing

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -284,11 +284,27 @@
                  <property name="title">
                   <string>General settings</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_26">
-                  <item row="3" column="0">
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_30">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Project home</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>titleEdit</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
                    <widget class="QLabel" name="label_3">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -304,7 +320,7 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="1">
+                  <item row="4" column="1">
                    <widget class="QComboBox" name="cbxAbsolutePath">
                     <item>
                      <property name="text">
@@ -318,8 +334,8 @@
                     </item>
                    </widget>
                   </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_4">
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="textLabel1">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                       <horstretch>0</horstretch>
@@ -327,56 +343,10 @@
                      </sizepolicy>
                     </property>
                     <property name="text">
-                     <string>Project file</string>
+                     <string>Selection color</string>
                     </property>
                     <property name="buddy">
-                     <cstring>titleEdit</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_2">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>Project title</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="2" colspan="2">
-                   <spacer>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="4" column="0" colspan="4">
-                   <widget class="QCheckBox" name="mMapTileRenderingCheckBox">
-                    <property name="toolTip">
-                     <string>Checking this setting avoids visible edge artifacts when rendering this project as separate map tiles. Rendering performance will be degraded.</string>
-                    </property>
-                    <property name="text">
-                     <string>Avoid artifacts when project is rendered as map tiles (degrades performance)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1" colspan="3">
-                   <widget class="QLineEdit" name="titleEdit">
-                    <property name="toolTip">
-                     <string>Descriptive project name</string>
-                    </property>
-                    <property name="text">
-                     <string>Default project title</string>
+                     <cstring>pbnSelectionColor</cstring>
                     </property>
                    </widget>
                   </item>
@@ -408,8 +378,18 @@
                     </item>
                    </layout>
                   </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="textLabel1">
+                  <item row="5" column="0" colspan="4">
+                   <widget class="QCheckBox" name="mMapTileRenderingCheckBox">
+                    <property name="toolTip">
+                     <string>Checking this setting avoids visible edge artifacts when rendering this project as separate map tiles. Rendering performance will be degraded.</string>
+                    </property>
+                    <property name="text">
+                     <string>Avoid artifacts when project is rendered as map tiles (degrades performance)</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_4">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                       <horstretch>0</horstretch>
@@ -417,14 +397,37 @@
                      </sizepolicy>
                     </property>
                     <property name="text">
-                     <string>Selection color</string>
+                     <string>Project file</string>
                     </property>
                     <property name="buddy">
-                     <cstring>pbnSelectionColor</cstring>
+                     <cstring>titleEdit</cstring>
                     </property>
                    </widget>
                   </item>
                   <item row="2" column="1" colspan="3">
+                   <widget class="QLineEdit" name="titleEdit">
+                    <property name="toolTip">
+                     <string>Descriptive project name</string>
+                    </property>
+                    <property name="text">
+                     <string>Default project title</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="label_2">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Project title</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1" colspan="3">
                    <layout class="QHBoxLayout" name="horizontalLayout_5">
                     <item>
                      <widget class="QgsColorButton" name="pbnSelectionColor">
@@ -495,6 +498,49 @@
                     </item>
                    </layout>
                   </item>
+                  <item row="4" column="2" colspan="2">
+                   <spacer>
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="1" column="1" colspan="3">
+                   <layout class="QHBoxLayout" name="horizontalLayout_14">
+                    <item>
+                     <widget class="QgsFilterLineEdit" name="mProjectHomeLineEdit">
+                      <property name="toolTip">
+                       <string>Project home path. Leave blank to use the current project file location.</string>
+                      </property>
+                      <property name="readOnly">
+                       <bool>false</bool>
+                      </property>
+                      <property name="clearButtonEnabled">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QToolButton" name="mButtonSetProjectHome">
+                      <property name="toolTip">
+                       <string>Set the project home path</string>
+                      </property>
+                      <property name="text">
+                       <string>…</string>
+                      </property>
+                      <property name="autoRaise">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
                  </layout>
                 </widget>
                </item>
@@ -503,7 +549,7 @@
                  <property name="title">
                   <string>Measurements</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayoutMeasureTool">
@@ -572,7 +618,7 @@
                  <property name="title">
                   <string>Coordinate display</string>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_18">
@@ -662,7 +708,7 @@
                  <property name="checked">
                   <bool>false</bool>
                  </property>
-                 <property name="syncGroup">
+                 <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
@@ -2710,6 +2756,8 @@
   <tabstop>scrollArea_2</tabstop>
   <tabstop>mProjectFileLineEdit</tabstop>
   <tabstop>mButtonOpenProjectFolder</tabstop>
+  <tabstop>mProjectHomeLineEdit</tabstop>
+  <tabstop>mButtonSetProjectHome</tabstop>
   <tabstop>titleEdit</tabstop>
   <tabstop>pbnSelectionColor</tabstop>
   <tabstop>pbnCanvasColor</tabstop>

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -24,7 +24,8 @@ from qgis.core import (QgsProject,
                        QgsCoordinateReferenceSystem,
                        QgsVectorLayer,
                        QgsRasterLayer,
-                       QgsMapLayer)
+                       QgsMapLayer,
+                       QgsExpressionContextUtils)
 from qgis.gui import (QgsLayerTreeMapCanvasBridge,
                       QgsMapCanvas)
 
@@ -880,6 +881,9 @@ class TestQgsProject(unittest.TestCase):
         self.assertEqual(p.homePath(), '/tmp/my_path')
         self.assertEqual(p.presetHomePath(), '/tmp/my_path')
         self.assertEqual(len(path_changed_spy), 2)
+        # check project scope
+        scope = QgsExpressionContextUtils.projectScope(p)
+        self.assertEqual(scope.variable('project_home'), '/tmp/my_path')
 
         # no extra signal if path is unchanged
         p.setPresetHomePath('/tmp/my_path')
@@ -897,11 +901,17 @@ class TestQgsProject(unittest.TestCase):
         self.assertEqual(p.presetHomePath(), '/tmp/my_path')
         self.assertEqual(len(path_changed_spy), 2)
 
+        scope = QgsExpressionContextUtils.projectScope(p)
+        self.assertEqual(scope.variable('project_home'), '/tmp/my_path')
+
         # clear manual path
         p.setPresetHomePath('')
         self.assertEqual(p.homePath(), tmp_dir.path() + '/project')
         self.assertFalse(p.presetHomePath())
         self.assertEqual(len(path_changed_spy), 3)
+
+        scope = QgsExpressionContextUtils.projectScope(p)
+        self.assertEqual(scope.variable('project_home'), tmp_dir.path() + '/project')
 
         # relative path
         p.setPresetHomePath('../home')
@@ -909,10 +919,16 @@ class TestQgsProject(unittest.TestCase):
         self.assertEqual(p.presetHomePath(), '../home')
         self.assertEqual(len(path_changed_spy), 4)
 
+        scope = QgsExpressionContextUtils.projectScope(p)
+        self.assertEqual(scope.variable('project_home'), tmp_dir.path() + '/home')
+
         # relative path, no filename
         p.setFileName('')
         self.assertEqual(p.homePath(), '../home')
         self.assertEqual(p.presetHomePath(), '../home')
+
+        scope = QgsExpressionContextUtils.projectScope(p)
+        self.assertEqual(scope.variable('project_home'), '../home')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows the project home path (which is used by the browser to create the 'Project Home' item) to be set by users for a project, instead of always matching the location where the project is saved.

This allows users to set the project home to a folder which contains data and other content, and is especially useful for organisations where qgis projects are not stored in the root folder of a  rganisational
'project'.

Project home paths can also be set to relative paths, in which case they will be relative to the project saved location.

The path can be set through the Project Properties dialog, or by right-clicking on the Project Home browser item and selecting 'set project home'

Sponsored by SMEC/SJ

Implements https://github.com/qgis/QGIS-Enhancement-Proposals/issues/112