### PR TITLE
[processing] fix QGIS build by replacing setFlag() method

### DIFF
--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -393,7 +393,7 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorDestination : public QgsProces
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
 
-      flags.setFlag( ParameterFlag::ExposeToModeler, false );
+      flags &= ~( ParameterFlag::ExposeToModeler );
 
       return flags;
     }
@@ -435,7 +435,7 @@ class CORE_EXPORT QgsProcessingParameterTypeFileDestination : public QgsProcessi
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
 
-      flags.setFlag( ParameterFlag::ExposeToModeler, false );
+      flags &= ~( ParameterFlag::ExposeToModeler );
 
       return flags;
     }
@@ -478,7 +478,7 @@ class CORE_EXPORT QgsProcessingParameterTypeFolderDestination : public QgsProces
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
 
-      flags.setFlag( ParameterFlag::ExposeToModeler, false );
+      flags &= ~( ParameterFlag::ExposeToModeler );
 
       return flags;
     }
@@ -520,7 +520,7 @@ class CORE_EXPORT QgsProcessingParameterTypeRasterDestination : public QgsProces
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
 
-      flags.setFlag( ParameterFlag::ExposeToModeler, false );
+      flags &= ~( ParameterFlag::ExposeToModeler );
 
       return flags;
     }


### PR DESCRIPTION
## Description
`setFlags()` introduced in Qt 5.7 while we require Qt 5.2 as minimum version. Thanks to Nyall for the help.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
