### PR TITLE
Don't mark a project as dirty when "view-only" changes occur

### DIFF
--- a/python/gui/layertree/qgslayertreeview.sip.in
+++ b/python/gui/layertree/qgslayertreeview.sip.in
@@ -148,6 +148,8 @@ Returns list of indicators associated with a particular layer tree node.
 .. versionadded:: 3.2
 %End
 
+
+
   public slots:
     void refreshLayerSymbology( const QString &layerId );
 %Docstring

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3168,7 +3168,6 @@ void QgisApp::setupConnections()
   connect( mMapCanvas, &QgsMapCanvas::scaleChanged, this, &QgisApp::updateMouseCoordinatePrecision );
   connect( mMapCanvas, &QgsMapCanvas::mapToolSet, this, &QgisApp::mapToolChanged );
   connect( mMapCanvas, &QgsMapCanvas::selectionChanged, this, &QgisApp::selectionChanged );
-  connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgisApp::markDirty );
   connect( mMapCanvas, &QgsMapCanvas::layersChanged, this, &QgisApp::markDirty );
 
   connect( mMapCanvas, &QgsMapCanvas::zoomLastStatusChanged, mActionZoomLast, &QAction::setEnabled );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3220,7 +3220,12 @@ void QgisApp::setupConnections()
   connect( mLayerTreeView->layerTreeModel()->rootGroup(), &QgsLayerTreeNode::visibilityChanged,
            this, &QgisApp::markDirty );
   connect( mLayerTreeView->layerTreeModel()->rootGroup(), &QgsLayerTreeNode::customPropertyChanged,
-           this, &QgisApp::markDirty );
+           this, [ = ]( QgsLayerTreeNode *, const QString & key )
+  {
+    // only mark dirty for non-view only changes
+    if ( !QgsLayerTreeView::viewOnlyCustomProperties().contains( key ) )
+      QgisApp::markDirty();
+  } );
 
   // connect map layer registry
   connect( QgsProject::instance(), &QgsProject::layersAdded,

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -355,6 +355,12 @@ QList<QgsLayerTreeViewIndicator *> QgsLayerTreeView::indicators( QgsLayerTreeNod
   return mIndicators.value( node );
 }
 
+///@cond PRIVATE
+QStringList QgsLayerTreeView::viewOnlyCustomProperties()
+{
+  return QStringList() << QStringLiteral( "expandedLegendNodes" );
+}
+///@endcond
 
 void QgsLayerTreeView::refreshLayerSymbology( const QString &layerId )
 {

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -135,6 +135,20 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
      */
     QList<QgsLayerTreeViewIndicator *> indicators( QgsLayerTreeNode *node ) const;
 
+///@cond PRIVATE
+
+    /**
+     * Returns a list of custom property keys which are considered as related to view operations
+     * only. E.g. node expanded state.
+     *
+     * Changes to these keys will not mark a project as "dirty" and trigger unsaved changes
+     * warnings.
+     *
+     * \since QGIS 3.2
+     */
+    static QStringList viewOnlyCustomProperties() SIP_SKIP;
+///@endcond
+
   public slots:
     //! Force refresh of layer symbology. Normally not needed as the changes of layer's renderer are monitored by the model
     void refreshLayerSymbology( const QString &layerId );


### PR DESCRIPTION
This PR implements a couple of possibly controversial changes to how projects are saved in QGIS:

~~- Disable save button when project doesn't have unsaved changes. Pros: nicer UI. Cons: if we don't correctly mark the project as dirty everywhere a change IS made, then the project can't be saved unless other changes are made. But maybe we should add this for the 3.2 dev cycle and revert just before release, in order to identify any missing areas where we should be dirtying a project where we aren't.~~ Rejected

- Don't mark a project as dirty when only the canvas extent changes. This has bugged me for a while -- changing the map view shouldn't be treated as editing a project, much like scrolling to the last page in a word processing document doesn't mark that document as dirty. It's changing the view, not the data.

~~- Add a "Revert Project" option to Project menu: Discards all unsaved changes to a project and reverts to the last saved version of the project. Pros: I'd find this super-useful, and many other apps have this feature. Cons: UI clutter.~~ Moved to https://github.com/qgis/QGIS/pull/6567


