### PR TITLE
GDAL color relief alg: add the deafult color option, i.e., no switches.

### DIFF
--- a/python/plugins/processing/algs/gdal/ColorRelief.py
+++ b/python/plugins/processing/algs/gdal/ColorRelief.py
@@ -53,9 +53,9 @@ class ColorRelief(GdalAlgorithm):
         super().__init__()
 
     def initAlgorithm(self, config=None):
-        self.modes = ((self.tr('Use smoothly blended colors'), ''),
-                      (self.tr('Use strict color matching'), '-exact_color_entry'),
-                      (self.tr('Use closest RGBA quadruplet'), '-nearest_color_entry'))
+        self.modes = ((self.tr('Use strict color matching'), '-exact_color_entry'),
+                      (self.tr('Use closest RGBA quadruplet'), '-nearest_color_entry'),
+                      (self.tr('Use smoothly blended colors'), ''))
 
         self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT,
                                                             self.tr('Input layer')))
@@ -70,7 +70,7 @@ class ColorRelief(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterEnum(self.MATCH_MODE,
                                                      self.tr('Matching mode'),
                                                      options=[i[0] for i in self.modes],
-                                                     defaultValue=0))
+                                                     defaultValue=2))
         options_param = QgsProcessingParameterString(self.OPTIONS,
                                                      self.tr('Additional creation parameters'),
                                                      defaultValue='',

--- a/python/plugins/processing/algs/gdal/ColorRelief.py
+++ b/python/plugins/processing/algs/gdal/ColorRelief.py
@@ -53,7 +53,8 @@ class ColorRelief(GdalAlgorithm):
         super().__init__()
 
     def initAlgorithm(self, config=None):
-        self.modes = ((self.tr('Use strict color matching'), '-exact_color_entry'),
+        self.modes = ((self.tr('Use smoothly blended colors'), ''),
+                      (self.tr('Use strict color matching'), '-exact_color_entry'),
                       (self.tr('Use closest RGBA quadruplet'), '-nearest_color_entry'))
 
         self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT,

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -80,7 +80,7 @@ tests:
         name: dem.tif
         type: raster
       MATCH_MODE: 1
-      OPTIONS: ''
+      OPTIONS: '-exact_color_entry'
     results:
       OUTPUT:
         hash: 3d1b5ddaf0e9763164b7865e5e4ac2d55c4993aa52de2705f2ba4232

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -79,7 +79,7 @@ tests:
       INPUT:
         name: dem.tif
         type: raster
-      MATCH_MODE: 0
+      MATCH_MODE: 2
       OPTIONS: ''
     results:
       OUTPUT:
@@ -97,7 +97,7 @@ tests:
       INPUT:
         name: dem.tif
         type: raster
-      MATCH_MODE: 2
+      MATCH_MODE: 1
       OPTIONS: ''
     results:
       OUTPUT:

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -80,7 +80,25 @@ tests:
         name: dem.tif
         type: raster
       MATCH_MODE: 1
-      OPTIONS: '-exact_color_entry'
+      OPTIONS: ''
+    results:
+      OUTPUT:
+        hash: f714597fadc9cfc3f5263dc0e35f7c6ba285de238dce439e4988faac
+        type: rasterhash
+
+- algorithm: gdal:colorrelief
+    name: Color relief (gdaldem)
+    params:
+      BAND: 1
+      COLOR_TABLE:
+        name: custom/color_relief.txt
+        type: file
+      COMPUTE_EDGES: false
+      INPUT:
+        name: dem.tif
+        type: raster
+      MATCH_MODE: 1
+      OPTIONS: '-nearest_color_entry'
     results:
       OUTPUT:
         hash: 3d1b5ddaf0e9763164b7865e5e4ac2d55c4993aa52de2705f2ba4232

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -86,7 +86,7 @@ tests:
         hash: f714597fadc9cfc3f5263dc0e35f7c6ba285de238dce439e4988faac
         type: rasterhash
 
-- algorithm: gdal:colorrelief
+  - algorithm: gdal:colorrelief
     name: Color relief (gdaldem)
     params:
       BAND: 1

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -79,7 +79,7 @@ tests:
       INPUT:
         name: dem.tif
         type: raster
-      MATCH_MODE: 1
+      MATCH_MODE: 0
       OPTIONS: ''
     results:
       OUTPUT:
@@ -97,8 +97,8 @@ tests:
       INPUT:
         name: dem.tif
         type: raster
-      MATCH_MODE: 1
-      OPTIONS: '-nearest_color_entry'
+      MATCH_MODE: 2
+      OPTIONS: ''
     results:
       OUTPUT:
         hash: 3d1b5ddaf0e9763164b7865e5e4ac2d55c4993aa52de2705f2ba4232


### PR DESCRIPTION
Currently gdaldem cannot be called without either -exact_color_entry or -nearest_color_entry. This adds the default option.