### PR TITLE
Set centroid as default placement for polygon diagramss

### DIFF
--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -258,7 +258,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
         break;
 
       case QgsWkbTypes::PolygonGeometry:
-        radAroundCentroid->setChecked( true );
+        radOverCentroid->setChecked( true );
         break;
 
       case QgsWkbTypes::UnknownGeometry:


### PR DESCRIPTION
Fix [#13435](https://issues.qgis.org/issues/13435)