### PR TITLE
use ctrl-shift-tab to toggle full map view

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -676,6 +676,11 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   profiler->beginGroup( QStringLiteral( "startup" ) );
   startProfile( QStringLiteral( "Setting up UI" ) );
   setupUi( this );
+  // because mActionToggleMapOnly can hide the menu (thereby disabling menu actions),
+  //  we attach the following actions to the MainWindow too (to be able to come back)
+  this->addAction( mActionToggleFullScreen );
+  this->addAction( mActionTogglePanelsVisibility );
+  this->addAction( mActionToggleMapOnly );
   endProfile();
 
 #if QT_VERSION >= 0x050600
@@ -6246,7 +6251,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
         }
       }
 
-      //this->menuBar()->setVisible( false );
+      this->menuBar()->setVisible( false );
       this->statusBar()->setVisible( false );
 
       settings.setValue( QStringLiteral( "UI/hiddenToolBarsActive" ), toolBarsActive );
@@ -6301,7 +6306,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
         toolBar->setVisible( true );
       }
     }
-    //this->menuBar()->setVisible( true ); // not working as no QMenuBar visible?
+    this->menuBar()->setVisible( true );
     this->statusBar()->setVisible( true );
 
     settings.setValue( QStringLiteral( "UI/allWidgetsVisible" ), true );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6229,9 +6229,9 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
   QStringList docksActive = settings.value( QStringLiteral( "UI/hiddenDocksActive" ), QStringList() ).toStringList();
   QStringList toolBarsActive = settings.value( QStringLiteral( "UI/hiddenToolBarsActive" ), QStringList() ).toStringList();
 
-  QList<QDockWidget *> docks = findChildren<QDockWidget *>();
-  QList<QTabBar *> tabBars = findChildren<QTabBar *>();
-  QList<QToolBar *> toolBars = findChildren<QToolBar *>();
+  const QList<QDockWidget *> docks = findChildren<QDockWidget *>();
+  const QList<QTabBar *> tabBars = findChildren<QTabBar *>();
+  const QList<QToolBar *> toolBars = findChildren<QToolBar *>();
 
   bool allWidgetsVisible = settings.value( QStringLiteral( "UI/allWidgetsVisible" ), true ).toBool();
 
@@ -6241,7 +6241,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
     if ( viewMapOnly )  //
     {
       // hide also statusbar and menubar and all toolbars
-      Q_FOREACH ( QToolBar *toolBar, toolBars )
+      for ( QToolBar *toolBar : toolBars )
       {
         if ( toolBar->isVisible() && !toolBar->isFloating() )
         {
@@ -6257,7 +6257,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
       settings.setValue( QStringLiteral( "UI/hiddenToolBarsActive" ), toolBarsActive );
     }
 
-    Q_FOREACH ( QDockWidget *dock, docks )
+    for ( QDockWidget *dock : docks )
     {
       if ( dock->isVisible() && !dock->isFloating() )
       {
@@ -6267,7 +6267,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
       }
     }
 
-    Q_FOREACH ( QTabBar *tabBar, tabBars )
+    for ( QTabBar *tabBar : tabBars )
     {
       // remember the active tab from the docks
       docksActive << tabBar->tabText( tabBar->currentIndex() );
@@ -6280,7 +6280,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
   }
   else  // currently panels or other widgets are hidden: show ALL based on 'remembered UI settings'
   {
-    Q_FOREACH ( QDockWidget *dock, docks )
+    for ( QDockWidget *dock : docks )
     {
       if ( docksTitle.contains( dock->windowTitle() ) )
       {
@@ -6288,7 +6288,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
       }
     }
 
-    Q_FOREACH ( QTabBar *tabBar, tabBars )
+    for ( QTabBar *tabBar : tabBars )
     {
       for ( int i = 0; i < tabBar->count(); ++i )
       {
@@ -6299,7 +6299,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
       }
     }
 
-    Q_FOREACH ( QToolBar *toolBar, toolBars )
+    for ( QToolBar *toolBar : toolBars )
     {
       if ( toolBarsActive.contains( toolBar->windowTitle() ) )
       {
@@ -6311,7 +6311,6 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
 
     settings.setValue( QStringLiteral( "UI/allWidgetsVisible" ), true );
   }
-
 }
 
 void QgisApp::showActiveWindowMinimized()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -527,6 +527,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QAction *actionToggleFullScreen() { return mActionToggleFullScreen; }
     QAction *actionTogglePanelsVisibility() { return mActionTogglePanelsVisibility; }
+    QAction *actionToggleMapOnly() { return mActionToggleMapOnly; }
     QAction *actionOptions() { return mActionOptions; }
     QAction *actionCustomProjection() { return mActionCustomProjection; }
     QAction *actionConfigureShortcuts() { return mActionConfigureShortcuts; }
@@ -1523,6 +1524,12 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Toggle visibility of opened panels
     void togglePanelsVisibility();
+
+    //! Toggle visibility of main map only
+    void toggleMapOnly();
+
+    //! Toggle between full QGIS view and reduced view (being either Map only or only hiding panels)
+    void toggleReducedView( bool viewMapOnly );
 
     //! Set minimized mode of active window
     void showActiveWindowMinimized();

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1647,6 +1647,14 @@
     <string>Ctrl+Tab</string>
    </property>
   </action>
+  <action name="mActionToggleMapOnly">
+   <property name="text">
+    <string>Toggle Map Only</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Tab</string>
+   </property>
+  </action>
   <action name="mActionProjectProperties">
    <property name="icon">
     <iconset resource="../../images/images.qrc">


### PR DESCRIPTION

This PR is a follow up on https://github.com/qgis/QGIS/pull/6523 

It adds a menu item 'Toggle Map Only' to the View menu. 
And a key binding 'Ctrl-Shift-Tab'.
It will hide ALL widgets from QGIS: panels (as is done by Ctrl-Tab) AND Toolbars, Statusbar (and TBD: menubar).
I had some thoughts on what would happen, when you were in  a state of 'hidden panels' and THEN added 'ctrl-shift-tab', or the other way around 'all hidden' and then 'ctrl-tab'.
My conclusion was: there is a 'full view' state and a 'reduced view state', where the latter is either all widgets hidden OR only panels hidden.
You toggle between 'full view' and 'reduced view state', NOT between one of the 'reduced states'.
Instead of counting on the content of a 'hiddenWidgets'-setting as was done in ctrl-tab, I added a 'UI/allWidgetsVisible' setting: if true we are in 'full view'.

Still todo: 
- do the same for the designer layout dialog?
- hide the menubar. It is in comments now, as when hidden, you cannot get it back anymore. @nyalldawson you offered to add some pointers on how to handle this?

Still a WIP I think, feel free to criticize stuff. 

## Description
This adds a 'Ctrl-Shift-Tab' / 'Toggle Map Only' action, to be able (especially in combination with F11) to have a screen filling map.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ X ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
