### PR TITLE
Project version check

### DIFF
--- a/python/core/qgsproject.sip.in
+++ b/python/core/qgsproject.sip.in
@@ -888,6 +888,8 @@ Returns the current auxiliary storage.
 .. versionadded:: 3.0
 %End
 
+    QgsError backup( const QString &fileName, const QString &suffix ) const;
+
   signals:
     void readProject( const QDomDocument & );
 %Docstring

--- a/python/core/qgsproject.sip.in
+++ b/python/core/qgsproject.sip.in
@@ -89,6 +89,8 @@ representation.
 .. seealso:: :py:func:`fileInfo`
 %End
 
+    QgsProjectVersion version() const;
+
     QFileInfo fileInfo() const;
 %Docstring
 Returns QFileInfo object for the project's associated file.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5690,7 +5690,7 @@ bool QgisApp::fileSave()
       if ( QMessageBox::warning( this,
                                  tr( "Saving project with dev version build." ),
                                  message,
-                                 QMessageBox::Yes | QMessageBox::No ) == QMessageBox::Yes )
+                                 QMessageBox::Save | QMessageBox::Cancel ) == QMessageBox::Save )
       {
         QString filename = QgsProject::instance()->fileName();
         QFileInfo info( filename );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5675,6 +5675,22 @@ bool QgisApp::fileSave()
   }
   else
   {
+
+    QgsProjectVersion thisVersion( Qgis::QGIS_VERSION );
+
+    if ( thisVersion > QgsProject::instance()->version() )
+    {
+      if ( QMessageBox::warning( this,
+                                 tr( "Saving older project version." ),
+                                 tr( "Saving a project that was saved with an older "
+                                     "version of qgis (saved in " + QgsProject.instance()->version().text() +
+                                     ", new save version " + Qgis::QGIS_VERSION +
+                                     "). Problems may occur." ),
+                                 QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
+        return false;
+
+    }
+
     QFileInfo fi( QgsProject::instance()->fileName() );
     fullPath = fi.absoluteFilePath();
     if ( fi.exists() && !mProjectLastModified.isNull() && mProjectLastModified != fi.lastModified() )

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1533,30 +1533,12 @@ bool QgsProject::writeProjectFile( const QString &filename )
   // Create backup file
   if ( QFile::exists( fileName() ) )
   {
-    QFile backupFile( QStringLiteral( "%1~" ).arg( filename ) );
-    bool ok = true;
-    ok &= backupFile.open( QIODevice::WriteOnly | QIODevice::Truncate );
-    ok &= projectFile.open( QIODevice::ReadOnly );
-
-    QByteArray ba;
-    while ( ok && !projectFile.atEnd() )
+    QgsError backupResult = backup( filename,  "~" );
+    if ( !backupResult.isEmpty() )
     {
-      ba = projectFile.read( 10240 );
-      ok &= backupFile.write( ba ) == ba.size();
-    }
-
-    projectFile.close();
-    backupFile.close();
-
-    if ( !ok )
-    {
-      setError( tr( "Unable to create backup file %1" ).arg( backupFile.fileName() ) );
+      setError( backupResult.messageList().at( 0 ).message() );
       return false;
     }
-
-    QFileInfo fi( fileName() );
-    struct utimbuf tb = { fi.lastRead().toTime_t(), fi.lastModified().toTime_t() };
-    utime( backupFile.fileName().toUtf8().constData(), &tb );
   }
 
   if ( !projectFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
@@ -1602,6 +1584,8 @@ bool QgsProject::writeProjectFile( const QString &filename )
   }
 
   setDirty( false );               // reset to pristine state
+
+  mProjectVersion = getVersion( *doc );
 
   emit projectSaved();
 
@@ -2512,4 +2496,34 @@ const QgsAuxiliaryStorage *QgsProject::auxiliaryStorage() const
 QgsAuxiliaryStorage *QgsProject::auxiliaryStorage()
 {
   return mAuxiliaryStorage.get();
+}
+
+QgsError QgsProject::backup( const QString &fileName, const QString &suffix ) const
+{
+  QgsError errors;
+  QFile projectFile( fileName );
+  QFile backupFile( QStringLiteral( "%1%2" ).arg( projectFile.fileName(), suffix ) );
+  bool ok = true;
+  ok &= backupFile.open( QIODevice::WriteOnly | QIODevice::Truncate );
+  ok &= projectFile.open( QIODevice::ReadOnly );
+
+  QByteArray ba;
+  while ( ok && !projectFile.atEnd() )
+  {
+    ba = projectFile.read( 10240 );
+    ok &= backupFile.write( ba ) == ba.size();
+  }
+
+  projectFile.close();
+  backupFile.close();
+
+  if ( !ok )
+  {
+    errors.append( tr( "Unable to create backup file %1" ).arg( backupFile.fileName() ) );
+  }
+
+  QFileInfo fi( projectFile.fileName() );
+  struct utimbuf tb = { fi.lastRead().toTime_t(), fi.lastModified().toTime_t() };
+  utime( backupFile.fileName().toUtf8().constData(), &tb );
+  return errors;
 }

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -456,6 +456,11 @@ QString QgsProject::fileName() const
   return mFile.fileName();
 }
 
+QgsProjectVersion QgsProject::version() const
+{
+  return mProjectVersion;
+}
+
 QFileInfo QgsProject::fileInfo() const
 {
   return QFileInfo( mFile );
@@ -878,6 +883,7 @@ bool QgsProject::readProjectFile( const QString &filename )
 
   // get project version string, if any
   QgsProjectVersion fileVersion = getVersion( *doc );
+  mProjectVersion = fileVersion;
   QgsProjectVersion thisVersion( Qgis::QGIS_VERSION );
 
   if ( thisVersion > fileVersion )

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -141,6 +141,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     */
     QString fileName() const;
 
+    QgsProjectVersion version() const;
+
     /**
      * Returns QFileInfo object for the project's associated file.
      * \see fileName()
@@ -1252,6 +1254,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     std::unique_ptr<QgsAuxiliaryStorage> mAuxiliaryStorage;
 
     QFile mFile;                 // current physical project file
+    QgsProjectVersion mProjectVersion;
 
     /**
      * Manual override for project home path - if empty, home path is automatically

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -873,6 +873,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     QgsAuxiliaryStorage *auxiliaryStorage();
 
+    QgsError backup( const QString &fileName, const QString &suffix ) const;
+
   signals:
     //! emitted when project is being read
     void readProject( const QDomDocument & );


### PR DESCRIPTION
Adds a check and warning when saving a non dev project with a dev build of QGIS.  On save the a new project file will be created with -dev on the end of the file name so that links to the old project don't break.

![image](https://user-images.githubusercontent.com/381660/37265131-4808f7e0-25a9-11e8-8e43-c1b1dadce208.png)


Why?

As people can, and we encourage for testing, run dev builds I think it's important that we protect the user's files from possible data changes that might render then broken in a release version.  in theory, the user should just create their own copy of the project but I think a bit of hand holding her is ok for added safty.