### PR TITLE
 [postgres] Add a timeout for postgres connections 

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -34,3 +34,7 @@ connections-xyz\OpenStreetMap\zmin=0
 # for now this is online version of the User Guide for latest (LTR) release
 helpSearchPath=https://docs.qgis.org/$qgis_short_version/$qgis_locale/docs/user_manual/
 
+[providers]
+# Default timeout for PostgreSQL servers (seconds)
+PostgreSQL\default_timeout=30
+

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -44,21 +44,7 @@
 #include "qgslogger.h"
 #include "qgsproperty.h"
 #include "qgslayertree.h"
-
-
-struct CursorOverride
-{
-  CursorOverride()
-  {
-    QApplication::setOverrideCursor( Qt::BusyCursor );
-  }
-
-  ~CursorOverride()
-  {
-    QApplication::restoreOverrideCursor();
-  }
-};
-
+#include "qgsguiutils.h"
 
 QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
   : QDialog( parent, f )
@@ -163,7 +149,7 @@ void QgsDwgImportDialog::pbLoadDatabase_clicked()
   if ( !QFileInfo::exists( leDatabase->text() ) )
     return;
 
-  CursorOverride waitCursor;
+  QgsTemporaryCursorOverride waitCursor( Qt::BusyCursor );
 
   bool lblVisible = false;
 
@@ -261,7 +247,7 @@ void QgsDwgImportDialog::pbBrowseDrawing_clicked()
 
 void QgsDwgImportDialog::pbImportDrawing_clicked()
 {
-  CursorOverride waitCursor;
+  QgsTemporaryCursorOverride waitCursor( Qt::BusyCursor );
 
   QgsDwgImporter importer( leDatabase->text(), mCrsSelector->crs() );
 
@@ -457,7 +443,7 @@ void QgsDwgImportDialog::pbDeselectAll_clicked()
 
 void QgsDwgImportDialog::buttonBox_accepted()
 {
-  CursorOverride waitCursor;
+  QgsTemporaryCursorOverride waitCursor( Qt::BusyCursor );
 
   QMap<QString, bool> layers;
   bool allLayers = true;

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -21,6 +21,7 @@
 
 #include <QImageWriter>
 #include <QFontDialog>
+#include <QApplication>
 
 
 namespace QgsGuiUtils
@@ -234,4 +235,18 @@ namespace QgsGuiUtils
     QString key = QStringLiteral( "Windows/%1/geometry" ).arg( subKey );
     return key;
   }
+}
+
+//
+// QgsTemporaryCursorOverride
+//
+
+QgsTemporaryCursorOverride::QgsTemporaryCursorOverride( const QCursor &cursor )
+{
+  QApplication::setOverrideCursor( cursor );
+}
+
+QgsTemporaryCursorOverride::~QgsTemporaryCursorOverride()
+{
+  QApplication::restoreOverrideCursor();
 }

--- a/src/gui/qgsguiutils.h
+++ b/src/gui/qgsguiutils.h
@@ -164,4 +164,26 @@ namespace QgsGuiUtils
   QString createWidgetKey( QWidget *widget, const QString &keyName = QString() );
 }
 
+/**
+ * Temporarily sets a cursor override for the QApplication for the lifetime of the object.
+ *
+ * When the object is deleted, the cursor override is removed.
+ *
+ * \ingroup gui
+ * \since QGIS 3.2
+ */
+class GUI_EXPORT QgsTemporaryCursorOverride
+{
+  public:
+
+    /**
+     * Constructor for QgsTemporaryCursorOverride. Sets the application override
+     * cursor to \a cursor.
+     */
+    QgsTemporaryCursorOverride( const QCursor &cursor );
+
+    ~QgsTemporaryCursorOverride();
+
+};
+
 #endif // QGSGUIUTILS_H

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -180,6 +180,8 @@ void QgsPgNewConnection::cb_geometryColumnsOnly_clicked()
 
 void QgsPgNewConnection::testConnection()
 {
+  QgsTemporaryCursorOverride cursorOverride( Qt::WaitCursor );
+
   QgsDataSourceUri uri;
   if ( !txtService->text().isEmpty() )
   {


### PR DESCRIPTION
Don't know if I'm the only one who gets driven mad by the infinite timeout for connecting to unavailable postgres servers... but this adds a configurable option to set a timeout for postgres provider, and defaults the timeout to 30 seconds.