### PR TITLE
[WIP] Add class QgsVectorLayerUpdater

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -311,6 +311,7 @@ SET(QGIS_CORE_SRCS
   qgsvectorlayerlabelprovider.cpp
   qgsvectorlayerrenderer.cpp
   qgsvectorlayertools.cpp
+  qgsvectorlayerupdater.cpp
   qgsvectorlayerundocommand.cpp
   qgsvectorlayerundopassthroughcommand.cpp
   qgsvectorlayerutils.cpp
@@ -924,6 +925,7 @@ SET(QGIS_CORE_HDRS
   qgsvectorlayerjoininfo.h
   qgsvectorlayerlabelprovider.h
   qgsvectorlayerlabeling.h
+  qgsvectorlayerupdater.h
   qgsvectorlayerundocommand.h
   qgsvectorlayerundopassthroughcommand.h
   qgsvectorlayerutils.h

--- a/src/core/qgsvectorlayerupdater.cpp
+++ b/src/core/qgsvectorlayerupdater.cpp
@@ -1,0 +1,87 @@
+#include "qgsvectorlayerupdater.h"
+
+
+QgsVectorLayerUpdater::QgsVectorLayerUpdater(
+  QgsVectorLayer &destinationLayer,
+  const QMap<QString, QgsExpression> fieldsMap,
+  QgsExpressionContext &context,
+  const QList<QString> primaryKeys,
+  const bool bypassEditBuffer )
+  : mLayer( destinationLayer )
+  , mFieldsMap( fieldsMap )
+  , mContext( context )
+  , mPrimaryKeys( primaryKeys )
+  , mBypassEditBuffer( bypassEditBuffer )
+{
+
+}
+
+bool QgsVectorLayerUpdater::addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags )
+{
+  Q_UNUSED( flags );
+
+  mContext.setFeature( ( const QgsFeature & ) feature );
+
+  QgsFeature f = QgsFeature();
+  f.setGeometry( feature.geometry() );
+
+  //QgsAttributes &values( mLayer.fields().count() );
+  for ( int i = 0; i < mLayer.fields().count(); i++ )
+  {
+    QgsField field = mLayer.fields()[i];
+    QgsExpression expr = mFieldsMap[field.name()];
+    f.setAttribute( i, expr.evaluate( ( const QgsExpressionContext * ) &mContext ) );
+  }
+
+  bool updated = false;
+  if ( !mPrimaryKeys.isEmpty() )
+  {
+    QgsFeatureRequest request = QgsFeatureRequest();
+    Q_FOREACH ( const QString &pKey, mPrimaryKeys )
+    {
+      request.combineFilterExpression( QgsExpression( QStringLiteral( "%1=%2" )
+                                       .arg( QgsExpression::quotedColumnRef( pKey )
+                                             .arg( QgsExpression::quotedValue( f.attribute( mLayer.fields().indexOf( pKey ) ) ) ) ) ) );
+    }
+    QgsFeatureIterator candidates = mLayer.getFeatures( request );
+    QgsFeature candidate;
+    while ( candidates.nextFeature( candidate ) )
+    {
+      f.setId( candidate.id() );
+      mLayer.updateFeature( f );
+      updated = true;
+    }
+  }
+  if ( !updated )
+  {
+    mLayer.addFeature( f );
+  }
+
+  return true;
+}
+
+bool QgsVectorLayerUpdater::addFeatures( QgsFeatureIterator &features, QgsFeatureSink::Flags flags )
+{
+  Q_UNUSED( flags );
+
+  QgsFeature f;
+  while ( features.nextFeature( f ) )
+  {
+    addFeature( f, flags );
+  }
+
+  return true;
+}
+
+
+bool QgsVectorLayerUpdater::addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags )
+{
+  Q_UNUSED( flags );
+
+  Q_FOREACH ( QgsFeature f, features )
+  {
+    addFeature( f, flags );
+  }
+
+  return true;
+}

--- a/src/core/qgsvectorlayerupdater.h
+++ b/src/core/qgsvectorlayerupdater.h
@@ -1,0 +1,57 @@
+/***************************************************************************
+                         qgsprocessingoutputs.h
+                         -------------------------
+    begin                : Feb 2018
+    copyright            : (C) 2018 by Arnaud Morvan
+    email                : arnaud dot morvan at camptocamp dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSVECTORLAYERUPDATER_H
+#define QGSVECTORLAYERUPDATER_H
+
+#include "qgis_core.h"
+#include "qgis.h"
+#include "qgsfeaturesink.h"
+#include "qgsvectorlayer.h"
+
+/**
+ * \class QgsVectorLayerUpdater
+ * \ingroup core
+ *
+ * Utility class to insert/update feature in an existing vector layer,
+ * using on source and destination fields mapping and primary key handling.
+ *
+ * \since QGIS 3.2
+ */
+
+class CORE_EXPORT QgsVectorLayerUpdater : public QgsFeatureSink
+{
+  public:
+    QgsVectorLayerUpdater(
+      QgsVectorLayer &destinationLayer,
+      const QMap<QString, QgsExpression> fieldsMap,
+      QgsExpressionContext &context,
+      const QList<QString> primaryKeys = QList<QString>(),
+      const bool bypassEditBuffer = false
+    );
+    bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = 0 ) override;
+    bool addFeatures( QgsFeatureIterator &features, QgsFeatureSink::Flags flags = 0 ) override;
+    bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = 0 ) override;
+  private:
+    QgsVectorLayer &mLayer;
+    const QMap<QString, QgsExpression> mFieldsMap;
+    QgsExpressionContext &mContext;
+    const QList<QString> mPrimaryKeys;
+    const bool mBypassEditBuffer;
+};
+
+#endif // QGSVECTORLAYERUPDATER_H

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -183,6 +183,7 @@ SET(TESTS
  testqgsvectorlayercache.cpp
  testqgsvectorlayerjoinbuffer.cpp
  testqgsvectorlayer.cpp
+ testqgsvectorlayerupdater.cpp
  testziplayer.cpp
     )
 

--- a/tests/src/core/testqgsvectorlayerupdater.cpp
+++ b/tests/src/core/testqgsvectorlayerupdater.cpp
@@ -1,0 +1,121 @@
+/***************************************************************************
+     testqgsvectorlayerupdater.cpp
+     --------------------------------------
+    Date                 : Feb 2018
+    Copyright            : (C) 2018 by Arnaud Morvan
+    Email                : arnaud dot morvan at coamptocamp dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectorlayerupdater.h"
+#include "qgsproject.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectorfilewriter.h"
+#include "qgsapplication.h"
+#include <QObject>
+#include "qgstest.h"
+
+
+class TestQgsVectorLayerUpdater : public QObject
+{
+    Q_OBJECT
+  public:
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+
+    void update();
+
+  private:
+    QgsVectorLayer mLayer;
+};
+
+void TestQgsVectorLayerUpdater::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  QString testDataDir( TEST_DATA_DIR );  //defined in CMakeLists.txt
+  //QString templatePath = testDataDir + "/polys_with_id.shp";
+  //QString templatePath = testDataDir + "/points.shp";
+  QString tempDir = QDir::tempPath();
+  QFile::copy( testDataDir + "/points.shp", tempDir + "/test_updater.shp" );
+  QFile::copy( testDataDir + "/points.dbf", tempDir + "/test_updater.dbf" );
+  QFile::copy( testDataDir + "/points.shx", tempDir + "/test_updater.shx" );
+  QFile::copy( testDataDir + "/points.prj", tempDir + "/test_updater.prj" );
+
+  QString layerPath =  QDir::tempPath() + "/test_updater.shp";
+
+  QgsVectorLayer *layer = new QgsVectorLayer( layerPath, QStringLiteral( "layer1" ), QStringLiteral( "ogr" ) );
+  QVERIFY( layer->isValid() );
+
+  layer->beginEditCommand( "Add primary key" );
+  //QgsVectorDataProvider *dp = layer->dataProvider();
+  layer->addAttribute( QgsField( QStringLiteral( "id" ), QVariant::Int ) );
+  QgsFeatureIterator it = layer->getFeatures();
+  QgsFeature f;
+  int i = 0;
+  while ( it.nextFeature( f ) )
+  {
+    f.setAttribute( "id", i );
+  }
+  layer->endEditCommand();
+  layer->commitChanges();
+}
+
+void TestQgsVectorLayerUpdater::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+
+  //QString layerPath =  QDir::tempPath() + "/test_updater.shp";
+  //QFile::remove( layerPath );
+}
+
+void TestQgsVectorLayerUpdater::init()
+{
+
+}
+
+void TestQgsVectorLayerUpdater::cleanup()
+{
+
+}
+
+
+void TestQgsVectorLayerUpdater::update()
+{
+  QString testDataDir( TEST_DATA_DIR );  //defined in CMakeLists.txt
+  QString srcPath =  testDataDir + "/lines.shp";
+  QString dstPath =  QDir::tempPath() + "/test_updater.shp";
+  const QgsVectorLayer &srcLayer = QgsVectorLayer( srcPath, QStringLiteral( "layer1" ), QStringLiteral( "ogr" ) );
+  const QgsVectorLayer &dstLayer = QgsVectorLayer( dstPath, QStringLiteral( "layer1" ), QStringLiteral( "ogr" ) );
+  QVERIFY( srcLayer.isValid() );
+  QVERIFY( dstLayer.isValid() );
+
+  const QMap<QString, QgsExpression> map = QMap<QString, QgsExpression>();
+  const QList<QString> primaryKeys = QList<QString>() << QStringLiteral( "id" );
+
+  const QgsVectorLayerUpdater &updater = QgsVectorLayerUpdater( dstLayer, map, srcLayer.createExpressionContext(), primaryKeys );
+
+  /*
+  QgsVectorLayerUpdater(
+        QgsVectorLayer &dstlayer,
+        const QMap<QString, QgsExpression> fieldsMap,
+        QgsExpressionContext &context,
+        const QList<QString> primaryKey = QList<QString>(),
+        const bool bypassEditBuffer = false
+      );
+      */
+}
+
+QGSTEST_MAIN( TestQgsVectorLayerUpdater )
+#include "testqgsvectorlayerupdater.moc"


### PR DESCRIPTION
## Description
Relate with https://github.com/qgis/QGIS-Enhancement-Proposals/issues/89

Add a QgsVectorLayerUpdater class that implements QgsFeatureSink for writing features in an existing vector layer data source.

This should be used by processing and copy/paste to insert and/or update features in an existing layer based on a fields map and primary key or where clause.
 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
