### PR TITLE
[processing] Add default values in model for destination parameters

### DIFF
--- a/python/core/processing/models/qgsprocessingmodelchildalgorithm.sip.in
+++ b/python/core/processing/models/qgsprocessingmodelchildalgorithm.sip.in
@@ -253,6 +253,17 @@ must be called on the parent model.
 .. seealso:: :py:func:`modelOutputs`
 %End
 
+    bool removeModelOutput( const QString &name );
+%Docstring
+Removes an existing output from the final model outputs.
+
+QgsProcessingModelAlgorithm.updateDestinationParameters() must be called on the parent model.
+
+.. seealso:: :py:func:`modelOutputs`
+
+.. versionadded:: 3.2
+%End
+
     QVariant toVariant() const;
 %Docstring
 Saves this child to a QVariant.

--- a/python/core/processing/models/qgsprocessingmodeloutput.sip.in
+++ b/python/core/processing/models/qgsprocessingmodeloutput.sip.in
@@ -61,6 +61,28 @@ Sets the default value for the model output.
 .. versionadded:: 3.2
 %End
 
+    bool isMandatory() const;
+%Docstring
+Returns true if the output is mandatory. This may override the associated
+child algorithm's parameter optional status - e.g. allowing
+an optional output from an algorithm to be mandatory within a model.
+
+.. seealso:: :py:func:`setMandatory`
+
+.. versionadded:: 3.2
+%End
+
+    void setMandatory( bool mandatory );
+%Docstring
+Sets whether the output is ``mandatory``. This may override the associated
+child algorithm's parameter optional status - e.g. allowing
+an optional output from an algorithm to be mandatory within a model.
+
+.. seealso:: :py:func:`isMandatory`
+
+.. versionadded:: 3.2
+%End
+
     QString childId() const;
 %Docstring
 Returns the child algorithm ID from which this output is generated.

--- a/python/core/processing/models/qgsprocessingmodeloutput.sip.in
+++ b/python/core/processing/models/qgsprocessingmodeloutput.sip.in
@@ -23,6 +23,7 @@ Represents a final output created by the model.
 %End
   public:
 
+
     QgsProcessingModelOutput( const QString &name = QString(), const QString &description = QString() );
 %Docstring
 Constructor for QgsProcessingModelOutput with the specified ``name`` and ``description``.
@@ -40,6 +41,24 @@ Returns the model output name.
 Sets the model output ``name``.
 
 .. seealso:: :py:func:`name`
+%End
+
+    QVariant defaultValue() const;
+%Docstring
+Returns the default value for the model output parameter.
+
+.. seealso:: :py:func:`setDefaultValue`
+
+.. versionadded:: 3.2
+%End
+
+    void setDefaultValue( const QVariant &value );
+%Docstring
+Sets the default value for the model output.
+
+.. seealso:: :py:func:`defaultValue`
+
+.. versionadded:: 3.2
 %End
 
     QString childId() const;

--- a/python/core/processing/models/qgsprocessingmodeloutput.sip.in
+++ b/python/core/processing/models/qgsprocessingmodeloutput.sip.in
@@ -23,7 +23,6 @@ Represents a final output created by the model.
 %End
   public:
 
-
     QgsProcessingModelOutput( const QString &name = QString(), const QString &description = QString() );
 %Docstring
 Constructor for QgsProcessingModelOutput with the specified ``name`` and ``description``.

--- a/python/core/processing/qgsprocessingparameters.sip.in
+++ b/python/core/processing/qgsprocessingparameters.sip.in
@@ -91,6 +91,8 @@ Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
 You can use QgsXmlUtils.writeVariant to save it to an XML document.
 
 .. seealso:: :py:func:`loadVariant`
+
+.. versionadded:: 3.2
 %End
 
     bool loadVariant( const QVariantMap &map );
@@ -99,6 +101,8 @@ Loads this output layer definition from a QVariantMap, wrapped in a QVariant.
 You can use QgsXmlUtils.readVariant to load it from an XML document.
 
 .. seealso:: :py:func:`toVariant`
+
+.. versionadded:: 3.2
 %End
 
     operator QVariant() const;

--- a/python/core/processing/qgsprocessingparameters.sip.in
+++ b/python/core/processing/qgsprocessingparameters.sip.in
@@ -85,6 +85,21 @@ to automatically load the resulting sink/layer after completing processing.
 
     QVariantMap createOptions;
 
+    QVariant toVariant() const;
+%Docstring
+Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
+You can use QgsXmlUtils.writeVariant to save it to an XML document.
+
+.. seealso:: :py:func:`loadVariant`
+%End
+
+    bool loadVariant( const QVariantMap &map );
+%Docstring
+Loads this output layer definition from a QVariantMap, wrapped in a QVariant.
+You can use QgsXmlUtils.readVariant to load it from an XML document.
+
+.. seealso:: :py:func:`toVariant`
+%End
 
     operator QVariant() const;
 

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -106,13 +106,13 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             else:
                 dest_project = None
                 if not param.flags() & QgsProcessingParameterDefinition.FlagHidden and \
-                        isinstance(param, (QgsProcessingParameterRasterDestination, QgsProcessingParameterFeatureSink, QgsProcessingParameterVectorDestination)):
+                        isinstance(param, (QgsProcessingParameterRasterDestination,
+                                           QgsProcessingParameterFeatureSink,
+                                           QgsProcessingParameterVectorDestination)):
                     if self.mainWidget().checkBoxes[param.name()].isChecked():
                         dest_project = QgsProject.instance()
 
                 value = self.mainWidget().outputWidgets[param.name()].getValue()
-                if value == '':
-                    value = self.parameter.generateTemporaryDestination()
                 if value and isinstance(value, QgsProcessingOutputLayerDefinition):
                     value.destinationProject = dest_project
                 if value:

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -111,6 +111,8 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                         dest_project = QgsProject.instance()
 
                 value = self.mainWidget().outputWidgets[param.name()].getValue()
+                if value == '':
+                    value = self.parameter.generateTemporaryDestination()
                 if value and isinstance(value, QgsProcessingOutputLayerDefinition):
                     value.destinationProject = dest_project
                 if value:

--- a/python/plugins/processing/gui/DestinationSelectionPanel.py
+++ b/python/plugins/processing/gui/DestinationSelectionPanel.py
@@ -290,9 +290,12 @@ signal        """
         if value == 'memory:' or not value:
             self.saveToTemporary()
         elif isinstance(value, QgsProcessingOutputLayerDefinition):
-            self.leText.setText(value.sink.staticValue())
+            if value.sink.staticValue() == 'memory:':
+                self.saveToTemporary()
+            else:
+                self.leText.setText(value.sink.staticValue())
+                self.use_temporary = False
             self.encoding = value.createOptions['fileEncoding']
-            self.use_temporary = False
         else:
             self.leText.setText(value)
             self.use_temporary = False

--- a/python/plugins/processing/gui/DestinationSelectionPanel.py
+++ b/python/plugins/processing/gui/DestinationSelectionPanel.py
@@ -85,6 +85,8 @@ class DestinationSelectionPanel(BASE, WIDGET):
             elif not isinstance(self.parameter, QgsProcessingParameterFolderDestination):
                 self.leText.setPlaceholderText(self.SAVE_TO_TEMP_FILE)
 
+        self.setValue(self.parameter.defaultValue())
+
         self.btnSelect.clicked.connect(self.selectOutput)
         self.leText.textEdited.connect(self.textChanged)
 
@@ -285,8 +287,12 @@ signal        """
         self.skipOutputChanged.emit(False)
 
     def setValue(self, value):
-        if value == 'memory:':
+        if value == 'memory:' or not value:
             self.saveToTemporary()
+        elif isinstance(value, QgsProcessingOutputLayerDefinition):
+            self.leText.setText(value.sink.staticValue())
+            self.encoding = value.createOptions['fileEncoding']
+            self.use_temporary = False
         else:
             self.leText.setText(value)
             self.use_temporary = False

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -246,8 +246,6 @@ class ModelerGraphicItem(QGraphicsItem):
                                              alg.position() + QPointF(
                 ModelerGraphicItem.BOX_WIDTH,
                 (i + 1.5) * ModelerGraphicItem.BOX_HEIGHT))
-            #if existing_child.modelOutput(out):
-            #    alg.modelOutput(out).setDefaultValue(existing_child.modelOutput(out).defaultValue())
         self.model.setChildAlgorithm(alg)
 
     def removeElement(self):

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -233,6 +233,7 @@ class ModelerGraphicItem(QGraphicsItem):
                 model_output = child_alg.modelOutput(self.element.name())
                 model_output.setDescription(dlg.param.description())
                 model_output.setDefaultValue(dlg.param.defaultValue())
+                model_output.setMandatory(not (dlg.param.flags() & QgsProcessingParameterDefinition.FlagOptional))
                 self.model.updateDestinationParameters()
 
     def updateAlgorithm(self, alg):

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -301,7 +301,7 @@ class ModelerParameterDefinitionDialog(QDialog):
 
         elif isinstance(self.param, QgsProcessingDestinationParameter):
             self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
-            self.defaultWidget = DestinationSelectionPanel(self.param, self.alg)
+            self.defaultWidget = DestinationSelectionPanel(self.param, self.alg, default_selection=True)
             self.verticalLayout.addWidget(self.defaultWidget)
 
         self.verticalLayout.addSpacing(20)
@@ -311,6 +311,16 @@ class ModelerParameterDefinitionDialog(QDialog):
         if self.param is not None:
             self.requiredCheck.setChecked(not self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
         self.verticalLayout.addWidget(self.requiredCheck)
+
+        # If child algorithm output is mandatory, disable checkbox
+        if isinstance(self.param, QgsProcessingDestinationParameter):
+            provider_name, child_name, output_name = self.param.name().split(':')
+            child = self.alg.childAlgorithms()['{}:{}'.format(provider_name, child_name)]
+            model_output = child.modelOutput(output_name)
+            param_def = child.algorithm().parameterDefinition(model_output.childOutputName())
+            if not (param_def.flags() & QgsProcessingParameterDefinition.FlagOptional):
+                self.requiredCheck.setEnabled(False)
+                self.requiredCheck.setChecked(True)
 
         self.buttonBox = QDialogButtonBox(self)
         self.buttonBox.setOrientation(Qt.Horizontal)
@@ -449,23 +459,23 @@ class ModelerParameterDefinitionDialog(QDialog):
                 name=name,
                 description=self.param.description(),
                 fileFilter=self.param.fileFilter(),
-                defaultValue=str(self.defaultWidget.getValue()))
+                defaultValue=self.defaultWidget.getValue())
         elif (isinstance(self.param, QgsProcessingParameterFolderDestination)):
             self.param = QgsProcessingParameterFolderDestination(
                 name=name,
                 description=self.param.description(),
-                defaultValue=str(self.defaultWidget.getValue()))
+                defaultValue=self.defaultWidget.getValue())
         elif (isinstance(self.param, QgsProcessingParameterRasterDestination)):
             self.param = QgsProcessingParameterRasterDestination(
                 name=name,
                 description=self.param.description(),
-                defaultValue=str(self.defaultWidget.getValue()))
+                defaultValue=self.defaultWidget.getValue())
         elif (isinstance(self.param, QgsProcessingParameterVectorDestination)):
             self.param = QgsProcessingParameterVectorDestination(
                 name=name,
                 description=self.param.description(),
                 type=self.param.dataType(),
-                defaultValue=str(self.defaultWidget.getValue()))
+                defaultValue=self.defaultWidget.getValue())
 
         else:
             if self.paramType:

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -63,9 +63,15 @@ from qgis.core import (QgsApplication,
                        QgsProcessingParameterVectorLayer,
                        QgsProcessingParameterField,
                        QgsProcessingParameterFeatureSource,
-                       QgsProcessingParameterBand
-                       )
+                       QgsProcessingParameterBand,
+                       QgsProcessingDestinationParameter,
+                       QgsProcessingParameterFeatureSink,
+                       QgsProcessingParameterFileDestination,
+                       QgsProcessingParameterFolderDestination,
+                       QgsProcessingParameterRasterDestination,
+                       QgsProcessingParameterVectorDestination)
 
+from processing.gui.DestinationSelectionPanel import DestinationSelectionPanel
 from processing.gui.enummodelerwidget import EnumModelerWidget
 from processing.gui.matrixmodelerwidget import MatrixModelerWidget
 from processing.core import parameters
@@ -293,6 +299,11 @@ class ModelerParameterDefinitionDialog(QDialog):
                 self.widget.setFixedRows(self.param.hasFixedNumberRows())
             self.verticalLayout.addWidget(self.widget)
 
+        elif isinstance(self.param, QgsProcessingDestinationParameter):
+            self.verticalLayout.addWidget(QLabel(self.tr('Default value')))
+            self.defaultWidget = DestinationSelectionPanel(self.param, self.alg)
+            self.verticalLayout.addWidget(self.defaultWidget)
+
         self.verticalLayout.addSpacing(20)
         self.requiredCheck = QCheckBox()
         self.requiredCheck.setText(self.tr('Mandatory'))
@@ -425,6 +436,42 @@ class ModelerParameterDefinitionDialog(QDialog):
         elif (self.paramType == parameters.PARAMETER_MATRIX or
                 isinstance(self.param, QgsProcessingParameterMatrix)):
             self.param = QgsProcessingParameterMatrix(name, description, hasFixedNumberRows=self.widget.fixedRows(), headers=self.widget.headers(), defaultValue=self.widget.value())
+
+        # Destination parameter
+        elif (isinstance(self.param, QgsProcessingParameterFeatureSink)):
+            self.param = QgsProcessingParameterFeatureSink(
+                name=name,
+                description=self.param.description(),
+                type=self.param.dataType(),
+                defaultValue=self.defaultWidget.getValue(),
+                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        elif (isinstance(self.param, QgsProcessingParameterFileDestination)):
+            self.param = QgsProcessingParameterFileDestination(
+                name=name,
+                description=self.param.description(),
+                fileFilter=self.param.fileFilter(),
+                defaultValue=str(self.defaultWidget.getValue()),
+                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        elif (isinstance(self.param, QgsProcessingParameterFolderDestination)):
+            self.param = QgsProcessingParameterFolderDestination(
+                name=name,
+                description=self.param.description(),
+                defaultValue=str(self.defaultWidget.getValue()),
+                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        elif (isinstance(self.param, QgsProcessingParameterRasterDestination)):
+            self.param = QgsProcessingParameterRasterDestination(
+                name=name,
+                description=self.param.description(),
+                defaultValue=str(self.defaultWidget.getValue()),
+                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+        elif (isinstance(self.param, QgsProcessingParameterVectorDestination)):
+            self.param = QgsProcessingParameterVectorDestination(
+                name=name,
+                description=self.param.description(),
+                type=self.param.dataType(),
+                defaultValue=str(self.defaultWidget.getValue()),
+                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+
         else:
             if self.paramType:
                 typeId = self.paramType

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -443,34 +443,29 @@ class ModelerParameterDefinitionDialog(QDialog):
                 name=name,
                 description=self.param.description(),
                 type=self.param.dataType(),
-                defaultValue=self.defaultWidget.getValue(),
-                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+                defaultValue=self.defaultWidget.getValue())
         elif (isinstance(self.param, QgsProcessingParameterFileDestination)):
             self.param = QgsProcessingParameterFileDestination(
                 name=name,
                 description=self.param.description(),
                 fileFilter=self.param.fileFilter(),
-                defaultValue=str(self.defaultWidget.getValue()),
-                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+                defaultValue=str(self.defaultWidget.getValue()))
         elif (isinstance(self.param, QgsProcessingParameterFolderDestination)):
             self.param = QgsProcessingParameterFolderDestination(
                 name=name,
                 description=self.param.description(),
-                defaultValue=str(self.defaultWidget.getValue()),
-                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+                defaultValue=str(self.defaultWidget.getValue()))
         elif (isinstance(self.param, QgsProcessingParameterRasterDestination)):
             self.param = QgsProcessingParameterRasterDestination(
                 name=name,
                 description=self.param.description(),
-                defaultValue=str(self.defaultWidget.getValue()),
-                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+                defaultValue=str(self.defaultWidget.getValue()))
         elif (isinstance(self.param, QgsProcessingParameterVectorDestination)):
             self.param = QgsProcessingParameterVectorDestination(
                 name=name,
                 description=self.param.description(),
                 type=self.param.dataType(),
-                defaultValue=str(self.defaultWidget.getValue()),
-                optional=self.param.flags() & QgsProcessingParameterDefinition.FlagOptional)
+                defaultValue=str(self.defaultWidget.getValue()))
 
         else:
             if self.paramType:
@@ -488,6 +483,8 @@ class ModelerParameterDefinitionDialog(QDialog):
 
         if not self.requiredCheck.isChecked():
             self.param.setFlags(self.param.flags() | QgsProcessingParameterDefinition.FlagOptional)
+        else:
+            self.param.setFlags(self.param.flags() & ~QgsProcessingParameterDefinition.FlagOptional)
 
         settings = QgsSettings()
         settings.setValue("/Processing/modelParametersDefinitionDialogGeometry", self.saveGeometry())

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -788,6 +788,7 @@ void QgsProcessingModelAlgorithm::updateDestinationParameters()
       param->setFlags( param->flags() & ~QgsProcessingParameterDefinition::FlagHidden );
       param->setName( outputIt->childId() + ':' + outputIt->name() );
       param->setDescription( outputIt->description() );
+      param->setDefaultValue( outputIt->defaultValue() );
       addParameter( param.release() );
     }
   }

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -786,6 +786,8 @@ void QgsProcessingModelAlgorithm::updateDestinationParameters()
       // Even if an output was hidden in a child algorithm, we want to show it here for the final
       // outputs.
       param->setFlags( param->flags() & ~QgsProcessingParameterDefinition::FlagHidden );
+      if ( outputIt->isMandatory() )
+        param->setFlags( param->flags() & ~QgsProcessingParameterDefinition::FlagOptional );
       param->setName( outputIt->childId() + ':' + outputIt->name() );
       param->setDescription( outputIt->description() );
       param->setDefaultValue( outputIt->defaultValue() );

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -74,6 +74,12 @@ void QgsProcessingModelChildAlgorithm::setModelOutputs( const QMap<QString, QgsP
   }
 }
 
+bool QgsProcessingModelChildAlgorithm::removeModelOutput( const QString &name )
+{
+  mModelOutputs.remove( name );
+  return true;
+}
+
 QVariant QgsProcessingModelChildAlgorithm::toVariant() const
 {
   QVariantMap map;

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
@@ -238,6 +238,16 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
     void setModelOutputs( const QMap<QString, QgsProcessingModelOutput> &outputs );
 
     /**
+     * Removes an existing output from the final model outputs.
+     *
+     * QgsProcessingModelAlgorithm::updateDestinationParameters() must be called on the parent model.
+     *
+     * \see modelOutputs()
+     * \since QGIS 3.2
+     */
+    bool removeModelOutput( const QString &name );
+
+    /**
      * Saves this child to a QVariant.
      * \see loadVariant()
      */

--- a/src/core/processing/models/qgsprocessingmodeloutput.cpp
+++ b/src/core/processing/models/qgsprocessingmodeloutput.cpp
@@ -55,9 +55,9 @@ bool QgsProcessingModelOutput::loadVariant( const QVariantMap &map )
   if ( defaultValue.type() == QVariant::Map )
   {
     QVariantMap defaultMap = defaultValue.toMap();
-    if ( defaultMap["class"] == "QgsProcessingOutputLayerDefinition" )
+    if ( defaultMap["class"] == QStringLiteral( "QgsProcessingOutputLayerDefinition" ) )
     {
-      QgsProcessingOutputLayerDefinition value( "" );
+      QgsProcessingOutputLayerDefinition value;
       value.loadVariant( defaultMap );
       mDefaultValue = QVariant( value );
     }

--- a/src/core/processing/models/qgsprocessingmodeloutput.cpp
+++ b/src/core/processing/models/qgsprocessingmodeloutput.cpp
@@ -42,6 +42,7 @@ QVariant QgsProcessingModelOutput::toVariant() const
 
   map.insert( QStringLiteral( "child_id" ), mChildId );
   map.insert( QStringLiteral( "output_name" ), mOutputName );
+  map.insert( QStringLiteral( "mandatory" ), mMandatory );
   saveCommonProperties( map );
   return map;
 }
@@ -72,6 +73,7 @@ bool QgsProcessingModelOutput::loadVariant( const QVariantMap &map )
 
   mChildId = map.value( QStringLiteral( "child_id" ) ).toString();
   mOutputName = map.value( QStringLiteral( "output_name" ) ).toString();
+  mMandatory = map.value( QStringLiteral( "mandatory" ), false ).toBool();
   restoreCommonProperties( map );
   return true;
 }

--- a/src/core/processing/models/qgsprocessingmodeloutput.cpp
+++ b/src/core/processing/models/qgsprocessingmodeloutput.cpp
@@ -28,6 +28,18 @@ QVariant QgsProcessingModelOutput::toVariant() const
 {
   QVariantMap map;
   map.insert( QStringLiteral( "name" ), mName );
+
+  if ( mDefaultValue.canConvert<QgsProcessingOutputLayerDefinition>() )
+  {
+    QVariantMap defaultMap = mDefaultValue.value<QgsProcessingOutputLayerDefinition>().toVariant().toMap();
+    defaultMap.insert( QStringLiteral( "class" ), QStringLiteral( "QgsProcessingOutputLayerDefinition" ) );
+    map.insert( QStringLiteral( "default_value" ), defaultMap );
+  }
+  else
+  {
+    map.insert( QStringLiteral( "default_value" ), mDefaultValue );
+  }
+
   map.insert( QStringLiteral( "child_id" ), mChildId );
   map.insert( QStringLiteral( "output_name" ), mOutputName );
   saveCommonProperties( map );
@@ -37,6 +49,27 @@ QVariant QgsProcessingModelOutput::toVariant() const
 bool QgsProcessingModelOutput::loadVariant( const QVariantMap &map )
 {
   mName = map.value( QStringLiteral( "name" ) ).toString();
+
+  QVariant defaultValue = map.value( QStringLiteral( "default_value" ) );
+  if ( defaultValue.type() == QVariant::Map )
+  {
+    QVariantMap defaultMap = defaultValue.toMap();
+    if ( defaultMap["class"] == "QgsProcessingOutputLayerDefinition" )
+    {
+      QgsProcessingOutputLayerDefinition value( "" );
+      value.loadVariant( defaultMap );
+      mDefaultValue = QVariant( value );
+    }
+    else
+    {
+      mDefaultValue = QVariant();
+    }
+  }
+  else
+  {
+    mDefaultValue = map.value( QStringLiteral( "default_value" ) );
+  }
+
   mChildId = map.value( QStringLiteral( "child_id" ) ).toString();
   mOutputName = map.value( QStringLiteral( "output_name" ) ).toString();
   restoreCommonProperties( map );

--- a/src/core/processing/models/qgsprocessingmodeloutput.h
+++ b/src/core/processing/models/qgsprocessingmodeloutput.h
@@ -21,6 +21,7 @@
 #include "qgis_core.h"
 #include "qgis.h"
 #include "qgsprocessingmodelcomponent.h"
+#include "qgsprocessingparameters.h"
 
 ///@cond NOT_STABLE
 
@@ -32,6 +33,11 @@
 class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
 {
   public:
+
+    /*
+    //! Output flags
+    Q_DECLARE_FLAGS( Flags, QgsProcessingParameterDefinition::Flag )
+    */
 
     /**
      * Constructor for QgsProcessingModelOutput with the specified \a name and \a description.
@@ -49,6 +55,20 @@ class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
      * \see name()
      */
     void setName( const QString &name ) { mName = name; }
+
+    /**
+     * Returns the default value for the model output parameter.
+     * \see setDefaultValue()
+     * \since QGIS 3.2
+     */
+    QVariant defaultValue() const { return mDefaultValue; }
+
+    /**
+     * Sets the default value for the model output.
+     * \see defaultValue()
+     * \since QGIS 3.2
+     */
+    void setDefaultValue( const QVariant &value ) { mDefaultValue = value; }
 
     /**
      * Returns the child algorithm ID from which this output is generated.
@@ -89,6 +109,7 @@ class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
   private:
 
     QString mName;
+    QVariant mDefaultValue;
     QString mChildId;
     QString mOutputName;
 };

--- a/src/core/processing/models/qgsprocessingmodeloutput.h
+++ b/src/core/processing/models/qgsprocessingmodeloutput.h
@@ -34,11 +34,6 @@ class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
 {
   public:
 
-    /*
-    //! Output flags
-    Q_DECLARE_FLAGS( Flags, QgsProcessingParameterDefinition::Flag )
-    */
-
     /**
      * Constructor for QgsProcessingModelOutput with the specified \a name and \a description.
      */

--- a/src/core/processing/models/qgsprocessingmodeloutput.h
+++ b/src/core/processing/models/qgsprocessingmodeloutput.h
@@ -71,6 +71,24 @@ class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
     void setDefaultValue( const QVariant &value ) { mDefaultValue = value; }
 
     /**
+     * Returns true if the output is mandatory. This may override the associated
+     * child algorithm's parameter optional status - e.g. allowing
+     * an optional output from an algorithm to be mandatory within a model.
+     * \see setMandatory()
+     * \since QGIS 3.2
+     */
+    bool isMandatory() const { return mMandatory; }
+
+    /**
+     * Sets whether the output is \a mandatory. This may override the associated
+     * child algorithm's parameter optional status - e.g. allowing
+     * an optional output from an algorithm to be mandatory within a model.
+     * \see isMandatory()
+     * \since QGIS 3.2
+     */
+    void setMandatory( bool mandatory ) { mMandatory = mandatory; }
+
+    /**
      * Returns the child algorithm ID from which this output is generated.
      * \see setChildId()
      */
@@ -112,6 +130,7 @@ class CORE_EXPORT QgsProcessingModelOutput : public QgsProcessingModelComponent
     QVariant mDefaultValue;
     QString mChildId;
     QString mOutputName;
+    bool mMandatory = false;
 };
 
 ///@endcond

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -29,6 +29,22 @@
 #include "qgsprocessingparametertype.h"
 #include <functional>
 
+
+QVariant QgsProcessingOutputLayerDefinition::toVariant() const
+{
+  QVariantMap map;
+  map.insert( QStringLiteral( "sink" ), sink.toVariant() );
+  map.insert( QStringLiteral( "create_options" ), createOptions );
+  return map;
+}
+
+bool QgsProcessingOutputLayerDefinition::loadVariant( const QVariantMap &map )
+{
+  sink.loadVariant( map.value( QStringLiteral( "sink" ) ) );
+  createOptions = map.value( QStringLiteral( "create_options" ) ).toMap();
+  return true;
+}
+
 bool QgsProcessingParameters::isDynamic( const QVariantMap &parameters, const QString &name )
 {
   QVariant val = parameters.value( name );

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -153,6 +153,21 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
      */
     QVariantMap createOptions;
 
+    /**
+     * Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
+     * You can use QgsXmlUtils::writeVariant to save it to an XML document.
+     *
+     * \see loadVariant()
+     */
+    QVariant toVariant() const;
+
+    /**
+     * Loads this output layer definition from a QVariantMap, wrapped in a QVariant.
+     * You can use QgsXmlUtils::readVariant to load it from an XML document.
+     *
+     * \see toVariant()
+     */
+    bool loadVariant( const QVariantMap &map );
 
     //! Allows direct construction of QVariants.
     operator QVariant() const

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -156,16 +156,16 @@ class CORE_EXPORT QgsProcessingOutputLayerDefinition
     /**
      * Saves this output layer definition to a QVariantMap, wrapped in a QVariant.
      * You can use QgsXmlUtils::writeVariant to save it to an XML document.
-     *
      * \see loadVariant()
+     * \since QGIS 3.2
      */
     QVariant toVariant() const;
 
     /**
      * Loads this output layer definition from a QVariantMap, wrapped in a QVariant.
      * You can use QgsXmlUtils::readVariant to load it from an XML document.
-     *
      * \see toVariant()
+     * \since QGIS 3.2
      */
     bool loadVariant( const QVariantMap &map );
 


### PR DESCRIPTION
## Description

Add possibility to store default values for destination parameters in models.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
