### PR TITLE
[FEATURE][needs-docs] Save/Load connections for XYZ Tiles

### DIFF
--- a/python/gui/qgsmanageconnectionsdialog.sip.in
+++ b/python/gui/qgsmanageconnectionsdialog.sip.in
@@ -32,7 +32,7 @@ class QgsManageConnectionsDialog : QDialog
       WCS,
       Oracle,
       GeoNode,
-      XYZTiles
+      XyzTiles
     };
 
     QgsManageConnectionsDialog( QWidget *parent /TransferThis/ = 0, Mode mode = Export, Type type = WMS, const QString &fileName = QString() );

--- a/python/gui/qgsmanageconnectionsdialog.sip.in
+++ b/python/gui/qgsmanageconnectionsdialog.sip.in
@@ -31,7 +31,8 @@ class QgsManageConnectionsDialog : QDialog
       DB2,
       WCS,
       Oracle,
-      GeoNode
+      GeoNode,
+      XYZTiles
     };
 
     QgsManageConnectionsDialog( QWidget *parent /TransferThis/ = 0, Mode mode = Export, Type type = WMS, const QString &fileName = QString() );

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -366,7 +366,7 @@ bool QgsManageConnectionsDialog::populateConnections()
         if ( root.tagName() != QLatin1String( "qgsXYZTilesConnections" ) )
         {
           QMessageBox::information( this, tr( "Loading Connections" ),
-                                    tr( "The file is not a Tiles XYZ connections exchange file." ) );
+                                    tr( "The file is not a XYZ Tiles connections exchange file." ) );
           return false;
         }
         break;
@@ -1278,7 +1278,7 @@ void QgsManageConnectionsDialog::loadXYZTilesConnections( const QDomDocument &do
   if ( root.tagName() != QLatin1String( "qgsXYZTilesConnections" ) )
   {
     QMessageBox::information( this, tr( "Loading Connections" ),
-                              tr( "The file is not a Tiles XYZ connections exchange file." ) );
+                              tr( "The file is not a XYZ Tiles connections exchange file." ) );
     return;
   }
 

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -133,8 +133,8 @@ void QgsManageConnectionsDialog::doExportImport()
       case GeoNode:
         doc = saveGeonodeConnections( items );
         break;
-      case XYZTiles:
-        doc = saveXYZTilesConnections( items );
+      case XyzTiles:
+        doc = saveXyzTilesConnections( items );
         break;
     }
 
@@ -204,8 +204,8 @@ void QgsManageConnectionsDialog::doExportImport()
       case GeoNode:
         loadGeonodeConnections( doc, items );
         break;
-      case XYZTiles:
-        loadXYZTilesConnections( doc, items );
+      case XyzTiles:
+        loadXyzTilesConnections( doc, items );
         break;
     }
     // clear connections list and close window
@@ -248,7 +248,7 @@ bool QgsManageConnectionsDialog::populateConnections()
       case GeoNode:
         settings.beginGroup( QStringLiteral( "/qgis/connections-geonode" ) );
         break;
-      case XYZTiles:
+      case XyzTiles:
         settings.beginGroup( QStringLiteral( "/qgis/connections-xyz" ) );
         break;
     }
@@ -362,7 +362,7 @@ bool QgsManageConnectionsDialog::populateConnections()
           return false;
         }
         break;
-      case XYZTiles:
+      case XyzTiles:
         if ( root.tagName() != QLatin1String( "qgsXYZTilesConnections" ) )
         {
           QMessageBox::information( this, tr( "Loading Connections" ),
@@ -639,7 +639,7 @@ QDomDocument QgsManageConnectionsDialog::saveGeonodeConnections( const QStringLi
   return doc;
 }
 
-QDomDocument QgsManageConnectionsDialog::saveXYZTilesConnections( const QStringList &connections )
+QDomDocument QgsManageConnectionsDialog::saveXyzTilesConnections( const QStringList &connections )
 {
   QDomDocument doc( QStringLiteral( "connections" ) );
   QDomElement root = doc.createElement( QStringLiteral( "qgsXYZTilesConnections" ) );
@@ -1272,7 +1272,7 @@ void QgsManageConnectionsDialog::loadGeonodeConnections( const QDomDocument &doc
   }
 }
 
-void QgsManageConnectionsDialog::loadXYZTilesConnections( const QDomDocument &doc, const QStringList &items )
+void QgsManageConnectionsDialog::loadXyzTilesConnections( const QDomDocument &doc, const QStringList &items )
 {
   QDomElement root = doc.documentElement();
   if ( root.tagName() != QLatin1String( "qgsXYZTilesConnections" ) )

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -133,6 +133,9 @@ void QgsManageConnectionsDialog::doExportImport()
       case GeoNode:
         doc = saveGeonodeConnections( items );
         break;
+      case XYZTiles:
+        doc = saveXYZTilesConnections( items );
+        break;
     }
 
     QFile file( mFileName );
@@ -201,6 +204,9 @@ void QgsManageConnectionsDialog::doExportImport()
       case GeoNode:
         loadGeonodeConnections( doc, items );
         break;
+      case XYZTiles:
+        loadXYZTilesConnections( doc, items );
+        break;
     }
     // clear connections list and close window
     listConnections->clear();
@@ -241,6 +247,9 @@ bool QgsManageConnectionsDialog::populateConnections()
         break;
       case GeoNode:
         settings.beginGroup( QStringLiteral( "/qgis/connections-geonode" ) );
+        break;
+      case XYZTiles:
+        settings.beginGroup( QStringLiteral( "/qgis/connections-xyz" ) );
         break;
     }
     QStringList keys = settings.childGroups();
@@ -350,6 +359,14 @@ bool QgsManageConnectionsDialog::populateConnections()
         {
           QMessageBox::information( this, tr( "Loading Connections" ),
                                     tr( "The file is not a GeoNode connections exchange file." ) );
+          return false;
+        }
+        break;
+      case XYZTiles:
+        if ( root.tagName() != QLatin1String( "qgsXYZTilesConnections" ) )
+        {
+          QMessageBox::information( this, tr( "Loading Connections" ),
+                                    tr( "The file is not a Tiles XYZ connections exchange file." ) );
           return false;
         }
         break;
@@ -616,6 +633,35 @@ QDomDocument QgsManageConnectionsDialog::saveGeonodeConnections( const QStringLi
     path = QStringLiteral( "/qgis/GeoNode/" );
     el.setAttribute( QStringLiteral( "username" ), settings.value( path + connections[ i ] + "/username", "" ).toString() );
     el.setAttribute( QStringLiteral( "password" ), settings.value( path + connections[ i ] + "/password", "" ).toString() );
+    root.appendChild( el );
+  }
+
+  return doc;
+}
+
+QDomDocument QgsManageConnectionsDialog::saveXYZTilesConnections( const QStringList &connections )
+{
+  QDomDocument doc( QStringLiteral( "connections" ) );
+  QDomElement root = doc.createElement( QStringLiteral( "qgsXYZTilesConnections" ) );
+  root.setAttribute( QStringLiteral( "version" ), QStringLiteral( "1.0" ) );
+  doc.appendChild( root );
+
+  QgsSettings settings;
+  QString path;
+  for ( int i = 0; i < connections.count(); ++i )
+  {
+    path = "qgis/connections-xyz/" + connections[ i ];
+    QDomElement el = doc.createElement( QStringLiteral( "xyztiles" ) );
+
+    el.setAttribute( QStringLiteral( "name" ), connections[ i ] );
+    el.setAttribute( QStringLiteral( "url" ), settings.value( path + "/url", "" ).toString() );
+    el.setAttribute( QStringLiteral( "zmin" ), settings.value( path + "/zmin", -1 ).toInt() );
+    el.setAttribute( QStringLiteral( "zmax" ), settings.value( path + "/zmax", -1 ).toInt() );
+    el.setAttribute( QStringLiteral( "authcfg" ), settings.value( path + "/authcfg", "" ).toString() );
+    el.setAttribute( QStringLiteral( "username" ), settings.value( path + "/username", "" ).toString() );
+    el.setAttribute( QStringLiteral( "password" ), settings.value( path + "/password", "" ).toString() );
+    el.setAttribute( QStringLiteral( "referer" ), settings.value( path + "/referer", "" ).toString() );
+
     root.appendChild( el );
   }
 
@@ -1225,6 +1271,85 @@ void QgsManageConnectionsDialog::loadGeonodeConnections( const QDomDocument &doc
     child = child.nextSiblingElement();
   }
 }
+
+void QgsManageConnectionsDialog::loadXYZTilesConnections( const QDomDocument &doc, const QStringList &items )
+{
+  QDomElement root = doc.documentElement();
+  if ( root.tagName() != QLatin1String( "qgsXYZTilesConnections" ) )
+  {
+    QMessageBox::information( this, tr( "Loading Connections" ),
+                              tr( "The file is not a Tiles XYZ connections exchange file." ) );
+    return;
+  }
+
+  QString connectionName;
+  QgsSettings settings;
+  settings.beginGroup( QStringLiteral( "/qgis/connections-xyz" ) );
+  QStringList keys = settings.childGroups();
+  settings.endGroup();
+  QDomElement child = root.firstChildElement();
+  bool prompt = true;
+  bool overwrite = true;
+
+  while ( !child.isNull() )
+  {
+    connectionName = child.attribute( QStringLiteral( "name" ) );
+    if ( !items.contains( connectionName ) )
+    {
+      child = child.nextSiblingElement();
+      continue;
+    }
+
+    // check for duplicates
+    if ( keys.contains( connectionName ) && prompt )
+    {
+      int res = QMessageBox::warning( this,
+                                      tr( "Loading Connections" ),
+                                      tr( "Connection with name '%1' already exists. Overwrite?" )
+                                      .arg( connectionName ),
+                                      QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
+
+      switch ( res )
+      {
+        case QMessageBox::Cancel:
+          return;
+        case QMessageBox::No:
+          child = child.nextSiblingElement();
+          continue;
+        case QMessageBox::Yes:
+          overwrite = true;
+          break;
+        case QMessageBox::YesToAll:
+          prompt = false;
+          overwrite = true;
+          break;
+        case QMessageBox::NoToAll:
+          prompt = false;
+          overwrite = false;
+          break;
+      }
+    }
+
+    if ( keys.contains( connectionName ) && !overwrite )
+    {
+      child = child.nextSiblingElement();
+      continue;
+    }
+
+    settings.beginGroup( "qgis/connections-xyz/" + connectionName );
+    settings.setValue( QStringLiteral( "url" ), child.attribute( QStringLiteral( "url" ) ) );
+    settings.setValue( QStringLiteral( "zmin" ), child.attribute( QStringLiteral( "zmin" ) ) );
+    settings.setValue( QStringLiteral( "zmax" ), child.attribute( QStringLiteral( "zmax" ) ) );
+    settings.setValue( QStringLiteral( "authcfg" ), child.attribute( QStringLiteral( "authcfg" ) ) );
+    settings.setValue( QStringLiteral( "username" ), child.attribute( QStringLiteral( "username" ) ) );
+    settings.setValue( QStringLiteral( "password" ), child.attribute( QStringLiteral( "password" ) ) );
+    settings.setValue( QStringLiteral( "referer" ), child.attribute( QStringLiteral( "referer" ) ) );
+    settings.endGroup();
+
+    child = child.nextSiblingElement();
+  }
+}
+
 
 void QgsManageConnectionsDialog::selectAll()
 {

--- a/src/gui/qgsmanageconnectionsdialog.h
+++ b/src/gui/qgsmanageconnectionsdialog.h
@@ -49,7 +49,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
       WCS,
       Oracle,
       GeoNode,
-      XYZTiles
+      XyzTiles
     };
 
     /**
@@ -73,7 +73,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
     QDomDocument saveOracleConnections( const QStringList &connections );
     QDomDocument saveDb2Connections( const QStringList &connections );
     QDomDocument saveGeonodeConnections( const QStringList &connections );
-    QDomDocument saveXYZTilesConnections( const QStringList &connections );
+    QDomDocument saveXyzTilesConnections( const QStringList &connections );
 
     void loadOWSConnections( const QDomDocument &doc, const QStringList &items, const QString &service );
     void loadWfsConnections( const QDomDocument &doc, const QStringList &items );
@@ -82,7 +82,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
     void loadOracleConnections( const QDomDocument &doc, const QStringList &items );
     void loadDb2Connections( const QDomDocument &doc, const QStringList &items );
     void loadGeonodeConnections( const QDomDocument &doc, const QStringList &items );
-    void loadXYZTilesConnections( const QDomDocument &doc, const QStringList &items );
+    void loadXyzTilesConnections( const QDomDocument &doc, const QStringList &items );
 
     QString mFileName;
     Mode mDialogMode;

--- a/src/gui/qgsmanageconnectionsdialog.h
+++ b/src/gui/qgsmanageconnectionsdialog.h
@@ -48,7 +48,8 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
       DB2,
       WCS,
       Oracle,
-      GeoNode
+      GeoNode,
+      XYZTiles
     };
 
     /**
@@ -72,6 +73,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
     QDomDocument saveOracleConnections( const QStringList &connections );
     QDomDocument saveDb2Connections( const QStringList &connections );
     QDomDocument saveGeonodeConnections( const QStringList &connections );
+    QDomDocument saveXYZTilesConnections( const QStringList &connections );
 
     void loadOWSConnections( const QDomDocument &doc, const QStringList &items, const QString &service );
     void loadWfsConnections( const QDomDocument &doc, const QStringList &items );
@@ -80,6 +82,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
     void loadOracleConnections( const QDomDocument &doc, const QStringList &items );
     void loadDb2Connections( const QDomDocument &doc, const QStringList &items );
     void loadGeonodeConnections( const QDomDocument &doc, const QStringList &items );
+    void loadXYZTilesConnections( const QDomDocument &doc, const QStringList &items );
 
     QString mFileName;
     Mode mDialogMode;

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -27,12 +27,14 @@
 #include "qgsnewhttpconnection.h"
 #include "qgstilescalewidget.h"
 #include "qgsxyzconnectiondialog.h"
+#include "qgsmanageconnectionsdialog.h"
 #endif
 #include "qgsgeonodeconnection.h"
 #include "qgsgeonoderequest.h"
 #include "qgssettings.h"
 
 #include <QInputDialog>
+#include <QFileDialog>
 
 // ---------------------------------------------------------------------------
 QgsWMSConnectionItem::QgsWMSConnectionItem( QgsDataItem *parent, QString name, QString path, QString uri )
@@ -474,9 +476,20 @@ QVector<QgsDataItem *> QgsXyzTileRootItem::createChildren()
 #ifdef HAVE_GUI
 QList<QAction *> QgsXyzTileRootItem::actions( QWidget *parent )
 {
+  QList<QAction *> lst;
+
   QAction *actionNew = new QAction( tr( "New Connection…" ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsXyzTileRootItem::newConnection );
-  return QList<QAction *>() << actionNew;
+  QAction *saveXYZTilesServers = new QAction( tr( "Save Connections…" ), parent );
+  connect( saveXYZTilesServers, &QAction::triggered, this, &QgsXyzTileRootItem::saveXYZTilesServers );
+  QAction *loadXYZTilesServers = new QAction( tr( "Load Connections…" ), parent );
+  connect( loadXYZTilesServers, &QAction::triggered, this, &QgsXyzTileRootItem::loadXYZTilesServers );
+
+  lst.append( actionNew );
+  lst.append( saveXYZTilesServers );
+  lst.append( loadXYZTilesServers );
+
+  return lst;
 }
 
 void QgsXyzTileRootItem::newConnection()
@@ -486,6 +499,26 @@ void QgsXyzTileRootItem::newConnection()
     return;
 
   QgsXyzConnectionUtils::addConnection( dlg.connection() );
+  refreshConnections();
+}
+
+void QgsXyzTileRootItem::saveXYZTilesServers()
+{
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::XYZTiles );
+  dlg.exec();
+}
+
+void QgsXyzTileRootItem::loadXYZTilesServers()
+{
+  QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
+                     tr( "XML files (*.xml *XML)" ) );
+  if ( fileName.isEmpty() )
+  {
+    return;
+  }
+
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::XYZTiles, fileName );
+  dlg.exec();
   refreshConnections();
 }
 #endif

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -480,14 +480,14 @@ QList<QAction *> QgsXyzTileRootItem::actions( QWidget *parent )
 
   QAction *actionNew = new QAction( tr( "New Connection…" ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsXyzTileRootItem::newConnection );
-  QAction *saveXYZTilesServers = new QAction( tr( "Save Connections…" ), parent );
-  connect( saveXYZTilesServers, &QAction::triggered, this, &QgsXyzTileRootItem::saveXYZTilesServers );
-  QAction *loadXYZTilesServers = new QAction( tr( "Load Connections…" ), parent );
-  connect( loadXYZTilesServers, &QAction::triggered, this, &QgsXyzTileRootItem::loadXYZTilesServers );
+  QAction *saveXyzTilesServers = new QAction( tr( "Save Connections…" ), parent );
+  connect( saveXyzTilesServers, &QAction::triggered, this, &QgsXyzTileRootItem::saveXyzTilesServers );
+  QAction *loadXyzTilesServers = new QAction( tr( "Load Connections…" ), parent );
+  connect( loadXyzTilesServers, &QAction::triggered, this, &QgsXyzTileRootItem::loadXyzTilesServers );
 
   lst.append( actionNew );
-  lst.append( saveXYZTilesServers );
-  lst.append( loadXYZTilesServers );
+  lst.append( saveXyzTilesServers );
+  lst.append( loadXyzTilesServers );
 
   return lst;
 }
@@ -502,13 +502,13 @@ void QgsXyzTileRootItem::newConnection()
   refreshConnections();
 }
 
-void QgsXyzTileRootItem::saveXYZTilesServers()
+void QgsXyzTileRootItem::saveXyzTilesServers()
 {
-  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::XYZTiles );
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Export, QgsManageConnectionsDialog::XyzTiles );
   dlg.exec();
 }
 
-void QgsXyzTileRootItem::loadXYZTilesServers()
+void QgsXyzTileRootItem::loadXyzTilesServers()
 {
   QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Load Connections" ), QDir::homePath(),
                      tr( "XML files (*.xml *XML)" ) );
@@ -517,7 +517,7 @@ void QgsXyzTileRootItem::loadXYZTilesServers()
     return;
   }
 
-  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::XYZTiles, fileName );
+  QgsManageConnectionsDialog dlg( nullptr, QgsManageConnectionsDialog::Import, QgsManageConnectionsDialog::XyzTiles, fileName );
   dlg.exec();
   refreshConnections();
 }

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -146,8 +146,8 @@ class QgsXyzTileRootItem : public QgsDataCollectionItem
   private slots:
 #ifdef HAVE_GUI
     void newConnection();
-    void saveXYZTilesServers();
-    void loadXYZTilesServers();
+    void saveXyzTilesServers();
+    void loadXyzTilesServers();
 #endif
 };
 

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -146,6 +146,8 @@ class QgsXyzTileRootItem : public QgsDataCollectionItem
   private slots:
 #ifdef HAVE_GUI
     void newConnection();
+    void saveXYZTilesServers();
+    void loadXYZTilesServers();
 #endif
 };
 


### PR DESCRIPTION
## Description
Add two actions to browser item "XYZ Tiles" to save/load connections to/from XML file for xyz servers.

~Video: removed~

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
