### PR TITLE
[ogr] Fix ref/unref mismatch when loading OGR layers

### DIFF
--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -18,6 +18,7 @@
 
 #define SIP_NO_FILE
 
+#include "qgis.h"
 #include <QCoreApplication>
 #include <QMap>
 #include <QMutex>
@@ -34,7 +35,7 @@
 
 /**
  * \ingroup core
- * Template that stores data related to one server.
+ * Template that stores data related to a connection to a single server or datasource.
  *
  * It is assumed that following functions exist:
  * - void qgsConnectionPool_ConnectionCreate(QString name, T& c)  ... create a new connection
@@ -74,7 +75,7 @@ class QgsConnectionPoolGroup
 
     ~QgsConnectionPoolGroup()
     {
-      Q_FOREACH ( Item item, conns )
+      for ( const Item &item : qgis::as_const( conns ) )
       {
         qgsConnectionPool_ConnectionDestroy( item.c );
       }
@@ -180,12 +181,12 @@ class QgsConnectionPoolGroup
     void invalidateConnections()
     {
       connMutex.lock();
-      Q_FOREACH ( Item i, conns )
+      for ( const Item &i : qgis::as_const( conns ) )
       {
         qgsConnectionPool_ConnectionDestroy( i.c );
       }
       conns.clear();
-      Q_FOREACH ( T c, acquiredConns )
+      for ( T c : qgis::as_const( acquiredConns ) )
         qgsConnectionPool_InvalidateConnection( c );
       connMutex.unlock();
     }
@@ -269,7 +270,7 @@ class QgsConnectionPool
     virtual ~QgsConnectionPool()
     {
       mMutex.lock();
-      Q_FOREACH ( T_Group *group, mGroups )
+      for ( T_Group *group : qgis::as_const( mGroups ) )
       {
         delete group;
       }

--- a/src/providers/ogr/qgsogrconnpool.h
+++ b/src/providers/ogr/qgsogrconnpool.h
@@ -65,8 +65,16 @@ class QgsOgrConnPoolGroup : public QObject, public QgsConnectionPoolGroup<QgsOgr
   public:
     explicit QgsOgrConnPoolGroup( const QString &name )
       : QgsConnectionPoolGroup<QgsOgrConn*>( name )
-      , mRefCount( 0 )
-    { initTimer( this ); }
+    {
+      initTimer( this );
+    }
+
+    //! QgsOgrConnPoolGroup cannot be copied
+    QgsOgrConnPoolGroup( const QgsOgrConnPoolGroup &other ) = delete;
+
+    //! QgsOgrConnPoolGroup cannot be copied
+    QgsOgrConnPoolGroup &operator=( const QgsOgrConnPoolGroup &other ) = delete;
+
     void ref() { ++mRefCount; }
     bool unref()
     {
@@ -79,11 +87,8 @@ class QgsOgrConnPoolGroup : public QObject, public QgsConnectionPoolGroup<QgsOgr
     void startExpirationTimer() { expirationTimer->start(); }
     void stopExpirationTimer() { expirationTimer->stop(); }
 
-  protected:
-    Q_DISABLE_COPY( QgsOgrConnPoolGroup )
-
   private:
-    int mRefCount;
+    int mRefCount = 0;
 
 };
 
@@ -109,6 +114,12 @@ class QgsOgrConnPool : public QgsConnectionPool<QgsOgrConn *, QgsOgrConnPoolGrou
     //          in double-free of the instance.
     //
     static void cleanupInstance();
+
+    //! QgsOgrConnPool cannot be copied
+    QgsOgrConnPool( const QgsOgrConnPool &other ) = delete;
+
+    //! QgsOgrConnPool cannot be copied
+    QgsOgrConnPool &operator=( const QgsOgrConnPool &other ) = delete;
 
     /**
      * \brief Increases the reference count on the connection pool for the specified connection.
@@ -150,9 +161,6 @@ class QgsOgrConnPool : public QgsConnectionPool<QgsOgrConn *, QgsOgrConnPoolGrou
       }
       mMutex.unlock();
     }
-
-  protected:
-    Q_DISABLE_COPY( QgsOgrConnPool )
 
   private:
     QgsOgrConnPool();

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -211,7 +211,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
     bool commitTransaction();
 
     //! Does the real job of settings the subset string and adds an argument to disable update capabilities
-    bool _setSubsetString( const QString &theSQL, bool updateFeatureCount = true, bool updateCapabilities = true );
+    bool _setSubsetString( const QString &theSQL, bool updateFeatureCount = true, bool updateCapabilities = true, bool hasExistingRef = true );
 
     void addSubLayerDetailsToSubLayerList( int i, QgsOgrLayer *layer ) const;
 


### PR DESCRIPTION
Causes an extra connection reference which is never removed,
blocking ogr dataset closing.

Fixes #18420, probably others
