### PR TITLE
[postgres] Automatically populate layer metadata from table

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -98,6 +98,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QgsCoordinateReferenceSystem crs() const override;
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request ) const override;
     QgsWkbTypes::Type wkbType() const override;
+    QgsLayerMetadata layerMetadata() const override;
 
     /**
      * Return the number of layers for the current data source
@@ -446,6 +447,8 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QHash<int, QString> mDefaultValues;
 
     bool mCheckPrimaryKeyUnicity = true;
+
+    QgsLayerMetadata mLayerMetadata;
 
     std::unique_ptr< QgsPostgresListener > mListener;
 };

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -37,6 +37,7 @@ from qgis.core import (
     QgsReadWriteContext,
     QgsRectangle,
     QgsDefaultValue,
+    QgsCoordinateReferenceSystem,
     QgsProject,
     QgsWkbTypes,
     QgsGeometry
@@ -196,6 +197,13 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         test_table(self.dbconn, 'mls3d', 'MultiLineStringZ ((0 0 0, 1 1 1),(2 2 2, 3 3 3))')
 
         test_table(self.dbconn, 'pt4d', 'PointZM (1 2 3 4)')
+
+    def testMetadata(self):
+        """ Test that metadata is correctly acquired from provider """
+        metadata = self.vl.metadata()
+        self.assertEqual(metadata.crs(), QgsCoordinateReferenceSystem.fromEpsgId(4326))
+        self.assertEqual(metadata.type(), 'dataset')
+        self.assertEqual(metadata.abstract(), 'QGIS Test Table')
 
     def testGetFeaturesUniqueId(self):
         """

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -43,6 +43,8 @@ CREATE TABLE qgis_test."someData" (
     geom public.geometry(Point,4326)
 );
 
+COMMENT ON TABLE qgis_test."someData" IS 'QGIS Test Table';
+
 CREATE TABLE qgis_test."some_poly_data" (
     pk SERIAL NOT NULL,
     geom public.geometry(Polygon,4326)


### PR DESCRIPTION
Not much is really available to automatically populate from postgres, but we can set the abstract to match the table comment, the crs, and datatype.
