### PR TITLE
Update writeOut to include isatty

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -79,6 +79,8 @@ class writeOut(object):
 
     def flush(self):
         pass
+    def isatty(self):
+        return False
 
 
 class ShellOutputScintilla(QsciScintilla):

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -79,6 +79,7 @@ class writeOut(object):
 
     def flush(self):
         pass
+    
     def isatty(self):
         return False
 

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -79,7 +79,7 @@ class writeOut(object):
 
     def flush(self):
         pass
-    
+
     def isatty(self):
         return False
 


### PR DESCRIPTION
Added these lines so that QGIS 3 python console works similar to osgeo python console

## Description
changes to make writeOut  similar to sys.stdout
```

Python Console 
Use iface to access QGIS API interface or Type help(iface) for more info
import sys
sys.stdout.isatty()
Traceback (most recent call last):
  File "C:\PROGRA~1\QGIS3~1.0\apps\Python36\lib\code.py", line 91, in runcode
    exec(code, self.locals)
  File "<input>", line 1, in <module>
AttributeError: 'writeOut' object has no attribute 'isatty'
```
but in osgeo it works fine:
![osgeo](https://user-images.githubusercontent.com/5653512/37401609-9ece8e1c-27ae-11e8-9a1a-9f2ed901c9d6.PNG)

Hence this change

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
