### PR TITLE
fix QgsApplication::setPrefixPath

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -208,32 +208,35 @@ void QgsApplication::init( QString profileFolder )
   }
   else
   {
-    char *prefixPath = getenv( "QGIS_PREFIX_PATH" );
-    if ( !prefixPath )
+    if ( ABISYM( mPrefixPath ).isNull() )
     {
-#if defined(Q_OS_MACX) || defined(Q_OS_WIN)
-      setPrefixPath( applicationDirPath(), true );
-#elif defined(ANDROID)
-      // this is  "/data/data/org.qgis.qgis" in android
-      QDir myDir( QDir::homePath() );
-      myDir.cdUp();
-      QString myPrefix = myDir.absolutePath();
-      setPrefixPath( myPrefix, true );
-#else
-      QDir myDir( applicationDirPath() );
-      // Fix for server which is one level deeper in /usr/lib/cgi-bin
-      if ( applicationDirPath().contains( QStringLiteral( "cgi-bin" ) ) )
+      char *prefixPath = getenv( "QGIS_PREFIX_PATH" );
+      if ( !prefixPath )
       {
+#if defined(Q_OS_MACX) || defined(Q_OS_WIN)
+        setPrefixPath( applicationDirPath(), true );
+#elif defined(ANDROID)
+        // this is  "/data/data/org.qgis.qgis" in android
+        QDir myDir( QDir::homePath() );
         myDir.cdUp();
-      }
-      myDir.cdUp(); // Go from /usr/bin or /usr/lib (for server) to /usr
-      QString myPrefix = myDir.absolutePath();
-      setPrefixPath( myPrefix, true );
+        QString myPrefix = myDir.absolutePath();
+        setPrefixPath( myPrefix, true );
+#else
+        QDir myDir( applicationDirPath() );
+        // Fix for server which is one level deeper in /usr/lib/cgi-bin
+        if ( applicationDirPath().contains( QStringLiteral( "cgi-bin" ) ) )
+        {
+          myDir.cdUp();
+        }
+        myDir.cdUp(); // Go from /usr/bin or /usr/lib (for server) to /usr
+        QString myPrefix = myDir.absolutePath();
+        setPrefixPath( myPrefix, true );
 #endif
-    }
-    else
-    {
-      setPrefixPath( prefixPath, true );
+      }
+      else
+      {
+        setPrefixPath( prefixPath, true );
+      }
     }
   }
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -208,10 +208,10 @@ void QgsApplication::init( QString profileFolder )
   }
   else
   {
-    if ( ABISYM( mPrefixPath ).isNull() )
+    char *prefixPath = getenv( "QGIS_PREFIX_PATH" );
+    if ( !prefixPath )
     {
-      char *prefixPath = getenv( "QGIS_PREFIX_PATH" );
-      if ( !prefixPath )
+      if ( ABISYM( mPrefixPath ).isNull() )
       {
 #if defined(Q_OS_MACX) || defined(Q_OS_WIN)
         setPrefixPath( applicationDirPath(), true );


### PR DESCRIPTION
setPrefixPath was useless outside of the app since mPrefixPath was overwritten by env variables

