### PR TITLE
[processing] Allow algorithms to set layer post-processors for created layers

### DIFF
--- a/python/core/processing/qgsprocessingcontext.sip.in
+++ b/python/core/processing/qgsprocessingcontext.sip.in
@@ -117,6 +117,8 @@ algorithm execution.
 {
 %Docstring
 Details for layers to load into projects.
+
+.. versionadded:: 3.0
 %End
 
 %TypeHeaderCode

--- a/python/core/processing/qgsprocessingcontext.sip.in
+++ b/python/core/processing/qgsprocessingcontext.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsProcessingContext
 {
 %Docstring
@@ -38,6 +39,8 @@ expression context.
 Constructor for QgsProcessingContext.
 %End
 
+
+    ~QgsProcessingContext();
 
     void copyThreadSafeSettings( const QgsProcessingContext &other );
 %Docstring
@@ -110,19 +113,52 @@ Returns a reference to the layer store used for storing temporary layers during
 algorithm execution.
 %End
 
-    struct LayerDetails
-    {
+    class LayerDetails
+{
+%Docstring
+Details for layers to load into projects.
+%End
 
-      LayerDetails( const QString &name, QgsProject *project, const QString &outputName = QString() );
+%TypeHeaderCode
+#include "qgsprocessingcontext.h"
+%End
+      public:
+
+        LayerDetails( const QString &name, QgsProject *project, const QString &outputName = QString() );
 %Docstring
 Constructor for LayerDetails.
 %End
 
-      QString name;
+        LayerDetails();
+%Docstring
+Default constructor
+%End
 
-      QString outputName;
+        QString name;
 
-      QgsProject *project;
+        QString outputName;
+
+        QgsProcessingLayerPostProcessorInterface *postProcessor() const;
+%Docstring
+Layer post-processor. May be None if no post-processing is required.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`setPostProcessor`
+%End
+
+        void setPostProcessor( QgsProcessingLayerPostProcessorInterface *processor /Transfer/ );
+%Docstring
+Sets the layer post-processor. May be None if no post-processing is required.
+
+Ownership of ``processor`` is transferred.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`postProcessor`
+%End
+
+        QgsProject *project;
 
     };
 
@@ -133,6 +169,26 @@ Returns a map of layers (by ID or datasource) to LayerDetails, to load into the 
 .. seealso:: :py:func:`setLayersToLoadOnCompletion`
 
 .. seealso:: :py:func:`addLayerToLoadOnCompletion`
+
+.. seealso:: :py:func:`willLoadLayerOnCompletion`
+
+.. seealso:: :py:func:`layerToLoadOnCompletionDetails`
+%End
+
+    bool willLoadLayerOnCompletion( const QString &layer ) const;
+%Docstring
+Returns true if the given ``layer`` (by ID or datasource) will be loaded into the current project
+upon completion of the algorithm or model.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`layersToLoadOnCompletion`
+
+.. seealso:: :py:func:`setLayersToLoadOnCompletion`
+
+.. seealso:: :py:func:`addLayerToLoadOnCompletion`
+
+.. seealso:: :py:func:`layerToLoadOnCompletionDetails`
 %End
 
     void setLayersToLoadOnCompletion( const QMap< QString, QgsProcessingContext::LayerDetails > &layers );
@@ -142,12 +198,41 @@ Sets the map of ``layers`` (by ID or datasource) to LayerDetails, to load into t
 .. seealso:: :py:func:`addLayerToLoadOnCompletion`
 
 .. seealso:: :py:func:`layersToLoadOnCompletion`
+
+.. seealso:: :py:func:`willLoadLayerOnCompletion`
+
+.. seealso:: :py:func:`layerToLoadOnCompletionDetails`
 %End
 
     void addLayerToLoadOnCompletion( const QString &layer, const QgsProcessingContext::LayerDetails &details );
 %Docstring
 Adds a ``layer`` to load (by ID or datasource) into the canvas upon completion of the algorithm or model.
 The ``details`` parameter dictates the LayerDetails.
+
+.. seealso:: :py:func:`setLayersToLoadOnCompletion`
+
+.. seealso:: :py:func:`layersToLoadOnCompletion`
+
+.. seealso:: :py:func:`willLoadLayerOnCompletion`
+
+.. seealso:: :py:func:`layerToLoadOnCompletionDetails`
+%End
+
+    QgsProcessingContext::LayerDetails &layerToLoadOnCompletionDetails( const QString &layer );
+%Docstring
+Returns a reference to the details for a given ``layer`` which is loaded on completion of the
+algorithm or model.
+
+.. warning::
+
+   First check willLoadLayerOnCompletion(), or calling this method will incorrectly
+   add ``layer`` as a layer to load on completion.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`willLoadLayerOnCompletion`
+
+.. seealso:: :py:func:`addLayerToLoadOnCompletion`
 
 .. seealso:: :py:func:`setLayersToLoadOnCompletion`
 
@@ -302,6 +387,47 @@ from a context.
 };
 
 QFlags<QgsProcessingContext::Flag> operator|(QgsProcessingContext::Flag f1, QFlags<QgsProcessingContext::Flag> f2);
+
+
+
+class QgsProcessingLayerPostProcessorInterface
+{
+%Docstring
+An interface for layer post-processing handlers for execution following a processing algorithm operation.
+
+Note that post-processing of a layer will ONLY occur if that layer is set to be loaded into a QGIS project
+on algorithm completion. See :py:func:`QgsProcessingContext.layersToLoadOnCompletion()`
+
+Algorithms that wish to set post-processing steps for generated layers should implement this interface
+in a separate class (NOT the algorithm class itself!).
+
+.. versionadded:: 3.2
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingcontext.h"
+%End
+  public:
+
+    virtual ~QgsProcessingLayerPostProcessorInterface();
+
+    virtual void postProcessLayer( QgsMapLayer *layer, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) = 0;
+%Docstring
+Post-processes the specified ``layer``, following successful execution of a processing algorithm. This method
+always runs in the main thread and can be used to setup renderers, editor widgets, metadata, etc for
+the given layer.
+
+Post-processing classes can utilize settings from the algorithm's ``context`` and report logging messages
+or errors via the given ``feedback`` object.
+
+In the case of an algorithm run as part of a larger model, the post-processing occurs following the completed
+execution of the entire model.
+
+Note that post-processing of a layer will ONLY occur if that layer is set to be loaded into a QGIS project
+on algorithm completion. See :py:func:`QgsProcessingContext.layersToLoadOnCompletion()`
+%End
+
+};
 
 
 

--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -77,7 +77,12 @@ def handleAlgorithmResults(alg, context, feedback=None, showResults=True):
                             style = ProcessingConfig.getSetting(ProcessingConfig.VECTOR_POLYGON_STYLE)
                 if style:
                     layer.loadNamedStyle(style)
+
                 details.project.addMapLayer(context.temporaryLayerStore().takeMapLayer(layer))
+
+                if details.postProcessor():
+                    details.postProcessor().postProcessLayer(layer, context, feedback)
+
             else:
                 wrongLayers.append(str(l))
         except Exception:

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -27,6 +27,8 @@
 #include "qgsexception.h"
 #include "qgsprocessingfeedback.h"
 
+class QgsProcessingLayerPostProcessorInterface;
+
 /**
  * \class QgsProcessingContext
  * \ingroup core
@@ -65,6 +67,8 @@ class CORE_EXPORT QgsProcessingContext
     QgsProcessingContext( const QgsProcessingContext &other ) = delete;
     //! QgsProcessingContext cannot be copied
     QgsProcessingContext &operator=( const QgsProcessingContext &other ) = delete;
+
+    ~QgsProcessingContext();
 
     /**
      * Copies all settings which are safe for use across different threads from
@@ -154,26 +158,52 @@ class CORE_EXPORT QgsProcessingContext
     QgsMapLayerStore *temporaryLayerStore() { return &tempLayerStore; }
 
     //! Details for layers to load into projects.
-    struct LayerDetails
+    class LayerDetails
     {
+      public:
 
-      /**
-       * Constructor for LayerDetails.
-       */
-      LayerDetails( const QString &name, QgsProject *project, const QString &outputName = QString() )
-        : name( name )
-        , outputName( outputName )
-        , project( project )
-      {}
+        /**
+         * Constructor for LayerDetails.
+         */
+        LayerDetails( const QString &name, QgsProject *project, const QString &outputName = QString() )
+          : name( name )
+          , outputName( outputName )
+          , project( project )
+        {}
 
-      //! Friendly name for layer, to use when loading layer into project.
-      QString name;
+        //! Default constructor
+        LayerDetails() = default;
 
-      //! Associated output name from algorithm which generated the layer.
-      QString outputName;
+        //! Friendly name for layer, to use when loading layer into project.
+        QString name;
 
-      //! Destination project
-      QgsProject *project = nullptr;
+        //! Associated output name from algorithm which generated the layer.
+        QString outputName;
+
+        /**
+         * Layer post-processor. May be nullptr if no post-processing is required.
+         * \since QGIS 3.2
+         * \see setPostProcessor()
+         */
+        QgsProcessingLayerPostProcessorInterface *postProcessor() const;
+
+        /**
+         * Sets the layer post-processor. May be nullptr if no post-processing is required.
+         *
+         * Ownership of \a processor is transferred.
+         *
+         * \since QGIS 3.2
+         * \see postProcessor()
+         */
+        void setPostProcessor( QgsProcessingLayerPostProcessorInterface *processor SIP_TRANSFER );
+
+        //! Destination project
+        QgsProject *project = nullptr;
+
+      private:
+
+        // Ideally a unique_ptr, but cannot be due to use within QMap. Is cleaned up by QgsProcessingContext.
+        QgsProcessingLayerPostProcessorInterface *mPostProcessor = nullptr;
 
     };
 
@@ -181,6 +211,8 @@ class CORE_EXPORT QgsProcessingContext
      * Returns a map of layers (by ID or datasource) to LayerDetails, to load into the canvas upon completion of the algorithm or model.
      * \see setLayersToLoadOnCompletion()
      * \see addLayerToLoadOnCompletion()
+     * \see willLoadLayerOnCompletion()
+     * \see layerToLoadOnCompletionDetails()
      */
     QMap< QString, QgsProcessingContext::LayerDetails > layersToLoadOnCompletion() const
     {
@@ -188,24 +220,54 @@ class CORE_EXPORT QgsProcessingContext
     }
 
     /**
+     * Returns true if the given \a layer (by ID or datasource) will be loaded into the current project
+     * upon completion of the algorithm or model.
+     * \since QGIS 3.2
+     * \see layersToLoadOnCompletion()
+     * \see setLayersToLoadOnCompletion()
+     * \see addLayerToLoadOnCompletion()
+     * \see layerToLoadOnCompletionDetails()
+     */
+    bool willLoadLayerOnCompletion( const QString &layer ) const
+    {
+      return mLayersToLoadOnCompletion.contains( layer );
+    }
+
+    /**
      * Sets the map of \a layers (by ID or datasource) to LayerDetails, to load into the canvas upon completion of the algorithm or model.
      * \see addLayerToLoadOnCompletion()
      * \see layersToLoadOnCompletion()
+     * \see willLoadLayerOnCompletion()
+     * \see layerToLoadOnCompletionDetails()
      */
-    void setLayersToLoadOnCompletion( const QMap< QString, QgsProcessingContext::LayerDetails > &layers )
-    {
-      mLayersToLoadOnCompletion = layers;
-    }
+    void setLayersToLoadOnCompletion( const QMap< QString, QgsProcessingContext::LayerDetails > &layers );
 
     /**
      * Adds a \a layer to load (by ID or datasource) into the canvas upon completion of the algorithm or model.
      * The \a details parameter dictates the LayerDetails.
      * \see setLayersToLoadOnCompletion()
      * \see layersToLoadOnCompletion()
+     * \see willLoadLayerOnCompletion()
+     * \see layerToLoadOnCompletionDetails()
      */
-    void addLayerToLoadOnCompletion( const QString &layer, const QgsProcessingContext::LayerDetails &details )
+    void addLayerToLoadOnCompletion( const QString &layer, const QgsProcessingContext::LayerDetails &details );
+
+    /**
+     * Returns a reference to the details for a given \a layer which is loaded on completion of the
+     * algorithm or model.
+     *
+     * \warning First check willLoadLayerOnCompletion(), or calling this method will incorrectly
+     * add \a layer as a layer to load on completion.
+     *
+     * \since QGIS 3.2
+     * \see willLoadLayerOnCompletion()
+     * \see addLayerToLoadOnCompletion()
+     * \see setLayersToLoadOnCompletion()
+     * \see layersToLoadOnCompletion()
+     */
+    QgsProcessingContext::LayerDetails &layerToLoadOnCompletionDetails( const QString &layer )
     {
-      mLayersToLoadOnCompletion.insert( layer, details );
+      return mLayersToLoadOnCompletion[ layer ];
     }
 
     /**
@@ -390,6 +452,44 @@ class CORE_EXPORT QgsProcessingContext
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProcessingContext::Flags )
+
+
+/**
+ * An interface for layer post-processing handlers for execution following a processing algorithm operation.
+ *
+ * Note that post-processing of a layer will ONLY occur if that layer is set to be loaded into a QGIS project
+ * on algorithm completion. See QgsProcessingContext::layersToLoadOnCompletion().
+ *
+ * Algorithms that wish to set post-processing steps for generated layers should implement this interface
+ * in a separate class (NOT the algorithm class itself!).
+ *
+ * \ingroup core
+ * \since QGIS 3.2
+ */
+class CORE_EXPORT QgsProcessingLayerPostProcessorInterface
+{
+  public:
+
+    virtual ~QgsProcessingLayerPostProcessorInterface() = default;
+
+    /**
+      * Post-processes the specified \a layer, following successful execution of a processing algorithm. This method
+      * always runs in the main thread and can be used to setup renderers, editor widgets, metadata, etc for
+      * the given layer.
+      *
+      * Post-processing classes can utilize settings from the algorithm's \a context and report logging messages
+      * or errors via the given \a feedback object.
+      *
+      * In the case of an algorithm run as part of a larger model, the post-processing occurs following the completed
+      * execution of the entire model.
+      *
+      * Note that post-processing of a layer will ONLY occur if that layer is set to be loaded into a QGIS project
+      * on algorithm completion. See QgsProcessingContext::layersToLoadOnCompletion().
+      */
+    virtual void postProcessLayer( QgsMapLayer *layer, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) = 0;
+
+};
+
 
 #endif // QGSPROCESSINGPARAMETERS_H
 

--- a/src/core/processing/qgsprocessingcontext.h
+++ b/src/core/processing/qgsprocessingcontext.h
@@ -157,7 +157,11 @@ class CORE_EXPORT QgsProcessingContext
      */
     QgsMapLayerStore *temporaryLayerStore() { return &tempLayerStore; }
 
-    //! Details for layers to load into projects.
+    /**
+     * Details for layers to load into projects.
+     * \ingroup core
+     * \since QGIS 3.0
+     */
     class LayerDetails
     {
       public:


### PR DESCRIPTION
This commit adds an interface for layer post-processing handlers for execution following a processing algorithm (or parent model) operation.

Post-processing of a layer will ONLY occur if that layer is set to be loaded into a QGIS project on algorithm completion.

Algorithms that wish to set post-processing steps for generated layers should implement this interface in a separate class (NOT the algorithm class itself!) and implement a method to handle the layer post-processing.

This method always runs in the main thread and can be used to setup renderers, editor widgets, metadata, etc for the given layer.

Refs discussion in https://github.com/qgis/QGIS/pull/6598, and fixes https://issues.qgis.org/issues/17961
