### PR TITLE
[processing] Fix algorithm progress bar resets to 0 when an algorithm reports a non-fatal error

### DIFF
--- a/python/core/processing/qgsprocessingfeedback.sip.in
+++ b/python/core/processing/qgsprocessingfeedback.sip.in
@@ -35,10 +35,11 @@ setProgress() to provide detailed progress reports, such as "Transformed
 .. seealso:: :py:func:`setProgress`
 %End
 
-    virtual void reportError( const QString &error );
+    virtual void reportError( const QString &error, bool fatalError = false );
 %Docstring
-Reports that the algorithm encountered an error which prevented it
-from successfully executing.
+Reports that the algorithm encountered an ``error`` while executing.
+
+If ``fatalError`` is true then the error prevented the algorithm from executing.
 %End
 
     virtual void pushInfo( const QString &info );
@@ -127,7 +128,7 @@ to scale the current progress to account for progress through the overall proces
 
     virtual void setProgressText( const QString &text );
 
-    virtual void reportError( const QString &error );
+    virtual void reportError( const QString &error, bool fatalError );
 
     virtual void pushInfo( const QString &info );
 

--- a/python/gui/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -100,9 +100,11 @@ Returns the parameter values for the algorithm to run in the dialog.
     virtual void accept();
 
 
-    void reportError( const QString &error );
+    void reportError( const QString &error, bool fatalError );
 %Docstring
 Reports an ``error`` string to the dialog's log.
+
+If ``fatalError`` is true, the error prevented the algorithm from executing.
 %End
 
     void pushInfo( const QString &info );

--- a/python/plugins/processing/algs/qgis/ui/FieldsCalculatorDialog.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsCalculatorDialog.py
@@ -67,7 +67,7 @@ class FieldCalculatorFeedback(QgsProcessingFeedback):
         QgsProcessingFeedback.__init__(self)
         self.dialog = dialog
 
-    def reportError(self, msg):
+    def reportError(self, msg, fatal_error):
         self.dialog.error(msg)
 
 

--- a/python/plugins/processing/gui/MessageBarProgress.py
+++ b/python/plugins/processing/gui/MessageBarProgress.py
@@ -48,7 +48,7 @@ class MessageBarProgress(QgsProcessingFeedback):
         iface.messageBar().pushWidget(self.progressMessageBar,
                                       Qgis.Info)
 
-    def reportError(self, msg):
+    def reportError(self, msg, fatal_error):
         self.msg.append(msg)
 
     def close(self):

--- a/src/core/processing/qgsprocessingfeedback.cpp
+++ b/src/core/processing/qgsprocessingfeedback.cpp
@@ -36,9 +36,9 @@ void QgsProcessingMultiStepFeedback::setProgressText( const QString &text )
   mFeedback->setProgressText( text );
 }
 
-void QgsProcessingMultiStepFeedback::reportError( const QString &error )
+void QgsProcessingMultiStepFeedback::reportError( const QString &error, bool fatalError )
 {
-  mFeedback->reportError( error );
+  mFeedback->reportError( error, fatalError );
 }
 
 void QgsProcessingMultiStepFeedback::pushInfo( const QString &info )

--- a/src/core/processing/qgsprocessingfeedback.h
+++ b/src/core/processing/qgsprocessingfeedback.h
@@ -47,10 +47,11 @@ class CORE_EXPORT QgsProcessingFeedback : public QgsFeedback
     virtual void setProgressText( const QString &text ) { Q_UNUSED( text ); }
 
     /**
-     * Reports that the algorithm encountered an error which prevented it
-     * from successfully executing.
+     * Reports that the algorithm encountered an \a error while executing.
+     *
+     * If \a fatalError is true then the error prevented the algorithm from executing.
      */
-    virtual void reportError( const QString &error ) { QgsMessageLog::logMessage( error ); }
+    virtual void reportError( const QString &error, bool fatalError = false ) { Q_UNUSED( fatalError ); QgsMessageLog::logMessage( error ); }
 
     /**
      * Pushes a general informational message from the algorithm. This can
@@ -125,7 +126,7 @@ class CORE_EXPORT QgsProcessingMultiStepFeedback : public QgsProcessingFeedback
     void setCurrentStep( int step );
 
     void setProgressText( const QString &text ) override;
-    void reportError( const QString &error ) override;
+    void reportError( const QString &error, bool fatalError ) override;
     void pushInfo( const QString &info ) override;
     void pushCommandInfo( const QString &info ) override;
     void pushDebugInfo( const QString &info ) override;

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -38,9 +38,9 @@ void QgsProcessingAlgorithmDialogFeedback::setProgressText( const QString &text 
   emit progressTextChanged( text );
 }
 
-void QgsProcessingAlgorithmDialogFeedback::reportError( const QString &error )
+void QgsProcessingAlgorithmDialogFeedback::reportError( const QString &error, bool fatalError )
 {
-  emit errorReported( error );
+  emit errorReported( error, fatalError );
 }
 
 void QgsProcessingAlgorithmDialogFeedback::pushInfo( const QString &info )
@@ -316,10 +316,11 @@ void QgsProcessingAlgorithmDialogBase::closeClicked()
   close();
 }
 
-void QgsProcessingAlgorithmDialogBase::reportError( const QString &error )
+void QgsProcessingAlgorithmDialogBase::reportError( const QString &error, bool fatalError )
 {
   setInfo( error, true );
-  resetGui();
+  if ( fatalError )
+    resetGui();
   showLog();
   processEvents();
 }
@@ -476,7 +477,7 @@ void QgsProcessingAlgorithmDialogBase::setCurrentTask( QgsProcessingAlgRunnerTas
 void QgsProcessingAlgorithmDialogBase::setInfo( const QString &message, bool isError, bool escapeHtml )
 {
   if ( isError )
-    txtLog->append( QStringLiteral( "<span style=\"color:red\">%1</span><br />" ).arg( message ) );
+    txtLog->append( QStringLiteral( "<span style=\"color:red\">%1</span>" ).arg( message ) );
   else if ( escapeHtml )
     txtLog->append( message.toHtmlEscaped() );
   else

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -54,7 +54,7 @@ class QgsProcessingAlgorithmDialogFeedback : public QgsProcessingFeedback
   signals:
 
     void progressTextChanged( const QString &text );
-    void errorReported( const QString &text );
+    void errorReported( const QString &text, bool fatalError );
     void infoPushed( const QString &text );
     void commandInfoPushed( const QString &text );
     void debugInfoPushed( const QString &text );
@@ -63,7 +63,7 @@ class QgsProcessingAlgorithmDialogFeedback : public QgsProcessingFeedback
   public slots:
 
     void setProgressText( const QString &text ) override;
-    void reportError( const QString &error ) override;
+    void reportError( const QString &error, bool fatalError ) override;
     void pushInfo( const QString &info ) override;
     void pushCommandInfo( const QString &info ) override;
     void pushDebugInfo( const QString &info ) override;
@@ -150,8 +150,10 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
 
     /**
      * Reports an \a error string to the dialog's log.
+     *
+     * If \a fatalError is true, the error prevented the algorithm from executing.
      */
-    void reportError( const QString &error );
+    void reportError( const QString &error, bool fatalError );
 
     /**
      * Pushes an information string to the dialog's log.


### PR DESCRIPTION
Fixes the "flashy" progress bar when an algorithm encounters a lot of errors.
