### PR TITLE
Fix attribute form position/size is remembered only per layer/feature combo

### DIFF
--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsattributedialog.h"
 
-#include "qgsgui.h"
 #include "qgsattributeform.h"
 #include "qgshighlight.h"
 #include "qgsapplication.h"
@@ -40,6 +39,22 @@ QgsAttributeDialog::~QgsAttributeDialog()
 
   if ( mOwnedFeature )
     delete mOwnedFeature;
+
+  saveGeometry();
+}
+
+void QgsAttributeDialog::saveGeometry()
+{
+  // WARNING!!!! Don't use QgsGui::enableAutoGeometryRestore for this dialog -- the object name
+  // is dynamic and is set to match the layer/feature combination.
+  QgsSettings().setValue( QStringLiteral( "Windows/AttributeDialog/geometry" ), QDialog::saveGeometry() );
+}
+
+void QgsAttributeDialog::restoreGeometry()
+{
+  // WARNING!!!! Don't use QgsGui::enableAutoGeometryRestore for this dialog -- the object name
+  // is dynamic and is set to match the layer/feature combination.
+  QDialog::restoreGeometry( QgsSettings().value( QStringLiteral( "Windows/AttributeDialog/geometry" ) ).toByteArray() );
 }
 
 void QgsAttributeDialog::setHighlight( QgsHighlight *h )
@@ -73,7 +88,6 @@ void QgsAttributeDialog::reject()
 
 void QgsAttributeDialog::init( QgsVectorLayer *layer, QgsFeature *feature, const QgsAttributeEditorContext &context, bool showDialogButtons )
 {
-  QgsGui::enableAutoGeometryRestore( this );
   QgsAttributeEditorContext trackedContext = context;
   setWindowTitle( tr( "%1 - Feature Attributes" ).arg( layer->name() ) );
   setLayout( new QGridLayout() );
@@ -99,6 +113,7 @@ void QgsAttributeDialog::init( QgsVectorLayer *layer, QgsFeature *feature, const
     layout()->setMenuBar( menuBar );
   }
 
+  restoreGeometry();
   focusNextChild();
 }
 

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -125,6 +125,8 @@ class GUI_EXPORT QgsAttributeDialog : public QDialog
     static int sFormCounter;
     static QString sSettingsPath;
 
+    void saveGeometry();
+    void restoreGeometry();
 };
 
 #endif


### PR DESCRIPTION
Revert 5b9be7a

Since the attribute table dialog object name is set to match
the layer/featureid combo, this commit was causing the attribute
form dialog to remember its position and size for each
feature/layer combo individually.

That's NOT what we want!

Fixes #18426
