### PR TITLE
[raster] skip non finite values when computing band min/max statistics

### DIFF
--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -188,9 +188,10 @@ QgsRasterBandStats QgsRasterInterface::bandStatistics( int bandNo,
         if ( blk->isNoData( i ) ) continue; // NULL
 
         double myValue = blk->value( i );
-
         myRasterBandStats.sum += myValue;
         myRasterBandStats.elementCount++;
+
+        if ( !std::isfinite( myValue ) ) continue; // inf
 
         if ( myFirstIterationFlag )
         {


### PR DESCRIPTION
## Description
Non-finite values aren't skipped when computing min/max stats in the `QgsRasterInterface::bandStatistics` function. This leads to scenarios when the min value is -inf, a problematic value when computing a cumulative cut's lower and higher values. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
