### PR TITLE
add label to wrapper widget class

### DIFF
--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -74,7 +74,6 @@ class ParametersPanel(BASE, WIDGET):
         self.alg = alg
         self.wrappers = {}
         self.outputWidgets = {}
-        self.labels = {}
         self.checkBoxes = {}
         self.dependentItems = {}
         self.iterateButtons = {}
@@ -108,14 +107,6 @@ class ParametersPanel(BASE, WIDGET):
             if param.isDestination():
                 continue
             else:
-                desc = param.description()
-                if isinstance(param, QgsProcessingParameterExtent):
-                    desc += self.tr(' (xmin, xmax, ymin, ymax)')
-                if isinstance(param, QgsProcessingParameterPoint):
-                    desc += self.tr(' (x, y)')
-                if param.flags() & QgsProcessingParameterDefinition.FlagOptional:
-                    desc += self.tr(' [optional]')
-
                 wrapper = WidgetWrapperFactory.create_wrapper(param, self.parent)
                 self.wrappers[param.name()] = wrapper
                 widget = wrapper.widget
@@ -141,21 +132,21 @@ class ParametersPanel(BASE, WIDGET):
 
                     widget.setToolTip(param.toolTip())
 
-                    if isinstance(widget, QCheckBox):
-                        # checkbox widget - so description is embedded in widget rather than a separate
-                        # label
-                        widget.setText(desc)
-                    else:
-                        label = QLabel(desc)
-                        # label.setToolTip(tooltip)
-                        self.labels[param.name()] = label
-
+                    if wrapper.label is not None:
                         if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
-                            self.layoutAdvanced.addWidget(label)
+                            self.layoutAdvanced.addWidget(wrapper.label)
                         else:
                             self.layoutMain.insertWidget(
-                                self.layoutMain.count() - 2, label)
-
+                                self.layoutMain.count() - 2, wrapper.label)
+                    else:
+                        desc = param.description()
+                        if isinstance(param, QgsProcessingParameterExtent):
+                            desc += self.tr(' (xmin, xmax, ymin, ymax)')
+                        if isinstance(param, QgsProcessingParameterPoint):
+                            desc += self.tr(' (x, y)')
+                        if param.flags() & QgsProcessingParameterDefinition.FlagOptional:
+                            desc += self.tr(' [optional]')
+                        widget.setText(desc)
                     if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
                         self.layoutAdvanced.addWidget(widget)
                     else:

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -77,6 +77,7 @@ from qgis.core import (
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QLabel,
     QDialog,
     QFileDialog,
     QHBoxLayout,
@@ -150,6 +151,7 @@ class WidgetWrapper(QObject):
         self.col = col
         self.dialogType = dialogTypes.get(dialog.__class__.__name__, DIALOG_STANDARD)
         self.widget = self.createWidget(**kwargs)
+        self.label = self.createLabel()
         if param.defaultValue() is not None:
             self.setValue(param.defaultValue())
 
@@ -171,6 +173,21 @@ class WidgetWrapper(QObject):
 
     def createWidget(self, **kwargs):
         pass
+
+    def createLabel(self):
+        if self.dialogType == DIALOG_BATCH:
+            return None
+        desc = self.param.description()
+        if isinstance(self.param, QgsProcessingParameterExtent):
+            desc += self.tr(' (xmin, xmax, ymin, ymax)')
+        if isinstance(self.param, QgsProcessingParameterPoint):
+            desc += self.tr(' (x, y)')
+        if self.param.flags() & QgsProcessingParameterDefinition.FlagOptional:
+            desc += self.tr(' [optional]')
+
+        label = QLabel(desc)
+        label.setToolTip(self.param.name())
+        return label
 
     def setValue(self, value):
         pass
@@ -239,6 +256,12 @@ class BasicWidgetWrapper(WidgetWrapper):
 
 
 class BooleanWidgetWrapper(WidgetWrapper):
+
+    def createLabel(self):
+        if self.dialogType == DIALOG_STANDARD:
+            return None
+        else:
+            return super().createLabel()
 
     def createWidget(self):
         if self.dialogType == DIALOG_STANDARD:

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -87,8 +87,6 @@ class ModelerParametersDialog(QDialog):
         super(ModelerParametersDialog, self).closeEvent(event)
 
     def setupUi(self):
-        self.labels = {}
-        self.widgets = {}
         self.checkBoxes = {}
         self.showAdvanced = False
         self.wrappers = {}
@@ -136,15 +134,6 @@ class ModelerParametersDialog(QDialog):
         for param in self._alg.parameterDefinitions():
             if param.isDestination() or param.flags() & QgsProcessingParameterDefinition.FlagHidden:
                 continue
-            desc = param.description()
-            if isinstance(param, QgsProcessingParameterExtent):
-                desc += self.tr('(xmin, xmax, ymin, ymax)')
-            if isinstance(param, QgsProcessingParameterPoint):
-                desc += self.tr('(x, y)')
-            if param.flags() & QgsProcessingParameterDefinition.FlagOptional:
-                desc += self.tr(' [optional]')
-            label = QLabel(desc)
-            self.labels[param.name()] = label
 
             wrapper = WidgetWrapperFactory.create_wrapper(param, self)
             self.wrappers[param.name()] = wrapper
@@ -153,14 +142,11 @@ class ModelerParametersDialog(QDialog):
             if widget is not None:
                 self.valueItems[param.name()] = widget
                 tooltip = param.description()
-                label.setToolTip(tooltip)
                 widget.setToolTip(tooltip)
                 if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
-                    label.setVisible(self.showAdvanced)
+                    wrapper.label.setVisible(self.showAdvanced)
                     widget.setVisible(self.showAdvanced)
-                    self.widgets[param.name()] = widget
-
-                self.verticalLayout.addWidget(label)
+                self.verticalLayout.addWidget(wrapper.label)
                 self.verticalLayout.addWidget(widget)
 
         for dest in self._alg.destinationParameterDefinitions():
@@ -230,8 +216,8 @@ class ModelerParametersDialog(QDialog):
             self.advancedButton.setText(self.tr('Show advanced parameters'))
         for param in self._alg.parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
-                self.labels[param.name()].setVisible(self.showAdvanced)
-                self.widgets[param.name()].setVisible(self.showAdvanced)
+                self.wrappers[param.name()].widget.setVisible(self.showAdvanced)
+                self.wrappers[param.name()].label.setVisible(self.showAdvanced)
 
     def getAvailableValuesOfType(self, paramType, outTypes=[], dataTypes=[]):
         # upgrade paramType to list


### PR DESCRIPTION
## Description
Part of pull request https://github.com/qgis/QGIS/pull/6272 to allows widgetwrapper to access label.

https://github.com/qgis/QGIS/pull/6272#issuecomment-372982492

There is also a future possibility to create a label in widgetwrapper class rather than ParametersPanel via WidgetWrapper.createWidget()
This allows to manage only list of wrappers and in AlgorithmDialog.  Right now there is self.wrappers (to hold list of wrapper)
self.labels (to hold list of labels)

@nyalldawson, can you confirm the above case using createWidget() ?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
