### PR TITLE
[bugfix] value relation widget with Allow multiple selection doesn't resolve

### DIFF
--- a/python/core/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -64,6 +64,17 @@ if doing multiple lookups in a loop.
 
 .. versionadded:: 3.0
 %End
+
+    static QStringList valueToStringList( const QVariant &value );
+%Docstring
+Utility to convert an array or a string representation of and array ``value`` to a string list
+
+:param value: The value to be converted
+
+:return: A string list
+
+.. versionadded:: 3.2
+%End
 };
 
 

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -54,7 +54,7 @@ QString QgsValueRelationFieldFormatter::representValue( QgsVectorLayer *layer, i
 
   if ( config.value( QStringLiteral( "AllowMulti" ) ).toBool() )
   {
-    QStringList keyList = value.toString().remove( QChar( '{' ) ).remove( QChar( '}' ) ).split( ',' );
+    QStringList keyList = valueToStringList( value );
     QStringList valueList;
 
     for ( const QgsValueRelationFieldFormatter::ValueRelationItem &item : qgis::as_const( vrCache ) )
@@ -141,4 +141,24 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
   }
 
   return cache;
+}
+
+QStringList QgsValueRelationFieldFormatter::valueToStringList( const QVariant &value )
+{
+  QStringList checkList;
+  if ( value.type() == QVariant::StringList )
+    checkList = value.toStringList();
+  else if ( value.type() == QVariant::String )
+    checkList = value.toString().remove( QChar( '{' ) ).remove( QChar( '}' ) ).split( ',' );
+  else if ( value.type() == QVariant::List )
+  {
+    QVariantList valuesList( value.toList( ) );
+    for ( const QVariant &listItem : qgis::as_const( valuesList ) )
+    {
+      QString v( listItem.toString( ) );
+      if ( ! v.isEmpty() )
+        checkList.append( v );
+    }
+  }
+  return checkList;
 }

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -70,6 +70,15 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
      * \since QGIS 3.0
      */
     static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config );
+
+    /**
+     * Utility to convert an array or a string representation of and array \a value to a string list
+     *
+     * \param value The value to be converted
+     * \return A string list
+     * \since QGIS 3.2
+     */
+    static QStringList valueToStringList( const QVariant &value );
 };
 
 Q_DECLARE_METATYPE( QgsValueRelationFieldFormatter::ValueRelationCache )

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -151,11 +151,7 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
 {
   if ( mListWidget )
   {
-    QStringList checkList;
-    if ( value.type() == QVariant::StringList )
-      checkList = value.toStringList();
-    else if ( value.type() == QVariant::String )
-      checkList = value.toString().remove( QChar( '{' ) ).remove( QChar( '}' ) ).split( ',' );
+    QStringList checkList( QgsValueRelationFieldFormatter::valueToStringList( value ) );
 
     for ( int i = 0; i < mListWidget->count(); ++i )
     {

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -107,6 +107,16 @@ class TestQgsValueRelationFieldFormatter(unittest.TestCase):
 
         QgsProject.instance().removeMapLayer(second_layer.id())
 
+    def test_valueToStringList(self):
+
+        def _test(a, b):
+            self.assertEqual(QgsValueRelationFieldFormatter.valueToStringList(a), b)
+
+        _test([1, 2, 3], ["1", "2", "3"])
+        _test("{1,2,3}", ["1", "2", "3"])
+        _test(['1', '2', '3'], ["1", "2", "3"])
+        _test('not an array', ['not an array'])
+
 
 class TestQgsRelationReferenceFieldFormatter(unittest.TestCase):
 


### PR DESCRIPTION
Now it will accept arrays as well as string representations of arrays

Added a test

Fixes #16967 value relation widget with Allow multiple selection doesn't resolve the values anymore

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
