### PR TITLE
Fix crash in Select by Radius

### DIFF
--- a/src/app/qgsmaptoolselectradius.cpp
+++ b/src/app/qgsmaptoolselectradius.cpp
@@ -124,9 +124,7 @@ void QgsMapToolSelectRadius::canvasMoveEvent( QgsMapMouseEvent *e )
 
   if ( !mRubberBand )
   {
-    mRubberBand = qgis::make_unique< QgsRubberBand >( mCanvas, QgsWkbTypes::PolygonGeometry );
-    mRubberBand->setFillColor( mFillColor );
-    mRubberBand->setStrokeColor( mStrokeColor );
+    createRubberBand();
   }
 
   updateRadiusFromEdge( radiusEdge );
@@ -156,9 +154,7 @@ void QgsMapToolSelectRadius::canvasReleaseEvent( QgsMapMouseEvent *e )
   {
     if ( !mRubberBand )
     {
-      mRubberBand = qgis::make_unique< QgsRubberBand >( mCanvas, QgsWkbTypes::PolygonGeometry );
-      mRubberBand->setFillColor( mFillColor );
-      mRubberBand->setStrokeColor( mStrokeColor );
+      createRubberBand();
     }
     QgsPointXY radiusEdge = e->snapPoint();
     updateRadiusFromEdge( radiusEdge );
@@ -205,6 +201,9 @@ void QgsMapToolSelectRadius::keyReleaseEvent( QKeyEvent *e )
 
 void QgsMapToolSelectRadius::updateRubberband( const double &radius )
 {
+  if ( !mRubberBand )
+    createRubberBand();
+
   mRubberBand->reset( QgsWkbTypes::PolygonGeometry );
   for ( int i = 0; i <= RADIUS_SEGMENTS; ++i )
   {
@@ -260,6 +259,13 @@ void QgsMapToolSelectRadius::createRotationWidget()
   connect( mDistanceWidget, &QgsDistanceWidget::distanceChanged, this, &QgsMapToolSelectRadius::updateRubberband );
   connect( mDistanceWidget, &QgsDistanceWidget::distanceEditingFinished, this, &QgsMapToolSelectRadius::radiusValueEntered );
   connect( mDistanceWidget, &QgsDistanceWidget::distanceEditingCanceled, this, &QgsMapToolSelectRadius::cancel );
+}
+
+void QgsMapToolSelectRadius::createRubberBand()
+{
+  mRubberBand = qgis::make_unique< QgsRubberBand >( mCanvas, QgsWkbTypes::PolygonGeometry );
+  mRubberBand->setFillColor( mFillColor );
+  mRubberBand->setStrokeColor( mStrokeColor );
 }
 
 void QgsMapToolSelectRadius::deleteRotationWidget()

--- a/src/app/qgsmaptoolselectradius.h
+++ b/src/app/qgsmaptoolselectradius.h
@@ -103,6 +103,8 @@ class APP_EXPORT QgsMapToolSelectRadius : public QgsMapTool
     void deleteRotationWidget();
     void createRotationWidget();
 
+    void createRubberBand();
+
     //! used for storing all of the maps point for the polygon
     std::unique_ptr< QgsRubberBand > mRubberBand;
     std::unique_ptr<QgsSnapIndicator> mSnapIndicator;


### PR DESCRIPTION
If a radius value is entered immediately after clicking with the tool (before any mouse movement), it would trigger a crash
