### PR TITLE
[FEATURE][locator] Add search for settings pages to locator bar

### DIFF
--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -141,7 +141,7 @@ class QgsBookmarkLocatorFilter : public QgsLocatorFilter
     QgsBookmarkLocatorFilter( QObject *parent = nullptr );
     QgsBookmarkLocatorFilter *clone() const override;
     QString name() const override { return QStringLiteral( "bookmarks" ); }
-    QString displayName() const override { return tr( "Spatial bookmarks" ); }
+    QString displayName() const override { return tr( "Spatial Bookmarks" ); }
     Priority priority() const override { return Highest; }
     QString prefix() const override { return QStringLiteral( "b" ); }
     QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
@@ -150,6 +150,32 @@ class QgsBookmarkLocatorFilter : public QgsLocatorFilter
     void triggerResult( const QgsLocatorResult &result ) override;
 
 };
+
+class QgsSettingsLocatorFilter : public QgsLocatorFilter
+{
+    Q_OBJECT
+
+  public:
+
+    QgsSettingsLocatorFilter( QObject *parent = nullptr );
+    QgsSettingsLocatorFilter *clone() const override;
+    QString name() const override { return QStringLiteral( "optionpages" ); }
+    QString displayName() const override { return tr( "Settings" ); }
+    Priority priority() const override { return Highest; }
+    QString prefix() const override { return QStringLiteral( "s" ); }
+    QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
+
+    void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
+    void triggerResult( const QgsLocatorResult &result ) override;
+
+    struct SettingsHandle
+    {
+      QString type;
+      QString page;
+    };
+};
+
+Q_DECLARE_METATYPE( QgsSettingsLocatorFilter::SettingsHandle )
 
 #endif // QGSINBUILTLOCATORFILTERS_H
 

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -148,7 +148,6 @@ class QgsBookmarkLocatorFilter : public QgsLocatorFilter
 
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
-
 };
 
 class QgsSettingsLocatorFilter : public QgsLocatorFilter
@@ -162,20 +161,16 @@ class QgsSettingsLocatorFilter : public QgsLocatorFilter
     QString name() const override { return QStringLiteral( "optionpages" ); }
     QString displayName() const override { return tr( "Settings" ); }
     Priority priority() const override { return Highest; }
-    QString prefix() const override { return QStringLiteral( "s" ); }
+    QString prefix() const override { return QStringLiteral( "set" ); }
     QgsLocatorFilter::Flags flags() const override { return QgsLocatorFilter::FlagFast; }
 
     void fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback *feedback ) override;
     void triggerResult( const QgsLocatorResult &result ) override;
 
-    struct SettingsHandle
-    {
-      QString type;
-      QString page;
-    };
-};
+  private:
 
-Q_DECLARE_METATYPE( QgsSettingsLocatorFilter::SettingsHandle )
+    QMap<QString, QString> settingsPage( const QString &type,  const QString &page );
+};
 
 #endif // QGSINBUILTLOCATORFILTERS_H
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1450,11 +1450,6 @@ QgisApp::~QgisApp()
   delete mVectorLayerTools;
   delete mWelcomePage;
 
-  delete mOptionsPagesMap;
-  delete mProjectPropertiesPagesMap;
-  delete mSettingPagesMap;
-
-
   deleteLayoutDesigners();
   removeAnnotationItems();
 
@@ -9967,12 +9962,12 @@ void QgisApp::options()
   showOptionsDialog( this );
 }
 
-QMap< QString, QString > *QgisApp::getProjectPropertiesPagesMap()
+QMap< QString, QString > QgisApp::projectPropertiesPagesMap()
 {
-  if ( mProjectPropertiesPagesMap == nullptr )
+  if ( mProjectPropertiesPagesMap.isEmpty() )
   {
     QgsProjectProperties *pp = new QgsProjectProperties( mMapCanvas, this );
-    mProjectPropertiesPagesMap = pp->createPageWidgetNameMap();
+    mProjectPropertiesPagesMap = pp->pageWidgetNameMap();
   }
   return mProjectPropertiesPagesMap;
 }
@@ -9982,15 +9977,14 @@ void QgisApp::showProjectProperties( const QString &page )
   projectProperties( page );
 }
 
-QMap< QString, QString > *QgisApp::getSettingPagesMap()
+QMap< QString, QString > QgisApp::settingPagesMap()
 {
-  if ( mSettingPagesMap == nullptr )
+  if ( mSettingPagesMap.isEmpty() )
   {
-    mSettingPagesMap = new QMap< QString, QString >();
-    mSettingPagesMap->insert( tr( "Style Manager" ), "stylemanager" );
-    mSettingPagesMap->insert( tr( "Keyboard Shortcuts" ), "shortcuts" );
-    mSettingPagesMap->insert( tr( "Custom Projections" ), "customprojection" );
-    mSettingPagesMap->insert( tr( "Interface Customization" ), "customize" );
+    mSettingPagesMap.insert( tr( "Style Manager" ), "stylemanager" );
+    mSettingPagesMap.insert( tr( "Keyboard Shortcuts" ), "shortcuts" );
+    mSettingPagesMap.insert( tr( "Custom Projections" ), "customprojection" );
+    mSettingPagesMap.insert( tr( "Interface Customization" ), "customize" );
   }
   return mSettingPagesMap;
 }
@@ -10015,9 +10009,9 @@ void QgisApp::showSettings( const QString &page )
   }
 }
 
-QMap< QString, QString > *QgisApp::getOptionsPagesMap()
+QMap< QString, QString > QgisApp::optionsPagesMap()
 {
-  if ( mOptionsPagesMap == nullptr )
+  if ( mOptionsPagesMap.isEmpty() )
   {
     QList< QgsOptionsWidgetFactory * > factories;
     Q_FOREACH ( const QPointer< QgsOptionsWidgetFactory > &f, mOptionsWidgetFactories )
@@ -10027,7 +10021,7 @@ QMap< QString, QString > *QgisApp::getOptionsPagesMap()
         factories << f;
     }
     std::unique_ptr< QgsOptions > f( new QgsOptions( this, QgsGuiUtils::ModalDialogFlags, factories ) );
-    mOptionsPagesMap = f->createPageWidgetNameMap();
+    mOptionsPagesMap = f->pageWidgetNameMap();
   }
   return mOptionsPagesMap;
 }
@@ -10310,23 +10304,15 @@ void QgisApp::unregisterMapLayerPropertiesFactory( QgsMapLayerConfigWidgetFactor
 void QgisApp::registerOptionsWidgetFactory( QgsOptionsWidgetFactory *factory )
 {
   mOptionsWidgetFactories << factory;
-  //Nullify mOptionsPagesMap forcing it to be repopulated next time getOptionsPagesMap() is called
-  if ( mOptionsPagesMap != nullptr )
-  {
-    delete mOptionsPagesMap;
-    mOptionsPagesMap = nullptr;
-  }
+  //clear mOptionsPagesMap forcing it to be repopulated next time optionsPagesMap() is called
+  mOptionsPagesMap.clear();
 }
 
 void QgisApp::unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory )
 {
   mOptionsWidgetFactories.removeAll( factory );
-  //Nullify mOptionsPagesMap forcing it to be repopulated next time getOptionsPagesMap() is called
-  if ( mOptionsPagesMap != nullptr )
-  {
-    delete mOptionsPagesMap;
-    mOptionsPagesMap = nullptr;
-  }
+  //clear mOptionsPagesMap forcing it to be repopulated next time optionsPagesMap() is called
+  mOptionsPagesMap.clear();
 }
 
 QgsMapLayer *QgisApp::activeLayer()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9966,7 +9966,7 @@ QMap< QString, QString > QgisApp::projectPropertiesPagesMap()
 {
   if ( mProjectPropertiesPagesMap.isEmpty() )
   {
-    QgsProjectProperties *pp = new QgsProjectProperties( mMapCanvas, this );
+    std::unique_ptr< QgsProjectProperties > pp( new QgsProjectProperties( mMapCanvas, this ) );
     mProjectPropertiesPagesMap = pp->pageWidgetNameMap();
   }
   return mProjectPropertiesPagesMap;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -936,11 +936,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * Settings pages section
      */
     //! Get map of option pages
-    QMap< QString, QString > *getOptionsPagesMap();
+    QMap< QString, QString > optionsPagesMap();
     //! Get map of project property pages
-    QMap< QString, QString > *getProjectPropertiesPagesMap();
+    QMap< QString, QString > projectPropertiesPagesMap();
     //! Get map of setting pages
-    QMap< QString, QString > *getSettingPagesMap();
+    QMap< QString, QString > settingPagesMap();
 
     void showProjectProperties( const QString  &page = QString() );
     void showSettings( const QString &page );
@@ -2229,9 +2229,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsFeature duplicateFeatureDigitized( QgsMapLayer *mlayer, const QgsFeature &feature );
 
     //! Internal vars supporting Settings Pages function
-    QMap< QString, QString > *mOptionsPagesMap = nullptr;
-    QMap< QString, QString > *mProjectPropertiesPagesMap = nullptr;
-    QMap< QString, QString > *mSettingPagesMap = nullptr;
+    QMap< QString, QString > mOptionsPagesMap;
+    QMap< QString, QString > mProjectPropertiesPagesMap;
+    QMap< QString, QString > mSettingPagesMap;
 
     friend class TestQgisAppPython;
 };

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -932,6 +932,20 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Update project menu with the project templates
     void updateProjectFromTemplates();
 
+    /**
+     * Settings pages section
+     */
+    //! Get map of option pages
+    QMap< QString, QString > *getOptionsPagesMap();
+    //! Get map of project property pages
+    QMap< QString, QString > *getProjectPropertiesPagesMap();
+    //! Get map of setting pages
+    QMap< QString, QString > *getSettingPagesMap();
+
+    void showProjectProperties( const QString  &page = QString() );
+    void showSettings( const QString &page );
+    // End Settings pages section
+
     //! Opens the options dialog
     void showOptionsDialog( QWidget *parent = nullptr, const QString &currentPage = QString() );
 
@@ -1333,8 +1347,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void options();
     //! Whats-this help slot
     void whatsThis();
-    //! Set project properties, including map untis
-    void projectProperties();
     //! Open project properties dialog and show the projections tab
     void projectPropertiesProjections();
     /*  void urlData(); */
@@ -1786,6 +1798,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void saveAsVectorFileGeneral( QgsVectorLayer *vlayer = nullptr, bool symbologyOption = true, bool onlySelected = false );
 
+    //! Set project properties, including map untis
+    void projectProperties( const QString  &currentPage = QString() );
+
     /**
      * Paste features from clipboard into a new memory layer.
      * If no features are in clipboard an empty layer is returned.
@@ -2212,6 +2227,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgsFeature duplicateFeatures( QgsMapLayer *mlayer, const QgsFeature &feature );
     QgsFeature duplicateFeatureDigitized( QgsMapLayer *mlayer, const QgsFeature &feature );
+
+    //! Internal vars supporting Settings Pages function
+    QMap< QString, QString > *mOptionsPagesMap = nullptr;
+    QMap< QString, QString > *mProjectPropertiesPagesMap = nullptr;
+    QMap< QString, QString > *mSettingPagesMap = nullptr;
 
     friend class TestQgisAppPython;
 };

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1068,16 +1068,16 @@ QgsOptions::~QgsOptions()
   delete mSettings;
 }
 
-QMap< QString, QString > *QgsOptions::createPageWidgetNameMap()
+QMap< QString, QString > QgsOptions::pageWidgetNameMap()
 {
-  QMap< QString, QString > *pageNames = new QMap< QString, QString >();
+  QMap< QString, QString > pageNames;
   for ( int idx = 0; idx < mOptionsListWidget->count(); ++idx )
   {
     QWidget *currentPage = mOptionsStackedWidget->widget( idx );
     QListWidgetItem *item = mOptionsListWidget->item( idx );
     QString title = item->text();
     QString name = currentPage->objectName();
-    pageNames->insert( title, name );
+    pageNames.insert( title, name );
   }
   return pageNames;
 }

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1068,6 +1068,20 @@ QgsOptions::~QgsOptions()
   delete mSettings;
 }
 
+QMap< QString, QString > *QgsOptions::createPageWidgetNameMap()
+{
+  QMap< QString, QString > *pageNames = new QMap< QString, QString >();
+  for ( int idx = 0; idx < mOptionsListWidget->count(); ++idx )
+  {
+    QWidget *currentPage = mOptionsStackedWidget->widget( idx );
+    QListWidgetItem *item = mOptionsListWidget->item( idx );
+    QString title = item->text();
+    QString name = currentPage->objectName();
+    pageNames->insert( title, name );
+  }
+  return pageNames;
+}
+
 void QgsOptions::setCurrentPage( const QString &pageWidgetName )
 {
   //find the page with a matching widget name

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -61,6 +61,9 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
      */
     void setCurrentPage( const QString &pageWidgetName );
 
+    QMap<QString, QString> *createPageWidgetNameMap();
+
+
   public slots:
     void cbxProjectDefaultNew_toggled( bool checked );
     void setCurrentProjectDefault();

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -61,7 +61,7 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
      */
     void setCurrentPage( const QString &pageWidgetName );
 
-    QMap<QString, QString> *createPageWidgetNameMap();
+    QMap<QString, QString> pageWidgetNameMap();
 
 
   public slots:

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2158,4 +2158,32 @@ void QgsProjectProperties::applyRequiredLayers()
     }
   }
   QgsProject::instance()->setRequiredLayers( requiredLayers );
+
+QMap< QString, QString > *QgsProjectProperties::createPageWidgetNameMap()
+{
+  QMap< QString, QString > *pageNames = new QMap< QString, QString >();
+  for ( int idx = 0; idx < mOptionsListWidget->count(); ++idx )
+  {
+    QWidget *currentPage = mOptionsStackedWidget->widget( idx );
+    QListWidgetItem *item = mOptionsListWidget->item( idx );
+    QString title = item->text();
+    QString name = currentPage->objectName();
+    pageNames->insert( title, name );
+  }
+  return pageNames;
+}
+
+void QgsProjectProperties::setCurrentPage( const QString &pageWidgetName )
+{
+  //find the page with a matching widget name
+  for ( int idx = 0; idx < mOptionsStackedWidget->count(); ++idx )
+  {
+    QWidget *currentPage = mOptionsStackedWidget->widget( idx );
+    if ( currentPage->objectName() == pageWidgetName )
+    {
+      //found the page, set it as current
+      mOptionsStackedWidget->setCurrentIndex( idx );
+      return;
+    }
+  }
 }

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2158,17 +2158,18 @@ void QgsProjectProperties::applyRequiredLayers()
     }
   }
   QgsProject::instance()->setRequiredLayers( requiredLayers );
+}
 
-QMap< QString, QString > *QgsProjectProperties::createPageWidgetNameMap()
+QMap< QString, QString > QgsProjectProperties::pageWidgetNameMap()
 {
-  QMap< QString, QString > *pageNames = new QMap< QString, QString >();
+  QMap< QString, QString > pageNames;
   for ( int idx = 0; idx < mOptionsListWidget->count(); ++idx )
   {
     QWidget *currentPage = mOptionsStackedWidget->widget( idx );
     QListWidgetItem *item = mOptionsListWidget->item( idx );
     QString title = item->text();
     QString name = currentPage->objectName();
-    pageNames->insert( title, name );
+    pageNames.insert( title, name );
   }
   return pageNames;
 }

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -46,7 +46,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     //! Constructor
     QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 
-    QMap< QString, QString > *createPageWidgetNameMap();
+    QMap< QString, QString > pageWidgetNameMap();
 
     void setCurrentPage( const QString & );
 

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -46,6 +46,9 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     //! Constructor
     QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 
+    QMap< QString, QString > *createPageWidgetNameMap();
+
+    void setCurrentPage( const QString & );
 
     ~QgsProjectProperties() override;
 

--- a/src/core/locator/qgslocator.cpp
+++ b/src/core/locator/qgslocator.cpp
@@ -26,7 +26,8 @@ const QList<QString> QgsLocator::CORE_FILTERS = QList<QString>() << QStringLiter
     <<  QStringLiteral( "layouts" )
     <<  QStringLiteral( "features" )
     <<  QStringLiteral( "calculator" )
-    <<  QStringLiteral( "bookmarks" );
+    <<  QStringLiteral( "bookmarks" )
+    <<  QStringLiteral( "optionpages" );
 
 QgsLocator::QgsLocator( QObject *parent )
   : QObject( parent )


### PR DESCRIPTION
Search Settings, Options, and Project Properties pages. Double clicking a search result will open the correct page and tab.

Short video: https://www.youtube.com/watch?v=duB2YekUmV0

The new filter presents itself with a prefix of "set" and with tr( "Settings" ) as displayname.

A settings locator filter is added to the built in locator filters (class QgsSettingsLocatorFilter is added to qgsinbuiltlocatorfilters.cpp). The wiring between the new filter and QgsApp has been implemented in:

For reading misc. pages:
* QgisApp::projectPropertiesPagesMap(),
* QgisApp::settingPagesMap(), and
* QgisApp::optionsPagesMap()

For navigating to selected page
* QgisApp::showProjectProperties( const QString &page ) and
* QgisApp::showSettings( const QString &page )
