### PR TITLE
[bugfix] Fix georeferencer crash when deleting a point through context menu #18227

### DIFF
--- a/src/plugins/georeferencer/qgsgcplistwidget.cpp
+++ b/src/plugins/georeferencer/qgsgcplistwidget.cpp
@@ -194,10 +194,6 @@ void QgsGCPListWidget::showContextMenu( QPoint p )
   connect( removeAction, &QAction::triggered, this, &QgsGCPListWidget::removeRow );
   m.addAction( removeAction );
   m.exec( QCursor::pos(), removeAction );
-
-  index = static_cast<const QSortFilterProxyModel *>( model() )->mapToSource( index );
-  mPrevRow = index.row();
-  mPrevColumn = index.column();
 }
 
 void QgsGCPListWidget::removeRow()
@@ -214,6 +210,8 @@ void QgsGCPListWidget::editCell()
 void QgsGCPListWidget::jumpToPoint()
 {
   QModelIndex index = static_cast<const QSortFilterProxyModel *>( model() )->mapToSource( currentIndex() );
+  mPrevRow = index.row();
+  mPrevColumn = index.column();
   emit jumpToGCP( index.row() );
 }
 


### PR DESCRIPTION
## Description

fixes #18227
Georeferencer crashes when deleting a point through context menu. This should fix it.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
