### PR TITLE
[needs-docs] Reorganize save action for map layer

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6995,7 +6995,7 @@ void QgisApp::saveStyleFile( QgsMapLayer *layer )
   QgsSettings settings;
   QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
   QString filename = QFileDialog::getSaveFileName( this,
-                     tr( "Save layer properties as style file" ),
+                     tr( "Save as QGIS Layer Style File" ),
                      lastUsedDir,
                      tr( "QGIS Layer Style File" ) + " (*.qml)" );
   if ( filename.isEmpty() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6985,6 +6985,28 @@ void QgisApp::saveAsLayerDefinition()
   }
 }
 
+void QgisApp::saveStyleFile( QgsMapLayer *layer )
+{
+  if ( !layer )
+  {
+    layer = qobject_cast<QgsMapLayer *>( activeLayer() );
+  }
+
+  QgsSettings settings;
+  QString lastUsedDir = settings.value( QStringLiteral( "style/lastStyleDir" ), QDir::homePath() ).toString();
+  QString filename = QFileDialog::getSaveFileName( this,
+                     tr( "Save layer properties as style file" ),
+                     lastUsedDir,
+                     tr( "QGIS Layer Style File" ) + " (*.qml)" );
+  if ( filename.isEmpty() )
+    return;
+
+  bool defaultLoadedFlag;
+  layer->saveNamedStyle( filename, defaultLoadedFlag );
+
+  settings.setValue( QStringLiteral( "style/lastStyleDir" ), filename );
+}
+
 ///@cond PRIVATE
 
 /**

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -695,7 +695,10 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void saveAsFile( QgsMapLayer *layer = nullptr );
     //! save qml style for the current layer
     void saveStyleFile( QgsMapLayer *layer = nullptr );
-
+    //! save qrl definition for the current layer
+    void saveAsLayerDefinition();
+    //! save current raster layer
+    void saveAsRasterFile( QgsRasterLayer *layer = nullptr );
     //! Process the list of URIs that have been dropped in QGIS
     void handleDropUriList( const QgsMimeDataUtils::UriList &lst );
     //! Convenience function to open either a project or a layer file.
@@ -1504,11 +1507,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! set the CAD dock widget visible
     void setCadDockVisible( bool visible );
-
-    void saveAsLayerDefinition();
-
-    //! save current raster layer
-    void saveAsRasterFile( QgsRasterLayer *layer = nullptr );
 
     //! show Python console
     void showPythonDialog();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -693,6 +693,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
   public slots:
     //! save current vector layer
     void saveAsFile( QgsMapLayer *layer = nullptr );
+    //! save qml style for the current layer
+    void saveStyleFile( QgsMapLayer *layer = nullptr );
 
     //! Process the list of URIs that have been dropped in QGIS
     void handleDropUriList( const QgsMimeDataUtils::UriList &lst );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -241,10 +241,6 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         if ( vlayer->storageType() == QLatin1String( "Memory storage" ) && mView->selectedLayerNodes().count() == 1 )
           duplicateLayersAction->setEnabled( false );
 
-        // save as vector file
-        menu->addAction( tr( "Save as…" ), QgisApp::instance(), SLOT( saveAsFile() ) );
-        menu->addAction( tr( "Save as Layer Definition File…" ), QgisApp::instance(), SLOT( saveAsLayerDefinition() ) );
-
         if ( vlayer->dataProvider()->supportsSubsetString() )
         {
           QAction *action = menu->addAction( tr( "&Filter…" ), QgisApp::instance(), SLOT( layerSubsetString() ) );
@@ -254,11 +250,24 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( actions->actionShowFeatureCount( menu ) );
 
         menu->addSeparator();
+
+        // save as vector file
+        QMenu *menuExportVector = new QMenu( tr( "Export" ), menu );
+        menuExportVector->addAction( tr( "Save as…" ), QgisApp::instance(), SLOT( saveAsFile() ) );
+        menuExportVector->addAction( tr( "Save as Layer Definition File…" ), QgisApp::instance(), SLOT( saveAsLayerDefinition() ) );
+        if ( vlayer->isSpatial() )
+            menuExportVector->addAction( tr( "QGIS Layer Style File…" ), QgisApp::instance(), SLOT( saveStyleFile() ) );
+        menu->addMenu( menuExportVector );
       }
       else if ( rlayer )
       {
-        menu->addAction( tr( "Save As…" ), QgisApp::instance(), SLOT( saveAsRasterFile() ) );
-        menu->addAction( tr( "Save As Layer Definition File…" ), QgisApp::instance(), SLOT( saveAsLayerDefinition() ) );
+        QMenu *menuExportRaster = new QMenu( tr( "Export" ), menu );
+        menuExportRaster->addAction( tr( "Save As…" ), QgisApp::instance(), SLOT( saveAsRasterFile() ) );
+        menuExportRaster->addAction( tr( "Save As Layer Definition File…" ), QgisApp::instance(), SLOT( saveAsLayerDefinition() ) );
+        menuExportRaster->addAction( tr( "QGIS Layer Style File…" ), QgisApp::instance(), SLOT( saveStyleFile() ) );
+        menu->addMenu( menuExportRaster );
+
+        menu->addSeparator();
       }
       else if ( layer && layer->type() == QgsMapLayer::PluginLayer && mView->selectedLayerNodes().count() == 1 )
       {

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -253,18 +253,32 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         // save as vector file
         QMenu *menuExportVector = new QMenu( tr( "Export" ), menu );
-        menuExportVector->addAction( tr( "Save as…" ), QgisApp::instance(), SLOT( saveAsFile() ) );
-        menuExportVector->addAction( tr( "Save as Layer Definition File…" ), QgisApp::instance(), SLOT( saveAsLayerDefinition() ) );
+        QAction *actionSaveAs = new QAction( tr( "Save as…" ), menuExportVector );
+        QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer Definition File…" ), menuExportVector );
+        connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
+        menuExportVector->addAction( actionSaveAs );
+        connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
+        menuExportVector->addAction( actionSaveAsDefinitionLayer );
         if ( vlayer->isSpatial() )
-            menuExportVector->addAction( tr( "QGIS Layer Style File…" ), QgisApp::instance(), SLOT( saveStyleFile() ) );
+        {
+          QAction *actionSaveStyle = new QAction( tr( "Save as QGIS Layer Style File…" ), menuExportVector );
+          connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
+          menuExportVector->addAction( actionSaveStyle );
+        }
         menu->addMenu( menuExportVector );
       }
       else if ( rlayer )
       {
         QMenu *menuExportRaster = new QMenu( tr( "Export" ), menu );
-        menuExportRaster->addAction( tr( "Save As…" ), QgisApp::instance(), SLOT( saveAsRasterFile() ) );
-        menuExportRaster->addAction( tr( "Save As Layer Definition File…" ), QgisApp::instance(), SLOT( saveAsLayerDefinition() ) );
-        menuExportRaster->addAction( tr( "QGIS Layer Style File…" ), QgisApp::instance(), SLOT( saveStyleFile() ) );
+        QAction *actionSaveAs = new QAction( tr( "Save as…" ), menuExportRaster );
+        QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer Definition File…" ), menuExportRaster );
+        QAction *actionSaveStyle = new QAction( tr( "Save as QGIS Layer Style File…" ), menuExportRaster );
+        connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
+        menuExportRaster->addAction( actionSaveAs );
+        connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
+        menuExportRaster->addAction( actionSaveAsDefinitionLayer );
+        connect( actionSaveStyle, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveStyleFile(); } );
+        menuExportRaster->addAction( actionSaveStyle );
         menu->addMenu( menuExportRaster );
 
         menu->addSeparator();


### PR DESCRIPTION
## Description
Proposal to reorganize some layer contextual menu entry: move save as, save definition file and (added) save style file to Export menu.

<img width="490" alt="schermata 2018-03-18 alle 23 40 10" src="https://user-images.githubusercontent.com/1374682/37572202-f6f20fae-2b07-11e8-99ff-9701910c66cc.png">


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
