### PR TITLE
Fix missing '(copy)' suffix on names of newly duplicated layers

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9234,7 +9234,7 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
   QString layerDupName, unSppType;
   QList<QgsMessageBarItem *> msgBars;
 
-  Q_FOREACH ( QgsMapLayer *selectedLyr, selectedLyrs )
+  for ( QgsMapLayer *selectedLyr : selectedLyrs )
   {
     dupLayer = nullptr;
     unSppType.clear();
@@ -9298,6 +9298,8 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
       continue;
     }
 
+    dupLayer->setName( layerDupName );
+
     // add layer to layer registry and legend
     QList<QgsMapLayer *> myList;
     myList << dupLayer;
@@ -9332,7 +9334,7 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
   freezeCanvases( false );
 
   // display errors in message bar after duplication of layers
-  Q_FOREACH ( QgsMessageBarItem *msgBar, msgBars )
+  for ( QgsMessageBarItem *msgBar : qgis::as_const( msgBars ) )
   {
     mInfoBar->pushItem( msgBar );
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9231,6 +9231,7 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
 
   freezeCanvases();
   QgsMapLayer *dupLayer = nullptr;
+  QgsMapLayer *newSelection = nullptr;
   QString layerDupName, unSppType;
   QList<QgsMessageBarItem *> msgBars;
 
@@ -9327,9 +9328,16 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *> &lyrList )
       messageBar()->pushMessage( errMsg,
                                  tr( "Cannot copy style to duplicated layer." ),
                                  Qgis::Critical, messageTimeout() );
+
+    if ( !newSelection )
+      newSelection = dupLayer;
   }
 
   dupLayer = nullptr;
+
+  // auto select first new duplicate layer
+  if ( newSelection )
+    setActiveLayer( newSelection );
 
   freezeCanvases( false );
 


### PR DESCRIPTION
Also auto-select newly duplicated layers in layer tree