### PR TITLE
Don't recreate vertex editor each time

### DIFF
--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -277,18 +277,12 @@ QgsVertexEditor::QgsVertexEditor(
   QgsVectorLayer *layer,
   QgsSelectedFeature *selectedFeature,
   QgsMapCanvas *canvas )
-  : mUpdatingTableSelection( false )
+  : mCanvas( canvas )
+  , mUpdatingTableSelection( false )
   , mUpdatingVertexSelection( false )
 {
   setWindowTitle( tr( "Vertex Editor" ) );
-
-  mLayer = layer;
-  mSelectedFeature = selectedFeature;
-  mCanvas = canvas;
-
   mTableView = new QTableView( this );
-  mVertexModel = new QgsVertexEditorModel( mLayer, mSelectedFeature, mCanvas, this );
-  mTableView->setModel( mVertexModel );
 
   mTableView->setSelectionMode( QTableWidget::ExtendedSelection );
   mTableView->setSelectionBehavior( QTableWidget::SelectRows );
@@ -300,8 +294,26 @@ QgsVertexEditor::QgsVertexEditor(
 
   setWidget( mTableView );
 
-  connect( mSelectedFeature, &QgsSelectedFeature::selectionChanged, this, &QgsVertexEditor::updateTableSelection );
   connect( mTableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsVertexEditor::updateVertexSelection );
+
+  updateEditor( layer, selectedFeature );
+}
+
+void QgsVertexEditor::updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *selectedFeature )
+{
+  if ( mVertexModel )
+  {
+    delete mVertexModel;
+  }
+
+  mLayer = layer;
+  mSelectedFeature = selectedFeature;
+
+  // TOOD We really should just update the model itself.
+  mVertexModel = new QgsVertexEditorModel( mLayer, mSelectedFeature, mCanvas, this );
+  mTableView->setModel( mVertexModel );
+
+  connect( mSelectedFeature, &QgsSelectedFeature::selectionChanged, this, &QgsVertexEditor::updateTableSelection );
 }
 
 void QgsVertexEditor::updateTableSelection()

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -75,6 +75,7 @@ class QgsVertexEditor : public QgsDockWidget
                      QgsMapCanvas *canvas );
 
   public:
+    void updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *selectedFeature );
     QgsVectorLayer *mLayer = nullptr;
     QgsSelectedFeature *mSelectedFeature = nullptr;
     QgsMapCanvas *mCanvas = nullptr;

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1036,10 +1036,18 @@ void QgsVertexTool::showVertexEditor()  //#spellok
     return;
 
   mSelectedFeature.reset( new QgsSelectedFeature( m.featureId(), m.layer(), mCanvas ) );
-  mVertexEditor.reset( new QgsVertexEditor( m.layer(), mSelectedFeature.get(), mCanvas ) );
-  QgisApp::instance()->addDockWidget( Qt::LeftDockWidgetArea, mVertexEditor.get() );
-  connect( mVertexEditor.get(), &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
-  connect( mVertexEditor.get(), &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
+  if ( !mVertexEditor )
+  {
+    mVertexEditor.reset( new QgsVertexEditor( m.layer(), mSelectedFeature.get(), mCanvas ) );
+    QgisApp::instance()->addDockWidget( Qt::LeftDockWidgetArea, mVertexEditor.get() );
+    connect( mVertexEditor.get(), &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
+    connect( mVertexEditor.get(), &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
+  }
+  else
+  {
+    mVertexEditor->updateEditor( m.layer(), mSelectedFeature.get() );
+  }
+
   connect( mSelectedFeature.get()->vlayer(), &QgsVectorLayer::featureDeleted, this, &QgsVertexTool::cleanEditor );
 }
 

--- a/src/gui/qgsvariableeditorwidget.cpp
+++ b/src/gui/qgsvariableeditorwidget.cpp
@@ -719,6 +719,8 @@ void VariableEditorDelegate::setModelData( QWidget *widget, QAbstractItemModel *
   {
     //edited variable name
     QString newName = lineEdit->text();
+    newName = newName.trimmed();
+    newName = newName.replace( QStringLiteral( " " ), "_" );
 
     //test for validity
     if ( newName == variableName )


### PR DESCRIPTION
## Description
At the moment the vertex is recreated each time it is opened which isn't really great UX as we forget state information as well as just waste cpu on stuff we don't have to.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
