### PR TITLE
Add toolTip to layout editor option in vector layer attributes form properties

### DIFF
--- a/src/ui/qgsattributesformproperties.ui
+++ b/src/ui/qgsattributesformproperties.ui
@@ -49,6 +49,9 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="toolTip">
+         <string>Select attribute layout editor</string>
+        </property>
         <item>
          <property name="text">
           <string>Autogenerate</string>


### PR DESCRIPTION
because it's not obvious what do these options and it's hard to refer to them when writing documentation.
Actually I wonder if it should not be a label, and this would be possible given the minimal width of this dialog.