### PR TITLE
[3.0 backport] Add a minimal data provider for plugin layers

### DIFF
--- a/python/core/qgspluginlayer.sip.in
+++ b/python/core/qgspluginlayer.sip.in
@@ -7,7 +7,6 @@
  ************************************************************************/
 
 
-
 class QgsPluginLayer : QgsMapLayer
 {
 %Docstring
@@ -53,6 +52,9 @@ Set source string. This is used for example in layer tree to show tooltip.
 
 .. versionadded:: 2.16
 %End
+
+    virtual QgsDataProvider *dataProvider();
+
 
   protected:
 };

--- a/src/core/qgspluginlayer.cpp
+++ b/src/core/qgspluginlayer.cpp
@@ -17,10 +17,33 @@
 #include "qgsmaplayerlegend.h"
 #include "qgsmaplayerrenderer.h"
 
+
+/**
+  A minimal data provider for plugin layers
+ */
+///@cond PRIVATE
+class QgsPluginLayerDataProvider : public QgsDataProvider
+{
+  public:
+    QgsPluginLayerDataProvider( const QString &layerType ) : mName( layerType ) {}
+    void setExtent( const QgsRectangle &extent ) { mExtent = extent; }
+    virtual QgsCoordinateReferenceSystem crs() const { return QgsCoordinateReferenceSystem(); }
+    virtual QString name() const override { return mName; }
+    QString description() const override { return ""; }
+    virtual QgsRectangle extent() const { return mExtent; }
+    virtual bool isValid() const { return true; }
+
+  private:
+    QString mName;
+    QgsRectangle mExtent;
+};
+///@endcond
+
 QgsPluginLayer::QgsPluginLayer( const QString &layerType, const QString &layerName )
   : QgsMapLayer( PluginLayer, layerName )
   , mPluginLayerType( layerType )
 {
+  mDataProvider = new QgsPluginLayerDataProvider( layerType );
 }
 
 QgsPluginLayer::~QgsPluginLayer()
@@ -28,6 +51,7 @@ QgsPluginLayer::~QgsPluginLayer()
   // TODO: shall we move the responsibility of emitting the signal to plugin
   // layer implementations before they start doing their part of cleanup...?
   emit willBeDeleted();
+  delete mDataProvider;
 }
 
 QString QgsPluginLayer::pluginLayerType()
@@ -38,9 +62,20 @@ QString QgsPluginLayer::pluginLayerType()
 void QgsPluginLayer::setExtent( const QgsRectangle &extent )
 {
   mExtent = extent;
+  static_cast<QgsPluginLayerDataProvider *>( mDataProvider )->setExtent( extent );
 }
 
 void QgsPluginLayer::setSource( const QString &source )
 {
   mDataSource = source;
+}
+
+QgsDataProvider *QgsPluginLayer::dataProvider()
+{
+  return mDataProvider;
+}
+
+const QgsDataProvider *QgsPluginLayer::dataProvider() const
+{
+  return mDataProvider;
 }

--- a/src/core/qgspluginlayer.h
+++ b/src/core/qgspluginlayer.h
@@ -17,7 +17,7 @@
 
 #include "qgis_core.h"
 #include "qgsmaplayer.h"
-
+#include "qgsdataprovider.h"
 
 /**
  * \ingroup core
@@ -55,8 +55,12 @@ class CORE_EXPORT QgsPluginLayer : public QgsMapLayer
      */
     void setSource( const QString &source );
 
+    QgsDataProvider *dataProvider() override;
+    const QgsDataProvider *dataProvider() const override SIP_SKIP;
+
   protected:
     QString mPluginLayerType;
+    QgsDataProvider *mDataProvider;
 };
 
 #endif // QGSPLUGINLAYER_H


### PR DESCRIPTION
Throughout the codebase, there is a general assumption that layer->dataProvider() is not null. This wasn't the case for plugin layers.
