### PR TITLE
Certs not removed with pki postgis on win port3

### DIFF
--- a/.ci/travis/linux/blacklist.txt
+++ b/.ci/travis/linux/blacklist.txt
@@ -29,4 +29,5 @@ PyQgsServerAccessControl
 PyQgsAuthManagerPKIPostgresTest
 PyQgsAuthManagerPasswordPostgresTest
 PyQgsAuthManagerOgrPostgresTest
+PyQgsDbManagerPostgis
 

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -67,7 +67,7 @@ class PostGisDBConnector(DBConnector):
             self.connection = psycopg2.connect(expandedConnInfo)
         except self.connection_error_types() as e:
             # get credentials if cached or asking to the user no more than 3 times
-            err = unicode(e)
+            err = str(e)
             uri = self.uri()
             conninfo = uri.connectionInfo(False)
 
@@ -89,7 +89,7 @@ class PostGisDBConnector(DBConnector):
                 except self.connection_error_types() as e:
                     if i == 2:
                         raise ConnectionError(e)
-                    err = unicode(e)
+                    err = str(e)
                 finally:
                     # clear certs for each time trying to connect
                     self._clearSslTempCertsIfAny(newExpandedConnInfo)

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -66,7 +66,7 @@ class PostGisDBConnector(DBConnector):
         try:
             self.connection = psycopg2.connect(expandedConnInfo)
         except self.connection_error_types() as e:
-            # get credentials if cached or assking to the user no more than 3 times
+            # get credentials if cached or asking to the user no more than 3 times
             err = unicode(e)
             uri = self.uri()
             conninfo = uri.connectionInfo(False)

--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -26,7 +26,7 @@ from builtins import range
 
 from functools import cmp_to_key
 
-from qgis.PyQt.QtCore import QRegExp
+from qgis.PyQt.QtCore import QRegExp, QFile
 from qgis.core import Qgis, QgsCredentials, QgsDataSourceUri
 
 from ..connector import DBConnector
@@ -66,7 +66,8 @@ class PostGisDBConnector(DBConnector):
         try:
             self.connection = psycopg2.connect(expandedConnInfo)
         except self.connection_error_types() as e:
-            err = str(e)
+            # get credentials if cached or assking to the user no more than 3 times
+            err = unicode(e)
             uri = self.uri()
             conninfo = uri.connectionInfo(False)
 
@@ -88,44 +89,13 @@ class PostGisDBConnector(DBConnector):
                 except self.connection_error_types() as e:
                     if i == 2:
                         raise ConnectionError(e)
-
-                    err = str(e)
+                    err = unicode(e)
                 finally:
-                    # remove certs (if any) of the expanded connectionInfo
-                    expandedUri = QgsDataSourceUri(newExpandedConnInfo)
-
-                    sslCertFile = expandedUri.param("sslcert")
-                    if sslCertFile:
-                        sslCertFile = sslCertFile.replace("'", "")
-                        os.remove(sslCertFile)
-
-                    sslKeyFile = expandedUri.param("sslkey")
-                    if sslKeyFile:
-                        sslKeyFile = sslKeyFile.replace("'", "")
-                        os.remove(sslKeyFile)
-
-                    sslCAFile = expandedUri.param("sslrootcert")
-                    if sslCAFile:
-                        sslCAFile = sslCAFile.replace("'", "")
-                        os.remove(sslCAFile)
+                    # clear certs for each time trying to connect
+                    self._clearSslTempCertsIfAny(newExpandedConnInfo)
         finally:
-            # remove certs (if any) of the expanded connectionInfo
-            expandedUri = QgsDataSourceUri(expandedConnInfo)
-
-            sslCertFile = expandedUri.param("sslcert")
-            if sslCertFile:
-                sslCertFile = sslCertFile.replace("'", "")
-                os.remove(sslCertFile)
-
-            sslKeyFile = expandedUri.param("sslkey")
-            if sslKeyFile:
-                sslKeyFile = sslKeyFile.replace("'", "")
-                os.remove(sslKeyFile)
-
-            sslCAFile = expandedUri.param("sslrootcert")
-            if sslCAFile:
-                sslCAFile = sslCAFile.replace("'", "")
-                os.remove(sslCAFile)
+            # clear certs of the first connection try
+            self._clearSslTempCertsIfAny(expandedConnInfo)
 
         self.connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
 
@@ -140,6 +110,33 @@ class PostGisDBConnector(DBConnector):
 
     def _connectionInfo(self):
         return str(self.uri().connectionInfo(True))
+
+    def _clearSslTempCertsIfAny(self, connectionInfo):
+        # remove certs (if any) of the connectionInfo
+        expandedUri = QgsDataSourceUri(connectionInfo)
+
+        def removeCert(certFile):
+            certFile = certFile.replace("'", "")
+            file = QFile(certFile)
+            # set permission to allow removing on Win.
+            # On linux and Mac if file is set with QFile::>ReadUser
+            # does not create problem removing certs
+            if not file.setPermissions(QFile.WriteOwner):
+                raise Exception('Cannot change permissions on {}: error code: {}'.format(file.fileName(), file.error()))
+            if not file.remove():
+                raise Exception('Cannot remove {}: error code: {}'.format(file.fileName(), file.error()))
+
+        sslCertFile = expandedUri.param("sslcert")
+        if sslCertFile:
+            removeCert(sslCertFile)
+
+        sslKeyFile = expandedUri.param("sslkey")
+        if sslKeyFile:
+            removeCert(sslKeyFile)
+
+        sslCAFile = expandedUri.param("sslrootcert")
+        if sslCAFile:
+            removeCert(sslCAFile)
 
     def _checkSpatial(self):
         """ check whether postgis_version is present in catalog """

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -244,8 +244,8 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
       fileName.remove( QStringLiteral( "'" ) );
       QFile file( fileName );
       // set minimal permission to allow removing on Win.
-      // On linux and Mac if file is set with QFile::>ReadUser
-      // does not create problem removin certs
+      // On linux and Mac if file is set with QFile::ReadUser
+      // does not create problem removing certs
       if ( !file.setPermissions( QFile::WriteOwner ) )
       {
         QString errorMsg = tr( "Cannot set WriteOwner permission to cert: %0 to allow removing it" ).arg( file.fileName() );

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -242,7 +242,26 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
     {
       QString fileName = expandedUri.param( param );
       fileName.remove( QStringLiteral( "'" ) );
-      QFile::remove( fileName );
+      QFile file( fileName );
+      // set minimal permission to allow removing on Win.
+      // On linux and Mac if file is set with QFile::>ReadUser
+      // does not create problem removin certs
+      if ( !file.setPermissions( QFile::WriteOwner ) )
+      {
+        QString errorMsg = tr( "Cannot set WriteOwner permission to cert: %0 to allow removing it" ).arg( file.fileName() );
+        PQfinish();
+        QgsMessageLog::logMessage( tr( "Client security failure" ) + '\n' + errorMsg, tr( "PostGIS" ) );
+        mRef = 0;
+        return;
+      }
+      if ( !file.remove() )
+      {
+        QString errorMsg = tr( "Cannot remove cert: %0" ).arg( file.fileName() );
+        PQfinish();
+        QgsMessageLog::logMessage( tr( "Client security failure" ) + '\n' + errorMsg, tr( "PostGIS" ) );
+        mRef = 0;
+        return;
+      }
     }
   }
 

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -233,6 +233,7 @@ IF (ENABLE_PGTEST)
   ADD_PYTHON_TEST(PyQgsAuthManagerPKIPostgresTest test_authmanager_pki_postgres.py)
   ADD_PYTHON_TEST(PyQgsAuthManagerPasswordPostgresTest test_authmanager_password_postgres.py)
   ADD_PYTHON_TEST(PyQgsAuthManagerOgrPostgresTest test_authmanager_ogr_postgres.py)
+  ADD_PYTHON_TEST(PyQgsDbManagerPostgis test_db_manager_postgis.py)
 ENDIF (ENABLE_PGTEST)
 
 IF (ENABLE_MSSQLTEST)

--- a/tests/src/python/test_db_manager_postgis.py
+++ b/tests/src/python/test_db_manager_postgis.py
@@ -245,7 +245,7 @@ class TestPyQgsDBManagerPostgis(unittest.TestCase):
 
     def testConnect(self):
         # create a PKI postgis connection
-        # that will be listed in postgis connection of db_amanger
+        # that will be listed in postgis connection of db_manager
         self.setUpProvider(self.auth_config.id())
 
         plugin = createDbPlugin('postgis')

--- a/tests/src/python/test_db_manager_postgis.py
+++ b/tests/src/python/test_db_manager_postgis.py
@@ -294,5 +294,6 @@ class TestPyQgsDBManagerPostgis(unittest.TestCase):
         pkies = glob.glob(os.path.join(tempfile.gettempdir(), 'tmp*_{*}.pem'))
         self.assertEqual(len(pkies), 0)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_db_manager_postgis.py
+++ b/tests/src/python/test_db_manager_postgis.py
@@ -1,63 +1,45 @@
 # -*- coding: utf-8 -*-
-"""
-Tests for auth manager PKI access to postgres.
-
-This is an integration test for QGIS Desktop Auth Manager postgres provider that
-checks if QGIS can use a stored auth manager auth configuration to access
-a PKI protected postgres.
-
-Configuration from the environment:
-
-    * QGIS_POSTGRES_SERVER_PORT (default: 55432)
-    * QGIS_POSTGRES_EXECUTABLE_PATH (default: /usr/lib/postgresql/9.4/bin)
-
-
-From build dir, run: ctest -R PyQgsAuthManagerPKIPostgresTest -V
-
-or, if your PostgreSQL path differs from the default:
-
-QGIS_POSTGRES_EXECUTABLE_PATH=/usr/lib/postgresql/<your_version_goes_here>/bin \
-    ctest -R PyQgsAuthManagerPKIPostgresTest -V
+"""QGIS Unit tests for the DBManager GPKG plugin
 
 .. note:: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 2 of the License, or
 (at your option) any later version.
 """
+__author__ = 'Luigi Pirelli'
+__date__ = '2017-11-02'
+__copyright__ = 'Copyright 2017, Boundless Spatial Inc'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
 import os
+import shutil
 import time
 import signal
 import stat
 import subprocess
 import tempfile
 import glob
-
 from shutil import rmtree
 
-from utilities import unitTestDataPath
 from qgis.core import (
     QgsApplication,
     QgsAuthManager,
     QgsAuthMethodConfig,
     QgsVectorLayer,
     QgsDataSourceUri,
+    QgsSettings,
+    QgsProviderRegistry,
     QgsWkbTypes,
 )
-
+from qgis.PyQt.QtCore import QCoreApplication, QFile
+from qgis.testing import start_app, unittest
 from qgis.PyQt.QtNetwork import QSslCertificate
-from qgis.PyQt.QtCore import QFile
 
-from qgis.testing import (
-    start_app,
-    unittest,
-)
+from plugins.db_manager.db_plugins import supportedDbTypes, createDbPlugin
+from plugins.db_manager.db_plugins.plugin import TableField
 
-
-__author__ = 'Alessandro Pasotti'
-__date__ = '25/10/2016'
-__copyright__ = 'Copyright 2016, The QGIS Project'
-# This will get replaced with a git SHA1 when you do a git archive
-__revision__ = '$Format:%H$'
+from utilities import unitTestDataPath
 
 QGIS_POSTGRES_SERVER_PORT = os.environ.get('QGIS_POSTGRES_SERVER_PORT', '55432')
 QGIS_POSTGRES_EXECUTABLE_PATH = os.environ.get('QGIS_POSTGRES_EXECUTABLE_PATH', '/usr/lib/postgresql/9.4/bin')
@@ -94,8 +76,10 @@ host       all           all             127.0.0.1/32           trust
 host       all           all             ::1/32                 trust
 """
 
+TEST_CONNECTION_NAME = 'test_connection'
 
-class TestAuthManager(unittest.TestCase):
+
+class TestPyQgsDBManagerPostgis(unittest.TestCase):
 
     @classmethod
     def setUpAuth(cls):
@@ -150,7 +134,7 @@ class TestAuthManager(unittest.TestCase):
             f.write(QGIS_POSTGRES_HBA_TEMPLATE)
 
     @classmethod
-    def setUpClass(cls):
+    def setUpServer(cls):
         """Run before all tests:
         Creates an auth configuration"""
         cls.port = QGIS_POSTGRES_SERVER_PORT
@@ -188,6 +172,58 @@ class TestAuthManager(unittest.TestCase):
         subprocess.check_call([os.path.join(QGIS_POSTGRES_EXECUTABLE_PATH, 'psql'), '-h', 'localhost', '-p', cls.port, '-c', 'CREATE ROLE "%s" WITH SUPERUSER LOGIN' % cls.username, cls.dbname])
 
     @classmethod
+    def setUpProvider(cls, authId):
+        cls.dbconn = 'dbname=\'qgis_test\''
+        if 'QGIS_PGTEST_DB' in os.environ:
+            cls.dbconn = os.environ['QGIS_PGTEST_DB']
+        uri = QgsDataSourceUri()
+        uri.setConnection("localhost", cls.port, cls.dbname, "", "", QgsDataSourceUri.SslVerifyFull, authId)
+        uri.setKeyColumn('pk')
+        uri.setSrid('EPSG:4326')
+        uri.setDataSource('qgis_test', 'someData', "geom", "", "pk")
+        provider = QgsProviderRegistry.instance().createProvider('postgres', uri.uri(False))
+        if provider is None:
+            raise Exception("cannot create postgres provider")
+        if not provider.isValid():
+            raise Exception("Created postgres provider is not valid: {}".format(str(provider.errors())))
+        # save provider config that is the way how db_manager is aware of a PG connection
+        cls.addConnectionConfig(TEST_CONNECTION_NAME, uri)
+
+    @classmethod
+    def addConnectionConfig(cls, conn_name, uri):
+        """Necessary to allow db_manager to have the list of connections get from settings."""
+        uri = QgsDataSourceUri(uri)
+
+        settings = QgsSettings()
+        baseKey = "/PostgreSQL/connections/"
+        baseKey += conn_name
+        settings.setValue(baseKey + "/service", uri.service())
+        settings.setValue(baseKey + "/host", uri.host())
+        settings.setValue(baseKey + "/port", uri.port())
+        settings.setValue(baseKey + "/database", uri.database())
+        if uri.username():
+            settings.setValue(baseKey + "/username", uri.username())
+        if uri.password():
+            settings.setValue(baseKey + "/password", uri.password())
+        if uri.authConfigId():
+            settings.setValue(baseKey + "/authcfg", uri.authConfigId())
+        if uri.sslMode():
+            settings.setValue(baseKey + "/sslmode", uri.sslMode())
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        # start ans setup server
+        cls.setUpServer()
+
+        # start a standalone qgis application
+        QCoreApplication.setOrganizationName("QGIS_Test")
+        QCoreApplication.setOrganizationDomain("TestPyQgsDBManagerPostgis.com")
+        QCoreApplication.setApplicationName("TestPyQgsDBManagerPostgis")
+        QgsSettings().clear()
+        start_app()
+
+    @classmethod
     def tearDownClass(cls):
         """Run after all tests"""
         cls.server.terminate()
@@ -196,50 +232,45 @@ class TestAuthManager(unittest.TestCase):
         time.sleep(2)
         rmtree(QGIS_AUTH_DB_DIR_PATH)
         rmtree(cls.tempfolder)
+        QgsSettings().clear()
 
-    def setUp(self):
-        """Run before each test."""
-        pass
+    ###########################################
 
-    def tearDown(self):
-        """Run after each test."""
-        pass
+    def testSupportedDbTypes(self):
+        self.assertIn('postgis', supportedDbTypes())
 
-    @classmethod
-    def _getPostGISLayer(cls, type_name, layer_name=None, authcfg=None):
-        """
-        PG layer factory
-        """
-        if layer_name is None:
-            layer_name = 'pg_' + type_name
-        uri = QgsDataSourceUri()
-        uri.setWkbType(QgsWkbTypes.Point)
-        uri.setConnection("localhost", cls.port, cls.dbname, "", "", QgsDataSourceUri.SslVerifyFull, authcfg)
-        uri.setKeyColumn('pk')
-        uri.setSrid('EPSG:4326')
-        uri.setDataSource('qgis_test', 'someData', "geom", "", "pk")
-        # Note: do not expand here!
-        layer = QgsVectorLayer(uri.uri(False), layer_name, 'postgres')
-        return layer
+    def testCreateDbPlugin(self):
+        plugin = createDbPlugin('postgis')
+        self.assertIsNotNone(plugin)
 
-    def testValidAuthAccess(self):
-        """
-        Access the protected layer with valid credentials
-        """
-        pg_layer = self._getPostGISLayer('testlayer_èé', authcfg=self.auth_config.id())
-        self.assertTrue(pg_layer.isValid())
+    def testConnect(self):
+        # create a PKI postgis connection
+        # that will be listed in postgis connection of db_amanger
+        self.setUpProvider(self.auth_config.id())
 
-    def testInvalidAuthAccess(self):
-        """
-        Access the protected layer with not valid credentials
-        """
-        pg_layer = self._getPostGISLayer('testlayer_èé')
-        self.assertFalse(pg_layer.isValid())
+        plugin = createDbPlugin('postgis')
+        connections = plugin.connections()
+        self.assertEqual(len(connections), 1)
+        # test connection
+        postgisConnPlugin = connections[0]
+        self.assertTrue(postgisConnPlugin.connect())
+        # test removing connection
+        self.assertTrue(postgisConnPlugin.remove())
+        self.assertEqual(len(plugin.connections()), 0)
+        # test without connection params => fail
+        connection = createDbPlugin('postgis', 'conn name')
+        connection_succeeded = False
+        try:
+            connection.connect()
+            connection_succeeded = True
+        except:
+            pass
+        self.assertFalse(connection_succeeded, 'exception should have been raised')
 
     def testRemoveTemporaryCerts(self):
         """
         Check that no temporary cert remain after connection with
-        postgres provider
+        db_manager postgis plugin
         """
         def cleanTempPki():
             pkies = glob.glob(os.path.join(tempfile.gettempdir(), 'tmp*_{*}.pem'))
@@ -251,13 +282,17 @@ class TestAuthManager(unittest.TestCase):
         # remove any temppki in temprorary path to check that no
         # other pki remain after connection
         cleanTempPki()
-        # connect using postgres provider
-        pg_layer = self._getPostGISLayer('testlayer_èé', authcfg=self.auth_config.id())
-        self.assertTrue(pg_layer.isValid())
+        # connect
+        self.setUpProvider(self.auth_config.id())
+        plugin = createDbPlugin('postgis')
+        connections = plugin.connections()
+        self.assertEqual(len(connections), 1)
+        # test connection
+        postgisConnPlugin = connections[0]
+        self.assertTrue(postgisConnPlugin.connect())
         # do test no certs remained
         pkies = glob.glob(os.path.join(tempfile.gettempdir(), 'tmp*_{*}.pem'))
         self.assertEqual(len(pkies), 0)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
port to 3.0 of #5477 with added unit tests.

ISSUE to resolve: On Windows, PKI PostGIS connections does not remove dumped and temporary certs on temp directory

For PKI db connections (at least Postgis) certs have to be dumped on files to setup connection and then removed.
File permissions are set here: https://qgis.org/api/2.18/qgsauthcertutils_8cpp_source.html#l00271
and python os.remove or QFile::remove(file) are enough on Linux and OSX. But not enough on Win because of ownership difference [1].
So it's necessary to explicitly setup minimum write permission to remove the file. The minimum is
QFile::WriteOwner.
In this moment only PostGIS provider is PKI enabled. The others DB, as far as I can read, still use basic auth.

This PR affect Postgis provider for c++ side and db_manager for the python side.

The issue need to be backported to 3.0.

[1] http://doc.qt.io/qt-4.8/qfile.html#Permission-enum

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
