### PR TITLE
[FEATURE] expression support for the copyright decorator

### DIFF
--- a/src/app/qgsdecorationcopyright.cpp
+++ b/src/app/qgsdecorationcopyright.cpp
@@ -26,6 +26,8 @@ email                : tim@linfiniti.com
 
 #include "qgisapp.h"
 #include "qgsapplication.h"
+#include "qgsexpression.h"
+#include "qgsexpressioncontext.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
@@ -64,7 +66,7 @@ void QgsDecorationCopyright::projectRead()
   //  mQFont.setFamily( QgsProject::instance()->readEntry( "CopyrightLabel", "/FontName", "Sans Serif" ) );
   //  mQFont.setPointSize( QgsProject::instance()->readNumEntry( "CopyrightLabel", "/FontSize", 9 ) );
 
-  mLabelQString = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Label" ), defString );
+  mLabelText = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Label" ), defString );
   mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
   mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
   mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
@@ -75,7 +77,7 @@ void QgsDecorationCopyright::saveToProject()
   QgsDecorationItem::saveToProject();
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/FontName" ), mQFont.family() );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/FontSize" ), mQFont.pointSize() );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Label" ), mLabelQString );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Label" ), mLabelText );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
@@ -95,6 +97,8 @@ void QgsDecorationCopyright::render( const QgsMapSettings &mapSettings, QgsRende
   //Large IF statement to enable/disable copyright label
   if ( enabled() )
   {
+    QString displayString = QgsExpression::replaceExpressionText( mLabelText, &context.expressionContext() );
+
     // need width/height of paint device
     int myHeight = context.painter()->device()->height();
     int myWidth = context.painter()->device()->width();
@@ -105,7 +109,7 @@ void QgsDecorationCopyright::render( const QgsMapSettings &mapSettings, QgsRende
 
     QString style = "<style type=\"text/css\"> p {color: " +
                     QStringLiteral( "rgba( %1, %2, %3, %4 )" ).arg( mColor.red() ).arg( mColor.green() ).arg( mColor.blue() ).arg( QString::number( mColor.alphaF(), 'f', 2 ) ) + "}</style>";
-    text.setHtml( style + "<p>" + mLabelQString + "</p>" );
+    text.setHtml( style + "<p>" + displayString + "</p>" );
     QSizeF size = text.size();
 
     float myXOffset( 0 ), myYOffset( 0 );

--- a/src/app/qgsdecorationcopyright.h
+++ b/src/app/qgsdecorationcopyright.h
@@ -53,7 +53,7 @@ class APP_EXPORT QgsDecorationCopyright : public QgsDecorationItem
     //! This is the font that will be used for the copyright label
     QFont mQFont;
     //! This is the string that will be used for the copyright label
-    QString mLabelQString;
+    QString mLabelText;
 
     //! This is the color for the copyright label
     QColor mColor;

--- a/src/app/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/qgsdecorationcopyrightdialog.cpp
@@ -13,7 +13,12 @@
 #include "qgsdecorationcopyrightdialog.h"
 #include "qgsdecorationcopyright.h"
 
+#include "qgisapp.h"
+#include "qgsexpression.h"
+#include "qgsexpressionbuilderdialog.h"
+#include "qgsexpressioncontext.h"
 #include "qgshelp.h"
+#include "qgsmapcanvas.h"
 #include "qgssettings.h"
 
 //qt includes
@@ -30,6 +35,7 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   setupUi( this );
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsDecorationCopyrightDialog::buttonBox_accepted );
   connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsDecorationCopyrightDialog::buttonBox_rejected );
+  connect( mInsertExpressionButton, &QPushButton::clicked, this, &QgsDecorationCopyrightDialog::mInsertExpressionButton_clicked );
   connect( pbnColorChooser, &QgsColorButton::colorChanged, this, &QgsDecorationCopyrightDialog::pbnColorChooser_colorChanged );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDecorationCopyrightDialog::showHelp );
 
@@ -41,7 +47,7 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
 
   grpEnable->setChecked( mDeco.enabled() );
   // text
-  txtCopyrightText->setPlainText( mDeco.mLabelQString );
+  txtCopyrightText->setPlainText( mDeco.mLabelText );
   // placement
   cboPlacement->addItem( tr( "Top left" ), QgsDecorationItem::TopLeft );
   cboPlacement->addItem( tr( "Top right" ), QgsDecorationItem::TopRight );
@@ -82,6 +88,27 @@ void QgsDecorationCopyrightDialog::buttonBox_rejected()
   reject();
 }
 
+void QgsDecorationCopyrightDialog::mInsertExpressionButton_clicked()
+{
+  QString selText = txtCopyrightText->textCursor().selectedText();
+
+  // edit the selected expression if there's one
+  if ( selText.startsWith( QLatin1String( "[%" ) ) && selText.endsWith( QLatin1String( "%]" ) ) )
+    selText = selText.mid( 2, selText.size() - 4 );
+
+  QgsExpressionBuilderDialog exprDlg( nullptr, selText, this, QStringLiteral( "generic" ), QgisApp::instance()->mapCanvas()->mapSettings().expressionContext() );
+
+  exprDlg.setWindowTitle( QObject::tr( "Insert Expression" ) );
+  if ( exprDlg.exec() == QDialog::Accepted )
+  {
+    QString expression = exprDlg.expressionText();
+    if ( !expression.isEmpty() )
+    {
+      txtCopyrightText->insertPlainText( "[%" + expression + "%]" );
+    }
+  }
+}
+
 void QgsDecorationCopyrightDialog::pbnColorChooser_colorChanged( const QColor &c )
 {
   QTextCursor cursor = txtCopyrightText->textCursor();
@@ -93,7 +120,7 @@ void QgsDecorationCopyrightDialog::pbnColorChooser_colorChanged( const QColor &c
 void QgsDecorationCopyrightDialog::apply()
 {
   mDeco.mQFont = txtCopyrightText->currentFont();
-  mDeco.mLabelQString = txtCopyrightText->toPlainText();
+  mDeco.mLabelText = txtCopyrightText->toPlainText();
   mDeco.mColor = pbnColorChooser->color();
   mDeco.setPlacement( static_cast< QgsDecorationItem::Placement>( cboPlacement->currentData().toInt() ) );
   mDeco.mMarginUnit = wgtUnitSelection->unit();

--- a/src/app/qgsdecorationcopyrightdialog.h
+++ b/src/app/qgsdecorationcopyrightdialog.h
@@ -31,6 +31,7 @@ class APP_EXPORT QgsDecorationCopyrightDialog : public QDialog, private Ui::QgsD
   private slots:
     void buttonBox_accepted();
     void buttonBox_rejected();
+    void mInsertExpressionButton_clicked();
     void showHelp();
     void pbnColorChooser_colorChanged( const QColor &c );
     void apply();

--- a/src/ui/qgsdecorationcopyrightdialog.ui
+++ b/src/ui/qgsdecorationcopyrightdialog.ui
@@ -56,7 +56,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1" colspan="2">
+      <item row="5" column="1" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QLabel" name="textLabel1_4">
@@ -122,8 +122,15 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="1" colspan="2">
+      <item row="4" column="1" colspan="2">
        <widget class="QComboBox" name="cboPlacement"/>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QPushButton" name="mInsertExpressionButton">
+        <property name="text">
+         <string>Insert an expression...</string>
+        </property>
+       </widget>
       </item>
       <item row="1" column="0" colspan="3">
        <widget class="QTextEdit" name="txtCopyrightText">
@@ -136,7 +143,7 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="textLabel16">
         <property name="maximumSize">
          <size>
@@ -152,7 +159,7 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="lblMargin">
         <property name="minimumSize">
          <size>
@@ -165,7 +172,7 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label">
         <property name="maximumSize">
          <size>
@@ -178,7 +185,7 @@ p, li { white-space: pre-wrap; }
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
+      <item row="3" column="1" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QgsColorButton" name="pbnColorChooser">


### PR DESCRIPTION
## Description
This PR adds expression support to the copyright decorator, adopting the layout label item expression support UI. 

This opens the door to make dynamic decoration labels, such as:
- label relying on variables and/or metadata (see @nyalldawson 's project metadata PR);
- label featuring names of visible layers within canvas extent
- label featuring dynamic feature count for a given feature
- etc., etc., etc.

For e.g., this expression-based label prints the current date and time onto the canvas when rendered (which can be useful to have when saving canvas as image/PDF):
![screenshot from 2018-03-21 10-49-38](https://user-images.githubusercontent.com/1728657/37693961-b1645a4c-2cf5-11e8-85d4-0bcadfa80cfe.png)

@nyalldawson , review appreciated, as always.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
