### PR TITLE
[processing][gdal] Use a text file for input file list to gdal_merge

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -397,3 +397,17 @@ class GdalUtils:
         for p in parts:
             options.extend(['-co', p])
         return options
+
+    @staticmethod
+    def writeLayerParameterToTextFile(filename, alg, parameters, parameter_name, context, quote=True, executing=False):
+        listFile = os.path.join(QgsProcessingUtils.tempFolder(), filename)
+        with open(listFile, 'w') as f:
+            if executing:
+                layers = []
+                for l in alg.parameterAsLayerList(parameters, parameter_name, context):
+                    if quote:
+                        layers.append('"' + l.source() + '"')
+                    else:
+                        layers.append(l.source())
+                f.write('\n'.join(layers))
+        return listFile

--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -113,15 +113,9 @@ class buildvrt(GdalAlgorithm):
             arguments.append('-allow_projection_difference')
         # Always write input files to a text file in case there are many of them and the
         # length of the command will be longer then allowed in command prompt
-        listFile = os.path.join(QgsProcessingUtils.tempFolder(), 'buildvrtInputFiles.txt')
-        with open(listFile, 'w') as f:
-            if executing:
-                layers = []
-                for l in self.parameterAsLayerList(parameters, self.INPUT, context):
-                    layers.append(l.source())
-                f.write('\n'.join(layers))
+        list_file = GdalUtils.writeLayerParameterToTextFile(filename='buildvrtInputFiles.txt', alg=self, parameters=parameters, parameter_name=self.INPUT, context=context, executing=executing, quote=False)
         arguments.append('-input_file_list')
-        arguments.append(listFile)
+        arguments.append(list_file)
 
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         arguments.append(out)

--- a/python/plugins/processing/algs/gdal/merge.py
+++ b/python/plugins/processing/algs/gdal/merge.py
@@ -83,10 +83,10 @@ class merge(GdalAlgorithm):
         self.addParameter(nodata_param)
 
         nodata_out_param = QgsProcessingParameterNumber(self.NODATA_OUTPUT,
-                                                    self.tr('Assign specified "nodata" value to output'),
-                                                    type=QgsProcessingParameterNumber.Integer,
-                                                    defaultValue=None,
-                                                    optional=True)
+                                                        self.tr('Assign specified "nodata" value to output'),
+                                                        type=QgsProcessingParameterNumber.Integer,
+                                                        defaultValue=None,
+                                                        optional=True)
         nodata_out_param.setFlags(nodata_out_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(nodata_out_param)
 
@@ -159,15 +159,9 @@ class merge(GdalAlgorithm):
 
         # Always write input files to a text file in case there are many of them and the
         # length of the command will be longer then allowed in command prompt
-        listFile = os.path.join(QgsProcessingUtils.tempFolder(), 'mergeInputFiles.txt')
-        with open(listFile, 'w') as f:
-            if executing:
-                layers = []
-                for l in self.parameterAsLayerList(parameters, self.INPUT, context):
-                    layers.append('"' + l.source() + '"')
-                f.write('\n'.join(layers))
+        list_file = GdalUtils.writeLayerParameterToTextFile(filename='mergeInputFiles.txt', alg=self, parameters=parameters, parameter_name=self.INPUT, context=context, quote=True, executing=executing)
         arguments.append('--optfile')
-        arguments.append(listFile)
+        arguments.append(list_file)
 
         commands = []
         if isWindows():

--- a/python/plugins/processing/algs/gdal/merge.py
+++ b/python/plugins/processing/algs/gdal/merge.py
@@ -36,6 +36,7 @@ from qgis.core import (QgsRasterFileWriter,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterString,
                        QgsProcessingParameterBoolean,
+                       QgsProcessingParameterNumber,
                        QgsProcessingParameterRasterDestination,
                        QgsProcessingUtils)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
@@ -53,6 +54,8 @@ class merge(GdalAlgorithm):
     SEPARATE = 'SEPARATE'
     OPTIONS = 'OPTIONS'
     DATA_TYPE = 'DATA_TYPE'
+    NODATA_INPUT = 'NODATA_INPUT'
+    NODATA_OUTPUT = 'NODATA_OUTPUT'
     OUTPUT = 'OUTPUT'
 
     TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
@@ -70,6 +73,22 @@ class merge(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterBoolean(self.SEPARATE,
                                                         self.tr('Place each input file into a separate band'),
                                                         defaultValue=False))
+
+        nodata_param = QgsProcessingParameterNumber(self.NODATA_INPUT,
+                                                    self.tr('Input pixel value to treat as "nodata"'),
+                                                    type=QgsProcessingParameterNumber.Integer,
+                                                    defaultValue=None,
+                                                    optional=True)
+        nodata_param.setFlags(nodata_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(nodata_param)
+
+        nodata_out_param = QgsProcessingParameterNumber(self.NODATA_OUTPUT,
+                                                    self.tr('Assign specified "nodata" value to output'),
+                                                    type=QgsProcessingParameterNumber.Integer,
+                                                    defaultValue=None,
+                                                    optional=True)
+        nodata_out_param.setFlags(nodata_out_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(nodata_out_param)
 
         options_param = QgsProcessingParameterString(self.OPTIONS,
                                                      self.tr('Additional creation parameters'),
@@ -114,6 +133,16 @@ class merge(GdalAlgorithm):
 
         if self.parameterAsBool(parameters, self.SEPARATE, context):
             arguments.append('-separate')
+
+        if self.NODATA_INPUT in parameters and parameters[self.NODATA_INPUT] is not None:
+            nodata_input = self.parameterAsInt(parameters, self.NODATA_INPUT, context)
+            arguments.append('-n')
+            arguments.append(str(nodata_input))
+
+        if self.NODATA_OUTPUT in parameters and parameters[self.NODATA_OUTPUT] is not None:
+            nodata_output = self.parameterAsInt(parameters, self.NODATA_OUTPUT, context)
+            arguments.append('-a_nodata')
+            arguments.append(str(nodata_output))
 
         arguments.append('-ot')
         arguments.append(self.TYPES[self.parameterAsEnum(parameters, self.DATA_TYPE, context)])

--- a/python/plugins/processing/algs/gdal/merge.py
+++ b/python/plugins/processing/algs/gdal/merge.py
@@ -36,7 +36,8 @@ from qgis.core import (QgsRasterFileWriter,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterString,
                        QgsProcessingParameterBoolean,
-                       QgsProcessingParameterRasterDestination)
+                       QgsProcessingParameterRasterDestination,
+                       QgsProcessingUtils)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 from processing.algs.gdal.GdalUtils import GdalUtils
 
@@ -105,7 +106,6 @@ class merge(GdalAlgorithm):
         return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'merge.png'))
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
-        layers = self.parameterAsLayerList(parameters, self.INPUT, context)
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
 
         arguments = []
@@ -128,8 +128,17 @@ class merge(GdalAlgorithm):
         arguments.append('-o')
         arguments.append(out)
 
-        for layer in layers:
-            arguments.append(layer.source())
+        # Always write input files to a text file in case there are many of them and the
+        # length of the command will be longer then allowed in command prompt
+        listFile = os.path.join(QgsProcessingUtils.tempFolder(), 'mergeInputFiles.txt')
+        with open(listFile, 'w') as f:
+            if executing:
+                layers = []
+                for l in self.parameterAsLayerList(parameters, self.INPUT, context):
+                    layers.append('"' + l.source() + '"')
+                f.write('\n'.join(layers))
+        arguments.append('--optfile')
+        arguments.append(listFile)
 
         commands = []
         if isWindows():


### PR DESCRIPTION
Otherwise command fails when attempting to merge many rasters due to length of command line. Now the algorithm uses the same approach as buildvrt and creates a text file containing the names of the rasters and then passes this to the gdal_merge command

Fixes gdal merge algorithm fails with many input files
