### PR TITLE
[processing][gdal] Skip expensive parameter validation when just showing command in dialog

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py
@@ -113,7 +113,7 @@ class GdalParametersPanel(ParametersPanel):
                     parameters[output.name()] = self.tr("[temporary file]")
             for p in self.alg.parameterDefinitions():
                 if (not p.name() in parameters and not p.flags() & QgsProcessingParameterDefinition.FlagOptional) \
-                        or (not p.checkValueIsAcceptable(parameters[p.name()], context)):
+                        or (not p.checkValueIsAcceptable(parameters[p.name()])):
                     # not ready yet
                     self.text.setPlainText('')
                     return

--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -115,10 +115,11 @@ class buildvrt(GdalAlgorithm):
         # length of the command will be longer then allowed in command prompt
         listFile = os.path.join(QgsProcessingUtils.tempFolder(), 'buildvrtInputFiles.txt')
         with open(listFile, 'w') as f:
-            layers = []
-            for l in self.parameterAsLayerList(parameters, self.INPUT, context):
-                layers.append(l.source())
-            f.write('\n'.join(layers))
+            if executing:
+                layers = []
+                for l in self.parameterAsLayerList(parameters, self.INPUT, context):
+                    layers.append(l.source())
+                f.write('\n'.join(layers))
         arguments.append('-input_file_list')
         arguments.append(listFile)
 


### PR DESCRIPTION
Otherwise it triggers a load of the layers, which isn't required to show the command line and can be slow to do (especially for merge/buildvrt algs where many layers are used as inputs)