### PR TITLE
[processing] Add method for algorithms to preprocess parameter values

### DIFF
--- a/python/core/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/processing/qgsprocessingalgorithm.sip.in
@@ -205,6 +205,15 @@ Overridden implementations should also check this base class implementation.
 :return: true if parameters are acceptable for the algorithm.
 %End
 
+    virtual QVariantMap preprocessParameters( const QVariantMap &parameters );
+%Docstring
+Pre-processes a set of ``parameters``, allowing the algorithm to clean their
+values.
+
+This method is automatically called after users enter parameters, e.g. via the algorithm
+dialog. This method should NOT be called manually by algorithms.
+%End
+
     QgsProcessingProvider *provider() const;
 %Docstring
 Returns the provider to which this algorithm belongs.

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -116,7 +116,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 if value:
                     parameters[param.name()] = value
 
-        return parameters
+        return self.algorithm().preprocessParameters(parameters)
 
     def checkExtentCRS(self):
         unmatchingCRS = False

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -134,6 +134,8 @@ class BatchAlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                 self.setProgressText(QCoreApplication.translate('BatchAlgorithmDialog', '\nProcessing algorithm {0}/{1}…').format(count + 1, len(alg_parameters)))
                 self.setInfo(self.tr('<b>Algorithm {0} starting&hellip;</b>').format(self.algorithm().displayName()), escapeHtml=False)
 
+                parameters = self.algorithm().preprocessParameters(parameters)
+
                 feedback.pushInfo(self.tr('Input parameters:'))
                 feedback.pushCommandInfo(pformat(parameters))
                 feedback.pushInfo('')

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -98,6 +98,11 @@ bool QgsProcessingAlgorithm::checkParameterValues( const QVariantMap &parameters
   return true;
 }
 
+QVariantMap QgsProcessingAlgorithm::preprocessParameters( const QVariantMap &parameters )
+{
+  return parameters;
+}
+
 QgsProcessingProvider *QgsProcessingAlgorithm::provider() const
 {
   return mProvider;

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -233,6 +233,15 @@ class CORE_EXPORT QgsProcessingAlgorithm
                                        QgsProcessingContext &context, QString *message SIP_OUT = nullptr ) const;
 
     /**
+     * Pre-processes a set of \a parameters, allowing the algorithm to clean their
+     * values.
+     *
+     * This method is automatically called after users enter parameters, e.g. via the algorithm
+     * dialog. This method should NOT be called manually by algorithms.
+     */
+    virtual QVariantMap preprocessParameters( const QVariantMap &parameters );
+
+    /**
      * Returns the provider to which this algorithm belongs.
      */
     QgsProcessingProvider *provider() const;


### PR DESCRIPTION
Allows algorithms to pre-processes a set of parameters, allowing the algorithm to clean their values.

This method is automatically called after users enter parameters, e.g. via the algorithm dialog. This method should NOT be called manually by algorithms.
