### PR TITLE
travis postgis rebirth and relative blacklisted tests

### DIFF
--- a/.ci/travis/linux/blacklist.txt
+++ b/.ci/travis/linux/blacklist.txt
@@ -30,8 +30,4 @@ PyQgsSpatialiteProvider
 # Flaky, see https://travis-ci.org/qgis/QGIS/jobs/297708174
 PyQgsServerAccessControl
 
-# Need a local postgres installation
-PyQgsAuthManagerPKIPostgresTest
-PyQgsAuthManagerPasswordPostgresTest
-PyQgsAuthManagerOgrPostgresTest
 

--- a/.ci/travis/linux/docker-build-test.sh
+++ b/.ci/travis/linux/docker-build-test.sh
@@ -102,6 +102,14 @@ pushd /root/QGIS > /dev/null
 /root/QGIS/tests/testdata/provider/testdata_pg.sh
 popd > /dev/null # /root/QGIS
 
+##########################################################
+# Set Postgres server location inside the docker running
+# the test. This is for that tests that require
+# setting up a custom server
+#########################################################
+export QGIS_POSTGRES_EXECUTABLE_PATH=/usr/lib/postgresql/10/bin
+export QGIS_POSTGRES_SERVER_PORT=55432
+
 ###########
 # Run tests
 ###########

--- a/.docker/qgis3-build-deps.dockerfile
+++ b/.docker/qgis3-build-deps.dockerfile
@@ -6,11 +6,17 @@ LABEL Description="Docker container with QGIS dependencies" Vendor="QGIS.org" Ve
 # && echo "deb http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu xenial main" >> /etc/apt/sources.list \
 # && echo "deb-src http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu xenial main" >> /etc/apt/sources.list \
 # && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 314DF160 \
+RUN apt-get update
+RUN apt-get install -y \
+    software-properties-common \
+    tzdata
 
-RUN  apt-get update \
-  && apt-get install -y software-properties-common \
-  && apt-get update \
-  && apt-get install -y \
+# configure tzdata maually to avoid the intereactive ask installing postgresql
+RUN echo "Europe/Berlin" > /etc/timezone && dpkg-reconfigure -f noninteractive tzdata
+ENV TZ=Europe/Berlin
+
+# continue installing packages
+RUN apt-get install -y \
     bison \
     ca-certificates \
     ccache \
@@ -88,6 +94,8 @@ RUN  apt-get update \
     xfonts-base \
     xfonts-scalable \
     xvfb \
+    postgresql-all \
+    postgis \
   && pip3 install \
     psycopg2 \
     numpy \


### PR DESCRIPTION
## Description
Some integrations test are configured to not use postgres on docker due to a more detailed configuration. so it's necessary to reintroduce a postgres server that can be configured and run in the test environment.

the docker where tests run has been changed
Adding:
Postgres 10
Postgis 2.4

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
