### PR TITLE
[needs-docs] Reorganisation of contextual menu for group and layer

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -831,6 +831,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! pastes group or layer from the clipboard to layer tree
     void pasteLayer();
 
+    //! Set CRS of a layer
+    void setLayerCrs();
+    //! Assign layer CRS to project
+    void setProjectCrsFromLayer();
+
     //! copies features to internal clipboard
     void copyFeatures( QgsFeatureStore &featureStore );
     void loadGDALSublayers( const QString &uri, const QStringList &list );
@@ -1040,10 +1045,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void setLayerScaleVisibility();
     //! Zoom to nearest scale such that current layer is visible
     void zoomToLayerScale();
-    //! Set CRS of a layer
-    void setLayerCrs();
-    //! Assign layer CRS to project
-    void setProjectCrsFromLayer();
 
     /**
      * Zooms so that the pixels of the raster layer occupies exactly one screen pixel.

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -129,9 +129,9 @@ QAction *QgsLayerTreeViewDefaultActions::actionCheckAndAllChildren( QObject *par
   if ( !node || !QgsLayerTree::isGroup( node ) || node->isItemVisibilityCheckedRecursive() )
     return nullptr;
 #ifdef Q_OS_MACX
-  QAction *a = new QAction( tr( "Check and all its Children (⌘-click)" ), parent );
+  QAction *a = new QAction( tr( "Check and All its Children (⌘-click)" ), parent );
 #else
-  QAction *a = new QAction( tr( "Check and all its Children (Ctrl-click)" ), parent );
+  QAction *a = new QAction( tr( "Check and All its Children (Ctrl-click)" ), parent );
 #endif
   connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::checkAndAllChildren );
   return a;
@@ -143,9 +143,9 @@ QAction *QgsLayerTreeViewDefaultActions::actionUncheckAndAllChildren( QObject *p
   if ( !node || !QgsLayerTree::isGroup( node ) || node->isItemVisibilityUncheckedRecursive() )
     return nullptr;
 #ifdef Q_OS_MACX
-  QAction *a = new QAction( tr( "Uncheck and all its Children (⌘-click)" ), parent );
+  QAction *a = new QAction( tr( "Uncheck and All its Children (⌘-click)" ), parent );
 #else
-  QAction *a = new QAction( tr( "Uncheck and all its Children (Ctrl-click)" ), parent );
+  QAction *a = new QAction( tr( "Uncheck and All its Children (Ctrl-click)" ), parent );
 #endif
   connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::uncheckAndAllChildren );
   return a;
@@ -156,7 +156,7 @@ QAction *QgsLayerTreeViewDefaultActions::actionCheckAndAllParents( QObject *pare
   QgsLayerTreeNode *node = mView->currentNode();
   if ( !node || !QgsLayerTree::isLayer( node ) || node->isVisible() )
     return nullptr;
-  QAction *a = new QAction( tr( "Check and all its Parents" ), parent );
+  QAction *a = new QAction( tr( "Check and All its Parents" ), parent );
   connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::checkAndAllParents );
   return a;
 }

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -51,7 +51,7 @@ QAction *QgsLayerTreeViewDefaultActions::actionShowInOverview( QObject *parent )
   if ( !node )
     return nullptr;
 
-  QAction *a = new QAction( tr( "&Show in Overview" ), parent );
+  QAction *a = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionInOverview.svg" ) ), tr( "&Show in Overview" ), parent );
   connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::showInOverview );
   a->setCheckable( true );
   a->setChecked( node->customProperty( QStringLiteral( "overview" ), 0 ).toInt() );


### PR DESCRIPTION
## Description
Another change to reorganize the contextual menu for group and layers. Please let me know if it looks good to you.

<img width="310" alt="schermata 2018-03-22 alle 11 31 40" src="https://user-images.githubusercontent.com/1374682/37765466-79620f98-2dc4-11e8-8a16-f181999f365c.png">

<img width="249" alt="schermata 2018-03-22 alle 11 31 32" src="https://user-images.githubusercontent.com/1374682/37765475-7e597054-2dc4-11e8-8694-434f45a860a1.png">

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
