### PR TITLE
Fix value map field formatter doesn't work

### DIFF
--- a/src/core/fieldformatter/qgsvaluemapfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluemapfieldformatter.cpp
@@ -34,9 +34,28 @@ QString QgsValueMapFieldFormatter::representValue( QgsVectorLayer *layer, int fi
   else
     valueInternalText = value.toString();
 
-  QVariantMap map = config.value( QStringLiteral( "map" ) ).toMap();
-
-  return map.key( valueInternalText, QVariant( QStringLiteral( "(%1)" ).arg( layer->fields().at( fieldIndex ).displayString( value ) ) ).toString() );
+  const QVariant v = config.value( QStringLiteral( "map" ) );
+  const QVariantList list = v.toList();
+  if ( !list.empty() )
+  {
+    for ( const QVariant &item : list )
+    {
+      const QVariantMap map = item.toMap();
+      // no built-in Qt way to check if a map contains a value, so iterate through each value
+      for ( auto it = map.constBegin(); it != map.constEnd(); ++it )
+      {
+        if ( it.value().toString() == valueInternalText )
+          return it.key();
+      }
+    }
+    return QStringLiteral( "(%1)" ).arg( layer->fields().at( fieldIndex ).displayString( value ) );
+  }
+  else
+  {
+    // old style config
+    QVariantMap map = v.toMap();
+    return map.key( valueInternalText, QVariant( QStringLiteral( "(%1)" ).arg( layer->fields().at( fieldIndex ).displayString( value ) ) ).toString() );
+  }
 }
 
 QVariant QgsValueMapFieldFormatter::sortValue( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config, const QVariant &cache, const QVariant &value ) const

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -39,6 +39,7 @@ class TestQgsValueMapFieldFormatter(unittest.TestCase):
         fieldFormatter = QgsValueMapFieldFormatter()
 
         # Tests with different value types occurring in the value map
+        # old style config (pre 3.0)
         config = {'map': {'two': '2', 'twoandhalf': '2.5', 'NULL text': 'NULL',
                           'nothing': self.VALUEMAP_NULL_TEXT}}
         self.assertEqual(fieldFormatter.representValue(layer, 0, config, None, 2), 'two')
@@ -48,6 +49,20 @@ class TestQgsValueMapFieldFormatter(unittest.TestCase):
         self.assertEqual(fieldFormatter.representValue(layer, 3, config, None, None), 'nothing')
         self.assertEqual(fieldFormatter.representValue(layer, 4, config, None, None), 'nothing')
         self.assertEqual(fieldFormatter.representValue(layer, 5, config, None, None), 'nothing')
+
+        # new style config (post 3.0)
+        config = {'map': [{'two': '2'},
+                          {'twoandhalf': '2.5'},
+                          {'NULL text': 'NULL'},
+                          {'nothing': self.VALUEMAP_NULL_TEXT}]}
+        self.assertEqual(fieldFormatter.representValue(layer, 0, config, None, 2), 'two')
+        self.assertEqual(fieldFormatter.representValue(layer, 1, config, None, 2.5), 'twoandhalf')
+        self.assertEqual(fieldFormatter.representValue(layer, 2, config, None, 'NULL'), 'NULL text')
+        # Tests with null values of different types, if value map contains null
+        self.assertEqual(fieldFormatter.representValue(layer, 3, config, None, None), 'nothing')
+        self.assertEqual(fieldFormatter.representValue(layer, 4, config, None, None), 'nothing')
+        self.assertEqual(fieldFormatter.representValue(layer, 5, config, None, None), 'nothing')
+
         # Tests with fallback display for different value types
         config = {}
         self.assertEqual(fieldFormatter.representValue(layer, 0, config, None, 2), '(2)')


### PR DESCRIPTION
The configuration format was changed without updating the unit
tests to flag this failure.
