### PR TITLE
[FEATURE][needs-docs] Move layer or group to top of layer panel

### DIFF
--- a/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -53,7 +53,14 @@ Action to check a group and all its parents
     QAction *actionZoomToGroup( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
 
     QAction *actionMakeTopLevel( QObject *parent = 0 ) /Factory/;
+
     QAction *actionMoveToTop( QObject *parent = 0 ) /Factory/;
+%Docstring
+
+.. seealso:: :py:func:`moveToTop`
+
+.. versionadded:: 3.2
+%End
     QAction *actionGroupSelected( QObject *parent = 0 ) /Factory/;
 
     QAction *actionMutuallyExclusiveGroup( QObject *parent = 0 ) /Factory/;
@@ -77,7 +84,14 @@ Action to enable/disable mutually exclusive flag of a group (only one child node
     void zoomToLayer();
     void zoomToGroup();
     void makeTopLevel();
+
     void moveToTop();
+%Docstring
+Moves selected layer(s) and/or group(s) to the top of the layer panel
+or the top of the group if the layer/group is placed within a group.
+
+.. versionadded:: 3.2
+%End
     void groupSelected();
 
     void mutuallyExclusiveGroup();

--- a/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -53,6 +53,7 @@ Action to check a group and all its parents
     QAction *actionZoomToGroup( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
 
     QAction *actionMakeTopLevel( QObject *parent = 0 ) /Factory/;
+    QAction *actionMoveToTop( QObject *parent = 0 ) /Factory/;
     QAction *actionGroupSelected( QObject *parent = 0 ) /Factory/;
 
     QAction *actionMutuallyExclusiveGroup( QObject *parent = 0 ) /Factory/;
@@ -76,6 +77,7 @@ Action to enable/disable mutually exclusive flag of a group (only one child node
     void zoomToLayer();
     void zoomToGroup();
     void makeTopLevel();
+    void moveToTop();
     void groupSelected();
 
     void mutuallyExclusiveGroup();

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -102,6 +102,11 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       menu->addAction( actions->actionUncheckAndAllChildren( menu ) );
 
+      if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == 0 ) )
+      {
+        menu->addAction( actions->actionMoveToTop( menu ) );
+      }
+
       menu->addSeparator();
 
       if ( mView->selectedNodes( true ).count() >= 2 )
@@ -119,8 +124,6 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       connect( actionSaveAsDefinitionGroup, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
       menuExportGroup->addAction( actionSaveAsDefinitionGroup );
 
-      if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == 0 ) )
-        menu->addAction( actions->actionMoveToTop( menu ) );
       menu->addMenu( menuExportGroup );
     }
     else if ( QgsLayerTree::isLayer( node ) )
@@ -168,6 +171,11 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       if ( node->parent() != mView->layerTreeModel()->rootGroup() )
         menu->addAction( actions->actionMakeTopLevel( menu ) );
+
+      if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == 0 ) )
+      {
+        menu->addAction( actions->actionMoveToTop( menu ) );
+      }
 
       QAction *checkAll = actions->actionCheckAndAllParents( menu );
       if ( checkAll )
@@ -296,8 +304,6 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         QgisApp *app = QgisApp::instance();
         menuStyleManager->addAction( tr( "Copy Style" ), app, SLOT( copyStyle() ) );
 
-      if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == 0 ) )
-        menu->addAction( actions->actionMoveToTop( menu ) );
         if ( app->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
         {
           menuStyleManager->addAction( tr( "Paste Style" ), app, SLOT( pasteStyle() ) );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -118,6 +118,9 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       QAction *actionSaveAsDefinitionGroup = new QAction( tr( "Save as Layer Definition File…" ), menuExportGroup );
       connect( actionSaveAsDefinitionGroup, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
       menuExportGroup->addAction( actionSaveAsDefinitionGroup );
+
+      if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == 0 ) )
+        menu->addAction( actions->actionMoveToTop( menu ) );
       menu->addMenu( menuExportGroup );
     }
     else if ( QgsLayerTree::isLayer( node ) )
@@ -292,6 +295,9 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         QgisApp *app = QgisApp::instance();
         menuStyleManager->addAction( tr( "Copy Style" ), app, SLOT( copyStyle() ) );
+
+      if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == 0 ) )
+        menu->addAction( actions->actionMoveToTop( menu ) );
         if ( app->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
         {
           menuStyleManager->addAction( tr( "Paste Style" ), app, SLOT( pasteStyle() ) );

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -363,7 +363,8 @@ void QgsLayerTreeViewDefaultActions::moveToTop()
 {
   QMap <QgsLayerTreeGroup *, int> groupInsertIdx;
   int insertIdx;
-  Q_FOREACH ( QgsLayerTreeNode *n, mView->selectedNodes() )
+  const QList< QgsLayerTreeNode * >  selectedNodes = mView->selectedNodes();
+  for ( QgsLayerTreeNode *n : selectedNodes )
   {
     QgsLayerTreeGroup *parentGroup = qobject_cast<QgsLayerTreeGroup *>( n->parent() );
     QgsLayerTreeNode *clonedNode = n->clone();

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -113,6 +113,13 @@ QAction *QgsLayerTreeViewDefaultActions::actionMakeTopLevel( QObject *parent )
   return a;
 }
 
+QAction *QgsLayerTreeViewDefaultActions::actionMoveToTop( QObject *parent )
+{
+  QAction *a = new QAction( tr( "Move to &Top" ), parent );
+  connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::moveToTop );
+  return a;
+}
+
 QAction *QgsLayerTreeViewDefaultActions::actionGroupSelected( QObject *parent )
 {
   QAction *a = new QAction( tr( "&Group Selected" ), parent );
@@ -352,6 +359,27 @@ void QgsLayerTreeViewDefaultActions::makeTopLevel()
   }
 }
 
+void QgsLayerTreeViewDefaultActions::moveToTop()
+{
+  QMap <QgsLayerTreeGroup *, int> groupInsertIdx;
+  int insertIdx;
+  Q_FOREACH ( QgsLayerTreeNode *n, mView->selectedNodes() )
+  {
+    QgsLayerTreeGroup *parentGroup = qobject_cast<QgsLayerTreeGroup *>( n->parent() );
+    QgsLayerTreeNode *clonedNode = n->clone();
+    if ( groupInsertIdx.contains( parentGroup ) )
+    {
+      insertIdx = groupInsertIdx.value( parentGroup );
+    }
+    else
+    {
+      insertIdx = 0;
+    }
+    parentGroup->insertChildNode( insertIdx, clonedNode );
+    parentGroup->removeChildNode( n );
+    groupInsertIdx.insert( parentGroup, insertIdx + 1 );
+  }
+}
 
 void QgsLayerTreeViewDefaultActions::groupSelected()
 {

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -62,6 +62,7 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     // TODO: zoom to selected
 
     QAction *actionMakeTopLevel( QObject *parent = nullptr ) SIP_FACTORY;
+    QAction *actionMoveToTop( QObject *parent = nullptr ) SIP_FACTORY;
     QAction *actionGroupSelected( QObject *parent = nullptr ) SIP_FACTORY;
 
     /**
@@ -84,6 +85,7 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     void zoomToLayer();
     void zoomToGroup();
     void makeTopLevel();
+    void moveToTop();
     void groupSelected();
 
     /**

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -62,6 +62,11 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     // TODO: zoom to selected
 
     QAction *actionMakeTopLevel( QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * \see moveToTop()
+     * \since QGIS 3.2
+     */
     QAction *actionMoveToTop( QObject *parent = nullptr ) SIP_FACTORY;
     QAction *actionGroupSelected( QObject *parent = nullptr ) SIP_FACTORY;
 
@@ -85,6 +90,12 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     void zoomToLayer();
     void zoomToGroup();
     void makeTopLevel();
+
+    /**
+     * Moves selected layer(s) and/or group(s) to the top of the layer panel
+     * or the top of the group if the layer/group is placed within a group.
+     * \since QGIS 3.2
+     */
     void moveToTop();
     void groupSelected();
 

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -19,10 +19,14 @@ import os
 from qgis.core import (
     QgsLayerTreeModel,
     QgsProject,
-    QgsVectorLayer
+    QgsVectorLayer,
+    QgsLayerTreeLayer,
+    QgsLayerTree,
 )
-from qgis.gui import (QgsLayerTreeView,
-                      QgsLayerTreeViewDefaultActions)
+from qgis.gui import (
+    QgsLayerTreeView,
+    QgsLayerTreeViewDefaultActions,
+)
 from qgis.testing import start_app, unittest
 from utilities import (unitTestDataPath)
 from qgis.PyQt.QtCore import QStringListModel
@@ -46,8 +50,25 @@ class TestQgsLayerTreeView(unittest.TestCase):
                                      "layer2", "memory")
         self.layer3 = QgsVectorLayer("Point?field=fldtxt:string",
                                      "layer3", "memory")
+        self.layer4 = QgsVectorLayer("Point?field=fldtxt:string",
+                                     "layer4", "memory")
+        self.layer5 = QgsVectorLayer("Point?field=fldtxt:string",
+                                     "layer5", "memory")
         self.project.addMapLayers([self.layer, self.layer2, self.layer3])
         self.model = QgsLayerTreeModel(self.project.layerTreeRoot())
+
+    def nodeOrder(self, group):
+        nodeorder = []
+        layerTree = QgsLayerTree()
+        for node in group:
+            if QgsLayerTree.isGroup(node):
+                groupname = node.name()
+                nodeorder.append(groupname)
+                for child in self.nodeOrder(node.children()):
+                    nodeorder.append(groupname + '-' + child)
+            elif QgsLayerTree.isLayer(node):
+                nodeorder.append(node.layer().name())
+        return nodeorder
 
     def testSetModel(self):
         view = QgsLayerTreeView()
@@ -90,8 +111,8 @@ class TestQgsLayerTreeView(unittest.TestCase):
         show_in_overview.trigger()
         self.assertEqual(view.currentNode().customProperty('overview', 0), False)
 
-    def testMoveToTopAction(self):
-        """Test move to top action"""
+    def testMoveToTopActionLayer(self):
+        """Test move to top action on layer"""
         view = QgsLayerTreeView()
         view.setModel(self.model)
         actions = QgsLayerTreeViewDefaultActions(view)
@@ -100,6 +121,67 @@ class TestQgsLayerTreeView(unittest.TestCase):
         movetotop = actions.actionMoveToTop()
         movetotop.trigger()
         self.assertEqual(self.project.layerTreeRoot().layerOrder(), [self.layer3, self.layer, self.layer2])
+
+    def testMoveToTopActionGroup(self):
+        """Test move to top action on group"""
+        view = QgsLayerTreeView()
+        group = self.project.layerTreeRoot().addGroup("embeddedgroup")
+        group.addLayer(self.layer4)
+        group.addLayer(self.layer5)
+        groupname = group.name()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+        ])
+
+        nodeLayerIndex = self.model.node2index(group)
+        view.setCurrentIndex(nodeLayerIndex)
+        movetotop = actions.actionMoveToTop()
+        movetotop.trigger()
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+        ])
+
+    def testMoveToTopActionEmbeddedGroup(self):
+        """Test move to top action on embeddedgroup layer"""
+        view = QgsLayerTreeView()
+        group = self.project.layerTreeRoot().addGroup("embeddedgroup")
+        group.addLayer(self.layer4)
+        group.addLayer(self.layer5)
+        groupname = group.name()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+        ])
+
+        view.setCurrentLayer(self.layer5)
+        movetotop = actions.actionMoveToTop()
+        movetotop.trigger()
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer5.name(),
+            groupname + '-' + self.layer4.name(),
+        ])
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -90,6 +90,17 @@ class TestQgsLayerTreeView(unittest.TestCase):
         show_in_overview.trigger()
         self.assertEqual(view.currentNode().customProperty('overview', 0), False)
 
+    def testMoveToTopAction(self):
+        """Test move to top action"""
+        view = QgsLayerTreeView()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.project.layerTreeRoot().layerOrder(), [self.layer, self.layer2, self.layer3])
+        view.setCurrentLayer(self.layer3)
+        movetotop = actions.actionMoveToTop()
+        movetotop.trigger()
+        self.assertEqual(self.project.layerTreeRoot().layerOrder(), [self.layer3, self.layer, self.layer2])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A feature that moves the layer(s) or group(s) to the top of the layer panel. This code implements the feature request: https://issues.qgis.org/issues/16936.

## Description
**The reason behind the new feature:**
This functionality is developed to make it easier to move a layer, layers or group(s) with layers to the top of the layer panel. This is especially a useful feature when the layer panel contains a lot of layers. Without this functionality, a user needs to drag the layer with the mouse to the top of the layer panel. This is cumbersome when the layer panel contains a lot of layers. Furthermore, sometimes it’s a little bit difficult to drop the layer at the correct place at the very top of the layer panel. When I switched from ArcMap to QGIS, this was one of the features that I missed in QGIS, especially when I add a layer to my QGIS-project, and then it is placed somewhere in the layer panel (just above the selected layer), quite often I want to have this layer at the very top – with this new feature, I just click on the layer and select ‘Move to Top’.

**Description of the new feature**
This code adds the ‘Move to Top’-functionality to the context menu in the layer panel. This is the menu that appears when right-clicking on a layer/layers or a group/groups in the layer panel. 
The feature works this way:
-	One layer (not in a group): 
	When the user right clicks on one layer (not in a group) and select ‘Move to Top’, the layer is moved to the very top of the layer panel.
-	Multiple layers (none of these are in a group): 
	When the user has selected more than one layer, right clicks on one of them and select ‘Move to Top’, the selected layers are all move to the very top of the layer panel – and with the same order as before.
-	Group(s) with layers: 
	When the user right clicks on a group with layers and select ‘Move to Top’, the group(s) - with all the layers in the group – is/are moved to the top of the layer panel.
-	One layer or more layers in a group: 
	When the user clicks on one layer or more layers within a group, the layer(s) is/are moved to the top of this group. I think this is the most intuitive way to handle this case. If a user wants to move a layer in a group to the top of the layer panel. The workflow would be first to use the ‘Make top level’-function to move a layer out of the group(s) and then use the ‘Move to top’ to move the layer to the top of the layer panel.

To avoid displaying the functionality where it does not make any purpose – i.e. if user clicks on a layer or a group that is already at the top, the code checks if this is the case and decide whether to show the functionality or not.

Currently the functionality is displayed below the ‘Make top level’ in the context menu. I think it make sense to have this feature below or above ‘Make top level’, but maybe all the different functions sometime in the future should be rearranged into something more intuitive order (I think having Properties as the last one would make more sense – but this is of cause not related to this feature request).

**Note**
The current feature ‘Make top level’ is available when a layer is in a group. When a user clicks on ‘Make top level’ the layer is moved out of the group(s). I suggest that the name of this currently feature is changed from ‘Make top level’ to either ‘Move out of group’ or ‘Ungroup’. I think this name change will make it clearer what the feature does and avoid confusion with the new feature ‘Move to Top’. 


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit