### PR TITLE
 [layouts] Fix data defined page sizes sometimes lead to incorrect created atlas image sizes

### DIFF
--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -169,6 +169,16 @@ QImage QgsLayoutExporter::renderPageToImage( int page, QSize imageSize, double d
   ( void )restorer;
 
   QRectF paperRect = QRectF( pageItem->pos().x(), pageItem->pos().y(), pageItem->rect().width(), pageItem->rect().height() );
+
+  if ( imageSize.isValid() && ( !qgsDoubleNear( static_cast< double >( imageSize.width() ) / imageSize.height(),
+                                paperRect.width() / paperRect.height(), 0.008 ) ) )
+  {
+    // specified image size is wrong aspect ratio for paper rect - so ignore it and just use dpi
+    // this can happen e.g. as a result of data defined page sizes
+    // see https://issues.qgis.org/issues/18534
+    imageSize = QSize();
+  }
+
   return renderRegionToImage( paperRect, imageSize, dpi );
 }
 

--- a/tests/src/python/test_qgslayoutexporter.py
+++ b/tests/src/python/test_qgslayoutexporter.py
@@ -378,12 +378,21 @@ class TestQgsLayoutExporter(unittest.TestCase):
 
         # image size
         settings.imageSize = QSize(600, 851)
-
         rendered_file_path = os.path.join(self.basetestpath, 'test_exporttoimagesize.png')
         self.assertEqual(exporter.exportToImage(rendered_file_path, settings), QgsLayoutExporter.Success)
         self.assertFalse(os.path.exists(rendered_file_path))
         page2_path = os.path.join(self.basetestpath, 'test_exporttoimagesize_2.png')
         self.assertTrue(self.checkImage('exporttoimagesize_page2', 'exporttoimagesize_page2', page2_path))
+
+        # image size with incorrect aspect ratio
+        # this can happen as a result of data defined page sizes
+        settings.imageSize = QSize(851, 600)
+        rendered_file_path = os.path.join(self.basetestpath, 'test_exporttoimagesizebadaspect.png')
+        self.assertEqual(exporter.exportToImage(rendered_file_path, settings), QgsLayoutExporter.Success)
+
+        page2_path = os.path.join(self.basetestpath, 'test_exporttoimagesizebadaspect_2.png')
+        im = QImage(page2_path)
+        self.assertTrue(self.checkImage('exporttoimagesize_badaspect', 'exporttoimagedpi_page2', page2_path), '{}x{}'.format(im.width(), im.height()))
 
     def testExportToPdf(self):
         md = QgsProject.instance().metadata()


### PR DESCRIPTION
Because the exporter prefers to use the image size when it's
specified (as is done in QGIS app), we need to ignore this
when the aspect ratio of that size doesn't match the aspect
ratio of the page to render.

Fixes #18534
