### PR TITLE
Improve copyright decorator default string

### DIFF
--- a/src/app/qgsdecorationcopyright.cpp
+++ b/src/app/qgsdecorationcopyright.cpp
@@ -59,14 +59,11 @@ void QgsDecorationCopyright::projectRead()
 {
   QgsDecorationItem::projectRead();
 
-  QDate now = QDate::currentDate();
-  QString defaultString = QString( "%1 %2 %3" ).arg( QChar( 0x00A9 ), QgsProject::instance()->metadata().author(), now.toString( QStringLiteral( "yyyy" ) ) );
-
   // there is no font setting in the UI, so just use the Qt/QGIS default font (what mQFont gets when created)
   //  mQFont.setFamily( QgsProject::instance()->readEntry( "CopyrightLabel", "/FontName", "Sans Serif" ) );
   //  mQFont.setPointSize( QgsProject::instance()->readNumEntry( "CopyrightLabel", "/FontSize", 9 ) );
 
-  mLabelText = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Label" ), defaultString );
+  mLabelText = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Label" ), QString() );
   mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
   mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
   mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );

--- a/src/app/qgsdecorationcopyright.cpp
+++ b/src/app/qgsdecorationcopyright.cpp
@@ -60,13 +60,13 @@ void QgsDecorationCopyright::projectRead()
   QgsDecorationItem::projectRead();
 
   QDate now = QDate::currentDate();
-  QString defString = "&copy; QGIS " + now.toString( QStringLiteral( "yyyy" ) );
+  QString defaultString = QString( "%1 %2 %3" ).arg( QChar( 0x00A9 ), QgsProject::instance()->metadata().author(), now.toString( QStringLiteral( "yyyy" ) ) );
 
   // there is no font setting in the UI, so just use the Qt/QGIS default font (what mQFont gets when created)
   //  mQFont.setFamily( QgsProject::instance()->readEntry( "CopyrightLabel", "/FontName", "Sans Serif" ) );
   //  mQFont.setPointSize( QgsProject::instance()->readNumEntry( "CopyrightLabel", "/FontSize", 9 ) );
 
-  mLabelText = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Label" ), defString );
+  mLabelText = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Label" ), defaultString );
   mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
   mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
   mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );

--- a/src/app/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/qgsdecorationcopyrightdialog.cpp
@@ -46,8 +46,19 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   connect( applyButton, &QAbstractButton::clicked, this, &QgsDecorationCopyrightDialog::apply );
 
   grpEnable->setChecked( mDeco.enabled() );
-  // text
-  txtCopyrightText->setPlainText( mDeco.mLabelText );
+
+  // label text
+  if ( !mDeco.enabled() && mDeco.mLabelText.isEmpty() )
+  {
+    QDate now = QDate::currentDate();
+    QString defaultString = QString( "%1 %2 %3" ).arg( QChar( 0x00A9 ), QgsProject::instance()->metadata().author(), now.toString( QStringLiteral( "yyyy" ) ) );
+    txtCopyrightText->setPlainText( defaultString );
+  }
+  else
+  {
+    txtCopyrightText->setPlainText( mDeco.mLabelText );
+  }
+
   // placement
   cboPlacement->addItem( tr( "Top left" ), QgsDecorationItem::TopLeft );
   cboPlacement->addItem( tr( "Top right" ), QgsDecorationItem::TopRight );


### PR DESCRIPTION
## Description
Instead of using (c) QGIS YYYY, rely on @nyalldawson 's recent work adding project metadata to insert the author name. It's a more useful default string, and might help avoid a misconception about ownership of maps produced in QGIS (a problem @NathanW2  recently raised on twitter et cie).

Also, instead of showing the not so friendly HTML "&copy;" expression, the default string now simply uses the © unicode character.

Before vs. PR:
![screenshot from 2018-03-26 15-08-57](https://user-images.githubusercontent.com/1728657/37894508-a9c14388-3108-11e8-8bad-59521cd5bb7f.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
