### PR TITLE
[bugfix] Fixes identify action on deactivated rules for QgsRuleBasedRenderer

### DIFF
--- a/python/core/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/core/symbology/qgsrulebasedrenderer.sip.in
@@ -324,7 +324,7 @@ Returns which legend keys match the feature
 .. versionadded:: 2.14
 %End
 
-        QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = 0, bool withElse = true, bool onlyActive = true );
+        QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = 0, bool onlyActive = true );
 %Docstring
 tell which rules will be used to render the feature
 %End

--- a/python/core/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/core/symbology/qgsrulebasedrenderer.sip.in
@@ -326,7 +326,12 @@ Returns which legend keys match the feature
 
         QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = 0, bool onlyActive = true );
 %Docstring
-tell which rules will be used to render the feature
+Returns the list of rules used to render the feature in a specific
+context.
+
+:param feat: The feature for which rules have to be find
+:param context: The rendering context
+:param onlyActive: True to search for active rules only, false otherwise
 %End
 
         void stopRender( QgsRenderContext &context );

--- a/python/core/symbology/qgsrulebasedrenderer.sip.in
+++ b/python/core/symbology/qgsrulebasedrenderer.sip.in
@@ -324,7 +324,7 @@ Returns which legend keys match the feature
 .. versionadded:: 2.14
 %End
 
-        QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = 0 );
+        QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = 0, bool withElse = true, bool onlyActive = true );
 %Docstring
 tell which rules will be used to render the feature
 %End
@@ -411,7 +411,7 @@ Sets if this rule is an ELSE rule
 :param iselse: If true, this rule is an ELSE rule
 %End
 
-        bool isElse();
+        bool isElse() const;
 %Docstring
 Check if this rule is an ELSE rule
 

--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -553,7 +553,9 @@ bool QgsRuleBasedRenderer::Rule::willRenderFeature( QgsFeature &feat, QgsRenderC
       lst.removeOne( rule );
 
       if ( lst.empty() )
+      {
         return true;
+      }
     }
     else if ( !rule->isElse( ) && rule->willRenderFeature( feat, context ) )
     {
@@ -587,7 +589,26 @@ QSet<QString> QgsRuleBasedRenderer::Rule::legendKeysForFeature( QgsFeature &feat
 
   Q_FOREACH ( Rule *rule, mActiveChildren )
   {
-    lst.unite( rule->legendKeysForFeature( feat, context ) );
+    bool validKey = false;
+    if ( rule->isElse() )
+    {
+      RuleList lst = rulesForFeature( feat, context, false );
+      lst.removeOne( rule );
+
+      if ( lst.empty() )
+      {
+        validKey = true;
+      }
+    }
+    else if ( !rule->isElse( ) && rule->willRenderFeature( feat, context ) )
+    {
+      validKey = true;
+    }
+
+    if ( validKey )
+    {
+      lst.unite( rule->legendKeysForFeature( feat, context ) );
+    }
   }
   return lst;
 }

--- a/src/core/symbology/qgsrulebasedrenderer.h
+++ b/src/core/symbology/qgsrulebasedrenderer.h
@@ -343,7 +343,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
         QSet< QString > legendKeysForFeature( QgsFeature &feat, QgsRenderContext *context = nullptr );
 
         //! tell which rules will be used to render the feature
-        QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = nullptr );
+        QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = nullptr, bool withElse = true, bool onlyActive = true );
 
         /**
          * Stop a rendering process. Used to clean up the internal state of this rule
@@ -419,7 +419,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
          *
          * \returns True if this rule is an else rule
          */
-        bool isElse() { return mElseRule; }
+        bool isElse() const { return mElseRule; }
 
       protected:
         void initFilter();

--- a/src/core/symbology/qgsrulebasedrenderer.h
+++ b/src/core/symbology/qgsrulebasedrenderer.h
@@ -342,7 +342,14 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
          */
         QSet< QString > legendKeysForFeature( QgsFeature &feat, QgsRenderContext *context = nullptr );
 
-        //! tell which rules will be used to render the feature
+        /**
+         * Returns the list of rules used to render the feature in a specific
+         * context.
+         *
+         * \param feat The feature for which rules have to be find
+         * \param context The rendering context
+         * \param onlyActive True to search for active rules only, false otherwise
+         */
         QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = nullptr, bool onlyActive = true );
 
         /**

--- a/src/core/symbology/qgsrulebasedrenderer.h
+++ b/src/core/symbology/qgsrulebasedrenderer.h
@@ -343,7 +343,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
         QSet< QString > legendKeysForFeature( QgsFeature &feat, QgsRenderContext *context = nullptr );
 
         //! tell which rules will be used to render the feature
-        QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = nullptr, bool withElse = true, bool onlyActive = true );
+        QgsRuleBasedRenderer::RuleList rulesForFeature( QgsFeature &feat, QgsRenderContext *context = nullptr, bool onlyActive = true );
 
         /**
          * Stop a rendering process. Used to clean up the internal state of this rule

--- a/tests/src/python/test_qgsrulebasedrenderer.py
+++ b/tests/src/python/test_qgsrulebasedrenderer.py
@@ -40,7 +40,8 @@ from qgis.core import (QgsVectorLayer,
                        QgsRendererCategory,
                        QgsCategorizedSymbolRenderer,
                        QgsGraduatedSymbolRenderer,
-                       QgsRendererRange
+                       QgsRendererRange,
+                       QgsRenderContext
                        )
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -100,6 +101,27 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
         result = renderchecker.runTest('rulebased_disabled_else')
 
         assert result
+
+    def testWillRenderFeature(self):
+        vl = self.mapsettings.layers()[0]
+        ft = vl.getFeature(0) # 'id' = 1
+        renderer = vl.renderer()
+
+        ctx = QgsRenderContext.fromMapSettings(self.mapsettings)
+        ctx.expressionContext().setFeature(ft)
+
+        renderer.rootRule().children()[0].setActive(False)
+        renderer.rootRule().children()[1].setActive(True)
+        renderer.rootRule().children()[2].setActive(True)
+
+        renderer.startRender(ctx, vl.fields()) # build mActiveChlidren
+
+        rendered = renderer.willRenderFeature(ft, ctx)
+        renderer.rootRule().children()[0].setActive(True)
+        assert rendered == False
+
+        rendered = renderer.willRenderFeature(ft, ctx)
+        assert rendered == True
 
     def testRefineWithCategories(self):
         # Test refining rule with categories (refs #10815)

--- a/tests/src/python/test_qgsrulebasedrenderer.py
+++ b/tests/src/python/test_qgsrulebasedrenderer.py
@@ -115,12 +115,14 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
         renderer.rootRule().children()[2].setActive(True)
 
         renderer.startRender(ctx, vl.fields()) # build mActiveChlidren
-
         rendered = renderer.willRenderFeature(ft, ctx)
+        renderer.stopRender(ctx)
         renderer.rootRule().children()[0].setActive(True)
         assert rendered == False
 
+        renderer.startRender(ctx, vl.fields()) # build mActiveChlidren
         rendered = renderer.willRenderFeature(ft, ctx)
+        renderer.stopRender(ctx)
         assert rendered == True
 
     def testRefineWithCategories(self):

--- a/tests/src/python/test_qgsrulebasedrenderer.py
+++ b/tests/src/python/test_qgsrulebasedrenderer.py
@@ -125,6 +125,29 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
         renderer.stopRender(ctx)
         assert rendered == True
 
+    def testFeatureCount(self):
+        vl = self.mapsettings.layers()[0]
+        ft = vl.getFeature(2) # 'id' = 3 => ELSE
+        renderer = vl.renderer()
+
+        ctx = QgsRenderContext.fromMapSettings(self.mapsettings)
+        ctx.expressionContext().setFeature(ft)
+
+        counter = vl.countSymbolFeatures()
+        counter.waitForFinished()
+
+        renderer.startRender(ctx, vl.fields())
+
+        elseRule = None
+        for rule in renderer.rootRule().children():
+            if rule.filterExpression() == 'ELSE':
+                elseRule = rule
+
+        assert elseRule != None
+
+        cnt = counter.featureCount(elseRule.ruleKey())
+        assert cnt == 1
+
     def testRefineWithCategories(self):
         # Test refining rule with categories (refs #10815)
 


### PR DESCRIPTION
## Description

This PR fixes an issue raised by @lbartoletti during its work on https://github.com/qgis/QGIS/pull/6657#issuecomment-375634020.

Actually, if a `ELSE` rule is defined and activated within the rule based renderer, then all others rules are valid even if they're deactivated. Then, an identify action can be done on invisible features.

A video is available, allowing to highlight the issue: https://github.com/lbartoletti/lbartoletti.github.io/tree/master/willRenderFeature.

A unit test has been added to test the underlying `willRenderFeature` method.


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
