### PR TITLE
Adding a context to QgsCoordinateTransform.

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -47,6 +47,7 @@
 #include "qgsexception.h"
 #include "qgssettings.h"
 #include "qgsogrutils.h"
+#include "qgsproject.h"
 
 #ifdef HAVE_GUI
 #include "qgswmssourceselect.h"
@@ -1189,7 +1190,7 @@ void QgsWmsProvider::setupXyzCapabilities( const QString &uri )
   parsedUri.setEncodedUri( uri );
 
   Q_NOWARN_DEPRECATED_PUSH
-  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( mSettings.mCrsId ) );
+  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( mSettings.mCrsId ), QgsProject::instance() );
   Q_NOWARN_DEPRECATED_POP
 
   // the whole world is projected to a square:


### PR DESCRIPTION
This should silence all the xyz warnings, see issue #18533

## Description
Currently when you add an xyz layer, and have a debug build of QGIS, the Qt tab in your MessagesLog will be filled with:
`WARNING    No QgsCoordinateTransformContext context set for transform`

Looking into some other code, it appears it can be silenced by adding a 'context' from the project.

Not sure if this is a proper way to do, to be honest. Just looked at other code parts in QGIS.
Added the context of the project, and the Warnings disappear in my setup.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
