### PR TITLE
Use QgsTextRender to power up copyright decoration styling

### DIFF
--- a/python/core/qgstextrenderer.sip.in
+++ b/python/core/qgstextrenderer.sip.in
@@ -1495,6 +1495,13 @@ and background shapes.
 %End
   public:
 
+    enum DrawMode
+    {
+      Rect,
+      Point,
+      Label,
+    };
+
     enum TextPart
     {
       Text,
@@ -1594,6 +1601,29 @@ with the text or background parts)
 :param drawAsOutlines: set to false to render text as text. This allows outputs to
 formats like SVG to maintain text as text objects, but at the cost of degraded
 rendering and may result in side effects like misaligned text buffers.
+%End
+
+    static double textWidth( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines,
+                             QFontMetricsF *fontMetrics = 0 );
+%Docstring
+Returns the width of a text based on a given format.
+
+:param context: render context
+:param format: text format
+:param textLines: list of lines of text to calculate width from
+:param fontMetrics: font metrics
+%End
+
+    static double textHeight( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines, DrawMode mode,
+                              QFontMetricsF *fontMetrics = 0 );
+%Docstring
+Returns the height of a text based on a given format.
+
+:param context: render context
+:param format: text format
+:param textLines: list of lines of text to calculate width from
+:param mode: draw mode
+:param fontMetrics: font metrics
 %End
 
 };

--- a/src/app/qgsdecorationcopyright.h
+++ b/src/app/qgsdecorationcopyright.h
@@ -20,6 +20,7 @@
 #define QGSCOPYRIGHTLABELPLUGIN
 
 #include "qgsdecorationitem.h"
+#include "qgstextrenderer.h"
 
 #include <QColor>
 #include <QFont>
@@ -49,18 +50,31 @@ class APP_EXPORT QgsDecorationCopyright : public QgsDecorationItem
     //! render the copyright label
     void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
 
+    /**
+     * Returns the text format for extent labels.
+     * \see setTextFormat()
+     * \see labelExtents()
+     * \since QGIS 3.2
+     */
+    QgsTextFormat textFormat() const { return mTextFormat; }
+
+    /**
+     * Sets the text \a format for extent labels.
+     * \see textFormat()
+     * \see setLabelExtents()
+     * \since QGIS 3.2
+     */
+    void setTextFormat( const QgsTextFormat &format ) { mTextFormat = format; }
+
   private:
-    //! This is the font that will be used for the copyright label
-    QFont mQFont;
     //! This is the string that will be used for the copyright label
     QString mLabelText;
-
-    //! This is the color for the copyright label
-    QColor mColor;
 
     //! enable or disable use of position percentage for placement
     int mMarginHorizontal = 0;
     int mMarginVertical = 0;
+
+    QgsTextFormat mTextFormat;
 
     friend class QgsDecorationCopyrightDialog;
 };

--- a/src/app/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/qgsdecorationcopyrightdialog.cpp
@@ -36,7 +36,6 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsDecorationCopyrightDialog::buttonBox_accepted );
   connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsDecorationCopyrightDialog::buttonBox_rejected );
   connect( mInsertExpressionButton, &QPushButton::clicked, this, &QgsDecorationCopyrightDialog::mInsertExpressionButton_clicked );
-  connect( pbnColorChooser, &QgsColorButton::colorChanged, this, &QgsDecorationCopyrightDialog::pbnColorChooser_colorChanged );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDecorationCopyrightDialog::showHelp );
 
   QgsSettings settings;
@@ -48,6 +47,7 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   grpEnable->setChecked( mDeco.enabled() );
 
   // label text
+  txtCopyrightText->setAcceptRichText( false );
   if ( !mDeco.enabled() && mDeco.mLabelText.isEmpty() )
   {
     QDate now = QDate::currentDate();
@@ -70,16 +70,10 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   wgtUnitSelection->setUnits( QgsUnitTypes::RenderUnitList() << QgsUnitTypes::RenderMillimeters << QgsUnitTypes::RenderPercentage << QgsUnitTypes::RenderPixels );
   wgtUnitSelection->setUnit( mDeco.mMarginUnit );
 
-  // color
-  pbnColorChooser->setAllowOpacity( true );
-  pbnColorChooser->setColor( mDeco.mColor );
-  pbnColorChooser->setContext( QStringLiteral( "gui" ) );
-  pbnColorChooser->setColorDialogTitle( tr( "Select Text color" ) );
-
-  QTextCursor cursor = txtCopyrightText->textCursor();
-  txtCopyrightText->selectAll();
-  txtCopyrightText->setTextColor( mDeco.mColor );
-  txtCopyrightText->setTextCursor( cursor );
+  // font settings
+  mButtonFontStyle->setDialogTitle( tr( "Copyright Label Text Format" ) );
+  mButtonFontStyle->setMapCanvas( QgisApp::instance()->mapCanvas() );
+  mButtonFontStyle->setTextFormat( mDeco.textFormat() );
 }
 
 QgsDecorationCopyrightDialog::~QgsDecorationCopyrightDialog()
@@ -120,19 +114,10 @@ void QgsDecorationCopyrightDialog::mInsertExpressionButton_clicked()
   }
 }
 
-void QgsDecorationCopyrightDialog::pbnColorChooser_colorChanged( const QColor &c )
-{
-  QTextCursor cursor = txtCopyrightText->textCursor();
-  txtCopyrightText->selectAll();
-  txtCopyrightText->setTextColor( c );
-  txtCopyrightText->setTextCursor( cursor );
-}
-
 void QgsDecorationCopyrightDialog::apply()
 {
-  mDeco.mQFont = txtCopyrightText->currentFont();
+  mDeco.setTextFormat( mButtonFontStyle->textFormat() );
   mDeco.mLabelText = txtCopyrightText->toPlainText();
-  mDeco.mColor = pbnColorChooser->color();
   mDeco.setPlacement( static_cast< QgsDecorationItem::Placement>( cboPlacement->currentData().toInt() ) );
   mDeco.mMarginUnit = wgtUnitSelection->unit();
   mDeco.mMarginHorizontal = spnHorizontal->value();

--- a/src/app/qgsdecorationcopyrightdialog.h
+++ b/src/app/qgsdecorationcopyrightdialog.h
@@ -33,7 +33,6 @@ class APP_EXPORT QgsDecorationCopyrightDialog : public QDialog, private Ui::QgsD
     void buttonBox_rejected();
     void mInsertExpressionButton_clicked();
     void showHelp();
-    void pbnColorChooser_colorChanged( const QColor &c );
     void apply();
 
   protected:

--- a/src/core/qgstextrenderer.cpp
+++ b/src/core/qgstextrenderer.cpp
@@ -1897,35 +1897,35 @@ void QgsTextRenderer::drawBuffer( QgsRenderContext &context, const QgsTextRender
   p->restore();
 }
 
-double QgsTextRenderer::textWidth( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines, QFontMetricsF *fm )
+double QgsTextRenderer::textWidth( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines, QFontMetricsF *fontMetrics )
 {
   //calculate max width of text lines
   std::unique_ptr< QFontMetricsF > newFm;
-  if ( !fm )
+  if ( !fontMetrics )
   {
     newFm.reset( new QFontMetricsF( format.scaledFont( context ) ) );
-    fm = newFm.get();
+    fontMetrics = newFm.get();
   }
 
   double maxWidth = 0;
   Q_FOREACH ( const QString &line, textLines )
   {
-    maxWidth = std::max( maxWidth, fm->width( line ) );
+    maxWidth = std::max( maxWidth, fontMetrics->width( line ) );
   }
   return maxWidth;
 }
 
-double QgsTextRenderer::textHeight( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines, DrawMode mode, QFontMetricsF *fm )
+double QgsTextRenderer::textHeight( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines, DrawMode mode, QFontMetricsF *fontMetrics )
 {
   //calculate max width of text lines
   std::unique_ptr< QFontMetricsF > newFm;
-  if ( !fm )
+  if ( !fontMetrics )
   {
     newFm.reset( new QFontMetricsF( format.scaledFont( context ) ) );
-    fm = newFm.get();
+    fontMetrics = newFm.get();
   }
 
-  double labelHeight = fm->ascent() + fm->descent(); // ignore +1 for baseline
+  double labelHeight = fontMetrics->ascent() + fontMetrics->descent(); // ignore +1 for baseline
 
   switch ( mode )
   {
@@ -1938,7 +1938,7 @@ double QgsTextRenderer::textHeight( const QgsRenderContext &context, const QgsTe
     case Rect:
     case Point:
       // standard rendering - designed to exactly replicate QPainter's drawText method
-      return labelHeight + ( textLines.size() - 1 ) * fm->lineSpacing() * format.lineHeight();
+      return labelHeight + ( textLines.size() - 1 ) * fontMetrics->lineSpacing() * format.lineHeight();
   }
 
   return 0;

--- a/src/core/qgstextrenderer.h
+++ b/src/core/qgstextrenderer.h
@@ -1277,6 +1277,14 @@ class CORE_EXPORT QgsTextRenderer
 {
   public:
 
+    //! Draw mode to calculate width and height
+    enum DrawMode
+    {
+      Rect = 0, //!< Text within rectangle draw mode
+      Point, //!< Text at point of origin draw mode
+      Label, //!< Label-specific draw mode
+    };
+
     //! Components of text
     enum TextPart
     {
@@ -1374,14 +1382,28 @@ class CORE_EXPORT QgsTextRenderer
                           QgsRenderContext &context, const QgsTextFormat &format,
                           TextPart part, bool drawAsOutlines = true );
 
-  private:
+    /**
+     * Returns the width of a text based on a given format.
+     * \param context render context
+     * \param format text format
+     * \param textLines list of lines of text to calculate width from
+     * \param fontMetrics font metrics
+     */
+    static double textWidth( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines,
+                             QFontMetricsF *fontMetrics = nullptr );
 
-    enum DrawMode
-    {
-      Rect = 0,
-      Point,
-      Label,
-    };
+    /**
+     * Returns the height of a text based on a given format.
+     * \param context render context
+     * \param format text format
+     * \param textLines list of lines of text to calculate width from
+     * \param mode draw mode
+     * \param fontMetrics font metrics
+     */
+    static double textHeight( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines, DrawMode mode,
+                              QFontMetricsF *fontMetrics = nullptr );
+
+  private:
 
     struct Component
     {
@@ -1447,11 +1469,6 @@ class CORE_EXPORT QgsTextRenderer
     friend class QgsLabelPreview;
 
     static QgsTextFormat updateShadowPosition( const QgsTextFormat &format );
-
-    static double textWidth( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines,
-                             QFontMetricsF *fm = nullptr );
-    static double textHeight( const QgsRenderContext &context, const QgsTextFormat &format, const QStringList &textLines, DrawMode mode,
-                              QFontMetricsF *fm = nullptr );
 
 
 };

--- a/src/ui/qgsdecorationcopyrightdialog.ui
+++ b/src/ui/qgsdecorationcopyrightdialog.ui
@@ -134,13 +134,6 @@
       </item>
       <item row="1" column="0" colspan="3">
        <widget class="QTextEdit" name="txtCopyrightText">
-        <property name="html">
-         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Verdana'; font-size:10pt;&quot;&gt;© QGIS 2016&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
        </widget>
       </item>
       <item row="4" column="0">
@@ -181,28 +174,25 @@ p, li { white-space: pre-wrap; }
          </size>
         </property>
         <property name="text">
-         <string>Color</string>
+         <string>Font</string>
         </property>
        </widget>
       </item>
       <item row="3" column="1" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QgsColorButton" name="pbnColorChooser">
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>0</height>
-           </size>
+        <item row="3" column="1" colspan="2">
+         <widget class="QgsFontButton" name="mButtonFontStyle">
+          <property name="enabled">
+           <bool>true</bool>
           </property>
-          <property name="maximumSize">
-           <size>
-            <width>120</width>
-            <height>16777215</height>
-           </size>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
           <property name="text">
-           <string/>
+           <string>Font</string>
           </property>
          </widget>
         </item>
@@ -229,10 +219,9 @@ p, li { white-space: pre-wrap; }
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
+   <class>QgsSymbolButton</class>
    <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
+   <header>qgssymbolbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsSpinBox</class>
@@ -249,7 +238,8 @@ p, li { white-space: pre-wrap; }
  <tabstops>
   <tabstop>grpEnable</tabstop>
   <tabstop>txtCopyrightText</tabstop>
-  <tabstop>pbnColorChooser</tabstop>
+  <tabstop>mInsertExpressionButton</tabstop>
+  <tabstop>mButtonFontStyle</tabstop>
   <tabstop>cboPlacement</tabstop>
   <tabstop>spnHorizontal</tabstop>
   <tabstop>spnVertical</tabstop>


### PR DESCRIPTION
## Description
Without further due, a before vs. PR screenshot:
![screenshot from 2018-03-27 10-18-54](https://user-images.githubusercontent.com/1728657/37945087-a35449d2-31a8-11e8-8d4f-979ee69db497.png)

@nyalldawson , review appreciated.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
