### PR TITLE
Always add a dummy atlas expression context scope to canvas expression context

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -499,6 +499,7 @@ void QgsMapCanvas::refreshMap()
   QgsExpressionContext expressionContext;
   expressionContext << QgsExpressionContextUtils::globalScope()
                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+                    << QgsExpressionContextUtils::atlasScope( nullptr )
                     << QgsExpressionContextUtils::mapSettingsScope( mSettings )
                     << new QgsExpressionContextScope( mExpressionContextScope );
 


### PR DESCRIPTION


This allows the atlas variables to be correctly available before
an atlas has been first opened - e.g. for rules which render
when a feature is not the current atlas feature.

Otherwise these variables are NULL, which creates confusing behavior
when rendering differences occur before/after an atlas is opened.
