### PR TITLE
Use QgsScaleBarRenderer to power up scale bar decoration

### DIFF
--- a/python/core/scalebar/qgsscalebarrenderer.sip.in
+++ b/python/core/scalebar/qgsscalebarrenderer.sip.in
@@ -27,6 +27,7 @@ custom labeling.
 
     struct ScaleBarContext
     {
+
       double segmentWidth;
 
       QSizeF size;

--- a/src/app/qgsdecorationscalebar.cpp
+++ b/src/app/qgsdecorationscalebar.cpp
@@ -147,6 +147,7 @@ void QgsDecorationScaleBar::setupScaleBar()
     case 3:
       mStyle = qgis::make_unique< QgsSingleBoxScaleBarRenderer >();
       mSettings.setFillColor( mColor );
+      mSettings.setFillColor2( QColor( "transparent" ) );
       mSettings.setLineColor( mOutlineColor );
       mSettings.setFont( mFont );
       mSettings.setFontColor( mColor );
@@ -279,12 +280,18 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
       else
         scaleBarUnitLabel = tr( "degrees" );
       break;
+    case QgsUnitTypes::DistanceKilometers:
+    case QgsUnitTypes::DistanceNauticalMiles:
+    case QgsUnitTypes::DistanceYards:
+    case QgsUnitTypes::DistanceMiles:
+    case QgsUnitTypes::DistanceCentimeters:
+    case QgsUnitTypes::DistanceMillimeters:
     case QgsUnitTypes::DistanceUnknownUnit:
+      scaleBarUnitLabel = QgsUnitTypes::toAbbreviatedString( scaleBarUnits );
+      break;
       scaleBarUnitLabel = tr( "unknown" );
-      //intentional fall-through
-      FALLTHROUGH;
-    default:
       QgsDebugMsg( QString( "Error: not picked up map units - actual value = %1" ).arg( scaleBarUnits ) );
+      break;
   }
 
   mSettings.setUnits( scaleBarUnits );
@@ -293,7 +300,6 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
   mSettings.setUnitLabel( scaleBarUnitLabel );
 
   QgsScaleBarRenderer::ScaleBarContext scaleContext;
-  scaleContext.size = QSizeF( deviceWidth, deviceHeight );
   scaleContext.segmentWidth = mStyleIndex == 3 ? segmentSize / 2 : segmentSize;
   scaleContext.scale = mapSettings.scale();
 
@@ -328,8 +334,11 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
       originY = ( ( deviceHeight ) / 100. ) * mMarginVertical;
       break;
     }
-
-    default:  // Use default of top left
+    case QgsUnitTypes::RenderMapUnits:
+    case QgsUnitTypes::RenderPoints:
+    case QgsUnitTypes::RenderInches:
+    case QgsUnitTypes::RenderUnknownUnit:
+    case QgsUnitTypes::RenderMetersInMapUnits:
       break;
   }
 
@@ -348,8 +357,6 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
       originX = deviceWidth - originX - size.width();
       originY = deviceHeight - originY - size.height();
       break;
-    default:
-      QgsDebugMsg( "Unable to determine where to put scale bar so defaulting to top left" );
   }
 
   context.painter()->save();

--- a/src/app/qgsdecorationscalebar.cpp
+++ b/src/app/qgsdecorationscalebar.cpp
@@ -25,6 +25,7 @@ email                : sbr00pwb@users.sourceforge.net
 
 #include "qgis.h"
 #include "qgisapp.h"
+#include "qgsfontutils.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
 #include "qgsmaplayer.h"
@@ -34,6 +35,11 @@ email                : sbr00pwb@users.sourceforge.net
 #include "qgsunittypes.h"
 #include "qgssettings.h"
 #include "qgssymbollayerutils.h"
+
+#include "qgsdoubleboxscalebarrenderer.h"
+#include "qgsnumericscalebarrenderer.h"
+#include "qgssingleboxscalebarrenderer.h"
+#include "qgsticksscalebarrenderer.h"
 
 #include <QPainter>
 #include <QAction>
@@ -61,6 +67,9 @@ QgsDecorationScaleBar::QgsDecorationScaleBar( QObject *parent )
 
   setName( "Scale Bar" );
   projectRead();
+
+  mSettings.setNumberOfSegments( 1 );
+  mSettings.setNumberOfSegmentsLeft( 0 );
 }
 
 void QgsDecorationScaleBar::projectRead()
@@ -73,6 +82,23 @@ void QgsDecorationScaleBar::projectRead()
   mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
   mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
   mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
+
+  QDomDocument doc;
+  QDomElement elem;
+  QString fontXml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Font" ) );
+  if ( !fontXml.isEmpty() )
+  {
+    doc.setContent( fontXml );
+    elem = doc.documentElement();
+    QgsDebugMsg( doc.toString() );
+    QgsFontUtils::setFromXmlElement( mFont, elem );
+  }
+  else
+  {
+    mFont = QFont();
+  }
+
+  setupScaleBar();
 }
 
 void QgsDecorationScaleBar::saveToProject()
@@ -85,6 +111,11 @@ void QgsDecorationScaleBar::saveToProject()
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
+
+  QDomDocument fontDoc;
+  QDomElement font = QgsFontUtils::toXmlElement( mFont, fontDoc, QStringLiteral( "BarFont" ) );
+  fontDoc.appendChild( font );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Font" ), fontDoc.toString() );
 }
 
 
@@ -94,407 +125,235 @@ void QgsDecorationScaleBar::run()
   dlg.exec();
 }
 
-
+void QgsDecorationScaleBar::setupScaleBar()
+{
+  switch ( mStyleIndex )
+  {
+    case 0:
+    case 1:
+    {
+      std::unique_ptr< QgsTicksScaleBarRenderer > tickStyle = qgis::make_unique< QgsTicksScaleBarRenderer >();
+      tickStyle->setTickPosition( mStyleIndex == 0 ? QgsTicksScaleBarRenderer::TicksDown : QgsTicksScaleBarRenderer::TicksUp );
+      mStyle = std::move( tickStyle );
+      mSettings.setFillColor( mColor );
+      mSettings.setLineColor( mColor ); // Compatibility with pre 3.2 configuration
+      mSettings.setFont( mFont );
+      mSettings.setFontColor( mColor );
+      mSettings.setHeight( 2.2 );
+      mSettings.setLineWidth( 0.3 );
+      break;
+    }
+    case 2:
+    case 3:
+      mStyle = qgis::make_unique< QgsSingleBoxScaleBarRenderer >();
+      mSettings.setFillColor( mColor );
+      mSettings.setLineColor( mOutlineColor );
+      mSettings.setFont( mFont );
+      mSettings.setFontColor( mColor );
+      mSettings.setHeight( mStyleIndex == 2 ? 1 : 3 );
+      mSettings.setLineWidth( mStyleIndex == 2 ? 0.2 : 0.3 );
+      break;
+  }
+  mSettings.setLabelBarSpace( 1.8 );
+}
 void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRenderContext &context )
 {
-  int myBufferSize = 1; //softcode this later
+  if ( !enabled() )
+    return;
 
   //Get canvas dimensions
-  int myCanvasHeight = context.painter()->device()->height();
-  int myCanvasWidth = context.painter()->device()->width();
+  int deviceHeight = context.painter()->device()->height();
+  int deviceWidth = context.painter()->device()->width();
 
   //Get map units per pixel. This can be negative at times (to do with
   //projections) and that just confuses the rest of the code in this
   //function, so force to a positive number.
-  double myMapUnitsPerPixelDouble = std::fabs( context.mapToPixel().mapUnitsPerPixel() );
-  double myActualSize = mPreferredSize;
+  double scaleBarUnitsPerPixel = std::fabs( context.mapToPixel().mapUnitsPerPixel() );
 
   // Exit if the canvas width is 0 or layercount is 0 or QGIS will freeze
-  int myLayerCount = mapSettings.layers().count();
-  if ( !myLayerCount || !myCanvasWidth || !myMapUnitsPerPixelDouble )
+  if ( !mapSettings.layers().count() || !deviceWidth || !scaleBarUnitsPerPixel )
     return;
 
-  //Large if statement which determines whether to render the scale bar
-  if ( enabled() )
+  double unitsPerSegment = mPreferredSize;
+
+  QgsSettings settings;
+  bool ok = false;
+  QgsUnitTypes::DistanceUnit preferredUnits = QgsUnitTypes::decodeDistanceUnit( settings.value( QStringLiteral( "qgis/measure/displayunits" ) ).toString(), &ok );
+  if ( !ok )
+    preferredUnits = QgsUnitTypes::DistanceMeters;
+
+  QgsUnitTypes::DistanceUnit scaleBarUnits = mapSettings.mapUnits();
+
+  // Adjust units meter/feet/... or vice versa
+  scaleBarUnitsPerPixel *= QgsUnitTypes::fromUnitToUnitFactor( scaleBarUnits, preferredUnits );
+  scaleBarUnits = preferredUnits;
+
+  //Calculate size of scale bar for preferred number of map units
+  double scaleBarWidth = mPreferredSize / scaleBarUnitsPerPixel;
+
+  //If scale bar is very small reset to 1/4 of the canvas wide
+  if ( scaleBarWidth < 30 )
   {
-    // Hard coded sizes
-    int myMajorTickSize = 8;
-    int myTextOffsetX = 3;
-
-    QgsSettings settings;
-    bool ok = false;
-    QgsUnitTypes::DistanceUnit myPreferredUnits = QgsUnitTypes::decodeDistanceUnit( settings.value( QStringLiteral( "qgis/measure/displayunits" ) ).toString(), &ok );
-    if ( !ok )
-      myPreferredUnits = QgsUnitTypes::DistanceMeters;
-    QgsUnitTypes::DistanceUnit myMapUnits = mapSettings.mapUnits();
-
-    // Adjust units meter/feet/... or vice versa
-    myMapUnitsPerPixelDouble *= QgsUnitTypes::fromUnitToUnitFactor( myMapUnits, myPreferredUnits );
-    myMapUnits = myPreferredUnits;
-
-    //Calculate size of scale bar for preferred number of map units
-    double myScaleBarWidth = mPreferredSize / myMapUnitsPerPixelDouble;
-
-    //If scale bar is very small reset to 1/4 of the canvas wide
-    if ( myScaleBarWidth < 30 )
-    {
-      myScaleBarWidth = myCanvasWidth / 4.0; // pixels
-      myActualSize = myScaleBarWidth * myMapUnitsPerPixelDouble; // map units
-    }
-
-    //if scale bar is more than half the canvas wide keep halving until not
-    while ( myScaleBarWidth > myCanvasWidth / 3.0 )
-    {
-      myScaleBarWidth = myScaleBarWidth / 3;
-    }
-    myActualSize = myScaleBarWidth * myMapUnitsPerPixelDouble;
-
-    // Work out the exponent for the number - e.g, 1234 will give 3,
-    // and .001234 will give -3
-    double myPowerOf10 = std::floor( std::log10( myActualSize ) );
-
-    // snap to integer < 10 times power of 10
-    if ( mSnapping )
-    {
-      double scaler = std::pow( 10.0, myPowerOf10 );
-      myActualSize = std::round( myActualSize / scaler ) * scaler;
-      myScaleBarWidth = myActualSize / myMapUnitsPerPixelDouble;
-    }
-
-    //Get type of map units and set scale bar unit label text
-    QString myScaleBarUnitLabel;
-    switch ( myMapUnits )
-    {
-      case QgsUnitTypes::DistanceMeters:
-        if ( myActualSize > 1000.0 )
-        {
-          myScaleBarUnitLabel = tr( " km" );
-          myActualSize = myActualSize / 1000;
-        }
-        else if ( myActualSize < 0.01 )
-        {
-          myScaleBarUnitLabel = tr( " mm" );
-          myActualSize = myActualSize * 1000;
-        }
-        else if ( myActualSize < 0.1 )
-        {
-          myScaleBarUnitLabel = tr( " cm" );
-          myActualSize = myActualSize * 100;
-        }
-        else
-          myScaleBarUnitLabel = tr( " m" );
-        break;
-      case QgsUnitTypes::DistanceFeet:
-        if ( myActualSize > 5280.0 ) //5280 feet to the mile
-        {
-          myScaleBarUnitLabel = tr( " miles" );
-          // Adjust scale bar width to get even numbers
-          myActualSize = myActualSize / 5000;
-          myScaleBarWidth = ( myScaleBarWidth * 5280 ) / 5000;
-        }
-        else if ( myActualSize == 5280.0 ) //5280 feet to the mile
-        {
-          myScaleBarUnitLabel = tr( " mile" );
-          // Adjust scale bar width to get even numbers
-          myActualSize = myActualSize / 5000;
-          myScaleBarWidth = ( myScaleBarWidth * 5280 ) / 5000;
-        }
-        else if ( myActualSize < 1 )
-        {
-          myScaleBarUnitLabel = tr( " inches" );
-          myActualSize = myActualSize * 10;
-          myScaleBarWidth = ( myScaleBarWidth * 10 ) / 12;
-        }
-        else if ( myActualSize == 1.0 )
-        {
-          myScaleBarUnitLabel = tr( " foot" );
-        }
-        else
-        {
-          myScaleBarUnitLabel = tr( " feet" );
-        }
-        break;
-      case QgsUnitTypes::DistanceDegrees:
-        if ( myActualSize == 1.0 )
-          myScaleBarUnitLabel = tr( " degree" );
-        else
-          myScaleBarUnitLabel = tr( " degrees" );
-        break;
-      case QgsUnitTypes::DistanceUnknownUnit:
-        myScaleBarUnitLabel = tr( " unknown" );
-        //intentional fall-through
-        FALLTHROUGH;
-      default:
-        QgsDebugMsg( QString( "Error: not picked up map units - actual value = %1" ).arg( myMapUnits ) );
-    }
-
-    //Set font and calculate width of unit label
-    int myFontSize = 10; //we use this later for buffering
-    QFont myFont( QStringLiteral( "helvetica" ), myFontSize );
-    context.painter()->setFont( myFont );
-    QFontMetrics myFontMetrics( myFont );
-    double myFontWidth = myFontMetrics.width( myScaleBarUnitLabel );
-    double myFontHeight = myFontMetrics.height();
-
-    //Set the maximum label
-    QString myScaleBarMaxLabel = QLocale::system().toString( myActualSize );
-
-    //Calculate total width of scale bar and label
-    double myTotalScaleBarWidth = myScaleBarWidth + myFontWidth;
-
-    int myMarginW = 10;
-    int myMarginH = 20;
-    int myOriginX = 0;
-    int myOriginY = 0;
-
-    // Set  margin according to selected units
-    switch ( mMarginUnit )
-    {
-      case QgsUnitTypes::RenderMillimeters:
-      {
-        int myPixelsInchX = context.painter()->device()->logicalDpiX();
-        int myPixelsInchY = context.painter()->device()->logicalDpiY();
-        myOriginX = myPixelsInchX * INCHES_TO_MM * mMarginHorizontal;
-        myOriginY = myPixelsInchY * INCHES_TO_MM * mMarginVertical;
-        break;
-      }
-
-      case QgsUnitTypes::RenderPixels:
-        myOriginX = mMarginHorizontal - 5.; // Minus 5 to shift tight into corner
-        myOriginY = mMarginVertical - 5.;
-        break;
-
-      case QgsUnitTypes::RenderPercentage:
-      {
-        float myMarginDoubledW = myMarginW * 2.0;
-        float myMarginDoubledH = myMarginH * 2.0;
-        myOriginX = ( ( myCanvasWidth - myMarginDoubledW - myTotalScaleBarWidth ) / 100. ) * mMarginHorizontal;
-        myOriginY = ( ( myCanvasHeight - myMarginDoubledH ) / 100. ) * mMarginVertical;
-        break;
-      }
-
-      default:  // Use default of top left
-        break;
-    }
-
-    //Determine the origin of scale bar depending on placement selected
-    switch ( mPlacement )
-    {
-      case BottomLeft:
-        myOriginX += myMarginW;
-        myOriginY = myCanvasHeight - myOriginY - myMarginH;
-        break;
-      case TopLeft:
-        myOriginX += myMarginW;
-        myOriginY += myMarginH;
-        break;
-      case TopRight:
-        myOriginX = myCanvasWidth - myOriginX - myMarginW - ( static_cast< int >( myTotalScaleBarWidth ) );
-        myOriginY += myMarginH;
-        break;
-      case BottomRight:
-        myOriginX = myCanvasWidth - myOriginX - myMarginW - ( static_cast< int >( myTotalScaleBarWidth ) );
-        myOriginY = myCanvasHeight - myOriginY - myMarginH;
-        break;
-      default:
-        QgsDebugMsg( "Unable to determine where to put scale bar so defaulting to top left" );
-    }
-
-    //Set pen to draw with
-    QPen myForegroundPen( mColor, 2 );
-    QPen myBackgroundPen( mOutlineColor, 4 );
-
-    //Cast myScaleBarWidth to int for drawing
-    int myScaleBarWidthInt = static_cast< int >( myScaleBarWidth );
-
-    //Create array of vertices for scale bar depending on style
-    switch ( mStyleIndex )
-    {
-      case 0: // Tick Down
-      {
-        QPolygon myTickDownArray( 4 );
-        //draw a buffer first so bar shows up on dark images
-        context.painter()->setPen( myBackgroundPen );
-        myTickDownArray.putPoints( 0, 4,
-                                   myOriginX,                      myOriginY + myMajorTickSize,
-                                   myOriginX,                      myOriginY,
-                                   myScaleBarWidthInt + myOriginX, myOriginY,
-                                   myScaleBarWidthInt + myOriginX, myOriginY + myMajorTickSize
-                                 );
-        context.painter()->drawPolyline( myTickDownArray );
-        //now draw the bar itself in user selected color
-        context.painter()->setPen( myForegroundPen );
-        myTickDownArray.putPoints( 0, 4,
-                                   myOriginX,                      myOriginY + myMajorTickSize,
-                                   myOriginX,                      myOriginY,
-                                   myScaleBarWidthInt + myOriginX, myOriginY,
-                                   myScaleBarWidthInt + myOriginX, myOriginY + myMajorTickSize
-                                 );
-        context.painter()->drawPolyline( myTickDownArray );
-        break;
-      }
-      case 1: // tick up
-      {
-        QPolygon myTickUpArray( 4 );
-        //draw a buffer first so bar shows up on dark images
-        context.painter()->setPen( myBackgroundPen );
-        myTickUpArray.putPoints( 0, 4,
-                                 myOriginX,                      myOriginY,
-                                 myOriginX,                      myOriginY + myMajorTickSize,
-                                 myScaleBarWidthInt + myOriginX, myOriginY + myMajorTickSize,
-                                 myScaleBarWidthInt + myOriginX, myOriginY
-                               );
-        context.painter()->drawPolyline( myTickUpArray );
-        //now draw the bar itself in user selected color
-        context.painter()->setPen( myForegroundPen );
-        myTickUpArray.putPoints( 0, 4,
-                                 myOriginX,                      myOriginY,
-                                 myOriginX,                      myOriginY + myMajorTickSize,
-                                 myScaleBarWidthInt + myOriginX, myOriginY + myMajorTickSize,
-                                 myScaleBarWidthInt + myOriginX, myOriginY
-                               );
-        context.painter()->drawPolyline( myTickUpArray );
-        break;
-      }
-      case 2: // Bar
-      {
-        QPolygon myBarArray( 2 );
-        //draw a buffer first so bar shows up on dark images
-        context.painter()->setPen( myBackgroundPen );
-        myBarArray.putPoints( 0, 2,
-                              myOriginX,                      myOriginY + ( myMajorTickSize / 2 ),
-                              myScaleBarWidthInt + myOriginX, myOriginY + ( myMajorTickSize / 2 )
-                            );
-        context.painter()->drawPolyline( myBarArray );
-        //now draw the bar itself in user selected color
-        context.painter()->setPen( myForegroundPen );
-        myBarArray.putPoints( 0, 2,
-                              myOriginX,                      myOriginY + ( myMajorTickSize / 2 ),
-                              myScaleBarWidthInt + myOriginX, myOriginY + ( myMajorTickSize / 2 )
-                            );
-        context.painter()->drawPolyline( myBarArray );
-        break;
-      }
-      case 3: // box
-      {
-        // Want square corners for a box
-        myBackgroundPen.setJoinStyle( Qt::MiterJoin );
-        myForegroundPen.setJoinStyle( Qt::MiterJoin );
-        QPolygon myBoxArray( 5 );
-        //draw a buffer first so bar shows up on dark images
-        context.painter()->setPen( myBackgroundPen );
-        myBoxArray.putPoints( 0, 5,
-                              myOriginX,                      myOriginY,
-                              myScaleBarWidthInt + myOriginX, myOriginY,
-                              myScaleBarWidthInt + myOriginX, myOriginY + myMajorTickSize,
-                              myOriginX,                      myOriginY + myMajorTickSize,
-                              myOriginX,                      myOriginY
-                            );
-        context.painter()->drawPolyline( myBoxArray );
-        //now draw the bar itself in user selected color
-        context.painter()->setPen( myForegroundPen );
-        context.painter()->setBrush( QBrush( mColor, Qt::SolidPattern ) );
-        int midPointX = myScaleBarWidthInt / 2 + myOriginX;
-        myBoxArray.putPoints( 0, 5,
-                              myOriginX, myOriginY,
-                              midPointX, myOriginY,
-                              midPointX, myOriginY + myMajorTickSize,
-                              myOriginX, myOriginY + myMajorTickSize,
-                              myOriginX, myOriginY
-                            );
-        context.painter()->drawPolygon( myBoxArray );
-
-        context.painter()->setBrush( Qt::NoBrush );
-        myBoxArray.putPoints( 0, 5,
-                              midPointX,                      myOriginY,
-                              myScaleBarWidthInt + myOriginX, myOriginY,
-                              myScaleBarWidthInt + myOriginX, myOriginY + myMajorTickSize,
-                              midPointX,                      myOriginY + myMajorTickSize,
-                              midPointX,                      myOriginY
-                            );
-        context.painter()->drawPolygon( myBoxArray );
-        break;
-      }
-      default:
-        QgsDebugMsg( "Unknown style" );
-    }
-
-    //Do actual drawing of scale bar
-
-    //
-    //Do drawing of scale bar text
-    //
-
-    QColor myBackColor = mOutlineColor;
-    QColor myForeColor = mColor;
-
-    //Draw the minimum label buffer
-    context.painter()->setPen( myBackColor );
-    myFontWidth = myFontMetrics.width( QStringLiteral( "0" ) );
-    myFontHeight = myFontMetrics.height();
-
-    for ( int i = 0 - myBufferSize; i <= myBufferSize; i++ )
-    {
-      for ( int j = 0 - myBufferSize; j <= myBufferSize; j++ )
-      {
-        context.painter()->drawText( int( i + ( myOriginX - ( myFontWidth / 2 ) ) ),
-                                     int( j + ( myOriginY - ( myFontHeight / 4 ) ) ),
-                                     QStringLiteral( "0" ) );
-      }
-    }
-
-    //Draw minimum label
-    context.painter()->setPen( myForeColor );
-
-    context.painter()->drawText(
-      int( myOriginX - ( myFontWidth / 2 ) ),
-      int( myOriginY - ( myFontHeight / 4 ) ),
-      QStringLiteral( "0" )
-    );
-
-    //
-    //Draw maximum label
-    //
-    context.painter()->setPen( myBackColor );
-    myFontWidth = myFontMetrics.width( myScaleBarMaxLabel );
-    myFontHeight = myFontMetrics.height();
-    //first the buffer
-    for ( int i = 0 - myBufferSize; i <= myBufferSize; i++ )
-    {
-      for ( int j = 0 - myBufferSize; j <= myBufferSize; j++ )
-      {
-        context.painter()->drawText( int( i + ( myOriginX + myScaleBarWidthInt - ( myFontWidth / 2 ) ) ),
-                                     int( j + ( myOriginY - ( myFontHeight / 4 ) ) ),
-                                     myScaleBarMaxLabel );
-      }
-    }
-    //then the text itself
-    context.painter()->setPen( myForeColor );
-    context.painter()->drawText(
-      int( myOriginX + myScaleBarWidthInt - ( myFontWidth / 2 ) ),
-      int( myOriginY - ( myFontHeight / 4 ) ),
-      myScaleBarMaxLabel
-    );
-
-    //
-    //Draw unit label
-    //
-    context.painter()->setPen( myBackColor );
-    //first the buffer
-    for ( int i = 0 - myBufferSize; i <= myBufferSize; i++ )
-    {
-      for ( int j = 0 - myBufferSize; j <= myBufferSize; j++ )
-      {
-        context.painter()->drawText( i + ( myOriginX + myScaleBarWidthInt + myTextOffsetX ),
-                                     j + ( myOriginY + myMajorTickSize ),
-                                     myScaleBarUnitLabel );
-      }
-    }
-    //then the text itself
-    context.painter()->setPen( myForeColor );
-    context.painter()->drawText(
-      ( myOriginX + myScaleBarWidthInt + myTextOffsetX ), ( myOriginY + myMajorTickSize ),
-      myScaleBarUnitLabel
-    );
+    scaleBarWidth = deviceWidth / 4.0; // value in pixels
+    unitsPerSegment = scaleBarWidth * scaleBarUnitsPerPixel; // value in map units
   }
+
+  //if scale bar is more than half the canvas wide keep halving until not
+  while ( scaleBarWidth > deviceWidth / 3.0 )
+  {
+    scaleBarWidth = scaleBarWidth / 3;
+  }
+  unitsPerSegment = scaleBarWidth * scaleBarUnitsPerPixel;
+
+  // Work out the exponent for the number - e.g, 1234 will give 3,
+  // and .001234 will give -3
+  double powerOf10 = std::floor( std::log10( unitsPerSegment ) );
+
+  // snap to integer < 10 times power of 10
+  if ( mSnapping )
+  {
+    double scaler = std::pow( 10.0, powerOf10 );
+    unitsPerSegment = std::round( unitsPerSegment / scaler ) * scaler;
+    scaleBarWidth = unitsPerSegment / scaleBarUnitsPerPixel;
+  }
+
+  //Get type of map units and set scale bar unit label text
+  double mapSize = unitsPerSegment * QgsUnitTypes::fromUnitToUnitFactor( scaleBarUnits, mapSettings.mapUnits() );
+  double segmentSize = context.convertFromMapUnits( mapSize, QgsUnitTypes::RenderMillimeters );
+
+  QString scaleBarUnitLabel;
+  switch ( scaleBarUnits )
+  {
+    case QgsUnitTypes::DistanceMeters:
+      if ( unitsPerSegment > 1000.0 )
+      {
+        scaleBarUnitLabel = tr( "km" );
+        unitsPerSegment = unitsPerSegment / 1000;
+      }
+      else if ( unitsPerSegment < 0.01 )
+      {
+        scaleBarUnitLabel = tr( "mm" );
+        unitsPerSegment = unitsPerSegment * 1000;
+      }
+      else if ( unitsPerSegment < 0.1 )
+      {
+        scaleBarUnitLabel = tr( "cm" );
+        unitsPerSegment = unitsPerSegment * 100;
+      }
+      else
+        scaleBarUnitLabel = tr( "m" );
+      break;
+    case QgsUnitTypes::DistanceFeet:
+      if ( unitsPerSegment > 5280.0 ) //5280 feet to the mile
+      {
+        scaleBarUnitLabel = tr( "miles" );
+        // Adjust scale bar width to get even numbers
+        unitsPerSegment = unitsPerSegment / 5000;
+        //scaleBarWidth = ( scaleBarWidth * 5280 ) / 5000;
+      }
+      else if ( unitsPerSegment == 5280.0 ) //5280 feet to the mile
+      {
+        scaleBarUnitLabel = tr( "mile" );
+        // Adjust scale bar width to get even numbers
+        unitsPerSegment = unitsPerSegment / 5000;
+        //scaleBarWidth = ( scaleBarWidth * 5280 ) / 5000;
+      }
+      else if ( unitsPerSegment < 1 )
+      {
+        scaleBarUnitLabel = tr( "inches" );
+        unitsPerSegment = unitsPerSegment * 10;
+        //scaleBarWidth = ( scaleBarWidth * 10 ) / 12;
+      }
+      else if ( unitsPerSegment == 1.0 )
+      {
+        scaleBarUnitLabel = tr( "foot" );
+      }
+      else
+      {
+        scaleBarUnitLabel = tr( "feet" );
+      }
+      break;
+    case QgsUnitTypes::DistanceDegrees:
+      if ( unitsPerSegment == 1.0 )
+        scaleBarUnitLabel = tr( "degree" );
+      else
+        scaleBarUnitLabel = tr( "degrees" );
+      break;
+    case QgsUnitTypes::DistanceUnknownUnit:
+      scaleBarUnitLabel = tr( "unknown" );
+      //intentional fall-through
+      FALLTHROUGH;
+    default:
+      QgsDebugMsg( QString( "Error: not picked up map units - actual value = %1" ).arg( scaleBarUnits ) );
+  }
+
+  mSettings.setUnits( scaleBarUnits );
+  mSettings.setNumberOfSegments( mStyleIndex == 3 ? 2 : 1 );
+  mSettings.setUnitsPerSegment( mStyleIndex == 3 ? unitsPerSegment / 2 : unitsPerSegment );
+  mSettings.setUnitLabel( scaleBarUnitLabel );
+
+  QgsScaleBarRenderer::ScaleBarContext scaleContext;
+  scaleContext.size = QSizeF( deviceWidth, deviceHeight );
+  scaleContext.segmentWidth = mStyleIndex == 3 ? segmentSize / 2 : segmentSize;
+  scaleContext.scale = mapSettings.scale();
+
+  //Calculate total width of scale bar and label
+  QSizeF size = mStyle->calculateBoxSize( mSettings, scaleContext );
+  size.setWidth( context.convertToPainterUnits( size.width(), QgsUnitTypes::RenderMillimeters ) );
+  size.setHeight( context.convertToPainterUnits( size.height(), QgsUnitTypes::RenderMillimeters ) );
+
+  int originX = 0;
+  int originY = 0;
+
+  // Set  margin according to selected units
+  switch ( mMarginUnit )
+  {
+    case QgsUnitTypes::RenderMillimeters:
+    {
+      int pixelsInchX = context.painter()->device()->logicalDpiX();
+      int pixelsInchY = context.painter()->device()->logicalDpiY();
+      originX = pixelsInchX * INCHES_TO_MM * mMarginHorizontal;
+      originY = pixelsInchY * INCHES_TO_MM * mMarginVertical;
+      break;
+    }
+
+    case QgsUnitTypes::RenderPixels:
+      originX = mMarginHorizontal - 5.; // Minus 5 to shift tight into corner
+      originY = mMarginVertical - 5.;
+      break;
+
+    case QgsUnitTypes::RenderPercentage:
+    {
+      originX = ( ( deviceWidth - size.width() ) / 100. ) * mMarginHorizontal;
+      originY = ( ( deviceHeight ) / 100. ) * mMarginVertical;
+      break;
+    }
+
+    default:  // Use default of top left
+      break;
+  }
+
+  //Determine the origin of scale bar depending on placement selected
+  switch ( mPlacement )
+  {
+    case TopLeft:
+      break;
+    case TopRight:
+      originX = deviceWidth - originX - size.width();
+      break;
+    case BottomLeft:
+      originY = deviceHeight - originY - size.height();
+      break;
+    case BottomRight:
+      originX = deviceWidth - originX - size.width();
+      originY = deviceHeight - originY - size.height();
+      break;
+    default:
+      QgsDebugMsg( "Unable to determine where to put scale bar so defaulting to top left" );
+  }
+
+  context.painter()->save();
+  context.painter()->translate( originX, originY );
+  mStyle->draw( context, mSettings, scaleContext );
+  context.painter()->restore();
 }

--- a/src/app/qgsdecorationscalebar.h
+++ b/src/app/qgsdecorationscalebar.h
@@ -23,6 +23,8 @@ email                : sbr00pwb@users.sourceforge.net
 
 #include "qgis.h"
 #include "qgsdecorationitem.h"
+#include "scalebar/qgsscalebarsettings.h"
+#include "scalebar/qgsscalebarrenderer.h"
 
 class QPainter;
 
@@ -41,11 +43,12 @@ class APP_EXPORT QgsDecorationScaleBar: public QgsDecorationItem
     void projectRead() override;
     //! save values to the project
     void saveToProject() override;
-
     //! this does the meaty bit of the work
     void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
     //! Show the dialog box
     void run() override;
+    //! Setup the QgsScaleBarSettings object
+    void setupScaleBar();
 
   private:
 
@@ -61,6 +64,13 @@ class APP_EXPORT QgsDecorationScaleBar: public QgsDecorationItem
     QColor mColor;
     //! The scale bar otuline color
     QColor mOutlineColor;
+    //! The scale bar font
+    QFont mFont;
+
+    QgsScaleBarSettings mSettings;
+
+    //! Scalebar style
+    std::unique_ptr< QgsScaleBarRenderer > mStyle;
 
     //! Margin percentage values
     int mMarginHorizontal = 0;

--- a/src/app/qgsdecorationscalebardialog.cpp
+++ b/src/app/qgsdecorationscalebardialog.cpp
@@ -83,6 +83,9 @@ QgsDecorationScaleBarDialog::QgsDecorationScaleBarDialog( QgsDecorationScaleBar 
   pbnChangeOutlineColor->setColor( mDeco.mOutlineColor );
   pbnChangeOutlineColor->setContext( QStringLiteral( "gui" ) );
   pbnChangeOutlineColor->setColorDialogTitle( tr( "Select Scale Bar Outline Color" ) );
+
+  mButtonFontStyle->setMode( QgsFontButton::ModeQFont );
+  mButtonFontStyle->setCurrentFont( mDeco.mFont );
 }
 
 QgsDecorationScaleBarDialog::~QgsDecorationScaleBarDialog()
@@ -108,6 +111,8 @@ void QgsDecorationScaleBarDialog::apply()
   mDeco.mStyleIndex = cboStyle->currentIndex();
   mDeco.mColor = pbnChangeColor->color();
   mDeco.mOutlineColor = pbnChangeOutlineColor->color();
+  mDeco.mFont = mButtonFontStyle->currentFont();
+  mDeco.setupScaleBar();
   mDeco.update();
 }
 

--- a/src/core/scalebar/qgsscalebarrenderer.h
+++ b/src/core/scalebar/qgsscalebarrenderer.h
@@ -40,10 +40,15 @@ class CORE_EXPORT QgsScaleBarRenderer
 
     /**
      * Contains parameters regarding scalebar calculations.
+     * \note The need to attribute the parameters vary depending on the targeted scalebar.
      */
     struct ScaleBarContext
     {
-      //! Width of each individual segment (in millimeters)
+
+      /**
+       * The width, in millimeters, of each individual segment drawn.
+       * \note The number of map units per segment needs to be set via QgsScaleBarSettings::setUnitsPerSegment.
+       */
       double segmentWidth { 0.0 };
 
       /**

--- a/src/ui/qgsdecorationscalebardialog.ui
+++ b/src/ui/qgsdecorationscalebardialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>565</width>
-    <height>271</height>
+    <height>279</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -124,7 +124,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="textLabel1_3">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -186,7 +186,36 @@
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="textLabel1_3_22">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Font of bar</string>
+        </property>
+       </widget>      
+      </item>
       <item row="4" column="1">
+       <widget class="QgsFontButton" name="mButtonFontStyle">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Font</string>
+        </property>
+       </widget>      
+      </item>
+      <item row="5" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QgsSpinBox" name="spnSize">
@@ -219,7 +248,7 @@
         </item>
        </layout>
       </item>
-      <item row="7" column="1">
+      <item row="8" column="1">
        <layout class="QHBoxLayout" name="hlytMargin" stretch="0,0,0,0,0">
         <property name="spacing">
          <number>10</number>
@@ -336,7 +365,7 @@
         </item>
        </layout>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="QComboBox" name="cboPlacement">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -346,7 +375,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="lblMargin">
         <property name="minimumSize">
          <size>
@@ -359,7 +388,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="lblLocation">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -375,7 +404,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="2">
+      <item row="6" column="0" colspan="2">
        <widget class="QCheckBox" name="chkSnapping">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -405,6 +434,11 @@
    <container>1</container>
   </customwidget>
   <customwidget>
+   <class>QgsFontButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsfontbutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsSpinBox</class>
    <extends>QSpinBox</extends>
    <header>qgsspinbox.h</header>
@@ -420,6 +454,7 @@
   <tabstop>grpEnable</tabstop>
   <tabstop>cboStyle</tabstop>
   <tabstop>pbnChangeColor</tabstop>
+  <tabstop>pbnChangeOutlineColor</tabstop>
   <tabstop>spnSize</tabstop>
   <tabstop>chkSnapping</tabstop>
   <tabstop>cboPlacement</tabstop>


### PR DESCRIPTION
## Description
@nyalldawson , this PR leverages the work you did during the 3.0 dev cycle by upgrading the scale bar decoration to rely on QgsScaleBarRenderer. 

Beyond removing duplicate scale bar code, this opens the door right away to styling the scale bar font family and size, which is a must have alongside PR #6684 .


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
