### PR TITLE
Add dependency on ui target to wms provider to fix parallel build.

### DIFF
--- a/src/providers/wms/CMakeLists.txt
+++ b/src/providers/wms/CMakeLists.txt
@@ -46,7 +46,7 @@ INCLUDE_DIRECTORIES(SYSTEM
 ADD_LIBRARY(wmsprovider_a STATIC ${WMS_SRCS} ${WMS_MOC_SRCS})
 ADD_LIBRARY(wmsprovider MODULE ${WMS_SRCS} ${WMS_MOC_SRCS})
 
-ADD_DEPENDENCIES(wmsprovider qgis_gui)
+ADD_DEPENDENCIES(wmsprovider qgis_gui ui)
 
 TARGET_LINK_LIBRARIES(wmsprovider
   qgis_core


### PR DESCRIPTION
Follow-up for #6471, because 2.18.18 failed to build on ppc64el ([buildlog](https://buildd.debian.org/status/fetch.php?pkg=qgis&arch=ppc64el&ver=2.18.18%2Bdfsg-1%7Eexp1&stamp=1522078081&raw=0)):
```make
[ 23%] Building CXX object src/providers/wms/CMakeFiles/wmsprovider_a.dir/qgswmssourceselect.cpp.o
cd /<<BUILDDIR>>/qgis-2.18.18+dfsg/debian/build/src/providers/wms && /usr/bin/c++  -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_SQL_LIB -DQT_SVG_LIB -DQT_XML_LIB -isystem /usr/include/qt4 -isystem /usr/include/qt4/QtSvg -isystem /usr/include/qt4/QtGui -isystem /usr/include/qt4/QtXml -isystem /usr/include/qt4/QtSql -isystem /usr/include/qt4/QtNetwork -isystem /usr/include/qt4/QtCore -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/debian/build -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/. -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/../../core -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/../../core/auth -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/../../core/geometry -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/../../core/raster -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/../../gui -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/../../gui/auth -I/<<BUILDDIR>>/qgis-2.18.18+dfsg/debian/build/src/providers/wms/../../ui -isystem /usr/include/gdal -isystem /usr/include/qt4/QtScript -isystem /usr/include/QtCrypto  -g -O2 -fdebug-prefix-map=/<<BUILDDIR>>/qgis-2.18.18+dfsg=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -O2 -Wdate-time -D_FORTIFY_SOURCE=2 -DSPATIALITE_VERSION_GE_4_0_0 -DSPATIALITE_VERSION_G_4_1_1 -DSPATIALITE_HAS_INIT_EX -std=c++11 -Wall -Wextra -Wno-long-long -Wformat-security -Wno-strict-aliasing -fvisibility=hidden   -fno-strict-aliasing -DCORE_EXPORT= -DGUI_EXPORT= -DPYTHON_EXPORT= -DANALYSIS_EXPORT= -DAPP_EXPORT= -DCUSTOMWIDGETS_EXPORT= -DSERVER_EXPORT= -o CMakeFiles/wmsprovider_a.dir/qgswmssourceselect.cpp.o -c /<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/qgswmssourceselect.cpp
In file included from /<<BUILDDIR>>/qgis-2.18.18+dfsg/debian/build/src/providers/wms/../../ui/ui_qgsgenericprojectionselectorbase.h:21:0,
                 from /<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/../../gui/qgsgenericprojectionselector.h:20,
                 from /<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/qgswmssourceselect.cpp:26:
/<<BUILDDIR>>/qgis-2.18.18+dfsg/src/providers/wms/../../gui/qgsprojectionselector.h:14:10: fatal error: ui_qgsprojectionselectorbase.h: No such file or directory
 #include <ui_qgsprojectionselectorbase.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Adding the `qgis_gui` dependency to the `wmsprovider` was not sufficient, apparently the dependency from `qgis_gui` on the `ui` target is not transitively applied to the `wmsprovider`. This PR adds the `ui` target to the `wmsprovider` target in addition to `qgis_gui`.