### PR TITLE
[needs-docs] Add a "save selected features as" layer item shortcut

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6959,7 +6959,7 @@ void QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer )
 }
 
 
-void QgisApp::saveAsFile( QgsMapLayer *layer )
+void QgisApp::saveAsFile( QgsMapLayer *layer, bool onlySelected )
 {
   if ( !layer )
     layer = activeLayer();
@@ -6974,7 +6974,7 @@ void QgisApp::saveAsFile( QgsMapLayer *layer )
   }
   else if ( layerType == QgsMapLayer::VectorLayer )
   {
-    saveAsVectorFileGeneral( qobject_cast<QgsVectorLayer *>( layer ) );
+    saveAsVectorFileGeneral( qobject_cast<QgsVectorLayer *>( layer ), true, onlySelected );
   }
 }
 
@@ -7074,7 +7074,7 @@ QgisAppFieldValueConverter *QgisAppFieldValueConverter::clone() const
 
 ///@endcond
 
-void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption )
+void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption, bool onlySelected )
 {
   if ( !vlayer )
   {
@@ -7096,6 +7096,7 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOpt
 
   dialog->setMapCanvas( mMapCanvas );
   dialog->setIncludeZ( QgsWkbTypes::hasZ( vlayer->wkbType() ) );
+  dialog->setOnlySelected( onlySelected );
 
   if ( dialog->exec() == QDialog::Accepted )
   {

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -692,7 +692,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
   public slots:
     //! save current vector layer
-    void saveAsFile( QgsMapLayer *layer = nullptr );
+    void saveAsFile( QgsMapLayer *layer = nullptr, bool onlySelected = false );
     //! save qml style for the current layer
     void saveStyleFile( QgsMapLayer *layer = nullptr );
     //! save qrl definition for the current layer
@@ -1768,7 +1768,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void setLayoutAtlasFeature( QgsPrintLayout *layout, QgsMapLayer *layer, const QgsFeature &feat );
 
-    void saveAsVectorFileGeneral( QgsVectorLayer *vlayer = nullptr, bool symbologyOption = true );
+    void saveAsVectorFileGeneral( QgsVectorLayer *vlayer = nullptr, bool symbologyOption = true, bool onlySelected = false );
 
     /**
      * Paste features from clipboard into a new memory layer.

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -244,10 +244,16 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       {
         // save as vector file
         QMenu *menuExportVector = new QMenu( tr( "Export" ), menu );
-        QAction *actionSaveAs = new QAction( tr( "Save as…" ), menuExportVector );
-        QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer Definition File…" ), menuExportVector );
+        QAction *actionSaveAs = new QAction( tr( "Save Features as…" ), menuExportVector );
         connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
         menuExportVector->addAction( actionSaveAs );
+        if ( vlayer->selectedFeatureCount() > 0 )
+        {
+          QAction *actionSaveSelectedFeaturesAs = new QAction( tr( "Save Selected Features as…" ), menuExportVector );
+          connect( actionSaveSelectedFeaturesAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile( nullptr, true ); } );
+          menuExportVector->addAction( actionSaveSelectedFeaturesAs );
+        }
+        QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer Definition File…" ), menuExportVector );
         connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
         menuExportVector->addAction( actionSaveAsDefinitionLayer );
         if ( vlayer->isSpatial() )

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -247,12 +247,10 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         QAction *actionSaveAs = new QAction( tr( "Save Features as…" ), menuExportVector );
         connect( actionSaveAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile(); } );
         menuExportVector->addAction( actionSaveAs );
-        if ( vlayer->selectedFeatureCount() > 0 )
-        {
-          QAction *actionSaveSelectedFeaturesAs = new QAction( tr( "Save Selected Features as…" ), menuExportVector );
-          connect( actionSaveSelectedFeaturesAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile( nullptr, true ); } );
-          menuExportVector->addAction( actionSaveSelectedFeaturesAs );
-        }
+        QAction *actionSaveSelectedFeaturesAs = new QAction( tr( "Save Selected Features as…" ), menuExportVector );
+        connect( actionSaveSelectedFeaturesAs, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->saveAsFile( nullptr, true ); } );
+        actionSaveSelectedFeaturesAs->setEnabled( vlayer->selectedFeatureCount() > 0 );
+        menuExportVector->addAction( actionSaveSelectedFeaturesAs );
         QAction *actionSaveAsDefinitionLayer = new QAction( tr( "Save as Layer Definition File…" ), menuExportVector );
         connect( actionSaveAsDefinitionLayer, &QAction::triggered, QgisApp::instance(), &QgisApp::saveAsLayerDefinition );
         menuExportVector->addAction( actionSaveAsDefinitionLayer );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -863,6 +863,11 @@ QgsRectangle QgsVectorLayerSaveAsDialog::filterExtent() const
   return mExtentGroupBox->outputExtent();
 }
 
+void QgsVectorLayerSaveAsDialog::setOnlySelected( bool onlySelected )
+{
+  mSelectedOnly->setChecked( onlySelected );
+}
+
 bool QgsVectorLayerSaveAsDialog::onlySelected() const
 {
   return mSelectedOnly->isChecked();

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -82,6 +82,14 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     bool hasFilterExtent() const;
     QgsRectangle filterExtent() const;
 
+    /**
+     * Sets whether only selected features will be saved.
+     */
+    void setOnlySelected( bool onlySelected );
+
+    /**
+     * Returns whether only selected features will be saved.
+     */
     bool onlySelected() const;
 
     /**


### PR DESCRIPTION
## Description
I've used QGIS for over 10 years now, and I can't remember the number of times I swore when accidentally saving all features when I meant to save the few features I'd just selected. The last of such incident occurred last week.

To plug in this recurring source of profanity, I'm proposing this addition of a "save selected features as..." export sub-menu item, which IMHO greatly improves the UX:
![screenshot from 2018-03-28 16-09-05](https://user-images.githubusercontent.com/1728657/38020798-592a9084-32a5-11e8-87c3-73c83d69477e.png)
 
The action itself simply checks the [x] save only selected features when opening the dialog. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
