### PR TITLE
[FEATURE][needs-docs] allow to clear filter for layer from contextual menu and properties dialog

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -965,6 +965,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! shows the snapping Options
     void snappingOptions();
 
+    //! change layer subset of current vector layer
+    void layerSubsetString();
+
   protected:
 
     //! Handle state changes (WindowTitleChange)
@@ -1418,9 +1421,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Update gui actions/menus when layers are modified
     void updateLayerModifiedActions();
-
-    //! change layer subset of current vector layer
-    void layerSubsetString();
 
     //! map tool changed
     void mapToolChanged( QgsMapTool *newTool, QgsMapTool *oldTool );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -210,8 +210,18 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         if ( vlayer->dataProvider()->supportsSubsetString() )
         {
-          QAction *action = menu->addAction( tr( "&Filter…" ), QgisApp::instance(), SLOT( layerSubsetString() ) );
-          action->setEnabled( !vlayer->isEditable() );
+          QMenu *menuFiltering = new QMenu( tr( "Filtering" ), menu );
+          QAction *actionFilter = new QAction( tr( "&Filter…" ), menuFiltering );
+          actionFilter->setEnabled( !vlayer->isEditable() );
+          connect( actionFilter, &QAction::triggered, QgisApp::instance(), &QgisApp::layerSubsetString );
+          menuFiltering->addAction( actionFilter );
+          QAction *actionClearFilter = new QAction( tr( "Clear Filter" ), menuFiltering );
+          actionClearFilter->setEnabled( !vlayer->subsetString().isEmpty() );
+          actionClearFilter->setProperty( "layerId", vlayer->id() );
+          connect( actionClearFilter, &QAction::triggered, this, &QgsAppLayerTreeViewMenuProvider::clearLayerFilter );
+          menuFiltering->addAction( actionClearFilter );
+
+          menu->addMenu( menuFiltering );
         }
       }
 
@@ -686,3 +696,20 @@ void QgsAppLayerTreeViewMenuProvider::setSymbolLegendNodeColor( const QColor &co
     layer->emitStyleChanged();
   }
 }
+
+void QgsAppLayerTreeViewMenuProvider::clearLayerFilter()
+{
+  QAction *action = qobject_cast< QAction *>( sender() );
+  if ( !action )
+    return;
+
+  QString layerId = action->property( "layerId" ).toString();
+  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+
+  if ( !layer )
+    return;
+
+  layer->setSubsetString( QLatin1String( "" ) );
+  QgsProject::instance()->setDirty( true );
+}
+

--- a/src/app/qgsapplayertreeviewmenuprovider.h
+++ b/src/app/qgsapplayertreeviewmenuprovider.h
@@ -67,6 +67,7 @@ class QgsAppLayerTreeViewMenuProvider : public QObject, public QgsLayerTreeViewM
     void setVectorSymbolColor( const QColor &color );
     void editSymbolLegendNodeSymbol();
     void setSymbolLegendNodeColor( const QColor &color );
+    void clearLayerFilter();
 };
 
 #endif // QGSAPPLAYERTREEVIEWMENUPROVIDER_H

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -96,6 +96,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   setupUi( this );
   connect( mLayerOrigNameLineEdit, &QLineEdit::textEdited, this, &QgsVectorLayerProperties::mLayerOrigNameLineEdit_textEdited );
   connect( pbnQueryBuilder, &QPushButton::clicked, this, &QgsVectorLayerProperties::pbnQueryBuilder_clicked );
+  connect( pbnClearQueryBuilder, &QPushButton::clicked, this, &QgsVectorLayerProperties::pbnClearQueryBuilder_clicked );
   connect( pbnIndex, &QPushButton::clicked, this, &QgsVectorLayerProperties::pbnIndex_clicked );
   connect( mCrsSelector, &QgsProjectionSelectionWidget::crsChanged, this, &QgsVectorLayerProperties::mCrsSelector_crsChanged );
   connect( pbnUpdateExtents, &QPushButton::clicked, this, &QgsVectorLayerProperties::pbnUpdateExtents_clicked );
@@ -814,6 +815,13 @@ void QgsVectorLayerProperties::pbnQueryBuilder_clicked()
   }
   // delete the query builder object
   delete qb;
+}
+
+void QgsVectorLayerProperties::pbnClearQueryBuilder_clicked()
+{
+  txtSubsetSQL->clear();
+  mLayer->setSubsetString( QLatin1String( "" ) );
+  pbnClearQueryBuilder->setEnabled( false );
 }
 
 void QgsVectorLayerProperties::pbnIndex_clicked()
@@ -1580,6 +1588,8 @@ void QgsVectorLayerProperties::setPbnQueryBuilderEnabled()
                                mLayer->dataProvider() &&
                                mLayer->dataProvider()->supportsSubsetString() &&
                                !mLayer->isEditable() );
+
+  pbnClearQueryBuilder->setEnabled( !mLayer->subsetString().isEmpty() );
 
   if ( mLayer && mLayer->isEditable() )
   {

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -811,8 +811,8 @@ void QgsVectorLayerProperties::pbnQueryBuilder_clicked()
 
     // The datasource for the layer needs to be updated with the new sql since this gets
     // saved to the project file. This should happen at the map layer level...
-
   }
+  pbnClearQueryBuilder->setEnabled( !mLayer->subsetString().isEmpty() );
   // delete the query builder object
   delete qb;
 }

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -112,6 +112,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     //
 
     void pbnQueryBuilder_clicked();
+    void pbnClearQueryBuilder_clicked();
     void pbnIndex_clicked();
     void mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs );
     void loadDefaultStyle_clicked();

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -345,7 +345,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>12</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="mOptsPage_Information">
           <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -421,8 +421,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>542</height>
+                <width>644</width>
+                <height>522</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -622,10 +622,16 @@ border-radius: 2px;</string>
                   <string>Provider feature filter</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_4">
-                  <item row="1" column="1">
-                   <widget class="QPushButton" name="pbnQueryBuilder">
-                    <property name="text">
-                     <string>Query Builder</string>
+                  <item row="0" column="0" colspan="3">
+                   <widget class="QTextEdit" name="txtSubsetSQL">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="acceptDrops">
+                     <bool>false</bool>
+                    </property>
+                    <property name="acceptRichText">
+                     <bool>false</bool>
                     </property>
                    </widget>
                   </item>
@@ -645,22 +651,24 @@ border-radius: 2px;</string>
                     </property>
                    </spacer>
                   </item>
-                  <item row="0" column="0" colspan="2">
-                   <widget class="QTextEdit" name="txtSubsetSQL">
-                    <property name="enabled">
-                     <bool>false</bool>
+                  <item row="1" column="2">
+                   <widget class="QPushButton" name="pbnQueryBuilder">
+                    <property name="text">
+                     <string>Query Builder</string>
                     </property>
-                    <property name="acceptDrops">
-                     <bool>false</bool>
-                    </property>
-                    <property name="acceptRichText">
-                     <bool>false</bool>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QPushButton" name="pbnClearQueryBuilder">
+                    <property name="text">
+                     <string>Clear</string>
                     </property>
                    </widget>
                   </item>
                  </layout>
                  <zorder>txtSubsetSQL</zorder>
                  <zorder>pbnQueryBuilder</zorder>
+                 <zorder>pbnClearQueryBuilder</zorder>
                 </widget>
                </item>
                <item>
@@ -895,8 +903,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>104</width>
-                <height>102</height>
+                <width>199</width>
+                <height>124</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1464,8 +1472,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>653</width>
-                <height>542</height>
+                <width>672</width>
+                <height>522</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1918,8 +1926,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>306</width>
-                <height>578</height>
+                <width>357</width>
+                <height>627</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2355,6 +2363,17 @@ border-radius: 2px;</string>
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
@@ -2384,11 +2403,6 @@ border-radius: 2px;</string>
    <header>qgsscalecombobox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsScaleRangeWidget</class>
    <extends>QWidget</extends>
    <header>qgsscalerangewidget.h</header>
@@ -2397,12 +2411,6 @@ border-radius: 2px;</string>
    <class>QgsLayerTreeEmbeddedConfigWidget</class>
    <extends>QWidget</extends>
    <header>qgslayertreeembeddedconfigwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsFieldExpressionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -2479,34 +2487,6 @@ border-radius: 2px;</string>
   <tabstop>mLayerLegendUrlFormatComboBox</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
## Description
This PR introduces the possibility to clear the filter of a vector layer in two different way:
from contextual menu of the layer (adding a submenu entry):

<img width="342" alt="schermata 2018-03-28 alle 20 38 01" src="https://user-images.githubusercontent.com/1374682/38049178-cb991074-32c7-11e8-8685-299d53f7679c.png">

from the properties dialog of the vector layer:

<img width="621" alt="schermata 2018-03-28 alle 20 38 17" src="https://user-images.githubusercontent.com/1374682/38049185-cf7743c8-32c7-11e8-8c55-79b25d44ceac.png">


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
