### PR TITLE
[needs-docs] Refactoring layout Manager dialog

### DIFF
--- a/src/app/layout/qgslayoutmanagerdialog.cpp
+++ b/src/app/layout/qgslayoutmanagerdialog.cpp
@@ -72,8 +72,8 @@ QgsLayoutManagerDialog::QgsLayoutManagerDialog( QWidget *parent, Qt::WindowFlags
   mLayoutListView->setModel( mProxyModel );
 
   connect( mButtonBox, &QDialogButtonBox::rejected, this, &QWidget::close );
-    connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsLayoutManagerDialog::showHelp );
-connect( mLayoutListView->selectionModel(), &QItemSelectionModel::selectionChanged,
+  connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsLayoutManagerDialog::showHelp );
+  connect( mLayoutListView->selectionModel(), &QItemSelectionModel::selectionChanged,
            this, &QgsLayoutManagerDialog::toggleButtons );
   connect( mLayoutListView, &QListView::doubleClicked, this, &QgsLayoutManagerDialog::itemDoubleClicked );
 
@@ -235,7 +235,7 @@ void QgsLayoutManagerDialog::mAddButton_clicked()
     }
   }
 
-  if ( mTemplate->currentIndex() = 1 ) // if it's an empty report
+  if ( mTemplate->currentIndex() == 1 ) // if it's an empty report
   {
     createReport();
   }

--- a/src/app/layout/qgslayoutmanagerdialog.h
+++ b/src/app/layout/qgslayoutmanagerdialog.h
@@ -126,7 +126,7 @@ class QgsLayoutManagerDialog: public QDialog, private Ui::QgsLayoutManagerBase
     void mTemplatesUserDirBtn_pressed();
     //! Slot to open help file
     void showHelp();
-    
+
     void createReport();
     void removeClicked();
     void showClicked();

--- a/src/app/layout/qgslayoutmanagerdialog.h
+++ b/src/app/layout/qgslayoutmanagerdialog.h
@@ -124,7 +124,9 @@ class QgsLayoutManagerDialog: public QDialog, private Ui::QgsLayoutManagerBase
     void mTemplatesDefaultDirBtn_pressed();
     //! Slot to open user templates dir with user's system
     void mTemplatesUserDirBtn_pressed();
-
+    //! Slot to open help file
+    void showHelp();
+    
     void createReport();
     void removeClicked();
     void showClicked();

--- a/src/ui/layout/qgslayoutmanagerbase.ui
+++ b/src/ui/layout/qgslayoutmanagerbase.ui
@@ -25,14 +25,70 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QListView" name="mLayoutListView">
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-    </widget>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="1" column="1">
+      <widget class="QToolButton" name="mDuplicateButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;Duplicate</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QToolButton" name="mRenameButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Re&amp;name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QToolButton" name="mRemoveButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;Remove</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0" colspan="4">
+      <widget class="QListView" name="mLayoutListView">
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectRows</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QToolButton" name="mShowButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>&amp;Show</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QgsCollapsibleGroupBox" name="mTemplateGrpBox">
@@ -140,7 +196,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>
@@ -162,6 +218,10 @@
  </customwidgets>
  <tabstops>
   <tabstop>mLayoutListView</tabstop>
+  <tabstop>mShowButton</tabstop>
+  <tabstop>mDuplicateButton</tabstop>
+  <tabstop>mRemoveButton</tabstop>
+  <tabstop>mRenameButton</tabstop>
   <tabstop>mTemplateGrpBox</tabstop>
   <tabstop>mTemplate</tabstop>
   <tabstop>mAddButton</tabstop>
@@ -170,34 +230,6 @@
   <tabstop>mTemplatesDefaultDirBtn</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
-  <include location="../../../images/images.qrc"/>
   <include location="../../../images/images.qrc"/>
  </resources>
  <connections>

--- a/src/ui/layout/qgslayoutmanagerbase.ui
+++ b/src/ui/layout/qgslayoutmanagerbase.ui
@@ -35,7 +35,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>&amp;Duplicate</string>
+        <string>&amp;Duplicate…</string>
        </property>
       </widget>
      </item>
@@ -48,7 +48,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Re&amp;name</string>
+        <string>Re&amp;name…</string>
        </property>
       </widget>
      </item>
@@ -61,7 +61,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>&amp;Remove</string>
+        <string>&amp;Remove…</string>
        </property>
       </widget>
      </item>
@@ -117,7 +117,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Create</string>
+         <string>Create…</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
The bottom of the layout manager dialog is full of buttons and the "create report" doesn't seem at the right place.
In the PR, buttons requiring a selection in the layout/report listview are moved near that frame and "create report" is merged with create layout button.
Also add help button
kind of screenshot from designer
![image](https://user-images.githubusercontent.com/7983394/38070752-caf32302-331d-11e8-8489-6e6b0bf037a5.png)

Also, questions:
* there are some settings and paths (eg default and user templates folders) that contain "composer" in their name. Should it not change to layout? see [issue report 18412](https://issues.qgis.org/issues/18412)
* how does saving a report as template work (what is saved)? afaics, creating a composer from a report template creates a print layout (or did I miss something?)