### PR TITLE
[FEATURE][needs-docs] Custom SVG path and size for the north arrow decoration

### DIFF
--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -231,11 +231,4 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
     //unrotate the canvas again
     context.painter()->restore();
   }
-  else
-  {
-    QFont font( QStringLiteral( "time" ), 12, QFont::Bold );
-    context.painter()->setFont( font );
-    context.painter()->setPen( Qt::black );
-    context.painter()->drawText( 10, 20, tr( "North arrow pixmap not found" ) );
-  }
 }

--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -70,6 +70,8 @@ void QgsDecorationNorthArrow::projectRead()
   QgsDecorationItem::projectRead();
   mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
   mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
+  mSize = QgsProject::instance()->readDoubleEntry( mNameConfig, QStringLiteral( "/Size" ), 16.0 );
+  mSvgPath = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/SvgPath" ), QString() );
   mRotationInt = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/Rotation" ), 0 );
   mAutomatic = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/Automatic" ), true );
   mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
@@ -81,7 +83,8 @@ void QgsDecorationNorthArrow::saveToProject()
   QgsDecorationItem::saveToProject();
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Rotation" ), mRotationInt );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Size" ), mSize );
+  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/SvgPath" ), mSvgPath );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Automatic" ), mAutomatic );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
   QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
@@ -94,128 +97,145 @@ void QgsDecorationNorthArrow::run()
   dlg.exec();
 }
 
+QString QgsDecorationNorthArrow::svgPath()
+{
+  if ( !mSvgPath.isEmpty() )
+  {
+    QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( mSvgPath, QgsProject::instance()->pathResolver() );
+    bool validSvg = QFileInfo::exists( resolvedPath );
+    if ( validSvg )
+    {
+      return resolvedPath;
+    }
+  }
+
+  return QStringLiteral( ":/images/north_arrows/default.svg" );
+}
+
 void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRenderContext &context )
 {
+  if ( !enabled() )
+    return;
 
-  //Large IF statement controlled by enable checkbox
-  if ( enabled() )
+  double maxLength = mSize * mapSettings.outputDpi() / 25.4;
+  QSvgRenderer svg;
+
+  const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( svgPath(), maxLength, mColor, mOutlineColor, 1.0, 1.0 );
+  svg.load( svgContent );
+
+  if ( svg.isValid() )
   {
-    QSize size( 64, 64 );
-    QSvgRenderer svg;
-
-    const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( QStringLiteral( ":/images/north_arrows/default.svg" ), size.width(), mColor, mOutlineColor, 1.0, 1.0 );
-    svg.load( svgContent );
-
-    if ( svg.isValid() )
+    QSize size( maxLength, maxLength );
+    QRectF viewBox = svg.viewBoxF();
+    if ( viewBox.height() > viewBox.width() )
     {
-      double centerXDouble = size.width() / 2.0;
-      double centerYDouble = size.width() / 2.0;
-
-      //save the current canvas rotation
-      context.painter()->save();
-      //
-      //work out how to shift the image so that it rotates
-      //           properly about its center
-      //(x cos a + y sin a - x, -x sin a + y cos a - y)
-      //
-
-      // could move this call to somewhere else so that it is only
-      // called when the projection or map extent changes
-      if ( mAutomatic )
-      {
-        try
-        {
-          mRotationInt = QgsBearingUtils:: bearingTrueNorth( mapSettings.destinationCrs(), mapSettings.transformContext(), context.extent().center() );
-        }
-        catch ( QgsException & )
-        {
-          mRotationInt = 0.0;
-          //QgsDebugMsg( "Can not get direction to true north. Probably project CRS is not defined." );
-        }
-        mRotationInt += mapSettings.rotation();
-      }
-
-      double myRadiansDouble = mRotationInt * M_PI / 180.0;
-      int xShift = static_cast<int>( (
-                                       ( centerXDouble * std::cos( myRadiansDouble ) ) +
-                                       ( centerYDouble * std::sin( myRadiansDouble ) )
-                                     ) - centerXDouble );
-      int yShift = static_cast<int>( (
-                                       ( -centerXDouble * std::sin( myRadiansDouble ) ) +
-                                       ( centerYDouble * std::cos( myRadiansDouble ) )
-                                     ) - centerYDouble );
-
-      // need width/height of paint device
-      int myHeight = context.painter()->device()->height();
-      int myWidth = context.painter()->device()->width();
-
-      //QgsDebugMsg("Rendering north arrow at " + mPlacementLabels.at(mPlacementIndex));
-
-      // Set  margin according to selected units
-      int myXOffset = 0;
-      int myYOffset = 0;
-      switch ( mMarginUnit )
-      {
-        case QgsUnitTypes::RenderMillimeters:
-        {
-          int myPixelsInchX = context.painter()->device()->logicalDpiX();
-          int myPixelsInchY = context.painter()->device()->logicalDpiY();
-          myXOffset = myPixelsInchX * INCHES_TO_MM * mMarginHorizontal;
-          myYOffset = myPixelsInchY * INCHES_TO_MM * mMarginVertical;
-          break;
-        }
-
-        case QgsUnitTypes::RenderPixels:
-          myXOffset = mMarginHorizontal - 5; // Minus 5 to shift tight into corner
-          myYOffset = mMarginVertical - 5;
-          break;
-
-        case QgsUnitTypes::RenderPercentage:
-          myXOffset = ( ( myWidth - size.width() ) / 100. ) * mMarginHorizontal;
-          myYOffset = ( ( myHeight - size.width() ) / 100. ) * mMarginVertical;
-          break;
-
-        default:  // Use default of top left
-          break;
-      }
-      //Determine placement of label from form combo box
-      switch ( mPlacement )
-      {
-        case BottomLeft:
-          context.painter()->translate( myXOffset, myHeight - myYOffset - size.width() );
-          break;
-        case TopLeft:
-          context.painter()->translate( myXOffset, myYOffset );
-          break;
-        case TopRight:
-          context.painter()->translate( myWidth - myXOffset - size.width(), myYOffset );
-          break;
-        case BottomRight:
-          context.painter()->translate( myWidth - myXOffset - size.width(),
-                                        myHeight - myYOffset - size.width() );
-          break;
-        default:
-        {
-          //QgsDebugMsg("Unable to determine where to put north arrow so defaulting to top left");
-        }
-      }
-
-      //rotate the canvas by the north arrow rotation amount
-      context.painter()->rotate( mRotationInt );
-      //Now we can actually do the drawing, and draw a smooth north arrow even when rotated
-
-      context.painter()->translate( xShift, yShift );
-      svg.render( context.painter(), QRectF( 0, 0, size.width(), size.height() ) );
-
-      //unrotate the canvas again
-      context.painter()->restore();
+      size.setWidth( maxLength * viewBox.width() / viewBox.height() );
     }
     else
     {
-      QFont myQFont( QStringLiteral( "time" ), 12, QFont::Bold );
-      context.painter()->setFont( myQFont );
-      context.painter()->setPen( Qt::black );
-      context.painter()->drawText( 10, 20, tr( "North arrow pixmap not found" ) );
+      size.setHeight( maxLength * viewBox.height() / viewBox.width() );
     }
+
+    double centerXDouble = size.width() / 2.0;
+    double centerYDouble = size.height() / 2.0;
+
+    //save the current canvas rotation
+    context.painter()->save();
+    //
+    //work out how to shift the image so that it rotates
+    //           properly about its center
+    //(x cos a + y sin a - x, -x sin a + y cos a - y)
+    //
+    // could move this call to somewhere else so that it is only
+    // called when the projection or map extent changes
+    if ( mAutomatic )
+    {
+      try
+      {
+        mRotationInt = QgsBearingUtils:: bearingTrueNorth( mapSettings.destinationCrs(), mapSettings.transformContext(), context.extent().center() );
+      }
+      catch ( QgsException & )
+      {
+        mRotationInt = 0.0;
+      }
+      mRotationInt += mapSettings.rotation();
+    }
+
+    double radiansDouble = mRotationInt * M_PI / 180.0;
+    int xShift = static_cast<int>( (
+                                     ( centerXDouble * std::cos( radiansDouble ) ) +
+                                     ( centerYDouble * std::sin( radiansDouble ) )
+                                   ) - centerXDouble );
+    int yShift = static_cast<int>( (
+                                     ( -centerXDouble * std::sin( radiansDouble ) ) +
+                                     ( centerYDouble * std::cos( radiansDouble ) )
+                                   ) - centerYDouble );
+    // need width/height of paint device
+    int deviceHeight = context.painter()->device()->height();
+    int deviceWidth = context.painter()->device()->width();
+
+    // Set  margin according to selected units
+    int xOffset = 0;
+    int yOffset = 0;
+    switch ( mMarginUnit )
+    {
+      case QgsUnitTypes::RenderMillimeters:
+      {
+        int pixelsInchX = context.painter()->device()->logicalDpiX();
+        int pixelsInchY = context.painter()->device()->logicalDpiY();
+        xOffset = pixelsInchX * INCHES_TO_MM * mMarginHorizontal;
+        yOffset = pixelsInchY * INCHES_TO_MM * mMarginVertical;
+        break;
+      }
+
+      case QgsUnitTypes::RenderPixels:
+        xOffset = mMarginHorizontal - 5; // Minus 5 to shift tight into corner
+        yOffset = mMarginVertical - 5;
+        break;
+
+      case QgsUnitTypes::RenderPercentage:
+        xOffset = ( ( deviceWidth - size.width() ) / 100. ) * mMarginHorizontal;
+        yOffset = ( ( deviceHeight - size.width() ) / 100. ) * mMarginVertical;
+        break;
+      case QgsUnitTypes::RenderMapUnits:
+      case QgsUnitTypes::RenderPoints:
+      case QgsUnitTypes::RenderInches:
+      case QgsUnitTypes::RenderUnknownUnit:
+      case QgsUnitTypes::RenderMetersInMapUnits:
+        break;
+    }
+    //Determine placement of label from form combo box
+    switch ( mPlacement )
+    {
+      case BottomLeft:
+        context.painter()->translate( xOffset, deviceHeight - yOffset - maxLength + ( maxLength - size.height() ) / 2 );
+        break;
+      case TopLeft:
+        context.painter()->translate( xOffset, yOffset );
+        break;
+      case TopRight:
+        context.painter()->translate( deviceWidth - xOffset - maxLength + ( maxLength - size.width() ) / 2, yOffset );
+        break;
+      case BottomRight:
+        context.painter()->translate( deviceWidth - xOffset - maxLength + ( maxLength - size.width() ) / 2,
+                                      deviceHeight - yOffset - maxLength + ( maxLength - size.height() ) / 2 );
+        break;
+    }
+
+    //rotate the canvas by the north arrow rotation amount
+    context.painter()->rotate( mRotationInt );
+    //Now we can actually do the drawing, and draw a smooth north arrow even when rotated
+    context.painter()->translate( xShift, yShift );
+    svg.render( context.painter(), QRectF( 0, 0, size.width(), size.height() ) );
+
+    //unrotate the canvas again
+    context.painter()->restore();
+  }
+  else
+  {
+    QFont font( QStringLiteral( "time" ), 12, QFont::Bold );
+    context.painter()->setFont( font );
+    context.painter()->setPen( Qt::black );
+    context.painter()->drawText( 10, 20, tr( "North arrow pixmap not found" ) );
   }
 }

--- a/src/app/qgsdecorationnortharrow.h
+++ b/src/app/qgsdecorationnortharrow.h
@@ -60,7 +60,7 @@ class APP_EXPORT QgsDecorationNorthArrow: public QgsDecorationItem
     //! The north arrow outline color
     QColor mOutlineColor;
     //! The north arrow size in millimeter
-    double mSize;
+    double mSize = 16.0;
     //! Custom north arrow svg path
     QString mSvgPath;
 

--- a/src/app/qgsdecorationnortharrow.h
+++ b/src/app/qgsdecorationnortharrow.h
@@ -37,15 +37,18 @@ class APP_EXPORT QgsDecorationNorthArrow: public QgsDecorationItem
     QgsDecorationNorthArrow( QObject *parent = nullptr );
 
   public slots:
-    //! set values on the gui when a project is read or the gui first loaded
+    //! Set values on the gui when a project is read or the gui first loaded
     void projectRead() override;
-    //! save values to the project
+    //! Save values to the project
     void saveToProject() override;
 
     //! Show the dialog box
     void run() override;
-    //! draw some arbitrary text to the screen
+    //! Draw some arbitrary text to the screen
     void render( const QgsMapSettings &mapSettings, QgsRenderContext &context ) override;
+
+    //! Return the north arrow SVG path
+    QString svgPath();
 
   private:
 
@@ -56,6 +59,10 @@ class APP_EXPORT QgsDecorationNorthArrow: public QgsDecorationItem
     QColor mColor;
     //! The north arrow outline color
     QColor mOutlineColor;
+    //! The north arrow size in millimeter
+    double mSize;
+    //! Custom north arrow svg path
+    QString mSvgPath;
 
     // The amount of rotation for the north arrow
     int mRotationInt = 0;

--- a/src/app/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/qgsdecorationnortharrowdialog.cpp
@@ -14,8 +14,11 @@
 #include "qgsdecorationnortharrow.h"
 #include "qgslogger.h"
 #include "qgshelp.h"
+#include "qgsproject.h"
 #include "qgssettings.h"
+#include "qgssymbollayerutils.h"
 #include "qgssvgcache.h"
+#include "qgssvgselectorwidget.h"
 
 #include <QPainter>
 #include <cmath>
@@ -30,8 +33,6 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
   setupUi( this );
   connect( buttonBox, &QDialogButtonBox::accepted, this, &QgsDecorationNorthArrowDialog::buttonBox_accepted );
   connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsDecorationNorthArrowDialog::buttonBox_rejected );
-  connect( spinAngle, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsDecorationNorthArrowDialog::spinAngle_valueChanged );
-  connect( sliderRotation, &QSlider::valueChanged, this, &QgsDecorationNorthArrowDialog::sliderRotation_valueChanged );
 
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/DecorationNorthArrow/geometry" ) ).toByteArray() );
@@ -40,9 +41,24 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
   connect( applyButton, &QAbstractButton::clicked, this, &QgsDecorationNorthArrowDialog::apply );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsDecorationNorthArrowDialog::showHelp );
 
+  spinSize->setValue( mDeco.mSize );
+
   // signal/slot connection defined in 'designer' causes the slider to
   // be moved to reflect the change in the spinbox.
   spinAngle->setValue( mDeco.mRotationInt );
+
+  // automatic
+  cboxAutomatic->setChecked( mDeco.mAutomatic );
+  spinAngle->setEnabled( !mDeco.mAutomatic );
+  sliderRotation->setEnabled( !mDeco.mAutomatic );
+
+  connect( cboxAutomatic, &QAbstractButton::toggled, [ = ]( bool checked )
+  {
+    spinAngle->setEnabled( !checked );
+    sliderRotation->setEnabled( !checked );
+  } );
+  connect( spinAngle, static_cast < void ( QSpinBox::* )( int ) > ( &QSpinBox::valueChanged ), this, &QgsDecorationNorthArrowDialog::spinAngle_valueChanged );
+  connect( sliderRotation, &QSlider::valueChanged, this, &QgsDecorationNorthArrowDialog::sliderRotation_valueChanged );
 
   // placement
   cboPlacement->addItem( tr( "Top left" ), QgsDecorationItem::TopLeft );
@@ -58,19 +74,31 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
   // enabled
   grpEnable->setChecked( mDeco.enabled() );
 
-  // automatic
-  cboxAutomatic->setChecked( mDeco.mAutomatic );
+  mSvgPathLineEdit->setText( mDeco.mSvgPath );
+  connect( mSvgPathLineEdit, &QLineEdit::textChanged, this, &QgsDecorationNorthArrowDialog::updateSvgPath );
+  connect( mSvgSelectorBtn, &QPushButton::clicked, this, [ = ]
+  {
+    QgsSvgSelectorDialog svgDlg( this );
+    svgDlg.setWindowTitle( tr( "Select SVG file" ) );
+    svgDlg.svgSelector()->setSvgPath( mSvgPathLineEdit->text().trimmed() );
+    if ( svgDlg.exec() == QDialog::Accepted )
+    {
+      QString svgPath = svgDlg.svgSelector()->currentSvgPath();
+      if ( !svgPath.isEmpty() )
+      {
+        updateSvgPath( svgPath );
+      }
+    }
+  } );
 
   pbnChangeColor->setAllowOpacity( true );
   pbnChangeColor->setColor( mDeco.mColor );
   pbnChangeColor->setContext( QStringLiteral( "gui" ) );
   pbnChangeColor->setColorDialogTitle( tr( "Select North Arrow Fill Color" ) );
-
   pbnChangeOutlineColor->setAllowOpacity( true );
   pbnChangeOutlineColor->setColor( mDeco.mOutlineColor );
   pbnChangeOutlineColor->setContext( QStringLiteral( "gui" ) );
   pbnChangeOutlineColor->setColorDialogTitle( tr( "Select North Arrow Outline Color" ) );
-
   connect( pbnChangeColor, &QgsColorButton::colorChanged, this, [ = ]( QColor ) { drawNorthArrow(); } );
   connect( pbnChangeOutlineColor, &QgsColorButton::colorChanged, this, [ = ]( QColor ) { drawNorthArrow(); } );
 
@@ -102,13 +130,13 @@ void QgsDecorationNorthArrowDialog::buttonBox_rejected()
 
 void QgsDecorationNorthArrowDialog::spinAngle_valueChanged( int spinAngle )
 {
-  Q_UNUSED( spinAngle );
+  sliderRotation->setValue( spinAngle );
+  drawNorthArrow();
 }
 
 void QgsDecorationNorthArrowDialog::sliderRotation_valueChanged( int rotationValue )
 {
-  Q_UNUSED( rotationValue );
-
+  spinAngle->setValue( rotationValue );
   drawNorthArrow();
 }
 
@@ -116,6 +144,7 @@ void QgsDecorationNorthArrowDialog::apply()
 {
   mDeco.mColor = pbnChangeColor->color();
   mDeco.mOutlineColor = pbnChangeOutlineColor->color();
+  mDeco.mSize = spinSize->value();
   mDeco.mRotationInt = sliderRotation->value();
   mDeco.setPlacement( static_cast< QgsDecorationItem::Placement>( cboPlacement->currentData().toInt() ) );
   mDeco.mMarginUnit = wgtUnitSelection->unit();
@@ -126,19 +155,47 @@ void QgsDecorationNorthArrowDialog::apply()
   mDeco.update();
 }
 
+void QgsDecorationNorthArrowDialog::updateSvgPath( const QString &svgPath )
+{
+  if ( mSvgPathLineEdit->text() != svgPath )
+  {
+    mSvgPathLineEdit->setText( svgPath );
+  }
+  mDeco.mSvgPath = svgPath;
+
+  QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( svgPath, QgsProject::instance()->pathResolver() );
+  bool validSvg = QFileInfo::exists( resolvedPath );
+
+  // draw red text for path field if invalid (path can't be resolved)
+  mSvgPathLineEdit->setStyleSheet( QString( !validSvg ? "QLineEdit{ color: rgb(225, 0, 0); }" : "" ) );
+  mSvgPathLineEdit->setToolTip( !validSvg ? tr( "File not found" ) : resolvedPath );
+
+  drawNorthArrow();
+}
+
 void QgsDecorationNorthArrowDialog::drawNorthArrow()
 {
   int rotation = spinAngle->value();
-
-  QSize size( 64, 64 );
+  double maxLength = 64;
   QSvgRenderer svg;
 
-  const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( QStringLiteral( ":/images/north_arrows/default.svg" ), size.width(), pbnChangeColor->color(), pbnChangeOutlineColor->color(), 1.0, 1.0 );
+  const QByteArray &svgContent = QgsApplication::svgCache()->svgContent( mDeco.svgPath(), maxLength, pbnChangeColor->color(), pbnChangeOutlineColor->color(), 1.0, 1.0 );
   svg.load( svgContent );
 
   if ( svg.isValid() )
   {
-    QPixmap  myPainterPixmap( size.height(), size.width() );
+    QSize size( maxLength, maxLength );
+    QRectF viewBox = svg.viewBoxF();
+    if ( viewBox.height() > viewBox.width() )
+    {
+      size.setWidth( maxLength * viewBox.width() / viewBox.height() );
+    }
+    else
+    {
+      size.setHeight( maxLength * viewBox.height() / viewBox.width() );
+    }
+
+    QPixmap  myPainterPixmap( maxLength, maxLength );
     myPainterPixmap.fill();
 
     QPainter myQPainter;
@@ -150,7 +207,7 @@ void QgsDecorationNorthArrowDialog::drawNorthArrow()
     double centerYDouble = size.height() / 2.0;
     //save the current canvas rotation
     myQPainter.save();
-    //myQPainter.translate( (int)centerXDouble, (int)centerYDouble );
+    myQPainter.translate( ( maxLength - size.width() ) / 2, ( maxLength - size.height() ) / 2 );
 
     //rotate the canvas
     myQPainter.rotate( rotation );

--- a/src/app/qgsdecorationnortharrowdialog.h
+++ b/src/app/qgsdecorationnortharrowdialog.h
@@ -26,6 +26,7 @@ class APP_EXPORT QgsDecorationNorthArrowDialog : public QDialog, private Ui::Qgs
     ~QgsDecorationNorthArrowDialog() override;
 
   private:
+    void updateSvgPath( const QString &svgPath );
     void drawNorthArrow();
     void resizeEvent( QResizeEvent * ) override; //overloads qwidget
 

--- a/src/ui/qgsdecorationnortharrowdialog.ui
+++ b/src/ui/qgsdecorationnortharrowdialog.ui
@@ -30,6 +30,74 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="1">
+       <widget class="QLabel" name="textLabel1_3_22">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2" colspan="3">
+       <widget class="QgsDoubleSpinBox" name="spinSize">
+        <property name="suffix">
+         <string> mm</string>
+        </property>
+        <property name="singleStep">
+         <double>0.5</double>
+        </property>
+        <property name="minimum">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="textLabel1_3_22">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Custom SVG</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout_26">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLineEdit" name="mSvgPathLineEdit"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="mSvgSelectorBtn">
+          <property name="text">
+           <string>…</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="0" column="1">
        <widget class="QLabel" name="textLabel1_3_2">
         <property name="sizePolicy">
@@ -99,7 +167,7 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="2" colspan="3">
+      <item row="5" column="2" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="labelHorizontal">
@@ -109,7 +177,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QgsSpinBox" name="spinVertical">
+         <widget class="QgsSpinBox" name="spinHorizontal">
           <property name="minimumSize">
            <size>
             <width>90</width>
@@ -138,7 +206,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QgsSpinBox" name="spinHorizontal">
+         <widget class="QgsSpinBox" name="spinVertical">
           <property name="minimumSize">
            <size>
             <width>90</width>
@@ -168,7 +236,7 @@
         </item>
        </layout>
       </item>
-      <item row="1" column="1">
+      <item row="3" column="1">
        <widget class="QLabel" name="textLabel6">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -190,7 +258,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="4">
+      <item row="3" column="4">
        <widget class="QSpinBox" name="spinAngle">
         <property name="maximum">
          <number>360</number>
@@ -203,7 +271,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="5" column="1">
        <widget class="QLabel" name="textLabel8">
         <property name="text">
          <string>Placement</string>
@@ -213,7 +281,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="6" column="1">
        <widget class="QLabel" name="lblMargin">
         <property name="minimumSize">
          <size>
@@ -226,7 +294,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2" colspan="3">
+      <item row="6" column="2" colspan="3">
        <widget class="QComboBox" name="cboPlacement">
         <property name="toolTip">
          <string>Placement on screen</string>
@@ -261,7 +329,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="7" column="1">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -274,7 +342,7 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="2" colspan="2">
+      <item row="3" column="2" colspan="2">
        <widget class="QSlider" name="sliderRotation">
         <property name="toolTip">
          <string/>
@@ -293,7 +361,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" rowspan="4">
+      <item row="3" column="0" rowspan="4">
        <widget class="QLabel" name="pixmapLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -344,6 +412,11 @@
    <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsUnitSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
@@ -352,6 +425,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>grpEnable</tabstop>
+  <tabstop>mSvgPathLineEdit</tabstop>
+  <tabstop>mSvgSelectorBtn</tabstop>
   <tabstop>pbnChangeColor</tabstop>
   <tabstop>sliderRotation</tabstop>
   <tabstop>spinAngle</tabstop>
@@ -362,38 +437,4 @@
   <tabstop>cboxAutomatic</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>sliderRotation</sender>
-   <signal>sliderMoved(int)</signal>
-   <receiver>spinAngle</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>374</x>
-     <y>257</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>527</x>
-     <y>259</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>spinAngle</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>sliderRotation</receiver>
-   <slot>setValue(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>524</x>
-     <y>244</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>351</x>
-     <y>263</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
 </ui>

--- a/src/ui/qgsdecorationnortharrowdialog.ui
+++ b/src/ui/qgsdecorationnortharrowdialog.ui
@@ -304,34 +304,6 @@
       <item row="3" column="2" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout_36">
         <item>
-         <widget class="QCheckBox" name="cboxAutomatic">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>30</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string/>
-          </property>
-          <property name="whatsThis">
-           <string/>
-          </property>
-          <property name="text">
-           <string>Automatic</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QSlider" name="sliderRotation">
           <property name="toolTip">
            <string/>
@@ -360,6 +332,34 @@
           </property>
           <property name="value">
            <number>0</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="cboxAutomatic">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="whatsThis">
+           <string/>
+          </property>
+          <property name="text">
+           <string>Automatic</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/src/ui/qgsdecorationnortharrowdialog.ui
+++ b/src/ui/qgsdecorationnortharrowdialog.ui
@@ -167,7 +167,7 @@
         </item>
        </layout>
       </item>
-      <item row="5" column="2" colspan="3">
+      <item row="4" column="2" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="labelHorizontal">
@@ -258,20 +258,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="4">
-       <widget class="QSpinBox" name="spinAngle">
-        <property name="maximum">
-         <number>360</number>
-        </property>
-        <property name="singleStep">
-         <number>1</number>
-        </property>
-        <property name="value">
-         <number>0</number>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
+      <item row="4" column="1">
        <widget class="QLabel" name="textLabel8">
         <property name="text">
          <string>Placement</string>
@@ -281,7 +268,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="5" column="1">
        <widget class="QLabel" name="lblMargin">
         <property name="minimumSize">
          <size>
@@ -294,42 +281,14 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="2" colspan="3">
+      <item row="5" column="2" colspan="3">
        <widget class="QComboBox" name="cboPlacement">
         <property name="toolTip">
          <string>Placement on screen</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1" colspan="2">
-       <widget class="QCheckBox" name="cboxAutomatic">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="whatsThis">
-         <string/>
-        </property>
-        <property name="text">
-         <string>Set direction automatically</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
+      <item row="6" column="1">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -342,26 +301,71 @@
         </property>
        </spacer>
       </item>
-      <item row="3" column="2" colspan="2">
-       <widget class="QSlider" name="sliderRotation">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="maximum">
-         <number>360</number>
-        </property>
-        <property name="singleStep">
-         <number>1</number>
-        </property>
-        <property name="pageStep">
-         <number>10</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
+      <item row="3" column="2" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout_36">
+        <item>
+         <widget class="QCheckBox" name="cboxAutomatic">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>30</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="whatsThis">
+           <string/>
+          </property>
+          <property name="text">
+           <string>Automatic</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSlider" name="sliderRotation">
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="maximum">
+           <number>360</number>
+          </property>
+          <property name="singleStep">
+           <number>1</number>
+          </property>
+          <property name="pageStep">
+           <number>10</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="spinAngle">
+          <property name="maximum">
+           <number>360</number>
+          </property>
+          <property name="singleStep">
+           <number>1</number>
+          </property>
+          <property name="value">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="3" column="0" rowspan="4">
+      <item row="0" column="0" rowspan="6">
        <widget class="QLabel" name="pixmapLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">


### PR DESCRIPTION
## Description
This is the last decoration upgrade on my to-do list: allow for a custom SVG and size for the north arrow decoration:
![screenshot from 2018-03-29 14-43-20](https://user-images.githubusercontent.com/1728657/38076774-d451558e-3360-11e8-882c-4821cd204c4d.png)

That's not only important style-wise, it's also crucial for non-English users, who might rely on a language which the word "north" doesn't start with N.

@nyalldawson , as always, review most welcome. FYI, I'm sorry to have convoluted two small fixes in this commit (i.e. a spinHorizontal <-> spinVertical mix up and a slider issue).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
