### PR TITLE
Use always id as identification on drag&drop form creator for relations

### DIFF
--- a/python/core/qgsattributeeditorelement.sip.in
+++ b/python/core/qgsattributeeditorelement.sip.in
@@ -268,23 +268,34 @@ This element will load a relation editor onto the form.
 %End
   public:
 
-    QgsAttributeEditorRelation( const QString &name, const QString &relationId, QgsAttributeEditorElement *parent );
+ QgsAttributeEditorRelation( const QString &name, const QString &relationId, QgsAttributeEditorElement *parent );
+%Docstring
+
+.. deprecated:: since QGIS 3.0.2. The name parameter is not used for anything and overwritten by the relationId internally.
+%End
+
+ QgsAttributeEditorRelation( const QString &name, const QgsRelation &relation, QgsAttributeEditorElement *parent );
+%Docstring
+
+.. deprecated:: since QGIS 3.0.2. The name parameter is not used for anything and overwritten by the relationId internally.
+%End
+
+    QgsAttributeEditorRelation( const QString &relationId, QgsAttributeEditorElement *parent );
 %Docstring
 Creates a new element which embeds a relation.
 
-:param name:         The name of this element
 :param relationId:   The id of the relation to embed
 :param parent:       The parent (used as container)
 %End
 
-    QgsAttributeEditorRelation( const QString &name, const QgsRelation &relation, QgsAttributeEditorElement *parent );
+    QgsAttributeEditorRelation( const QgsRelation &relation, QgsAttributeEditorElement *parent );
 %Docstring
 Creates a new element which embeds a relation.
 
-:param name:         The name of this element
 :param relation:     The relation to embed
 :param parent:       The parent (used as container)
 %End
+
 
     const QgsRelation &relation() const;
 %Docstring

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -115,7 +115,7 @@ void QgsAttributesFormProperties::initAvailableWidgetsTree()
 
   for ( const QgsRelation &relation : relations )
   {
-    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, QStringLiteral( "%1" ).arg( relation.id() ) ); //relation.name() );
+    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, QStringLiteral( "%1" ).arg( relation.id() ) );
     itemData.setShowLabel( true );
 
     RelationConfig cfg( mLayer, relation.id() );
@@ -374,13 +374,14 @@ void QgsAttributesFormProperties::storeAttributeRelationEdit()
   }
 }
 
-QgsAttributesFormProperties::RelationConfig QgsAttributesFormProperties::configForRelation( const QString &relationName )
+QgsAttributesFormProperties::RelationConfig QgsAttributesFormProperties::configForRelation( const QString &relationId )
 {
   QTreeWidgetItemIterator itemIt( mAvailableWidgetsTree );
   while ( *itemIt )
   {
     QTreeWidgetItem *item = *itemIt;
-    if ( item->data( 0, FieldNameRole ).toString() == relationName )
+
+    if ( item->data( 0, FieldNameRole ).toString() == relationId )
       return item->data( 0, RelationConfigRole ).value<RelationConfig>();
     ++itemIt;
   }
@@ -407,13 +408,12 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     case QgsAttributeEditorElement::AeTypeRelation:
     {
       const QgsAttributeEditorRelation *relationEditor = static_cast<const QgsAttributeEditorRelation *>( widgetDef );
-      DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, widgetDef->name() );
+      DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id());
       itemData.setShowLabel( widgetDef->showLabel() );
       RelationEditorConfiguration relEdConfig;
       relEdConfig.showLinkButton = relationEditor->showLinkButton();
       relEdConfig.showUnlinkButton = relationEditor->showUnlinkButton();
       itemData.setRelationEditorConfiguration( relEdConfig );
-
       newWidget = tree->addItem( parent, itemData );
       break;
     }
@@ -531,7 +531,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
     case DnDTreeItemData::Relation:
     {
       QgsRelation relation = QgsProject::instance()->relationManager()->relation( itemData.name() );
-      QgsAttributeEditorRelation *relDef = new QgsAttributeEditorRelation( itemData.name(), relation, parent );
+      QgsAttributeEditorRelation *relDef = new QgsAttributeEditorRelation( relation, parent );
       relDef->setShowLinkButton( itemData.relationEditorConfiguration().showLinkButton );
       relDef->setShowUnlinkButton( itemData.relationEditorConfiguration().showUnlinkButton );
       widgetDef = relDef;
@@ -811,6 +811,7 @@ QTreeWidgetItem *DnDTree::addItem( QTreeWidgetItem *parent, QgsAttributesFormPro
     }
   }
   newItem->setData( 0, QgsAttributesFormProperties::DnDTreeRole, data );
+
   if ( index < 0 )
     parent->addChild( newItem );
   else

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -88,14 +88,14 @@ void QgsAttributesFormProperties::initAvailableWidgetsTree()
 
   //load Fields
 
-  DnDTreeItemData catItemData = DnDTreeItemData( DnDTreeItemData::Container, "Fields" );
+  DnDTreeItemData catItemData = DnDTreeItemData( DnDTreeItemData::Container, "Fields", "Fields" );
   QTreeWidgetItem *catitem = mAvailableWidgetsTree->addItem( mAvailableWidgetsTree->invisibleRootItem(), catItemData );
 
   const QgsFields fields = mLayer->fields();
   for ( int i = 0; i < fields.size(); ++i )
   {
     const QgsField field = fields.at( i );
-    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, field.name() );
+    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, field.name(), field.name() );
     itemData.setShowLabel( true );
 
     FieldConfig cfg( mLayer, i );
@@ -108,14 +108,14 @@ void QgsAttributesFormProperties::initAvailableWidgetsTree()
   catitem->setExpanded( true );
 
   //load Relations
-  catItemData = DnDTreeItemData( DnDTreeItemData::Container, "Relations" );
+  catItemData = DnDTreeItemData( DnDTreeItemData::Container, "Relations", "Relations" );
   catitem = mAvailableWidgetsTree->addItem( mAvailableWidgetsTree->invisibleRootItem(), catItemData );
 
   const QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencedRelations( mLayer );
 
   for ( const QgsRelation &relation : relations )
   {
-    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, QStringLiteral( "%1" ).arg( relation.id() ) );
+    DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, QStringLiteral( "%1" ).arg( relation.id() ), QStringLiteral( "%1" ).arg( relation.name() ) );
     itemData.setShowLabel( true );
 
     RelationConfig cfg( mLayer, relation.id() );
@@ -399,7 +399,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
   {
     case QgsAttributeEditorElement::AeTypeField:
     {
-      DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, widgetDef->name() );
+      DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Field, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
       newWidget = tree->addItem( parent, itemData );
       break;
@@ -408,7 +408,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     case QgsAttributeEditorElement::AeTypeRelation:
     {
       const QgsAttributeEditorRelation *relationEditor = static_cast<const QgsAttributeEditorRelation *>( widgetDef );
-      DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id());
+      DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id(), relationEditor->relation().name());
       itemData.setShowLabel( widgetDef->showLabel() );
       RelationEditorConfiguration relEdConfig;
       relEdConfig.showLinkButton = relationEditor->showLinkButton();
@@ -420,7 +420,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
 
     case QgsAttributeEditorElement::AeTypeContainer:
     {
-      DnDTreeItemData itemData( DnDTreeItemData::Container, widgetDef->name() );
+      DnDTreeItemData itemData( DnDTreeItemData::Container, widgetDef->name(), widgetDef->name() );
       itemData.setShowLabel( widgetDef->showLabel() );
 
       const QgsAttributeEditorContainer *container = static_cast<const QgsAttributeEditorContainer *>( widgetDef );
@@ -771,7 +771,7 @@ QTreeWidgetItem *DnDTree::addContainer( QTreeWidgetItem *parent, const QString &
   QTreeWidgetItem *newItem = new QTreeWidgetItem( QStringList() << title );
   newItem->setBackground( 0, QBrush( Qt::lightGray ) );
   newItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled );
-  QgsAttributesFormProperties::DnDTreeItemData itemData( QgsAttributesFormProperties::DnDTreeItemData::Container, title );
+  QgsAttributesFormProperties::DnDTreeItemData itemData( QgsAttributesFormProperties::DnDTreeItemData::Container, title, title );
   itemData.setColumnCount( columnCount );
   newItem->setData( 0, QgsAttributesFormProperties::DnDTreeRole, itemData );
   parent->addChild( newItem );
@@ -811,6 +811,7 @@ QTreeWidgetItem *DnDTree::addItem( QTreeWidgetItem *parent, QgsAttributesFormPro
     }
   }
   newItem->setData( 0, QgsAttributesFormProperties::DnDTreeRole, data );
+  newItem->setText( 0, data.displayName() );
 
   if ( index < 0 )
     parent->addChild( newItem );
@@ -1082,19 +1083,21 @@ void DnDTree::setType( const Type &value )
 
 QDataStream &operator<<( QDataStream &stream, const QgsAttributesFormProperties::DnDTreeItemData &data )
 {
-  stream << ( quint32 )data.type() << data.name();
+  stream << ( quint32 )data.type() << data.name() << data.displayName();
   return stream;
 }
 
 QDataStream &operator>>( QDataStream &stream, QgsAttributesFormProperties::DnDTreeItemData &data )
 {
   QString name;
+  QString displayName;
   quint32 type;
 
-  stream >> type >> name;
+  stream >> type >> name >> displayName;
 
   data.setType( ( QgsAttributesFormProperties::DnDTreeItemData::Type )type );
   data.setName( name );
+  data.setDisplayName( displayName );
 
   return stream;
 }

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -408,7 +408,7 @@ QTreeWidgetItem *QgsAttributesFormProperties::loadAttributeEditorTreeItem( QgsAt
     case QgsAttributeEditorElement::AeTypeRelation:
     {
       const QgsAttributeEditorRelation *relationEditor = static_cast<const QgsAttributeEditorRelation *>( widgetDef );
-      DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id(), relationEditor->relation().name());
+      DnDTreeItemData itemData = DnDTreeItemData( DnDTreeItemData::Relation, relationEditor->relation().id(), relationEditor->relation().name() );
       itemData.setShowLabel( widgetDef->showLabel() );
       RelationEditorConfiguration relEdConfig;
       relEdConfig.showLinkButton = relationEditor->showLinkButton();

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -122,6 +122,7 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
         Type mType = Field;
         QString mName;
         QString mDisplayName;
+
         int mColumnCount = 1;
         bool mShowAsGroupBox = false;
         bool mShowLabel = true;

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -83,9 +83,10 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
         //do we need that
         DnDTreeItemData() = default;
 
-        DnDTreeItemData( Type type, const QString &name )
+        DnDTreeItemData( Type type, const QString &name, const QString &displayName )
           : mType( type )
           , mName( name )
+          , mDisplayName( displayName )
           , mColumnCount( 1 )
           , mShowAsGroupBox( false )
           , mShowLabel( true )
@@ -93,6 +94,9 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
 
         QString name() const { return mName; }
         void setName( const QString &name ) { mName = name; }
+
+        QString displayName() const { return mDisplayName; }
+        void setDisplayName( const QString &displayName ) { mDisplayName = displayName; }
 
         Type type() const { return mType; }
         void setType( Type type ) { mType = type; }
@@ -117,6 +121,7 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
       private:
         Type mType = Field;
         QString mName;
+        QString mDisplayName;
         int mColumnCount = 1;
         bool mShowAsGroupBox = false;
         bool mShowLabel = true;

--- a/src/core/qgsattributeeditorelement.cpp
+++ b/src/core/qgsattributeeditorelement.cpp
@@ -82,7 +82,7 @@ bool QgsAttributeEditorRelation::init( QgsRelationManager *relationManager )
 
 QgsAttributeEditorElement *QgsAttributeEditorRelation::clone( QgsAttributeEditorElement *parent ) const
 {
-  QgsAttributeEditorRelation *element = new QgsAttributeEditorRelation( name(), mRelationId, parent );
+  QgsAttributeEditorRelation *element = new QgsAttributeEditorRelation( mRelationId, parent );
   element->mRelation = mRelation;
   element->mShowLinkButton = mShowLinkButton;
   element->mShowUnlinkButton = mShowUnlinkButton;

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -319,7 +319,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     /**
      * \deprecated since QGIS 3.0.2. The name parameter is not used for anything and overwritten by the relationId internally.
      */
-    Q_DECL_DEPRECATED QgsAttributeEditorRelation(const QString &name, const QString &relationId, QgsAttributeEditorElement *parent)
+    Q_DECL_DEPRECATED QgsAttributeEditorRelation( const QString &name, const QString &relationId, QgsAttributeEditorElement *parent )
       : QgsAttributeEditorElement( AeTypeRelation, name, parent )
       , mRelationId( relationId )
       , mShowLinkButton( true )
@@ -329,7 +329,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     /**
      * \deprecated since QGIS 3.0.2. The name parameter is not used for anything and overwritten by the relationId internally.
      */
-    Q_DECL_DEPRECATED QgsAttributeEditorRelation(const QString &name, const QgsRelation &relation, QgsAttributeEditorElement *parent)
+    Q_DECL_DEPRECATED QgsAttributeEditorRelation( const QString &name, const QgsRelation &relation, QgsAttributeEditorElement *parent )
       : QgsAttributeEditorElement( AeTypeRelation, name, parent )
       , mRelationId( relation.id() )
       , mRelation( relation )
@@ -343,7 +343,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
      * \param relationId   The id of the relation to embed
      * \param parent       The parent (used as container)
      */
-    QgsAttributeEditorRelation( const QString &relationId, QgsAttributeEditorElement *parent)
+    QgsAttributeEditorRelation( const QString &relationId, QgsAttributeEditorElement *parent )
       : QgsAttributeEditorElement( AeTypeRelation, relationId, parent )
       , mRelationId( relationId )
       , mShowLinkButton( true )
@@ -356,7 +356,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
      * \param relation     The relation to embed
      * \param parent       The parent (used as container)
      */
-    QgsAttributeEditorRelation( const QgsRelation &relation, QgsAttributeEditorElement *parent)
+    QgsAttributeEditorRelation( const QgsRelation &relation, QgsAttributeEditorElement *parent )
       : QgsAttributeEditorElement( AeTypeRelation, relation.id(), parent )
       , mRelationId( relation.id() )
       , mRelation( relation )

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -322,8 +322,6 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     Q_DECL_DEPRECATED QgsAttributeEditorRelation( const QString &name, const QString &relationId, QgsAttributeEditorElement *parent )
       : QgsAttributeEditorElement( AeTypeRelation, name, parent )
       , mRelationId( relationId )
-      , mShowLinkButton( true )
-      , mShowUnlinkButton( true )
     {}
 
     /**
@@ -333,8 +331,6 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
       : QgsAttributeEditorElement( AeTypeRelation, name, parent )
       , mRelationId( relation.id() )
       , mRelation( relation )
-      , mShowLinkButton( true )
-      , mShowUnlinkButton( true )
     {}
 
     /**
@@ -346,8 +342,6 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     QgsAttributeEditorRelation( const QString &relationId, QgsAttributeEditorElement *parent )
       : QgsAttributeEditorElement( AeTypeRelation, relationId, parent )
       , mRelationId( relationId )
-      , mShowLinkButton( true )
-      , mShowUnlinkButton( true )
     {}
 
     /**
@@ -360,8 +354,6 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
       : QgsAttributeEditorElement( AeTypeRelation, relation.id(), parent )
       , mRelationId( relation.id() )
       , mRelation( relation )
-      , mShowLinkButton( true )
-      , mShowUnlinkButton( true )
     {}
 
 
@@ -416,8 +408,8 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     QString typeIdentifier() const override;
     QString mRelationId;
     QgsRelation mRelation;
-    bool mShowLinkButton;
-    bool mShowUnlinkButton;
+    bool mShowLinkButton = true;
+    bool mShowUnlinkButton = true;
 };
 
 

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -364,6 +364,7 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
       , mShowUnlinkButton( true )
     {}
 
+
     /**
      * Get the id of the relation which shall be embedded
      *

--- a/src/core/qgsattributeeditorelement.h
+++ b/src/core/qgsattributeeditorelement.h
@@ -317,14 +317,34 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
   public:
 
     /**
+     * \deprecated since QGIS 3.0.2. The name parameter is not used for anything and overwritten by the relationId internally.
+     */
+    Q_DECL_DEPRECATED QgsAttributeEditorRelation(const QString &name, const QString &relationId, QgsAttributeEditorElement *parent)
+      : QgsAttributeEditorElement( AeTypeRelation, name, parent )
+      , mRelationId( relationId )
+      , mShowLinkButton( true )
+      , mShowUnlinkButton( true )
+    {}
+
+    /**
+     * \deprecated since QGIS 3.0.2. The name parameter is not used for anything and overwritten by the relationId internally.
+     */
+    Q_DECL_DEPRECATED QgsAttributeEditorRelation(const QString &name, const QgsRelation &relation, QgsAttributeEditorElement *parent)
+      : QgsAttributeEditorElement( AeTypeRelation, name, parent )
+      , mRelationId( relation.id() )
+      , mRelation( relation )
+      , mShowLinkButton( true )
+      , mShowUnlinkButton( true )
+    {}
+
+    /**
      * Creates a new element which embeds a relation.
      *
-     * \param name         The name of this element
      * \param relationId   The id of the relation to embed
      * \param parent       The parent (used as container)
      */
-    QgsAttributeEditorRelation( const QString &name, const QString &relationId, QgsAttributeEditorElement *parent )
-      : QgsAttributeEditorElement( AeTypeRelation, name, parent )
+    QgsAttributeEditorRelation( const QString &relationId, QgsAttributeEditorElement *parent)
+      : QgsAttributeEditorElement( AeTypeRelation, relationId, parent )
       , mRelationId( relationId )
       , mShowLinkButton( true )
       , mShowUnlinkButton( true )
@@ -333,12 +353,11 @@ class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
     /**
      * Creates a new element which embeds a relation.
      *
-     * \param name         The name of this element
      * \param relation     The relation to embed
      * \param parent       The parent (used as container)
      */
-    QgsAttributeEditorRelation( const QString &name, const QgsRelation &relation, QgsAttributeEditorElement *parent )
-      : QgsAttributeEditorElement( AeTypeRelation, name, parent )
+    QgsAttributeEditorRelation( const QgsRelation &relation, QgsAttributeEditorElement *parent)
+      : QgsAttributeEditorElement( AeTypeRelation, relation.id(), parent )
       , mRelationId( relation.id() )
       , mRelation( relation )
       , mShowLinkButton( true )

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -550,8 +550,7 @@ QgsAttributeEditorElement *QgsEditFormConfig::attributeEditorElementFromDomEleme
   {
     // At this time, the relations are not loaded
     // So we only grab the id and delegate the rest to onRelationsLoaded()
-    QString name = elem.attribute( QStringLiteral( "name" ) );
-    QgsAttributeEditorRelation *relElement = new QgsAttributeEditorRelation( name, elem.attribute( QStringLiteral( "relation" ), QStringLiteral( "[None]" ) ), parent );
+    QgsAttributeEditorRelation *relElement = new QgsAttributeEditorRelation( elem.attribute( QStringLiteral( "relation" ), QStringLiteral( "[None]" ) ), parent );
     relElement->setShowLinkButton( elem.attribute( QStringLiteral( "showLinkButton" ), QStringLiteral( "1" ) ).toInt() );
     relElement->setShowUnlinkButton( elem.attribute( QStringLiteral( "showUnlinkButton" ), QStringLiteral( "1" ) ).toInt() );
     newElement = relElement;


### PR DESCRIPTION
## Description
Regarding this issue [18290](https://issues.qgis.org/issues/18290) when something else created a form with drag and drop than the attributesform in the vectorlayerproperties there could have been the danger, that attributesform destroys data. This because it always expected the relation-id as identification, but the name of the field was name. 

This name is removed in the constructor of `QgsAttributeEditorRelation` now and will be **filled automatically with the relation.id** - so there will be no problems with this anymore.

Additionally with this PR the handling is improved to have always a **"DisplayName" for labeling the items in the Drag&Drop** - usually these are the field or relation names. But they don't have to be unique anymore, means in case an external plugin creates them not uniquely it will still not break the project.

Fix #18290
