### PR TITLE
Do not save .qgd file alongside .qgs when it's not used

### DIFF
--- a/python/core/qgsauxiliarystorage.sip.in
+++ b/python/core/qgsauxiliarystorage.sip.in
@@ -347,6 +347,15 @@ Duplicates a table and its content.
 Returns the extension used for auxiliary databases.
 %End
 
+    static bool exists( const QgsProject &project );
+%Docstring
+Returns true if the auxiliary database yet exists for a project, false otherwise.
+
+:param project: The project for which the database is checked
+
+.. versionadded:: 3.2
+%End
+
 };
 
 /************************************************************************

--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -647,6 +647,12 @@ QString QgsAuxiliaryStorage::extension()
   return AS_EXTENSION;
 }
 
+bool QgsAuxiliaryStorage::exists( const QgsProject &project )
+{
+  const QFileInfo fileinfo( filenameForProject( project ) );
+  return fileinfo.exists() && fileinfo.isFile();
+}
+
 bool QgsAuxiliaryStorage::exec( const QString &sql, sqlite3 *handler )
 {
   bool rc = false;

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -377,6 +377,15 @@ class CORE_EXPORT QgsAuxiliaryStorage
      */
     static QString extension();
 
+    /**
+     * Returns true if the auxiliary database yet exists for a project, false otherwise.
+     *
+     * \param project The project for which the database is checked
+     *
+     * \since QGIS 3.2
+     */
+    static bool exists( const QgsProject &project );
+
   private:
     spatialite_database_unique_ptr open( const QString &filename = QString() );
     spatialite_database_unique_ptr open( const QgsProject &project );

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2505,6 +2505,7 @@ void QgsProject::setTrustLayerMetadata( bool trust )
 bool QgsProject::saveAuxiliaryStorage( const QString &filename )
 {
   const QMap<QString, QgsMapLayer *> layers = mapLayers();
+  bool empty = true;
   for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )
   {
     if ( it.value()->type() != QgsMapLayer::VectorLayer )
@@ -2514,10 +2515,15 @@ bool QgsProject::saveAuxiliaryStorage( const QString &filename )
     if ( vl && vl->auxiliaryLayer() )
     {
       vl->auxiliaryLayer()->save();
+      empty &= vl->auxiliaryLayer()->auxiliaryFields().isEmpty();
     }
   }
 
-  if ( !filename.isEmpty() )
+  if ( !mAuxiliaryStorage->exists( *this ) && filename.isEmpty() && empty )
+  {
+    return true; // it's not an error
+  }
+  else if ( !filename.isEmpty() )
   {
     return mAuxiliaryStorage->saveAs( filename );
   }

--- a/tests/src/python/test_qgsauxiliarystorage.py
+++ b/tests/src/python/test_qgsauxiliarystorage.py
@@ -40,7 +40,7 @@ def tmpPath():
     f.close()
     os.remove(f.fileName())
 
-    return f.fileName()
+    return f.fileName().replace('.', '_')
 
 
 def createLayer():
@@ -404,6 +404,45 @@ class TestQgsAuxiliaryStorage(unittest.TestCase):
         afName = QgsAuxiliaryLayer.nameFromProperty(p, True)
         afIndex = vl.fields().indexOf(afName)
         self.assertEqual(index, afIndex)
+
+    def testQgdCreation(self):
+        # New project
+        p = QgsProject()
+        self.assertTrue(p.auxiliaryStorage().isValid())
+
+        # Save the project
+        path = tmpPath()
+        qgs = path + '.qgs'
+        self.assertTrue(p.write(qgs))
+        self.assertTrue(os.path.exists(qgs))
+
+        # Auxiliary storage is empty so .qgd file should not be saved
+        qgd = path + '.qgd'
+        self.assertFalse(os.path.exists(qgd))
+
+        # Add a vector layer and an auxiliary layer in the project
+        vl = createLayer()
+        self.assertTrue(vl.isValid())
+        p.addMapLayers([vl])
+
+        pkf = vl.fields().field(vl.fields().indexOf('pk'))
+        al = p.auxiliaryStorage().createAuxiliaryLayer(pkf, vl)
+        self.assertTrue(al.isValid())
+        vl.setAuxiliaryLayer(al)
+
+        # Add an auxiliary field to have a non empty auxiliary storage
+        pdef = QgsPropertyDefinition('propname', QgsPropertyDefinition.DataTypeNumeric, '', '', 'ut')
+        self.assertTrue(al.addAuxiliaryField(pdef))
+
+        # Save the project
+        newpath = tmpPath()
+        qgs = newpath + '.qgs'
+        self.assertTrue(p.write(qgs))
+        self.assertTrue(os.path.exists(qgs))
+
+        # Auxiliary storage is NOT empty so .qgd file should be saved now
+        qgd = newpath + '.qgd'
+        self.assertTrue(os.path.exists(qgd))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

The aim of this PR is to save a `.qgd` file (database used for auxiliary storage) alongside `.qgs` only when it's effectively used.

See: http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-Discussing-qgd-files-td5356740.html

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
