### PR TITLE
[backport][bugfix] Update all attributes in a single transaction

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -954,6 +954,39 @@ class QgsVectorLayer : QgsMapLayer
      */
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
 
+    /**
+    * Changes attributes' values for a feature (but does not immediately
+    * commit the changes).
+    * The \a fid argument specifies the ID of the feature to be changed.
+    *
+    * The new values to be assigned to the fields are given by \a newValues.
+    *
+    * If a valid QVariant is specified for a field in \a oldValues, it will be
+    * used as the field value in the case of an undo operation corresponding
+    * to this attribute value change. If an invalid QVariant is used (the
+    * default behavior), then the feature's current value will be
+    * automatically retrieved and used. Note that this involves a feature
+    * request to the underlying data provider, so it is more efficient to
+    * explicitly pass an oldValue if it is already available.
+    *
+    * Returns true if feature's attributes was successfully changed.
+    *
+    * @note Calls to changeAttributeValues() are only valid for layers in
+    * which edits have been enabled by a call to startEditing(). Changes made
+    * to features using this method are not committed to the underlying data
+    * provider until a commitChanges() call is made. Any uncommitted changes
+    * can be discarded by calling rollBack().
+    *
+    * @see startEditing()
+    * @see commitChanges()
+    * @see changeGeometry()
+    * @see updateFeature()
+    * @see changeAttributeValue()
+    *
+    * @note added in QGIS 2.18
+    */
+   bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
+
     /** Add an attribute field (but does not commit it)
      * returns true if the field was added
      */

--- a/python/core/qgsvectorlayereditbuffer.sip
+++ b/python/core/qgsvectorlayereditbuffer.sip
@@ -70,7 +70,12 @@ class QgsVectorLayerEditBuffer : QObject
     /** Stop editing and discard the edits */
     virtual void rollBack();
 
-
+    /**
+     * Changes values of attributes (but does not commit it).
+     * @return true if attributes are well updated, false otherwise
+     * @note added in QGIS 2.18
+     */
+    virtual bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
 
     /** New features which are not commited. */
     const QgsFeatureMap& addedFeatures();

--- a/python/core/qgsvectorlayereditpassthrough.sip
+++ b/python/core/qgsvectorlayereditpassthrough.sip
@@ -12,6 +12,7 @@ class QgsVectorLayerEditPassthrough : QgsVectorLayerEditBuffer
     bool deleteFeatures( const QgsFeatureIds& fids );
     bool changeGeometry( QgsFeatureId fid, QgsGeometry* geom );
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
     bool addAttribute( const QgsField &field );
     bool deleteAttribute( int attr );
     bool renameAttribute( int attr, const QString& newName );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1347,6 +1347,39 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
 
+    /**
+     * Changes attributes' values for a feature (but does not immediately
+     * commit the changes).
+     * The \a fid argument specifies the ID of the feature to be changed.
+     *
+     * The new values to be assigned to the fields are given by \a newValues.
+     *
+     * If a valid QVariant is specified for a field in \a oldValues, it will be
+     * used as the field value in the case of an undo operation corresponding
+     * to this attribute value change. If an invalid QVariant is used (the
+     * default behavior), then the feature's current value will be
+     * automatically retrieved and used. Note that this involves a feature
+     * request to the underlying data provider, so it is more efficient to
+     * explicitly pass an oldValue if it is already available.
+     *
+     * Returns true if feature's attributes was successfully changed.
+     *
+     * \note Calls to changeAttributeValues() are only valid for layers in
+     * which edits have been enabled by a call to startEditing(). Changes made
+     * to features using this method are not committed to the underlying data
+     * provider until a commitChanges() call is made. Any uncommitted changes
+     * can be discarded by calling rollBack().
+     *
+     * \see startEditing()
+     * \see commitChanges()
+     * \see changeGeometry()
+     * \see updateFeature()
+     * \see changeAttributeValue()
+     *
+     * \since QGIS 2.18
+     */
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
+
     /** Add an attribute field (but does not commit it)
      * returns true if the field was added
      */

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1364,19 +1364,19 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * Returns true if feature's attributes was successfully changed.
      *
-     * \note Calls to changeAttributeValues() are only valid for layers in
+     * @note Calls to changeAttributeValues() are only valid for layers in
      * which edits have been enabled by a call to startEditing(). Changes made
      * to features using this method are not committed to the underlying data
      * provider until a commitChanges() call is made. Any uncommitted changes
      * can be discarded by calling rollBack().
      *
-     * \see startEditing()
-     * \see commitChanges()
-     * \see changeGeometry()
-     * \see updateFeature()
-     * \see changeAttributeValue()
+     * @see startEditing()
+     * @see commitChanges()
+     * @see changeGeometry()
+     * @see updateFeature()
+     * @see changeAttributeValue()
      *
-     * \since QGIS 2.18
+     * @note added in QGIS 2.18
      */
     bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
 

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -776,3 +776,22 @@ void QgsVectorLayerEditBuffer::updateLayerFields()
 {
   L->updateFields();
 }
+
+bool QgsVectorLayerEditBuffer::changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues )
+{
+  bool success = true;
+  QgsAttributeMap::const_iterator it;
+  for ( it = newValues.constBegin() ; it != newValues.constEnd(); ++it )
+  {
+    const int field = it.key();
+    const QVariant newValue = it.value();
+    QVariant oldValue;
+
+    if ( oldValues.contains( field ) )
+      oldValue = oldValues[field];
+
+    success &= changeAttributeValue( fid, field, newValue, oldValue );
+  }
+
+  return success;
+}

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -99,7 +99,12 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     /** Stop editing and discard the edits */
     virtual void rollBack();
 
-
+    /**
+     * Changes values of attributes (but does not commit it).
+     * \returns true if attributes are well updated, false otherwise
+     * \since QGIS 2.18
+     */
+    virtual bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
 
     /** New features which are not commited. */
     inline const QgsFeatureMap& addedFeatures() { return mAddedFeatures; }

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -101,8 +101,8 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
 
     /**
      * Changes values of attributes (but does not commit it).
-     * \returns true if attributes are well updated, false otherwise
-     * \since QGIS 2.18
+     * @return true if attributes are well updated, false otherwise
+     * @note added in QGIS 2.18
      */
     virtual bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues );
 

--- a/src/core/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/qgsvectorlayereditpassthrough.cpp
@@ -109,6 +109,27 @@ bool QgsVectorLayerEditPassthrough::changeAttributeValue( QgsFeatureId fid, int 
   return false;
 }
 
+bool QgsVectorLayerEditPassthrough::changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues )
+{
+  Q_UNUSED( oldValues );
+  bool result = false;
+
+  QgsChangedAttributesMap attribMap;
+  attribMap.insert( fid, newValues );
+
+  if ( L->dataProvider()->changeAttributeValues( attribMap ) )
+  {
+    result = true;
+    QgsAttributeMap::const_iterator it;
+    for ( it = newValues.constBegin(); it != newValues.constEnd(); ++it )
+    {
+      emit attributeValueChanged( fid, it.key(), it.value() );
+    }
+  }
+
+  return result;
+}
+
 bool QgsVectorLayerEditPassthrough::addAttribute( const QgsField &field )
 {
   if ( L->dataProvider()->addAttributes( QList<QgsField>() << field ) )

--- a/src/core/qgsvectorlayereditpassthrough.h
+++ b/src/core/qgsvectorlayereditpassthrough.h
@@ -34,6 +34,7 @@ class CORE_EXPORT QgsVectorLayerEditPassthrough : public QgsVectorLayerEditBuffe
     bool deleteFeatures( const QgsFeatureIds& fids ) override;
     bool changeGeometry( QgsFeatureId fid, QgsGeometry* geom ) override;
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() ) override;
+    bool changeAttributeValues( QgsFeatureId fid, const QgsAttributeMap &newValues, const QgsAttributeMap &oldValues ) override;
     bool addAttribute( const QgsField &field ) override;
     bool deleteAttribute( int attr ) override;
     bool renameAttribute( int attr, const QString& newName ) override;

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -337,6 +337,9 @@ bool QgsAttributeForm::saveEdits()
       {
         mLayer->beginEditCommand( mEditCommandMessage );
 
+        QgsAttributeMap newValues;
+        QgsAttributeMap oldValues;
+
         int n = 0;
         for ( int i = 0; i < dst.count(); ++i )
         {
@@ -353,9 +356,13 @@ bool QgsAttributeForm::saveEdits()
           QgsDebugMsg( QString( "src:'%1' (type:%2, isNull:%3, isValid:%4)" )
                        .arg( src.at( i ).toString(), src.at( i ).typeName() ).arg( src.at( i ).isNull() ).arg( src.at( i ).isValid() ) );
 
-          success &= mLayer->changeAttributeValue( mFeature.id(), i, dst.at( i ), src.at( i ) );
+          newValues[i] = dst.at( i );
+          oldValues[i] = src.at( i );
+
           n++;
         }
+
+        success = mLayer->changeAttributeValues( mFeature.id(), newValues, oldValues );
 
         if ( success && n > 0 )
         {

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -30,7 +30,7 @@ SET default_with_oids = false;
 
 --
 -- TOC entry 171 (class 1259 OID 377761)
--- Name: someData; Type: TABLE; Schema: qgis_test; Owner: postgres; Tablespace: 
+-- Name: someData; Type: TABLE; Schema: qgis_test; Owner: postgres; Tablespace:
 --
 
 CREATE TABLE qgis_test."someData" (
@@ -70,7 +70,7 @@ INSERT INTO qgis_test."some_poly_data" (pk, geom) VALUES
 
 --
 -- TOC entry 3953 (class 2606 OID 377768)
--- Name: someData_pkey; Type: CONSTRAINT; Schema: qgis_test; Owner: postgres; Tablespace: 
+-- Name: someData_pkey; Type: CONSTRAINT; Schema: qgis_test; Owner: postgres; Tablespace:
 --
 
 ALTER TABLE ONLY qgis_test."someData"
@@ -399,6 +399,16 @@ CREATE TABLE qgis_test.domains
   fld_numeric_domain qgis_test.numeric_domain
 );
 
+CREATE TABLE qgis_test.check_constraints (
+  id integer PRIMARY KEY,
+  a integer,
+  b integer, CHECK (a > b)
+);
+INSERT INTO qgis_test.check_constraints VALUES (
+  1, -- id
+  4, -- a
+  3  -- b
+);
 
 --------------------------------------
 -- Temporary table for testing renaming fields


### PR DESCRIPTION
## Description

Backport to 2.18 for https://github.com/qgis/QGIS/pull/6142.

Update all attributes in one transaction in order to correctly check database constraints.

Fixes https://issues.qgis.org/issues/17869

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
