### PR TITLE
[needs-docs] add zoom to selection action to contextual menu of the layer

### DIFF
--- a/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -70,7 +70,14 @@ Action to enable/disable mutually exclusive flag of a group (only one child node
 %End
 
     void zoomToLayer( QgsMapCanvas *canvas );
+
     void zoomToSelection( QgsMapCanvas *canvas );
+%Docstring
+
+.. seealso:: :py:func:`zoomToSelection`
+
+.. versionadded:: 3.2
+%End
     void zoomToGroup( QgsMapCanvas *canvas );
 
   public slots:

--- a/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -50,6 +50,13 @@ Action to check a group and all its parents
 %End
 
     QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
+
+    QAction *actionZoomToSelection( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
+%Docstring
+Action to zoom to selected features of a vector layer
+
+.. versionadded:: 3.2
+%End
     QAction *actionZoomToGroup( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
 
     QAction *actionMakeTopLevel( QObject *parent = 0 ) /Factory/;
@@ -63,6 +70,7 @@ Action to enable/disable mutually exclusive flag of a group (only one child node
 %End
 
     void zoomToLayer( QgsMapCanvas *canvas );
+    void zoomToSelection( QgsMapCanvas *canvas );
     void zoomToGroup( QgsMapCanvas *canvas );
 
   public slots:
@@ -74,6 +82,13 @@ Action to enable/disable mutually exclusive flag of a group (only one child node
     void renameGroupOrLayer();
     void showFeatureCount();
     void zoomToLayer();
+
+    void zoomToSelection();
+%Docstring
+Slot to zoom to selected features of a vector layer
+
+.. versionadded:: 3.2
+%End
     void zoomToGroup();
     void makeTopLevel();
     void groupSelected();

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -129,6 +129,12 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       if ( layer && layer->isSpatial() )
       {
         menu->addAction( actions->actionZoomToLayer( mCanvas, menu ) );
+        if ( vlayer )
+        {
+          QAction *actionZoomSelected = actions->actionZoomToSelection( mCanvas, menu );
+          actionZoomSelected->setEnabled( !vlayer->selectedFeatures().isEmpty() );
+          menu->addAction( actionZoomSelected );
+        }
         menu->addAction( actions->actionShowInOverview( menu ) );
       }
 

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -296,9 +296,8 @@ void QgsLayerTreeViewDefaultActions::zoomToSelection()
 {
   QAction *s = qobject_cast<QAction *>( sender() );
   QgsMapCanvas *canvas = reinterpret_cast<QgsMapCanvas *>( s->data().value<void *>() );
-  QApplication::setOverrideCursor( Qt::WaitCursor );
+  QgsTemporaryCursorOverride waitCursor( Qt::WaitCursor );
   zoomToSelection( canvas );
-  QApplication::restoreOverrideCursor();
 }
 
 void QgsLayerTreeViewDefaultActions::zoomToGroup()

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -97,6 +97,15 @@ QAction *QgsLayerTreeViewDefaultActions::actionZoomToLayer( QgsMapCanvas *canvas
   return a;
 }
 
+QAction *QgsLayerTreeViewDefaultActions::actionZoomToSelection( QgsMapCanvas *canvas, QObject *parent )
+{
+  QAction *a = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToSelected.svg" ) ),
+                            tr( "&Zoom to Selection" ), parent );
+  a->setData( QVariant::fromValue( reinterpret_cast<void *>( canvas ) ) );
+  connect( a, &QAction::triggered, this, static_cast<void ( QgsLayerTreeViewDefaultActions::* )()>( &QgsLayerTreeViewDefaultActions::zoomToSelection ) );
+  return a;
+}
+
 QAction *QgsLayerTreeViewDefaultActions::actionZoomToGroup( QgsMapCanvas *canvas, QObject *parent )
 {
   QAction *a = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomToLayer.svg" ) ),
@@ -252,6 +261,15 @@ void QgsLayerTreeViewDefaultActions::zoomToLayer( QgsMapCanvas *canvas )
   zoomToLayers( canvas, layers );
 }
 
+void QgsLayerTreeViewDefaultActions::zoomToSelection( QgsMapCanvas *canvas )
+{
+  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( mView->currentLayer() );
+  if ( !layer )
+    return;
+
+  canvas->zoomToSelected( layer );
+}
+
 void QgsLayerTreeViewDefaultActions::zoomToGroup( QgsMapCanvas *canvas )
 {
   QgsLayerTreeGroup *groupNode = mView->currentGroupNode();
@@ -271,6 +289,15 @@ void QgsLayerTreeViewDefaultActions::zoomToLayer()
   QgsMapCanvas *canvas = reinterpret_cast<QgsMapCanvas *>( s->data().value<void *>() );
   QApplication::setOverrideCursor( Qt::WaitCursor );
   zoomToLayer( canvas );
+  QApplication::restoreOverrideCursor();
+}
+
+void QgsLayerTreeViewDefaultActions::zoomToSelection()
+{
+  QAction *s = qobject_cast<QAction *>( sender() );
+  QgsMapCanvas *canvas = reinterpret_cast<QgsMapCanvas *>( s->data().value<void *>() );
+  QApplication::setOverrideCursor( Qt::WaitCursor );
+  zoomToSelection( canvas );
   QApplication::restoreOverrideCursor();
 }
 

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -58,8 +58,13 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     QAction *actionCheckAndAllParents( QObject *parent = nullptr );
 
     QAction *actionZoomToLayer( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * Action to zoom to selected features of a vector layer
+     * \since QGIS 3.2
+     */
+    QAction *actionZoomToSelection( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
     QAction *actionZoomToGroup( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
-    // TODO: zoom to selected
 
     QAction *actionMakeTopLevel( QObject *parent = nullptr ) SIP_FACTORY;
     QAction *actionGroupSelected( QObject *parent = nullptr ) SIP_FACTORY;
@@ -71,6 +76,7 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     QAction *actionMutuallyExclusiveGroup( QObject *parent = nullptr ) SIP_FACTORY;
 
     void zoomToLayer( QgsMapCanvas *canvas );
+    void zoomToSelection( QgsMapCanvas *canvas );
     void zoomToGroup( QgsMapCanvas *canvas );
 
   public slots:
@@ -82,6 +88,12 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     void renameGroupOrLayer();
     void showFeatureCount();
     void zoomToLayer();
+
+    /**
+     * Slot to zoom to selected features of a vector layer
+     * \since QGIS 3.2
+     */
+    void zoomToSelection();
     void zoomToGroup();
     void makeTopLevel();
     void groupSelected();

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -76,6 +76,11 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     QAction *actionMutuallyExclusiveGroup( QObject *parent = nullptr ) SIP_FACTORY;
 
     void zoomToLayer( QgsMapCanvas *canvas );
+
+    /**
+     * \see zoomToSelection()
+     * \since QGIS 3.2
+     */
     void zoomToSelection( QgsMapCanvas *canvas );
     void zoomToGroup( QgsMapCanvas *canvas );
 


### PR DESCRIPTION
## Description
There was TODO to zoom to selection action and I think could be useful to have this action shortcut.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
