### PR TITLE
processing] Rename "Add Script from Template"

### DIFF
--- a/python/plugins/processing/script/AddScriptFromTemplateAction.py
+++ b/python/plugins/processing/script/AddScriptFromTemplateAction.py
@@ -40,7 +40,7 @@ from processing.script.ScriptEditorDialog import ScriptEditorDialog
 class AddScriptFromTemplateAction(ToolboxAction):
 
     def __init__(self):
-        self.name = QCoreApplication.translate("AddScriptFromTemplate", "Load Script From Template...")
+        self.name = QCoreApplication.translate("AddScriptFromTemplate", "Create New Script from Template…")
         self.group = self.tr("Tools")
 
     def execute(self):

--- a/python/plugins/processing/script/ScriptAlgorithmProvider.py
+++ b/python/plugins/processing/script/ScriptAlgorithmProvider.py
@@ -50,8 +50,8 @@ class ScriptAlgorithmProvider(QgsProcessingProvider):
         self.algs = []
         self.folder_algorithms = []
         self.actions = [CreateNewScriptAction(),
-                        AddScriptFromFileAction(),
                         AddScriptFromTemplateAction(),
+                        AddScriptFromFileAction()
                         ]
         self.contextMenuActions = [EditScriptAction(),
                                    DeleteScriptAction()]

--- a/python/plugins/processing/ui/DlgScriptEditor.ui
+++ b/python/plugins/processing/ui/DlgScriptEditor.ui
@@ -123,10 +123,10 @@
   </widget>
   <action name="actionOpenScript">
    <property name="text">
-    <string>Open script...</string>
+    <string>Open Script…</string>
    </property>
    <property name="toolTip">
-    <string>Open script</string>
+    <string>Open Script</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -134,10 +134,10 @@
   </action>
   <action name="actionSaveScript">
    <property name="text">
-    <string>Save script...</string>
+    <string>Save Script…</string>
    </property>
    <property name="toolTip">
-    <string>Save script...</string>
+    <string>Save Script</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
@@ -145,10 +145,10 @@
   </action>
   <action name="actionSaveScriptAs">
    <property name="text">
-    <string>Save script as...</string>
+    <string>Save Script as…</string>
    </property>
    <property name="toolTip">
-    <string>Save script as...</string>
+    <string>Save Script as</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
@@ -156,10 +156,10 @@
   </action>
   <action name="actionRunScript">
    <property name="text">
-    <string>Run script</string>
+    <string>Run Script</string>
    </property>
    <property name="toolTip">
-    <string>Run script</string>
+    <string>Run Script</string>
    </property>
    <property name="shortcut">
     <string>F5</string>
@@ -222,18 +222,18 @@
   </action>
   <action name="actionIncreaseFontSize">
    <property name="text">
-    <string>Increase font size</string>
+    <string>Increase Font Size</string>
    </property>
    <property name="toolTip">
-    <string>Increase font size</string>
+    <string>Increase Font Size</string>
    </property>
   </action>
   <action name="actionDecreaseFontSize">
    <property name="text">
-    <string>Decrease font size</string>
+    <string>Decrease Font Size</string>
    </property>
    <property name="toolTip">
-    <string>Decrease font size</string>
+    <string>Decrease Font Size</string>
    </property>
   </action>
   <action name="actionFindReplace">
@@ -241,7 +241,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Find &amp; replace</string>
+    <string>Find &amp;&amp; &amp;Replace</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Rename action to "Create New Script from Template" - to me this name is more descriptive of what happens, because triggering the action doesn't actually Add a new script - that only happens if the script in the dialog is later saved.

