### PR TITLE
[processing] Throw exception when combining clip geometry fails in clip alg

### DIFF
--- a/src/analysis/processing/qgsalgorithmclip.cpp
+++ b/src/analysis/processing/qgsalgorithmclip.cpp
@@ -105,6 +105,10 @@ QVariantMap QgsClipAlgorithm::processAlgorithm( const QVariantMap &parameters, Q
   if ( clipGeoms.length() > 1 )
   {
     combinedClipGeom = QgsGeometry::unaryUnion( clipGeoms );
+    if ( combinedClipGeom.isEmpty() )
+    {
+      throw QgsProcessingException( QObject::tr( "Could not create the combined clip geometry: %1" ).arg( combinedClipGeom.lastError() ) );
+    }
     singleClipFeature = false;
   }
   else


### PR DESCRIPTION
## Description
It took me a little while to figure out what was happening here, let's make it easier for users to understand in the future by throwing an error when the creation of a combined clip geometry fails.

@nyalldawson , as discussed over Google Hangout.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
