### PR TITLE
Fix QGIS hang on exit when closing app while large dataset rendering

### DIFF
--- a/python/gui/qgsmapcanvas.sip.in
+++ b/python/gui/qgsmapcanvas.sip.in
@@ -744,7 +744,7 @@ Sets whether a user has disabled canvas renders via the GUI.
 while setRenderFlag() should only be used when users disable rendering via GUI.
 %End
 
-    void stopRendering();
+    void stopRendering( bool blocking = false );
 %Docstring
 stop rendering (if there is any right now)
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1357,7 +1357,11 @@ QgisApp::QgisApp()
 
 QgisApp::~QgisApp()
 {
-  stopRendering();
+  const QList<QgsMapCanvas *> canvases = mapCanvases();
+  for ( QgsMapCanvas *canvas : canvases )
+  {
+    canvas->stopRendering( true );
+  }
 
   delete mInternalClipboard;
   delete mQgisInterface;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -686,7 +686,7 @@ void QgsMapCanvas::mapUpdateTimeout()
   }
 }
 
-void QgsMapCanvas::stopRendering()
+void QgsMapCanvas::stopRendering( bool blocking )
 {
   if ( mJob )
   {
@@ -694,10 +694,17 @@ void QgsMapCanvas::stopRendering()
     mJobCanceled = true;
     disconnect( mJob, &QgsMapRendererJob::finished, this, &QgsMapCanvas::rendererJobFinished );
     connect( mJob, &QgsMapRendererQImageJob::finished, mJob, &QgsMapRendererQImageJob::deleteLater );
-    mJob->cancelWithoutBlocking();
+    if ( !blocking )
+    {
+      mJob->cancelWithoutBlocking();
+    }
+    else
+    {
+      mJob->cancel();
+    }
     mJob = nullptr;
   }
-  stopPreviewJobs();
+  stopPreviewJobs( blocking );
 }
 
 //the format defaults to "PNG" if not specified
@@ -2256,7 +2263,7 @@ void QgsMapCanvas::startPreviewJob( int number )
   job->start();
 }
 
-void QgsMapCanvas::stopPreviewJobs()
+void QgsMapCanvas::stopPreviewJobs( bool blocking )
 {
   mPreviewTimer.stop();
   QList< QgsMapRendererQImageJob * >::const_iterator it = mPreviewJobs.constBegin();
@@ -2266,7 +2273,14 @@ void QgsMapCanvas::stopPreviewJobs()
     {
       disconnect( *it, &QgsMapRendererJob::finished, this, &QgsMapCanvas::previewJobFinished );
       connect( *it, &QgsMapRendererQImageJob::finished, *it, &QgsMapRendererQImageJob::deleteLater );
-      ( *it )->cancelWithoutBlocking();
+      if ( !blocking )
+      {
+        ( *it )->cancelWithoutBlocking();
+      }
+      else
+      {
+        ( *it )->cancel();
+      }
     }
   }
   mPreviewJobs.clear();

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -660,7 +660,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      * stop rendering (if there is any right now)
      * \since QGIS 2.4
      */
-    void stopRendering();
+    void stopRendering( bool blocking = false );
 
     //! called to read map canvas settings from project
     void readProject( const QDomDocument & );
@@ -1037,7 +1037,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     void setLayersPrivate( const QList<QgsMapLayer *> &layers );
 
     void startPreviewJobs();
-    void stopPreviewJobs();
+    void stopPreviewJobs( bool blocking = false );
     void schedulePreviewJob( int number );
 
     friend class TestQgsMapCanvas;

--- a/src/providers/ogr/qgsogrconnpool.h
+++ b/src/providers/ogr/qgsogrconnpool.h
@@ -75,7 +75,10 @@ class QgsOgrConnPoolGroup : public QObject, public QgsConnectionPoolGroup<QgsOgr
     //! QgsOgrConnPoolGroup cannot be copied
     QgsOgrConnPoolGroup &operator=( const QgsOgrConnPoolGroup &other ) = delete;
 
-    void ref() { ++mRefCount; }
+    void ref()
+    {
+      ++mRefCount;
+    }
     bool unref()
     {
       Q_ASSERT( mRefCount > 0 );


### PR DESCRIPTION
## Description
QGIS hangs when exiting the app while a large dataset is being rendered. This PR fixes the issue by stopping any pending rendering while exiting the app.

@nyalldawson , I've been hit by this issue when exiting QGIS with a large OGR provider-based .OSM dataset (300mb). The PR might only be a band-aid to an underlying issue, but I couldn't put my finger on whatever goes wrong here. Plus, I think stopping ongoing rendering upon exit is a nice behavior to add to begin with :)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
