### PR TITLE
Update FindQextserialport.cmake for Qt5

### DIFF
--- a/cmake/FindQextserialport.cmake
+++ b/cmake/FindQextserialport.cmake
@@ -18,10 +18,10 @@ FIND_PATH(QEXTSERIALPORT_INCLUDE_DIR NAMES qextserialport.h PATHS
   /usr/local/include
   "$ENV{LIB_DIR}/include"
   "$ENV{INCLUDE}"
-  PATH_SUFFIXES QtExtSerialPort
+  PATH_SUFFIXES QtExtSerialPort qt/QtExtSerialPort
   )
 
-FIND_LIBRARY(QEXTSERIALPORT_LIBRARY NAMES qextserialport-1.2 PATHS
+FIND_LIBRARY(QEXTSERIALPORT_LIBRARY NAMES Qt5ExtSerialPort PATHS
   /usr/lib
   /usr/local/lib
   "$ENV{LIB_DIR}/lib"


### PR DESCRIPTION
The library names for Qextserialport are different between Qt4 and Qt5, but this file was never updated in QGIS3. I'm assuming it's not used much, since using the bundled lib is default.

Arch also ships it's Qt5 headers in a qt subdir, so I've added that to the search path.

Tested on Arch Linux.