### PR TITLE
[BUGFIX][FEATURE][NEEDS-DOCS] Disable snapping on invisible features. Second version

### DIFF
--- a/python/core/qgspointlocator.sip.in
+++ b/python/core/qgspointlocator.sip.in
@@ -73,7 +73,7 @@ Configure extent - if not null, it will index only that area
 .. versionadded:: 2.14
 %End
 
-    void setRenderContext( const QgsRenderContext &context );
+    void setRenderContext( const QgsRenderContext *context );
 %Docstring
 Configure render context  - if not null, it will use to index only visible feature
 

--- a/python/core/qgspointlocator.sip.in
+++ b/python/core/qgspointlocator.sip.in
@@ -73,6 +73,13 @@ Configure extent - if not null, it will index only that area
 .. versionadded:: 2.14
 %End
 
+    void setRenderContext( const QgsRenderContext &context );
+%Docstring
+Configure render context  - if not null, it will use to index only visible feature
+
+.. versionadded:: 3.2
+%End
+
     enum Type
     {
       Invalid,
@@ -198,7 +205,6 @@ Override of edgesInRect that construct rectangle from a center point and toleran
 %Docstring
 find out if the point is in any polygons
 %End
-
 
     int cachedGeometryCount() const;
 %Docstring

--- a/python/core/qgssnappingutils.sip.in
+++ b/python/core/qgssnappingutils.sip.in
@@ -35,7 +35,7 @@ which keeps the configuration in sync with map canvas (e.g. current view, active
 %End
   public:
 
-    QgsSnappingUtils( QObject *parent /TransferThis/ = 0 );
+    QgsSnappingUtils( QObject *parent /TransferThis/ = 0, bool enableSnappingForInvisibleFeature = true );
 %Docstring
 Constructor for QgsSnappingUtils
 %End
@@ -139,6 +139,15 @@ Get extra information about the instance
     QgsSnappingConfig config() const;
 %Docstring
 The snapping configuration controls the behavior of this object
+%End
+
+    void setEnableSnappingForInvisibleFeature( bool enable );
+%Docstring
+Set if invisible features must be snapped or not.
+
+:param enable: Enable or not this feature
+
+.. versionadded:: 3.2
 %End
 
   public slots:

--- a/python/gui/qgsmapcanvassnappingutils.sip.in
+++ b/python/gui/qgsmapcanvassnappingutils.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsMapCanvasSnappingUtils : QgsSnappingUtils
 {
 %Docstring

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -20,6 +20,9 @@ digitizing\default_snap_type=1
 # 2 = Project units
 digitizing\default_snapping_tolerance_unit=1
 
+# Snap on invisble feature
+digitizing\snap_invisible_feature=false
+
 # Default XYZ tile servers to include
 connections-xyz\OpenStreetMap\authcfg=
 connections-xyz\OpenStreetMap\password=

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -971,6 +971,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
 
   mSnappingMarkerColorButton->setColor( mSettings->value( QStringLiteral( "/qgis/digitizing/snap_color" ), QColor( Qt::magenta ) ).value<QColor>() );
   mSnappingTooltipsCheckbox->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/snap_tooltip" ), false ).toBool() );
+  mEnableSnappingOnInvisibleFeatureCheckbox->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool() );
 
   //vertex marker
   mMarkersOnlyForSelectedCheckBox->setChecked( mSettings->value( QStringLiteral( "/qgis/digitizing/marker_only_for_selected" ), true ).toBool() );
@@ -1483,6 +1484,7 @@ void QgsOptions::saveOptions()
 
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/snap_color" ), mSnappingMarkerColorButton->color() );
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/snap_tooltip" ), mSnappingTooltipsCheckbox->isChecked() );
+  mSettings->setValue( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), mEnableSnappingOnInvisibleFeatureCheckbox->isChecked() );
 
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/marker_only_for_selected" ), mMarkersOnlyForSelectedCheckBox->isChecked() );
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -331,6 +331,7 @@ bool QgsSymbolLegendNode::setData( const QVariant &value, int role )
   vlayer->renderer()->checkLegendSymbolItem( mItem.ruleKey(), value == Qt::Checked );
 
   emit dataChanged();
+  emit vlayer->styleChanged();
 
   vlayer->triggerRepaint();
 

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -331,7 +331,7 @@ bool QgsSymbolLegendNode::setData( const QVariant &value, int role )
   vlayer->renderer()->checkLegendSymbolItem( mItem.ruleKey(), value == Qt::Checked );
 
   emit dataChanged();
-  emit vlayer->styleChanged();
+  vlayer->emitStyleChanged();
 
   vlayer->triggerRepaint();
 

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -637,9 +637,6 @@ QgsPointLocator::QgsPointLocator( QgsVectorLayer *layer, const QgsCoordinateRefe
   connect( mLayer, &QgsVectorLayer::featureDeleted, this, &QgsPointLocator::onFeatureDeleted );
   connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsPointLocator::onGeometryChanged );
   connect( mLayer, &QgsVectorLayer::dataChanged, this, &QgsPointLocator::destroyIndex );
-  connect( mLayer, &QgsVectorLayer::rendererChanged, this, &QgsPointLocator::destroyIndex );
-  connect( mLayer, &QgsVectorLayer::styleChanged, this, &QgsPointLocator::destroyIndex );
-  connect( mLayer, &QgsVectorLayer::layerModified, this, &QgsPointLocator::destroyIndex );
 }
 
 
@@ -669,6 +666,7 @@ void QgsPointLocator::setRenderContext( const QgsRenderContext &context )
 {
   mContext = std::unique_ptr<QgsRenderContext>( new QgsRenderContext( context ) );
 
+  connect( mLayer, &QgsVectorLayer::styleChanged, this, &QgsPointLocator::destroyIndex );
   destroyIndex();
 }
 
@@ -740,10 +738,10 @@ bool QgsPointLocator::rebuildIndex( int maxFeaturesToIndex )
     if ( !f.hasGeometry() )
       continue;
 
-    if ( ctx && renderer )
+    if ( filter && ctx && renderer )
     {
       ctx->expressionContext().setFeature( f );
-      if ( filter && !renderer->willRenderFeature( f, *ctx ) )
+      if ( !renderer->willRenderFeature( f, *ctx ) )
       {
         continue;
       }

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -663,12 +663,19 @@ void QgsPointLocator::setExtent( const QgsRectangle *extent )
   destroyIndex();
 }
 
-void QgsPointLocator::setRenderContext( const QgsRenderContext &context )
+void QgsPointLocator::setRenderContext( const QgsRenderContext *context )
 {
-  mContext = std::unique_ptr<QgsRenderContext>( new QgsRenderContext( context ) );
+  disconnect( mLayer, &QgsVectorLayer::styleChanged, this, &QgsPointLocator::destroyIndex );
 
-  connect( mLayer, &QgsVectorLayer::styleChanged, this, &QgsPointLocator::destroyIndex );
   destroyIndex();
+  mContext.reset( nullptr );
+
+  if ( context )
+  {
+    mContext = std::unique_ptr<QgsRenderContext>( new QgsRenderContext( *context ) );
+    connect( mLayer, &QgsVectorLayer::styleChanged, this, &QgsPointLocator::destroyIndex );
+  }
+
 }
 
 bool QgsPointLocator::init( int maxFeaturesToIndex )

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -842,10 +842,11 @@ void QgsPointLocator::onFeatureAdded( QgsFeatureId fid )
     if ( !f.hasGeometry() )
       return;
 
-    std::unique_ptr< QgsFeatureRenderer > renderer( mLayer->renderer() ? mLayer->renderer()->clone() : nullptr );
-    QgsRenderContext *ctx = nullptr;
     if ( mContext )
     {
+      std::unique_ptr< QgsFeatureRenderer > renderer( mLayer->renderer() ? mLayer->renderer()->clone() : nullptr );
+      QgsRenderContext *ctx = nullptr;
+
       mContext->expressionContext() << QgsExpressionContextUtils::layerScope( mLayer );
       ctx = mContext.get();
       if ( renderer && ctx )
@@ -920,8 +921,11 @@ void QgsPointLocator::onAttributeValueChanged( QgsFeatureId fid, int idx, const 
 {
   Q_UNUSED( idx );
   Q_UNUSED( value );
-  onFeatureDeleted( fid );
-  onFeatureAdded( fid );
+  if ( mContext )
+  {
+    onFeatureDeleted( fid );
+    onFeatureAdded( fid );
+  }
 }
 
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -285,7 +285,6 @@ class CORE_EXPORT QgsPointLocator : public QObject
     //! flag whether the layer is currently empty (i.e. mRTree is null but it is not necessary to rebuild it)
     bool mIsEmptyLayer;
 
-    QgsFeatureIds mFeatureIds;
 
     //! R-tree containing spatial index
     QgsCoordinateTransform mTransform;

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -18,12 +18,15 @@
 
 class QgsPointXY;
 class QgsVectorLayer;
+class QgsFeatureRenderer;
+class QgsRenderContext;
 
 #include "qgis_core.h"
 #include "qgsfeature.h"
 #include "qgspointxy.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransform.h"
+#include <memory>
 
 class QgsPointLocator_VisitorNearestVertex;
 class QgsPointLocator_VisitorNearestEdge;
@@ -91,6 +94,12 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * \since QGIS 2.14
      */
     void setExtent( const QgsRectangle *extent );
+
+    /**
+     * Configure render context  - if not null, it will use to index only visible feature
+     * \since QGIS 3.2
+     */
+    void setRenderContext( const QgsRenderContext &context );
 
     /**
      * The type of a snap result or the filter type for a snap request.
@@ -251,8 +260,6 @@ class CORE_EXPORT QgsPointLocator : public QObject
     //! find out if the point is in any polygons
     MatchList pointInPolygon( const QgsPointXY &point );
 
-    //
-
     /**
      * Return how many geometries are cached in the index
      * \since QGIS 2.14
@@ -278,10 +285,14 @@ class CORE_EXPORT QgsPointLocator : public QObject
     //! flag whether the layer is currently empty (i.e. mRTree is null but it is not necessary to rebuild it)
     bool mIsEmptyLayer;
 
+    QgsFeatureIds mFeatureIds;
+
     //! R-tree containing spatial index
     QgsCoordinateTransform mTransform;
     QgsVectorLayer *mLayer = nullptr;
     QgsRectangle *mExtent = nullptr;
+
+    std::unique_ptr<QgsRenderContext> mContext;
 
     friend class QgsPointLocator_VisitorNearestVertex;
     friend class QgsPointLocator_VisitorNearestEdge;

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -274,6 +274,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
     void onFeatureAdded( QgsFeatureId fid );
     void onFeatureDeleted( QgsFeatureId fid );
     void onGeometryChanged( QgsFeatureId fid, const QgsGeometry &geom );
+    void onAttributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value );
 
   private:
     //! Storage manager

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -99,7 +99,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * Configure render context  - if not null, it will use to index only visible feature
      * \since QGIS 3.2
      */
-    void setRenderContext( const QgsRenderContext &context );
+    void setRenderContext( const QgsRenderContext *context );
 
     /**
      * The type of a snap result or the filter type for a snap request.

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -363,7 +363,10 @@ void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers
       QgsPointLocator *loc = locatorForLayer( vl );
 
       if ( !mEnableSnappingForInvisibleFeature )
-        loc->setRenderContext( QgsRenderContext::fromMapSettings( mMapSettings ) );
+      {
+        QgsRenderContext ctx = QgsRenderContext::fromMapSettings( mMapSettings );
+        loc->setRenderContext( &ctx );
+      }
 
       if ( mStrategy == IndexExtent )
       {

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -53,7 +53,7 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
   public:
 
     //! Constructor for QgsSnappingUtils
-    QgsSnappingUtils( QObject *parent SIP_TRANSFERTHIS = nullptr );
+    QgsSnappingUtils( QObject *parent SIP_TRANSFERTHIS = nullptr, bool enableSnappingForInvisibleFeature = true );
     ~QgsSnappingUtils() override;
 
     // main actions
@@ -159,6 +159,15 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
      */
     QgsSnappingConfig config() const;
 
+    /**
+     * Set if invisible features must be snapped or not.
+     *
+     * \param enable Enable or not this feature
+     *
+     * \since QGIS 3.2
+     */
+    void setEnableSnappingForInvisibleFeature( bool enable );
+
   public slots:
 
     /**
@@ -242,6 +251,10 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     //! internal flag that an indexing process is going on. Prevents starting two processes in parallel.
     bool mIsIndexing = false;
+
+    //! Disable or not the snapping on all features. By default is always true except for non visible features on map canvas.
+    bool mEnableSnappingForInvisibleFeature = true;
+
 };
 
 

--- a/src/gui/qgsmapcanvassnappingutils.cpp
+++ b/src/gui/qgsmapcanvassnappingutils.cpp
@@ -16,12 +16,13 @@
 
 #include "qgsmapcanvas.h"
 #include "qgsvectorlayer.h"
+#include "qgssettings.h"
 
 #include <QApplication>
 #include <QProgressDialog>
 
 QgsMapCanvasSnappingUtils::QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObject *parent )
-  : QgsSnappingUtils( parent )
+  : QgsSnappingUtils( parent, QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool() )
   , mCanvas( canvas )
 
 {
@@ -30,6 +31,7 @@ QgsMapCanvasSnappingUtils::QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObj
   connect( canvas, &QgsMapCanvas::layersChanged, this, &QgsMapCanvasSnappingUtils::canvasMapSettingsChanged );
   connect( canvas, &QgsMapCanvas::currentLayerChanged, this, &QgsMapCanvasSnappingUtils::canvasCurrentLayerChanged );
   connect( canvas, &QgsMapCanvas::transformContextChanged, this, &QgsMapCanvasSnappingUtils::canvasTransformContextChanged );
+  connect( canvas, &QgsMapCanvas::mapToolSet, this, &QgsMapCanvasSnappingUtils::canvasMapToolChanged );
   canvasMapSettingsChanged();
   canvasCurrentLayerChanged();
 }
@@ -37,6 +39,7 @@ QgsMapCanvasSnappingUtils::QgsMapCanvasSnappingUtils( QgsMapCanvas *canvas, QObj
 void QgsMapCanvasSnappingUtils::canvasMapSettingsChanged()
 {
   setMapSettings( mCanvas->mapSettings() );
+  setEnableSnappingForInvisibleFeature( QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool() );
 }
 
 void QgsMapCanvasSnappingUtils::canvasTransformContextChanged()
@@ -49,6 +52,11 @@ void QgsMapCanvasSnappingUtils::canvasTransformContextChanged()
 void QgsMapCanvasSnappingUtils::canvasCurrentLayerChanged()
 {
   setCurrentLayer( qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() ) );
+}
+
+void QgsMapCanvasSnappingUtils::canvasMapToolChanged()
+{
+  setEnableSnappingForInvisibleFeature( QgsSettings().value( QStringLiteral( "/qgis/digitizing/snap_invisible_feature" ), false ).toBool() );
 }
 
 void QgsMapCanvasSnappingUtils::prepareIndexStarting( int count )

--- a/src/gui/qgsmapcanvassnappingutils.h
+++ b/src/gui/qgsmapcanvassnappingutils.h
@@ -18,6 +18,8 @@
 #include "qgssnappingutils.h"
 #include "qgis_gui.h"
 
+#include "qgsmaptool.h"
+
 class QgsMapCanvas;
 
 class QProgressDialog;
@@ -42,6 +44,7 @@ class GUI_EXPORT QgsMapCanvasSnappingUtils : public QgsSnappingUtils
     void canvasMapSettingsChanged();
     void canvasTransformContextChanged();
     void canvasCurrentLayerChanged();
+    void canvasMapToolChanged();
 
   private:
     QgsMapCanvas *mCanvas = nullptr;

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -320,7 +320,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>7</number>
+          <number>8</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -349,8 +349,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>839</height>
+                <width>411</width>
+                <height>662</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -654,11 +654,11 @@
                     </property>
                     <item row="1" column="0">
                      <widget class="QCheckBox" name="mDataSourceManagerNonModal">
-                      <property name="text">
-                       <string>Modeless data source manager dialog</string>
-                      </property>
                       <property name="toolTip">
                        <string>A modeless dialog allows you to interact with QGIS main window and dialogs.</string>
+                      </property>
+                      <property name="text">
+                       <string>Modeless data source manager dialog</string>
                       </property>
                      </widget>
                     </item>
@@ -1040,8 +1040,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>1110</height>
+                <width>437</width>
+                <height>1011</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1576,8 +1576,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>826</height>
+                <width>443</width>
+                <height>312</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -1743,8 +1743,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>826</height>
+                <width>393</width>
+                <height>648</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -2111,8 +2111,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>843</width>
-                <height>1110</height>
+                <width>541</width>
+                <height>866</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -2862,8 +2862,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>826</height>
+                <width>449</width>
+                <height>195</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -3119,8 +3119,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>826</height>
+                <width>515</width>
+                <height>527</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3563,8 +3563,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>857</width>
-                <height>826</height>
+                <width>124</width>
+                <height>230</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -3731,8 +3731,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>572</width>
-                <height>889</height>
+                <width>862</width>
+                <height>838</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -3954,39 +3954,75 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                  <property name="title">
                   <string>Snapping</string>
                  </property>
-                 <layout class="QGridLayout" name="_10">
-                  <item row="6" column="5">
-                   <widget class="QgsColorButton" name="mSnappingMarkerColorButton"/>
-                  </item>
-                  <item row="1" column="1" colspan="6">
+                 <layout class="QGridLayout" name="gridLayout_3">
+                  <item row="0" column="0" colspan="4">
                    <widget class="QCheckBox" name="mSnappingEnabledDefault">
                     <property name="text">
                      <string>Enable snapping by default</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="1">
-                   <widget class="QLabel" name="label_49">
-                    <property name="text">
-                     <string>Display main dialog as (restart required)</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="6" column="1">
-                   <widget class="QLabel" name="label_2">
-                    <property name="text">
-                     <string>Snapping marker color</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
+                  <item row="1" column="0">
                    <widget class="QLabel" name="mDefaultSnapModeLabel">
                     <property name="text">
                      <string>Default snap mode</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="6">
+                  <item row="1" column="1">
+                   <spacer>
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>273</width>
+                      <height>19</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="1" column="2">
+                   <widget class="QComboBox" name="mDefaultSnapModeComboBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="mDefaultSnappingToleranceTextLabel">
+                    <property name="text">
+                     <string>Default snapping tolerance</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <spacer>
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>241</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QDoubleSpinBox" name="mDefaultSnappingToleranceSpinBox">
+                    <property name="decimals">
+                     <number>5</number>
+                    </property>
+                    <property name="maximum">
+                     <double>99999999.989999994635582</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="3">
                    <widget class="QComboBox" name="mDefaultSnappingToleranceComboBox">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -4006,7 +4042,14 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     </item>
                    </widget>
                   </item>
-                  <item row="4" column="4">
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="mVertexSearchRadiusVertexEditLabel">
+                    <property name="text">
+                     <string>Search radius for vertex edits</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="1">
                    <spacer>
                     <property name="orientation">
                      <enum>Qt::Horizontal</enum>
@@ -4019,30 +4062,17 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     </property>
                    </spacer>
                   </item>
-                  <item row="3" column="3" colspan="2">
-                   <spacer>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
+                  <item row="3" column="2">
+                   <widget class="QDoubleSpinBox" name="mSearchRadiusVertexEditSpinBox">
+                    <property name="decimals">
+                     <number>5</number>
                     </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>241</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="2" column="5" colspan="2">
-                   <widget class="QComboBox" name="mDefaultSnapModeComboBox">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
+                    <property name="maximum">
+                     <double>99999999.989999994635582</double>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="6">
+                  <item row="3" column="3">
                    <widget class="QComboBox" name="mSearchRadiusVertexEditComboBox">
                     <item>
                      <property name="text">
@@ -4056,60 +4086,37 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                     </item>
                    </widget>
                   </item>
-                  <item row="4" column="5">
-                   <widget class="QDoubleSpinBox" name="mSearchRadiusVertexEditSpinBox">
-                    <property name="decimals">
-                     <number>5</number>
-                    </property>
-                    <property name="maximum">
-                     <double>99999999.989999994635582</double>
+                  <item row="4" column="0">
+                   <widget class="QLabel" name="label_49">
+                    <property name="text">
+                     <string>Display main dialog as (restart required)</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="5">
-                   <widget class="QDoubleSpinBox" name="mDefaultSnappingToleranceSpinBox">
-                    <property name="decimals">
-                     <number>5</number>
-                    </property>
-                    <property name="maximum">
-                     <double>99999999.989999994635582</double>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="2" colspan="3">
-                   <spacer>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>311</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="5" column="5" colspan="2">
+                  <item row="4" column="2">
                    <widget class="QComboBox" name="mSnappingMainDialogComboBox"/>
                   </item>
-                  <item row="4" column="1" colspan="3">
-                   <widget class="QLabel" name="mVertexSearchRadiusVertexEditLabel">
+                  <item row="5" column="0">
+                   <widget class="QLabel" name="label_2">
                     <property name="text">
-                     <string>Search radius for vertex edits</string>
+                     <string>Snapping marker color</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="1" colspan="2">
-                   <widget class="QLabel" name="mDefaultSnappingToleranceTextLabel">
-                    <property name="text">
-                     <string>Default snapping tolerance</string>
-                    </property>
-                   </widget>
+                  <item row="5" column="2">
+                   <widget class="QgsColorButton" name="mSnappingMarkerColorButton"/>
                   </item>
-                  <item row="7" column="1" colspan="6">
+                  <item row="6" column="0" colspan="4">
                    <widget class="QCheckBox" name="mSnappingTooltipsCheckbox">
                     <property name="text">
                      <string>Show snapping tooltips</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="7" column="0" colspan="4">
+                   <widget class="QCheckBox" name="mEnableSnappingOnInvisibleFeatureCheckbox">
+                    <property name="text">
+                     <string>Enable snapping on invisible features (not shown on the map canvas)</string>
                     </property>
                    </widget>
                   </item>
@@ -4326,8 +4333,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>509</width>
-                <height>623</height>
+                <width>390</width>
+                <height>539</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -4595,8 +4602,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>435</width>
-                <height>402</height>
+                <width>862</width>
+                <height>838</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4764,8 +4771,8 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>655</width>
-                <height>768</height>
+                <width>862</width>
+                <height>838</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -5533,7 +5540,6 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
   <tabstop>mSearchRadiusVertexEditComboBox</tabstop>
   <tabstop>mSnappingMainDialogComboBox</tabstop>
   <tabstop>mSnappingMarkerColorButton</tabstop>
-  <tabstop>mSnappingTooltipsCheckbox</tabstop>
   <tabstop>mMarkersOnlyForSelectedCheckBox</tabstop>
   <tabstop>mMarkerStyleComboBox</tabstop>
   <tabstop>mMarkerSizeSpinBox</tabstop>
@@ -5581,7 +5587,6 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
   <tabstop>mAdvancedSettingsEnableButton</tabstop>
  </tabstops>
  <resources>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -136,7 +136,6 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( !m.hasVertex() );
 
       u.setEnableSnappingForInvisibleFeature( true );
-      mVL->styleChanged();
       m = u.snapToMap( QPoint( 2, 2 ) );
       QVERIFY( m.isValid() );
       QVERIFY( m.hasVertex() );


### PR DESCRIPTION
## Description
Following the discussions, I open a new PR with modifications for #6657 / Fixes #16838.

If you are ok with the new propositions, I will add tests

A comment, I thought that by activating/deactivating a style, the styleChanged or rendererChanged signal would be emitted. This is not the case, I added the repaintRequested signal. See the [video](https://raw.githubusercontent.com/lbartoletti/lbartoletti.github.io/master/snapPrepared/snapPrepared.webm)

I tested on a data set with the cadastre and all networks (water, sanitation, road, etc.) on an old computer and for me it is usable.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
