### PR TITLE
[processing] Fix GDAL algorithms do not run with memory layer inputs

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -73,7 +73,7 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
         input_layer = self.parameterAsVectorLayer(parameters, parameter_name, context)
         ogr_data_path = None
         ogr_layer_name = None
-        if input_layer is None:
+        if input_layer is None or input_layer.dataProvider().name() == 'memory':
             if executing:
                 # parameter is not a vector layer - try to convert to a source compatible with OGR
                 # and extract selection if required


### PR DESCRIPTION
Breaks execution of mixed QGIS/GDAL algorithms

Refs https://gis.stackexchange.com/questions/278527/cannot-use-gdal-algorithms-in-processing-modeler-qgis-3-0