### PR TITLE
server tests for GetFeatureinfo different widget values

### DIFF
--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -197,6 +197,22 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
         #                          'wms_getfeatureinfo-values1-text-xml',
         #                          'test_project_values.qgs')
 
+        # Test GetFeatureInfo resolves "relation reference" widget "display expression" values
+        # TODO make GetFeatureInfo show what's in the display expression and enable test
+        # mypath = self.testdata_path + "test_project_values.qgs"
+        # self.wms_request_compare('GetFeatureInfo',
+        #                          '&layers=layer2&styles=&' +
+        #                          'VERSION=1.3.0&' +
+        #                          'info_format=text%2Fxml&' +
+        #                          'width=926&height=787&srs=EPSG%3A4326' +
+        #                          '&bbox=912217,5605059,914099,5606652' +
+        #                          '&CRS=EPSG:3857' +
+        #                          '&FEATURE_COUNT=10' +
+        #                          '&WITH_GEOMETRY=True' +
+        #                          '&QUERY_LAYERS=layer2&I=487&J=308',
+        #                          'wms_getfeatureinfo-values2-text-xml',
+        #                          'test_project_values.qgs')
+
     def testGetFeatureInfoFilter(self):
         # Test getfeatureinfo response xml
 

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -66,7 +66,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'query_layers=testlayer%20%C3%A8%C3%A9&X=190&Y=320',
                                  'wms_getfeatureinfo-text-html')
 
-        #Test getfeatureinfo response html with geometry
+        # Test getfeatureinfo response html with geometry
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
                                  'info_format=text%2Fhtml&transparent=true&' +
@@ -76,7 +76,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'with_geometry=true',
                                  'wms_getfeatureinfo-text-html-geometry')
 
-        #Test getfeatureinfo response html with maptip
+        # Test getfeatureinfo response html with maptip
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=testlayer%20%C3%A8%C3%A9&styles=&' +
                                  'info_format=text%2Fhtml&transparent=true&' +
@@ -181,53 +181,59 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'wms_getfeatureinfo-values1-text-xml',
                                  'test_project_values.qgs')
 
-        # Test GetFeatureInfo resolves "value relation" widget values
-        # TODO fix regression and enable test
-        # mypath = self.testdata_path + "test_project_values.qgs"
-        # self.wms_request_compare('GetFeatureInfo',
-        #                          '&layers=layer1&styles=&' +
-        #                          'VERSION=1.3.0&' +
-        #                          'info_format=text%2Fxml&' +
-        #                          'width=926&height=787&srs=EPSG%3A4326' +
-        #                          '&bbox=912217,5605059,914099,5606652' +
-        #                          '&CRS=EPSG:3857' +
-        #                          '&FEATURE_COUNT=10' +
-        #                          '&WITH_GEOMETRY=True' +
-        #                          '&QUERY_LAYERS=layer1&I=487&J=308',
-        #                          'wms_getfeatureinfo-values1-text-xml',
-        #                          'test_project_values.qgs')
+    # TODO fix regression in QGIS 3 as the widget values don't get solved and enable test
+    @unittest.expectedFailure
+    def testGetFeatureInfoValueRelation(self):
+        """Test GetFeatureInfo resolves "value relation" widget values"""
+        mypath = self.testdata_path + "test_project_values.qgs"
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=layer1&styles=&' +
+                                 'VERSION=1.3.0&' +
+                                 'info_format=text%2Fxml&' +
+                                 'width=926&height=787&srs=EPSG%3A4326' +
+                                 '&bbox=912217,5605059,914099,5606652' +
+                                 '&CRS=EPSG:3857' +
+                                 '&FEATURE_COUNT=10' +
+                                 '&WITH_GEOMETRY=True' +
+                                 '&QUERY_LAYERS=layer1&I=487&J=308',
+                                 'wms_getfeatureinfo-values1-text-xml',
+                                 'test_project_values.qgs')
 
-        # Test GetFeatureInfo on "value relation" widget with array field (multiple selections)
-        # TODO make GetFeatureInfo show the dictionary values and enable test
-        # mypath = self.testdata_path + "test_project_values.qgs"
-        # self.wms_request_compare('GetFeatureInfo',
-        #                          '&layers=layer3&styles=&' +
-        #                          'VERSION=1.3.0&' +
-        #                          'info_format=text%2Fxml&' +
-        #                          'width=926&height=787&srs=EPSG%3A4326' +
-        #                          '&bbox=912217,5605059,914099,5606652' +
-        #                          '&CRS=EPSG:3857' +
-        #                          '&FEATURE_COUNT=10' +
-        #                          '&WITH_GEOMETRY=True' +
-        #                          '&QUERY_LAYERS=layer3&I=487&J=308',
-        #                          'wms_getfeatureinfo-values3-text-xml',
-        #                          'test_project_values.qgs')
+    # TODO make GetFeatureInfo show the dictionary values and enable test
+    @unittest.expectedFailure
+    def testGetFeatureInfoValueRelationArray(self):
+        """Test GetFeatureInfo on "value relation" widget with array field (multiple selections)"""
+        mypath = self.testdata_path + "test_project_values.qgs"
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=layer3&styles=&' +
+                                 'VERSION=1.3.0&' +
+                                 'info_format=text%2Fxml&' +
+                                 'width=926&height=787&srs=EPSG%3A4326' +
+                                 '&bbox=912217,5605059,914099,5606652' +
+                                 '&CRS=EPSG:3857' +
+                                 '&FEATURE_COUNT=10' +
+                                 '&WITH_GEOMETRY=True' +
+                                 '&QUERY_LAYERS=layer3&I=487&J=308',
+                                 'wms_getfeatureinfo-values3-text-xml',
+                                 'test_project_values.qgs')
 
-        # Test GetFeatureInfo resolves "relation reference" widget "display expression" values
-        # TODO make GetFeatureInfo show what's in the display expression and enable test
-        # mypath = self.testdata_path + "test_project_values.qgs"
-        # self.wms_request_compare('GetFeatureInfo',
-        #                          '&layers=layer2&styles=&' +
-        #                          'VERSION=1.3.0&' +
-        #                          'info_format=text%2Fxml&' +
-        #                          'width=926&height=787&srs=EPSG%3A4326' +
-        #                          '&bbox=912217,5605059,914099,5606652' +
-        #                          '&CRS=EPSG:3857' +
-        #                          '&FEATURE_COUNT=10' +
-        #                          '&WITH_GEOMETRY=True' +
-        #                          '&QUERY_LAYERS=layer2&I=487&J=308',
-        #                          'wms_getfeatureinfo-values2-text-xml',
-        #                          'test_project_values.qgs')
+    # TODO make GetFeatureInfo show what's in the display expression and enable test
+    @unittest.expectedFailure
+    def testGetFeatureInfoRelationReference(self):
+        """Test GetFeatureInfo solves "relation reference" widget "display expression" values"""
+        mypath = self.testdata_path + "test_project_values.qgs"
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=layer2&styles=&' +
+                                 'VERSION=1.3.0&' +
+                                 'info_format=text%2Fxml&' +
+                                 'width=926&height=787&srs=EPSG%3A4326' +
+                                 '&bbox=912217,5605059,914099,5606652' +
+                                 '&CRS=EPSG:3857' +
+                                 '&FEATURE_COUNT=10' +
+                                 '&WITH_GEOMETRY=True' +
+                                 '&QUERY_LAYERS=layer2&I=487&J=308',
+                                 'wms_getfeatureinfo-values2-text-xml',
+                                 'test_project_values.qgs')
 
     def testGetFeatureInfoFilter(self):
         # Test getfeatureinfo response xml

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -167,6 +167,20 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'wms_getfeatureinfo_notvisible',
                                  'test_project_scalevisibility.qgs')
 
+        # Test GetFeatureInfo resolves value map widget values
+        mypath = self.testdata_path + "test_project_values.qgs"
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=layer0&styles=&' +
+                                 'VERSION=1.3.0&' +
+                                 'info_format=text%2Fxml&' +
+                                 'width=926&height=787&srs=EPSG%3A4326' +
+                                 '&bbox=912217,5605059,914099,5606652' +
+                                 '&CRS=EPSG:3857' +
+                                 '&FEATURE_COUNT=10' +
+                                 '&QUERY_LAYERS=layer0&I=487&J=308',
+                                 'wms_getfeatureinfo-values1-text-xml',
+                                 'test_project_values.qgs')
+
     def testGetFeatureInfoFilter(self):
         # Test getfeatureinfo response xml
 

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -197,6 +197,22 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
         #                          'wms_getfeatureinfo-values1-text-xml',
         #                          'test_project_values.qgs')
 
+        # Test GetFeatureInfo on "value relation" widget with array field (multiple selections)
+        # TODO make GetFeatureInfo show the dictionary values and enable test
+        # mypath = self.testdata_path + "test_project_values.qgs"
+        # self.wms_request_compare('GetFeatureInfo',
+        #                          '&layers=layer3&styles=&' +
+        #                          'VERSION=1.3.0&' +
+        #                          'info_format=text%2Fxml&' +
+        #                          'width=926&height=787&srs=EPSG%3A4326' +
+        #                          '&bbox=912217,5605059,914099,5606652' +
+        #                          '&CRS=EPSG:3857' +
+        #                          '&FEATURE_COUNT=10' +
+        #                          '&WITH_GEOMETRY=True' +
+        #                          '&QUERY_LAYERS=layer3&I=487&J=308',
+        #                          'wms_getfeatureinfo-values3-text-xml',
+        #                          'test_project_values.qgs')
+
         # Test GetFeatureInfo resolves "relation reference" widget "display expression" values
         # TODO make GetFeatureInfo show what's in the display expression and enable test
         # mypath = self.testdata_path + "test_project_values.qgs"

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -167,7 +167,7 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  'wms_getfeatureinfo_notvisible',
                                  'test_project_scalevisibility.qgs')
 
-        # Test GetFeatureInfo resolves value map widget values
+        # Test GetFeatureInfo resolves "value map" widget values
         mypath = self.testdata_path + "test_project_values.qgs"
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=layer0&styles=&' +
@@ -180,6 +180,22 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  '&QUERY_LAYERS=layer0&I=487&J=308',
                                  'wms_getfeatureinfo-values1-text-xml',
                                  'test_project_values.qgs')
+
+        # Test GetFeatureInfo resolves "value relation" widget values
+        # TODO fix regression and enable test
+        # mypath = self.testdata_path + "test_project_values.qgs"
+        # self.wms_request_compare('GetFeatureInfo',
+        #                          '&layers=layer1&styles=&' +
+        #                          'VERSION=1.3.0&' +
+        #                          'info_format=text%2Fxml&' +
+        #                          'width=926&height=787&srs=EPSG%3A4326' +
+        #                          '&bbox=912217,5605059,914099,5606652' +
+        #                          '&CRS=EPSG:3857' +
+        #                          '&FEATURE_COUNT=10' +
+        #                          '&WITH_GEOMETRY=True' +
+        #                          '&QUERY_LAYERS=layer1&I=487&J=308',
+        #                          'wms_getfeatureinfo-values1-text-xml',
+        #                          'test_project_values.qgs')
 
     def testGetFeatureInfoFilter(self):
         # Test getfeatureinfo response xml

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -76,6 +76,14 @@ INSERT INTO qgis_test."some_poly_data" (pk, geom) VALUES
 (4, NULL)
 ;
 
+
+CREATE TABLE qgis_test.array_tbl (id serial PRIMARY KEY, location int[], geom geometry(Point,3857));
+
+INSERT INTO qgis_test.array_tbl (location, geom) VALUES ('{1, 2, 3}', 'srid=3857;Point(913209.0358 5606025.2373)'::geometry);
+INSERT INTO qgis_test.array_tbl (location, geom) VALUES ('{}', 'srid=3857;Point(913214.6741 5606017.8743)'::geometry);
+INSERT INTO qgis_test.array_tbl (geom) VALUES ('srid=3857;Point(913204.9128 5606011.4565)'::geometry);
+
+
 -- Provider check with compound key
 
 CREATE TABLE qgis_test."someDataCompound" (

--- a/tests/testdata/qgis_server/material_values.csv
+++ b/tests/testdata/qgis_server/material_values.csv
@@ -1,0 +1,4 @@
+id,short_ro,_displayname_en,diameter,pressure_nominal
+1,PE,PE 1000 PN6,1000,6
+2,PE,PE,,
+3,PE,PE 1000 PN8,1000,8

--- a/tests/testdata/qgis_server/test_project_values.qgs
+++ b/tests/testdata/qgis_server/test_project_values.qgs
@@ -19,7 +19,7 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties/>
-    <layer-tree-layer expanded="1" checked="Qt::Checked" id="testlayer20150528120452665" name="layer0" source="../../../../qgis2/tests/testdata/qgis_server/testlayer.shp" providerKey="ogr">
+    <layer-tree-layer expanded="1" checked="Qt::Checked" id="testlayer20150528120452665" name="layer0" source="./testlayer.shp" providerKey="ogr">
       <customproperties/>
     </layer-tree-layer>
     <custom-order enabled="0">
@@ -72,7 +72,7 @@
         <ymax>44.90148252600183554</ymax>
       </extent>
       <id>testlayer20150528120452665</id>
-      <datasource>../../../../qgis2/tests/testdata/qgis_server/testlayer.shp</datasource>
+      <datasource>./testlayer.shp</datasource>
       <title>A test vector layer</title>
       <abstract>A test vector layer with unicode òà</abstract>
       <keywordList>

--- a/tests/testdata/qgis_server/test_project_values.qgs
+++ b/tests/testdata/qgis_server/test_project_values.qgs
@@ -1,0 +1,461 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis projectname="QGIS Test Project" version="3.1.0-Master">
+  <homePath path=""/>
+  <title>QGIS Test Project</title>
+  <autotransaction active="0"/>
+  <evaluateDefaultValues active="0"/>
+  <trust active="0"/>
+  <projectCrs>
+    <spatialrefsys>
+      <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+      <srsid>3452</srsid>
+      <srid>4326</srid>
+      <authid>EPSG:4326</authid>
+      <description>WGS 84</description>
+      <projectionacronym>longlat</projectionacronym>
+      <ellipsoidacronym>WGS84</ellipsoidacronym>
+      <geographicflag>true</geographicflag>
+    </spatialrefsys>
+  </projectCrs>
+  <layer-tree-group>
+    <customproperties/>
+    <layer-tree-layer expanded="1" checked="Qt::Checked" id="testlayer20150528120452665" name="layer0" source="../../../../qgis2/tests/testdata/qgis_server/testlayer.shp" providerKey="ogr">
+      <customproperties/>
+    </layer-tree-layer>
+    <custom-order enabled="0">
+      <item>testlayer20150528120452665</item>
+    </custom-order>
+  </layer-tree-group>
+  <snapping-settings type="2" enabled="0" intersection-snapping="0" tolerance="0" unit="2" mode="1">
+    <individual-layer-settings>
+      <layer-setting id="testlayer20150528120452665" type="2" units="2" enabled="0" tolerance="0"/>
+    </individual-layer-settings>
+  </snapping-settings>
+  <relations/>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+    <units>degrees</units>
+    <extent>
+      <xmin>8.20315414376310059</xmin>
+      <ymin>44.90112783049693235</ymin>
+      <xmax>8.204164917965862</xmax>
+      <ymax>44.90170711558835137</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>WGS84</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+  </mapcanvas>
+  <legend updateDrawingOrder="true">
+    <legendlayer checked="Qt::Checked" drawingOrder="-1" open="true" name="layer0" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile layerid="testlayer20150528120452665" isInOverview="0" visible="1"/>
+      </filegroup>
+    </legendlayer>
+  </legend>
+  <mapViewDocks/>
+  <projectlayers>
+    <maplayer simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" readOnly="0" labelsEnabled="1" simplifyAlgorithm="0" type="vector" simplifyLocal="1" minScale="1e+8" refreshOnNotifyMessage="" simplifyDrawingTol="1" refreshOnNotifyEnabled="0" autoRefreshTime="0" maxScale="0" simplifyDrawingHints="0" geometry="Point" autoRefreshEnabled="0">
+      <extent>
+        <xmin>8.20345930703634352</xmin>
+        <ymin>44.90139483904469131</ymin>
+        <xmax>8.20354699399348775</xmax>
+        <ymax>44.90148252600183554</ymax>
+      </extent>
+      <id>testlayer20150528120452665</id>
+      <datasource>../../../../qgis2/tests/testdata/qgis_server/testlayer.shp</datasource>
+      <title>A test vector layer</title>
+      <abstract>A test vector layer with unicode òà</abstract>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>layer0</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
+        <symbols>
+          <symbol alpha="1" type="marker" name="0" clip_to_extent="1">
+            <layer pass="0" class="SimpleMarker" enabled="1" locked="0">
+              <prop k="angle" v="0"/>
+              <prop k="color" v="102,164,67,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="name" v="circle"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_style" v="solid"/>
+              <prop k="outline_width" v="0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="area"/>
+              <prop k="size" v="2"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
+              <effect type="effectStack" enabled="0">
+                <effect type="drawSource">
+                  <prop k="blend_mode" v="0"/>
+                  <prop k="draw_mode" v="2"/>
+                  <prop k="enabled" v="1"/>
+                  <prop k="opacity" v="1"/>
+                </effect>
+              </effect>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option value="" type="QString" name="name"/>
+                  <Option name="properties"/>
+                  <Option value="collection" type="QString" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+        <effect type="effectStack" enabled="0">
+          <effect type="drawSource">
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
+          </effect>
+        </effect>
+      </renderer-v2>
+      <customproperties>
+        <property value="0" key="embeddedWidgets/count"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+        <DiagramCategory sizeType="MM" labelPlacementMethod="XHeight" lineSizeType="MM" barWidth="5" scaleBasedVisibility="0" maxScaleDenominator="1e+8" penColor="#000000" penWidth="0" backgroundColor="#ffffff" diagramOrientation="Up" backgroundAlpha="255" height="15" penAlpha="255" minimumSize="0" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" enabled="0" minScaleDenominator="inf" lineSizeScale="3x:0,0,0,0,0,0" width="15" rotationOffset="270" opacity="1">
+          <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute label="" field="" color="#000000"/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings showAll="1" placement="0" priority="0" zIndex="0" dist="0" linePlacementFlags="10" obstacle="0">
+        <properties>
+          <Option type="Map">
+            <Option value="" type="QString" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option value="true" type="bool" name="active"/>
+                <Option value="id" type="QString" name="field"/>
+                <Option value="2" type="int" name="type"/>
+              </Option>
+            </Option>
+            <Option value="collection" type="QString" name="type"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <fieldConfiguration>
+        <field name="id">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="name">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option value="0" type="QString" name="IsMultiline"/>
+                <Option value="0" type="QString" name="UseHtml"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="utf8nameè">
+          <editWidget type="ValueMap">
+            <config>
+              <Option type="Map">
+                <Option type="Map" name="map">
+                  <Option value="one èé" type="QString" name="First Value"/>
+                  <Option value="two àò" type="QString" name="Second Value"/>
+                  <Option value="three èé↓" type="QString" name="Third èé↓"/>
+                </Option>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias index="0" name="" field="id"/>
+        <alias index="1" name="" field="name"/>
+        <alias index="2" name="" field="utf8nameè"/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default expression="" field="id" applyOnUpdate="0"/>
+        <default expression="" field="name" applyOnUpdate="0"/>
+        <default expression="" field="utf8nameè" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint exp_strength="0" constraints="0" notnull_strength="0" field="id" unique_strength="0"/>
+        <constraint exp_strength="0" constraints="0" notnull_strength="0" field="name" unique_strength="0"/>
+        <constraint exp_strength="0" constraints="0" notnull_strength="0" field="utf8nameè" unique_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint exp="" desc="" field="id"/>
+        <constraint exp="" desc="" field="name"/>
+        <constraint exp="" desc="" field="utf8nameè"/>
+      </constraintExpressions>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+        <columns>
+          <column hidden="0" type="field" name="id" width="-1"/>
+          <column hidden="0" type="field" name="name" width="-1"/>
+          <column hidden="0" type="field" name="utf8nameè" width="130"/>
+          <column hidden="1" type="actions" width="-1"/>
+        </columns>
+      </attributetableconfig>
+      <editform>../../../../qgis2/tests/testdata/qgis_server</editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath>../../../../qgis2/tests/testdata/qgis_server</editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable/>
+      <labelOnTop/>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <expressionfields/>
+      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+  </projectlayers>
+  <layerorder>
+    <layer id="testlayer20150528120452665"/>
+  </layerorder>
+  <properties>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <Identify>
+      <disabledLayers type="QStringList"/>
+    </Identify>
+    <WMSExtent type="QStringList">
+      <value>8.20315414376310059</value>
+      <value>44.901236559338642</value>
+      <value>8.204164917965862</value>
+      <value>44.90159838674664172</value>
+    </WMSExtent>
+    <WMSContactPosition type="QString"></WMSContactPosition>
+    <WMSRestrictedLayers type="QStringList"/>
+    <WMSContactOrganization type="QString">QGIS dev team</WMSContactOrganization>
+    <WFSLayersPrecision>
+      <testlayer20150528120452665 type="int">8</testlayer20150528120452665>
+    </WFSLayersPrecision>
+    <WMSContactPerson type="QString">Alessandro Pasotti</WMSContactPerson>
+    <Gui>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
+      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+    </Gui>
+    <DefaultStyles>
+      <Marker type="QString"></Marker>
+      <ColorRamp type="QString"></ColorRamp>
+      <Fill type="QString"></Fill>
+      <AlphaInt type="int">255</AlphaInt>
+      <Line type="QString"></Line>
+      <RandomColors type="bool">true</RandomColors>
+    </DefaultStyles>
+    <SpatialRefSys>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+      <ProjectCrs type="QString">EPSG:4326</ProjectCrs>
+      <ProjectCRSProj4String type="QString">+proj=longlat +datum=WGS84 +no_defs</ProjectCRSProj4String>
+      <ProjectCRSID type="int">3452</ProjectCRSID>
+    </SpatialRefSys>
+    <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
+    <WMSFees type="QString">conditions unknown</WMSFees>
+    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
+    <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
+    <Digitizing>
+      <LayerSnappingToleranceList type="QStringList">
+        <value>0.000000</value>
+      </LayerSnappingToleranceList>
+      <LayerSnappingToleranceUnitList type="QStringList">
+        <value>2</value>
+      </LayerSnappingToleranceUnitList>
+      <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
+      <LayerSnappingList type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </LayerSnappingList>
+      <SnappingMode type="QString">current_layer</SnappingMode>
+      <DefaultSnapType type="QString">off</DefaultSnapType>
+      <AvoidIntersectionsList type="QStringList"/>
+      <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
+      <LayerSnappingEnabledList type="QStringList">
+        <value>disabled</value>
+      </LayerSnappingEnabledList>
+      <LayerSnapToList type="QStringList">
+        <value>to_vertex_and_segment</value>
+      </LayerSnapToList>
+    </Digitizing>
+    <WMSPrecision type="QString">4</WMSPrecision>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <WMSUrl type="QString"></WMSUrl>
+    <WFSLayers type="QStringList">
+      <value>testlayer20150528120452665</value>
+    </WFSLayers>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <PAL>
+      <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
+      <CandidatesPoint type="int">16</CandidatesPoint>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <SearchMethod type="int">0</SearchMethod>
+      <CandidatesLine type="int">50</CandidatesLine>
+    </PAL>
+    <PositionPrecision>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+      <DegreeFormat type="QString">D</DegreeFormat>
+      <Automatic type="bool">true</Automatic>
+    </PositionPrecision>
+    <Measure>
+      <Ellipsoid type="QString">WGS84</Ellipsoid>
+    </Measure>
+    <WCSUrl type="QString"></WCSUrl>
+    <WMSServiceAbstract type="QString">Some UTF8 text èòù</WMSServiceAbstract>
+    <Legend>
+      <filterByMap type="bool">false</filterByMap>
+    </Legend>
+    <WMSRestrictedComposers type="QStringList"/>
+    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
+    <WFSUrl type="QString"></WFSUrl>
+    <Paths>
+      <Absolute type="bool">false</Absolute>
+    </Paths>
+    <Variables>
+      <variableNames type="QStringList"/>
+      <variableValues type="QStringList"/>
+    </Variables>
+    <WMSServiceTitle type="QString">QGIS TestProject</WMSServiceTitle>
+    <WCSLayers type="QStringList"/>
+    <WMSImageQuality type="int">90</WMSImageQuality>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <WMSKeywordList type="QStringList">
+      <value></value>
+    </WMSKeywordList>
+    <WFSTLayers>
+      <Insert type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Insert>
+      <Delete type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Delete>
+      <Update type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Update>
+    </WFSTLayers>
+    <WMSContactMail type="QString">elpaso@itopen.it</WMSContactMail>
+  </properties>
+  <visibility-presets/>
+  <transformContext/>
+  <projectMetadata>
+    <identifier></identifier>
+    <parentidentifier></parentidentifier>
+    <language></language>
+    <type></type>
+    <title>QGIS Test Project</title>
+    <abstract></abstract>
+    <links/>
+    <author></author>
+    <creation></creation>
+  </projectMetadata>
+  <Annotations/>
+  <Layouts/>
+</qgis>

--- a/tests/testdata/qgis_server/test_project_values.qgs
+++ b/tests/testdata/qgis_server/test_project_values.qgs
@@ -19,40 +19,45 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties/>
-    <layer-tree-layer source="./material_values.csv" id="material_values_07693a17_8d8d_4657_8645_0d1364588136" checked="Qt::Checked" expanded="1" providerKey="ogr" name="material_values">
+    <layer-tree-layer name="material_values" providerKey="ogr" expanded="1" id="material_values_07693a17_8d8d_4657_8645_0d1364588136" source="./material_values.csv" checked="Qt::Checked">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer source="./value_dict.csv" id="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" checked="Qt::Checked" expanded="1" providerKey="ogr" name="value_dict">
+    <layer-tree-layer name="value_dict" providerKey="ogr" expanded="1" id="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" source="./value_dict.csv" checked="Qt::Checked">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer source="./testlayer.shp" id="testlayer20150528120452665" checked="Qt::Checked" expanded="1" providerKey="ogr" name="layer0">
+    <layer-tree-layer name="layer0" providerKey="ogr" expanded="1" id="testlayer20150528120452665" source="./testlayer.shp" checked="Qt::Checked">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer source="./testlayer.shp" id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" checked="Qt::Checked" expanded="1" providerKey="ogr" name="layer1">
+    <layer-tree-layer name="layer1" providerKey="ogr" expanded="1" id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" source="./testlayer.shp" checked="Qt::Checked">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer source="./testlayer.shp" id="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" checked="Qt::Checked" expanded="1" providerKey="ogr" name="layer2">
+    <layer-tree-layer name="layer2" providerKey="ogr" expanded="1" id="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" source="./testlayer.shp" checked="Qt::Checked">
+      <customproperties/>
+    </layer-tree-layer>
+    <layer-tree-layer name="layer3" providerKey="postgres" expanded="1" id="array_tbl_70c06ef2_bdfe_4412_94f0_5b8d1c317281" source="service='qgis_test' sslmode=disable key='id' srid=3857 type=Point table=&quot;qgis_test&quot;.&quot;array_tbl&quot; (geom) sql=" checked="Qt::Checked">
       <customproperties/>
     </layer-tree-layer>
     <custom-order enabled="0">
       <item>testlayer20150528120452665</item>
       <item>layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1</item>
       <item>layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5</item>
+      <item>array_tbl_70c06ef2_bdfe_4412_94f0_5b8d1c317281</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings type="2" mode="1" enabled="0" unit="2" intersection-snapping="0" tolerance="0">
+  <snapping-settings type="2" tolerance="0" unit="2" intersection-snapping="0" enabled="0" mode="1">
     <individual-layer-settings>
-      <layer-setting type="2" units="1" enabled="1" id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" tolerance="30"/>
-      <layer-setting type="2" units="1" enabled="1" id="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" tolerance="30"/>
-      <layer-setting type="2" units="2" enabled="0" id="testlayer20150528120452665" tolerance="0"/>
+      <layer-setting type="2" tolerance="0" units="2" id="testlayer20150528120452665" enabled="0"/>
+      <layer-setting type="2" tolerance="30" units="1" id="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" enabled="1"/>
+      <layer-setting type="2" tolerance="30" units="1" id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" enabled="1"/>
+      <layer-setting type="2" tolerance="30" units="1" id="array_tbl_70c06ef2_bdfe_4412_94f0_5b8d1c317281" enabled="1"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations>
-    <relation referencingLayer="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" referencedLayer="material_values_07693a17_8d8d_4657_8645_0d1364588136" strength="Association" id="test-relation" name="test-relation">
-      <fieldRef referencedField="id" referencingField="id"/>
+    <relation name="test-relation" id="test-relation" referencingLayer="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" strength="Association" referencedLayer="material_values_07693a17_8d8d_4657_8645_0d1364588136">
+      <fieldRef referencingField="id" referencedField="id"/>
     </relation>
   </relations>
-  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+  <mapcanvas name="theMapCanvas" annotationsVisible="1">
     <units>degrees</units>
     <extent>
       <xmin>8.20264578195449801</xmin>
@@ -76,35 +81,335 @@
     <rendermaptile>0</rendermaptile>
   </mapcanvas>
   <legend updateDrawingOrder="true">
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="material_values">
+    <legendlayer name="material_values" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" open="true">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="material_values_07693a17_8d8d_4657_8645_0d1364588136" visible="1"/>
+        <legendlayerfile layerid="material_values_07693a17_8d8d_4657_8645_0d1364588136" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="value_dict">
+    <legendlayer name="value_dict" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" open="true">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" visible="1"/>
+        <legendlayerfile layerid="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="layer0">
+    <legendlayer name="layer0" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" open="true">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="testlayer20150528120452665" visible="1"/>
+        <legendlayerfile layerid="testlayer20150528120452665" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="layer1">
+    <legendlayer name="layer1" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" open="true">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" visible="1"/>
+        <legendlayerfile layerid="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
-    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="layer2">
+    <legendlayer name="layer2" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" open="true">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" layerid="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" visible="1"/>
+        <legendlayerfile layerid="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" visible="1" isInOverview="0"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer name="layer3" drawingOrder="-1" checked="Qt::Checked" showFeatureCount="0" open="true">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile layerid="array_tbl_70c06ef2_bdfe_4412_94f0_5b8d1c317281" visible="1" isInOverview="0"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
+  <mapcanvas name="mAreaCanvas" annotationsVisible="1">
+    <units>degrees</units>
+    <extent>
+      <xmin>0</xmin>
+      <ymin>0</ymin>
+      <xmax>0</xmax>
+      <ymax>0</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>WGS84</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+  </mapcanvas>
+  <mapcanvas name="mAreaCanvas" annotationsVisible="1">
+    <units>degrees</units>
+    <extent>
+      <xmin>0</xmin>
+      <ymin>0</ymin>
+      <xmax>0</xmax>
+      <ymax>0</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>WGS84</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+  </mapcanvas>
+  <mapcanvas name="mAreaCanvas" annotationsVisible="1">
+    <units>degrees</units>
+    <extent>
+      <xmin>0</xmin>
+      <ymin>0</ymin>
+      <xmax>0</xmax>
+      <ymax>0</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+        <srsid>3452</srsid>
+        <srid>4326</srid>
+        <authid>EPSG:4326</authid>
+        <description>WGS 84</description>
+        <projectionacronym>longlat</projectionacronym>
+        <ellipsoidacronym>WGS84</ellipsoidacronym>
+        <geographicflag>true</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+  </mapcanvas>
   <projectlayers>
-    <maplayer type="vector" simplifyAlgorithm="0" labelsEnabled="0" simplifyDrawingHints="0" readOnly="0" maxScale="0" simplifyMaxScale="1" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="Point" simplifyDrawingTol="1">
+    <maplayer refreshOnNotifyEnabled="0" simplifyAlgorithm="0" refreshOnNotifyMessage="" type="vector" labelsEnabled="0" minScale="1e+8" simplifyMaxScale="1" simplifyDrawingHints="0" simplifyLocal="0" hasScaleBasedVisibilityFlag="0" maxScale="0" autoRefreshEnabled="0" geometry="Point" readOnly="0" autoRefreshTime="0" simplifyDrawingTol="1">
+      <extent>
+        <xmin>913204.91280000004917383</xmin>
+        <ymin>5606011.45650000032037497</ymin>
+        <xmax>913214.67409999994561076</xmax>
+        <ymax>5606025.23730000015348196</ymax>
+      </extent>
+      <id>array_tbl_70c06ef2_bdfe_4412_94f0_5b8d1c317281</id>
+      <datasource>service='qgis_test' sslmode=disable key='id' srid=3857 type=Point table="qgis_test"."array_tbl" (geom) sql=</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>layer3</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+          <srsid>3857</srsid>
+          <srid>3857</srid>
+          <authid>EPSG:3857</authid>
+          <description>WGS 84 / Pseudo Mercator</description>
+          <projectionacronym>merc</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type>dataset</type>
+        <title></title>
+        <abstract></abstract>
+        <contact>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
+        </contact>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4>+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs</proj4>
+            <srsid>3857</srsid>
+            <srid>3857</srid>
+            <authid>EPSG:3857</authid>
+            <description>WGS 84 / Pseudo Mercator</description>
+            <projectionacronym>merc</projectionacronym>
+            <ellipsoidacronym>WGS84</ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent>
+          <spatial crs="EPSG:3857" minx="0" dimensions="2" minz="0" miny="0" maxz="0" maxx="0" maxy="0"/>
+          <temporal>
+            <period>
+              <start></start>
+              <end></end>
+            </period>
+          </temporal>
+        </extent>
+      </resourceMetadata>
+      <provider encoding="UTF-8">postgres</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
+        <symbols>
+          <symbol name="0" type="marker" clip_to_extent="1" alpha="1">
+            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
+              <prop v="0" k="angle"/>
+              <prop v="141,90,153,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" type="QString" value=""/>
+                  <Option name="properties"/>
+                  <Option name="type" type="QString" value="collection"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties>
+        <property key="embeddedWidgets/count" value="0"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+        <DiagramCategory labelPlacementMethod="XHeight" penWidth="0" barWidth="5" rotationOffset="270" opacity="1" width="15" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" penColor="#000000" backgroundColor="#ffffff" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" maxScaleDenominator="1e+8" enabled="0" minScaleDenominator="0" scaleBasedVisibility="0" minimumSize="0" sizeType="MM" height="15" diagramOrientation="Up">
+          <fontProperties style="" description="Sans Serif,9,-1,5,50,0,0,0,0,0"/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings priority="0" dist="0" obstacle="0" linePlacementFlags="18" placement="0" zIndex="0" showAll="1">
+        <properties>
+          <Option type="Map">
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties"/>
+            <Option name="type" type="QString" value="collection"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <fieldConfiguration>
+        <field name="id">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="location">
+          <editWidget type="ValueRelation">
+            <config>
+              <Option type="Map">
+                <Option name="AllowMulti" type="bool" value="true"/>
+                <Option name="AllowNull" type="bool" value="false"/>
+                <Option name="FilterExpression" type="QString" value=""/>
+                <Option name="Key" type="QString" value="id"/>
+                <Option name="Layer" type="QString" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09"/>
+                <Option name="NofColumns" type="int" value="3"/>
+                <Option name="OrderByValue" type="bool" value="false"/>
+                <Option name="UseCompleter" type="bool" value="false"/>
+                <Option name="Value" type="QString" value="value_id"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="location" index="1"/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="location" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint notnull_strength="1" constraints="3" exp_strength="0" field="id" unique_strength="1"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="location" unique_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="location" exp=""/>
+      </constraintExpressions>
+      <attributeactions>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns>
+          <column name="id" type="field" hidden="0" width="-1"/>
+          <column name="location" type="field" hidden="0" width="-1"/>
+          <column type="actions" hidden="1" width="-1"/>
+        </columns>
+      </attributetableconfig>
+      <editform></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable>
+        <field name="id" editable="1"/>
+        <field name="location" editable="1"/>
+      </editable>
+      <labelOnTop>
+        <field name="id" labelOnTop="0"/>
+        <field name="location" labelOnTop="0"/>
+      </labelOnTop>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <expressionfields/>
+      <previewExpression>id</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer refreshOnNotifyEnabled="0" simplifyAlgorithm="0" refreshOnNotifyMessage="" type="vector" labelsEnabled="0" minScale="1e+8" simplifyMaxScale="1" simplifyDrawingHints="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" maxScale="0" autoRefreshEnabled="0" geometry="Point" readOnly="0" autoRefreshTime="0" simplifyDrawingTol="1">
       <extent>
         <xmin>8.20345930703634352</xmin>
         <ymin>44.90139483904469131</ymin>
@@ -159,11 +464,11 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minz="0" maxx="0" maxz="0" crs="" minx="0" dimensions="2" miny="0" maxy="0"/>
+          <spatial crs="" minx="0" dimensions="2" minz="0" miny="0" maxz="0" maxx="0" maxy="0"/>
           <temporal>
             <period>
               <start></start>
@@ -181,10 +486,10 @@
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
+      <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
         <symbols>
-          <symbol type="marker" clip_to_extent="1" name="0" alpha="1">
-            <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+          <symbol name="0" type="marker" clip_to_extent="1" alpha="1">
+            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
               <prop v="0" k="angle"/>
               <prop v="102,164,67,255" k="color"/>
               <prop v="1" k="horizontal_anchor_point"/>
@@ -213,9 +518,9 @@
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option name="name" type="QString" value=""/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="type" type="QString" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -233,31 +538,31 @@
         </effect>
       </renderer-v2>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory penAlpha="255" diagramOrientation="Up" scaleDependency="Area" enabled="0" lineSizeType="MM" minScaleDenominator="0" rotationOffset="270" width="15" maxScaleDenominator="1e+8" height="15" opacity="1" penWidth="0" backgroundColor="#ffffff" backgroundAlpha="255" sizeType="MM" minimumSize="0" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" scaleBasedVisibility="0">
-          <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory labelPlacementMethod="XHeight" penWidth="0" barWidth="5" rotationOffset="270" opacity="1" width="15" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" penColor="#000000" backgroundColor="#ffffff" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" maxScaleDenominator="1e+8" enabled="0" minScaleDenominator="0" scaleBasedVisibility="0" minimumSize="0" sizeType="MM" height="15" diagramOrientation="Up">
+          <fontProperties style="" description="Ubuntu,9,-1,5,50,0,0,0,0,0"/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings zIndex="0" placement="0" linePlacementFlags="2" dist="0" obstacle="0" priority="0" showAll="1">
+      <DiagramLayerSettings priority="0" dist="0" obstacle="0" linePlacementFlags="2" placement="0" zIndex="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
-            <Option type="Map" name="properties">
-              <Option type="Map" name="show">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties" type="Map">
+              <Option name="show" type="Map">
+                <Option name="active" type="bool" value="true"/>
+                <Option name="field" type="QString" value="id"/>
+                <Option name="type" type="int" value="2"/>
               </Option>
             </Option>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
@@ -266,15 +571,15 @@
           <editWidget type="ValueRelation">
             <config>
               <Option type="Map">
-                <Option type="bool" value="false" name="AllowMulti"/>
-                <Option type="bool" value="false" name="AllowNull"/>
-                <Option type="QString" value="" name="FilterExpression"/>
-                <Option type="QString" value="id" name="Key"/>
-                <Option type="QString" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" name="Layer"/>
-                <Option type="int" value="1" name="NofColumns"/>
-                <Option type="bool" value="false" name="OrderByValue"/>
-                <Option type="bool" value="false" name="UseCompleter"/>
-                <Option type="QString" value="value_id" name="Value"/>
+                <Option name="AllowMulti" type="bool" value="false"/>
+                <Option name="AllowNull" type="bool" value="false"/>
+                <Option name="FilterExpression" type="QString" value=""/>
+                <Option name="Key" type="QString" value="id"/>
+                <Option name="Layer" type="QString" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09"/>
+                <Option name="NofColumns" type="int" value="1"/>
+                <Option name="OrderByValue" type="bool" value="false"/>
+                <Option name="UseCompleter" type="bool" value="false"/>
+                <Option name="Value" type="QString" value="value_id"/>
               </Option>
             </config>
           </editWidget>
@@ -283,15 +588,15 @@
           <editWidget type="ValueRelation">
             <config>
               <Option type="Map">
-                <Option type="bool" value="false" name="AllowMulti"/>
-                <Option type="bool" value="false" name="AllowNull"/>
-                <Option type="QString" value="" name="FilterExpression"/>
-                <Option type="QString" value="reverse" name="Key"/>
-                <Option type="QString" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" name="Layer"/>
-                <Option type="int" value="1" name="NofColumns"/>
-                <Option type="bool" value="false" name="OrderByValue"/>
-                <Option type="bool" value="false" name="UseCompleter"/>
-                <Option type="QString" value="reverse_val" name="Value"/>
+                <Option name="AllowMulti" type="bool" value="false"/>
+                <Option name="AllowNull" type="bool" value="false"/>
+                <Option name="FilterExpression" type="QString" value=""/>
+                <Option name="Key" type="QString" value="reverse"/>
+                <Option name="Layer" type="QString" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09"/>
+                <Option name="NofColumns" type="int" value="1"/>
+                <Option name="OrderByValue" type="bool" value="false"/>
+                <Option name="UseCompleter" type="bool" value="false"/>
+                <Option name="Value" type="QString" value="reverse_val"/>
               </Option>
             </config>
           </editWidget>
@@ -300,43 +605,43 @@
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="bool" value="false" name="IsMultiline"/>
-                <Option type="bool" value="false" name="UseHtml"/>
+                <Option name="IsMultiline" type="bool" value="false"/>
+                <Option name="UseHtml" type="bool" value="false"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""/>
-        <alias field="name" index="1" name=""/>
-        <alias field="utf8nameè" index="2" name=""/>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="name" index="1"/>
+        <alias name="" field="utf8nameè" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default expression="" field="id" applyOnUpdate="0"/>
-        <default expression="" field="name" applyOnUpdate="0"/>
-        <default expression="" field="utf8nameè" applyOnUpdate="0"/>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
+        <default field="utf8nameè" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint constraints="0" unique_strength="0" field="id" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="name" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="utf8nameè" exp_strength="0" notnull_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="id" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="name" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="utf8nameè" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="id" desc=""/>
-        <constraint exp="" field="name" desc=""/>
-        <constraint exp="" field="utf8nameè" desc=""/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="name" exp=""/>
+        <constraint desc="" field="utf8nameè" exp=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" hidden="0" name="id" width="-1"/>
-          <column type="field" hidden="0" name="name" width="-1"/>
-          <column type="field" hidden="0" name="utf8nameè" width="130"/>
+          <column name="id" type="field" hidden="0" width="-1"/>
+          <column name="name" type="field" hidden="0" width="-1"/>
+          <column name="utf8nameè" type="field" hidden="0" width="130"/>
           <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
@@ -364,14 +669,14 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="id"/>
-        <field editable="1" name="name"/>
-        <field editable="1" name="utf8nameè"/>
+        <field name="id" editable="1"/>
+        <field name="name" editable="1"/>
+        <field name="utf8nameè" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="id"/>
-        <field labelOnTop="0" name="name"/>
-        <field labelOnTop="0" name="utf8nameè"/>
+        <field name="id" labelOnTop="0"/>
+        <field name="name" labelOnTop="0"/>
+        <field name="utf8nameè" labelOnTop="0"/>
       </labelOnTop>
       <widgets/>
       <conditionalstyles>
@@ -382,7 +687,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer type="vector" simplifyAlgorithm="0" labelsEnabled="0" simplifyDrawingHints="0" readOnly="0" maxScale="0" simplifyMaxScale="1" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="Point" simplifyDrawingTol="1">
+    <maplayer refreshOnNotifyEnabled="0" simplifyAlgorithm="0" refreshOnNotifyMessage="" type="vector" labelsEnabled="0" minScale="1e+8" simplifyMaxScale="1" simplifyDrawingHints="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" maxScale="0" autoRefreshEnabled="0" geometry="Point" readOnly="0" autoRefreshTime="0" simplifyDrawingTol="1">
       <extent>
         <xmin>8.20345930703634352</xmin>
         <ymin>44.90139483904469131</ymin>
@@ -441,7 +746,7 @@ def my_form_open(dialog, layer, feature):
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial minz="0" maxx="0" maxz="0" crs="" minx="0" dimensions="2" miny="0" maxy="0"/>
+          <spatial crs="" minx="0" dimensions="2" minz="0" miny="0" maxz="0" maxx="0" maxy="0"/>
           <temporal>
             <period>
               <start></start>
@@ -459,10 +764,10 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
+      <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
         <symbols>
-          <symbol type="marker" clip_to_extent="1" name="0" alpha="1">
-            <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+          <symbol name="0" type="marker" clip_to_extent="1" alpha="1">
+            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
               <prop v="0" k="angle"/>
               <prop v="102,164,67,255" k="color"/>
               <prop v="1" k="horizontal_anchor_point"/>
@@ -491,9 +796,9 @@ def my_form_open(dialog, layer, feature):
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option name="name" type="QString" value=""/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="type" type="QString" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -515,31 +820,31 @@ def my_form_open(dialog, layer, feature):
           <value>COALESCE( "name", '&lt;NULL>' )</value>
           <value>COALESCE( "name", '&lt;NULL>' )</value>
         </property>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory penAlpha="255" diagramOrientation="Up" scaleDependency="Area" enabled="0" lineSizeType="MM" minScaleDenominator="0" rotationOffset="270" width="15" maxScaleDenominator="1e+8" height="15" opacity="1" penWidth="0" backgroundColor="#ffffff" backgroundAlpha="255" sizeType="MM" minimumSize="0" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" scaleBasedVisibility="0">
-          <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory labelPlacementMethod="XHeight" penWidth="0" barWidth="5" rotationOffset="270" opacity="1" width="15" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" penColor="#000000" backgroundColor="#ffffff" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" maxScaleDenominator="1e+8" enabled="0" minScaleDenominator="0" scaleBasedVisibility="0" minimumSize="0" sizeType="MM" height="15" diagramOrientation="Up">
+          <fontProperties style="" description="Ubuntu,9,-1,5,50,0,0,0,0,0"/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings zIndex="0" placement="0" linePlacementFlags="2" dist="0" obstacle="0" priority="0" showAll="1">
+      <DiagramLayerSettings priority="0" dist="0" obstacle="0" linePlacementFlags="2" placement="0" zIndex="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
-            <Option type="Map" name="properties">
-              <Option type="Map" name="show">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties" type="Map">
+              <Option name="show" type="Map">
+                <Option name="active" type="bool" value="true"/>
+                <Option name="field" type="QString" value="id"/>
+                <Option name="type" type="int" value="2"/>
               </Option>
             </Option>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
@@ -548,19 +853,19 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="RelationReference">
             <config>
               <Option type="Map">
-                <Option type="bool" value="false" name="AllowAddFeatures"/>
-                <Option type="bool" value="false" name="AllowNULL"/>
-                <Option type="bool" value="true" name="ChainFilters"/>
-                <Option type="StringList" name="FilterFields">
+                <Option name="AllowAddFeatures" type="bool" value="false"/>
+                <Option name="AllowNULL" type="bool" value="false"/>
+                <Option name="ChainFilters" type="bool" value="true"/>
+                <Option name="FilterFields" type="StringList">
                   <Option type="QString" value="short_ro"/>
                   <Option type="QString" value="diameter"/>
                 </Option>
-                <Option type="bool" value="false" name="MapIdentification"/>
-                <Option type="bool" value="false" name="OrderByValue"/>
-                <Option type="bool" value="false" name="ReadOnly"/>
-                <Option type="QString" value="test-relation" name="Relation"/>
-                <Option type="bool" value="false" name="ShowForm"/>
-                <Option type="bool" value="true" name="ShowOpenFormButton"/>
+                <Option name="MapIdentification" type="bool" value="false"/>
+                <Option name="OrderByValue" type="bool" value="false"/>
+                <Option name="ReadOnly" type="bool" value="false"/>
+                <Option name="Relation" type="QString" value="test-relation"/>
+                <Option name="ShowForm" type="bool" value="false"/>
+                <Option name="ShowOpenFormButton" type="bool" value="true"/>
               </Option>
             </config>
           </editWidget>
@@ -569,8 +874,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="bool" value="false" name="IsMultiline"/>
-                <Option type="bool" value="false" name="UseHtml"/>
+                <Option name="IsMultiline" type="bool" value="false"/>
+                <Option name="UseHtml" type="bool" value="false"/>
               </Option>
             </config>
           </editWidget>
@@ -579,43 +884,43 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="bool" value="false" name="IsMultiline"/>
-                <Option type="bool" value="false" name="UseHtml"/>
+                <Option name="IsMultiline" type="bool" value="false"/>
+                <Option name="UseHtml" type="bool" value="false"/>
               </Option>
             </config>
           </editWidget>
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""/>
-        <alias field="name" index="1" name=""/>
-        <alias field="utf8nameè" index="2" name=""/>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="name" index="1"/>
+        <alias name="" field="utf8nameè" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default expression="" field="id" applyOnUpdate="0"/>
-        <default expression="" field="name" applyOnUpdate="0"/>
-        <default expression="" field="utf8nameè" applyOnUpdate="0"/>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
+        <default field="utf8nameè" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint constraints="1" unique_strength="0" field="id" exp_strength="0" notnull_strength="2"/>
-        <constraint constraints="0" unique_strength="0" field="name" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="utf8nameè" exp_strength="0" notnull_strength="0"/>
+        <constraint notnull_strength="2" constraints="1" exp_strength="0" field="id" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="name" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="utf8nameè" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="id" desc=""/>
-        <constraint exp="" field="name" desc=""/>
-        <constraint exp="" field="utf8nameè" desc=""/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="name" exp=""/>
+        <constraint desc="" field="utf8nameè" exp=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" hidden="0" name="id" width="-1"/>
-          <column type="field" hidden="0" name="name" width="-1"/>
-          <column type="field" hidden="0" name="utf8nameè" width="130"/>
+          <column name="id" type="field" hidden="0" width="-1"/>
+          <column name="name" type="field" hidden="0" width="-1"/>
+          <column name="utf8nameè" type="field" hidden="0" width="130"/>
           <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
@@ -643,14 +948,14 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field editable="1" name="id"/>
-        <field editable="1" name="name"/>
-        <field editable="1" name="utf8nameè"/>
+        <field name="id" editable="1"/>
+        <field name="name" editable="1"/>
+        <field name="utf8nameè" editable="1"/>
       </editable>
       <labelOnTop>
-        <field labelOnTop="0" name="id"/>
-        <field labelOnTop="0" name="name"/>
-        <field labelOnTop="0" name="utf8nameè"/>
+        <field name="id" labelOnTop="0"/>
+        <field name="name" labelOnTop="0"/>
+        <field name="utf8nameè" labelOnTop="0"/>
       </labelOnTop>
       <widgets/>
       <conditionalstyles>
@@ -661,7 +966,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer type="vector" readOnly="0" maxScale="0" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="No geometry">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="vector" minScale="1e+8" hasScaleBasedVisibilityFlag="0" maxScale="0" autoRefreshEnabled="0" geometry="No geometry" readOnly="0" autoRefreshTime="0">
       <id>material_values_07693a17_8d8d_4657_8645_0d1364588136</id>
       <datasource>./material_values.csv</datasource>
       <keywordList>
@@ -757,45 +1062,45 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""/>
-        <alias field="short_ro" index="1" name=""/>
-        <alias field="_displayname_en" index="2" name=""/>
-        <alias field="diameter" index="3" name=""/>
-        <alias field="pressure_nominal" index="4" name=""/>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="short_ro" index="1"/>
+        <alias name="" field="_displayname_en" index="2"/>
+        <alias name="" field="diameter" index="3"/>
+        <alias name="" field="pressure_nominal" index="4"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default expression="" field="id" applyOnUpdate="0"/>
-        <default expression="" field="short_ro" applyOnUpdate="0"/>
-        <default expression="" field="_displayname_en" applyOnUpdate="0"/>
-        <default expression="" field="diameter" applyOnUpdate="0"/>
-        <default expression="" field="pressure_nominal" applyOnUpdate="0"/>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="short_ro" expression="" applyOnUpdate="0"/>
+        <default field="_displayname_en" expression="" applyOnUpdate="0"/>
+        <default field="diameter" expression="" applyOnUpdate="0"/>
+        <default field="pressure_nominal" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint constraints="0" unique_strength="0" field="id" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="short_ro" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="_displayname_en" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="diameter" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="pressure_nominal" exp_strength="0" notnull_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="id" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="short_ro" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="_displayname_en" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="diameter" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="pressure_nominal" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="id" desc=""/>
-        <constraint exp="" field="short_ro" desc=""/>
-        <constraint exp="" field="_displayname_en" desc=""/>
-        <constraint exp="" field="diameter" desc=""/>
-        <constraint exp="" field="pressure_nominal" desc=""/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="short_ro" exp=""/>
+        <constraint desc="" field="_displayname_en" exp=""/>
+        <constraint desc="" field="diameter" exp=""/>
+        <constraint desc="" field="pressure_nominal" exp=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" hidden="0" name="id" width="-1"/>
-          <column type="field" hidden="0" name="short_ro" width="-1"/>
-          <column type="field" hidden="0" name="_displayname_en" width="150"/>
-          <column type="field" hidden="0" name="diameter" width="-1"/>
-          <column type="field" hidden="0" name="pressure_nominal" width="136"/>
+          <column name="id" type="field" hidden="0" width="-1"/>
+          <column name="short_ro" type="field" hidden="0" width="-1"/>
+          <column name="_displayname_en" type="field" hidden="0" width="150"/>
+          <column name="diameter" type="field" hidden="0" width="-1"/>
+          <column name="pressure_nominal" type="field" hidden="0" width="136"/>
           <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
@@ -817,7 +1122,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>'value ' || _displayname_en</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer type="vector" simplifyAlgorithm="0" labelsEnabled="1" simplifyDrawingHints="0" readOnly="0" maxScale="0" simplifyMaxScale="1" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="Point" simplifyDrawingTol="1">
+    <maplayer refreshOnNotifyEnabled="0" simplifyAlgorithm="0" refreshOnNotifyMessage="" type="vector" labelsEnabled="1" minScale="1e+8" simplifyMaxScale="1" simplifyDrawingHints="0" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" maxScale="0" autoRefreshEnabled="0" geometry="Point" readOnly="0" autoRefreshTime="0" simplifyDrawingTol="1">
       <extent>
         <xmin>8.20345930703634352</xmin>
         <ymin>44.90139483904469131</ymin>
@@ -877,10 +1182,10 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
+      <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
         <symbols>
-          <symbol type="marker" clip_to_extent="1" name="0" alpha="1">
-            <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+          <symbol name="0" type="marker" clip_to_extent="1" alpha="1">
+            <layer locked="0" pass="0" enabled="1" class="SimpleMarker">
               <prop v="0" k="angle"/>
               <prop v="102,164,67,255" k="color"/>
               <prop v="1" k="horizontal_anchor_point"/>
@@ -909,9 +1214,9 @@ def my_form_open(dialog, layer, feature):
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option type="QString" value="" name="name"/>
+                  <Option name="name" type="QString" value=""/>
                   <Option name="properties"/>
-                  <Option type="QString" value="collection" name="type"/>
+                  <Option name="type" type="QString" value="collection"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -929,31 +1234,31 @@ def my_form_open(dialog, layer, feature):
         </effect>
       </renderer-v2>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
       <blendMode>0</blendMode>
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
-      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory penAlpha="255" diagramOrientation="Up" scaleDependency="Area" enabled="0" lineSizeType="MM" minScaleDenominator="inf" rotationOffset="270" width="15" maxScaleDenominator="1e+8" height="15" opacity="1" penWidth="0" backgroundColor="#ffffff" backgroundAlpha="255" sizeType="MM" minimumSize="0" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" scaleBasedVisibility="0">
-          <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute color="#000000" field="" label=""/>
+      <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Pie">
+        <DiagramCategory labelPlacementMethod="XHeight" penWidth="0" barWidth="5" rotationOffset="270" opacity="1" width="15" lineSizeScale="3x:0,0,0,0,0,0" penAlpha="255" penColor="#000000" backgroundColor="#ffffff" lineSizeType="MM" backgroundAlpha="255" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" maxScaleDenominator="1e+8" enabled="0" minScaleDenominator="inf" scaleBasedVisibility="0" minimumSize="0" sizeType="MM" height="15" diagramOrientation="Up">
+          <fontProperties style="" description="Ubuntu,9,-1,5,50,0,0,0,0,0"/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings zIndex="0" placement="0" linePlacementFlags="10" dist="0" obstacle="0" priority="0" showAll="1">
+      <DiagramLayerSettings priority="0" dist="0" obstacle="0" linePlacementFlags="10" placement="0" zIndex="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option type="QString" value="" name="name"/>
-            <Option type="Map" name="properties">
-              <Option type="Map" name="show">
-                <Option type="bool" value="true" name="active"/>
-                <Option type="QString" value="id" name="field"/>
-                <Option type="int" value="2" name="type"/>
+            <Option name="name" type="QString" value=""/>
+            <Option name="properties" type="Map">
+              <Option name="show" type="Map">
+                <Option name="active" type="bool" value="true"/>
+                <Option name="field" type="QString" value="id"/>
+                <Option name="type" type="int" value="2"/>
               </Option>
             </Option>
-            <Option type="QString" value="collection" name="type"/>
+            <Option name="type" type="QString" value="collection"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
@@ -962,8 +1267,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" value="0" name="IsMultiline"/>
-                <Option type="QString" value="0" name="UseHtml"/>
+                <Option name="IsMultiline" type="QString" value="0"/>
+                <Option name="UseHtml" type="QString" value="0"/>
               </Option>
             </config>
           </editWidget>
@@ -972,8 +1277,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option type="QString" value="0" name="IsMultiline"/>
-                <Option type="QString" value="0" name="UseHtml"/>
+                <Option name="IsMultiline" type="QString" value="0"/>
+                <Option name="UseHtml" type="QString" value="0"/>
               </Option>
             </config>
           </editWidget>
@@ -982,10 +1287,10 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="Map" name="map">
-                  <Option type="QString" value="one èé" name="First Value"/>
-                  <Option type="QString" value="two àò" name="Second Value"/>
-                  <Option type="QString" value="three èé↓" name="Third èé↓"/>
+                <Option name="map" type="Map">
+                  <Option name="First Value" type="QString" value="one èé"/>
+                  <Option name="Second Value" type="QString" value="two àò"/>
+                  <Option name="Third èé↓" type="QString" value="three èé↓"/>
                 </Option>
               </Option>
             </config>
@@ -993,35 +1298,35 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""/>
-        <alias field="name" index="1" name=""/>
-        <alias field="utf8nameè" index="2" name=""/>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="name" index="1"/>
+        <alias name="" field="utf8nameè" index="2"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default expression="" field="id" applyOnUpdate="0"/>
-        <default expression="" field="name" applyOnUpdate="0"/>
-        <default expression="" field="utf8nameè" applyOnUpdate="0"/>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
+        <default field="utf8nameè" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint constraints="0" unique_strength="0" field="id" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="name" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="utf8nameè" exp_strength="0" notnull_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="id" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="name" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="utf8nameè" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="id" desc=""/>
-        <constraint exp="" field="name" desc=""/>
-        <constraint exp="" field="utf8nameè" desc=""/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="name" exp=""/>
+        <constraint desc="" field="utf8nameè" exp=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" hidden="0" name="id" width="-1"/>
-          <column type="field" hidden="0" name="name" width="-1"/>
-          <column type="field" hidden="0" name="utf8nameè" width="130"/>
+          <column name="id" type="field" hidden="0" width="-1"/>
+          <column name="name" type="field" hidden="0" width="-1"/>
+          <column name="utf8nameè" type="field" hidden="0" width="130"/>
           <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
@@ -1059,7 +1364,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer type="vector" readOnly="0" maxScale="0" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="No geometry">
+    <maplayer refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" type="vector" minScale="1e+8" hasScaleBasedVisibilityFlag="0" maxScale="0" autoRefreshEnabled="0" geometry="No geometry" readOnly="0" autoRefreshTime="0">
       <id>value_dict_4e5dce19_7169_42fe_8408_4927be615c09</id>
       <datasource>./value_dict.csv</datasource>
       <keywordList>
@@ -1103,7 +1408,7 @@ def my_form_open(dialog, layer, feature):
         <extent/>
       </resourceMetadata>
       <customproperties>
-        <property value="&quot;id&quot;" key="dualview/previewExpressions"/>
+        <property key="dualview/previewExpressions" value="&quot;id&quot;"/>
       </customproperties>
       <provider encoding="UTF-8">ogr</provider>
       <vectorjoins/>
@@ -1145,40 +1450,40 @@ def my_form_open(dialog, layer, feature):
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias field="id" index="0" name=""/>
-        <alias field="value_id" index="1" name=""/>
-        <alias field="reverse" index="2" name=""/>
-        <alias field="reverse_val" index="3" name=""/>
+        <alias name="" field="id" index="0"/>
+        <alias name="" field="value_id" index="1"/>
+        <alias name="" field="reverse" index="2"/>
+        <alias name="" field="reverse_val" index="3"/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default expression="" field="id" applyOnUpdate="0"/>
-        <default expression="" field="value_id" applyOnUpdate="0"/>
-        <default expression="" field="reverse" applyOnUpdate="0"/>
-        <default expression="" field="reverse_val" applyOnUpdate="0"/>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="value_id" expression="" applyOnUpdate="0"/>
+        <default field="reverse" expression="" applyOnUpdate="0"/>
+        <default field="reverse_val" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint constraints="0" unique_strength="0" field="id" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="value_id" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="reverse" exp_strength="0" notnull_strength="0"/>
-        <constraint constraints="0" unique_strength="0" field="reverse_val" exp_strength="0" notnull_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="id" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="value_id" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="reverse" unique_strength="0"/>
+        <constraint notnull_strength="0" constraints="0" exp_strength="0" field="reverse_val" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" field="id" desc=""/>
-        <constraint exp="" field="value_id" desc=""/>
-        <constraint exp="" field="reverse" desc=""/>
-        <constraint exp="" field="reverse_val" desc=""/>
+        <constraint desc="" field="id" exp=""/>
+        <constraint desc="" field="value_id" exp=""/>
+        <constraint desc="" field="reverse" exp=""/>
+        <constraint desc="" field="reverse_val" exp=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column type="field" hidden="0" name="id" width="-1"/>
-          <column type="field" hidden="0" name="value_id" width="-1"/>
-          <column type="field" hidden="0" name="reverse" width="-1"/>
-          <column type="field" hidden="0" name="reverse_val" width="-1"/>
+          <column name="id" type="field" hidden="0" width="-1"/>
+          <column name="value_id" type="field" hidden="0" width="-1"/>
+          <column name="reverse" type="field" hidden="0" width="-1"/>
+          <column name="reverse_val" type="field" hidden="0" width="-1"/>
           <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
@@ -1205,142 +1510,143 @@ def my_form_open(dialog, layer, feature):
     <layer id="testlayer20150528120452665"/>
     <layer id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1"/>
     <layer id="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5"/>
+    <layer id="array_tbl_70c06ef2_bdfe_4412_94f0_5b8d1c317281"/>
   </layerorder>
   <properties>
-    <WMSRestrictedLayers type="QStringList"/>
+    <WFSUrl type="QString"></WFSUrl>
     <PositionPrecision>
-      <DegreeFormat type="QString">D</DegreeFormat>
       <DecimalPlaces type="int">2</DecimalPlaces>
       <Automatic type="bool">true</Automatic>
+      <DegreeFormat type="QString">D</DegreeFormat>
     </PositionPrecision>
-    <Variables>
-      <variableValues type="QStringList"/>
-      <variableNames type="QStringList"/>
-    </Variables>
-    <DefaultStyles>
-      <RandomColors type="bool">true</RandomColors>
-      <Fill type="QString"></Fill>
-      <Opacity type="double">1</Opacity>
-      <AlphaInt type="int">255</AlphaInt>
-      <Marker type="QString"></Marker>
-      <ColorRamp type="QString"></ColorRamp>
-      <Line type="QString"></Line>
-    </DefaultStyles>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <WMSRestrictedLayers type="QStringList"/>
+    <WMSContactOrganization type="QString">QGIS dev team</WMSContactOrganization>
+    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
+    <WFSLayers type="QStringList">
+      <value>testlayer20150528120452665</value>
+    </WFSLayers>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
-    <Digitizing>
-      <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
-      <AvoidIntersectionsList type="QStringList"/>
-      <LayerSnapToList type="QStringList">
-        <value>to_vertex_and_segment</value>
-      </LayerSnapToList>
-      <LayerSnappingEnabledList type="QStringList">
-        <value>disabled</value>
-      </LayerSnappingEnabledList>
-      <SnappingMode type="QString">current_layer</SnappingMode>
-      <LayerSnappingToleranceUnitList type="QStringList">
-        <value>2</value>
-      </LayerSnappingToleranceUnitList>
-      <DefaultSnapType type="QString">off</DefaultSnapType>
-      <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
-      <LayerSnappingToleranceList type="QStringList">
-        <value>0.000000</value>
-      </LayerSnappingToleranceList>
-      <LayerSnappingList type="QStringList">
-        <value>testlayer20150528120452665</value>
-      </LayerSnappingList>
-    </Digitizing>
-    <WMSServiceAbstract type="QString">Some UTF8 text èòù</WMSServiceAbstract>
-    <Gui>
-      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
-      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
-      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
-      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
-      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
-      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
-      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
-    </Gui>
-    <WMSContactMail type="QString">elpaso@itopen.it</WMSContactMail>
     <Legend>
       <filterByMap type="bool">false</filterByMap>
     </Legend>
-    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
-    <WFSTLayers>
-      <Insert type="QStringList">
-        <value>testlayer20150528120452665</value>
-      </Insert>
-      <Update type="QStringList">
-        <value>testlayer20150528120452665</value>
-      </Update>
-      <Delete type="QStringList">
-        <value>testlayer20150528120452665</value>
-      </Delete>
-    </WFSTLayers>
-    <WMSRestrictedComposers type="QStringList"/>
-    <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
-    <Measure>
-      <Ellipsoid type="QString">WGS84</Ellipsoid>
-    </Measure>
     <WMSKeywordList type="QStringList">
       <value></value>
     </WMSKeywordList>
+    <WMSContactMail type="QString">elpaso@itopen.it</WMSContactMail>
+    <WFSLayersPrecision>
+      <testlayer20150528120452665 type="int">8</testlayer20150528120452665>
+    </WFSLayersPrecision>
+    <PAL>
+      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
+      <CandidatesLine type="int">50</CandidatesLine>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <CandidatesPoint type="int">16</CandidatesPoint>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <SearchMethod type="int">0</SearchMethod>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+    </PAL>
+    <Gui>
+      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+    </Gui>
+    <Digitizing>
+      <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
+      <LayerSnappingToleranceList type="QStringList">
+        <value>0.000000</value>
+      </LayerSnappingToleranceList>
+      <LayerSnappingToleranceUnitList type="QStringList">
+        <value>2</value>
+      </LayerSnappingToleranceUnitList>
+      <LayerSnapToList type="QStringList">
+        <value>to_vertex_and_segment</value>
+      </LayerSnapToList>
+      <DefaultSnapType type="QString">off</DefaultSnapType>
+      <SnappingMode type="QString">current_layer</SnappingMode>
+      <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
+      <LayerSnappingList type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </LayerSnappingList>
+      <AvoidIntersectionsList type="QStringList"/>
+      <LayerSnappingEnabledList type="QStringList">
+        <value>disabled</value>
+      </LayerSnappingEnabledList>
+    </Digitizing>
+    <WMSRestrictedComposers type="QStringList"/>
+    <SpatialRefSys>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+      <ProjectCRSID type="int">3452</ProjectCRSID>
+      <ProjectCRSProj4String type="QString">+proj=longlat +datum=WGS84 +no_defs</ProjectCRSProj4String>
+      <ProjectCrs type="QString">EPSG:4326</ProjectCrs>
+    </SpatialRefSys>
+    <Identify>
+      <disabledLayers type="QStringList"/>
+    </Identify>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
+    <Measure>
+      <Ellipsoid type="QString">WGS84</Ellipsoid>
+    </Measure>
     <WMSExtent type="QStringList">
       <value>8.20315414376310059</value>
       <value>44.901236559338642</value>
       <value>8.204164917965862</value>
       <value>44.90159838674664172</value>
     </WMSExtent>
+    <WFSTLayers>
+      <Delete type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Delete>
+      <Update type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Update>
+      <Insert type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Insert>
+    </WFSTLayers>
+    <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
+    <Variables>
+      <variableNames type="QStringList"/>
+      <variableValues type="QStringList"/>
+    </Variables>
+    <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
+    <WMSContactPerson type="QString">Alessandro Pasotti</WMSContactPerson>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <WMSUrl type="QString"></WMSUrl>
+    <WMSFees type="QString">conditions unknown</WMSFees>
+    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <WCSUrl type="QString"></WCSUrl>
+    <WMSPrecision type="QString">4</WMSPrecision>
     <Paths>
       <Absolute type="bool">false</Absolute>
     </Paths>
     <WMSImageQuality type="int">90</WMSImageQuality>
-    <WMSPrecision type="QString">4</WMSPrecision>
-    <WMSServiceTitle type="QString">QGIS TestProject</WMSServiceTitle>
-    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
-    <WMSContactOrganization type="QString">QGIS dev team</WMSContactOrganization>
-    <Measurement>
-      <AreaUnits type="QString">m2</AreaUnits>
-      <DistanceUnits type="QString">meters</DistanceUnits>
-    </Measurement>
-    <WMSUrl type="QString"></WMSUrl>
-    <WFSLayersPrecision>
-      <testlayer20150528120452665 type="int">8</testlayer20150528120452665>
-    </WFSLayersPrecision>
-    <SpatialRefSys>
-      <ProjectCrs type="QString">EPSG:4326</ProjectCrs>
-      <ProjectCRSProj4String type="QString">+proj=longlat +datum=WGS84 +no_defs</ProjectCRSProj4String>
-      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
-      <ProjectCRSID type="int">3452</ProjectCRSID>
-    </SpatialRefSys>
-    <WMSOnlineResource type="QString"></WMSOnlineResource>
-    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
-    <WFSLayers type="QStringList">
-      <value>testlayer20150528120452665</value>
-    </WFSLayers>
-    <Macros>
-      <pythonCode type="QString"></pythonCode>
-    </Macros>
-    <WMSContactPosition type="QString"></WMSContactPosition>
-    <Identify>
-      <disabledLayers type="QStringList"/>
-    </Identify>
-    <WCSUrl type="QString"></WCSUrl>
-    <PAL>
-      <ShowingCandidates type="bool">false</ShowingCandidates>
-      <SearchMethod type="int">0</SearchMethod>
-      <ShowingAllLabels type="bool">false</ShowingAllLabels>
-      <CandidatesPolygon type="int">30</CandidatesPolygon>
-      <DrawRectOnly type="bool">false</DrawRectOnly>
-      <CandidatesPoint type="int">16</CandidatesPoint>
-      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
-      <CandidatesLine type="int">50</CandidatesLine>
-      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
-    </PAL>
-    <WMSFees type="QString">conditions unknown</WMSFees>
-    <WMSContactPhone type="QString"></WMSContactPhone>
-    <WMSContactPerson type="QString">Alessandro Pasotti</WMSContactPerson>
-    <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
-    <WFSUrl type="QString"></WFSUrl>
+    <WMSServiceAbstract type="QString">Some UTF8 text èòù</WMSServiceAbstract>
+    <DefaultStyles>
+      <ColorRamp type="QString"></ColorRamp>
+      <Opacity type="double">1</Opacity>
+      <Marker type="QString"></Marker>
+      <RandomColors type="bool">true</RandomColors>
+      <Fill type="QString"></Fill>
+      <AlphaInt type="int">255</AlphaInt>
+      <Line type="QString"></Line>
+    </DefaultStyles>
     <WCSLayers type="QStringList"/>
+    <WMSServiceTitle type="QString">QGIS TestProject</WMSServiceTitle>
+    <WMSContactPosition type="QString"></WMSContactPosition>
   </properties>
   <visibility-presets/>
   <transformContext/>

--- a/tests/testdata/qgis_server/test_project_values.qgs
+++ b/tests/testdata/qgis_server/test_project_values.qgs
@@ -19,25 +19,34 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties/>
-    <layer-tree-layer expanded="1" checked="Qt::Checked" id="testlayer20150528120452665" name="layer0" source="./testlayer.shp" providerKey="ogr">
+    <layer-tree-layer id="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" name="value_dict" providerKey="ogr" checked="Qt::Checked" expanded="1" source="./value_dict.csv">
+      <customproperties/>
+    </layer-tree-layer>
+    <layer-tree-layer id="testlayer20150528120452665" name="layer0" providerKey="ogr" checked="Qt::Checked" expanded="1" source="./testlayer.shp">
+      <customproperties/>
+    </layer-tree-layer>
+    <layer-tree-layer id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" name="layer1" providerKey="ogr" checked="Qt::Checked" expanded="1" source="./testlayer.shp">
       <customproperties/>
     </layer-tree-layer>
     <custom-order enabled="0">
       <item>testlayer20150528120452665</item>
+      <item>layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1</item>
+      <item>value_dict_4e5dce19_7169_42fe_8408_4927be615c09</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings type="2" enabled="0" intersection-snapping="0" tolerance="0" unit="2" mode="1">
+  <snapping-settings intersection-snapping="0" mode="1" tolerance="0" unit="2" enabled="0" type="2">
     <individual-layer-settings>
-      <layer-setting id="testlayer20150528120452665" type="2" units="2" enabled="0" tolerance="0"/>
+      <layer-setting id="testlayer20150528120452665" tolerance="0" enabled="0" units="2" type="2"/>
+      <layer-setting id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" tolerance="30" enabled="1" units="1" type="2"/>
     </individual-layer-settings>
   </snapping-settings>
   <relations/>
-  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+  <mapcanvas name="theMapCanvas" annotationsVisible="1">
     <units>degrees</units>
     <extent>
-      <xmin>8.20315414376310059</xmin>
+      <xmin>8.20264578195449801</xmin>
       <ymin>44.90112783049693235</ymin>
-      <xmax>8.204164917965862</xmax>
+      <xmax>8.20467327977446459</xmax>
       <ymax>44.90170711558835137</ymax>
     </extent>
     <rotation>0</rotation>
@@ -56,15 +65,303 @@
     <rendermaptile>0</rendermaptile>
   </mapcanvas>
   <legend updateDrawingOrder="true">
-    <legendlayer checked="Qt::Checked" drawingOrder="-1" open="true" name="layer0" showFeatureCount="0">
+    <legendlayer name="value_dict" drawingOrder="-1" open="true" checked="Qt::Checked" showFeatureCount="0">
       <filegroup hidden="false" open="true">
-        <legendlayerfile layerid="testlayer20150528120452665" isInOverview="0" visible="1"/>
+        <legendlayerfile isInOverview="0" visible="1" layerid="value_dict_4e5dce19_7169_42fe_8408_4927be615c09"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer name="layer0" drawingOrder="-1" open="true" checked="Qt::Checked" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" visible="1" layerid="testlayer20150528120452665"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer name="layer1" drawingOrder="-1" open="true" checked="Qt::Checked" showFeatureCount="0">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" visible="1" layerid="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
   <projectlayers>
-    <maplayer simplifyMaxScale="1" hasScaleBasedVisibilityFlag="0" readOnly="0" labelsEnabled="1" simplifyAlgorithm="0" type="vector" simplifyLocal="1" minScale="1e+8" refreshOnNotifyMessage="" simplifyDrawingTol="1" refreshOnNotifyEnabled="0" autoRefreshTime="0" maxScale="0" simplifyDrawingHints="0" geometry="Point" autoRefreshEnabled="0">
+    <maplayer readOnly="0" simplifyAlgorithm="0" autoRefreshEnabled="0" simplifyDrawingHints="0" simplifyMaxScale="1" maxScale="0" autoRefreshTime="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+8" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" geometry="Point" type="vector" labelsEnabled="0">
+      <extent>
+        <xmin>8.20345930703634352</xmin>
+        <ymin>44.90139483904469131</ymin>
+        <xmax>8.20354699399348775</xmax>
+        <ymax>44.90148252600183554</ymax>
+      </extent>
+      <id>layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1</id>
+      <datasource>./testlayer.shp</datasource>
+      <title>A test vector layer</title>
+      <abstract>A test vector layer with unicode òà</abstract>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>layer1</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <contact>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
+        </contact>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent>
+          <spatial dimensions="2" miny="0" maxx="0" crs="" minz="0" maxz="0" maxy="0" minx="0"/>
+          <temporal>
+            <period>
+              <start></start>
+              <end></end>
+            </period>
+          </temporal>
+        </extent>
+      </resourceMetadata>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
+        <symbols>
+          <symbol name="0" alpha="1" clip_to_extent="1" type="marker">
+            <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
+              <prop k="angle" v="0"/>
+              <prop k="color" v="102,164,67,255"/>
+              <prop k="horizontal_anchor_point" v="1"/>
+              <prop k="joinstyle" v="bevel"/>
+              <prop k="name" v="circle"/>
+              <prop k="offset" v="0,0"/>
+              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="offset_unit" v="MM"/>
+              <prop k="outline_color" v="0,0,0,255"/>
+              <prop k="outline_style" v="solid"/>
+              <prop k="outline_width" v="0"/>
+              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="outline_width_unit" v="MM"/>
+              <prop k="scale_method" v="area"/>
+              <prop k="size" v="2"/>
+              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+              <prop k="size_unit" v="MM"/>
+              <prop k="vertical_anchor_point" v="1"/>
+              <effect enabled="0" type="effectStack">
+                <effect type="drawSource">
+                  <prop k="blend_mode" v="0"/>
+                  <prop k="draw_mode" v="2"/>
+                  <prop k="enabled" v="1"/>
+                  <prop k="opacity" v="1"/>
+                </effect>
+              </effect>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option name="name" value="" type="QString"/>
+                  <Option name="properties"/>
+                  <Option name="type" value="collection" type="QString"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+        <effect enabled="0" type="effectStack">
+          <effect type="drawSource">
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
+          </effect>
+        </effect>
+      </renderer-v2>
+      <customproperties>
+        <property key="embeddedWidgets/count" value="0"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+        <DiagramCategory rotationOffset="270" sizeType="MM" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" penWidth="0" maxScaleDenominator="1e+8" height="15" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" penAlpha="255" scaleDependency="Area" diagramOrientation="Up" opacity="1" minScaleDenominator="0" penColor="#000000" minimumSize="0" enabled="0" barWidth="5" backgroundAlpha="255" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0">
+          <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute field="" color="#000000" label=""/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings zIndex="0" linePlacementFlags="2" showAll="1" priority="0" obstacle="0" dist="0" placement="0">
+        <properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties" type="Map">
+              <Option name="show" type="Map">
+                <Option name="active" value="true" type="bool"/>
+                <Option name="field" value="id" type="QString"/>
+                <Option name="type" value="2" type="int"/>
+              </Option>
+            </Option>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <fieldConfiguration>
+        <field name="id">
+          <editWidget type="ValueRelation">
+            <config>
+              <Option type="Map">
+                <Option name="AllowMulti" value="false" type="bool"/>
+                <Option name="AllowNull" value="false" type="bool"/>
+                <Option name="FilterExpression" value="" type="QString"/>
+                <Option name="Key" value="id" type="QString"/>
+                <Option name="Layer" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" type="QString"/>
+                <Option name="NofColumns" value="1" type="int"/>
+                <Option name="OrderByValue" value="false" type="bool"/>
+                <Option name="UseCompleter" value="false" type="bool"/>
+                <Option name="Value" value="value_id" type="QString"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="name">
+          <editWidget type="ValueRelation">
+            <config>
+              <Option type="Map">
+                <Option name="AllowMulti" value="false" type="bool"/>
+                <Option name="AllowNull" value="false" type="bool"/>
+                <Option name="FilterExpression" value="" type="QString"/>
+                <Option name="Key" value="reverse" type="QString"/>
+                <Option name="Layer" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" type="QString"/>
+                <Option name="NofColumns" value="1" type="int"/>
+                <Option name="OrderByValue" value="false" type="bool"/>
+                <Option name="UseCompleter" value="false" type="bool"/>
+                <Option name="Value" value="reverse_val" type="QString"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="utf8nameè">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option name="IsMultiline" value="false" type="bool"/>
+                <Option name="UseHtml" value="false" type="bool"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="id" index="0" name=""/>
+        <alias field="name" index="1" name=""/>
+        <alias field="utf8nameè" index="2" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
+        <default field="utf8nameè" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint field="id" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint field="name" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint field="utf8nameè" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="id" exp="" desc=""/>
+        <constraint field="name" exp="" desc=""/>
+        <constraint field="utf8nameè" exp="" desc=""/>
+      </constraintExpressions>
+      <attributeactions>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns>
+          <column width="-1" name="id" hidden="0" type="field"/>
+          <column width="-1" name="name" hidden="0" type="field"/>
+          <column width="130" name="utf8nameè" hidden="0" type="field"/>
+          <column width="-1" hidden="1" type="actions"/>
+        </columns>
+      </attributetableconfig>
+      <editform>../../../../qgis2/tests/testdata/qgis_server</editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath>../../../../qgis2/tests/testdata/qgis_server</editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable>
+        <field name="id" editable="1"/>
+        <field name="name" editable="1"/>
+        <field name="utf8nameè" editable="1"/>
+      </editable>
+      <labelOnTop>
+        <field name="id" labelOnTop="0"/>
+        <field name="name" labelOnTop="0"/>
+        <field name="utf8nameè" labelOnTop="0"/>
+      </labelOnTop>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <expressionfields/>
+      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer readOnly="0" simplifyAlgorithm="0" autoRefreshEnabled="0" simplifyDrawingHints="0" simplifyMaxScale="1" maxScale="0" autoRefreshTime="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+8" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" geometry="Point" type="vector" labelsEnabled="1">
       <extent>
         <xmin>8.20345930703634352</xmin>
         <ymin>44.90139483904469131</ymin>
@@ -110,7 +407,7 @@
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>false</geographicflag>
+            <geographicflag>true</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -124,10 +421,10 @@
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
+      <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
         <symbols>
-          <symbol alpha="1" type="marker" name="0" clip_to_extent="1">
-            <layer pass="0" class="SimpleMarker" enabled="1" locked="0">
+          <symbol name="0" alpha="1" clip_to_extent="1" type="marker">
+            <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
               <prop k="angle" v="0"/>
               <prop k="color" v="102,164,67,255"/>
               <prop k="horizontal_anchor_point" v="1"/>
@@ -146,7 +443,7 @@
               <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
               <prop k="size_unit" v="MM"/>
               <prop k="vertical_anchor_point" v="1"/>
-              <effect type="effectStack" enabled="0">
+              <effect enabled="0" type="effectStack">
                 <effect type="drawSource">
                   <prop k="blend_mode" v="0"/>
                   <prop k="draw_mode" v="2"/>
@@ -156,9 +453,9 @@
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option value="" type="QString" name="name"/>
+                  <Option name="name" value="" type="QString"/>
                   <Option name="properties"/>
-                  <Option value="collection" type="QString" name="type"/>
+                  <Option name="type" value="collection" type="QString"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -166,7 +463,7 @@
         </symbols>
         <rotation/>
         <sizescale/>
-        <effect type="effectStack" enabled="0">
+        <effect enabled="0" type="effectStack">
           <effect type="drawSource">
             <prop k="blend_mode" v="0"/>
             <prop k="draw_mode" v="2"/>
@@ -176,7 +473,7 @@
         </effect>
       </renderer-v2>
       <customproperties>
-        <property value="0" key="embeddedWidgets/count"/>
+        <property key="embeddedWidgets/count" value="0"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
@@ -184,23 +481,23 @@
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory sizeType="MM" labelPlacementMethod="XHeight" lineSizeType="MM" barWidth="5" scaleBasedVisibility="0" maxScaleDenominator="1e+8" penColor="#000000" penWidth="0" backgroundColor="#ffffff" diagramOrientation="Up" backgroundAlpha="255" height="15" penAlpha="255" minimumSize="0" sizeScale="3x:0,0,0,0,0,0" scaleDependency="Area" enabled="0" minScaleDenominator="inf" lineSizeScale="3x:0,0,0,0,0,0" width="15" rotationOffset="270" opacity="1">
+        <DiagramCategory rotationOffset="270" sizeType="MM" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" penWidth="0" maxScaleDenominator="1e+8" height="15" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" penAlpha="255" scaleDependency="Area" diagramOrientation="Up" opacity="1" minScaleDenominator="inf" penColor="#000000" minimumSize="0" enabled="0" barWidth="5" backgroundAlpha="255" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0">
           <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute label="" field="" color="#000000"/>
+          <attribute field="" color="#000000" label=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings showAll="1" placement="0" priority="0" zIndex="0" dist="0" linePlacementFlags="10" obstacle="0">
+      <DiagramLayerSettings zIndex="0" linePlacementFlags="10" showAll="1" priority="0" obstacle="0" dist="0" placement="0">
         <properties>
           <Option type="Map">
-            <Option value="" type="QString" name="name"/>
-            <Option type="Map" name="properties">
-              <Option type="Map" name="show">
-                <Option value="true" type="bool" name="active"/>
-                <Option value="id" type="QString" name="field"/>
-                <Option value="2" type="int" name="type"/>
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties" type="Map">
+              <Option name="show" type="Map">
+                <Option name="active" value="true" type="bool"/>
+                <Option name="field" value="id" type="QString"/>
+                <Option name="type" value="2" type="int"/>
               </Option>
             </Option>
-            <Option value="collection" type="QString" name="type"/>
+            <Option name="type" value="collection" type="QString"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
@@ -209,8 +506,8 @@
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" type="QString" name="IsMultiline"/>
-                <Option value="0" type="QString" name="UseHtml"/>
+                <Option name="IsMultiline" value="0" type="QString"/>
+                <Option name="UseHtml" value="0" type="QString"/>
               </Option>
             </config>
           </editWidget>
@@ -219,8 +516,8 @@
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option value="0" type="QString" name="IsMultiline"/>
-                <Option value="0" type="QString" name="UseHtml"/>
+                <Option name="IsMultiline" value="0" type="QString"/>
+                <Option name="UseHtml" value="0" type="QString"/>
               </Option>
             </config>
           </editWidget>
@@ -229,10 +526,10 @@
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option type="Map" name="map">
-                  <Option value="one èé" type="QString" name="First Value"/>
-                  <Option value="two àò" type="QString" name="Second Value"/>
-                  <Option value="three èé↓" type="QString" name="Third èé↓"/>
+                <Option name="map" type="Map">
+                  <Option name="First Value" value="one èé" type="QString"/>
+                  <Option name="Second Value" value="two àò" type="QString"/>
+                  <Option name="Third èé↓" value="three èé↓" type="QString"/>
                 </Option>
               </Option>
             </config>
@@ -240,36 +537,36 @@
         </field>
       </fieldConfiguration>
       <aliases>
-        <alias index="0" name="" field="id"/>
-        <alias index="1" name="" field="name"/>
-        <alias index="2" name="" field="utf8nameè"/>
+        <alias field="id" index="0" name=""/>
+        <alias field="name" index="1" name=""/>
+        <alias field="utf8nameè" index="2" name=""/>
       </aliases>
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default expression="" field="id" applyOnUpdate="0"/>
-        <default expression="" field="name" applyOnUpdate="0"/>
-        <default expression="" field="utf8nameè" applyOnUpdate="0"/>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
+        <default field="utf8nameè" expression="" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint exp_strength="0" constraints="0" notnull_strength="0" field="id" unique_strength="0"/>
-        <constraint exp_strength="0" constraints="0" notnull_strength="0" field="name" unique_strength="0"/>
-        <constraint exp_strength="0" constraints="0" notnull_strength="0" field="utf8nameè" unique_strength="0"/>
+        <constraint field="id" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint field="name" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint field="utf8nameè" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint exp="" desc="" field="id"/>
-        <constraint exp="" desc="" field="name"/>
-        <constraint exp="" desc="" field="utf8nameè"/>
+        <constraint field="id" exp="" desc=""/>
+        <constraint field="name" exp="" desc=""/>
+        <constraint field="utf8nameè" exp="" desc=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
       </attributeactions>
-      <attributetableconfig sortOrder="0" actionWidgetStyle="dropDown" sortExpression="">
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column hidden="0" type="field" name="id" width="-1"/>
-          <column hidden="0" type="field" name="name" width="-1"/>
-          <column hidden="0" type="field" name="utf8nameè" width="130"/>
-          <column hidden="1" type="actions" width="-1"/>
+          <column width="-1" name="id" hidden="0" type="field"/>
+          <column width="-1" name="name" hidden="0" type="field"/>
+          <column width="130" name="utf8nameè" hidden="0" type="field"/>
+          <column width="-1" hidden="1" type="actions"/>
         </columns>
       </attributetableconfig>
       <editform>../../../../qgis2/tests/testdata/qgis_server</editform>
@@ -306,130 +603,164 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
+    <maplayer readOnly="0" autoRefreshEnabled="0" maxScale="0" autoRefreshTime="0" minScale="1e+8" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" geometry="No geometry" type="vector">
+      <id>value_dict_4e5dce19_7169_42fe_8408_4927be615c09</id>
+      <datasource>./value_dict.csv</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>value_dict</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <customproperties/>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <fieldConfiguration>
+        <field name="id">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="value_id">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="reverse">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="reverse_val">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="id" index="0" name=""/>
+        <alias field="value_id" index="1" name=""/>
+        <alias field="reverse" index="2" name=""/>
+        <alias field="reverse_val" index="3" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="value_id" expression="" applyOnUpdate="0"/>
+        <default field="reverse" expression="" applyOnUpdate="0"/>
+        <default field="reverse_val" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint field="id" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint field="value_id" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint field="reverse" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint field="reverse_val" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="id" exp="" desc=""/>
+        <constraint field="value_id" exp="" desc=""/>
+        <constraint field="reverse" exp="" desc=""/>
+        <constraint field="reverse_val" exp="" desc=""/>
+      </constraintExpressions>
+      <attributeactions>
+        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns/>
+      </attributetableconfig>
+      <editform></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable/>
+      <labelOnTop/>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <expressionfields/>
+      <previewExpression></previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
   </projectlayers>
   <layerorder>
     <layer id="testlayer20150528120452665"/>
+    <layer id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1"/>
+    <layer id="value_dict_4e5dce19_7169_42fe_8408_4927be615c09"/>
   </layerorder>
   <properties>
-    <Macros>
-      <pythonCode type="QString"></pythonCode>
-    </Macros>
-    <Identify>
-      <disabledLayers type="QStringList"/>
-    </Identify>
-    <WMSExtent type="QStringList">
-      <value>8.20315414376310059</value>
-      <value>44.901236559338642</value>
-      <value>8.204164917965862</value>
-      <value>44.90159838674664172</value>
-    </WMSExtent>
-    <WMSContactPosition type="QString"></WMSContactPosition>
-    <WMSRestrictedLayers type="QStringList"/>
-    <WMSContactOrganization type="QString">QGIS dev team</WMSContactOrganization>
-    <WFSLayersPrecision>
-      <testlayer20150528120452665 type="int">8</testlayer20150528120452665>
-    </WFSLayersPrecision>
-    <WMSContactPerson type="QString">Alessandro Pasotti</WMSContactPerson>
-    <Gui>
-      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
-      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
-      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
-      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
-      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
-      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
-      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
-    </Gui>
-    <DefaultStyles>
-      <Marker type="QString"></Marker>
-      <ColorRamp type="QString"></ColorRamp>
-      <Fill type="QString"></Fill>
-      <AlphaInt type="int">255</AlphaInt>
-      <Line type="QString"></Line>
-      <RandomColors type="bool">true</RandomColors>
-    </DefaultStyles>
-    <SpatialRefSys>
-      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
-      <ProjectCrs type="QString">EPSG:4326</ProjectCrs>
-      <ProjectCRSProj4String type="QString">+proj=longlat +datum=WGS84 +no_defs</ProjectCRSProj4String>
-      <ProjectCRSID type="int">3452</ProjectCRSID>
-    </SpatialRefSys>
-    <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
-    <WMSFees type="QString">conditions unknown</WMSFees>
     <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
+    <WMSContactMail type="QString">elpaso@itopen.it</WMSContactMail>
+    <WMSServiceAbstract type="QString">Some UTF8 text èòù</WMSServiceAbstract>
+    <WMSContactOrganization type="QString">QGIS dev team</WMSContactOrganization>
+    <WMSRestrictedLayers type="QStringList"/>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
-    <Digitizing>
-      <LayerSnappingToleranceList type="QStringList">
-        <value>0.000000</value>
-      </LayerSnappingToleranceList>
-      <LayerSnappingToleranceUnitList type="QStringList">
-        <value>2</value>
-      </LayerSnappingToleranceUnitList>
-      <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
-      <LayerSnappingList type="QStringList">
-        <value>testlayer20150528120452665</value>
-      </LayerSnappingList>
-      <SnappingMode type="QString">current_layer</SnappingMode>
-      <DefaultSnapType type="QString">off</DefaultSnapType>
-      <AvoidIntersectionsList type="QStringList"/>
-      <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
-      <LayerSnappingEnabledList type="QStringList">
-        <value>disabled</value>
-      </LayerSnappingEnabledList>
-      <LayerSnapToList type="QStringList">
-        <value>to_vertex_and_segment</value>
-      </LayerSnapToList>
-    </Digitizing>
-    <WMSPrecision type="QString">4</WMSPrecision>
+    <WFSUrl type="QString"></WFSUrl>
+    <WMSImageQuality type="int">90</WMSImageQuality>
     <Measurement>
       <AreaUnits type="QString">m2</AreaUnits>
       <DistanceUnits type="QString">meters</DistanceUnits>
     </Measurement>
-    <WMSUrl type="QString"></WMSUrl>
-    <WFSLayers type="QStringList">
-      <value>testlayer20150528120452665</value>
-    </WFSLayers>
-    <WMSContactPhone type="QString"></WMSContactPhone>
-    <PAL>
-      <CandidatesPolygon type="int">30</CandidatesPolygon>
-      <ShowingAllLabels type="bool">false</ShowingAllLabels>
-      <ShowingCandidates type="bool">false</ShowingCandidates>
-      <DrawRectOnly type="bool">false</DrawRectOnly>
-      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
-      <CandidatesPoint type="int">16</CandidatesPoint>
-      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
-      <SearchMethod type="int">0</SearchMethod>
-      <CandidatesLine type="int">50</CandidatesLine>
-    </PAL>
-    <PositionPrecision>
-      <DecimalPlaces type="int">2</DecimalPlaces>
-      <DegreeFormat type="QString">D</DegreeFormat>
-      <Automatic type="bool">true</Automatic>
-    </PositionPrecision>
-    <Measure>
-      <Ellipsoid type="QString">WGS84</Ellipsoid>
-    </Measure>
-    <WCSUrl type="QString"></WCSUrl>
-    <WMSServiceAbstract type="QString">Some UTF8 text èòù</WMSServiceAbstract>
-    <Legend>
-      <filterByMap type="bool">false</filterByMap>
-    </Legend>
-    <WMSRestrictedComposers type="QStringList"/>
-    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
-    <WFSUrl type="QString"></WFSUrl>
-    <Paths>
-      <Absolute type="bool">false</Absolute>
-    </Paths>
-    <Variables>
-      <variableNames type="QStringList"/>
-      <variableValues type="QStringList"/>
-    </Variables>
-    <WMSServiceTitle type="QString">QGIS TestProject</WMSServiceTitle>
     <WCSLayers type="QStringList"/>
-    <WMSImageQuality type="int">90</WMSImageQuality>
-    <WMSOnlineResource type="QString"></WMSOnlineResource>
-    <WMSKeywordList type="QStringList">
-      <value></value>
-    </WMSKeywordList>
+    <WMSServiceTitle type="QString">QGIS TestProject</WMSServiceTitle>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <WFSLayersPrecision>
+      <testlayer20150528120452665 type="int">8</testlayer20150528120452665>
+    </WFSLayersPrecision>
     <WFSTLayers>
       <Insert type="QStringList">
         <value>testlayer20150528120452665</value>
@@ -441,7 +772,108 @@ def my_form_open(dialog, layer, feature):
         <value>testlayer20150528120452665</value>
       </Update>
     </WFSTLayers>
-    <WMSContactMail type="QString">elpaso@itopen.it</WMSContactMail>
+    <WMSUrl type="QString"></WMSUrl>
+    <Paths>
+      <Absolute type="bool">false</Absolute>
+    </Paths>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <Legend>
+      <filterByMap type="bool">false</filterByMap>
+    </Legend>
+    <Digitizing>
+      <AvoidIntersectionsList type="QStringList"/>
+      <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
+      <LayerSnapToList type="QStringList">
+        <value>to_vertex_and_segment</value>
+      </LayerSnapToList>
+      <LayerSnappingToleranceUnitList type="QStringList">
+        <value>2</value>
+      </LayerSnappingToleranceUnitList>
+      <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
+      <DefaultSnapType type="QString">off</DefaultSnapType>
+      <LayerSnappingToleranceList type="QStringList">
+        <value>0.000000</value>
+      </LayerSnappingToleranceList>
+      <SnappingMode type="QString">current_layer</SnappingMode>
+      <LayerSnappingEnabledList type="QStringList">
+        <value>disabled</value>
+      </LayerSnappingEnabledList>
+      <LayerSnappingList type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </LayerSnappingList>
+    </Digitizing>
+    <WMSFees type="QString">conditions unknown</WMSFees>
+    <SpatialRefSys>
+      <ProjectCrs type="QString">EPSG:4326</ProjectCrs>
+      <ProjectCRSProj4String type="QString">+proj=longlat +datum=WGS84 +no_defs</ProjectCRSProj4String>
+      <ProjectCRSID type="int">3452</ProjectCRSID>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+    </SpatialRefSys>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <WMSRestrictedComposers type="QStringList"/>
+    <WMSContactPosition type="QString"></WMSContactPosition>
+    <Variables>
+      <variableNames type="QStringList"/>
+      <variableValues type="QStringList"/>
+    </Variables>
+    <DefaultStyles>
+      <Line type="QString"></Line>
+      <AlphaInt type="int">255</AlphaInt>
+      <Fill type="QString"></Fill>
+      <Marker type="QString"></Marker>
+      <ColorRamp type="QString"></ColorRamp>
+      <RandomColors type="bool">true</RandomColors>
+    </DefaultStyles>
+    <Gui>
+      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+    </Gui>
+    <WMSExtent type="QStringList">
+      <value>8.20315414376310059</value>
+      <value>44.901236559338642</value>
+      <value>8.204164917965862</value>
+      <value>44.90159838674664172</value>
+    </WMSExtent>
+    <PositionPrecision>
+      <Automatic type="bool">true</Automatic>
+      <DegreeFormat type="QString">D</DegreeFormat>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+    </PositionPrecision>
+    <WMSKeywordList type="QStringList">
+      <value></value>
+    </WMSKeywordList>
+    <WMSContactPerson type="QString">Alessandro Pasotti</WMSContactPerson>
+    <PAL>
+      <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
+      <SearchMethod type="int">0</SearchMethod>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <CandidatesPoint type="int">16</CandidatesPoint>
+      <CandidatesLine type="int">50</CandidatesLine>
+    </PAL>
+    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
+    <WFSLayers type="QStringList">
+      <value>testlayer20150528120452665</value>
+    </WFSLayers>
+    <Measure>
+      <Ellipsoid type="QString">WGS84</Ellipsoid>
+    </Measure>
+    <WCSUrl type="QString"></WCSUrl>
+    <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
+    <Identify>
+      <disabledLayers type="QStringList"/>
+    </Identify>
+    <WMSPrecision type="QString">4</WMSPrecision>
   </properties>
   <visibility-presets/>
   <transformContext/>

--- a/tests/testdata/qgis_server/test_project_values.qgs
+++ b/tests/testdata/qgis_server/test_project_values.qgs
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis projectname="QGIS Test Project" version="3.1.0-Master">
+<qgis version="3.1.0-Master" projectname="QGIS Test Project">
   <homePath path=""/>
   <title>QGIS Test Project</title>
   <autotransaction active="0"/>
@@ -19,29 +19,40 @@
   </projectCrs>
   <layer-tree-group>
     <customproperties/>
-    <layer-tree-layer id="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" name="value_dict" providerKey="ogr" checked="Qt::Checked" expanded="1" source="./value_dict.csv">
+    <layer-tree-layer source="./material_values.csv" id="material_values_07693a17_8d8d_4657_8645_0d1364588136" checked="Qt::Checked" expanded="1" providerKey="ogr" name="material_values">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer id="testlayer20150528120452665" name="layer0" providerKey="ogr" checked="Qt::Checked" expanded="1" source="./testlayer.shp">
+    <layer-tree-layer source="./value_dict.csv" id="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" checked="Qt::Checked" expanded="1" providerKey="ogr" name="value_dict">
       <customproperties/>
     </layer-tree-layer>
-    <layer-tree-layer id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" name="layer1" providerKey="ogr" checked="Qt::Checked" expanded="1" source="./testlayer.shp">
+    <layer-tree-layer source="./testlayer.shp" id="testlayer20150528120452665" checked="Qt::Checked" expanded="1" providerKey="ogr" name="layer0">
+      <customproperties/>
+    </layer-tree-layer>
+    <layer-tree-layer source="./testlayer.shp" id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" checked="Qt::Checked" expanded="1" providerKey="ogr" name="layer1">
+      <customproperties/>
+    </layer-tree-layer>
+    <layer-tree-layer source="./testlayer.shp" id="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" checked="Qt::Checked" expanded="1" providerKey="ogr" name="layer2">
       <customproperties/>
     </layer-tree-layer>
     <custom-order enabled="0">
       <item>testlayer20150528120452665</item>
       <item>layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1</item>
-      <item>value_dict_4e5dce19_7169_42fe_8408_4927be615c09</item>
+      <item>layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5</item>
     </custom-order>
   </layer-tree-group>
-  <snapping-settings intersection-snapping="0" mode="1" tolerance="0" unit="2" enabled="0" type="2">
+  <snapping-settings type="2" mode="1" enabled="0" unit="2" intersection-snapping="0" tolerance="0">
     <individual-layer-settings>
-      <layer-setting id="testlayer20150528120452665" tolerance="0" enabled="0" units="2" type="2"/>
-      <layer-setting id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" tolerance="30" enabled="1" units="1" type="2"/>
+      <layer-setting type="2" units="1" enabled="1" id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" tolerance="30"/>
+      <layer-setting type="2" units="1" enabled="1" id="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" tolerance="30"/>
+      <layer-setting type="2" units="2" enabled="0" id="testlayer20150528120452665" tolerance="0"/>
     </individual-layer-settings>
   </snapping-settings>
-  <relations/>
-  <mapcanvas name="theMapCanvas" annotationsVisible="1">
+  <relations>
+    <relation referencingLayer="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" referencedLayer="material_values_07693a17_8d8d_4657_8645_0d1364588136" strength="Association" id="test-relation" name="test-relation">
+      <fieldRef referencedField="id" referencingField="id"/>
+    </relation>
+  </relations>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
     <units>degrees</units>
     <extent>
       <xmin>8.20264578195449801</xmin>
@@ -65,25 +76,35 @@
     <rendermaptile>0</rendermaptile>
   </mapcanvas>
   <legend updateDrawingOrder="true">
-    <legendlayer name="value_dict" drawingOrder="-1" open="true" checked="Qt::Checked" showFeatureCount="0">
+    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="material_values">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" visible="1" layerid="value_dict_4e5dce19_7169_42fe_8408_4927be615c09"/>
+        <legendlayerfile isInOverview="0" layerid="material_values_07693a17_8d8d_4657_8645_0d1364588136" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer name="layer0" drawingOrder="-1" open="true" checked="Qt::Checked" showFeatureCount="0">
+    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="value_dict">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" visible="1" layerid="testlayer20150528120452665"/>
+        <legendlayerfile isInOverview="0" layerid="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" visible="1"/>
       </filegroup>
     </legendlayer>
-    <legendlayer name="layer1" drawingOrder="-1" open="true" checked="Qt::Checked" showFeatureCount="0">
+    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="layer0">
       <filegroup hidden="false" open="true">
-        <legendlayerfile isInOverview="0" visible="1" layerid="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1"/>
+        <legendlayerfile isInOverview="0" layerid="testlayer20150528120452665" visible="1"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="layer1">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1" visible="1"/>
+      </filegroup>
+    </legendlayer>
+    <legendlayer showFeatureCount="0" drawingOrder="-1" checked="Qt::Checked" open="true" name="layer2">
+      <filegroup hidden="false" open="true">
+        <legendlayerfile isInOverview="0" layerid="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5" visible="1"/>
       </filegroup>
     </legendlayer>
   </legend>
   <mapViewDocks/>
   <projectlayers>
-    <maplayer readOnly="0" simplifyAlgorithm="0" autoRefreshEnabled="0" simplifyDrawingHints="0" simplifyMaxScale="1" maxScale="0" autoRefreshTime="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+8" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" geometry="Point" type="vector" labelsEnabled="0">
+    <maplayer type="vector" simplifyAlgorithm="0" labelsEnabled="0" simplifyDrawingHints="0" readOnly="0" maxScale="0" simplifyMaxScale="1" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="Point" simplifyDrawingTol="1">
       <extent>
         <xmin>8.20345930703634352</xmin>
         <ymin>44.90139483904469131</ymin>
@@ -142,7 +163,7 @@
           </spatialrefsys>
         </crs>
         <extent>
-          <spatial dimensions="2" miny="0" maxx="0" crs="" minz="0" maxz="0" maxy="0" minx="0"/>
+          <spatial minz="0" maxx="0" maxz="0" crs="" minx="0" dimensions="2" miny="0" maxy="0"/>
           <temporal>
             <period>
               <start></start>
@@ -160,41 +181,41 @@
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="marker">
-            <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-              <prop k="angle" v="0"/>
-              <prop k="color" v="102,164,67,255"/>
-              <prop k="horizontal_anchor_point" v="1"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="name" v="circle"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="0,0,0,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="scale_method" v="area"/>
-              <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="size_unit" v="MM"/>
-              <prop k="vertical_anchor_point" v="1"/>
-              <effect enabled="0" type="effectStack">
+          <symbol type="marker" clip_to_extent="1" name="0" alpha="1">
+            <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+              <prop v="0" k="angle"/>
+              <prop v="102,164,67,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="0,0,0,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="area" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <effect type="effectStack" enabled="0">
                 <effect type="drawSource">
-                  <prop k="blend_mode" v="0"/>
-                  <prop k="draw_mode" v="2"/>
-                  <prop k="enabled" v="1"/>
-                  <prop k="opacity" v="1"/>
+                  <prop v="0" k="blend_mode"/>
+                  <prop v="2" k="draw_mode"/>
+                  <prop v="1" k="enabled"/>
+                  <prop v="1" k="opacity"/>
                 </effect>
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -202,17 +223,17 @@
         </symbols>
         <rotation/>
         <sizescale/>
-        <effect enabled="0" type="effectStack">
+        <effect type="effectStack" enabled="0">
           <effect type="drawSource">
-            <prop k="blend_mode" v="0"/>
-            <prop k="draw_mode" v="2"/>
-            <prop k="enabled" v="1"/>
-            <prop k="opacity" v="1"/>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
           </effect>
         </effect>
       </renderer-v2>
       <customproperties>
-        <property key="embeddedWidgets/count" value="0"/>
+        <property value="0" key="embeddedWidgets/count"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
@@ -220,23 +241,23 @@
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory rotationOffset="270" sizeType="MM" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" penWidth="0" maxScaleDenominator="1e+8" height="15" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" penAlpha="255" scaleDependency="Area" diagramOrientation="Up" opacity="1" minScaleDenominator="0" penColor="#000000" minimumSize="0" enabled="0" barWidth="5" backgroundAlpha="255" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0">
+        <DiagramCategory penAlpha="255" diagramOrientation="Up" scaleDependency="Area" enabled="0" lineSizeType="MM" minScaleDenominator="0" rotationOffset="270" width="15" maxScaleDenominator="1e+8" height="15" opacity="1" penWidth="0" backgroundColor="#ffffff" backgroundAlpha="255" sizeType="MM" minimumSize="0" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" scaleBasedVisibility="0">
           <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" color="#000000" label=""/>
+          <attribute color="#000000" field="" label=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings zIndex="0" linePlacementFlags="2" showAll="1" priority="0" obstacle="0" dist="0" placement="0">
+      <DiagramLayerSettings zIndex="0" placement="0" linePlacementFlags="2" dist="0" obstacle="0" priority="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option name="active" value="true" type="bool"/>
-                <Option name="field" value="id" type="QString"/>
-                <Option name="type" value="2" type="int"/>
+            <Option type="QString" value="" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option type="bool" value="true" name="active"/>
+                <Option type="QString" value="id" name="field"/>
+                <Option type="int" value="2" name="type"/>
               </Option>
             </Option>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
@@ -245,15 +266,15 @@
           <editWidget type="ValueRelation">
             <config>
               <Option type="Map">
-                <Option name="AllowMulti" value="false" type="bool"/>
-                <Option name="AllowNull" value="false" type="bool"/>
-                <Option name="FilterExpression" value="" type="QString"/>
-                <Option name="Key" value="id" type="QString"/>
-                <Option name="Layer" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" type="QString"/>
-                <Option name="NofColumns" value="1" type="int"/>
-                <Option name="OrderByValue" value="false" type="bool"/>
-                <Option name="UseCompleter" value="false" type="bool"/>
-                <Option name="Value" value="value_id" type="QString"/>
+                <Option type="bool" value="false" name="AllowMulti"/>
+                <Option type="bool" value="false" name="AllowNull"/>
+                <Option type="QString" value="" name="FilterExpression"/>
+                <Option type="QString" value="id" name="Key"/>
+                <Option type="QString" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" name="Layer"/>
+                <Option type="int" value="1" name="NofColumns"/>
+                <Option type="bool" value="false" name="OrderByValue"/>
+                <Option type="bool" value="false" name="UseCompleter"/>
+                <Option type="QString" value="value_id" name="Value"/>
               </Option>
             </config>
           </editWidget>
@@ -262,15 +283,15 @@
           <editWidget type="ValueRelation">
             <config>
               <Option type="Map">
-                <Option name="AllowMulti" value="false" type="bool"/>
-                <Option name="AllowNull" value="false" type="bool"/>
-                <Option name="FilterExpression" value="" type="QString"/>
-                <Option name="Key" value="reverse" type="QString"/>
-                <Option name="Layer" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" type="QString"/>
-                <Option name="NofColumns" value="1" type="int"/>
-                <Option name="OrderByValue" value="false" type="bool"/>
-                <Option name="UseCompleter" value="false" type="bool"/>
-                <Option name="Value" value="reverse_val" type="QString"/>
+                <Option type="bool" value="false" name="AllowMulti"/>
+                <Option type="bool" value="false" name="AllowNull"/>
+                <Option type="QString" value="" name="FilterExpression"/>
+                <Option type="QString" value="reverse" name="Key"/>
+                <Option type="QString" value="value_dict_4e5dce19_7169_42fe_8408_4927be615c09" name="Layer"/>
+                <Option type="int" value="1" name="NofColumns"/>
+                <Option type="bool" value="false" name="OrderByValue"/>
+                <Option type="bool" value="false" name="UseCompleter"/>
+                <Option type="QString" value="reverse_val" name="Value"/>
               </Option>
             </config>
           </editWidget>
@@ -279,8 +300,8 @@
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="false" type="bool"/>
-                <Option name="UseHtml" value="false" type="bool"/>
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -294,29 +315,29 @@
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="id" expression="" applyOnUpdate="0"/>
-        <default field="name" expression="" applyOnUpdate="0"/>
-        <default field="utf8nameè" expression="" applyOnUpdate="0"/>
+        <default expression="" field="id" applyOnUpdate="0"/>
+        <default expression="" field="name" applyOnUpdate="0"/>
+        <default expression="" field="utf8nameè" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="id" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
-        <constraint field="name" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
-        <constraint field="utf8nameè" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="id" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="name" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="utf8nameè" exp_strength="0" notnull_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="id" exp="" desc=""/>
-        <constraint field="name" exp="" desc=""/>
-        <constraint field="utf8nameè" exp="" desc=""/>
+        <constraint exp="" field="id" desc=""/>
+        <constraint exp="" field="name" desc=""/>
+        <constraint exp="" field="utf8nameè" desc=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column width="-1" name="id" hidden="0" type="field"/>
-          <column width="-1" name="name" hidden="0" type="field"/>
-          <column width="130" name="utf8nameè" hidden="0" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column type="field" hidden="0" name="id" width="-1"/>
+          <column type="field" hidden="0" name="name" width="-1"/>
+          <column type="field" hidden="0" name="utf8nameè" width="130"/>
+          <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
       <editform>../../../../qgis2/tests/testdata/qgis_server</editform>
@@ -343,14 +364,14 @@ def my_form_open(dialog, layer, feature):
       <featformsuppress>0</featformsuppress>
       <editorlayout>generatedlayout</editorlayout>
       <editable>
-        <field name="id" editable="1"/>
-        <field name="name" editable="1"/>
-        <field name="utf8nameè" editable="1"/>
+        <field editable="1" name="id"/>
+        <field editable="1" name="name"/>
+        <field editable="1" name="utf8nameè"/>
       </editable>
       <labelOnTop>
-        <field name="id" labelOnTop="0"/>
-        <field name="name" labelOnTop="0"/>
-        <field name="utf8nameè" labelOnTop="0"/>
+        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="name"/>
+        <field labelOnTop="0" name="utf8nameè"/>
       </labelOnTop>
       <widgets/>
       <conditionalstyles>
@@ -361,7 +382,442 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer readOnly="0" simplifyAlgorithm="0" autoRefreshEnabled="0" simplifyDrawingHints="0" simplifyMaxScale="1" maxScale="0" autoRefreshTime="0" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+8" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" geometry="Point" type="vector" labelsEnabled="1">
+    <maplayer type="vector" simplifyAlgorithm="0" labelsEnabled="0" simplifyDrawingHints="0" readOnly="0" maxScale="0" simplifyMaxScale="1" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="Point" simplifyDrawingTol="1">
+      <extent>
+        <xmin>8.20345930703634352</xmin>
+        <ymin>44.90139483904469131</ymin>
+        <xmax>8.20354699399348775</xmax>
+        <ymax>44.90148252600183554</ymax>
+      </extent>
+      <id>layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5</id>
+      <datasource>./testlayer.shp</datasource>
+      <title>A test vector layer</title>
+      <abstract>A test vector layer with unicode òà</abstract>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>layer2</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <contact>
+          <name></name>
+          <organization></organization>
+          <position></position>
+          <voice></voice>
+          <fax></fax>
+          <email></email>
+          <role></role>
+        </contact>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent>
+          <spatial minz="0" maxx="0" maxz="0" crs="" minx="0" dimensions="2" miny="0" maxy="0"/>
+          <temporal>
+            <period>
+              <start></start>
+              <end></end>
+            </period>
+          </temporal>
+        </extent>
+      </resourceMetadata>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
+        <symbols>
+          <symbol type="marker" clip_to_extent="1" name="0" alpha="1">
+            <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+              <prop v="0" k="angle"/>
+              <prop v="102,164,67,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="0,0,0,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="area" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <effect type="effectStack" enabled="0">
+                <effect type="drawSource">
+                  <prop v="0" k="blend_mode"/>
+                  <prop v="2" k="draw_mode"/>
+                  <prop v="1" k="enabled"/>
+                  <prop v="1" k="opacity"/>
+                </effect>
+              </effect>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+        <effect type="effectStack" enabled="0">
+          <effect type="drawSource">
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
+          </effect>
+        </effect>
+      </renderer-v2>
+      <customproperties>
+        <property key="dualview/previewExpressions">
+          <value>COALESCE( "name", '&lt;NULL>' )</value>
+          <value>COALESCE( "name", '&lt;NULL>' )</value>
+        </property>
+        <property value="0" key="embeddedWidgets/count"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
+        <DiagramCategory penAlpha="255" diagramOrientation="Up" scaleDependency="Area" enabled="0" lineSizeType="MM" minScaleDenominator="0" rotationOffset="270" width="15" maxScaleDenominator="1e+8" height="15" opacity="1" penWidth="0" backgroundColor="#ffffff" backgroundAlpha="255" sizeType="MM" minimumSize="0" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" scaleBasedVisibility="0">
+          <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
+          <attribute color="#000000" field="" label=""/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings zIndex="0" placement="0" linePlacementFlags="2" dist="0" obstacle="0" priority="0" showAll="1">
+        <properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option type="bool" value="true" name="active"/>
+                <Option type="QString" value="id" name="field"/>
+                <Option type="int" value="2" name="type"/>
+              </Option>
+            </Option>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <fieldConfiguration>
+        <field name="id">
+          <editWidget type="RelationReference">
+            <config>
+              <Option type="Map">
+                <Option type="bool" value="false" name="AllowAddFeatures"/>
+                <Option type="bool" value="false" name="AllowNULL"/>
+                <Option type="bool" value="true" name="ChainFilters"/>
+                <Option type="StringList" name="FilterFields">
+                  <Option type="QString" value="short_ro"/>
+                  <Option type="QString" value="diameter"/>
+                </Option>
+                <Option type="bool" value="false" name="MapIdentification"/>
+                <Option type="bool" value="false" name="OrderByValue"/>
+                <Option type="bool" value="false" name="ReadOnly"/>
+                <Option type="QString" value="test-relation" name="Relation"/>
+                <Option type="bool" value="false" name="ShowForm"/>
+                <Option type="bool" value="true" name="ShowOpenFormButton"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="name">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+        <field name="utf8nameè">
+          <editWidget type="TextEdit">
+            <config>
+              <Option type="Map">
+                <Option type="bool" value="false" name="IsMultiline"/>
+                <Option type="bool" value="false" name="UseHtml"/>
+              </Option>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="id" index="0" name=""/>
+        <alias field="name" index="1" name=""/>
+        <alias field="utf8nameè" index="2" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default expression="" field="id" applyOnUpdate="0"/>
+        <default expression="" field="name" applyOnUpdate="0"/>
+        <default expression="" field="utf8nameè" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint constraints="1" unique_strength="0" field="id" exp_strength="0" notnull_strength="2"/>
+        <constraint constraints="0" unique_strength="0" field="name" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="utf8nameè" exp_strength="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint exp="" field="id" desc=""/>
+        <constraint exp="" field="name" desc=""/>
+        <constraint exp="" field="utf8nameè" desc=""/>
+      </constraintExpressions>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns>
+          <column type="field" hidden="0" name="id" width="-1"/>
+          <column type="field" hidden="0" name="name" width="-1"/>
+          <column type="field" hidden="0" name="utf8nameè" width="130"/>
+          <column type="actions" hidden="1" width="-1"/>
+        </columns>
+      </attributetableconfig>
+      <editform>../../../../qgis2/tests/testdata/qgis_server</editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath>../../../../qgis2/tests/testdata/qgis_server</editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable>
+        <field editable="1" name="id"/>
+        <field editable="1" name="name"/>
+        <field editable="1" name="utf8nameè"/>
+      </editable>
+      <labelOnTop>
+        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="name"/>
+        <field labelOnTop="0" name="utf8nameè"/>
+      </labelOnTop>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <expressionfields/>
+      <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer type="vector" readOnly="0" maxScale="0" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="No geometry">
+      <id>material_values_07693a17_8d8d_4657_8645_0d1364588136</id>
+      <datasource>./material_values.csv</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>material_values</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=longlat +datum=WGS84 +no_defs</proj4>
+          <srsid>3452</srsid>
+          <srid>4326</srid>
+          <authid>EPSG:4326</authid>
+          <description>WGS 84</description>
+          <projectionacronym>longlat</projectionacronym>
+          <ellipsoidacronym>WGS84</ellipsoidacronym>
+          <geographicflag>true</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <customproperties>
+        <property key="dualview/previewExpressions">
+          <value>_displayname_en</value>
+          <value>"id"</value>
+        </property>
+      </customproperties>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <fieldConfiguration>
+        <field name="id">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="short_ro">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="_displayname_en">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="diameter">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="pressure_nominal">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="id" index="0" name=""/>
+        <alias field="short_ro" index="1" name=""/>
+        <alias field="_displayname_en" index="2" name=""/>
+        <alias field="diameter" index="3" name=""/>
+        <alias field="pressure_nominal" index="4" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default expression="" field="id" applyOnUpdate="0"/>
+        <default expression="" field="short_ro" applyOnUpdate="0"/>
+        <default expression="" field="_displayname_en" applyOnUpdate="0"/>
+        <default expression="" field="diameter" applyOnUpdate="0"/>
+        <default expression="" field="pressure_nominal" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint constraints="0" unique_strength="0" field="id" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="short_ro" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="_displayname_en" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="diameter" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="pressure_nominal" exp_strength="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint exp="" field="id" desc=""/>
+        <constraint exp="" field="short_ro" desc=""/>
+        <constraint exp="" field="_displayname_en" desc=""/>
+        <constraint exp="" field="diameter" desc=""/>
+        <constraint exp="" field="pressure_nominal" desc=""/>
+      </constraintExpressions>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
+        <columns>
+          <column type="field" hidden="0" name="id" width="-1"/>
+          <column type="field" hidden="0" name="short_ro" width="-1"/>
+          <column type="field" hidden="0" name="_displayname_en" width="150"/>
+          <column type="field" hidden="0" name="diameter" width="-1"/>
+          <column type="field" hidden="0" name="pressure_nominal" width="136"/>
+          <column type="actions" hidden="1" width="-1"/>
+        </columns>
+      </attributetableconfig>
+      <editform>.</editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable/>
+      <labelOnTop/>
+      <widgets/>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <expressionfields/>
+      <previewExpression>'value ' || _displayname_en</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer type="vector" simplifyAlgorithm="0" labelsEnabled="1" simplifyDrawingHints="0" readOnly="0" maxScale="0" simplifyMaxScale="1" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" simplifyLocal="1" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="Point" simplifyDrawingTol="1">
       <extent>
         <xmin>8.20345930703634352</xmin>
         <ymin>44.90139483904469131</ymin>
@@ -407,7 +863,7 @@ def my_form_open(dialog, layer, feature):
             <description></description>
             <projectionacronym></projectionacronym>
             <ellipsoidacronym></ellipsoidacronym>
-            <geographicflag>true</geographicflag>
+            <geographicflag>false</geographicflag>
           </spatialrefsys>
         </crs>
         <extent/>
@@ -421,41 +877,41 @@ def my_form_open(dialog, layer, feature):
         <map-layer-style name="default"/>
       </map-layer-style-manager>
       <auxiliaryLayer/>
-      <renderer-v2 forceraster="0" symbollevels="0" enableorderby="0" type="singleSymbol">
+      <renderer-v2 type="singleSymbol" symbollevels="0" enableorderby="0" forceraster="0">
         <symbols>
-          <symbol name="0" alpha="1" clip_to_extent="1" type="marker">
-            <layer locked="0" class="SimpleMarker" enabled="1" pass="0">
-              <prop k="angle" v="0"/>
-              <prop k="color" v="102,164,67,255"/>
-              <prop k="horizontal_anchor_point" v="1"/>
-              <prop k="joinstyle" v="bevel"/>
-              <prop k="name" v="circle"/>
-              <prop k="offset" v="0,0"/>
-              <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="offset_unit" v="MM"/>
-              <prop k="outline_color" v="0,0,0,255"/>
-              <prop k="outline_style" v="solid"/>
-              <prop k="outline_width" v="0"/>
-              <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="outline_width_unit" v="MM"/>
-              <prop k="scale_method" v="area"/>
-              <prop k="size" v="2"/>
-              <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
-              <prop k="size_unit" v="MM"/>
-              <prop k="vertical_anchor_point" v="1"/>
-              <effect enabled="0" type="effectStack">
+          <symbol type="marker" clip_to_extent="1" name="0" alpha="1">
+            <layer class="SimpleMarker" locked="0" pass="0" enabled="1">
+              <prop v="0" k="angle"/>
+              <prop v="102,164,67,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="0,0,0,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="area" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <effect type="effectStack" enabled="0">
                 <effect type="drawSource">
-                  <prop k="blend_mode" v="0"/>
-                  <prop k="draw_mode" v="2"/>
-                  <prop k="enabled" v="1"/>
-                  <prop k="opacity" v="1"/>
+                  <prop v="0" k="blend_mode"/>
+                  <prop v="2" k="draw_mode"/>
+                  <prop v="1" k="enabled"/>
+                  <prop v="1" k="opacity"/>
                 </effect>
               </effect>
               <data_defined_properties>
                 <Option type="Map">
-                  <Option name="name" value="" type="QString"/>
+                  <Option type="QString" value="" name="name"/>
                   <Option name="properties"/>
-                  <Option name="type" value="collection" type="QString"/>
+                  <Option type="QString" value="collection" name="type"/>
                 </Option>
               </data_defined_properties>
             </layer>
@@ -463,17 +919,17 @@ def my_form_open(dialog, layer, feature):
         </symbols>
         <rotation/>
         <sizescale/>
-        <effect enabled="0" type="effectStack">
+        <effect type="effectStack" enabled="0">
           <effect type="drawSource">
-            <prop k="blend_mode" v="0"/>
-            <prop k="draw_mode" v="2"/>
-            <prop k="enabled" v="1"/>
-            <prop k="opacity" v="1"/>
+            <prop v="0" k="blend_mode"/>
+            <prop v="2" k="draw_mode"/>
+            <prop v="1" k="enabled"/>
+            <prop v="1" k="opacity"/>
           </effect>
         </effect>
       </renderer-v2>
       <customproperties>
-        <property key="embeddedWidgets/count" value="0"/>
+        <property value="0" key="embeddedWidgets/count"/>
         <property key="variableNames"/>
         <property key="variableValues"/>
       </customproperties>
@@ -481,23 +937,23 @@ def my_form_open(dialog, layer, feature):
       <featureBlendMode>0</featureBlendMode>
       <layerOpacity>1</layerOpacity>
       <SingleCategoryDiagramRenderer diagramType="Pie" attributeLegend="1">
-        <DiagramCategory rotationOffset="270" sizeType="MM" lineSizeType="MM" sizeScale="3x:0,0,0,0,0,0" penWidth="0" maxScaleDenominator="1e+8" height="15" scaleBasedVisibility="0" width="15" backgroundColor="#ffffff" penAlpha="255" scaleDependency="Area" diagramOrientation="Up" opacity="1" minScaleDenominator="inf" penColor="#000000" minimumSize="0" enabled="0" barWidth="5" backgroundAlpha="255" labelPlacementMethod="XHeight" lineSizeScale="3x:0,0,0,0,0,0">
+        <DiagramCategory penAlpha="255" diagramOrientation="Up" scaleDependency="Area" enabled="0" lineSizeType="MM" minScaleDenominator="inf" rotationOffset="270" width="15" maxScaleDenominator="1e+8" height="15" opacity="1" penWidth="0" backgroundColor="#ffffff" backgroundAlpha="255" sizeType="MM" minimumSize="0" penColor="#000000" sizeScale="3x:0,0,0,0,0,0" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" barWidth="5" scaleBasedVisibility="0">
           <fontProperties description="Ubuntu,9,-1,5,50,0,0,0,0,0" style=""/>
-          <attribute field="" color="#000000" label=""/>
+          <attribute color="#000000" field="" label=""/>
         </DiagramCategory>
       </SingleCategoryDiagramRenderer>
-      <DiagramLayerSettings zIndex="0" linePlacementFlags="10" showAll="1" priority="0" obstacle="0" dist="0" placement="0">
+      <DiagramLayerSettings zIndex="0" placement="0" linePlacementFlags="10" dist="0" obstacle="0" priority="0" showAll="1">
         <properties>
           <Option type="Map">
-            <Option name="name" value="" type="QString"/>
-            <Option name="properties" type="Map">
-              <Option name="show" type="Map">
-                <Option name="active" value="true" type="bool"/>
-                <Option name="field" value="id" type="QString"/>
-                <Option name="type" value="2" type="int"/>
+            <Option type="QString" value="" name="name"/>
+            <Option type="Map" name="properties">
+              <Option type="Map" name="show">
+                <Option type="bool" value="true" name="active"/>
+                <Option type="QString" value="id" name="field"/>
+                <Option type="int" value="2" name="type"/>
               </Option>
             </Option>
-            <Option name="type" value="collection" type="QString"/>
+            <Option type="QString" value="collection" name="type"/>
           </Option>
         </properties>
       </DiagramLayerSettings>
@@ -506,8 +962,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="0" type="QString"/>
-                <Option name="UseHtml" value="0" type="QString"/>
+                <Option type="QString" value="0" name="IsMultiline"/>
+                <Option type="QString" value="0" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -516,8 +972,8 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="TextEdit">
             <config>
               <Option type="Map">
-                <Option name="IsMultiline" value="0" type="QString"/>
-                <Option name="UseHtml" value="0" type="QString"/>
+                <Option type="QString" value="0" name="IsMultiline"/>
+                <Option type="QString" value="0" name="UseHtml"/>
               </Option>
             </config>
           </editWidget>
@@ -526,10 +982,10 @@ def my_form_open(dialog, layer, feature):
           <editWidget type="ValueMap">
             <config>
               <Option type="Map">
-                <Option name="map" type="Map">
-                  <Option name="First Value" value="one èé" type="QString"/>
-                  <Option name="Second Value" value="two àò" type="QString"/>
-                  <Option name="Third èé↓" value="three èé↓" type="QString"/>
+                <Option type="Map" name="map">
+                  <Option type="QString" value="one èé" name="First Value"/>
+                  <Option type="QString" value="two àò" name="Second Value"/>
+                  <Option type="QString" value="three èé↓" name="Third èé↓"/>
                 </Option>
               </Option>
             </config>
@@ -544,29 +1000,29 @@ def my_form_open(dialog, layer, feature):
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="id" expression="" applyOnUpdate="0"/>
-        <default field="name" expression="" applyOnUpdate="0"/>
-        <default field="utf8nameè" expression="" applyOnUpdate="0"/>
+        <default expression="" field="id" applyOnUpdate="0"/>
+        <default expression="" field="name" applyOnUpdate="0"/>
+        <default expression="" field="utf8nameè" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="id" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
-        <constraint field="name" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
-        <constraint field="utf8nameè" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="id" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="name" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="utf8nameè" exp_strength="0" notnull_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="id" exp="" desc=""/>
-        <constraint field="name" exp="" desc=""/>
-        <constraint field="utf8nameè" exp="" desc=""/>
+        <constraint exp="" field="id" desc=""/>
+        <constraint exp="" field="name" desc=""/>
+        <constraint exp="" field="utf8nameè" desc=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
         <columns>
-          <column width="-1" name="id" hidden="0" type="field"/>
-          <column width="-1" name="name" hidden="0" type="field"/>
-          <column width="130" name="utf8nameè" hidden="0" type="field"/>
-          <column width="-1" hidden="1" type="actions"/>
+          <column type="field" hidden="0" name="id" width="-1"/>
+          <column type="field" hidden="0" name="name" width="-1"/>
+          <column type="field" hidden="0" name="utf8nameè" width="130"/>
+          <column type="actions" hidden="1" width="-1"/>
         </columns>
       </attributetableconfig>
       <editform>../../../../qgis2/tests/testdata/qgis_server</editform>
@@ -603,7 +1059,7 @@ def my_form_open(dialog, layer, feature):
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <mapTip></mapTip>
     </maplayer>
-    <maplayer readOnly="0" autoRefreshEnabled="0" maxScale="0" autoRefreshTime="0" minScale="1e+8" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" geometry="No geometry" type="vector">
+    <maplayer type="vector" readOnly="0" maxScale="0" autoRefreshTime="0" autoRefreshEnabled="0" refreshOnNotifyEnabled="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" minScale="1e+8" geometry="No geometry">
       <id>value_dict_4e5dce19_7169_42fe_8408_4927be615c09</id>
       <datasource>./value_dict.csv</datasource>
       <keywordList>
@@ -646,7 +1102,9 @@ def my_form_open(dialog, layer, feature):
         </crs>
         <extent/>
       </resourceMetadata>
-      <customproperties/>
+      <customproperties>
+        <property value="&quot;id&quot;" key="dualview/previewExpressions"/>
+      </customproperties>
       <provider encoding="UTF-8">ogr</provider>
       <vectorjoins/>
       <layerDependencies/>
@@ -695,30 +1153,36 @@ def my_form_open(dialog, layer, feature):
       <excludeAttributesWMS/>
       <excludeAttributesWFS/>
       <defaults>
-        <default field="id" expression="" applyOnUpdate="0"/>
-        <default field="value_id" expression="" applyOnUpdate="0"/>
-        <default field="reverse" expression="" applyOnUpdate="0"/>
-        <default field="reverse_val" expression="" applyOnUpdate="0"/>
+        <default expression="" field="id" applyOnUpdate="0"/>
+        <default expression="" field="value_id" applyOnUpdate="0"/>
+        <default expression="" field="reverse" applyOnUpdate="0"/>
+        <default expression="" field="reverse_val" applyOnUpdate="0"/>
       </defaults>
       <constraints>
-        <constraint field="id" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
-        <constraint field="value_id" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
-        <constraint field="reverse" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
-        <constraint field="reverse_val" exp_strength="0" notnull_strength="0" constraints="0" unique_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="id" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="value_id" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="reverse" exp_strength="0" notnull_strength="0"/>
+        <constraint constraints="0" unique_strength="0" field="reverse_val" exp_strength="0" notnull_strength="0"/>
       </constraints>
       <constraintExpressions>
-        <constraint field="id" exp="" desc=""/>
-        <constraint field="value_id" exp="" desc=""/>
-        <constraint field="reverse" exp="" desc=""/>
-        <constraint field="reverse_val" exp="" desc=""/>
+        <constraint exp="" field="id" desc=""/>
+        <constraint exp="" field="value_id" desc=""/>
+        <constraint exp="" field="reverse" desc=""/>
+        <constraint exp="" field="reverse_val" desc=""/>
       </constraintExpressions>
       <attributeactions>
-        <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
       </attributeactions>
       <attributetableconfig actionWidgetStyle="dropDown" sortExpression="" sortOrder="0">
-        <columns/>
+        <columns>
+          <column type="field" hidden="0" name="id" width="-1"/>
+          <column type="field" hidden="0" name="value_id" width="-1"/>
+          <column type="field" hidden="0" name="reverse" width="-1"/>
+          <column type="field" hidden="0" name="reverse_val" width="-1"/>
+          <column type="actions" hidden="1" width="-1"/>
+        </columns>
       </attributetableconfig>
-      <editform></editform>
+      <editform>.</editform>
       <editforminit/>
       <editforminitcodesource>0</editforminitcodesource>
       <editforminitfilepath></editforminitfilepath>
@@ -733,147 +1197,150 @@ def my_form_open(dialog, layer, feature):
         <fieldstyles/>
       </conditionalstyles>
       <expressionfields/>
-      <previewExpression></previewExpression>
+      <previewExpression>"id"</previewExpression>
       <mapTip></mapTip>
     </maplayer>
   </projectlayers>
   <layerorder>
     <layer id="testlayer20150528120452665"/>
     <layer id="layer0_5eef4a92_d4ca_47ad_a912_4860ad969cc1"/>
-    <layer id="value_dict_4e5dce19_7169_42fe_8408_4927be615c09"/>
+    <layer id="layer1_66e93820_d5fe_42f0_aa38_75ac431a64f5"/>
   </layerorder>
   <properties>
-    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
-    <WMSContactMail type="QString">elpaso@itopen.it</WMSContactMail>
-    <WMSServiceAbstract type="QString">Some UTF8 text èòù</WMSServiceAbstract>
-    <WMSContactOrganization type="QString">QGIS dev team</WMSContactOrganization>
     <WMSRestrictedLayers type="QStringList"/>
+    <PositionPrecision>
+      <DegreeFormat type="QString">D</DegreeFormat>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+      <Automatic type="bool">true</Automatic>
+    </PositionPrecision>
+    <Variables>
+      <variableValues type="QStringList"/>
+      <variableNames type="QStringList"/>
+    </Variables>
+    <DefaultStyles>
+      <RandomColors type="bool">true</RandomColors>
+      <Fill type="QString"></Fill>
+      <Opacity type="double">1</Opacity>
+      <AlphaInt type="int">255</AlphaInt>
+      <Marker type="QString"></Marker>
+      <ColorRamp type="QString"></ColorRamp>
+      <Line type="QString"></Line>
+    </DefaultStyles>
     <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
-    <WFSUrl type="QString"></WFSUrl>
-    <WMSImageQuality type="int">90</WMSImageQuality>
-    <Measurement>
-      <AreaUnits type="QString">m2</AreaUnits>
-      <DistanceUnits type="QString">meters</DistanceUnits>
-    </Measurement>
-    <WCSLayers type="QStringList"/>
-    <WMSServiceTitle type="QString">QGIS TestProject</WMSServiceTitle>
-    <WMSContactPhone type="QString"></WMSContactPhone>
-    <WFSLayersPrecision>
-      <testlayer20150528120452665 type="int">8</testlayer20150528120452665>
-    </WFSLayersPrecision>
-    <WFSTLayers>
-      <Insert type="QStringList">
-        <value>testlayer20150528120452665</value>
-      </Insert>
-      <Delete type="QStringList">
-        <value>testlayer20150528120452665</value>
-      </Delete>
-      <Update type="QStringList">
-        <value>testlayer20150528120452665</value>
-      </Update>
-    </WFSTLayers>
-    <WMSUrl type="QString"></WMSUrl>
-    <Paths>
-      <Absolute type="bool">false</Absolute>
-    </Paths>
-    <WMSOnlineResource type="QString"></WMSOnlineResource>
-    <Legend>
-      <filterByMap type="bool">false</filterByMap>
-    </Legend>
     <Digitizing>
+      <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
       <AvoidIntersectionsList type="QStringList"/>
-      <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
       <LayerSnapToList type="QStringList">
         <value>to_vertex_and_segment</value>
       </LayerSnapToList>
-      <LayerSnappingToleranceUnitList type="QStringList">
-        <value>2</value>
-      </LayerSnappingToleranceUnitList>
-      <DefaultSnapToleranceUnit type="int">2</DefaultSnapToleranceUnit>
-      <DefaultSnapType type="QString">off</DefaultSnapType>
-      <LayerSnappingToleranceList type="QStringList">
-        <value>0.000000</value>
-      </LayerSnappingToleranceList>
-      <SnappingMode type="QString">current_layer</SnappingMode>
       <LayerSnappingEnabledList type="QStringList">
         <value>disabled</value>
       </LayerSnappingEnabledList>
+      <SnappingMode type="QString">current_layer</SnappingMode>
+      <LayerSnappingToleranceUnitList type="QStringList">
+        <value>2</value>
+      </LayerSnappingToleranceUnitList>
+      <DefaultSnapType type="QString">off</DefaultSnapType>
+      <DefaultSnapTolerance type="double">0</DefaultSnapTolerance>
+      <LayerSnappingToleranceList type="QStringList">
+        <value>0.000000</value>
+      </LayerSnappingToleranceList>
       <LayerSnappingList type="QStringList">
         <value>testlayer20150528120452665</value>
       </LayerSnappingList>
     </Digitizing>
-    <WMSFees type="QString">conditions unknown</WMSFees>
-    <SpatialRefSys>
-      <ProjectCrs type="QString">EPSG:4326</ProjectCrs>
-      <ProjectCRSProj4String type="QString">+proj=longlat +datum=WGS84 +no_defs</ProjectCRSProj4String>
-      <ProjectCRSID type="int">3452</ProjectCRSID>
-      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
-    </SpatialRefSys>
-    <Macros>
-      <pythonCode type="QString"></pythonCode>
-    </Macros>
-    <WMSRestrictedComposers type="QStringList"/>
-    <WMSContactPosition type="QString"></WMSContactPosition>
-    <Variables>
-      <variableNames type="QStringList"/>
-      <variableValues type="QStringList"/>
-    </Variables>
-    <DefaultStyles>
-      <Line type="QString"></Line>
-      <AlphaInt type="int">255</AlphaInt>
-      <Fill type="QString"></Fill>
-      <Marker type="QString"></Marker>
-      <ColorRamp type="QString"></ColorRamp>
-      <RandomColors type="bool">true</RandomColors>
-    </DefaultStyles>
+    <WMSServiceAbstract type="QString">Some UTF8 text èòù</WMSServiceAbstract>
     <Gui>
       <CanvasColorBluePart type="int">255</CanvasColorBluePart>
-      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
-      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
-      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
       <SelectionColorRedPart type="int">255</SelectionColorRedPart>
-      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
       <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
     </Gui>
+    <WMSContactMail type="QString">elpaso@itopen.it</WMSContactMail>
+    <Legend>
+      <filterByMap type="bool">false</filterByMap>
+    </Legend>
+    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
+    <WFSTLayers>
+      <Insert type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Insert>
+      <Update type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Update>
+      <Delete type="QStringList">
+        <value>testlayer20150528120452665</value>
+      </Delete>
+    </WFSTLayers>
+    <WMSRestrictedComposers type="QStringList"/>
+    <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
+    <Measure>
+      <Ellipsoid type="QString">WGS84</Ellipsoid>
+    </Measure>
+    <WMSKeywordList type="QStringList">
+      <value></value>
+    </WMSKeywordList>
     <WMSExtent type="QStringList">
       <value>8.20315414376310059</value>
       <value>44.901236559338642</value>
       <value>8.204164917965862</value>
       <value>44.90159838674664172</value>
     </WMSExtent>
-    <PositionPrecision>
-      <Automatic type="bool">true</Automatic>
-      <DegreeFormat type="QString">D</DegreeFormat>
-      <DecimalPlaces type="int">2</DecimalPlaces>
-    </PositionPrecision>
-    <WMSKeywordList type="QStringList">
-      <value></value>
-    </WMSKeywordList>
-    <WMSContactPerson type="QString">Alessandro Pasotti</WMSContactPerson>
-    <PAL>
-      <CandidatesPolygon type="int">30</CandidatesPolygon>
-      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
-      <SearchMethod type="int">0</SearchMethod>
-      <DrawRectOnly type="bool">false</DrawRectOnly>
-      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
-      <ShowingCandidates type="bool">false</ShowingCandidates>
-      <ShowingAllLabels type="bool">false</ShowingAllLabels>
-      <CandidatesPoint type="int">16</CandidatesPoint>
-      <CandidatesLine type="int">50</CandidatesLine>
-    </PAL>
+    <Paths>
+      <Absolute type="bool">false</Absolute>
+    </Paths>
+    <WMSImageQuality type="int">90</WMSImageQuality>
+    <WMSPrecision type="QString">4</WMSPrecision>
+    <WMSServiceTitle type="QString">QGIS TestProject</WMSServiceTitle>
     <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
+    <WMSContactOrganization type="QString">QGIS dev team</WMSContactOrganization>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <WMSUrl type="QString"></WMSUrl>
+    <WFSLayersPrecision>
+      <testlayer20150528120452665 type="int">8</testlayer20150528120452665>
+    </WFSLayersPrecision>
+    <SpatialRefSys>
+      <ProjectCrs type="QString">EPSG:4326</ProjectCrs>
+      <ProjectCRSProj4String type="QString">+proj=longlat +datum=WGS84 +no_defs</ProjectCRSProj4String>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+      <ProjectCRSID type="int">3452</ProjectCRSID>
+    </SpatialRefSys>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
     <WFSLayers type="QStringList">
       <value>testlayer20150528120452665</value>
     </WFSLayers>
-    <Measure>
-      <Ellipsoid type="QString">WGS84</Ellipsoid>
-    </Measure>
-    <WCSUrl type="QString"></WCSUrl>
-    <WMSAddWktGeometry type="bool">true</WMSAddWktGeometry>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <WMSContactPosition type="QString"></WMSContactPosition>
     <Identify>
       <disabledLayers type="QStringList"/>
     </Identify>
-    <WMSPrecision type="QString">4</WMSPrecision>
+    <WCSUrl type="QString"></WCSUrl>
+    <PAL>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <SearchMethod type="int">0</SearchMethod>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+      <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <CandidatesPoint type="int">16</CandidatesPoint>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <CandidatesLine type="int">50</CandidatesLine>
+      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
+    </PAL>
+    <WMSFees type="QString">conditions unknown</WMSFees>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <WMSContactPerson type="QString">Alessandro Pasotti</WMSContactPerson>
+    <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
+    <WFSUrl type="QString"></WFSUrl>
+    <WCSLayers type="QStringList"/>
   </properties>
   <visibility-presets/>
   <transformContext/>
@@ -884,9 +1351,18 @@ def my_form_open(dialog, layer, feature):
     <type></type>
     <title>QGIS Test Project</title>
     <abstract></abstract>
+    <contact>
+      <name></name>
+      <organization></organization>
+      <position></position>
+      <voice></voice>
+      <fax></fax>
+      <email></email>
+      <role></role>
+    </contact>
     <links/>
     <author></author>
-    <creation></creation>
+    <creation>2000-01-01T00:00:00</creation>
   </projectMetadata>
   <Annotations/>
   <Layouts/>

--- a/tests/testdata/qgis_server/value_dict.csv
+++ b/tests/testdata/qgis_server/value_dict.csv
@@ -1,0 +1,4 @@
+id,value_id,reverse,reverse_val
+1,Id no. 1 value,one,one_value
+2,Id no. 2 value,two,two_val
+3,Id número 3 value,three,three_val

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values1-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values1-text-xml.txt
@@ -1,0 +1,22 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<GetFeatureInfoResponse>
+ <Layer name="layer0">
+  <Feature id="0">
+   <Attribute value="1" name="id"/>
+   <Attribute value="one" name="name"/>
+   <Attribute value="First Value" name="utf8nameè"/>
+  </Feature>
+  <Feature id="1">
+   <Attribute value="2" name="id"/>
+   <Attribute value="two" name="name"/>
+   <Attribute value="Second Value" name="utf8nameè"/>
+  </Feature>
+  <Feature id="2">
+   <Attribute value="3" name="id"/>
+   <Attribute value="three" name="name"/>
+   <Attribute value="Third èé↓" name="utf8nameè"/>
+  </Feature>
+ </Layer>
+</GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values2-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values2-text-xml.txt
@@ -1,0 +1,29 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<GetFeatureInfoResponse>
+ <Layer name="layer2">
+  <Feature id="0">
+   <Attribute value="value PE 1000 PN6" name="id"/>
+   <Attribute value="one" name="name"/>
+   <Attribute value="one èé" name="utf8nameè"/>
+   <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
+   <Attribute type="derived" value="Point (913209.0358 5606025.2373)" name="geometry"/>
+  </Feature>
+  <Feature id="1">
+   <Attribute value="value PE" name="id"/>
+   <Attribute value="two" name="name"/>
+   <Attribute value="two àò" name="utf8nameè"/>
+   <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
+   <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
+  </Feature>
+  <Feature id="2">
+   <Attribute value="value PE 1000 PN8" name="id"/>
+   <Attribute value="three" name="name"/>
+   <Attribute value="three èé↓" name="utf8nameè"/>
+   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
+   <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
+  </Feature>
+ </Layer>
+</GetFeatureInfoResponse>
+

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values3-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values3-text-xml.txt
@@ -1,0 +1,25 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<GetFeatureInfoResponse>
+ <Layer name="layer3">
+  <Feature id="1">
+   <Attribute value="1" name="id"/>
+   <Attribute value="Id no. 1 value, Id no. 2 value, Id número 3 value" name="location"/>
+   <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
+   <Attribute type="derived" value="Point (913209.0358 5606025.2373)" name="geometry"/>
+  </Feature>
+  <Feature id="2">
+   <Attribute value="2" name="id"/>
+   <Attribute value="" name="location"/>
+   <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
+   <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
+  </Feature>
+  <Feature id="3">
+   <Attribute value="3" name="id"/>
+   <Attribute value="" name="location"/>
+   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
+   <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
+  </Feature>
+ </Layer>
+</GetFeatureInfoResponse>


### PR DESCRIPTION
Follow-up from https://github.com/qgis/QGIS/pull/6450 discussion

QGIS Server tests to insure Server GetFeatureInfo request output the different widget correct values

@pblottiere I commented out the failing tests so that it's merge-able. Thank you.

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
