### PR TITLE
Better parser error handling

### DIFF
--- a/python/core/expression/qgsexpression.sip.in
+++ b/python/core/expression/qgsexpression.sip.in
@@ -66,6 +66,28 @@ Implicit sharing was added in 2.14
 %End
   public:
 
+    struct ParserError
+    {
+      enum ParserErrorType
+      {
+        Unknown,
+        FunctionUnknown,
+        FunctionWrongArgs,
+        FunctionInvalidParams,
+        FunctionNamedArgsError
+      };
+
+      ParserErrorType errorType;
+
+      int firstLine;
+
+      int firstColumn;
+
+      int lastLine;
+
+      int lastColumn;
+    };
+
     QgsExpression( const QString &expr );
 %Docstring
 Creates a new expression based on the provided string.
@@ -109,6 +131,13 @@ Returns true if an error occurred when parsing the input expression
     QString parserErrorString() const;
 %Docstring
 Returns parser error
+%End
+
+    ParserError parserError() const;
+%Docstring
+Returns parser error details including location of error.
+
+.. versionadded:: 3.0
 %End
 
     const QgsExpressionNode *rootNode() const;

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -26,7 +26,7 @@
 
 
 // from parser
-extern QgsExpressionNode *parseExpression( const QString &str, QString &parserErrorMsg );
+extern QgsExpressionNode *parseExpression( const QString &str, QString &parserErrorMsg, QgsExpression::ParserError &parserError );
 
 ///////////////////////////////////////////////
 // QVariant checks and conversions
@@ -99,7 +99,7 @@ bool QgsExpression::checkExpression( const QString &text, const QgsExpressionCon
 void QgsExpression::setExpression( const QString &expression )
 {
   detach();
-  d->mRootNode = ::parseExpression( expression, d->mParserErrorString );
+  d->mRootNode = ::parseExpression( expression, d->mParserErrorString, d->mParserError );
   d->mEvalErrorString = QString();
   d->mExp = expression;
 }
@@ -195,7 +195,7 @@ int QgsExpression::functionCount()
 QgsExpression::QgsExpression( const QString &expr )
   : d( new QgsExpressionPrivate )
 {
-  d->mRootNode = ::parseExpression( expr, d->mParserErrorString );
+  d->mRootNode = ::parseExpression( expr, d->mParserErrorString, d->mParserError );
   d->mExp = expr;
   Q_ASSERT( !d->mParserErrorString.isNull() || d->mRootNode );
 }
@@ -253,6 +253,11 @@ bool QgsExpression::hasParserError() const
 QString QgsExpression::parserErrorString() const
 {
   return d->mParserErrorString;
+}
+
+QgsExpression::ParserError QgsExpression::parserError() const
+{
+  return d->mParserError;
 }
 
 QSet<QString> QgsExpression::referencedColumns() const
@@ -338,7 +343,7 @@ bool QgsExpression::prepare( const QgsExpressionContext *context )
     //re-parse expression. Creation of QgsExpressionContexts may have added extra
     //known functions since this expression was created, so we have another try
     //at re-parsing it now that the context must have been created
-    d->mRootNode = ::parseExpression( d->mExp, d->mParserErrorString );
+    d->mRootNode = ::parseExpression( d->mExp, d->mParserErrorString, d->mParserError );
   }
 
   if ( !d->mRootNode )

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -116,6 +116,49 @@ class CORE_EXPORT QgsExpression
   public:
 
     /**
+     * Details about any parser errors that were found when parsing the expression.
+     * \since QGIS 3.0
+     */
+    struct CORE_EXPORT ParserError
+    {
+      enum ParserErrorType
+      {
+        Unknown = 0,  //!< Unknown error type.
+        FunctionUnknown = 1, //!< Function was unknown.
+        FunctionWrongArgs = 2, //!< Function was called with the wrong number of args.
+        FunctionInvalidParams = 3, //!< Function was called with invalid args.
+        FunctionNamedArgsError = 4 //!< Non named function arg used after named arg.
+      };
+
+      /**
+       * The type of parser error that was found.
+       */
+      ParserErrorType errorType = ParserErrorType::Unknown;
+
+      /**
+       * The first line that contained the error in the parser.
+       * Depending on the error sometimes this doesn't mean anything.
+       */
+      int firstLine = 0;
+
+      /**
+       * The first column that contained the error in the parser.
+       * Depending on the error sometimes this doesn't mean anything.
+       */
+      int firstColumn = 0;
+
+      /**
+       * The last line that contained the error in the parser.
+       */
+      int lastLine = 0;
+
+      /**
+       * The last column that contained the error in the parser.
+       */
+      int lastColumn = 0;
+    };
+
+    /**
      * Creates a new expression based on the provided string.
      * The string will immediately be parsed. For optimization
      * prepare() should always be called before every
@@ -173,6 +216,12 @@ class CORE_EXPORT QgsExpression
     bool hasParserError() const;
     //! Returns parser error
     QString parserErrorString() const;
+
+    /**
+     * Returns parser error details including location of error.
+     * \since QGIS 3.0
+     */
+    ParserError parserError() const;
 
     //! Returns root node of the expression. Root node is null is parsing has failed
     const QgsExpressionNode *rootNode() const;

--- a/src/core/qgsexpressionlexer.ll
+++ b/src/core/qgsexpressionlexer.ll
@@ -20,8 +20,11 @@
 %option prefix="exp_"
  // this makes flex generate lexer with context + init/destroy functions
 %option reentrant
+%option yylineno
  // this makes Bison send yylex another argument to use instead of using the global variable yylval
 %option bison-bridge
+%option bison-locations
+
 
  // ensure that lexer will be 8-bit (and not just 7-bit)
 %option 8bit
@@ -53,6 +56,19 @@
 #define U_OP(x) yylval->u_op = QgsExpressionNodeUnaryOperator::x
 #define TEXT                   yylval->text = new QString( QString::fromUtf8(yytext) );
 #define TEXT_FILTER(filter_fn) yylval->text = new QString( filter_fn( QString::fromUtf8(yytext) ) );
+
+#define YY_USER_ACTION \
+    yylloc->first_line = yylloc->last_line; \
+    yylloc->first_column = yylloc->last_column; \
+    for(int i = 0; yytext[i] != '\0'; i++) { \
+    if(yytext[i] == '\n') { \
+        yylloc->last_line++; \
+        yylloc->last_column = 0; \
+    } \
+    else { \
+        yylloc->last_column++; \
+    } \
+}
 
 static QString stripText(QString text)
 {

--- a/src/core/qgsexpressionprivate.h
+++ b/src/core/qgsexpressionprivate.h
@@ -44,6 +44,7 @@ class QgsExpressionPrivate
       , mRootNode( other.mRootNode ? other.mRootNode->clone() : nullptr )
       , mParserErrorString( other.mParserErrorString )
       , mEvalErrorString( other.mEvalErrorString )
+      , mParserError( other.mParserError )
       , mExp( other.mExp )
       , mCalc( other.mCalc )
       , mDistanceUnit( other.mDistanceUnit )
@@ -61,6 +62,8 @@ class QgsExpressionPrivate
 
     QString mParserErrorString;
     QString mEvalErrorString;
+
+    QgsExpression::ParserError mParserError;
 
     QString mExp;
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -115,8 +115,20 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   QModelIndex firstItem = mProxyModel->index( 0, 0, QModelIndex() );
   expressionTree->setCurrentIndex( firstItem );
 
-  lblAutoSave->clear();
   txtExpressionString->setWrapMode( QsciScintilla::WrapWord );
+  lblAutoSave->clear();
+
+  // Note: If you add a indicator here you should add it to clearErrors method if you need to clear it on text parse.
+  txtExpressionString->indicatorDefine( QgsCodeEditor::SquiggleIndicator, QgsExpression::ParserError::FunctionUnknown );
+  txtExpressionString->indicatorDefine( QgsCodeEditor::SquiggleIndicator, QgsExpression::ParserError::FunctionWrongArgs );
+  txtExpressionString->indicatorDefine( QgsCodeEditor::SquiggleIndicator, QgsExpression::ParserError::FunctionInvalidParams );
+  txtExpressionString->indicatorDefine( QgsCodeEditor::SquiggleIndicator, QgsExpression::ParserError::FunctionNamedArgsError );
+  txtExpressionString->indicatorDefine( QgsCodeEditor::TriangleIndicator, QgsExpression::ParserError::Unknown );
+
+  // Set all the error markers as red. -1 is all.
+  txtExpressionString->setIndicatorForegroundColor( QColor( Qt::red ), -1 );
+  txtExpressionString->setIndicatorHoverForegroundColor( QColor( Qt::red ), -1 );
+  txtExpressionString->setIndicatorOutlineColor( QColor( Qt::red ), -1 );
 }
 
 
@@ -571,6 +583,7 @@ void QgsExpressionBuilderWidget::setExpressionContext( const QgsExpressionContex
 void QgsExpressionBuilderWidget::txtExpressionString_textChanged()
 {
   QString text = expressionText();
+  clearErrors();
 
   // If the string is empty the expression will still "fail" although
   // we don't show the user an error as it will be confusing.
@@ -585,6 +598,7 @@ void QgsExpressionBuilderWidget::txtExpressionString_textChanged()
     setEvalError( true );
     return;
   }
+
 
   QgsExpression exp( text );
 
@@ -614,6 +628,19 @@ void QgsExpressionBuilderWidget::txtExpressionString_textChanged()
     if ( exp.hasEvalError() )
       tooltip += QStringLiteral( "<br><br><b>%1:</b><br>%2" ).arg( tr( "Eval Error" ), exp.evalErrorString() );
 
+    int errorFirstLine = exp.parserError().firstLine - 1 ;
+    int errorFirstColumn = exp.parserError().firstColumn - 1;
+    int errorLastColumn = exp.parserError().lastColumn - 1;
+    int errorLastLine = exp.parserError().lastLine - 1;
+
+    // If we have a unknown error we just mark the point that hit the error for now
+    // until we can handle others more.
+    if ( exp.parserError().errorType == QgsExpression::ParserError::Unknown )
+    {
+      errorFirstLine = errorLastLine;
+      errorFirstColumn = errorLastColumn - 1;
+    }
+
     lblPreview->setText( tr( "Expression is invalid <a href=""more"">(more info)</a>" ) );
     lblPreview->setStyleSheet( QStringLiteral( "color: rgba(255, 6, 10,  255);" ) );
     txtExpressionString->setToolTip( tooltip );
@@ -621,6 +648,10 @@ void QgsExpressionBuilderWidget::txtExpressionString_textChanged()
     emit expressionParsed( false );
     setParserError( exp.hasParserError() );
     setEvalError( exp.hasEvalError() );
+    txtExpressionString->fillIndicatorRange( errorFirstLine,
+        errorFirstColumn,
+        errorLastLine,
+        errorLastColumn, exp.parserError().errorType );
     return;
   }
   else
@@ -632,6 +663,7 @@ void QgsExpressionBuilderWidget::txtExpressionString_textChanged()
     setParserError( false );
     setEvalError( false );
   }
+
 }
 
 void QgsExpressionBuilderWidget::loadExpressionContext()
@@ -729,6 +761,17 @@ void QgsExpressionBuilderWidget::showEvent( QShowEvent *e )
 {
   QWidget::showEvent( e );
   txtExpressionString->setFocus();
+}
+
+void QgsExpressionBuilderWidget::clearErrors()
+{
+  int lastLine = txtExpressionString->lines() - 1;
+  // Note: -1 here doesn't seem to do the clear all like the other functions.  Will need to make this a bit smarter.
+  txtExpressionString->clearIndicatorRange( 0, 0, lastLine, txtExpressionString->text( lastLine ).length() - 1, QgsExpression::ParserError::Unknown );
+  txtExpressionString->clearIndicatorRange( 0, 0, lastLine, txtExpressionString->text( lastLine ).length() - 1, QgsExpression::ParserError::FunctionInvalidParams );
+  txtExpressionString->clearIndicatorRange( 0, 0, lastLine, txtExpressionString->text( lastLine ).length() - 1, QgsExpression::ParserError::FunctionUnknown );
+  txtExpressionString->clearIndicatorRange( 0, 0, lastLine, txtExpressionString->text( lastLine ).length() - 1, QgsExpression::ParserError::FunctionWrongArgs );
+  txtExpressionString->clearIndicatorRange( 0, 0, lastLine, txtExpressionString->text( lastLine ).length() - 1, QgsExpression::ParserError::FunctionNamedArgsError );
 }
 
 void QgsExpressionBuilderWidget::txtSearchEdit_textChanged()

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -352,6 +352,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void showEvent( QShowEvent *e ) override;
 
   private:
+    void clearErrors();
     void runPythonCode( const QString &code );
     void updateFunctionTree();
     void fillFieldValues( const QString &fieldName, int countLimit );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -257,6 +257,36 @@ class TestQgsExpression: public QObject
       QCOMPARE( !exp.hasParserError(), valid );
     }
 
+    void parsing_error_line_column_data()
+    {
+      QTest::addColumn<QString>( "string" );
+      QTest::addColumn<int>( "firstLine" );
+      QTest::addColumn<int>( "firstColumn" );
+      QTest::addColumn<int>( "lastLine" );
+      QTest::addColumn<int>( "lastColumn" );
+
+      // invalid strings
+      QTest::newRow( "No close brace" ) << "(" << 1 << 1 << 1 << 2;
+      QTest::newRow( "No close brace 2" ) << "to_string(" << 1 << 10 << 1 << 11;
+      QTest::newRow( "No close brace 2 - Multiline" ) << "to_string\n(" << 2 << 0 << 2 << 1;
+    }
+
+    void parsing_error_line_column()
+    {
+      QFETCH( QString, string );
+      QFETCH( int, firstLine );
+      QFETCH( int, firstColumn );
+      QFETCH( int, lastLine );
+      QFETCH( int, lastColumn );
+
+      QgsExpression exp( string );
+      QCOMPARE( exp.hasParserError(), true );
+      QCOMPARE( exp.parserError().firstLine, firstLine );
+      QCOMPARE( exp.parserError().firstColumn, firstColumn );
+      QCOMPARE( exp.parserError().lastLine, lastLine );
+      QCOMPARE( exp.parserError().lastColumn, lastColumn );
+    }
+
     void parsing_with_locale()
     {
       // check that parsing of numbers works correctly even when using some other locale


### PR DESCRIPTION
## Description
Crappy parser messages are crappy so lets make this a little bit better for the user.  With this we can now highlight errors using line and column numbers in the expression builder.

This is still a work in progress but opened for feedback and code review.

Currently supports two highlight methods.
- Underline
- Marker

Underline is used for unknown functions (although we never really have them yet due to how the code is written), wrong args, or invalid args)

![image](https://user-images.githubusercontent.com/381660/38480867-8e2dd8d4-3bb7-11e8-9145-37d7866c254d.png)

Marker point is for every other error at a single location which may or may not have a friendly message yet. We can add better handling for this in the future but it's here mainly to show the location of the error in the parser.

![image](https://user-images.githubusercontent.com/381660/38480923-d44bb9e4-3bb7-11e8-85d0-97ba08569482.png)

I will also improve the error display so that we show the real error without having to click a new window which is a bit hidden.

Funded by my QGIS dev days at [TechnologyOne](https://www.technologyonecorp.com/)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
