### PR TITLE
Expose extra arguments to QgsGeometry::transform

### DIFF
--- a/python/core/geometry/qgsgeometry.sip.in
+++ b/python/core/geometry/qgsgeometry.sip.in
@@ -616,9 +616,20 @@ Translates this geometry by dx, dy, dz and dm.
 :return: OperationResult a result code: success or reason of failure
 %End
 
-    OperationResult transform( const QgsCoordinateTransform &ct );
+    OperationResult transform( const QgsCoordinateTransform &ct,
+                               QgsCoordinateTransform::TransformDirection direction = QgsCoordinateTransform::ForwardTransform,
+                               bool transformZ = false );
 %Docstring
-Transforms this geometry as described by CoordinateTransform ct
+Transforms this geometry as described by the coordinate transform ``ct``.
+
+The transformation defaults to a forward transform, but the direction can be swapped
+by setting the ``direction`` argument.
+
+By default, z-coordinates are not transformed, even if the coordinate transform
+includes a vertical datum transformation. To transform z-coordinates, set
+``transformZ`` to true. This requires that the z coordinates in the geometry represent
+height relative to the vertical datum of the source CRS (generally ellipsoidal heights)
+and are expressed in its vertical units (generally meters).
 
 :return: OperationResult a result code: success or reason of failure
 %End

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2337,7 +2337,7 @@ bool QgsGeometry::requiresConversionToStraightSegments() const
   return d->geometry->hasCurvedSegments();
 }
 
-QgsGeometry::OperationResult QgsGeometry::transform( const QgsCoordinateTransform &ct )
+QgsGeometry::OperationResult QgsGeometry::transform( const QgsCoordinateTransform &ct, const QgsCoordinateTransform::TransformDirection direction, const bool transformZ )
 {
   if ( !d->geometry )
   {
@@ -2345,7 +2345,7 @@ QgsGeometry::OperationResult QgsGeometry::transform( const QgsCoordinateTransfor
   }
 
   detach();
-  d->geometry->transform( ct );
+  d->geometry->transform( ct, direction, transformZ );
   return QgsGeometry::Success;
 }
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -659,10 +659,22 @@ class CORE_EXPORT QgsGeometry
     OperationResult translate( double dx, double dy, double dz = 0.0, double dm = 0.0 );
 
     /**
-     * Transforms this geometry as described by CoordinateTransform ct
+     * Transforms this geometry as described by the coordinate transform \a ct.
+     *
+     * The transformation defaults to a forward transform, but the direction can be swapped
+     * by setting the \a direction argument.
+     *
+     * By default, z-coordinates are not transformed, even if the coordinate transform
+     * includes a vertical datum transformation. To transform z-coordinates, set
+     * \a transformZ to true. This requires that the z coordinates in the geometry represent
+     * height relative to the vertical datum of the source CRS (generally ellipsoidal heights)
+     * and are expressed in its vertical units (generally meters).
+     *
      * \returns OperationResult a result code: success or reason of failure
      */
-    OperationResult transform( const QgsCoordinateTransform &ct );
+    OperationResult transform( const QgsCoordinateTransform &ct,
+                               QgsCoordinateTransform::TransformDirection direction = QgsCoordinateTransform::ForwardTransform,
+                               bool transformZ = false );
 
     /**
      * Transforms the x and y components of the geometry using a QTransform object \a t.


### PR DESCRIPTION
Previously these were only available via the raw QgsAbstractGeometry
API.

Also add more unit tests for QgsGeometry::transform


Refs https://gis.stackexchange.com/questions/278802/how-can-i-apply-a-reverse-qgscoordinatetransform-on-a-qgsgeometry-in-pyqgis