### PR TITLE
Map themes: store also expanded/collapsed state of nodes

### DIFF
--- a/python/core/qgsmapthemecollection.sip.in
+++ b/python/core/qgsmapthemecollection.sip.in
@@ -59,6 +59,10 @@ Set the map layer for this record
         QString currentStyle;
         bool usingLegendItems;
         QSet<QString> checkedLegendItems;
+
+        QSet<QString> expandedLegendItems;
+
+        bool expandedLayerNode;
     };
 
     class MapThemeRecord
@@ -97,6 +101,38 @@ Removes a record for ``layer`` if present.
 Add a new record for a layer.
 %End
 
+
+        bool hasExpandedStateInfo() const;
+%Docstring
+Returns whether information about expanded/collapsed state of nodes has been recorded
+and thus whether expandedGroupNodes() and expandedLegendItems + expandedLayerNode from layer records are valid.
+
+.. versionadded:: 3.2
+%End
+
+        void setHasExpandedStateInfo( bool hasInfo );
+%Docstring
+Sets whether the map theme contains valid expanded/collapsed state of nodes
+
+.. versionadded:: 3.2
+%End
+
+        QSet<QString> expandedGroupNodes() const;
+%Docstring
+Returns a set of group identifiers for group nodes that should have expanded state (other group nodes should be collapsed).
+The returned value is valid only when hasExpandedStateInfo() returns true.
+Group identifiers are built using group names, a sub-group name is prepended by parent group's identifier
+and a forward slash, e.g. "level1/level2"
+
+.. versionadded:: 3.2
+%End
+
+        void setExpandedGroupNodes( const QSet<QString> &expandedGroupNodes );
+%Docstring
+Sets a set of group identifiers for group nodes that should have expanded state. See expandedGroupNodes().
+
+.. versionadded:: 3.2
+%End
 
     };
 

--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -37,6 +37,8 @@ QgsMapThemeCollection::MapThemeLayerRecord QgsMapThemeCollection::createThemeLay
   MapThemeLayerRecord layerRec( nodeLayer->layer() );
   layerRec.usingCurrentStyle = true;
   layerRec.currentStyle = nodeLayer->layer()->styleManager()->currentStyle();
+  layerRec.expandedLayerNode = nodeLayer->isExpanded();
+  layerRec.expandedLegendItems = nodeLayer->customProperty( QStringLiteral( "expandedLegendNodes" ) ).toStringList().toSet();
 
   // get checked legend items
   bool hasCheckableItems = false;
@@ -63,12 +65,27 @@ QgsMapThemeCollection::MapThemeLayerRecord QgsMapThemeCollection::createThemeLay
   return layerRec;
 }
 
+static QString _groupId( QgsLayerTreeNode *node )
+{
+  QStringList lst;
+  while ( node->parent() )
+  {
+    lst.prepend( node->name() );
+    node = node->parent();
+  }
+  return lst.join( '/' );
+}
+
 void QgsMapThemeCollection::createThemeFromCurrentState( QgsLayerTreeGroup *parent, QgsLayerTreeModel *model, QgsMapThemeCollection::MapThemeRecord &rec )
 {
   Q_FOREACH ( QgsLayerTreeNode *node, parent->children() )
   {
     if ( QgsLayerTree::isGroup( node ) )
+    {
       createThemeFromCurrentState( QgsLayerTree::toGroup( node ), model, rec );
+      if ( node->isExpanded() )
+        rec.mExpandedGroupNodes.insert( _groupId( node ) );
+    }
     else if ( QgsLayerTree::isLayer( node ) )
     {
       QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
@@ -81,6 +98,7 @@ void QgsMapThemeCollection::createThemeFromCurrentState( QgsLayerTreeGroup *pare
 QgsMapThemeCollection::MapThemeRecord QgsMapThemeCollection::createThemeFromCurrentState( QgsLayerTreeGroup *root, QgsLayerTreeModel *model )
 {
   QgsMapThemeCollection::MapThemeRecord rec;
+  rec.setHasExpandedStateInfo( true );  // all newly created theme records have expanded state info
   createThemeFromCurrentState( root, model, rec );
   return rec;
 }
@@ -140,6 +158,13 @@ void QgsMapThemeCollection::applyThemeToLayer( QgsLayerTreeLayer *nodeLayer, Qgs
         legendNode->setData( Qt::Checked, Qt::CheckStateRole );
     }
   }
+
+  // apply expanded/collapsed state to the layer and its legend nodes
+  if ( rec.hasExpandedStateInfo() )
+  {
+    nodeLayer->setExpanded( layerRec.expandedLayerNode );
+    nodeLayer->setCustomProperty( QStringLiteral( "expandedLegendNodes" ), QStringList( layerRec.expandedLegendItems.toList() ) );
+  }
 }
 
 
@@ -148,7 +173,11 @@ void QgsMapThemeCollection::applyThemeToGroup( QgsLayerTreeGroup *parent, QgsLay
   Q_FOREACH ( QgsLayerTreeNode *node, parent->children() )
   {
     if ( QgsLayerTree::isGroup( node ) )
+    {
       applyThemeToGroup( QgsLayerTree::toGroup( node ), model, rec );
+      if ( rec.hasExpandedStateInfo() )
+        node->setExpanded( rec.expandedGroupNodes().contains( _groupId( node ) ) );
+    }
     else if ( QgsLayerTree::isLayer( node ) )
       applyThemeToLayer( QgsLayerTree::toLayer( node ), model, rec );
   }
@@ -385,6 +414,10 @@ void QgsMapThemeCollection::readXml( const QDomDocument &doc )
   {
     QHash<QString, MapThemeLayerRecord> layerRecords; // key = layer ID
 
+    bool expandedStateInfo = false;
+    if ( visPresetElem.hasAttribute( QStringLiteral( "has-expanded-info" ) ) )
+      expandedStateInfo = visPresetElem.attribute( QStringLiteral( "has-expanded-info" ) ).toInt();
+
     QString presetName = visPresetElem.attribute( QStringLiteral( "name" ) );
     QDomElement visPresetLayerElem = visPresetElem.firstChildElement( QStringLiteral( "layer" ) );
     while ( !visPresetLayerElem.isNull() )
@@ -399,6 +432,9 @@ void QgsMapThemeCollection::readXml( const QDomDocument &doc )
           layerRecords[layerID].usingCurrentStyle = true;
           layerRecords[layerID].currentStyle = visPresetLayerElem.attribute( QStringLiteral( "style" ) );
         }
+
+        if ( visPresetLayerElem.hasAttribute( QStringLiteral( "expanded" ) ) )
+          layerRecords[layerID].expandedLayerNode = visPresetLayerElem.attribute( QStringLiteral( "expanded" ) ).toInt();
       }
       visPresetLayerElem = visPresetLayerElem.nextSiblingElement( QStringLiteral( "layer" ) );
     }
@@ -424,8 +460,47 @@ void QgsMapThemeCollection::readXml( const QDomDocument &doc )
       checkedLegendNodesElem = checkedLegendNodesElem.nextSiblingElement( QStringLiteral( "checked-legend-nodes" ) );
     }
 
+    QSet<QString> expandedGroupNodes;
+    if ( expandedStateInfo )
+    {
+      // expanded state of legend nodes
+      QDomElement expandedLegendNodesElem = visPresetElem.firstChildElement( QStringLiteral( "expanded-legend-nodes" ) );
+      while ( !expandedLegendNodesElem.isNull() )
+      {
+        QSet<QString> expandedLegendNodes;
+
+        QDomElement expandedLegendNodeElem = expandedLegendNodesElem.firstChildElement( QStringLiteral( "expanded-legend-node" ) );
+        while ( !expandedLegendNodeElem.isNull() )
+        {
+          expandedLegendNodes << expandedLegendNodeElem.attribute( QStringLiteral( "id" ) );
+          expandedLegendNodeElem = expandedLegendNodeElem.nextSiblingElement( QStringLiteral( "expanded-legend-node" ) );
+        }
+
+        QString layerID = expandedLegendNodesElem.attribute( QStringLiteral( "id" ) );
+        if ( mProject->mapLayer( layerID ) ) // only use valid IDs
+        {
+          layerRecords[layerID].expandedLegendItems = expandedLegendNodes;
+        }
+        expandedLegendNodesElem = expandedLegendNodesElem.nextSiblingElement( QStringLiteral( "expanded-legend-nodes" ) );
+      }
+
+      // expanded state of group nodes
+      QDomElement expandedGroupNodesElem = visPresetElem.firstChildElement( QStringLiteral( "expanded-group-nodes" ) );
+      if ( !expandedGroupNodesElem.isNull() )
+      {
+        QDomElement expandedGroupNodeElem = expandedGroupNodesElem.firstChildElement( QStringLiteral( "expanded-group-node" ) );
+        while ( !expandedGroupNodeElem.isNull() )
+        {
+          expandedGroupNodes << expandedGroupNodeElem.attribute( QStringLiteral( "id" ) );
+          expandedGroupNodeElem = expandedGroupNodeElem.nextSiblingElement( QStringLiteral( "expanded-group-node" ) );
+        }
+      }
+    }
+
     MapThemeRecord rec;
     rec.setLayerRecords( layerRecords.values() );
+    rec.setHasExpandedStateInfo( expandedStateInfo );
+    rec.setExpandedGroupNodes( expandedGroupNodes );
     mMapThemes.insert( presetName, rec );
     emit mapThemeChanged( presetName );
 
@@ -446,6 +521,8 @@ void QgsMapThemeCollection::writeXml( QDomDocument &doc )
     const MapThemeRecord &rec = it.value();
     QDomElement visPresetElem = doc.createElement( QStringLiteral( "visibility-preset" ) );
     visPresetElem.setAttribute( QStringLiteral( "name" ), grpName );
+    if ( rec.hasExpandedStateInfo() )
+      visPresetElem.setAttribute( QStringLiteral( "has-expanded-info" ), QStringLiteral( "1" ) );
     Q_FOREACH ( const MapThemeLayerRecord &layerRec, rec.mLayerRecords )
     {
       if ( !layerRec.layer() )
@@ -469,6 +546,34 @@ void QgsMapThemeCollection::writeXml( QDomDocument &doc )
         }
         visPresetElem.appendChild( checkedLegendNodesElem );
       }
+
+      if ( rec.hasExpandedStateInfo() )
+      {
+        layerElem.setAttribute( QStringLiteral( "expanded" ), layerRec.expandedLayerNode ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+
+        QDomElement expandedLegendNodesElem = doc.createElement( QStringLiteral( "expanded-legend-nodes" ) );
+        expandedLegendNodesElem.setAttribute( QStringLiteral( "id" ), layerID );
+        for ( const QString &expandedLegendNode : qgis::as_const( layerRec.expandedLegendItems ) )
+        {
+          QDomElement expandedLegendNodeElem = doc.createElement( QStringLiteral( "expanded-legend-node" ) );
+          expandedLegendNodeElem.setAttribute( QStringLiteral( "id" ), expandedLegendNode );
+          expandedLegendNodesElem.appendChild( expandedLegendNodeElem );
+        }
+        visPresetElem.appendChild( expandedLegendNodesElem );
+      }
+    }
+
+    if ( rec.hasExpandedStateInfo() )
+    {
+      QDomElement expandedGroupElems = doc.createElement( QStringLiteral( "expanded-group-nodes" ) );
+      const QSet<QString> expandedGroupNodes = rec.expandedGroupNodes();
+      for ( const QString &groupId : expandedGroupNodes )
+      {
+        QDomElement expandedGroupElem = doc.createElement( QStringLiteral( "expanded-group-node" ) );
+        expandedGroupElem.setAttribute( QStringLiteral( "id" ), groupId );
+        expandedGroupElems.appendChild( expandedGroupElem );
+      }
+      visPresetElem.appendChild( expandedGroupElems );
     }
 
     visPresetsElem.appendChild( visPresetElem );

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -192,6 +192,9 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     void onExpandedChanged( QgsLayerTreeNode *node, bool expanded );
     void onModelReset();
 
+  private slots:
+    void onCustomPropertyChanged( QgsLayerTreeNode *node, const QString &key );
+
   protected:
     //! helper class with default actions. Lazily initialized.
     QgsLayerTreeViewDefaultActions *mDefaultActions = nullptr;

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -141,6 +141,7 @@ SET(TESTS
  testqgsmaprotation.cpp
  testqgsmapsettings.cpp
  testqgsmapsettingsutils.cpp
+ testqgsmapthemecollection.cpp
  testqgsmaptopixelgeometrysimplifier.cpp
  testqgsmaptopixel.cpp
  testqgsmarkerlinesymbol.cpp

--- a/tests/src/core/testqgsmapthemecollection.cpp
+++ b/tests/src/core/testqgsmapthemecollection.cpp
@@ -1,0 +1,210 @@
+/***************************************************************************
+                         testqgsmapthemecollection.cpp
+                         ----------------------
+    begin                : April 2018
+    copyright            : (C) 2018 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include "qgslayertree.h"
+#include "qgslayertreemodel.h"
+#include "qgsmapthemecollection.h"
+#include "qgsrulebasedrenderer.h"
+#include "qgsvectorlayer.h"
+
+class TestQgsMapThemeCollection : public QObject
+{
+    Q_OBJECT
+
+  public:
+    TestQgsMapThemeCollection() = default;
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+
+    void expandedState();
+
+  private:
+    QgsVectorLayer *mPointsLayer = nullptr;
+    QgsVectorLayer *mPolysLayer = nullptr;
+    QgsVectorLayer *mLinesLayer = nullptr;
+    QgsLayerTree *mLayerTree = nullptr;
+    QgsLayerTreeModel *mLayerTreeModel = nullptr;
+    QgsProject *mProject = nullptr;
+
+    QgsLayerTreeGroup *mNodeGroup1;
+    QgsLayerTreeGroup *mNodeGroup2;
+    QgsLayerTreeGroup *mNodeGroup3;
+    QgsLayerTreeLayer *mNodeLayerPoints;
+    QgsLayerTreeLayer *mNodeLayerLines;
+    QgsLayerTreeLayer *mNodeLayerPolys;
+};
+
+void TestQgsMapThemeCollection::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  QFileInfo pointFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/points.shp" );
+  mPointsLayer = new QgsVectorLayer( pointFileInfo.filePath(),
+                                     pointFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
+
+  QFileInfo polyFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/polys.shp" );
+  mPolysLayer = new QgsVectorLayer( polyFileInfo.filePath(),
+                                    polyFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
+
+  QFileInfo lineFileInfo( QStringLiteral( TEST_DATA_DIR ) + "/lines.shp" );
+  mLinesLayer = new QgsVectorLayer( lineFileInfo.filePath(),
+                                    lineFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
+
+  // rule-based renderer for points layer with two levels of rules
+  QgsRuleBasedRenderer::Rule *rule0 = new QgsRuleBasedRenderer::Rule( nullptr );
+  QgsRuleBasedRenderer::Rule *ruleA = new QgsRuleBasedRenderer::Rule( nullptr, 0, 0, QString(), "A" );
+  QgsRuleBasedRenderer::Rule *ruleB = new QgsRuleBasedRenderer::Rule( nullptr, 0, 0, QString(), "B" );
+  QgsRuleBasedRenderer::Rule *ruleC = new QgsRuleBasedRenderer::Rule( nullptr, 0, 0, QString(), "C" );
+  QgsRuleBasedRenderer::Rule *ruleD = new QgsRuleBasedRenderer::Rule( nullptr, 0, 0, QString(), "D" );
+  rule0->appendChild( ruleA );
+  ruleA->appendChild( ruleB );
+  rule0->appendChild( ruleC );
+  ruleC->appendChild( ruleD );
+  mPointsLayer->setRenderer( new QgsRuleBasedRenderer( rule0 ) );
+
+  mLayerTree = new QgsLayerTree;
+  mNodeGroup1 = mLayerTree->addGroup( "group1" );
+  mNodeGroup2 = mLayerTree->addGroup( "group2" );
+  mNodeGroup3 = mNodeGroup2->addGroup( "group3" );
+  mNodeLayerPoints = mNodeGroup1->addLayer( mPointsLayer );
+  mNodeLayerLines = mNodeGroup2->addLayer( mLinesLayer );
+  mNodeLayerPolys = mNodeGroup3->addLayer( mPolysLayer );
+
+  mLayerTreeModel = new QgsLayerTreeModel( mLayerTree );
+
+  // layers need to be in project to be accessible from map themes
+  mProject = new QgsProject;
+  mProject->addMapLayers( QList<QgsMapLayer *>() << mPointsLayer << mPolysLayer << mLinesLayer );
+}
+
+void TestQgsMapThemeCollection::cleanupTestCase()
+{
+  delete mLayerTreeModel;
+  delete mLayerTree;
+  delete mProject;
+
+  QgsApplication::exitQgis();
+}
+
+
+static QgsMapThemeCollection::MapThemeLayerRecord _recordForLayer( QgsMapLayer *l, const QgsMapThemeCollection::MapThemeRecord &rec )
+{
+  const QList<QgsMapThemeCollection::MapThemeLayerRecord> layerRecords = rec.layerRecords();
+  for ( const QgsMapThemeCollection::MapThemeLayerRecord &layerRec : layerRecords )
+    if ( layerRec.layer() == l )
+      return layerRec;
+  Q_ASSERT( false );
+  return QgsMapThemeCollection::MapThemeLayerRecord();
+}
+
+
+void TestQgsMapThemeCollection::expandedState()
+{
+  QgsMapThemeCollection themes( mProject );
+
+  QStringList pointLayerRootLegendNodes;
+  const QList<QgsLayerTreeModelLegendNode *> legendNodes = mLayerTreeModel->layerLegendNodes( mNodeLayerPoints, true );
+  for ( QgsLayerTreeModelLegendNode *legendNode : legendNodes )
+  {
+    QString key = legendNode->data( QgsLayerTreeModelLegendNode::RuleKeyRole ).toString();
+    pointLayerRootLegendNodes << key;
+  }
+  QCOMPARE( pointLayerRootLegendNodes.count(), 4 );
+
+  // make two themes: 1. all expanded, 2. all collapsed
+
+  mNodeGroup1->setExpanded( false );
+  mNodeGroup2->setExpanded( false );
+  mNodeGroup3->setExpanded( false );
+  mNodeLayerPoints->setExpanded( false );
+  mNodeLayerLines->setExpanded( false );
+  mNodeLayerPolys->setExpanded( false );
+  mNodeLayerPoints->setCustomProperty( "expandedLegendNodes", QStringList() );
+
+  themes.insert( "all-collapsed", QgsMapThemeCollection::createThemeFromCurrentState( mLayerTree, mLayerTreeModel ) );
+
+  mNodeGroup1->setExpanded( true );
+  mNodeGroup2->setExpanded( true );
+  mNodeGroup3->setExpanded( true );
+  mNodeLayerPoints->setExpanded( true );
+  mNodeLayerLines->setExpanded( true );
+  mNodeLayerPolys->setExpanded( true );
+  mNodeLayerPoints->setCustomProperty( "expandedLegendNodes", pointLayerRootLegendNodes );
+
+  themes.insert( "all-expanded", QgsMapThemeCollection::createThemeFromCurrentState( mLayerTree, mLayerTreeModel ) );
+
+  // check theme data
+
+  QgsMapThemeCollection::MapThemeRecord recCollapsed = themes.mapThemeState( "all-collapsed" );
+  QVERIFY( recCollapsed.hasExpandedStateInfo() );
+  QCOMPARE( recCollapsed.expandedGroupNodes().count(), 0 );
+  QgsMapThemeCollection::MapThemeLayerRecord recCollapsedPoints = _recordForLayer( mPointsLayer, recCollapsed );
+  QCOMPARE( recCollapsedPoints.expandedLayerNode, false );
+  QVERIFY( recCollapsedPoints.expandedLegendItems.isEmpty() );
+
+  QgsMapThemeCollection::MapThemeRecord recExpanded = themes.mapThemeState( "all-expanded" );
+  QVERIFY( recExpanded.hasExpandedStateInfo() );
+  QCOMPARE( recExpanded.expandedGroupNodes().count(), 3 );
+  QgsMapThemeCollection::MapThemeLayerRecord recExpandedPoints = _recordForLayer( mPointsLayer, recExpanded );
+  QCOMPARE( recExpandedPoints.expandedLayerNode, true );
+  QCOMPARE( recExpandedPoints.expandedLegendItems.count(), 4 );
+
+  // switch themes
+
+  themes.applyTheme( "all-collapsed", mLayerTree, mLayerTreeModel );
+  QCOMPARE( mNodeGroup1->isExpanded(), false );
+  QCOMPARE( mNodeGroup3->isExpanded(), false );
+  QCOMPARE( mNodeLayerPolys->isExpanded(), false );
+  QVERIFY( mNodeLayerPoints->customProperty( "expandedLegendNodes" ).toStringList().isEmpty() );
+
+  themes.applyTheme( "all-expanded", mLayerTree, mLayerTreeModel );
+  QCOMPARE( mNodeGroup1->isExpanded(), true );
+  QCOMPARE( mNodeGroup3->isExpanded(), true );
+  QCOMPARE( mNodeLayerPolys->isExpanded(), true );
+  QVERIFY( mNodeLayerPoints->customProperty( "expandedLegendNodes" ).toStringList().count() == 4 );
+
+  // test read+write
+
+  QDomDocument doc;
+  QDomElement elemRoot = doc.createElement( "qgis" );
+  doc.appendChild( elemRoot );
+  themes.writeXml( doc );
+
+  QgsMapThemeCollection themes2( mProject );
+  themes2.readXml( doc );
+
+  QgsMapThemeCollection::MapThemeRecord recCollapsed2 = themes2.mapThemeState( "all-collapsed" );
+  QVERIFY( recCollapsed2.hasExpandedStateInfo() );
+  QCOMPARE( recCollapsed2.expandedGroupNodes().count(), 0 );
+  QgsMapThemeCollection::MapThemeLayerRecord recCollapsedPoints2 = _recordForLayer( mPointsLayer, recCollapsed2 );
+  QCOMPARE( recCollapsedPoints2.expandedLayerNode, false );
+  QVERIFY( recCollapsedPoints2.expandedLegendItems.isEmpty() );
+
+  QgsMapThemeCollection::MapThemeRecord recExpanded2 = themes2.mapThemeState( "all-expanded" );
+  QVERIFY( recExpanded2.hasExpandedStateInfo() );
+  QCOMPARE( recExpanded2.expandedGroupNodes().count(), 3 );
+  QgsMapThemeCollection::MapThemeLayerRecord recExpandedPoints2 = _recordForLayer( mPointsLayer, recExpanded2 );
+  QCOMPARE( recExpandedPoints2.expandedLayerNode, true );
+  QCOMPARE( recExpandedPoints2.expandedLegendItems.count(), 4 );
+}
+
+QGSTEST_MAIN( TestQgsMapThemeCollection )
+#include "testqgsmapthemecollection.moc"


### PR DESCRIPTION
Each map theme will also record which layers, groups and legend items are expanded, so when a map theme is selected, the expanded/collapsed states get applied in the layer tree.

Developed for Arpa Piemonte (Dipartimento Tematico Geologia e Dissesto) within ERIKUS project.