### PR TITLE
Conditional formatting on relation reference widget

### DIFF
--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -448,16 +448,10 @@ QgsConditionalStyle QgsFeatureFilterModel::featureStyle( const QgsFeature &featu
   QgsVectorLayer *layer = mSourceLayer;
   QgsFeatureId fid = feature.id();
   mExpressionContext.setFeature( feature );
-  QgsConditionalStyle style;
-
-  if ( mEntryStylesMap.contains( fid ) )
-  {
-    style = mEntryStylesMap.value( fid );
-  }
 
   auto styles = QgsConditionalStyle::matchingConditionalStyles( layer->conditionalStyles()->rowStyles(), QVariant(),  mExpressionContext );
 
-  if ( mDisplayExpression.isField() )
+  if ( mDisplayExpression.referencedColumns().count() == 1 )
   {
     // Style specific for this field
     QString fieldName = *mDisplayExpression.referencedColumns().constBegin();
@@ -465,10 +459,11 @@ QgsConditionalStyle QgsFeatureFilterModel::featureStyle( const QgsFeature &featu
     const auto matchingFieldStyles = QgsConditionalStyle::matchingConditionalStyles( allStyles, feature.attribute( fieldName ),  mExpressionContext );
 
     styles += matchingFieldStyles;
-
-    style = QgsConditionalStyle::compressStyles( styles );
-    mEntryStylesMap.insert( fid, style );
   }
+
+  QgsConditionalStyle style;
+  style = QgsConditionalStyle::compressStyles( styles );
+  mEntryStylesMap.insert( fid, style );
 
   return style;
 }


### PR DESCRIPTION
In case we have additional display expressions in the relation reference widget, it uses now the style of the conditional formatting of the **row**.

In case there is a display expression like:
`CASE WHEN inaktiv = true THEN 'I -' ELSE 'A -' END || waermetraegerfluessigkeit` 
only the formatting of the row is applied.

If there is only one field used, like:
`'Tra:' || waermetraegerfluessigkeit`
or 
`waermetraegerfluessigkeit || waermetraegerfluessigkeit || waermetraegerfluessigkeit`
the formatting of the field is applied.

Fix: #18521