### PR TITLE
Save and load alpha of conditional style color

### DIFF
--- a/src/core/qgsconditionalstyle.cpp
+++ b/src/core/qgsconditionalstyle.cpp
@@ -273,7 +273,9 @@ bool QgsConditionalStyle::writeXml( QDomNode &node, QDomDocument &doc, const Qgs
   stylesel.setAttribute( QStringLiteral( "rule" ), mRule );
   stylesel.setAttribute( QStringLiteral( "name" ), mName );
   stylesel.setAttribute( QStringLiteral( "background_color" ), mBackColor.name() );
+  stylesel.setAttribute( QStringLiteral( "background_color_alpha" ), mBackColor.alpha() );
   stylesel.setAttribute( QStringLiteral( "text_color" ), mTextColor.name() );
+  stylesel.setAttribute( QStringLiteral( "text_color_alpha" ), mTextColor.alpha() );
   QDomElement labelFontElem = QgsFontUtils::toXmlElement( mFont, doc, QStringLiteral( "font" ) );
   stylesel.appendChild( labelFontElem );
   if ( mSymbol )
@@ -290,8 +292,18 @@ bool QgsConditionalStyle::readXml( const QDomNode &node, const QgsReadWriteConte
   QDomElement styleElm = node.toElement();
   setRule( styleElm.attribute( QStringLiteral( "rule" ) ) );
   setName( styleElm.attribute( QStringLiteral( "name" ) ) );
-  setBackgroundColor( QColor( styleElm.attribute( QStringLiteral( "background_color" ) ) ) );
-  setTextColor( QColor( styleElm.attribute( QStringLiteral( "text_color" ) ) ) );
+  QColor bColor = QColor( styleElm.attribute( QStringLiteral( "background_color" ) ) );
+  if( styleElm.hasAttribute( "background_color_alpha" ) )
+  {
+    bColor.setAlpha( styleElm.attribute( QStringLiteral( "background_color_alpha" ) ).toInt() );
+  }
+  setBackgroundColor( bColor );
+  QColor tColor = QColor( styleElm.attribute( QStringLiteral( "text_color" ) ) );
+  if( styleElm.hasAttribute( "text_color_alpha" ) )
+  {
+    tColor.setAlpha( styleElm.attribute( QStringLiteral( "text_color_alpha" ) ).toInt() );
+  }
+  setTextColor( tColor );
   QgsFontUtils::setFromXmlChildNode( mFont, styleElm, QStringLiteral( "font" ) );
   QDomElement symbolElm = styleElm.firstChildElement( QStringLiteral( "symbol" ) );
   if ( !symbolElm.isNull() )

--- a/src/core/qgsconditionalstyle.cpp
+++ b/src/core/qgsconditionalstyle.cpp
@@ -293,13 +293,13 @@ bool QgsConditionalStyle::readXml( const QDomNode &node, const QgsReadWriteConte
   setRule( styleElm.attribute( QStringLiteral( "rule" ) ) );
   setName( styleElm.attribute( QStringLiteral( "name" ) ) );
   QColor bColor = QColor( styleElm.attribute( QStringLiteral( "background_color" ) ) );
-  if( styleElm.hasAttribute( "background_color_alpha" ) )
+  if ( styleElm.hasAttribute( "background_color_alpha" ) )
   {
     bColor.setAlpha( styleElm.attribute( QStringLiteral( "background_color_alpha" ) ).toInt() );
   }
   setBackgroundColor( bColor );
   QColor tColor = QColor( styleElm.attribute( QStringLiteral( "text_color" ) ) );
-  if( styleElm.hasAttribute( "text_color_alpha" ) )
+  if ( styleElm.hasAttribute( "text_color_alpha" ) )
   {
     tColor.setAlpha( styleElm.attribute( QStringLiteral( "text_color_alpha" ) ).toInt() );
   }

--- a/src/core/qgsconditionalstyle.cpp
+++ b/src/core/qgsconditionalstyle.cpp
@@ -293,13 +293,13 @@ bool QgsConditionalStyle::readXml( const QDomNode &node, const QgsReadWriteConte
   setRule( styleElm.attribute( QStringLiteral( "rule" ) ) );
   setName( styleElm.attribute( QStringLiteral( "name" ) ) );
   QColor bColor = QColor( styleElm.attribute( QStringLiteral( "background_color" ) ) );
-  if ( styleElm.hasAttribute( "background_color_alpha" ) )
+  if ( styleElm.hasAttribute( QStringLiteral( "background_color_alpha" ) ) )
   {
     bColor.setAlpha( styleElm.attribute( QStringLiteral( "background_color_alpha" ) ).toInt() );
   }
   setBackgroundColor( bColor );
   QColor tColor = QColor( styleElm.attribute( QStringLiteral( "text_color" ) ) );
-  if ( styleElm.hasAttribute( "text_color_alpha" ) )
+  if ( styleElm.hasAttribute( QStringLiteral( "text_color_alpha" ) ) )
   {
     tColor.setAlpha( styleElm.attribute( QStringLiteral( "text_color_alpha" ) ).toInt() );
   }


### PR DESCRIPTION
Alpha (opacity) will be saved and loaded for the conditional style color of text and background.

Before there was not only the problem, that it was not possible to use them - it had additionally the issue, that background with no color was completely black after reopening the project (because of default opacity of FF and default color black).

This is fixed now.

But if we open an old project with no color set on background color, we still don't read the saturation (because it's not saved) and it displays it black, like before. Otherwise (if we would read the empty opacity - zero) there would be no more background colors. But with every new configuration it works now.