### PR TITLE
Replace Edit Nodes Item icon

### DIFF
--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -1152,7 +1152,7 @@
    </property>
    <property name="icon">
     <iconset resource="../../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionVertexTool.svg</normaloff>:/images/themes/default/mActionVertexTool.svg</iconset>
+     <normaloff>:/images/themes/default/mActionEditNodesItem.svg</normaloff>:/images/themes/default/mActionEditNodesItem.svg</iconset>
    </property>
    <property name="text">
     <string>Edit Nodes Item</string>


### PR DESCRIPTION
I don't know if the change was intentional but in the layout the edit nodes tool is using the  Vertex Tool icon ![image](https://user-images.githubusercontent.com/7983394/38552444-6944d134-3cbc-11e8-84f7-f71ef137bb4e.png) instead of the previous icon ![image](https://user-images.githubusercontent.com/7983394/38552480-82ee2fa4-3cbc-11e8-9be4-ebd579090a0f.png)
Because the edit nodes tool in layout does not have the click-click behavior nor all the advanced features (like mid-point indication) of the vertex tool, I wonder if it's not less confusing to keep using the old icon.
@nyalldawson ?