### PR TITLE
[server][bugfix] Cleaning GetCapabilities response

### DIFF
--- a/.docker/qgis3-build-deps.dockerfile
+++ b/.docker/qgis3-build-deps.dockerfile
@@ -97,7 +97,7 @@ RUN  apt-get update \
     mock \
     future \
     termcolor \
-  && apt-get autoremove -y python3-pip \
+    owslib \
   && apt-get clean
 
 RUN echo "alias python=python3" >> ~/.bash_aliases

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -756,39 +756,38 @@ namespace QgsWms
 
     QDomElement layerParentElem = doc.createElement( QStringLiteral( "Layer" ) );
 
-    // Root Layer title
-    QDomElement layerParentTitleElem = doc.createElement( QStringLiteral( "Title" ) );
-    QDomText layerParentTitleText = doc.createTextNode( project->title() );
-    layerParentTitleElem.appendChild( layerParentTitleText );
-    layerParentElem.appendChild( layerParentTitleElem );
+    if ( !project->title().isEmpty() )
+    {
+      // Root Layer title
+      QDomElement layerParentTitleElem = doc.createElement( QStringLiteral( "Title" ) );
+      QDomText layerParentTitleText = doc.createTextNode( project->title() );
+      layerParentTitleElem.appendChild( layerParentTitleText );
+      layerParentElem.appendChild( layerParentTitleElem );
 
-    // Root Layer abstract
-    QDomElement layerParentAbstElem = doc.createElement( QStringLiteral( "Abstract" ) );
-    QDomText layerParentAbstText = doc.createTextNode( project->title() );
-    layerParentAbstElem.appendChild( layerParentAbstText );
-    layerParentElem.appendChild( layerParentAbstElem );
+      // Root Layer abstract
+      QDomElement layerParentAbstElem = doc.createElement( QStringLiteral( "Abstract" ) );
+      QDomText layerParentAbstText = doc.createTextNode( project->title() );
+      layerParentAbstElem.appendChild( layerParentAbstText );
+      layerParentElem.appendChild( layerParentAbstElem );
+    }
 
     // Root Layer name
-    QDomElement layerParentNameElem = doc.createElement( QStringLiteral( "Name" ) );
-    QString rootName = QgsServerProjectUtils::wmsRootName( *project );
-    if ( rootName.isEmpty() )
+    QString rootLayerName = QgsServerProjectUtils::wmsRootName( *project );
+    if ( rootLayerName.isEmpty() && !project->title().isEmpty() )
     {
-      QDomText layerParentNameText = doc.createTextNode( project->title() );
-      layerParentNameElem.appendChild( layerParentNameText );
+      rootLayerName = project->title();
     }
-    else
+
+    if ( !rootLayerName.isEmpty() )
     {
-      QDomText layerParentNameText = doc.createTextNode( rootName );
+      QDomElement layerParentNameElem = doc.createElement( QStringLiteral( "Name" ) );
+      QDomText layerParentNameText = doc.createTextNode( rootLayerName );
       layerParentNameElem.appendChild( layerParentNameText );
+      layerParentElem.appendChild( layerParentNameElem );
     }
-    layerParentElem.appendChild( layerParentNameElem );
 
     // Keyword list
     addKeywordListElement( project, doc, layerParentElem );
-
-    // Metadata (empty but needed for OGC tests RECOMMENDATIONS)
-    QDomElement metaUrlElem = doc.createElement( QStringLiteral( "MetadataURL" ) );
-    layerParentElem.appendChild( metaUrlElem );
 
     // Root Layer tree name
     if ( projectSettings )

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -31,6 +31,8 @@ from qgis.PyQt.QtCore import QSize
 
 import osgeo.gdal  # NOQA
 
+from owslib.wms import WebMapService
+
 from test_qgsserver import QgsServerTestBase
 from qgis.core import QgsProject
 
@@ -215,6 +217,26 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         self.assertTrue(xmlResult.find("<WMSBackgroundLayer>1</WMSBackgroundLayer>") != -1)
         self.assertTrue(xmlResult.find("<WMSDataSource>contextualWMSLegend=0&amp;crs=EPSG:21781&amp;dpiMode=7&amp;featureCount=10&amp;format=image/png&amp;layers=public_geo_gemeinden&amp;styles=&amp;url=https://qgiscloud.com/mhugent/qgis_unittest_wms/wms?</WMSDataSource>") != -1)
         self.assertTrue(xmlResult.find("<WMSPrintLayer>contextualWMSLegend=0&amp;amp;crs=EPSG:21781&amp;amp;dpiMode=7&amp;amp;featureCount=10&amp;amp;format=image/png&amp;amp;layers=public_geo_gemeinden&amp;amp;styles=&amp;amp;url=https://qgiscloud.com/mhugent/qgis_unittest_wms_print/wms?</WMSPrintLayer>") != -1)
+
+    def test_getcapabilities_owslib(self):
+
+        # read getcapabilities document
+        docPath = self.testdata_path + 'getcapabilities.txt'
+        f = open(docPath, 'r')
+        doc = f.read()
+        f.close()
+
+        # clean header in doc
+        doc = doc.replace('Content-Length: 5775\n', '')
+        doc = doc.replace('Content-Type: text/xml; charset=utf-8\n\n', '')
+        doc = doc.replace('<?xml version="1.0" encoding="utf-8"?>\n', '')
+
+        # read capabilities document with owslib
+        w = WebMapService(None, xml=doc, version='1.3.0')
+
+        # check content
+        rootLayerName = 'QGIS Test Project'
+        self.assertTrue(rootLayerName in w.contents.keys())
 
 
 if __name__ == '__main__':

--- a/tests/testdata/qgis_server/getcapabilities.txt
+++ b/tests/testdata/qgis_server/getcapabilities.txt
@@ -115,7 +115,6 @@ Content-Type: text/xml; charset=utf-8
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>
-   <MetadataURL/>
    <Layer queryable="1">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>

--- a/tests/testdata/qgis_server/getcapabilities_inspire.txt
+++ b/tests/testdata/qgis_server/getcapabilities_inspire.txt
@@ -137,7 +137,6 @@ Content-Type: text/xml; charset=utf-8
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>
-   <MetadataURL/>
    <Layer queryable="1">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -137,7 +137,6 @@ Content-Type: text/xml; charset=utf-8
    <KeywordList>
     <Keyword vocabulary="ISO">infoMapAccessService</Keyword>
    </KeywordList>
-   <MetadataURL/>
    <TreeName>QGIS Test Project</TreeName>
    <Layer geometryType="Point" queryable="1" displayField="name" visible="1">
     <Name>testlayer èé</Name>


### PR DESCRIPTION
## Description

This PR fixes https://issues.qgis.org/issues/18197.

Actually, OGC tests for WMS are currently green, but owslib python package is not able to parse the `GetCapabilities` document due to an empty `MetadataURL` element defined for the root layer.

By removing this tag, OGC tests are failing because the root layer has a `Name` element. So this PR removes `Name` and `MetadataURL` elements for the root layer (`WMSRootName` parameter is still used for the `Title` tag).

This way, OGC tests are green and owslib is now able to parse the document.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
