### PR TITLE
[BUGFIX][Oracle] Force Geometry to WKB

### DIFF
--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -448,7 +448,7 @@ bool QgsOracleFeatureIterator::openQuery( QString whereClause, QVariantList args
 
     if ( mFetchGeometry )
     {
-      query += QgsOracleProvider::quotedIdentifier( mSource->mGeometryColumn );
+      query += QString( "SDO_UTIL.TO_WKBGEOMETRY( %1 ) AS %1" ).arg( QgsOracleProvider::quotedIdentifier( mSource->mGeometryColumn ) );
       delim = ",";
     }
 


### PR DESCRIPTION
## Description
In some cases, the one this PR has been done, the geometry provided by the database is not a Well Known Binary as the QGIS Oracle Provider is waiting for.
In my  case the database is oracle 11g, the geometry is point, and the result is not well located point when the feomerry is not cobverted to WKB. The coordinate are not well extracted from the oracle Binary.

So this PR le done to force Oracle to provide WKB. 


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
