### PR TITLE
[Processing] None is the default value for parameters also for string

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -740,7 +740,7 @@ class ParameterString(Parameter):
     NEWLINE = '\n'
     ESCAPED_NEWLINE = '\\n'
 
-    def __init__(self, name='', description='', default='', multiline=False,
+    def __init__(self, name='', description='', default=None, multiline=False,
                  optional=False, evaluateExpressions=False):
         Parameter.__init__(self, name, description, default, optional)
         self.multiline = parseBool(multiline)


### PR DESCRIPTION
It's a fix for regression between 2.14.