### PR TITLE
[oracle] Ensure that all attributes required for order by are fetched

### DIFF
--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -74,6 +74,14 @@ QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *sour
       }
     }
 
+    // ensure that all attributes required for order by are fetched
+    const QSet< QString > orderByAttributes = mRequest.orderBy().usedAttributes();
+    for ( const QString &attr : orderByAttributes )
+    {
+      int attrIndex = mSource->mFields.lookupField( attr );
+      if ( !mAttributeList.contains( attrIndex ) )
+        mAttributeList << attrIndex;
+    }
   }
   else
     mAttributeList = mSource->mFields.allAttributesList();

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -320,6 +320,10 @@ class FeatureSourceTestCase(object):
         values = [f['name'] for f in self.source.getFeatures(request)]
         self.assertEqual(values, ['Pear', 'Orange', 'Honey', 'Apple', NULL])
 
+        request = QgsFeatureRequest().addOrderBy('num_char', False)
+        values = [f['pk'] for f in self.source.getFeatures(request)]
+        self.assertEqual(values, [5, 4, 3, 2, 1])
+
         # Case sensitivity
         request = QgsFeatureRequest().addOrderBy('name2')
         values = [f['name2'] for f in self.source.getFeatures(request)]


### PR DESCRIPTION
Fixes potentially broken iterator sorting with oracle provider when a subset of attributes is fetched
