### PR TITLE
 [FEATURE][oracle] Allow restricting table list for a connection to a specific schema

### DIFF
--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -548,6 +548,7 @@ QDomDocument QgsManageConnectionsDialog::saveOracleConnections( const QStringLis
     el.setAttribute( QStringLiteral( "database" ), settings.value( path + "/database", "" ).toString() );
     el.setAttribute( QStringLiteral( "dboptions" ), settings.value( path + "/dboptions", "" ).toString() );
     el.setAttribute( QStringLiteral( "dbworkspace" ), settings.value( path + "/dbworkspace", "" ).toString() );
+    el.setAttribute( QStringLiteral( "schema" ), settings.value( path + "/schema", QString() ).toString() );
     el.setAttribute( QStringLiteral( "estimatedMetadata" ), settings.value( path + "/estimatedMetadata", "0" ).toString() );
     el.setAttribute( QStringLiteral( "userTablesOnly" ), settings.value( path + "/userTablesOnly", "0" ).toString() );
     el.setAttribute( QStringLiteral( "geometryColumnsOnly" ), settings.value( path + "/geometryColumnsOnly", "0" ).toString() );
@@ -1088,6 +1089,7 @@ void QgsManageConnectionsDialog::loadOracleConnections( const QDomDocument &doc,
     settings.setValue( QStringLiteral( "/database" ), child.attribute( QStringLiteral( "database" ) ) );
     settings.setValue( QStringLiteral( "/dboptions" ), child.attribute( QStringLiteral( "dboptions" ) ) );
     settings.setValue( QStringLiteral( "/dbworkspace" ), child.attribute( QStringLiteral( "dbworkspace" ) ) );
+    settings.setValue( QStringLiteral( "/schema" ), child.attribute( QStringLiteral( "schema" ) ) );
     settings.setValue( QStringLiteral( "/estimatedMetadata" ), child.attribute( QStringLiteral( "estimatedMetadata" ) ) );
     settings.setValue( QStringLiteral( "/userTablesOnly" ), child.attribute( QStringLiteral( "userTablesOnly" ) ) );
     settings.setValue( QStringLiteral( "/geometryColumnsOnly" ), child.attribute( QStringLiteral( "geometryColumnsOnly" ) ) );

--- a/src/providers/oracle/qgsoraclecolumntypethread.cpp
+++ b/src/providers/oracle/qgsoraclecolumntypethread.cpp
@@ -21,7 +21,7 @@ email                : jef at norbit dot de
 
 #include <QMetaType>
 
-QgsOracleColumnTypeThread::QgsOracleColumnTypeThread( QString name, bool useEstimatedMetadata, bool allowGeometrylessTables )
+QgsOracleColumnTypeThread::QgsOracleColumnTypeThread( const QString &name, bool useEstimatedMetadata, bool allowGeometrylessTables )
   : QThread()
   , mName( name )
   , mUseEstimatedMetadata( useEstimatedMetadata )
@@ -70,9 +70,9 @@ void QgsOracleColumnTypeThread::run()
     {
       emit progress( i++, n );
       emit progressMessage( tr( "Scanning column %1.%2.%3…" )
-                            .arg( layerProperty.ownerName )
-                            .arg( layerProperty.tableName )
-                            .arg( layerProperty.geometryColName ) );
+                            .arg( layerProperty.ownerName,
+                                  layerProperty.tableName,
+                                  layerProperty.geometryColName ) );
       conn->retrieveLayerTypes( layerProperty, mUseEstimatedMetadata, QgsOracleConn::onlyExistingTypes( mName ) );
     }
 

--- a/src/providers/oracle/qgsoraclecolumntypethread.cpp
+++ b/src/providers/oracle/qgsoraclecolumntypethread.cpp
@@ -21,9 +21,10 @@ email                : jef at norbit dot de
 
 #include <QMetaType>
 
-QgsOracleColumnTypeThread::QgsOracleColumnTypeThread( const QString &name, bool useEstimatedMetadata, bool allowGeometrylessTables )
+QgsOracleColumnTypeThread::QgsOracleColumnTypeThread( const QString &name, const QString &limitToSchema, bool useEstimatedMetadata, bool allowGeometrylessTables )
   : QThread()
   , mName( name )
+  , mSchema( limitToSchema )
   , mUseEstimatedMetadata( useEstimatedMetadata )
   , mAllowGeometrylessTables( allowGeometrylessTables )
   , mStopped( false )
@@ -52,6 +53,7 @@ void QgsOracleColumnTypeThread::run()
   emit progressMessage( tr( "Retrieving tables of %1…" ).arg( mName ) );
   QVector<QgsOracleLayerProperty> layerProperties;
   if ( !conn->supportedLayers( layerProperties,
+                               mSchema,
                                QgsOracleConn::geometryColumnsOnly( mName ),
                                QgsOracleConn::userTablesOnly( mName ),
                                mAllowGeometrylessTables ) ||

--- a/src/providers/oracle/qgsoraclecolumntypethread.h
+++ b/src/providers/oracle/qgsoraclecolumntypethread.h
@@ -28,7 +28,7 @@ class QgsOracleColumnTypeThread : public QThread
 {
     Q_OBJECT
   public:
-    QgsOracleColumnTypeThread( QString connName,
+    QgsOracleColumnTypeThread( const QString &connName,
                                bool useEstimatedMetaData,
                                bool allowGeometrylessTables );
 
@@ -51,12 +51,12 @@ class QgsOracleColumnTypeThread : public QThread
     void stop();
 
   private:
-    QgsOracleColumnTypeThread() {}
+    QgsOracleColumnTypeThread() = default;
 
     QString mName;
-    bool mUseEstimatedMetadata;
-    bool mAllowGeometrylessTables;
-    bool mStopped;
+    bool mUseEstimatedMetadata = false;
+    bool mAllowGeometrylessTables = false;
+    bool mStopped = false;
     QVector<QgsOracleLayerProperty> mLayerProperties;
 };
 

--- a/src/providers/oracle/qgsoraclecolumntypethread.h
+++ b/src/providers/oracle/qgsoraclecolumntypethread.h
@@ -28,7 +28,16 @@ class QgsOracleColumnTypeThread : public QThread
 {
     Q_OBJECT
   public:
+
+    /**
+     *
+     * \param connName
+     * \param limitToSchema If specified, only tables from this schema will be scanned
+     * \param useEstimatedMetaData
+     * \param allowGeometrylessTables
+     */
     QgsOracleColumnTypeThread( const QString &connName,
+                               const QString &limitToSchema,
                                bool useEstimatedMetaData,
                                bool allowGeometrylessTables );
 
@@ -54,6 +63,7 @@ class QgsOracleColumnTypeThread : public QThread
     QgsOracleColumnTypeThread() = default;
 
     QString mName;
+    QString mSchema;
     bool mUseEstimatedMetadata = false;
     bool mAllowGeometrylessTables = false;
     bool mStopped = false;

--- a/src/providers/oracle/qgsoracleconn.h
+++ b/src/providers/oracle/qgsoracleconn.h
@@ -127,16 +127,27 @@ class QgsOracleConn : public QObject
      */
     static QString quotedValue( const QVariant &value, QVariant::Type type = QVariant::Invalid );
 
-    //! Get the list of supported layers
+    /**
+     * Get the list of supported layers.
+     *
+     * If \a limitToSchema is specified, than only layers from the matching schema will be
+     * returned.
+     *
+     */
     bool supportedLayers( QVector<QgsOracleLayerProperty> &layers,
+                          const QString &limitToSchema,
                           bool geometryTablesOnly,
                           bool userTablesOnly = true,
                           bool allowGeometrylessTables = false );
 
     void retrieveLayerTypes( QgsOracleLayerProperty &layerProperty, bool useEstimatedMetadata, bool onlyExistingTypes );
 
-    //! Gets information about the spatial tables
-    bool tableInfo( bool geometryTablesOnly, bool userTablesOnly, bool allowGeometrylessTables );
+    /**
+     * Gets information about the spatial tables.
+     *
+     * If \a schema is specified, only tables from this schema will be retrieved.
+     */
+    bool tableInfo( const QString &schema, bool geometryTablesOnly, bool userTablesOnly, bool allowGeometrylessTables );
 
     //! Get primary key candidates (all int4 columns)
     QStringList pkCandidates( const QString &ownerName, const QString &viewName );
@@ -163,6 +174,7 @@ class QgsOracleConn : public QObject
     static void setSelectedConnection( const QString &connName );
     static QgsDataSourceUri connUri( const QString &connName );
     static bool userTablesOnly( const QString &connName );
+    static QString restrictToSchema( const QString &connName );
     static bool geometryColumnsOnly( const QString &connName );
     static bool allowGeometrylessTables( const QString &connName );
     static bool estimatedMetadata( const QString &connName );

--- a/src/providers/oracle/qgsoracleconn.h
+++ b/src/providers/oracle/qgsoracleconn.h
@@ -139,7 +139,7 @@ class QgsOracleConn : public QObject
     bool tableInfo( bool geometryTablesOnly, bool userTablesOnly, bool allowGeometrylessTables );
 
     //! Get primary key candidates (all int4 columns)
-    QStringList pkCandidates( QString ownerName, QString viewName );
+    QStringList pkCandidates( const QString &ownerName, const QString &viewName );
 
     static QString fieldExpression( const QgsField &fld );
 
@@ -160,15 +160,15 @@ class QgsOracleConn : public QObject
 
     static QStringList connectionList();
     static QString selectedConnection();
-    static void setSelectedConnection( QString connName );
-    static QgsDataSourceUri connUri( QString connName );
-    static bool userTablesOnly( QString connName );
-    static bool geometryColumnsOnly( QString connName );
-    static bool allowGeometrylessTables( QString connName );
-    static bool estimatedMetadata( QString connName );
-    static bool onlyExistingTypes( QString connName );
+    static void setSelectedConnection( const QString &connName );
+    static QgsDataSourceUri connUri( const QString &connName );
+    static bool userTablesOnly( const QString &connName );
+    static bool geometryColumnsOnly( const QString &connName );
+    static bool allowGeometrylessTables( const QString &connName );
+    static bool estimatedMetadata( const QString &connName );
+    static bool onlyExistingTypes( const QString &connName );
     static void deleteConnection( QString connName );
-    static QString databaseName( QString database, QString host, QString port );
+    static QString databaseName( const QString &database, const QString &host, const QString &port );
     static QString toPoolName( const QgsDataSourceUri &uri );
 
     operator QSqlDatabase() { return mDatabase; }
@@ -177,7 +177,7 @@ class QgsOracleConn : public QObject
     explicit QgsOracleConn( QgsDataSourceUri uri );
     ~QgsOracleConn();
 
-    bool exec( QSqlQuery &qry, QString sql, const QVariantList &params );
+    bool exec( QSqlQuery &qry, const QString &sql, const QVariantList &params );
 
     //! reference count
     int mRef;

--- a/src/providers/oracle/qgsoracleconn.h
+++ b/src/providers/oracle/qgsoracleconn.h
@@ -165,7 +165,7 @@ class QgsOracleConn : public QObject
     static QString displayStringForWkbType( QgsWkbTypes::Type wkbType );
     static QgsWkbTypes::Type wkbTypeFromDatabase( int gtype );
 
-    static QString databaseTypeFilter( QString alias, QString geomCol, QgsWkbTypes::Type wkbType );
+    static QString databaseTypeFilter( const QString &alias, QString geomCol, QgsWkbTypes::Type wkbType );
 
     static QgsWkbTypes::Type wkbTypeFromGeomType( QgsWkbTypes::GeometryType geomType );
 
@@ -179,7 +179,7 @@ class QgsOracleConn : public QObject
     static bool allowGeometrylessTables( const QString &connName );
     static bool estimatedMetadata( const QString &connName );
     static bool onlyExistingTypes( const QString &connName );
-    static void deleteConnection( QString connName );
+    static void deleteConnection( const QString &connName );
     static QString databaseName( const QString &database, const QString &host, const QString &port );
     static QString toPoolName( const QgsDataSourceUri &uri );
 

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -29,11 +29,11 @@
 QGISEXTERN bool deleteLayer( const QString &uri, QString &errCause );
 
 // ---------------------------------------------------------------------------
-QgsOracleConnectionItem::QgsOracleConnectionItem( QgsDataItem *parent, QString name, QString path )
+QgsOracleConnectionItem::QgsOracleConnectionItem( QgsDataItem *parent, const QString &name, const QString &path )
   : QgsDataCollectionItem( parent, name, path )
   , mColumnTypeThread( nullptr )
 {
-  mIconName = "mIconConnect.svg";
+  mIconName = QStringLiteral( "mIconConnect.svg" );
   mCapabilities |= Collapse;
 }
 
@@ -95,10 +95,10 @@ QVector<QgsDataItem *> QgsOracleConnectionItem::createChildren()
         /* useEstimatedMetadata */ true,
         QgsOracleConn::allowGeometrylessTables( mName ) );
 
-    connect( mColumnTypeThread, SIGNAL( setLayerType( QgsOracleLayerProperty ) ),
-             this, SLOT( setLayerType( QgsOracleLayerProperty ) ) );
-    connect( mColumnTypeThread, SIGNAL( started() ), this, SLOT( threadStarted() ) );
-    connect( mColumnTypeThread, SIGNAL( finished() ), this, SLOT( threadFinished() ) );
+    connect( mColumnTypeThread, &QgsOracleColumnTypeThread::setLayerType,
+             this, &QgsOracleConnectionItem::setLayerType );
+    connect( mColumnTypeThread, &QThread::started, this, &QgsOracleConnectionItem::threadStarted );
+    connect( mColumnTypeThread, &QThread::finished, this, &QgsOracleConnectionItem::threadFinished );
 
     if ( QgsOracleRootItem::sMainWindow )
     {
@@ -123,26 +123,26 @@ QVector<QgsDataItem *> QgsOracleConnectionItem::createChildren()
 
 void QgsOracleConnectionItem::threadStarted()
 {
-  QgsDebugMsgLevel( "Entering.", 3 );
+  QgsDebugMsgLevel( QStringLiteral( "Entering." ), 3 );
 }
 
 void QgsOracleConnectionItem::threadFinished()
 {
-  QgsDebugMsgLevel( "Entering.", 3 );
+  QgsDebugMsgLevel( QStringLiteral( "Entering." ), 3 );
   setAllAsPopulated();
 }
 
-void QgsOracleConnectionItem::setLayerType( QgsOracleLayerProperty layerProperty )
+void QgsOracleConnectionItem::setLayerType( const QgsOracleLayerProperty &layerProperty )
 {
   QgsDebugMsgLevel( layerProperty.toString(), 3 );
-  QgsOracleOwnerItem *ownerItem = mOwnerMap.value( layerProperty.ownerName, 0 );
+  QgsOracleOwnerItem *ownerItem = mOwnerMap.value( layerProperty.ownerName, nullptr );
 
   for ( int i = 0 ; i < layerProperty.size(); i++ )
   {
     QgsWkbTypes::Type wkbType = layerProperty.types.at( i );
     if ( wkbType == QgsWkbTypes::Unknown )
     {
-      QgsDebugMsgLevel( "skip unknown geometry type", 3 );
+      QgsDebugMsgLevel( QStringLiteral( "skip unknown geometry type" ), 3 );
       continue;
     }
 
@@ -155,7 +155,7 @@ void QgsOracleConnectionItem::setLayerType( QgsOracleLayerProperty layerProperty
       mOwnerMap[ layerProperty.ownerName ] = ownerItem;
     }
 
-    QgsDebugMsgLevel( "ADD LAYER", 3 );
+    QgsDebugMsgLevel( QStringLiteral( "ADD LAYER" ), 3 );
     ownerItem->addLayer( layerProperty.at( i ) );
   }
 }
@@ -176,7 +176,7 @@ QList<QAction *> QgsOracleConnectionItem::actions( QWidget *parent )
   QList<QAction *> lst;
 
   QAction *actionRefresh = new QAction( tr( "Refresh" ), parent );
-  connect( actionRefresh, SIGNAL( triggered() ), this, SLOT( refreshConnection() ) );
+  connect( actionRefresh, &QAction::triggered, this, &QgsOracleConnectionItem::refreshConnection );
   lst.append( actionRefresh );
 
   QAction *separator = new QAction( parent );
@@ -184,11 +184,11 @@ QList<QAction *> QgsOracleConnectionItem::actions( QWidget *parent )
   lst.append( separator );
 
   QAction *actionEdit = new QAction( tr( "Edit Connection…" ), parent );
-  connect( actionEdit, SIGNAL( triggered() ), this, SLOT( editConnection() ) );
+  connect( actionEdit, &QAction::triggered, this, &QgsOracleConnectionItem::editConnection );
   lst.append( actionEdit );
 
   QAction *actionDelete = new QAction( tr( "Delete Connection" ), parent );
-  connect( actionDelete, SIGNAL( triggered() ), this, SLOT( deleteConnection() ) );
+  connect( actionDelete, &QAction::triggered, this, &QgsOracleConnectionItem::deleteConnection );
   lst.append( actionDelete );
 
   return lst;
@@ -196,7 +196,7 @@ QList<QAction *> QgsOracleConnectionItem::actions( QWidget *parent )
 
 void QgsOracleConnectionItem::editConnection()
 {
-  QgsOracleNewConnection nc( NULL, mName );
+  QgsOracleNewConnection nc( nullptr, mName );
   if ( nc.exec() )
   {
     // the parent should be updated
@@ -238,7 +238,7 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
   QgsMimeDataUtils::UriList lst = QgsMimeDataUtils::decodeUriList( data );
   Q_FOREACH ( const QgsMimeDataUtils::Uri &u, lst )
   {
-    if ( u.layerType != "vector" )
+    if ( u.layerType != QLatin1String( "vector" ) )
     {
       importResults.append( tr( "%1: Not a vector layer!" ).arg( u.name ) );
       hasError = true; // only vectors can be imported
@@ -250,10 +250,10 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
 
     if ( srcLayer->isValid() )
     {
-      uri.setDataSource( QString(), u.name.left( 30 ).toUpper(), "GEOM" );
+      uri.setDataSource( QString(), u.name.left( 30 ).toUpper(), QStringLiteral( "GEOM" ) );
       uri.setWkbType( srcLayer->wkbType() );
       QString authid = srcLayer->crs().authid();
-      if ( authid.startsWith( "EPSG:", Qt::CaseInsensitive ) )
+      if ( authid.startsWith( QStringLiteral( "EPSG:" ), Qt::CaseInsensitive ) )
       {
         uri.setSrid( authid.mid( 5 ) );
       }
@@ -301,7 +301,7 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
   {
     QgsMessageOutput *output = QgsMessageOutput::createMessageOutput();
     output->setTitle( tr( "Import to Oracle database" ) );
-    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( "\n" ), QgsMessageOutput::MessageText );
+    output->setMessage( tr( "Failed to import some layers!\n\n" ) + importResults.join( '\n' ), QgsMessageOutput::MessageText );
     output->showMessage();
   }
 
@@ -309,16 +309,12 @@ bool QgsOracleConnectionItem::handleDrop( const QMimeData *data, Qt::DropAction 
 }
 
 // ---------------------------------------------------------------------------
-QgsOracleLayerItem::QgsOracleLayerItem( QgsDataItem *parent, QString name, QString path, QgsLayerItem::LayerType layerType, QgsOracleLayerProperty layerProperty )
-  : QgsLayerItem( parent, name, path, QString(), layerType, "oracle" )
+QgsOracleLayerItem::QgsOracleLayerItem( QgsDataItem *parent, const QString &name, const QString &path, QgsLayerItem::LayerType layerType, const QgsOracleLayerProperty &layerProperty )
+  : QgsLayerItem( parent, name, path, QString(), layerType, QStringLiteral( "oracle" ) )
   , mLayerProperty( layerProperty )
 {
   mUri = createUri();
   setState( Populated );
-}
-
-QgsOracleLayerItem::~QgsOracleLayerItem()
-{
 }
 
 QList<QAction *> QgsOracleLayerItem::actions( QWidget *parent )
@@ -326,7 +322,7 @@ QList<QAction *> QgsOracleLayerItem::actions( QWidget *parent )
   QList<QAction *> lst;
 
   QAction *actionDeleteLayer = new QAction( tr( "Delete Table" ), parent );
-  connect( actionDeleteLayer, SIGNAL( triggered() ), this, SLOT( deleteLayer() ) );
+  connect( actionDeleteLayer, &QAction::triggered, this, &QgsOracleLayerItem::deleteLayer );
   lst.append( actionDeleteLayer );
 
   return lst;
@@ -343,11 +339,11 @@ void QgsOracleLayerItem::deleteLayer()
   bool res = ::deleteLayer( mUri, errCause );
   if ( !res )
   {
-    QMessageBox::warning( 0, tr( "Delete Table" ), errCause );
+    QMessageBox::warning( nullptr, tr( "Delete Table" ), errCause );
   }
   else
   {
-    QMessageBox::information( 0, tr( "Delete Table" ), tr( "Table deleted successfully." ) );
+    QMessageBox::information( nullptr, tr( "Delete Table" ), tr( "Table deleted successfully." ) );
     deleteLater();
   }
 }
@@ -355,11 +351,11 @@ void QgsOracleLayerItem::deleteLayer()
 QString QgsOracleLayerItem::createUri()
 {
   Q_ASSERT( mLayerProperty.size() == 1 );
-  QgsOracleConnectionItem *connItem = qobject_cast<QgsOracleConnectionItem *>( parent() ? parent()->parent() : 0 );
+  QgsOracleConnectionItem *connItem = qobject_cast<QgsOracleConnectionItem *>( parent() ? parent()->parent() : nullptr );
 
   if ( !connItem )
   {
-    QgsDebugMsg( "connection item not found." );
+    QgsDebugMsg( QStringLiteral( "connection item not found." ) );
     return QString();
   }
 
@@ -369,22 +365,22 @@ QString QgsOracleLayerItem::createUri()
   uri.setWkbType( mLayerProperty.types.at( 0 ) );
   if ( mLayerProperty.isView && mLayerProperty.pkCols.size() > 0 )
     uri.setKeyColumn( mLayerProperty.pkCols[0] );
-  QgsDebugMsgLevel( QString( "layer uri: %1" ).arg( uri.uri() ), 3 );
+  QgsDebugMsgLevel( QString( QStringLiteral( "layer uri: %1" ) ).arg( uri.uri() ), 3 );
   return uri.uri();
 }
 
 // ---------------------------------------------------------------------------
-QgsOracleOwnerItem::QgsOracleOwnerItem( QgsDataItem *parent, QString name, QString path )
+QgsOracleOwnerItem::QgsOracleOwnerItem( QgsDataItem *parent, const QString &name, const QString &path )
   : QgsDataCollectionItem( parent, name, path )
 {
-  mIconName = "mIconDbOwner.png";
+  mIconName = QStringLiteral( "mIconDbOwner.png" );
   //not fertile, since children are created by QgsOracleConnectionItem
   mCapabilities &= ~( Fertile );
 }
 
 QVector<QgsDataItem *> QgsOracleOwnerItem::createChildren()
 {
-  QgsDebugMsgLevel( "Entering.", 3 );
+  QgsDebugMsgLevel( QStringLiteral( "Entering." ), 3 );
   return QVector<QgsDataItem *>();
 }
 
@@ -392,13 +388,13 @@ QgsOracleOwnerItem::~QgsOracleOwnerItem()
 {
 }
 
-void QgsOracleOwnerItem::addLayer( QgsOracleLayerProperty layerProperty )
+void QgsOracleOwnerItem::addLayer( const QgsOracleLayerProperty &layerProperty )
 {
   QgsDebugMsgLevel( layerProperty.toString(), 3 );
 
   Q_ASSERT( layerProperty.size() == 1 );
   QgsWkbTypes::Type wkbType = layerProperty.types.at( 0 );
-  QString tip = tr( "%1 as %2 in %3" ).arg( layerProperty.geometryColName ).arg( QgsOracleConn::displayStringForWkbType( wkbType ) ).arg( layerProperty.srids.at( 0 ) );
+  QString tip = tr( "%1 as %2 in %3" ).arg( layerProperty.geometryColName, QgsOracleConn::displayStringForWkbType( wkbType ) ).arg( layerProperty.srids.at( 0 ) );
 
   QgsLayerItem::LayerType layerType;
   switch ( wkbType )
@@ -433,16 +429,16 @@ void QgsOracleOwnerItem::addLayer( QgsOracleLayerProperty layerProperty )
       }
   }
 
-  QgsOracleLayerItem *layerItem = new QgsOracleLayerItem( this, layerProperty.tableName, mPath + "/" + layerProperty.tableName, layerType, layerProperty );
+  QgsOracleLayerItem *layerItem = new QgsOracleLayerItem( this, layerProperty.tableName, mPath + '/' + layerProperty.tableName, layerType, layerProperty );
   layerItem->setToolTip( tip );
   addChildItem( layerItem, true );
 }
 
 // ---------------------------------------------------------------------------
-QgsOracleRootItem::QgsOracleRootItem( QgsDataItem *parent, QString name, QString path )
+QgsOracleRootItem::QgsOracleRootItem( QgsDataItem *parent, const QString &name, const QString &path )
   : QgsDataCollectionItem( parent, name, path )
 {
-  mIconName = "mIconOracle.svg";
+  mIconName = QStringLiteral( "mIconOracle.svg" );
   populate();
 }
 
@@ -455,7 +451,7 @@ QVector<QgsDataItem *> QgsOracleRootItem::createChildren()
   QVector<QgsDataItem *> connections;
   Q_FOREACH ( QString connName, QgsOracleConn::connectionList() )
   {
-    connections << new QgsOracleConnectionItem( this, connName, mPath + "/" + connName );
+    connections << new QgsOracleConnectionItem( this, connName, mPath + '/' + connName );
   }
   return connections;
 }
@@ -465,7 +461,7 @@ QList<QAction *> QgsOracleRootItem::actions( QWidget *parent )
   QList<QAction *> lst;
 
   QAction *actionNew = new QAction( tr( "New Connection…" ), parent );
-  connect( actionNew, SIGNAL( triggered() ), this, SLOT( newConnection() ) );
+  connect( actionNew, &QAction::triggered, this, &QgsOracleRootItem::newConnection );
   lst.append( actionNew );
 
   return lst;
@@ -474,7 +470,7 @@ QList<QAction *> QgsOracleRootItem::actions( QWidget *parent )
 QWidget *QgsOracleRootItem::paramWidget()
 {
   QgsOracleSourceSelect *select = new QgsOracleSourceSelect();
-  connect( select, SIGNAL( connectionsChanged() ), this, SLOT( connectionsChanged() ) );
+  connect( select, &QgsAbstractDataSourceWidget::connectionsChanged, this, &QgsOracleRootItem::connectionsChanged );
   return select;
 }
 
@@ -485,14 +481,14 @@ void QgsOracleRootItem::connectionsChanged()
 
 void QgsOracleRootItem::newConnection()
 {
-  QgsOracleNewConnection nc( NULL );
+  QgsOracleNewConnection nc( nullptr );
   if ( nc.exec() )
   {
     refreshConnections();
   }
 }
 
-QMainWindow *QgsOracleRootItem::sMainWindow = 0;
+QMainWindow *QgsOracleRootItem::sMainWindow = nullptr;
 
 QGISEXTERN void registerGui( QMainWindow *mainWindow )
 {

--- a/src/providers/oracle/qgsoracledataitems.cpp
+++ b/src/providers/oracle/qgsoracledataitems.cpp
@@ -91,6 +91,7 @@ QVector<QgsDataItem *> QgsOracleConnectionItem::createChildren()
   if ( !mColumnTypeThread )
   {
     mColumnTypeThread = new QgsOracleColumnTypeThread( mName,
+        QgsOracleConn::restrictToSchema( mName ),
         /* useEstimatedMetadata */ true,
         QgsOracleConn::allowGeometrylessTables( mName ) );
 

--- a/src/providers/oracle/qgsoracledataitems.h
+++ b/src/providers/oracle/qgsoracledataitems.h
@@ -36,8 +36,8 @@ class QgsOracleRootItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsOracleRootItem( QgsDataItem *parent, QString name, QString path );
-    ~QgsOracleRootItem();
+    QgsOracleRootItem( QgsDataItem *parent, const QString &name, const QString &path );
+    ~QgsOracleRootItem() override;
 
     QVector<QgsDataItem *> createChildren() override;
 
@@ -58,8 +58,8 @@ class QgsOracleConnectionItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsOracleConnectionItem( QgsDataItem *parent, QString name, QString path );
-    ~QgsOracleConnectionItem();
+    QgsOracleConnectionItem( QgsDataItem *parent, const QString &name, const QString &path );
+    ~QgsOracleConnectionItem() override;
 
     QVector<QgsDataItem *> createChildren() override;
     virtual bool equal( const QgsDataItem *other ) override;
@@ -78,7 +78,7 @@ class QgsOracleConnectionItem : public QgsDataCollectionItem
     void deleteConnection();
     void refreshConnection();
 
-    void setLayerType( QgsOracleLayerProperty layerProperty );
+    void setLayerType( const QgsOracleLayerProperty &layerProperty );
 
     void threadStarted();
     void threadFinished();
@@ -94,12 +94,12 @@ class QgsOracleOwnerItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsOracleOwnerItem( QgsDataItem *parent, QString name, QString path );
+    QgsOracleOwnerItem( QgsDataItem *parent, const QString &name, const QString &path );
     ~QgsOracleOwnerItem();
 
     QVector<QgsDataItem *> createChildren();
 
-    void addLayer( QgsOracleLayerProperty layerProperty );
+    void addLayer( const QgsOracleLayerProperty &layerProperty );
 };
 
 class QgsOracleLayerItem : public QgsLayerItem
@@ -107,8 +107,7 @@ class QgsOracleLayerItem : public QgsLayerItem
     Q_OBJECT
 
   public:
-    QgsOracleLayerItem( QgsDataItem *parent, QString name, QString path, QgsLayerItem::LayerType layerType, QgsOracleLayerProperty layerProperties );
-    ~QgsOracleLayerItem();
+    QgsOracleLayerItem( QgsDataItem *parent, const QString &name, const QString &path, QgsLayerItem::LayerType layerType, const QgsOracleLayerProperty &layerProperties );
 
     QString createUri();
 

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -28,9 +28,6 @@
 
 QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsOracleFeatureSource>( source, ownSource, request )
-  , mRewind( false )
-  , mExpressionCompiled( false )
-  , mFetchGeometry( false )
 {
   mConnection = QgsOracleConnPool::instance()->acquireConnection( QgsOracleConn::toPoolName( mSource->mUri ) );
   if ( !mConnection )

--- a/src/providers/oracle/qgsoraclefeatureiterator.h
+++ b/src/providers/oracle/qgsoraclefeatureiterator.h
@@ -75,9 +75,9 @@ class QgsOracleFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Qgs
 
     QgsOracleConn *mConnection = nullptr;
     QSqlQuery mQry;
-    bool mRewind;
-    bool mExpressionCompiled;
-    bool mFetchGeometry;
+    bool mRewind = false;
+    bool mExpressionCompiled = false;
+    bool mFetchGeometry = false;
     QgsAttributeList mAttributeList;
     QString mSql;
     QVariantList mArgs;

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -26,10 +26,12 @@
 #include "qgsoracleconnpool.h"
 
 QgsOracleNewConnection::QgsOracleNewConnection( QWidget *parent, const QString &connName, Qt::WindowFlags fl )
-  : QDialog( parent, fl ), mOriginalConnName( connName )
+  : QDialog( parent, fl )
+  , mOriginalConnName( connName )
 {
   setupUi( this );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsOracleNewConnection::showHelp );
+  connect( btnConnect, &QPushButton::clicked, this, &QgsOracleNewConnection::testConnection );
 
   if ( !connName.isEmpty() )
   {
@@ -37,58 +39,58 @@ QgsOracleNewConnection::QgsOracleNewConnection( QWidget *parent, const QString &
     // populate the fields with the stored setting parameters
     QgsSettings settings;
 
-    QString key = "/Oracle/connections/" + connName;
-    txtDatabase->setText( settings.value( key + "/database" ).toString() );
-    txtHost->setText( settings.value( key + "/host" ).toString() );
-    QString port = settings.value( key + "/port" ).toString();
+    QString key = QStringLiteral( "/Oracle/connections/" ) + connName;
+    txtDatabase->setText( settings.value( key + QStringLiteral( "/database" ) ).toString() );
+    txtHost->setText( settings.value( key + QStringLiteral( "/host" ) ).toString() );
+    QString port = settings.value( key + QStringLiteral( "/port" ) ).toString();
     if ( port.length() == 0 )
     {
-      port = "1521";
+      port = QStringLiteral( "1521" );
     }
     txtPort->setText( port );
-    txtOptions->setText( settings.value( key + "/dboptions" ).toString() );
-    txtWorkspace->setText( settings.value( key + "/dbworkspace" ).toString() );
-    cb_userTablesOnly->setChecked( settings.value( key + "/userTablesOnly", false ).toBool() );
-    cb_geometryColumnsOnly->setChecked( settings.value( key + "/geometryColumnsOnly", true ).toBool() );
-    cb_allowGeometrylessTables->setChecked( settings.value( key + "/allowGeometrylessTables", false ).toBool() );
-    cb_useEstimatedMetadata->setChecked( settings.value( key + "/estimatedMetadata", false ).toBool() );
-    cb_onlyExistingTypes->setChecked( settings.value( key + "/onlyExistingTypes", true ).toBool() );
-    cb_includeGeoAttributes->setChecked( settings.value( key + "/includeGeoAttributes", false ).toBool() );
+    txtOptions->setText( settings.value( key + QStringLiteral( "/dboptions" ) ).toString() );
+    txtWorkspace->setText( settings.value( key + QStringLiteral( "/dbworkspace" ) ).toString() );
+    cb_userTablesOnly->setChecked( settings.value( key + QStringLiteral( "/userTablesOnly" ), false ).toBool() );
+    cb_geometryColumnsOnly->setChecked( settings.value( key + QStringLiteral( "/geometryColumnsOnly" ), true ).toBool() );
+    cb_allowGeometrylessTables->setChecked( settings.value( key + QStringLiteral( "/allowGeometrylessTables" ), false ).toBool() );
+    cb_useEstimatedMetadata->setChecked( settings.value( key + QStringLiteral( "/estimatedMetadata" ), false ).toBool() );
+    cb_onlyExistingTypes->setChecked( settings.value( key + QStringLiteral( "/onlyExistingTypes" ), true ).toBool() );
+    cb_includeGeoAttributes->setChecked( settings.value( key + QStringLiteral( "/includeGeoAttributes" ), false ).toBool() );
 
-    if ( settings.value( key + "/saveUsername" ).toString() == "true" )
+    if ( settings.value( key + QStringLiteral( "/saveUsername" ) ).toString() == QLatin1String( "true" ) )
     {
-      txtUsername->setText( settings.value( key + "/username" ).toString() );
+      txtUsername->setText( settings.value( key + QStringLiteral( "/username" ) ).toString() );
       chkStoreUsername->setChecked( true );
     }
 
-    if ( settings.value( key + "/savePassword" ).toString() == "true" )
+    if ( settings.value( key + QStringLiteral( "/savePassword" ) ).toString() == QLatin1String( "true" ) )
     {
-      txtPassword->setText( settings.value( key + "/password" ).toString() );
+      txtPassword->setText( settings.value( key + QStringLiteral( "/password" ) ).toString() );
       chkStorePassword->setChecked( true );
     }
 
     // Old save setting
-    if ( settings.contains( key + "/save" ) )
+    if ( settings.contains( key + QStringLiteral( "/save" ) ) )
     {
-      txtUsername->setText( settings.value( key + "/username" ).toString() );
+      txtUsername->setText( settings.value( key + QStringLiteral( "/username" ) ).toString() );
       chkStoreUsername->setChecked( !txtUsername->text().isEmpty() );
 
-      if ( settings.value( key + "/save" ).toString() == "true" )
-        txtPassword->setText( settings.value( key + "/password" ).toString() );
+      if ( settings.value( key + QStringLiteral( "/save" ) ).toString() == QLatin1String( "true" ) )
+        txtPassword->setText( settings.value( key + QStringLiteral( "/password" ) ).toString() );
 
       chkStorePassword->setChecked( true );
     }
 
     txtName->setText( connName );
   }
-  txtName->setValidator( new QRegExpValidator( QRegExp( "[^\\/]+" ), txtName ) );
+  txtName->setValidator( new QRegExpValidator( QRegExp( QStringLiteral( "[^\\/]+" ) ), txtName ) );
 }
-//! Autoconnected SLOTS *
+
 void QgsOracleNewConnection::accept()
 {
   QgsSettings settings;
-  QString baseKey = "/Oracle/connections/";
-  settings.setValue( baseKey + "selected", txtName->text() );
+  QString baseKey = QStringLiteral( "/Oracle/connections/" );
+  settings.setValue( baseKey + QStringLiteral( "selected" ), txtName->text() );
 
   if ( chkStorePassword->isChecked() &&
        QMessageBox::question( this,
@@ -101,8 +103,8 @@ void QgsOracleNewConnection::accept()
 
   // warn if entry was renamed to an existing connection
   if ( ( mOriginalConnName.isNull() || mOriginalConnName.compare( txtName->text(), Qt::CaseInsensitive ) != 0 ) &&
-       ( settings.contains( baseKey + txtName->text() + "/service" ) ||
-         settings.contains( baseKey + txtName->text() + "/host" ) ) &&
+       ( settings.contains( baseKey + txtName->text() + QStringLiteral( "/service" ) ) ||
+         settings.contains( baseKey + txtName->text() + QStringLiteral( "/host" ) ) ) &&
        QMessageBox::question( this,
                               tr( "Save Connection" ),
                               tr( "Should the existing connection %1 be overwritten?" ).arg( txtName->text() ),
@@ -119,33 +121,33 @@ void QgsOracleNewConnection::accept()
   }
 
   baseKey += txtName->text();
-  settings.setValue( baseKey + "/database", txtDatabase->text() );
-  settings.setValue( baseKey + "/host", txtHost->text() );
-  settings.setValue( baseKey + "/port", txtPort->text() );
-  settings.setValue( baseKey + "/username", chkStoreUsername->isChecked() ? txtUsername->text() : "" );
-  settings.setValue( baseKey + "/password", chkStorePassword->isChecked() ? txtPassword->text() : "" );
-  settings.setValue( baseKey + "/userTablesOnly", cb_userTablesOnly->isChecked() );
-  settings.setValue( baseKey + "/geometryColumnsOnly", cb_geometryColumnsOnly->isChecked() );
-  settings.setValue( baseKey + "/allowGeometrylessTables", cb_allowGeometrylessTables->isChecked() );
-  settings.setValue( baseKey + "/estimatedMetadata", cb_useEstimatedMetadata->isChecked() ? "true" : "false" );
-  settings.setValue( baseKey + "/onlyExistingTypes", cb_onlyExistingTypes->isChecked() ? "true" : "false" );
-  settings.setValue( baseKey + "/includeGeoAttributes", cb_includeGeoAttributes->isChecked() ? "true" : "false" );
-  settings.setValue( baseKey + "/saveUsername", chkStoreUsername->isChecked() ? "true" : "false" );
-  settings.setValue( baseKey + "/savePassword", chkStorePassword->isChecked() ? "true" : "false" );
-  settings.setValue( baseKey + "/dboptions", txtOptions->text() );
-  settings.setValue( baseKey + "/dbworkspace", txtWorkspace->text() );
+  settings.setValue( baseKey + QStringLiteral( "/database" ), txtDatabase->text() );
+  settings.setValue( baseKey + QStringLiteral( "/host" ), txtHost->text() );
+  settings.setValue( baseKey + QStringLiteral( "/port" ), txtPort->text() );
+  settings.setValue( baseKey + QStringLiteral( "/username" ), chkStoreUsername->isChecked() ? txtUsername->text() : QString() );
+  settings.setValue( baseKey + QStringLiteral( "/password" ), chkStorePassword->isChecked() ? txtPassword->text() : QString() );
+  settings.setValue( baseKey + QStringLiteral( "/userTablesOnly" ), cb_userTablesOnly->isChecked() );
+  settings.setValue( baseKey + QStringLiteral( "/geometryColumnsOnly" ), cb_geometryColumnsOnly->isChecked() );
+  settings.setValue( baseKey + QStringLiteral( "/allowGeometrylessTables" ), cb_allowGeometrylessTables->isChecked() );
+  settings.setValue( baseKey + QStringLiteral( "/estimatedMetadata" ), cb_useEstimatedMetadata->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  settings.setValue( baseKey + QStringLiteral( "/onlyExistingTypes" ), cb_onlyExistingTypes->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  settings.setValue( baseKey + QStringLiteral( "/includeGeoAttributes" ), cb_includeGeoAttributes->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  settings.setValue( baseKey + QStringLiteral( "/saveUsername" ), chkStoreUsername->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  settings.setValue( baseKey + QStringLiteral( "/savePassword" ), chkStorePassword->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  settings.setValue( baseKey + QStringLiteral( "/dboptions" ), txtOptions->text() );
+  settings.setValue( baseKey + QStringLiteral( "/dbworkspace" ), txtWorkspace->text() );
 
   QDialog::accept();
 }
 
-void QgsOracleNewConnection::on_btnConnect_clicked()
+void QgsOracleNewConnection::testConnection()
 {
   QgsDataSourceUri uri;
   uri.setConnection( txtHost->text(), txtPort->text(), txtDatabase->text(), txtUsername->text(), txtPassword->text() );
   if ( !txtOptions->text().isEmpty() )
-    uri.setParam( "dboptions", txtOptions->text() );
+    uri.setParam( QStringLiteral( "dboptions" ), txtOptions->text() );
   if ( !txtWorkspace->text().isEmpty() )
-    uri.setParam( "dbworkspace", txtWorkspace->text() );
+    uri.setParam( QStringLiteral( "dbworkspace" ), txtWorkspace->text() );
 
   QgsOracleConn *conn = QgsOracleConnPool::instance()->acquireConnection( QgsOracleConn::toPoolName( uri ) );
 
@@ -163,13 +165,6 @@ void QgsOracleNewConnection::on_btnConnect_clicked()
                       Qgis::Warning );
   }
 }
-
-//! End  Autoconnected SLOTS *
-
-QgsOracleNewConnection::~QgsOracleNewConnection()
-{
-}
-
 
 void QgsOracleNewConnection::showHelp()
 {

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -30,6 +30,9 @@ QgsOracleNewConnection::QgsOracleNewConnection( QWidget *parent, const QString &
   , mOriginalConnName( connName )
 {
   setupUi( this );
+
+  txtSchema->setShowClearButton( true );
+
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsOracleNewConnection::showHelp );
   connect( btnConnect, &QPushButton::clicked, this, &QgsOracleNewConnection::testConnection );
 
@@ -50,6 +53,7 @@ QgsOracleNewConnection::QgsOracleNewConnection( QWidget *parent, const QString &
     txtPort->setText( port );
     txtOptions->setText( settings.value( key + QStringLiteral( "/dboptions" ) ).toString() );
     txtWorkspace->setText( settings.value( key + QStringLiteral( "/dbworkspace" ) ).toString() );
+    txtSchema->setText( settings.value( key + QStringLiteral( "/schema" ) ).toString() );
     cb_userTablesOnly->setChecked( settings.value( key + QStringLiteral( "/userTablesOnly" ), false ).toBool() );
     cb_geometryColumnsOnly->setChecked( settings.value( key + QStringLiteral( "/geometryColumnsOnly" ), true ).toBool() );
     cb_allowGeometrylessTables->setChecked( settings.value( key + QStringLiteral( "/allowGeometrylessTables" ), false ).toBool() );
@@ -136,6 +140,7 @@ void QgsOracleNewConnection::accept()
   settings.setValue( baseKey + QStringLiteral( "/savePassword" ), chkStorePassword->isChecked() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
   settings.setValue( baseKey + QStringLiteral( "/dboptions" ), txtOptions->text() );
   settings.setValue( baseKey + QStringLiteral( "/dbworkspace" ), txtWorkspace->text() );
+  settings.setValue( baseKey + QStringLiteral( "/schema" ), txtSchema->text() );
 
   QDialog::accept();
 }

--- a/src/providers/oracle/qgsoraclenewconnection.h
+++ b/src/providers/oracle/qgsoraclenewconnection.h
@@ -31,15 +31,16 @@ class QgsOracleNewConnection : public QDialog, private Ui::QgsOracleNewConnectio
   public:
     //! Constructor
     QgsOracleNewConnection( QWidget *parent = nullptr, const QString &connName = QString(), Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
-    //! Destructor
-    ~QgsOracleNewConnection();
 
     QString originalConnName() const { return mOriginalConnName; }
     QString connName() const { return txtName->text(); }
 
   public slots:
-    void accept();
-    void on_btnConnect_clicked();
+    void accept() override;
+
+  private slots:
+    void testConnection();
+
   private:
     QString mOriginalConnName; //store initial name to delete entry in case of rename
     void showHelp();

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -44,7 +44,7 @@ QWidget *QgsOracleSourceSelectDelegate::createEditor( QWidget *parent, const QSt
 
   QString tableName = index.sibling( index.row(), QgsOracleTableModel::DbtmTable ).data( Qt::DisplayRole ).toString();
   if ( tableName.isEmpty() )
-    return 0;
+    return nullptr;
 
   if ( index.column() == QgsOracleTableModel::DbtmSql )
   {
@@ -515,6 +515,7 @@ void QgsOracleSourceSelect::on_btnConnect_clicked()
   mTablesTreeDelegate->setConnectionInfo( uri );
 
   mColumnTypeThread = new QgsOracleColumnTypeThread( cmbConnections->currentText(),
+      QgsOracleConn::restrictToSchema( cmbConnections->currentText() ),
       uri.useEstimatedMetadata(),
       cbxAllowGeometrylessTables->isChecked() );
 

--- a/src/providers/oracle/qgsoraclesourceselect.h
+++ b/src/providers/oracle/qgsoraclesourceselect.h
@@ -91,7 +91,7 @@ class QgsOracleSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qg
     //! Constructor
     QgsOracleSourceSelect( QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::None );
     //! Destructor
-    ~QgsOracleSourceSelect();
+    ~QgsOracleSourceSelect() override;
     //! Populate the connection list combo box
     void populateConnectionList();
     //! String list containing the selected tables
@@ -130,7 +130,7 @@ class QgsOracleSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qg
     void on_cmbConnections_currentIndexChanged( const QString &text );
     void setSql( const QModelIndex &index );
     //! Store the selected database
-    void setLayerType( QgsOracleLayerProperty layerProperty );
+    void setLayerType( const QgsOracleLayerProperty &layerProperty );
     void on_mTablesTreeView_clicked( const QModelIndex &index );
     void on_mTablesTreeView_doubleClicked( const QModelIndex &index );
     void treeWidgetSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
@@ -154,7 +154,7 @@ class QgsOracleSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qg
     void setConnectionListPosition();
     // Combine the schema, table and column data into a single string
     // useful for display to the user
-    QString fullDescription( QString schema, QString table, QString column, QString type );
+    QString fullDescription( const QString &schema, const QString &table, const QString &column, const QString &type );
     // The column labels
     QStringList mColumnLabels;
     // Our thread for doing long running queries
@@ -173,7 +173,7 @@ class QgsOracleSourceSelect : public QgsAbstractDataSourceWidget, private Ui::Qg
     QPushButton *mAddButton = nullptr;
 
     void finishList();
-    bool mIsConnected;
+    bool mIsConnected = false;
 
     void showHelp();
 

--- a/src/ui/qgsoraclenewconnectionbase.ui
+++ b/src/ui/qgsoraclenewconnectionbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>529</height>
+    <height>637</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -54,36 +54,6 @@
       <string>Connection Information</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_1">
-      <item row="9" column="0" colspan="2">
-       <widget class="QCheckBox" name="chkStorePassword">
-        <property name="text">
-         <string>Save Password</string>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_useEstimatedMetadata">
-        <property name="toolTip">
-         <string>Use estimated table statistics for the layer metadata.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the layer is setup various metadata is required for the Oracle table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;&lt;p&gt;1) Row count is determined from all_tables.num_rows.&lt;/p&gt;&lt;p&gt;2) Table extents are always determined with the SDO_TUNE.EXTENTS_OF function even if a layer filter is applied.&lt;/p&gt;&lt;p&gt;3) The table geometry is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Use estimated table metadata</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="TextLabel3_2">
-        <property name="text">
-         <string>Password</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtPassword</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="0">
        <widget class="QLabel" name="TextLabel3">
         <property name="text">
@@ -94,131 +64,8 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Database</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtDatabase</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="TextLabel1_2">
-        <property name="text">
-         <string>Name</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtName</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="10" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
-        <property name="toolTip">
-         <string>Restrict the displayed tables to those that are in the all_sdo_geom_metadata table</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restricts the displayed tables to those that are in the all_sdo_geom_metadata view. This can speed up the initial display of spatial tables.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Only look in meta data table</string>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_userTablesOnly">
-        <property name="toolTip">
-         <string>When searching for spatial tables restrict the search to tables that are owned by the user.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When searching for spatial tables restrict the search to tables that are owned by the user.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Only look for user's tables</string>
-        </property>
-       </widget>
-      </item>
-      <item row="12" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_allowGeometrylessTables">
-        <property name="text">
-         <string>Also list tables with no geometry</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="TextLabel2_2">
-        <property name="text">
-         <string>Port</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtPort</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="TextLabel1">
-        <property name="text">
-         <string>Host</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtHost</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0" colspan="3">
-       <widget class="QCheckBox" name="cb_onlyExistingTypes">
-        <property name="toolTip">
-         <string>Only list the existing geometry types and don't offer to add others.</string>
-        </property>
-        <property name="whatsThis">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the layer is setup various metadata is required for the Oracle table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;&lt;p&gt;1) Row count is determined from all_tables.num_rows.&lt;/p&gt;&lt;p&gt;2) Table extents are always determined with the SDO_TUNE.EXTENTS_OF function even if a layer filter is applied.&lt;/p&gt;&lt;p&gt;3) The table geometry is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Only existing geometry types</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="2" rowspan="2">
-       <widget class="QPushButton" name="btnConnect">
-        <property name="text">
-         <string>&amp;Test Connect</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtUsername"/>
-      </item>
-      <item row="8" column="0" colspan="2">
-       <widget class="QCheckBox" name="chkStoreUsername">
-        <property name="text">
-         <string>Save Username</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1" colspan="2">
        <widget class="QLineEdit" name="txtDatabase"/>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtName">
-        <property name="toolTip">
-         <string>Name of the new connection</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtHost"/>
-      </item>
-      <item row="5" column="1" colspan="2">
-       <widget class="QgsPasswordLineEdit" name="txtPassword">
-        <property name="echoMode">
-         <enum>QLineEdit::Password</enum>
-        </property>
-       </widget>
       </item>
       <item row="3" column="1" colspan="2">
        <widget class="QLineEdit" name="txtPort">
@@ -227,13 +74,17 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="TextLabel3_3">
-        <property name="text">
-         <string>Options</string>
+      <item row="0" column="1" colspan="2">
+       <widget class="QLineEdit" name="txtName">
+        <property name="toolTip">
+         <string>Name of the new connection</string>
         </property>
-        <property name="buddy">
-         <cstring>txtPassword</cstring>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QgsPasswordLineEdit" name="txtPassword">
+        <property name="echoMode">
+         <enum>QLineEdit::Password</enum>
         </property>
        </widget>
       </item>
@@ -244,10 +95,26 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1" colspan="2">
-       <widget class="QLineEdit" name="txtWorkspace">
-        <property name="echoMode">
-         <enum>QLineEdit::Normal</enum>
+      <item row="10" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkStorePassword">
+        <property name="text">
+         <string>Save password</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1" colspan="2">
+       <widget class="QLineEdit" name="txtHost"/>
+      </item>
+      <item row="11" column="0" colspan="3">
+       <widget class="QCheckBox" name="cb_geometryColumnsOnly">
+        <property name="toolTip">
+         <string>Restrict the displayed tables to those that are in the all_sdo_geom_metadata table</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Restricts the displayed tables to those that are in the all_sdo_geom_metadata view. This can speed up the initial display of spatial tables.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Only look in metadata table</string>
         </property>
        </widget>
       </item>
@@ -261,7 +128,100 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Database</string>
+        </property>
+        <property name="buddy">
+         <cstring>txtDatabase</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="2" rowspan="2">
+       <widget class="QPushButton" name="btnConnect">
+        <property name="text">
+         <string>&amp;Test Connect</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkStoreUsername">
+        <property name="text">
+         <string>Save username</string>
+        </property>
+       </widget>
+      </item>
       <item row="15" column="0" colspan="3">
+       <widget class="QCheckBox" name="cb_onlyExistingTypes">
+        <property name="toolTip">
+         <string>Only list the existing geometry types and don't offer to add others.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the layer is setup various metadata is required for the Oracle table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;&lt;p&gt;1) Row count is determined from all_tables.num_rows.&lt;/p&gt;&lt;p&gt;2) Table extents are always determined with the SDO_TUNE.EXTENTS_OF function even if a layer filter is applied.&lt;/p&gt;&lt;p&gt;3) The table geometry is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Only existing geometry types</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1" colspan="2">
+       <widget class="QLineEdit" name="txtUsername"/>
+      </item>
+      <item row="12" column="0" colspan="3">
+       <widget class="QCheckBox" name="cb_userTablesOnly">
+        <property name="toolTip">
+         <string>When searching for spatial tables restrict the search to tables that are owned by the user.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When searching for spatial tables restrict the search to tables that are owned by the user.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Only look for user's tables</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
+       <widget class="QLineEdit" name="txtWorkspace">
+        <property name="echoMode">
+         <enum>QLineEdit::Normal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="TextLabel3_3">
+        <property name="text">
+         <string>Options</string>
+        </property>
+        <property name="buddy">
+         <cstring>txtPassword</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="0" colspan="3">
+       <widget class="QCheckBox" name="cb_useEstimatedMetadata">
+        <property name="toolTip">
+         <string>Use estimated table statistics for the layer metadata.</string>
+        </property>
+        <property name="whatsThis">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When the layer is setup various metadata is required for the Oracle table. This includes information such as the table row count, geometry type and spatial extents of the data in the geometry column. If the table contains a large number of rows determining this metadata is time consuming.&lt;/p&gt;&lt;p&gt;By activating this option the following fast table metadata operations are done:&lt;/p&gt;&lt;p&gt;1) Row count is determined from all_tables.num_rows.&lt;/p&gt;&lt;p&gt;2) Table extents are always determined with the SDO_TUNE.EXTENTS_OF function even if a layer filter is applied.&lt;/p&gt;&lt;p&gt;3) The table geometry is determined from the first 100 non-null geometry rows in the table.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Use estimated table metadata</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="TextLabel2_2">
+        <property name="text">
+         <string>Port</string>
+        </property>
+        <property name="buddy">
+         <cstring>txtPort</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="16" column="0" colspan="3">
        <widget class="QCheckBox" name="cb_includeGeoAttributes">
         <property name="toolTip">
          <string/>
@@ -271,6 +231,66 @@
         </property>
         <property name="text">
          <string>Include additional geometry attributes</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="TextLabel3_2">
+        <property name="text">
+         <string>Password</string>
+        </property>
+        <property name="buddy">
+         <cstring>txtPassword</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0" colspan="3">
+       <widget class="QCheckBox" name="cb_allowGeometrylessTables">
+        <property name="text">
+         <string>Also list tables with no geometry</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="TextLabel1_2">
+        <property name="text">
+         <string>Name</string>
+        </property>
+        <property name="buddy">
+         <cstring>txtName</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="TextLabel1">
+        <property name="text">
+         <string>Host</string>
+        </property>
+        <property name="buddy">
+         <cstring>txtHost</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="TextLabel3_5">
+        <property name="text">
+         <string>Schema</string>
+        </property>
+        <property name="buddy">
+         <cstring>txtPassword</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1" colspan="2">
+       <widget class="QgsFilterLineEdit" name="txtSchema">
+        <property name="toolTip">
+         <string>If specified, only tables from the matching schema will be fetched and listed for the provider</string>
+        </property>
+        <property name="echoMode">
+         <enum>QLineEdit::Normal</enum>
         </property>
        </widget>
       </item>
@@ -295,6 +315,11 @@
    <header>qgsmessagebar.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>txtName</tabstop>
@@ -305,6 +330,7 @@
   <tabstop>txtPassword</tabstop>
   <tabstop>txtOptions</tabstop>
   <tabstop>txtWorkspace</tabstop>
+  <tabstop>txtSchema</tabstop>
   <tabstop>chkStoreUsername</tabstop>
   <tabstop>chkStorePassword</tabstop>
   <tabstop>btnConnect</tabstop>
@@ -314,7 +340,6 @@
   <tabstop>cb_useEstimatedMetadata</tabstop>
   <tabstop>cb_onlyExistingTypes</tabstop>
   <tabstop>cb_includeGeoAttributes</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This allows a schema to be set in the connection properties for an oracle db connection. If set, only tables within that schema will be scanned and listed for the connection.

Previously the option existed to restrict the scan to tables which belong to the user, but this option does not support the use case where a connection must access tables from a different user, and the default "scan everything" setting is too expensive (since it often takes multiple minutes to perform, especially
when geometryless tables are shown).

![schema](https://user-images.githubusercontent.com/1829991/38791105-0d375264-4189-11e8-82c5-b224c0aaa860.png)

Sponsored by Open Spatial (http://www.openspatial.com)
