### PR TITLE
Use relation id instead of name for nesting detection

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -76,7 +76,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
   // If this widget is already embedded by the same relation, reduce functionality
   do
   {
-    if ( ctx->relation().name() == relation.name() )
+    if ( ctx->relation().id() == relation.id() )
     {
       mWidget->setEmbedForm( false );
       mWidget->setReadOnlySelector( true );


### PR DESCRIPTION
Relation reference widgets use "nesting detection" and reduce their functionality in case they are embedded in a cyclic way. In such a scenario they will show up as simple line edit instead of combobox.

This detection often fired when inappropriate because so far the name (and not the id) was used for this detection and in the case the name was left empty, this triggered even when it was not embedded in a relation.