### PR TITLE
Fix identify tool with rule renderer and nested else

### DIFF
--- a/src/core/symbology/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology/qgsrulebasedrenderer.cpp
@@ -549,15 +549,22 @@ bool QgsRuleBasedRenderer::Rule::willRenderFeature( QgsFeature &feat, QgsRenderC
   {
     if ( rule->isElse() )
     {
-      RuleList lst = rulesForFeature( feat, context, false );
-      lst.removeOne( rule );
-
-      if ( lst.empty() )
+      if ( rule->children().isEmpty() )
       {
-        return true;
+        RuleList lst = rulesForFeature( feat, context, false );
+        lst.removeOne( rule );
+
+        if ( lst.empty() )
+        {
+          return true;
+        }
+      }
+      else
+      {
+        return rule->willRenderFeature( feat, context );
       }
     }
-    else if ( !rule->isElse( ) && rule->willRenderFeature( feat, context ) )
+    else if ( rule->willRenderFeature( feat, context ) )
     {
       return true;
     }


### PR DESCRIPTION
See https://github.com/qgis/QGIS/pull/6679#issuecomment-381890447

Nested else rules would no longer work with the identify tool

![image](https://user-images.githubusercontent.com/588407/38856467-d970b684-4226-11e8-9c2f-5915f9920ea0.png)