### PR TITLE
[feature][processing] Add save/clear/copy log actions

### DIFF
--- a/python/gui/processing/qgsprocessingalgorithmdialogbase.sip.in
+++ b/python/gui/processing/qgsprocessingalgorithmdialogbase.sip.in
@@ -28,6 +28,12 @@ class QgsProcessingAlgorithmDialogBase : QDialog
 %End
   public:
 
+    enum LogFormat
+    {
+      FormatPlainText,
+      FormatHtml,
+    };
+
     QgsProcessingAlgorithmDialogBase( QWidget *parent = 0, Qt::WindowFlags flags = 0 );
 %Docstring
 Constructor for QgsProcessingAlgorithmDialogBase.
@@ -95,6 +101,16 @@ slots in this dialog.
 Returns the parameter values for the algorithm to run in the dialog.
 %End
 
+    void saveLogToFile( const QString &path, LogFormat format = FormatPlainText );
+%Docstring
+Saves the log contents to a text file (specified by the file ``path``), in
+the given ``format``.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`saveLog`
+%End
+
   public slots:
 
     virtual void accept();
@@ -141,6 +157,29 @@ Pushes a console info string to the dialog's log.
 %Docstring
 Creates a modal progress dialog showing progress and log messages
 from this dialog.
+%End
+
+    void clearLog();
+%Docstring
+Clears the current log contents.
+
+.. versionadded:: 3.2
+%End
+
+    void saveLog();
+%Docstring
+Opens a dialog allowing users to save the current log contents.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`saveLogToFile`
+%End
+
+    void copyLogToClipboard();
+%Docstring
+Copies the current log contents to the clipboard.
+
+.. versionadded:: 3.2
 %End
 
   protected:

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -200,7 +200,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             self.setProgressText(QCoreApplication.translate('AlgorithmDialog', 'Processing algorithm…'))
 
             self.setInfo(
-                self.tr('AlgorithmDialog', '<b>Algorithm \'{0}\' starting&hellip;</b>').format(self.algorithm().displayName()), escapeHtml=False)
+                QCoreApplication.translate('AlgorithmDialog', '<b>Algorithm \'{0}\' starting&hellip;</b>').format(self.algorithm().displayName()), escapeHtml=False)
 
             feedback.pushInfo(self.tr('Input parameters:'))
             display_params = []

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.h
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.h
@@ -86,6 +86,16 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
   public:
 
     /**
+     * Log format options.
+     * \since QGIS 3.2
+     */
+    enum LogFormat
+    {
+      FormatPlainText, //!< Plain text file (.txt)
+      FormatHtml, //!< HTML file (.html)
+    };
+
+    /**
      * Constructor for QgsProcessingAlgorithmDialogBase.
      */
     QgsProcessingAlgorithmDialogBase( QWidget *parent = nullptr, Qt::WindowFlags flags = nullptr );
@@ -144,6 +154,14 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      */
     virtual QVariantMap getParameterValues() const;
 
+    /**
+     * Saves the log contents to a text file (specified by the file \a path), in
+     * the given \a format.
+     * \since QGIS 3.2
+     * \see saveLog()
+     */
+    void saveLogToFile( const QString &path, LogFormat format = FormatPlainText );
+
   public slots:
 
     void accept() override;
@@ -190,6 +208,25 @@ class GUI_EXPORT QgsProcessingAlgorithmDialogBase : public QDialog, private Ui::
      * from this dialog.
      */
     QDialog *createProgressDialog();
+
+    /**
+     * Clears the current log contents.
+     * \since QGIS 3.2
+     */
+    void clearLog();
+
+    /**
+     * Opens a dialog allowing users to save the current log contents.
+     * \since QGIS 3.2
+     * \see saveLogToFile()
+     */
+    void saveLog();
+
+    /**
+     * Copies the current log contents to the clipboard.
+     * \since QGIS 3.2
+     */
+    void copyLogToClipboard();
 
   protected:
 

--- a/src/ui/processing/qgsprocessingalgorithmdialogbase.ui
+++ b/src/ui/processing/qgsprocessingalgorithmdialogbase.ui
@@ -87,6 +87,77 @@
           </property>
          </widget>
         </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QToolButton" name="mButtonSaveLog">
+            <property name="toolTip">
+             <string>Save Log to File</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../images/images.qrc">
+              <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
+            </property>
+            <property name="autoRaise">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="mButtonCopyLog">
+            <property name="toolTip">
+             <string>Copy Log to Clipboard</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../images/images.qrc">
+              <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+            </property>
+            <property name="autoRaise">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="mButtonClearLog">
+            <property name="toolTip">
+             <string>Clear Log</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../images/images.qrc">
+              <normaloff>:/images/themes/default/console/iconClearConsole.svg</normaloff>:/images/themes/default/console/iconClearConsole.svg</iconset>
+            </property>
+            <property name="autoRaise">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
       </widget>
      </widget>
@@ -146,6 +217,37 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
In the algorithm execution dialog, this adds buttons to allow users to save the current log (to text or HTML files), copy the log contents to the clipboard, and clear the log.

![log](https://user-images.githubusercontent.com/1829991/38966764-307319bc-43c7-11e8-8cf4-cf43ba267db0.png)
