### PR TITLE
[processing] Add API for specifying logical parameter groups

### DIFF
--- a/python/core/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/processing/qgsprocessingalgorithm.sip.in
@@ -48,6 +48,25 @@ Abstract base class for processing algorithms.
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;
 
 
+    enum LogicalParameterGroupType
+    {
+      AtLeastOneRequired,
+      AllRequired,
+      MutuallyExclusiveOptional,
+      MutuallyExclusiveRequired,
+    };
+
+    struct LogicalParameterGroup
+    {
+      QString name;
+
+      LogicalParameterGroupType type;
+
+      QSet<QString> parameters;
+
+      QList< QgsProcessingAlgorithm::LogicalParameterGroup > childGroups;
+    };
+
     QgsProcessingAlgorithm();
 %Docstring
 Constructor for QgsProcessingAlgorithm.
@@ -437,6 +456,24 @@ occur.
 %Docstring
 Removes the parameter with matching ``name`` from the algorithm, and deletes any existing
 definition.
+%End
+
+    void addLogicalParameterGroup( const QgsProcessingAlgorithm::LogicalParameterGroup &group );
+%Docstring
+Adds a new logical parameter ``group`` to the algorithm. Logical parameter groups specify how sets of related optional parameters are handled.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`logicalParameterGroups`
+%End
+
+    QList< QgsProcessingAlgorithm::LogicalParameterGroup > logicalParameterGroups() const;
+%Docstring
+Returns the list of logical parameter groups used by the algorithm.
+
+.. versionadded:: 3.2
+
+.. seealso:: :py:func:`addLogicalParameterGroup`
 %End
 
     bool addOutput( QgsProcessingOutputDefinition *outputDefinition /Transfer/ );

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -211,6 +211,23 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
                     line = line.strip('\n').strip()
                     if line.startswith('Hardcoded'):
                         self.hardcodedStrings.append(line[len('Hardcoded|'):])
+                    elif line.startswith('#logical_group='):
+                        # group
+                        line = line[15:]
+                        group = QgsProcessingAlgorithm.LogicalParameterGroup()
+                        if line.lower().startswith('atleastonerequired'):
+                            group.type = QgsProcessingAlgorithm.AtLeastOneRequired
+                        elif line.lower().startswith('allrequired'):
+                            group.type = QgsProcessingAlgorithm.AllRequired
+                        elif line.lower().startswith('mutuallyexclusiveoptional'):
+                            group.type = QgsProcessingAlgorithm.MutuallyExclusiveOptional
+                        elif line.lower().startswith('mutuallyexclusiverequired'):
+                            group.type = QgsProcessingAlgorithm.MutuallyExclusiveRequired
+                        line = ''.join(line.split(':')[1:])
+                        parts = line.split('|')
+                        group.parameters = set(parts)
+                        self.addLogicalParameterGroup(group)
+                        continue
                     parameter = getParameterFromString(line)
                     if parameter is not None:
                         self.params.append(parameter)

--- a/python/plugins/processing/algs/grass7/description/r.cost.txt
+++ b/python/plugins/processing/algs/grass7/description/r.cost.txt
@@ -15,3 +15,4 @@ QgsProcessingParameterNumber|memory|Maximum memory to be used in MB|QgsProcessin
 QgsProcessingParameterRasterDestination|output|Cumulative cost|None|True
 QgsProcessingParameterRasterDestination|nearest|Cost allocation map|None|True
 QgsProcessingParameterRasterDestination|outdir|Movement directions|None|True
+#logical_group=MutuallyExclusiveRequired:start_coordinates|start_points|start_raster

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -183,7 +183,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             ok, msg = self.algorithm().checkParameterValues(parameters, context)
             if msg:
                 self.messageBar().pushMessage("", msg,
-                                          level=Qgis.Warning, duration=5)
+                                              level=Qgis.Warning, duration=5)
                 return
             self.runButton().setEnabled(False)
             self.cancelButton().setEnabled(False)

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -182,8 +182,8 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
                     return
             ok, msg = self.algorithm().checkParameterValues(parameters, context)
             if msg:
-                QMessageBox.warning(
-                    self, self.tr('Unable to execute algorithm'), msg)
+                self.messageBar().pushMessage("", msg,
+                                          level=Qgis.Warning, duration=5)
                 return
             self.runButton().setEnabled(False)
             self.cancelButton().setEnabled(False)

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -97,7 +97,7 @@ bool QgsProcessingAlgorithm::checkParameterValues( const QVariantMap &parameters
 
   std::function< bool( const QgsProcessingAlgorithm::LogicalParameterGroup &group, State &state ) > checkGroup;
 
-  checkGroup = [&parameters, &checkGroup, message, &messageStack]( const QgsProcessingAlgorithm::LogicalParameterGroup & group, State & state )->bool
+  checkGroup = [&parameters, &checkGroup, &messageStack]( const QgsProcessingAlgorithm::LogicalParameterGroup & group, State & state )->bool
   {
     int countSpecified = 0;
     int countMaybeSpecified = 0;

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -78,6 +78,43 @@ class CORE_EXPORT QgsProcessingAlgorithm
     Q_DECLARE_FLAGS( Flags, Flag )
 
     /**
+     * Parameter group types.
+     * \since QGIS 3.2
+    */
+    enum LogicalParameterGroupType
+    {
+      AtLeastOneRequired, //!< At least one of the grouped parameters must be specified, and more than one may be specified
+      AllRequired, //! All grouped parameters must be specified
+      MutuallyExclusiveOptional, //!< At most one of the grouped parameters must be specified
+      MutuallyExclusiveRequired, //!< One parameter from the group MUST be specified
+    };
+
+    /**
+     * Contains settings related to a single group of linked parameters.
+     *
+     * Both the group's parameters and childGroups are considered when
+     * validating the group - so a group with type AllRequired
+     * will only be valid if all parameters listed by parameter name
+     * AND all childGroups are valid.
+     *
+     * \since QGIS 3.2
+    */
+    struct LogicalParameterGroup
+    {
+      //! Group name, used for notifying users of validation errors
+      QString name;
+
+      //! Type of group
+      LogicalParameterGroupType type = AllRequired;
+
+      //! Names of parameters contained within the group
+      QSet<QString> parameters;
+
+      //! Child groups
+      QList< QgsProcessingAlgorithm::LogicalParameterGroup > childGroups;
+    };
+
+    /**
      * Constructor for QgsProcessingAlgorithm.
      *
      * initAlgorithm() should be called after creating an algorithm to ensure it can correctly configure
@@ -443,6 +480,22 @@ class CORE_EXPORT QgsProcessingAlgorithm
     void removeParameter( const QString &name );
 
     /**
+     * Adds a new logical parameter \a group to the algorithm. Logical parameter groups specify how sets of related optional parameters are handled.
+     *
+     * \since QGIS 3.2
+     * \see logicalParameterGroups()
+     */
+    void addLogicalParameterGroup( const QgsProcessingAlgorithm::LogicalParameterGroup &group );
+
+    /**
+     * Returns the list of logical parameter groups used by the algorithm.
+     *
+     * \since QGIS 3.2
+     * \see addLogicalParameterGroup()
+     */
+    QList< QgsProcessingAlgorithm::LogicalParameterGroup > logicalParameterGroups() const;
+
+    /**
      * Adds an output \a definition to the algorithm. Ownership of the definition is transferred to the algorithm.
      * Returns true if the output could be successfully added, or false if the output could not be added (e.g.
      * as a result of a duplicate name).
@@ -748,6 +801,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
 
     QgsProcessingProvider *mProvider = nullptr;
     QgsProcessingParameterDefinitions mParameters;
+    QgsProcessingAlgorithm::LogicalParameterGroup mLogicalParameterGroups;
     QgsProcessingOutputDefinitions mOutputs;
     bool mHasPrepared = false;
     bool mHasExecuted = false;
@@ -759,6 +813,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
     friend class QgsProcessingProvider;
     friend class TestQgsProcessing;
     friend class QgsProcessingModelAlgorithm;
+    friend class DummyAlgorithm;
 
 #ifdef SIP_RUN
     QgsProcessingAlgorithm( const QgsProcessingAlgorithm &other );


### PR DESCRIPTION
Implements a revised version of https://github.com/qgis/QGIS-Enhancement-Proposals/issues/120, taking into account @wonder-sk's more advanced logic requirements.

Initially only a single grass algorithm utilises this (r.cost, for the start coordinate parameters) as a test.