### PR TITLE
[FEATURE] Copy statistics panel content to clipboard button

### DIFF
--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -126,6 +126,11 @@ class APP_EXPORT QgsStatisticalSummaryDockWidget : public QgsDockWidget, private
   public slots:
 
     /**
+     * Copy the displayed statistics to the clipboard
+     */
+    void copyStatistics();
+
+    /**
      * Recalculates the displayed statistics
      */
     void refreshStatistics();

--- a/src/ui/qgsstatisticalsummarybase.ui
+++ b/src/ui/qgsstatisticalsummarybase.ui
@@ -103,6 +103,23 @@
        </widget>
       </item>
       <item>
+       <widget class="QToolButton" name="mButtonCopy">
+        <property name="toolTip">
+         <string>Copy Statistics to Clipboard</string>
+        </property>
+        <property name="text">
+         <string>…</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionEditCopy.svg</normaloff>:/images/themes/default/mActionEditCopy.svg</iconset>
+        </property>
+        <property name="autoRaise">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QToolButton" name="mButtonRefresh">
         <property name="toolTip">
          <string>Recalculate Statistics</string>


### PR DESCRIPTION
## Description
Because re-typing large numbers into a spreadsheet is the perfect recipe for calculation typos, let's offer users a "copy to clipboard" button in the statistics panel.

Screenshot of UI:
![screenshot from 2018-04-20 13-24-15](https://user-images.githubusercontent.com/1728657/39033886-6ad2efba-449e-11e8-8e55-7cfdecd03448.png)

@nyalldawson , review appreciated.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
