### PR TITLE
Add locale de_CH

### DIFF
--- a/i18n/CMakeLists.txt
+++ b/i18n/CMakeLists.txt
@@ -22,7 +22,47 @@ ENDMACRO(ADD_TRANSLATION_FILES)
 # make sure the output directory exists
 file(MAKE_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/i18n)
 
-SET(TS_FILES qgis_ar.ts qgis_bg.ts qgis_bs.ts qgis_ca.ts qgis_cs.ts qgis_da.ts qgis_de.ts qgis_el.ts qgis_eo.ts qgis_es.ts qgis_et.ts qgis_eu.ts qgis_fi.ts qgis_fr.ts qgis_gl.ts qgis_hi.ts qgis_hu.ts qgis_id.ts qgis_is.ts qgis_it.ts qgis_ja.ts qgis_km.ts qgis_ko.ts qgis_ky.ts qgis_lt.ts qgis_lv.ts qgis_nb.ts qgis_nl.ts qgis_pl.ts qgis_pt_BR.ts qgis_pt_PT.ts qgis_ro.ts qgis_ru.ts qgis_sl.ts qgis_sv.ts qgis_tr.ts qgis_uk.ts qgis_vi.ts qgis_zh-Hans.ts qgis_zh-Hant.ts)
+SET(TS_FILES
+qgis_ar.ts
+qgis_bg.ts
+qgis_bs.ts
+qgis_ca.ts
+qgis_cs.ts
+qgis_da.ts
+qgis_de.ts
+qgis_el.ts
+qgis_eo.ts
+qgis_es.ts
+qgis_et.ts
+qgis_eu.ts
+qgis_fi.ts
+qgis_fr.ts
+qgis_gl.ts
+qgis_hi.ts
+qgis_hu.ts
+qgis_id.ts
+qgis_is.ts
+qgis_it.ts
+qgis_ja.ts
+qgis_km.ts
+qgis_ko.ts
+qgis_ky.ts
+qgis_lt.ts
+qgis_lv.ts
+qgis_nb.ts
+qgis_nl.ts
+qgis_pl.ts
+qgis_pt_BR.ts
+qgis_pt_PT.ts
+qgis_ro.ts
+qgis_ru.ts
+qgis_sl.ts
+qgis_sv.ts
+qgis_tr.ts
+qgis_uk.ts
+qgis_vi.ts
+qgis_zh-Hans.ts
+qgis_zh-Hant.ts)
 
 ADD_TRANSLATION_FILES (QM_FILES ${TS_FILES})
 

--- a/i18n/CMakeLists.txt
+++ b/i18n/CMakeLists.txt
@@ -30,6 +30,7 @@ qgis_ca.ts
 qgis_cs.ts
 qgis_da.ts
 qgis_de.ts
+qgis_de_CH.ts
 qgis_el.ts
 qgis_eo.ts
 qgis_es.ts

--- a/i18n/qgis_de_CH.ts
+++ b/i18n/qgis_de_CH.ts
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_CH">
+</TS>


### PR DESCRIPTION
The reason for this is mostly, that the de locale represents the decimal point as comma `,` while Swiss people like points `.`.

So far the whole translation internally falls back to de (automatically) and the .ts file is empty. I'm not sure how this is handled if the .ts file is filled with values, I just hope an `unfinished` translation will also fallback.

It would be even better if transifex would be aware of this (i.e. a potential Swiss translator would be able to see on the interface if there's a fallback available for a term and then be able to choose if he overwrites in `de_CH` or changes the base `de`)

The main risk I see is an increased useless workload on translators maintaining two almost completely equal translations in (Swiss-)German. Are there experiences with this from Portuguese?

TODO:

 - [ ] Decide if this is the appropriate approach
 - [ ] If yes, add flag icon

@rduivenvoorde @jef-n @mach0 