### PR TITLE
[oracle] Always check bounding box intersection when using filter rect 

### DIFF
--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -308,22 +308,22 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
       {
         if ( !feature.hasGeometry() )
         {
-          QgsDebugMsg( QStringLiteral( "no geometry to intersect" ) );
+          QgsDebugMsgLevel( QStringLiteral( "no geometry to intersect" ), 4 );
           continue;
         }
 
         if ( ( mRequest.flags() & QgsFeatureRequest::ExactIntersect ) == 0 )
         {
-          // couldn't use sdo_filter earlier
-          if ( !mSource->mHasSpatialIndex )
+          // even if we could use sdo_filter earlier, we still need to double-check the results
+          // as sdo_filter can return results outside the filter (it's only a first-pass
+          // filtering operation!)
+
+          // only want features which intersect with bbox
+          if ( !feature.geometry().boundingBox().intersects( mFilterRect ) )
           {
-            // only intersect with bbox
-            if ( !feature.geometry().boundingBox().intersects( mFilterRect ) )
-            {
-              // skip feature that don't intersect with our rectangle
-              QgsDebugMsg( QStringLiteral( "no bbox intersect" ) );
-              continue;
-            }
+            // skip feature that don't intersect with our rectangle
+            QgsDebugMsgLevel( QStringLiteral( "no bbox intersect" ), 4 );
+            continue;
           }
         }
         else if ( !mConnection->hasSpatial() || !mSource->mHasSpatialIndex )
@@ -332,7 +332,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature &feature )
           if ( !feature.geometry().intersects( mFilterRect ) )
           {
             // skip feature that don't intersect with our rectangle
-            QgsDebugMsg( QStringLiteral( "no exact intersect" ) );
+            QgsDebugMsgLevel( QStringLiteral( "no exact intersect" ), 4 );
             continue;
           }
         }


### PR DESCRIPTION
Because oracle sdo_filter sometimes returns results outside
the given filter (depending on the spatial index), and is
only designed for use as a fast "first-pass" filter.

From the Oracle docs:

"This operator performs only a primary filter operation..

The secondary filtering operation, performed by the SDO_RELATE operator,
can be used to determine with certainty if objects interact spatially."

Instead of using SDO_RELATE we can instead just do a bounding
box intersection inside QGIS if an exact intersection is not
required.

Fixes failing provider conformance test suite for oracle provider due to provider returning point features outside the requested filter rect.