### PR TITLE
Report more parser errors in expression parser

### DIFF
--- a/python/core/expression/qgsexpression.sip.in
+++ b/python/core/expression/qgsexpression.sip.in
@@ -79,6 +79,8 @@ Implicit sharing was added in 2.14
 
       ParserErrorType errorType;
 
+      QString errorMsg;
+
       int firstLine;
 
       int firstColumn;
@@ -133,7 +135,7 @@ Returns true if an error occurred when parsing the input expression
 Returns parser error
 %End
 
-    ParserError parserError() const;
+    QList<QgsExpression::ParserError> parserErrors() const;
 %Docstring
 Returns parser error details including location of error.
 

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -26,7 +26,7 @@
 
 
 // from parser
-extern QgsExpressionNode *parseExpression( const QString &str, QString &parserErrorMsg, QgsExpression::ParserError &parserError );
+extern QgsExpressionNode *parseExpression( const QString &str, QString &parserErrorMsg, QList<QgsExpression::ParserError> &parserErrors );
 
 ///////////////////////////////////////////////
 // QVariant checks and conversions
@@ -99,7 +99,7 @@ bool QgsExpression::checkExpression( const QString &text, const QgsExpressionCon
 void QgsExpression::setExpression( const QString &expression )
 {
   detach();
-  d->mRootNode = ::parseExpression( expression, d->mParserErrorString, d->mParserError );
+  d->mRootNode = ::parseExpression( expression, d->mParserErrorString, d->mParserErrors );
   d->mEvalErrorString = QString();
   d->mExp = expression;
 }
@@ -195,7 +195,7 @@ int QgsExpression::functionCount()
 QgsExpression::QgsExpression( const QString &expr )
   : d( new QgsExpressionPrivate )
 {
-  d->mRootNode = ::parseExpression( expr, d->mParserErrorString, d->mParserError );
+  d->mRootNode = ::parseExpression( expr, d->mParserErrorString, d->mParserErrors );
   d->mExp = expr;
   Q_ASSERT( !d->mParserErrorString.isNull() || d->mRootNode );
 }
@@ -247,7 +247,7 @@ bool QgsExpression::isValid() const
 
 bool QgsExpression::hasParserError() const
 {
-  return !d->mParserErrorString.isNull();
+  return d->mParserErrors.count() > 0;
 }
 
 QString QgsExpression::parserErrorString() const
@@ -255,9 +255,9 @@ QString QgsExpression::parserErrorString() const
   return d->mParserErrorString;
 }
 
-QgsExpression::ParserError QgsExpression::parserError() const
+QList<QgsExpression::ParserError> QgsExpression::parserErrors() const
 {
-  return d->mParserError;
+  return d->mParserErrors;
 }
 
 QSet<QString> QgsExpression::referencedColumns() const
@@ -343,7 +343,7 @@ bool QgsExpression::prepare( const QgsExpressionContext *context )
     //re-parse expression. Creation of QgsExpressionContexts may have added extra
     //known functions since this expression was created, so we have another try
     //at re-parsing it now that the context must have been created
-    d->mRootNode = ::parseExpression( d->mExp, d->mParserErrorString, d->mParserError );
+    d->mRootNode = ::parseExpression( d->mExp, d->mParserErrorString, d->mParserErrors );
   }
 
   if ( !d->mRootNode )

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -136,6 +136,11 @@ class CORE_EXPORT QgsExpression
       ParserErrorType errorType = ParserErrorType::Unknown;
 
       /**
+       * The message for the error at this location.
+       */
+      QString errorMsg;
+
+      /**
        * The first line that contained the error in the parser.
        * Depending on the error sometimes this doesn't mean anything.
        */
@@ -221,7 +226,7 @@ class CORE_EXPORT QgsExpression
      * Returns parser error details including location of error.
      * \since QGIS 3.0
      */
-    ParserError parserError() const;
+    QList<QgsExpression::ParserError> parserErrors() const;
 
     //! Returns root node of the expression. Root node is null is parsing has failed
     const QgsExpressionNode *rootNode() const;

--- a/src/core/qgsexpressionprivate.h
+++ b/src/core/qgsexpressionprivate.h
@@ -44,7 +44,7 @@ class QgsExpressionPrivate
       , mRootNode( other.mRootNode ? other.mRootNode->clone() : nullptr )
       , mParserErrorString( other.mParserErrorString )
       , mEvalErrorString( other.mEvalErrorString )
-      , mParserError( other.mParserError )
+      , mParserErrors( other.mParserErrors )
       , mExp( other.mExp )
       , mCalc( other.mCalc )
       , mDistanceUnit( other.mDistanceUnit )
@@ -63,7 +63,7 @@ class QgsExpressionPrivate
     QString mParserErrorString;
     QString mEvalErrorString;
 
-    QgsExpression::ParserError mParserError;
+    QList<QgsExpression::ParserError> mParserErrors;
 
     QString mExp;
 

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -354,6 +354,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
   private:
     int FUNCTION_MARKER_ID = 25;
+    void createErrorMarkers( QList<QgsExpression::ParserError> errors );
     void createMarkers( const QgsExpressionNode *node );
     void clearFunctionMarkers();
     void clearErrors();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -281,10 +281,10 @@ class TestQgsExpression: public QObject
 
       QgsExpression exp( string );
       QCOMPARE( exp.hasParserError(), true );
-      QCOMPARE( exp.parserError().firstLine, firstLine );
-      QCOMPARE( exp.parserError().firstColumn, firstColumn );
-      QCOMPARE( exp.parserError().lastLine, lastLine );
-      QCOMPARE( exp.parserError().lastColumn, lastColumn );
+      QCOMPARE( exp.parserErrors().first().firstLine, firstLine );
+      QCOMPARE( exp.parserErrors().first().firstColumn, firstColumn );
+      QCOMPARE( exp.parserErrors().first().lastLine, lastLine );
+      QCOMPARE( exp.parserErrors().first().lastColumn, lastColumn );
     }
 
     void parsing_with_locale()


### PR DESCRIPTION
## Description
At the moment the parser will bail on the first error it finds which isn't helpful if there are more errors later on.  This PR adds parser recovery in order to pull out anymore errors we might find in the rest of the string.  The result of this is being able to show all the errors in the string in the expression builder.  The expression will still not be valid but at least we can get the errors out for the user to see.

![image](https://user-images.githubusercontent.com/381660/39094480-6b68a88a-4673-11e8-90a1-220bc4f2940e.png)

Funded by my QGIS dev days at TechnologyOne


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
