### PR TITLE
[FEATURE][needs-docs] Show data defined expected format in expression builder

### DIFF
--- a/python/gui/qgsexpressionbuilderdialog.sip.in
+++ b/python/gui/qgsexpressionbuilderdialog.sip.in
@@ -35,6 +35,26 @@ The builder widget that is used by the dialog
 
     QString expressionText();
 
+    QString expectedOutputFormat();
+%Docstring
+The set expected format string. This is pure text format and no expression validation
+is done against it.
+
+:return: The expected value format.
+%End
+
+    void setExpectedOutputFormat( const QString &expected );
+%Docstring
+The set expected format string. This is pure text format and no expression validation
+is done against it.
+
+:param expected: The expected value format for the expression.
+
+.. note::
+
+   Only a UI hint and not used for expression validation.
+%End
+
     QgsExpressionContext expressionContext() const;
 %Docstring
 Returns the expression context for the dialog. The context is used for the expression

--- a/python/gui/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/qgsexpressionbuilderwidget.sip.in
@@ -153,6 +153,26 @@ Gets the expression string that has been set in the expression area.
 Sets the expression string for the widget
 %End
 
+    QString expectedOutputFormat();
+%Docstring
+The set expected format string. This is pure text format and no expression validation
+is done against it.
+
+:return: The expected value format.
+%End
+
+    void setExpectedOutputFormat( const QString &expected );
+%Docstring
+The set expected format string. This is pure text format and no expression validation
+is done against it.
+
+:param expected: The expected value format for the expression.
+
+.. note::
+
+   Only a UI hint and not used for expression validation.
+%End
+
     QgsExpressionContext expressionContext() const;
 %Docstring
 Returns the expression context for the widget. The context is used for the expression

--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -52,6 +52,16 @@ QString QgsExpressionBuilderDialog::expressionText()
   return builder->expressionText();
 }
 
+QString QgsExpressionBuilderDialog::expectedOutputFormat()
+{
+  return builder->expectedOutputFormat();
+}
+
+void QgsExpressionBuilderDialog::setExpectedOutputFormat( const QString &expected )
+{
+  builder->setExpectedOutputFormat( expected );
+}
+
 QgsExpressionContext QgsExpressionBuilderDialog::expressionContext() const
 {
   return builder->expressionContext();

--- a/src/gui/qgsexpressionbuilderdialog.h
+++ b/src/gui/qgsexpressionbuilderdialog.h
@@ -48,6 +48,21 @@ class GUI_EXPORT QgsExpressionBuilderDialog : public QDialog, private Ui::QgsExp
     QString expressionText();
 
     /**
+     * The set expected format string. This is pure text format and no expression validation
+     * is done against it.
+     * \returns The expected value format.
+     */
+    QString expectedOutputFormat();
+
+    /**
+     * The set expected format string. This is pure text format and no expression validation
+     * is done against it.
+     * \param expected The expected value format for the expression.
+     * \note Only a UI hint and not used for expression validation.
+     */
+    void setExpectedOutputFormat( const QString &expected );
+
+    /**
      * Returns the expression context for the dialog. The context is used for the expression
      * preview result and for populating the list of available functions and variables.
      * \see setExpressionContext

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -143,6 +143,8 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   txtExpressionString->setIndicatorHoverStyle( QgsCodeEditor::DotsIndicator, FUNCTION_MARKER_ID );
 
   connect( txtExpressionString, &QgsCodeEditorSQL::indicatorClicked, this, &QgsExpressionBuilderWidget::indicatorClicked );
+
+  setExpectedOutputFormat( QString() );
 }
 
 
@@ -595,6 +597,17 @@ QString QgsExpressionBuilderWidget::expressionText()
 void QgsExpressionBuilderWidget::setExpressionText( const QString &expression )
 {
   txtExpressionString->setText( expression );
+}
+
+QString QgsExpressionBuilderWidget::expectedOutputFormat()
+{
+  return lblExpected->text();
+}
+
+void QgsExpressionBuilderWidget::setExpectedOutputFormat( const QString &expected )
+{
+  lblExpected->setText( expected );
+  mExpectedOutputFrame->setVisible( !expected.isNull() );
 }
 
 void QgsExpressionBuilderWidget::setExpressionContext( const QgsExpressionContext &context )

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -174,6 +174,21 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void setExpressionText( const QString &expression );
 
     /**
+     * The set expected format string. This is pure text format and no expression validation
+     * is done against it.
+     * \returns The expected value format.
+     */
+    QString expectedOutputFormat();
+
+    /**
+     * The set expected format string. This is pure text format and no expression validation
+     * is done against it.
+     * \param expected The expected value format for the expression.
+     * \note Only a UI hint and not used for expression validation.
+     */
+    void setExpectedOutputFormat( const QString &expected );
+
+    /**
      * Returns the expression context for the widget. The context is used for the expression
      * preview result and for populating the list of available functions and variables.
      * \see setExpressionContext

--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -596,6 +596,7 @@ void QgsPropertyOverrideButton::showExpressionDialog()
                               : mProperty.asExpression();
 
   QgsExpressionBuilderDialog d( const_cast<QgsVectorLayer *>( mVectorLayer ), currentExpression, this, QStringLiteral( "generic" ), context );
+  d.setExpectedOutputFormat( mInputDescription );
   if ( d.exec() == QDialog::Accepted )
   {
     mExpressionString = d.expressionText().trimmed();

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>989</width>
-    <height>520</height>
+    <height>519</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -99,23 +99,8 @@
                <height>0</height>
               </size>
              </property>
-             <layout class="QGridLayout" name="gridLayout">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item row="1" column="0" colspan="2">
-               <widget class="QgsCodeEditorSQL" name="txtExpressionString" native="true"/>
-              </item>
-              <item row="0" column="0">
+             <layout class="QVBoxLayout" name="verticalLayout_6">
+              <item>
                <widget class="QFrame" name="mOperatorsGroupBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Maximum">
@@ -287,59 +272,172 @@
                 </layout>
                </widget>
               </item>
-              <item row="2" column="0" colspan="2">
-               <layout class="QHBoxLayout" name="horizontalLayout_4">
-                <item>
-                 <widget class="QLabel" name="label_2">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
-                  </property>
-                  <property name="text">
-                   <string>Output preview: </string>
-                  </property>
+              <item>
+               <widget class="QgsCodeEditorSQL" name="txtExpressionString" native="true"/>
+              </item>
+              <item>
+               <layout class="QGridLayout" name="gridLayout">
+                <property name="sizeConstraint">
+                 <enum>QLayout::SetMinAndMaxSize</enum>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <item row="1" column="0">
+                 <widget class="QFrame" name="frame">
+                  <layout class="QHBoxLayout" name="horizontalLayout_4">
+                   <property name="spacing">
+                    <number>3</number>
+                   </property>
+                   <property name="sizeConstraint">
+                    <enum>QLayout::SetMinAndMaxSize</enum>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="label_2">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="toolTip">
+                      <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
+                     </property>
+                     <property name="text">
+                      <string>Output preview: </string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="lblPreview">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="toolTip">
+                      <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
+                     </property>
+                     <property name="frameShape">
+                      <enum>QFrame::NoFrame</enum>
+                     </property>
+                     <property name="frameShadow">
+                      <enum>QFrame::Sunken</enum>
+                     </property>
+                     <property name="lineWidth">
+                      <number>0</number>
+                     </property>
+                     <property name="midLineWidth">
+                      <number>0</number>
+                     </property>
+                     <property name="text">
+                      <string>123232</string>
+                     </property>
+                     <property name="scaledContents">
+                      <bool>false</bool>
+                     </property>
+                     <property name="wordWrap">
+                      <bool>false</bool>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </widget>
                 </item>
-                <item>
-                 <widget class="QLabel" name="lblPreview">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="toolTip">
-                   <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
-                  </property>
-                  <property name="frameShape">
-                   <enum>QFrame::NoFrame</enum>
-                  </property>
-                  <property name="frameShadow">
-                   <enum>QFrame::Sunken</enum>
-                  </property>
-                  <property name="lineWidth">
-                   <number>0</number>
-                  </property>
-                  <property name="midLineWidth">
-                   <number>0</number>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="scaledContents">
-                   <bool>false</bool>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>false</bool>
-                  </property>
-                  <property name="textInteractionFlags">
-                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-                  </property>
+                <item row="0" column="0">
+                 <widget class="QFrame" name="mExpectedOutputFrame">
+                  <layout class="QHBoxLayout" name="horizontalLayout_7">
+                   <property name="spacing">
+                    <number>3</number>
+                   </property>
+                   <property name="sizeConstraint">
+                    <enum>QLayout::SetMinAndMaxSize</enum>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item>
+                    <widget class="QLabel" name="label_3">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="toolTip">
+                      <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
+                     </property>
+                     <property name="text">
+                      <string>Expected Format:</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="lblExpected">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="toolTip">
+                      <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
+                     </property>
+                     <property name="frameShape">
+                      <enum>QFrame::NoFrame</enum>
+                     </property>
+                     <property name="frameShadow">
+                      <enum>QFrame::Sunken</enum>
+                     </property>
+                     <property name="lineWidth">
+                      <number>0</number>
+                     </property>
+                     <property name="midLineWidth">
+                      <number>0</number>
+                     </property>
+                     <property name="text">
+                      <string>string [r,g,b,a] as int 0-255 or #RRGGBBAA as hex or color as color's name</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::RichText</enum>
+                     </property>
+                     <property name="scaledContents">
+                      <bool>false</bool>
+                     </property>
+                     <property name="wordWrap">
+                      <bool>true</bool>
+                     </property>
+                     <property name="textInteractionFlags">
+                      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
                  </widget>
                 </item>
                </layout>


### PR DESCRIPTION
## Description
Adds text to show what the expected output format of the expression should be in the case of data defined properties. 

![image](https://user-images.githubusercontent.com/381660/39104204-bd1aea32-469e-11e8-8ab3-bc00f1f24961.png)

Thanks to @cartocalypse on Twitter for that idea. 

Funded by my QGIS dev days at [TechnologyOne](https://www.technologyonecorp.com/)
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
