### PR TITLE
[bugfix] Fixes regression in relation reference widget with 'chain filter' option

### DIFF
--- a/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfeaturelistcombobox.sip.in
@@ -58,6 +58,14 @@ An additional expression to further restrict the available features.
 This can be used to integrate additional spatial or other constraints.
 %End
 
+    int nullIndex() const;
+%Docstring
+Returns the current index of the NULL value, or -1 if NULL values are
+not allowed.
+
+.. versionadded:: 3.2
+%End
+
     void setFilterExpression( const QString &filterExpression );
 %Docstring
 An additional expression to further restrict the available features.
@@ -118,6 +126,13 @@ The index of the currently selected item.
 
 
   signals:
+
+    void modelUpdated();
+%Docstring
+The underlying model has been updated.
+
+.. versionadded:: 3.2
+%End
 
     void sourceLayerChanged();
 %Docstring

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -145,6 +145,7 @@ QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget *parent )
   connect( mRemoveFKButton, &QAbstractButton::clicked, this, &QgsRelationReferenceWidget::deleteForeignKey );
   connect( mAddEntryButton, &QAbstractButton::clicked, this, &QgsRelationReferenceWidget::addEntry );
   connect( mComboBox, &QComboBox::editTextChanged, this, &QgsRelationReferenceWidget::updateAddEntryButton );
+  connect( mComboBox, &QgsFeatureListComboBox::modelUpdated, this, &QgsRelationReferenceWidget::updateIndex );
 }
 
 QgsRelationReferenceWidget::~QgsRelationReferenceWidget()
@@ -153,6 +154,38 @@ QgsRelationReferenceWidget::~QgsRelationReferenceWidget()
   unsetMapTool();
   if ( mMapTool )
     delete mMapTool;
+}
+
+void QgsRelationReferenceWidget::updateIndex()
+{
+  if ( mChainFilters && mComboBox->count() > 0 )
+  {
+    int index = -1;
+
+    // uninitialized filter
+    if ( ! mFilterComboBoxes.isEmpty()
+         && mFilterComboBoxes[0]->currentIndex() == 0 && mAllowNull )
+    {
+      index = mComboBox->nullIndex();
+    }
+    else if ( mComboBox->count() > mComboBox->nullIndex() )
+    {
+      index = mComboBox->nullIndex() + 1;
+    }
+    else if ( mAllowNull )
+    {
+      index = mComboBox->nullIndex();
+    }
+    else
+    {
+      index = 0;
+    }
+
+    if ( mComboBox->count() > index )
+    {
+      mComboBox->setCurrentIndex( index );
+    }
+  }
 }
 
 void QgsRelationReferenceWidget::setRelation( const QgsRelation &relation, bool allowNullValue )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -184,6 +184,12 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     void addEntry();
     void updateAddEntryButton();
 
+    /**
+     * Updates the FK index as soon as the underlying model is updated when
+     * the chainFilter option is activated.
+     */
+    void updateIndex();
+
   private:
     void highlightFeature( QgsFeature f = QgsFeature(), CanvasExtent canvasExtent = Fixed );
     void updateAttributeEditorFrame( const QgsFeature &feature );

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -259,7 +259,11 @@ void QgsValueRelationWidgetWrapper::populate( )
   else if ( mTableWidget )
   {
     if ( mCache.size() > 0 )
-      mTableWidget->setRowCount( ( mCache.size() + config( QStringLiteral( "NofColumns" ) ).toInt() - 1 ) / config( QStringLiteral( "NofColumns" ) ).toInt() );
+    {
+      const int nofCols = config( QStringLiteral( "NofColumns" ) ).toInt();
+      const int denom = nofCols != 0 ? nofCols : 1;
+      mTableWidget->setRowCount( ( mCache.size() + nofCols - 1 ) / denom );
+    }
     else
       mTableWidget->setRowCount( 1 );
     if ( config( QStringLiteral( "NofColumns" ) ).toInt() > 0 )

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -46,6 +46,7 @@ QgsFeatureListComboBox::QgsFeatureListComboBox( QWidget *parent )
   connect( mCompleter, static_cast<void( QCompleter::* )( const QModelIndex & )>( &QCompleter::activated ), this, &QgsFeatureListComboBox::onActivated );
   connect( mModel, &QgsFeatureFilterModel::beginUpdate, this, &QgsFeatureListComboBox::storeLineEditState );
   connect( mModel, &QgsFeatureFilterModel::endUpdate, this, &QgsFeatureListComboBox::restoreLineEditState );
+  connect( mModel, &QgsFeatureFilterModel::endUpdate, this, &QgsFeatureListComboBox::modelUpdated );
   connect( mModel, &QgsFeatureFilterModel::dataChanged, this, &QgsFeatureListComboBox::onDataChanged );
 
   connect( this, static_cast<void( QgsFeatureListComboBox::* )( int )>( &QgsFeatureListComboBox::currentIndexChanged ), this, &QgsFeatureListComboBox::onCurrentIndexChanged );
@@ -134,6 +135,18 @@ void QgsFeatureListComboBox::restoreLineEditState()
 {
   if ( mIsCurrentlyEdited )
     mLineEditState.restore( mLineEdit );
+}
+
+int QgsFeatureListComboBox::nullIndex() const
+{
+  int index = -1;
+
+  if ( allowNull() )
+  {
+    index = findText( tr( "NULL" ) );
+  }
+
+  return index;
 }
 
 void QgsFeatureListComboBox::onDataChanged( const QModelIndex &topLeft, const QModelIndex &bottomRight, const QVector<int> &roles )

--- a/src/gui/qgsfeaturelistcombobox.h
+++ b/src/gui/qgsfeaturelistcombobox.h
@@ -83,6 +83,14 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
     QString filterExpression() const;
 
     /**
+     * Returns the current index of the NULL value, or -1 if NULL values are
+     * not allowed.
+     *
+     * \since QGIS 3.2
+     */
+    int nullIndex() const;
+
+    /**
      * An additional expression to further restrict the available features.
      * This can be used to integrate additional spatial or other constraints.
      *
@@ -140,6 +148,13 @@ class GUI_EXPORT QgsFeatureListComboBox : public QComboBox
     void keyPressEvent( QKeyEvent *event ) override;
 
   signals:
+
+    /**
+     * The underlying model has been updated.
+     *
+     * \since QGIS 3.2
+     */
+    void modelUpdated();
 
     /**
      * The layer from which features should be listed.

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -185,12 +185,36 @@ void TestQgsRelationReferenceWidget::testChainFilter()
 
   // set the filter for "raccord" and then reset filter for "diameter". As
   // chain filter is activated, the filter on "raccord" field should be reset
-  cbs[2]->setCurrentIndex( cbs[2]->findText( QStringLiteral( "brides" ) ) );
-  cbs[1]->setCurrentIndex( cbs[1]->findText( QStringLiteral( "diameter" ) ) );
-
   QEventLoop loop;
   connect( qobject_cast<QgsFeatureFilterModel *>( w.mComboBox->model() ), &QgsFeatureFilterModel::filterJobCompleted, &loop, &QEventLoop::quit );
+
+  cbs[0]->setCurrentIndex( 0 );
   loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "NULL" ) );
+
+  cbs[0]->setCurrentIndex( cbs[0]->findText( "iron" ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+
+  cbs[0]->setCurrentIndex( cbs[0]->findText( "steel" ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "12" ) );
+
+  cbs[0]->setCurrentIndex( cbs[0]->findText( "iron" ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+
+  cbs[1]->setCurrentIndex( cbs[1]->findText( "120" ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+
+  cbs[2]->setCurrentIndex( cbs[2]->findText( QStringLiteral( "brides" ) ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
+
+  cbs[1]->setCurrentIndex( cbs[1]->findText( QStringLiteral( "diameter" ) ) );
+  loop.exec();
+  QCOMPARE( w.mComboBox->currentText(), QString( "10" ) );
 
   // combobox should propose NULL, 10 and 11 because the filter is now:
   // "material" == 'iron'
@@ -200,6 +224,7 @@ void TestQgsRelationReferenceWidget::testChainFilter()
   cbs[0]->setCurrentIndex( cbs[0]->findText( QStringLiteral( "material" ) ) );
   loop.exec();
   QCOMPARE( w.mComboBox->count(), 4 );
+  QCOMPARE( w.mComboBox->currentText(), QString( "NULL" ) );
 }
 
 void TestQgsRelationReferenceWidget::testChainFilterRefreshed()


### PR DESCRIPTION
## Description

 This PR fixes a regression in the relation reference widget when the `chain filters` option is activated.

 See https://github.com/qwat/QWAT/issues/190#issuecomment-380454685 for a GIF highlighting the issue.

 Some tests have been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
