### PR TITLE
Fix labels in Displacement Point renderer GUI

### DIFF
--- a/src/ui/qgspointdisplacementrendererwidgetbase.ui
+++ b/src/ui/qgspointdisplacementrendererwidgetbase.ui
@@ -193,7 +193,7 @@
    <item row="8" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBoxBasic" name="mDisplacementCirclesGroupBox">
      <property name="title">
-      <string>Displacement guides</string>
+      <string>Displacement lines</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="2" column="1">

--- a/src/ui/qgspointdisplacementrendererwidgetbase.ui
+++ b/src/ui/qgspointdisplacementrendererwidgetbase.ui
@@ -134,6 +134,9 @@
      <property name="text">
       <string>Distance</string>
      </property>
+     <property name="toolTip">
+      <string>Point distance tolerance</string>
+     </property>
     </widget>
    </item>
    <item row="4" column="0" colspan="2">
@@ -190,7 +193,7 @@
    <item row="8" column="0" colspan="2">
     <widget class="QgsCollapsibleGroupBoxBasic" name="mDisplacementCirclesGroupBox">
      <property name="title">
-      <string>Displacement rings</string>
+      <string>Displacement guides</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="2" column="1">


### PR DESCRIPTION
Because it's not only about rings (but also grid), displacement rings --> displacement guides (not sure it's the best wording: marks? targets?)
Also add a tooltip (using the original label though I think a more verbose text would be nice but could not find anything suitable for both displacement and cluster dialogs)

OLD widget

![displacement](https://user-images.githubusercontent.com/7983394/39143860-5add76be-472f-11e8-8bad-e975ecc129dd.PNG)