### PR TITLE
[ogr] Use SHAPE_RESTORE_SHX option to recreate missing SHX files when opening shapefiles

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -431,6 +431,8 @@ QgsOgrProvider::QgsOgrProvider( QString const &uri )
 
   QgsSettings settings;
   CPLSetConfigOption( "SHAPE_ENCODING", settings.value( QStringLiteral( "qgis/ignoreShapeEncoding" ), true ).toBool() ? "" : nullptr );
+  // be forgiving and always restore missing SHX files if they are absent
+  CPLSetConfigOption( "SHAPE_RESTORE_SHX", "YES" );
 
 #ifndef QT_NO_NETWORKPROXY
   setupProxy();
@@ -3922,6 +3924,7 @@ void QgsOgrProvider::open( OpenMode mode )
   QgsDebugMsgLevel( "mSubsetString: " + mSubsetString, 3 );
   CPLSetConfigOption( "OGR_ORGANIZE_POLYGONS", "ONLY_CCW" );  // "SKIP" returns MULTIPOLYGONs for multiringed POLYGONs
   CPLSetConfigOption( "GPX_ELE_AS_25D", "YES" );  // use GPX elevation as z values
+
 
   if ( mFilePath.startsWith( QLatin1String( "MySQL:" ) ) && !mLayerName.isEmpty() && !mFilePath.endsWith( ",tables=" + mLayerName ) )
   {

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -600,6 +600,21 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
         self.assertFalse(vl.dataProvider().createAttributeIndex(100))
         self.assertTrue(vl.dataProvider().createAttributeIndex(1))
 
+    def testNoShx(self):
+        tmpdir = tempfile.mkdtemp()
+        self.dirs_to_cleanup.append(tmpdir)
+        srcpath = os.path.join(TEST_DATA_DIR, 'provider')
+        for file in glob.glob(os.path.join(srcpath, 'shapefile.*')):
+            shutil.copy(os.path.join(srcpath, file), tmpdir)
+
+        # delete the shx!
+        os.remove(os.path.join(tmpdir, 'shapefile.shx'))
+        datasource = os.path.join(tmpdir, 'shapefile.shp')
+
+        # make sure we can still load it - ogr should automatically re-create the shx
+        vl = QgsVectorLayer('{}'.format(datasource), 'test', 'ogr')
+        self.assertTrue(vl.isValid())
+
     def testCreateSpatialIndex(self):
         tmpdir = tempfile.mkdtemp()
         self.dirs_to_cleanup.append(tmpdir)


### PR DESCRIPTION
Allows us to be a bit more forgiving when opening shapefiles, by auto-repairing them if the shx file is missing.

@rouault is this option safe in your opinion?