### PR TITLE
[osx] Fix offset cursor positions

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -572,7 +572,6 @@ QCursor QgsApplication::getThemeCursor( Cursor cursor )
     if ( app->devicePixelRatio() >= 2 )
     {
       scale *= app->devicePixelRatio();
-      activeX = activeY = 5;
     }
 #endif
     cursorIcon = QCursor( icon.pixmap( std::ceil( scale * 32 ), std::ceil( scale * 32 ) ), std::ceil( scale * activeX ), std::ceil( scale * activeY ) );


### PR DESCRIPTION
Followup 3283afd3

@slarosa I think 3283afd3 caused this regression by always resetting the active cursor point to 5,5, regardless of the cursor. This means that the crosshairs digitizing cursor is located offset from the position where the node will be digitized. 