### PR TITLE
[processing] Make line intersection alg able to handle collections

### DIFF
--- a/python/plugins/processing/tests/testdata/custom/line_intersection_collection1.gml
+++ b/python/plugins/processing/tests/testdata/custom/line_intersection_collection1.gml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ line_intersection_collection1.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>963795.9543288001</gml:X><gml:Y>1077577.066142281</gml:Y></gml:coord>
+      <gml:coord><gml:X>964309.9869270925</gml:X><gml:Y>1077925.530188314</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                
+  <gml:featureMember>
+    <ogr:line_intersection_collection1 fid="line_intersection_collection1.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:3116"><gml:coordinates>963795.9543288,1077590.54265235 963905.691625065,1077713.75645868 963926.868998028,1077925.53018831 963980.775038299,1077802.31638198 964219.501788067,1077867.7737166 964059.761477611,1077699.94219859 964144.709036072,1077671.41702938 964211.234771022,1077618.29701916 964261.241936687,1077648.19439743 964309.986927093,1077617.49567248 964144.418374834,1077577.06614228 963905.691625065,1077713.75645868</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:longitud>1804.4</ogr:longitud>
+    </ogr:line_intersection_collection1>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/custom/line_intersection_collection1.xsd
+++ b/python/plugins/processing/tests/testdata/custom/line_intersection_collection1.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="line_intersection_collection1" type="ogr:line_intersection_collection1_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="line_intersection_collection1_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="longitud" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/custom/line_intersection_collection2.gml
+++ b/python/plugins/processing/tests/testdata/custom/line_intersection_collection2.gml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ line_intersection_collection2.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>963718.9456998424</gml:X><gml:Y>1077618.297019162</gml:Y></gml:coord>
+      <gml:coord><gml:X>964257.4287541196</gml:X><gml:Y>1077989.062307205</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                
+  <gml:featureMember>
+    <ogr:line_intersection_collection2 fid="line_intersection_collection2.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:3116"><gml:coordinates>964257.42875412,1077702.09075594 964211.234771022,1077618.29701916 963980.775038299,1077802.31638198 963926.868998028,1077925.53018831 963718.945699842,1077989.0623072</gml:coordinates></gml:LineString></ogr:geometryProperty>
+      <ogr:longitud>672.7</ogr:longitud>
+    </ogr:line_intersection_collection2>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/custom/line_intersection_collection2.xsd
+++ b/python/plugins/processing/tests/testdata/custom/line_intersection_collection2.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="line_intersection_collection2" type="ogr:line_intersection_collection2_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="line_intersection_collection2_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:LineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="longitud" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/line_intersection_collection.gml
+++ b/python/plugins/processing/tests/testdata/expected/line_intersection_collection.gml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ line_intersection_collection.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>964081.0170018662</gml:X><gml:Y>1077618.29701916</gml:Y></gml:coord>
+      <gml:coord><gml:X>964211.234771022</gml:X><gml:Y>1077722.274363162</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                  
+  <gml:featureMember>
+    <ogr:line_intersection_collection fid="line_intersection_collection1.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:3116"><gml:coordinates>964081.017001866,1077722.27436316</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:longitud>1804.4</ogr:longitud>
+      <ogr:fid_2>line_intersection_collection2.0</ogr:fid_2>
+      <ogr:longitud_2>672.7</ogr:longitud_2>
+    </ogr:line_intersection_collection>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:line_intersection_collection fid="line_intersection_collection1.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:3116"><gml:coordinates>964144.709036063,1077671.41702938</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:longitud>1804.4</ogr:longitud>
+      <ogr:fid_2>line_intersection_collection2.0</ogr:fid_2>
+      <ogr:longitud_2>672.7</ogr:longitud_2>
+    </ogr:line_intersection_collection>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:line_intersection_collection fid="line_intersection_collection1.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:3116"><gml:coordinates>964211.234771022,1077618.29701916</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:longitud>1804.4</ogr:longitud>
+      <ogr:fid_2>line_intersection_collection2.0</ogr:fid_2>
+      <ogr:longitud_2>672.7</ogr:longitud_2>
+    </ogr:line_intersection_collection>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/line_intersection_collection.xsd
+++ b/python/plugins/processing/tests/testdata/expected/line_intersection_collection.xsd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="line_intersection_collection" type="ogr:line_intersection_collection_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="line_intersection_collection_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="longitud" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="fid_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="255"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="longitud_2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -1681,6 +1681,20 @@ tests:
           fields:
             fid: skip
 
+  - algorithm: native:lineintersections
+    name: Line intersections with geometry collection
+    params:
+      INPUT:
+        name: custom/line_intersection_collection1.gml
+        type: vector
+      INTERSECT:
+        name: custom/line_intersection_collection2.gml
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/line_intersection_collection.gml
+        type: vector
+
   - algorithm: qgis:sumlinelengths
     name: Sum line lengths
     params:

--- a/src/analysis/processing/qgsalgorithmlineintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmlineintersection.cpp
@@ -196,10 +196,10 @@ QVariantMap QgsLineIntersectionAlgorithm::processAlgorithm( const QVariantMap &p
           {
             outAttributes.append( inFeatureB.attribute( b ) );
           }
-          if ( intersectGeom.wkbType() == QgsWkbTypes::GeometryCollection )
+          if ( QgsWkbTypes::flatType( intersectGeom.wkbType() ) == QgsWkbTypes::GeometryCollection )
           {
-            QVector<QgsGeometry> geomCollection = intersectGeom.asGeometryCollection();
-            for ( const QgsGeometry &part : qgis::as_const( geomCollection ) )
+            const QVector<QgsGeometry> geomCollection = intersectGeom.asGeometryCollection();
+            for ( const QgsGeometry &part : geomCollection )
             {
               if ( part.type() == QgsWkbTypes::PointGeometry )
               {
@@ -214,18 +214,15 @@ QVariantMap QgsLineIntersectionAlgorithm::processAlgorithm( const QVariantMap &p
               }
             }
           }
-          else
+          else if ( intersectGeom.type() == QgsWkbTypes::PointGeometry )
           {
-            if ( intersectGeom.type() == QgsWkbTypes::PointGeometry )
+            if ( intersectGeom.isMultipart() )
             {
-              if ( intersectGeom.isMultipart() )
-              {
-                points = intersectGeom.asMultiPoint();
-              }
-              else
-              {
-                points.append( intersectGeom.asPoint() );
-              }
+              points = intersectGeom.asMultiPoint();
+            }
+            else
+            {
+              points.append( intersectGeom.asPoint() );
             }
           }
           for ( const QgsPointXY &j : qgis::as_const( points ) )


### PR DESCRIPTION
## Description
If an intersection returns a geometry collection (i.e., list of geometries of different type), we should iterate it and extract point geometries for the output.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
