### PR TITLE
[bugfix]  Fixes Add Feature map tool when snapped layer has ZM support 

### DIFF
--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -403,12 +403,12 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
       layerPoint = f.geometry().constGet()->vertexAt( vId );
 
       // ZM support depends on the target layer
-      if ( layerPoint.is3D() && !QgsWkbTypes::hasZ( vlayer->wkbType() ) )
+      if ( !QgsWkbTypes::hasZ( vlayer->wkbType() ) )
       {
         layerPoint.dropZValue();
       }
 
-      if ( layerPoint.isMeasure() && !QgsWkbTypes::hasM( vlayer->wkbType() ) )
+      if ( !QgsWkbTypes::hasM( vlayer->wkbType() ) )
       {
         layerPoint.dropMValue();
       }

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -399,7 +399,20 @@ int QgsMapToolCapture::fetchLayerPoint( const QgsPointLocator::Match &match, Qgs
       QgsVertexId vId;
       if ( !f.geometry().vertexIdFromVertexNr( match.vertexIndex(), vId ) )
         return 2;
+
       layerPoint = f.geometry().constGet()->vertexAt( vId );
+
+      // ZM support depends on the target layer
+      if ( layerPoint.is3D() && !QgsWkbTypes::hasZ( vlayer->wkbType() ) )
+      {
+        layerPoint.dropZValue();
+      }
+
+      if ( layerPoint.isMeasure() && !QgsWkbTypes::hasM( vlayer->wkbType() ) )
+      {
+        layerPoint.dropMValue();
+      }
+
       return 0;
     }
     else

--- a/tests/src/app/testqgsmaptoolutils.h
+++ b/tests/src/app/testqgsmaptoolutils.h
@@ -69,22 +69,30 @@ class TestQgsMapToolAdvancedDigitizingUtils
       mMapTool->cadCanvasMoveEvent( &e );
     }
 
-    void mousePress( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers() )
+    void mousePress( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers(), bool snap = false )
     {
       QgsMapMouseEvent e1( mMapTool->canvas(), QEvent::MouseButtonPress, mapToScreen( mapX, mapY ), button, button, stateKey );
+
+      if ( snap )
+        e1.snapPoint();
+
       mMapTool->cadCanvasPressEvent( &e1 );
     }
 
-    void mouseRelease( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers() )
+    void mouseRelease( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers(), bool snap = false )
     {
       QgsMapMouseEvent e2( mMapTool->canvas(), QEvent::MouseButtonRelease, mapToScreen( mapX, mapY ), button, Qt::MouseButton(), stateKey );
+
+      if ( snap )
+        e2.snapPoint();
+
       mMapTool->cadCanvasReleaseEvent( &e2 );
     }
 
-    void mouseClick( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers() )
+    void mouseClick( double mapX, double mapY, Qt::MouseButton button, Qt::KeyboardModifiers stateKey = Qt::KeyboardModifiers(), bool snap = false )
     {
-      mousePress( mapX, mapY, button, stateKey );
-      mouseRelease( mapX, mapY, button, stateKey );
+      mousePress( mapX, mapY, button, stateKey, snap );
+      mouseRelease( mapX, mapY, button, stateKey, snap );
     }
 
     void keyClick( int key )


### PR DESCRIPTION
## Description

When a line is added on a layer without ZM support thanks to the "Add Feature" map tool with a point snapped on a layer with ZM support, then the resulting new feature has also ZM values (whereas it should not).

This PR fixes the issue. For more detailed information and a GIF, see https://github.com/qwat/QWAT/issues/181#issuecomment-379694415. 

Some unit tests have been added.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
