### PR TITLE
Remove groups definition from RPM spec

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -16,7 +16,6 @@ Name:           qgis
 Version:        %{_version}
 Release:        %{_relver}%{?dist}
 Summary:        A user friendly Open Source Geographic Information System
-Group:          Applications/Engineering
 
 License:        GPLv3+ with exceptions
 URL:            http://www.qgis.org
@@ -115,7 +114,6 @@ and USGS ASCII DEM.
 
 %package devel
 Summary:        Development Libraries for the QGIS
-Group:          Development/Libraries
 Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description devel
@@ -123,7 +121,6 @@ Development packages for QGIS including the C header files.
 
 %package grass
 Summary:        GRASS Support Libraries for QGIS
-Group:          Applications/Engineering
 Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 
 # The plug-in requires more than just the grass-libs.
@@ -144,7 +141,6 @@ Provides: %{name}-python%{?_isa} = %{version}-%{release}
 Obsoletes: %{name}-python < %{version}-%{release}
 Obsoletes: python2-%{name} < %{version}-%{release}
 Summary:        Python integration and plug-ins for QGIS
-Group:          Applications/Engineering
 Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 Requires: gdal-python3
 Requires: python3-future
@@ -163,7 +159,6 @@ Python integration and plug-ins for QGIS.
 
 %package server
 Summary:        FCGI-based OGC web map server
-Group:          Applications/Engineering
 Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
 Requires:       mod_fcgid
 Provides: mapserver = %{version}-%{release}


### PR DESCRIPTION
## Description
`Group:` tag in RPMs has been deprecated (as per https://fedoraproject.org/wiki/RPMGroups), so I'm removing it from `qgis.spec.template`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
