### PR TITLE
Make RPM package compatible with Fedora 28

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -12,6 +12,12 @@
 %define builddate %(date '+%a %b %d %Y')
 %endif
 
+%if 0%{?fedora} >= 28
+%define grass grass74
+%else
+%define grass grass72
+%endif
+
 Name:           qgis
 Version:        %{_version}
 Release:        %{_relver}%{?dist}
@@ -203,7 +209,7 @@ gzip ChangeLog
       -D QGIS_CGIBIN_SUBDIR=%{_libexecdir}/%{name} \
       -D WITH_BINDINGS:BOOL=TRUE \
       -D WITH_GRASS7:BOOL=TRUE \
-      -D GRASS_PREFIX7=%{_libdir}/grass72 \
+      -D GRASS_PREFIX7=%{_libdir}/%{grass} \
       -D WITH_CUSTOM_WIDGETS:BOOL=TRUE \
       -D BINDINGS_GLOBAL_INSTALL:BOOL=TRUE \
       -D ENABLE_TESTS:BOOL=FALSE \


### PR DESCRIPTION
## Description

Make RPM package compatible with Fedora 28 which ships GRASS 7.4.
Currently QGIS does not compile against shipped GRASS because of this issue https://bugzilla.redhat.com/show_bug.cgi?id=1571441, unless this https://daniele.vigano.me/git/dani/grass/commit/d06da9005a526de8211a8b8142130c46b3dfa983 patch is applied to GRASS.

You can find a patched GRASS 7.4 and a QGIS 3.0.2 built on top of it, for F28, here: https://copr.fedorainfracloud.org/coprs/dani/qgis3-grass74/build/745091/

This change stays backward compatible with F26 and F27.

/cc @m-kuhn @mbernasocchi 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
