### PR TITLE
Fix BBOX CRS in WFS GetFeature

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -336,11 +336,6 @@ namespace QgsWfs
         requestPrecision = QgsServerProjectUtils::wfsLayerPrecision( *project, vlayer->id() );
       }
 
-      if ( onlyOneLayer && !featureRequest.filterRect().isEmpty() )
-      {
-        requestRect = featureRequest.filterRect();
-      }
-
       if ( aRequest.maxFeatures > 0 )
       {
         featureRequest.setLimit( aRequest.maxFeatures + aRequest.startIndex - sentFeatures );
@@ -361,6 +356,23 @@ namespace QgsWfs
       if ( !query.srsName.isEmpty() )
       {
         outputCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( query.srsName );
+      }
+
+      if ( onlyOneLayer && !featureRequest.filterRect().isEmpty() )
+      {
+        Q_NOWARN_DEPRECATED_PUSH
+        QgsCoordinateTransform transform( outputCrs, requestCrs );
+        Q_NOWARN_DEPRECATED_POP
+        try
+        {
+          featureRequest.setFilterRect( transform.transform( featureRequest.filterRect() ) );
+        }
+        catch ( QgsException &cse )
+        {
+          Q_UNUSED( cse );
+        }
+
+        requestRect = featureRequest.filterRect();
       }
 
       // Iterate through features

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -219,8 +219,8 @@ class TestQgsServerWFS(QgsServerTestBase):
       <ogc:BBOX>
         <ogc:PropertyName>geometry</ogc:PropertyName>
         <gml:Envelope xmlns:gml="http://www.opengis.net/gml">
-          <gml:lowerCorner>8 44</gml:lowerCorner>
-          <gml:upperCorner>9 45</gml:upperCorner>
+          <gml:lowerCorner>890555.92634619 5465442.18332275</gml:lowerCorner>
+          <gml:upperCorner>1001875.41713946 5621521.48619207</gml:upperCorner>
         </gml:Envelope>
       </ogc:BBOX>
     </ogc:Filter>
@@ -267,6 +267,11 @@ class TestQgsServerWFS(QgsServerTestBase):
         self.wfs_request_compare("GetFeature", '1.0.0', "SRSNAME=EPSG:4326&TYPENAME=testlayer&RESULTTYPE=hits&BBOX=913206,5606024,913213,5606026,EPSG:3857", 'wfs_getFeature_1_0_0_epsgbbox_1_feature_3857')
         self.wfs_request_compare("GetFeature", '1.1.0', "SRSNAME=EPSG:4326&TYPENAME=testlayer&RESULTTYPE=hits&BBOX=913144,5605992,913303,5606048,EPSG:3857", 'wfs_getFeature_1_1_0_epsgbbox_3_feature_3857')
         self.wfs_request_compare("GetFeature", '1.1.0', "SRSNAME=EPSG:4326&TYPENAME=testlayer&RESULTTYPE=hits&BBOX=913206,5606024,913213,5606026,EPSG:3857", 'wfs_getFeature_1_1_0_epsgbbox_1_feature_3857')
+
+        self.wfs_request_compare("GetFeature", '1.0.0', "SRSNAME=EPSG:3857&TYPENAME=testlayer&RESULTTYPE=hits&BBOX=913144,5605992,913303,5606048,EPSG:3857", 'wfs_getFeature_1_0_0_epsgbbox_3_feature_3857')
+        self.wfs_request_compare("GetFeature", '1.0.0', "SRSNAME=EPSG:3857&TYPENAME=testlayer&RESULTTYPE=hits&BBOX=913206,5606024,913213,5606026,EPSG:3857", 'wfs_getFeature_1_0_0_epsgbbox_1_feature_3857')
+        self.wfs_request_compare("GetFeature", '1.1.0', "SRSNAME=EPSG:3857&TYPENAME=testlayer&RESULTTYPE=hits&BBOX=913144,5605992,913303,5606048,EPSG:3857", 'wfs_getFeature_1_1_0_epsgbbox_3_feature_3857')
+        self.wfs_request_compare("GetFeature", '1.1.0', "SRSNAME=EPSG:3857&TYPENAME=testlayer&RESULTTYPE=hits&BBOX=913206,5606024,913213,5606026,EPSG:3857", 'wfs_getFeature_1_1_0_epsgbbox_1_feature_3857')
 
     def test_getFeatureFeatureId(self):
         """Test GetFeature with featureid"""


### PR DESCRIPTION
## Description

Apply WFS GetFeature BBOX filter using query CRS.

I've made the PR on release-3_0 as this is a bug fix. Should be merged in master too.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
