### PR TITLE
[processing] Remove modal confirmation dialog in Refactor Fields algorithm dialog

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -328,17 +328,7 @@ class FieldsMappingPanel(BASE, WIDGET):
         self.model.setLayer(layer)
         if layer is None:
             return
-        if self.model.rowCount() == 0:
-            self.on_resetButton_clicked()
-            return
-        dlg = QMessageBox(self)
-        dlg.setText(self.tr("Do you want to reset the field mapping?"))
-        dlg.setStandardButtons(
-            QMessageBox.StandardButtons(QMessageBox.Yes |
-                                        QMessageBox.No))
-        dlg.setDefaultButton(QMessageBox.No)
-        if dlg.exec_() == QMessageBox.Yes:
-            self.on_resetButton_clicked()
+        self.on_resetButton_clicked()
 
     def value(self):
         return self.model.mapping()


### PR DESCRIPTION
## Description
There is a modal confirmation dialog in Refactor Fields algorithm that, in my opinion, affects QGIS usability by hampering some workflows based on QGIS Processing.

![reset_field_mapping](https://user-images.githubusercontent.com/652785/39218268-660cbf9e-47e9-11e8-8ef1-fba451bc2ea0.png)

I've opened [this thread in QGIS-Developer maiiling list](http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-Can-we-remove-a-confirmation-dialog-in-Refactor-Fields-algorithm-td5362583.html) to explain why we should remove it.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit


