### PR TITLE
Consistent locale usage for number representation

### DIFF
--- a/src/core/fieldformatter/qgsrangefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrangefieldformatter.cpp
@@ -40,16 +40,6 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
 
   QString result;
 
-  // Prepare locale
-  std::function<QLocale()> f_locale = [ ]
-  {
-    QLocale locale( QgsApplication::instance()->locale() );
-    QLocale::NumberOptions options( locale.numberOptions() );
-    options |= QLocale::NumberOption::OmitGroupSeparator;
-    locale.setNumberOptions( options );
-    return locale;
-  };
-
   const QgsField field = layer->fields().at( fieldIndex );
 
   if ( field.type() == QVariant::Double &&
@@ -64,7 +54,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
       if ( ok )
       {
         // TODO: make the format configurable!
-        result = f_locale().toString( val, 'f', precision );
+        result = QLocale::system().toString( val, 'f', precision );
       }
     }
   }
@@ -75,7 +65,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
     double val( value.toInt( &ok ) );
     if ( ok )
     {
-      result =  f_locale().toString( val, 'f', 0 );
+      result =  QLocale::system().toString( val, 'f', 0 );
     }
   }
   else if ( ( field.type() == QVariant::LongLong ) &&
@@ -85,7 +75,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
     double val( value.toLongLong( &ok ) );
     if ( ok )
     {
-      result =  f_locale().toString( val, 'f', 0 );
+      result =  QLocale::system().toString( val, 'f', 0 );
     }
   }
   else

--- a/src/core/fieldformatter/qgsrangefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrangefieldformatter.cpp
@@ -54,7 +54,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
       if ( ok )
       {
         // TODO: make the format configurable!
-        result = QLocale::system().toString( val, 'f', precision );
+        result = QLocale().toString( val, 'f', precision );
       }
     }
   }
@@ -65,7 +65,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
     double val( value.toInt( &ok ) );
     if ( ok )
     {
-      result =  QLocale::system().toString( val, 'f', 0 );
+      result =  QLocale().toString( val, 'f', 0 );
     }
   }
   else if ( ( field.type() == QVariant::LongLong ) &&
@@ -75,7 +75,7 @@ QString QgsRangeFieldFormatter::representValue( QgsVectorLayer *layer, int field
     double val( value.toLongLong( &ok ) );
     if ( ok )
     {
-      result =  QLocale::system().toString( val, 'f', 0 );
+      result =  QLocale().toString( val, 'f', 0 );
     }
   }
   else

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -32,7 +32,6 @@ QgsDoubleSpinBox::QgsDoubleSpinBox( QWidget *parent )
   mLineEdit = new QgsSpinBoxLineEdit();
 
   // By default, group separator is off
-  setLocale( QLocale( QgsApplication::locale( ) ) );
   setLineEdit( mLineEdit );
 
   QSize msz = minimumSizeHint();

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -371,7 +371,7 @@
                     <item row="0" column="0">
                      <widget class="QLabel" name="label_5">
                       <property name="text">
-                       <string>Locale to use instead</string>
+                       <string>User Interface Translation</string>
                       </property>
                      </widget>
                     </item>
@@ -392,6 +392,9 @@
                   </item>
                   <item>
                    <widget class="QLabel" name="lblSystemLocale">
+                    <property name="toolTip">
+                     <string>This locale is used for number representation.</string>
+                    </property>
                     <property name="text">
                      <string>Detected active locale on your system</string>
                     </property>

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -18,7 +18,7 @@ from qgis.core import (QgsFeature, QgsProject, QgsRelation, QgsVectorLayer,
                        QgsValueMapFieldFormatter, QgsValueRelationFieldFormatter,
                        QgsRelationReferenceFieldFormatter, QgsRangeFieldFormatter, QgsSettings)
 
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication, QLocale
 from qgis.testing import start_app, unittest
 
 start_app()
@@ -243,6 +243,8 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
 
         fieldFormatter = QgsRangeFieldFormatter()
 
+        QLocale.setDefault(QLocale.c())
+
         # Precision is ignored for integers and longlongs
         self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '123'), '123')
         self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '123000'), '123000')
@@ -272,18 +274,17 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 3}, None, '-0.127'), '-0.127')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 3}, None, '-1.27e-1'), '-0.127')
 
-        QgsSettings().setValue("locale/overrideFlag", True)
-        QgsSettings().setValue("locale/userLocale", 'it')
+        QLocale.setDefault(QLocale('it'))
 
         self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '9999999'),
-                         '9999999')  # no scientific notation for integers!
+                         '9.999.999')  # scientific notation for integers!
         self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '123'), '123')
-        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '123000'), '123000')
-        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '9999999'), '9999999')  # no scientific notation for long longs!
+        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '123000'), '123.000')
+        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '9999999'), '9.999.999')  # scientific notation for long longs!
         self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, None), 'NULL')
 
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, None), 'NULL')
-        self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '123000'), '123000,00')
+        self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '123000'), '123.000,00')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '0'), '0,00')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '123'), '123,00')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '0.123'), '0,12')


### PR DESCRIPTION
Followup on discussion in https://github.com/qgis/QGIS/pull/6833

@elpaso this reverts some code where the user locale is used for number representation while everything else uses the system locale for this. What was it that looked different and led you to 
https://github.com/qgis/QGIS/commit/8ae65b3c70291a19c440a76172ac02bdfcb27c86#diff-327a6927d0fab68c4c6cb99928081e9cR35