### PR TITLE
[DBManager] Fix encoding error if a field/table/database/file name co…

### DIFF
--- a/python/plugins/db_manager/db_plugins/html_elems.py
+++ b/python/plugins/db_manager/db_plugins/html_elems.py
@@ -36,7 +36,12 @@ class HtmlContent:
         if hasattr(self.data, 'toHtml'):
             return self.data.toHtml()
 
-        html = unicode(self.data).replace("\n", "<br>")
+        if isinstance(self.data, str):
+            html = unicode(self.data, encoding='utf-8', errors='replace')
+        else:
+            html = unicode(self.data)
+        html = html.replace("\n", "<br>")
+
         return html
 
     def hasContents(self):

--- a/python/plugins/db_manager/db_plugins/html_elems.py
+++ b/python/plugins/db_manager/db_plugins/html_elems.py
@@ -38,6 +38,8 @@ class HtmlContent:
 
         if isinstance(self.data, str):
             html = unicode(self.data, encoding='utf-8', errors='replace')
+        elif isinstance(self.data, unicode):
+            html = self.data
         else:
             html = unicode(self.data)
         html = html.replace("\n", "<br>")


### PR DESCRIPTION
If a file, table or column name contains an unicode character, DBManager fails to displays its details and raises the well known ascii codec exception.

This PR assumes all non-ascii strings are utf-8, what should be true in most cases (in Postgis, GPKG and Spatialite). In other cases at least the exception should be suppressed and all other characters should be displayed (not tested though). 
