### PR TITLE
[processing] Add createByDefault argument to destination parameter constructors

### DIFF
--- a/python/core/processing/qgsprocessingparameters.sip.in
+++ b/python/core/processing/qgsprocessingparameters.sip.in
@@ -1819,9 +1819,12 @@ which are used for the destination for layers output by an algorithm.
   public:
 
     QgsProcessingDestinationParameter( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
-                                       bool optional = false );
+                                       bool optional = false, bool createByDefault = true );
 %Docstring
 Constructor for QgsProcessingDestinationParameter.
+
+If ``createByDefault`` is false and the parameter is ``optional``, then the destination
+output will not be created by default.
 %End
 
     virtual bool isDestination() const;
@@ -1900,9 +1903,12 @@ A parameter which represents the destination feature sink for features created b
   public:
 
     QgsProcessingParameterFeatureSink( const QString &name, const QString &description = QString(), QgsProcessing::SourceType type = QgsProcessing::TypeVectorAnyGeometry, const QVariant &defaultValue = QVariant(),
-                                       bool optional = false );
+                                       bool optional = false, bool createByDefault = true );
 %Docstring
 Constructor for QgsProcessingParameterFeatureSink.
+
+If ``createByDefault`` is false and the parameter is ``optional``, then this destination
+output will not be created by default.
 %End
 
     static QString typeName();
@@ -1978,9 +1984,12 @@ created by the algorithm.
   public:
 
     QgsProcessingParameterVectorDestination( const QString &name, const QString &description = QString(), QgsProcessing::SourceType type = QgsProcessing::TypeVectorAnyGeometry, const QVariant &defaultValue = QVariant(),
-        bool optional = false );
+        bool optional = false, bool createByDefault = true );
 %Docstring
 Constructor for QgsProcessingParameterVectorDestination.
+
+If ``createByDefault`` is false and the parameter is ``optional``, then this destination
+output will not be created by default.
 %End
 
     static QString typeName();
@@ -2050,9 +2059,13 @@ created by the algorithm.
 
     QgsProcessingParameterRasterDestination( const QString &name, const QString &description = QString(),
         const QVariant &defaultValue = QVariant(),
-        bool optional = false );
+        bool optional = false,
+        bool createByDefault = true );
 %Docstring
 Constructor for QgsProcessingParameterRasterDestination.
+
+If ``createByDefault`` is false and the parameter is ``optional``, then this destination
+output will not be created by default.
 %End
 
     static QString typeName();
@@ -2094,9 +2107,13 @@ created by the algorithm.
     QgsProcessingParameterFileDestination( const QString &name, const QString &description = QString(),
                                            const QString &fileFilter = QString(),
                                            const QVariant &defaultValue = QVariant(),
-                                           bool optional = false );
+                                           bool optional = false,
+                                           bool createByDefault = true );
 %Docstring
 Constructor for QgsProcessingParameterFileDestination.
+
+If ``createByDefault`` is false and the parameter is ``optional``, then this destination
+output will not be created by default.
 %End
 
     static QString typeName();

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -3055,11 +3055,10 @@ QgsProcessingParameterFeatureSource *QgsProcessingParameterFeatureSource::fromSc
   return new QgsProcessingParameterFeatureSource( name, description, types, def, isOptional );
 }
 
-QgsProcessingParameterFeatureSink::QgsProcessingParameterFeatureSink( const QString &name, const QString &description, QgsProcessing::SourceType type, const QVariant &defaultValue, bool optional )
-  : QgsProcessingDestinationParameter( name, description, defaultValue, optional )
+QgsProcessingParameterFeatureSink::QgsProcessingParameterFeatureSink( const QString &name, const QString &description, QgsProcessing::SourceType type, const QVariant &defaultValue, bool optional, bool createByDefault )
+  : QgsProcessingDestinationParameter( name, description, defaultValue, optional, createByDefault )
   , mDataType( type )
 {
-
 }
 
 QgsProcessingParameterDefinition *QgsProcessingParameterFeatureSink::clone() const
@@ -3251,9 +3250,10 @@ QgsProcessingParameterFeatureSink *QgsProcessingParameterFeatureSink::fromScript
   return new QgsProcessingParameterFeatureSink( name, description, type, definition, isOptional );
 }
 
-QgsProcessingParameterRasterDestination::QgsProcessingParameterRasterDestination( const QString &name, const QString &description, const QVariant &defaultValue, bool optional )
-  : QgsProcessingDestinationParameter( name, description, defaultValue, optional )
-{}
+QgsProcessingParameterRasterDestination::QgsProcessingParameterRasterDestination( const QString &name, const QString &description, const QVariant &defaultValue, bool optional, bool createByDefault )
+  : QgsProcessingDestinationParameter( name, description, defaultValue, optional, createByDefault )
+{
+}
 
 QgsProcessingParameterDefinition *QgsProcessingParameterRasterDestination::clone() const
 {
@@ -3331,8 +3331,8 @@ QgsProcessingParameterRasterDestination *QgsProcessingParameterRasterDestination
 }
 
 
-QgsProcessingParameterFileDestination::QgsProcessingParameterFileDestination( const QString &name, const QString &description, const QString &fileFilter, const QVariant &defaultValue, bool optional )
-  : QgsProcessingDestinationParameter( name, description, defaultValue, optional )
+QgsProcessingParameterFileDestination::QgsProcessingParameterFileDestination( const QString &name, const QString &description, const QString &fileFilter, const QVariant &defaultValue, bool optional, bool createByDefault )
+  : QgsProcessingDestinationParameter( name, description, defaultValue, optional, createByDefault )
   , mFileFilter( fileFilter.isEmpty() ? QObject::tr( "All files (*.*)" ) : fileFilter )
 {
 
@@ -3492,8 +3492,9 @@ QgsProcessingParameterFolderDestination *QgsProcessingParameterFolderDestination
   return new QgsProcessingParameterFolderDestination( name, description, definition.isEmpty() ? QVariant() : definition, isOptional );
 }
 
-QgsProcessingDestinationParameter::QgsProcessingDestinationParameter( const QString &name, const QString &description, const QVariant &defaultValue, bool optional )
+QgsProcessingDestinationParameter::QgsProcessingDestinationParameter( const QString &name, const QString &description, const QVariant &defaultValue, bool optional, bool createByDefault )
   : QgsProcessingParameterDefinition( name, description, defaultValue, optional )
+  , mCreateByDefault( createByDefault )
 {
 
 }
@@ -3529,8 +3530,8 @@ void QgsProcessingDestinationParameter::setCreateByDefault( bool createByDefault
   mCreateByDefault = createByDefault;
 }
 
-QgsProcessingParameterVectorDestination::QgsProcessingParameterVectorDestination( const QString &name, const QString &description, QgsProcessing::SourceType type, const QVariant &defaultValue, bool optional )
-  : QgsProcessingDestinationParameter( name, description, defaultValue, optional )
+QgsProcessingParameterVectorDestination::QgsProcessingParameterVectorDestination( const QString &name, const QString &description, QgsProcessing::SourceType type, const QVariant &defaultValue, bool optional, bool createByDefault )
+  : QgsProcessingDestinationParameter( name, description, defaultValue, optional, createByDefault )
   , mDataType( type )
 {
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -1758,9 +1758,12 @@ class CORE_EXPORT QgsProcessingDestinationParameter : public QgsProcessingParame
 
     /**
      * Constructor for QgsProcessingDestinationParameter.
+     *
+     * If \a createByDefault is false and the parameter is \a optional, then the destination
+     * output will not be created by default.
      */
     QgsProcessingDestinationParameter( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
-                                       bool optional = false );
+                                       bool optional = false, bool createByDefault = true );
 
     bool isDestination() const override { return true; }
     QVariantMap toVariantMap() const override;
@@ -1835,9 +1838,12 @@ class CORE_EXPORT QgsProcessingParameterFeatureSink : public QgsProcessingDestin
 
     /**
      * Constructor for QgsProcessingParameterFeatureSink.
+     *
+     * If \a createByDefault is false and the parameter is \a optional, then this destination
+     * output will not be created by default.
      */
     QgsProcessingParameterFeatureSink( const QString &name, const QString &description = QString(), QgsProcessing::SourceType type = QgsProcessing::TypeVectorAnyGeometry, const QVariant &defaultValue = QVariant(),
-                                       bool optional = false );
+                                       bool optional = false, bool createByDefault = true );
 
     /**
      * Returns the type name for the parameter class.
@@ -1900,9 +1906,12 @@ class CORE_EXPORT QgsProcessingParameterVectorDestination : public QgsProcessing
 
     /**
      * Constructor for QgsProcessingParameterVectorDestination.
+     *
+     * If \a createByDefault is false and the parameter is \a optional, then this destination
+     * output will not be created by default.
      */
     QgsProcessingParameterVectorDestination( const QString &name, const QString &description = QString(), QgsProcessing::SourceType type = QgsProcessing::TypeVectorAnyGeometry, const QVariant &defaultValue = QVariant(),
-        bool optional = false );
+        bool optional = false, bool createByDefault = true );
 
     /**
      * Returns the type name for the parameter class.
@@ -1961,10 +1970,14 @@ class CORE_EXPORT QgsProcessingParameterRasterDestination : public QgsProcessing
 
     /**
      * Constructor for QgsProcessingParameterRasterDestination.
+     *
+     * If \a createByDefault is false and the parameter is \a optional, then this destination
+     * output will not be created by default.
      */
     QgsProcessingParameterRasterDestination( const QString &name, const QString &description = QString(),
         const QVariant &defaultValue = QVariant(),
-        bool optional = false );
+        bool optional = false,
+        bool createByDefault = true );
 
     /**
      * Returns the type name for the parameter class.
@@ -1996,11 +2009,15 @@ class CORE_EXPORT QgsProcessingParameterFileDestination : public QgsProcessingDe
 
     /**
      * Constructor for QgsProcessingParameterFileDestination.
+     *
+     * If \a createByDefault is false and the parameter is \a optional, then this destination
+     * output will not be created by default.
      */
     QgsProcessingParameterFileDestination( const QString &name, const QString &description = QString(),
                                            const QString &fileFilter = QString(),
                                            const QVariant &defaultValue = QVariant(),
-                                           bool optional = false );
+                                           bool optional = false,
+                                           bool createByDefault = true );
 
     /**
      * Returns the type name for the parameter class.


### PR DESCRIPTION
Allows this setting to be set for parameters created from description text files
