### PR TITLE
[server] Avoid %2B to be interpreted as space in querystring

### DIFF
--- a/src/server/qgsserverrequest.cpp
+++ b/src/server/qgsserverrequest.cpp
@@ -76,14 +76,12 @@ QMap<QString, QString> QgsServerRequest::parameters() const
     typedef QPair<QString, QString> pair_t;
 
     QUrlQuery query( mUrl );
+    query.setQuery( query.query().replace( '+', QStringLiteral( "%20" ) ) );
+
     QList<pair_t> items = query.queryItems( QUrl::FullyDecoded );
     Q_FOREACH ( const pair_t &pair, items )
     {
-      // prepare the value
-      QString value = pair.second;
-      value.replace( '+', ' ' );
-
-      mParams.insert( pair.first.toUpper(), value );
+      mParams.insert( pair.first.toUpper(), pair.second );
     }
     mDecoded = true;
   }

--- a/tests/src/python/test_qgsserver_request.py
+++ b/tests/src/python/test_qgsserver_request.py
@@ -48,6 +48,11 @@ class QgsServerRequestTest(unittest.TestCase):
         for k, v in request.headers().items():
             self.assertEqual(parameters[k], v)
 
+    def test_requestParametersDecoding(self):
+        """Test request parameters decoding"""
+        request = QgsServerRequest('http://somesite.com/somepath?parm1=val1%20%2B+val2', QgsServerRequest.GetMethod)
+        self.assertEqual(request.parameters()['PARM1'], 'val1 + val2')
+
     def test_requestUrl(self):
         """Test url"""
         request = QgsServerRequest('http://somesite.com/somepath', QgsServerRequest.GetMethod)


### PR DESCRIPTION
If '+' is replaced by ' ' after percent decoding, '%2B' is interpreted as ' '.

Fix this by replacing '+' by '%20' before percent decoding.

PR open as bug fix on release-3_0, needs to be cherry-picked in master too.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
