### PR TITLE
Update RPM spec since GRASS 7.4 has been backported to F27

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -12,7 +12,7 @@
 %define builddate %(date '+%a %b %d %Y')
 %endif
 
-%if 0%{?fedora} >= 28
+%if 0%{?fedora} >= 27
 %define grass grass74
 %else
 %define grass grass72


### PR DESCRIPTION
## Description
Thanks to the work done by @neteler GRASS 7.4 is going to be backported to Fedora 27 too (https://bodhi.fedoraproject.org/updates/FEDORA-2018-e13babe183), so the check introduced by #6854 needs to be updated.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
