### PR TITLE
[needs-docs] New layer panel action 'Move Out of Group', replaces 'Make Top Level' (deprecated). Small modification of the actions behavior

### DIFF
--- a/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
+++ b/python/gui/layertree/qgslayertreeviewdefaultactions.sip.in
@@ -59,7 +59,19 @@ Action to zoom to selected features of a vector layer
 %End
     QAction *actionZoomToGroup( QgsMapCanvas *canvas, QObject *parent = 0 ) /Factory/;
 
-    QAction *actionMakeTopLevel( QObject *parent = 0 ) /Factory/;
+ QAction *actionMakeTopLevel( QObject *parent = 0 ) /Factory/;
+%Docstring
+
+.. deprecated:: since QGIS 3.2, use actionMoveOutOfGroup()
+%End
+
+    QAction *actionMoveOutOfGroup( QObject *parent = 0 ) /Factory/;
+%Docstring
+
+.. seealso:: :py:func:`moveOutOfGroup`
+
+.. versionadded:: 3.2
+%End
 
     QAction *actionMoveToTop( QObject *parent = 0 ) /Factory/;
 %Docstring
@@ -105,7 +117,19 @@ Slot to zoom to selected features of a vector layer
 .. versionadded:: 3.2
 %End
     void zoomToGroup();
-    void makeTopLevel();
+
+ void makeTopLevel();
+%Docstring
+
+.. deprecated:: since QGIS 3.2, use moveOutOfGroup()
+%End
+
+    void moveOutOfGroup();
+%Docstring
+Moves selected layer(s) out of the group(s) and places this/these above the group(s)
+
+.. versionadded:: 3.2
+%End
 
     void moveToTop();
 %Docstring

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -178,7 +178,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       menu->addSeparator();
 
       if ( node->parent() != mView->layerTreeModel()->rootGroup() )
-        menu->addAction( actions->actionMakeTopLevel( menu ) );
+        menu->addAction( actions->actionMoveOutOfGroup( menu ) );
 
       if ( !( mView->selectedNodes( true ).count() == 1 && idx.row() == 0 ) )
       {

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -118,7 +118,16 @@ QAction *QgsLayerTreeViewDefaultActions::actionZoomToGroup( QgsMapCanvas *canvas
 QAction *QgsLayerTreeViewDefaultActions::actionMakeTopLevel( QObject *parent )
 {
   QAction *a = new QAction( tr( "&Move to Top-level" ), parent );
+  Q_NOWARN_DEPRECATED_PUSH
   connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::makeTopLevel );
+  Q_NOWARN_DEPRECATED_POP
+  return a;
+}
+
+QAction *QgsLayerTreeViewDefaultActions::actionMoveOutOfGroup( QObject *parent )
+{
+  QAction *a = new QAction( tr( "Move Out of &Group" ), parent );
+  connect( a, &QAction::triggered, this, &QgsLayerTreeViewDefaultActions::moveOutOfGroup );
   return a;
 }
 
@@ -384,6 +393,29 @@ void QgsLayerTreeViewDefaultActions::makeTopLevel()
     parentGroup->removeChildNode( l );
   }
 }
+
+
+void QgsLayerTreeViewDefaultActions::moveOutOfGroup()
+{
+  const QList< QgsLayerTreeLayer * >  selectedLayerNodes = mView->selectedLayerNodes();
+  for ( QgsLayerTreeLayer *l : selectedLayerNodes )
+  {
+    QgsLayerTreeGroup *rootGroup = mView->layerTreeModel()->rootGroup();
+    QgsLayerTreeGroup *parentGroup = qobject_cast<QgsLayerTreeGroup *>( l->parent() );
+    if ( !parentGroup || parentGroup == rootGroup )
+      continue;
+    QgsLayerTreeGroup *tempGroup = parentGroup;
+    while ( tempGroup->parent() != rootGroup )
+    {
+      tempGroup = qobject_cast<QgsLayerTreeGroup *>( tempGroup->parent() );
+    }
+    QgsLayerTreeLayer *clonedLayer = l->clone();
+    int insertIdx = rootGroup->children().indexOf( tempGroup );
+    rootGroup->insertChildNode( insertIdx, clonedLayer );
+    parentGroup->removeChildNode( l );
+  }
+}
+
 
 void QgsLayerTreeViewDefaultActions::moveToTop()
 {

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.h
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.h
@@ -66,7 +66,16 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
     QAction *actionZoomToSelection( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
     QAction *actionZoomToGroup( QgsMapCanvas *canvas, QObject *parent = nullptr ) SIP_FACTORY;
 
-    QAction *actionMakeTopLevel( QObject *parent = nullptr ) SIP_FACTORY;
+    /**
+     * \deprecated since QGIS 3.2, use actionMoveOutOfGroup()
+     */
+    Q_DECL_DEPRECATED QAction *actionMakeTopLevel( QObject *parent = nullptr ) SIP_FACTORY;
+
+    /**
+     * \see moveOutOfGroup()
+     * \since QGIS 3.2
+     */
+    QAction *actionMoveOutOfGroup( QObject *parent = nullptr ) SIP_FACTORY;
 
     /**
      * \see moveToTop()
@@ -106,7 +115,17 @@ class GUI_EXPORT QgsLayerTreeViewDefaultActions : public QObject
      */
     void zoomToSelection();
     void zoomToGroup();
-    void makeTopLevel();
+
+    /**
+     * \deprecated since QGIS 3.2, use moveOutOfGroup()
+     */
+    Q_DECL_DEPRECATED void makeTopLevel();
+
+    /**
+     * Moves selected layer(s) out of the group(s) and places this/these above the group(s)
+     * \since QGIS 3.2
+     */
+    void moveOutOfGroup();
 
     /**
      * Moves selected layer(s) and/or group(s) to the top of the layer panel

--- a/tests/src/python/test_qgslayertreeview.py
+++ b/tests/src/python/test_qgslayertreeview.py
@@ -111,6 +111,36 @@ class TestQgsLayerTreeView(unittest.TestCase):
         show_in_overview.trigger()
         self.assertEqual(view.currentNode().customProperty('overview', 0), False)
 
+    def testMoveOutOfGroupActionLayer(self):
+        """Test move out of group action on layer"""
+        view = QgsLayerTreeView()
+        group = self.project.layerTreeRoot().addGroup("embeddedgroup")
+        group.addLayer(self.layer4)
+        group.addLayer(self.layer5)
+        groupname = group.name()
+        view.setModel(self.model)
+        actions = QgsLayerTreeViewDefaultActions(view)
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            groupname,
+            groupname + '-' + self.layer4.name(),
+            groupname + '-' + self.layer5.name(),
+        ])
+
+        view.setCurrentLayer(self.layer5)
+        moveOutOfGroup = actions.actionMoveOutOfGroup()
+        moveOutOfGroup.trigger()
+        self.assertEqual(self.nodeOrder(self.project.layerTreeRoot().children()), [
+            self.layer.name(),
+            self.layer2.name(),
+            self.layer3.name(),
+            self.layer5.name(),
+            groupname,
+            groupname + '-' + self.layer4.name(),
+        ])
+
     def testMoveToTopActionLayer(self):
         """Test move to top action on layer"""
         view = QgsLayerTreeView()


### PR DESCRIPTION
## Description
The code in this PR changes the name of the layer panel action 'Move to Top Level' to 'Ungroup'.
This new name, 'Ungroup', is more informative of the action and avoids confusion with the action 'Move to Top' (added in version 3.2). 

Furthermore, the action is slightly changed: Now the selected layers in a group are placed just above this group. This is more intuitive and it resembles the behavior of the 'Group Selected'-action. Before the 'Move to Top level'-action moved the selected layers to the bottom of the layer panel.

Unit test of the changed action is added. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
