### PR TITLE
Remove unrequired `;` semicolons

### DIFF
--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
       WARNING = 1,
       CRITICAL = 2
     };
-    Q_ENUM( MessageLevel );
+    Q_ENUM( MessageLevel )
 
     /**
      * \brief init initialize QCA, prioritize qca-ossl plugin and optionally set up the authentication database

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -84,7 +84,7 @@ class CORE_EXPORT QgsDataItem : public QObject
       Custom, //!< Custom item type
     };
 
-    Q_ENUM( Type );
+    Q_ENUM( Type )
 
     //! Create new data item.
     QgsDataItem( QgsDataItem::Type type, QgsDataItem *parent SIP_TRANSFERTHIS, const QString &name, const QString &path );
@@ -105,7 +105,7 @@ class CORE_EXPORT QgsDataItem : public QObject
       Populating,   //!< Creating children in separate thread (populating or refreshing)
       Populated     //!< Children created
     };
-    Q_ENUM( State );
+    Q_ENUM( State )
 
     //! \since QGIS 2.8
     State state() const;
@@ -426,7 +426,7 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
       Mesh       //!< Added in 3.2
     };
 
-    Q_ENUM( LayerType );
+    Q_ENUM( LayerType )
 
     QgsLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &uri, LayerType layerType, const QString &providerKey );
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -81,7 +81,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
       Database            = 1 << 2,
       Net                 = 1 << 3  // Internet source
     };
-    Q_ENUM( DataCapability );
+    Q_ENUM( DataCapability )
 
     /**
      * Properties are used to pass custom configuration options into data providers.

--- a/src/core/qgssnappingconfig.h
+++ b/src/core/qgssnappingconfig.h
@@ -48,7 +48,7 @@ class CORE_EXPORT QgsSnappingConfig
       AllLayers = 2, //!< On all vector layers
       AdvancedConfiguration = 3, //!< On a per layer configuration basis
     };
-    Q_ENUM( SnappingMode );
+    Q_ENUM( SnappingMode )
 
     /**
      * SnappingType defines on what object the snapping is performed
@@ -59,7 +59,7 @@ class CORE_EXPORT QgsSnappingConfig
       VertexAndSegment = 2, //!< Both on vertices and segments
       Segment = 3, //!< On segments only
     };
-    Q_ENUM( SnappingType );
+    Q_ENUM( SnappingType )
 
     /**
      * \ingroup core

--- a/src/core/qgstolerance.h
+++ b/src/core/qgstolerance.h
@@ -46,7 +46,7 @@ class CORE_EXPORT QgsTolerance
       //! Map (project) units. Added in 2.8
       ProjectUnits
     };
-    Q_ENUM( UnitType );
+    Q_ENUM( UnitType )
 
     /**
      * Static function to get vertex tolerance value.

--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -53,7 +53,7 @@ class CORE_EXPORT QgsUnitTypes
       DistanceMillimeters, //!< Millimeters
       DistanceUnknownUnit, //!< Unknown distance unit
     };
-    Q_ENUM( DistanceUnit );
+    Q_ENUM( DistanceUnit )
 
     /**
      * Types of distance units
@@ -81,7 +81,7 @@ class CORE_EXPORT QgsUnitTypes
       AreaSquareMillimeters, //! Square millimeters
       AreaUnknownUnit, //!< Unknown areal unit
     };
-    Q_ENUM( AreaUnit );
+    Q_ENUM( AreaUnit )
 
     //! Units of angles
     enum AngleUnit
@@ -94,7 +94,7 @@ class CORE_EXPORT QgsUnitTypes
       AngleTurn, //!< Turn/revolutions
       AngleUnknownUnit, //!< Unknown angle unit
     };
-    Q_ENUM( AngleUnit );
+    Q_ENUM( AngleUnit )
 
     //! Rendering size units
     enum RenderUnit
@@ -108,7 +108,7 @@ class CORE_EXPORT QgsUnitTypes
       RenderUnknownUnit, //!< Mixed or unknown units
       RenderMetersInMapUnits, //!< Meters value as Map units
     };
-    Q_ENUM( RenderUnit );
+    Q_ENUM( RenderUnit )
 
     //! Layout measurement units
     enum LayoutUnit
@@ -122,7 +122,7 @@ class CORE_EXPORT QgsUnitTypes
       LayoutPicas, //!< Typographic picas
       LayoutPixels //!< Pixels
     };
-    Q_ENUM( LayoutUnit );
+    Q_ENUM( LayoutUnit )
 
     //! Types of layout units
     enum LayoutUnitType

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -67,7 +67,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
       AttributeEditor = 1
     };
 
-    Q_ENUM( ViewMode );
+    Q_ENUM( ViewMode )
 
     /**
      * \brief Constructor

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -67,7 +67,7 @@ class GUI_EXPORT QgsColorButton : public QToolButton
       ShowDialog = 0, //!< Show a color picker dialog when clicked
       SignalOnly //!< Emit colorClicked signal only, no dialog
     };
-    Q_ENUM( Behavior );
+    Q_ENUM( Behavior )
 
     /**
      * Construct a new color ramp button.

--- a/src/gui/qgsfloatingwidget.h
+++ b/src/gui/qgsfloatingwidget.h
@@ -52,7 +52,7 @@ class GUI_EXPORT QgsFloatingWidget: public QWidget
       BottomMiddle, //!< Bottom center of widget
       BottomRight, //!< Bottom-right of widget
     };
-    Q_ENUM( AnchorPoint );
+    Q_ENUM( AnchorPoint )
 
     /**
      * Constructor for QgsFloatingWidget.

--- a/src/gui/qgsfontbutton.h
+++ b/src/gui/qgsfontbutton.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsFontButton : public QToolButton
       ModeQFont, //!< Configure font settings for use with QFont objects
     };
 
-    Q_ENUM( Mode );
+    Q_ENUM( Mode )
 
     /**
      * Construct a new font button.

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -62,7 +62,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
       ForeignTable, // f
       PartitionedTable // p - PostgreSQL 10
     };
-    Q_ENUM( Relkind );
+    Q_ENUM( Relkind )
 
     /**
      * Import a vector layer into the database


### PR DESCRIPTION
Because they trigger warnings in the QtCreator editor ui