### PR TITLE
Remove QgsSnapper API change docs. It is ✝

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2152,12 +2152,6 @@ QgsSlider        {#qgis_api_break_3_0_QgsSlider}
 - The protected valueChanged slot was removed.
 
 
-QgsSnapper        {#qgis_api_break_3_0_QgsSnapper}
-----------
-
-- Constructor variant with QgsMapRenderer has been removed. Use the variant with QgsMapSettings.
-- Signature for snapPoint() has changed.
-
 QgsSnappingUtils        {#qgis_api_break_3_0_QgsSnappingUtils}
 ----------------
 


### PR DESCRIPTION
## Description
Removed classes should be documented for their removal and replacement, not API changes they experienced prior to their demise.