### PR TITLE
[afs] Fix handling of date/datetime field values

### DIFF
--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -108,6 +108,11 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
           // ensure that null values are mapped correctly for PyQGIS
           attribute = QVariant( QVariant::Int );
         }
+
+        // date/datetime fields must be converted
+        if ( mFields.at( idx ).type() == QVariant::DateTime || mFields.at( idx ).type() == QVariant::Date )
+          attribute = QgsArcGisRestUtils::parseDateTime( attribute );
+
         if ( !mFields.at( idx ).convertCompatible( attribute ) )
         {
           QgsDebugMsg( QStringLiteral( "Invalid value %1 for field %2 of type %3" ).arg( attributesData[mFields.at( idx ).name()].toString(), mFields.at( idx ).name(), mFields.at( idx ).typeName() ) );

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -756,6 +756,21 @@ Qt::BrushStyle QgsArcGisRestUtils::parseEsriFillStyle( const QString &style )
     return Qt::SolidPattern;
 }
 
+QDateTime QgsArcGisRestUtils::parseDateTime( const QVariant &value )
+{
+  if ( value.isNull() )
+    return QDateTime();
+  bool ok = false;
+  QDateTime dt = QDateTime::fromMSecsSinceEpoch( value.toLongLong( &ok ) );
+  if ( !ok )
+  {
+    QgsDebugMsg( QStringLiteral( "Invalid value %1 for datetime" ).arg( value.toString() ) );
+    return QDateTime();
+  }
+  else
+    return dt;
+}
+
 QUrl QgsArcGisRestUtils::parseUrl( const QUrl &url )
 {
   QUrl modifiedUrl( url );

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -61,6 +61,8 @@ class QgsArcGisRestUtils
     static Qt::PenStyle parseEsriLineStyle( const QString &style );
     static Qt::BrushStyle parseEsriFillStyle( const QString &style );
 
+    static QDateTime parseDateTime( const QVariant &value );
+
     static QUrl parseUrl( const QUrl &url );
 };
 


### PR DESCRIPTION
The AFS provider cannot currently handle date/datetime values - all are silently discarded. We need to convert these manually from ms since epoch to QDateTime values.