### PR TITLE
[afs] Fix handling of custom projections

### DIFF
--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -47,7 +47,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri )
   mSharedData->mDataSource = QgsDataSourceUri( uri );
 
   // Set CRS
-  mSharedData->mSourceCRS = QgsCoordinateReferenceSystem::fromOgcWmsCrs( mSharedData->mDataSource.param( QStringLiteral( "crs" ) ) );
+  mSharedData->mSourceCRS.createFromString( mSharedData->mDataSource.param( QStringLiteral( "crs" ) ) );
 
   // Get layer info
   QString errorTitle, errorMessage;

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -90,11 +90,6 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
     cachedItem->setCheckState( Qt::Checked );
 
     QgsCoordinateReferenceSystem crs = QgsArcGisRestUtils::parseSpatialReference( serviceInfoMap[QStringLiteral( "spatialReference" )].toMap() );
-    if ( !crs.isValid() )
-    {
-      // If not spatial reference, just use WGS84
-      crs.createFromString( QStringLiteral( "EPSG:4326" ) );
-    }
     mAvailableCRS[layerData[QStringLiteral( "name" )].toString()] = QList<QString>()  << crs.authid();
 
     mModel->appendRow( QList<QStandardItem *>() << idItem << nameItem << abstractItem << cachedItem << filterItem );

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -342,8 +342,11 @@ QgsCoordinateReferenceSystem QgsArcGisRestUtils::parseSpatialReference( const QV
     spatialReference = QStringLiteral( "EPSG:%1" ).arg( spatialReference );
   QgsCoordinateReferenceSystem crs;
   crs.createFromString( spatialReference );
-  if ( crs.authid().startsWith( QLatin1String( "USER:" ) ) )
-    crs.createFromString( QStringLiteral( "EPSG:4326" ) ); // If we can't recognize the SRS, fall back to WGS84
+  if ( !crs.isValid() )
+  {
+    // If not spatial reference, just use WGS84
+    crs.createFromString( QStringLiteral( "EPSG:4326" ) );
+  }
   return crs;
 }
 

--- a/tests/src/providers/testqgsarcgisrestutils.cpp
+++ b/tests/src/providers/testqgsarcgisrestutils.cpp
@@ -37,6 +37,7 @@ class TestQgsArcGisRestUtils : public QObject
     void init() {}// will be called before each testfunction is executed.
     void cleanup() {}// will be called after every testfunction.
     void testMapEsriFieldType();
+    void testParseSpatialReference();
     void testMapEsriGeometryType();
     void testParseEsriFillStyle();
     void testParseEsriLineStyle();
@@ -87,6 +88,18 @@ void TestQgsArcGisRestUtils::testMapEsriFieldType()
   // not valid fields
   QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "esriFieldTypeGeometry" ) ), QVariant::Invalid );
   QCOMPARE( QgsArcGisRestUtils::mapEsriFieldType( QStringLiteral( "xxx" ) ), QVariant::Invalid );
+}
+
+void TestQgsArcGisRestUtils::testParseSpatialReference()
+{
+  QVariantMap map;
+  map.insert(
+    QStringLiteral( "wkt" ),
+    QStringLiteral( "PROJCS[\"NewJTM\",GEOGCS[\"GCS_ETRF_1989\",DATUM[\"D_ETRF_1989\",SPHEROID[\"WGS_1984\",6378137.0,298.257223563]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"False_Easting\",40000.0],PARAMETER[\"False_Northing\",70000.0],PARAMETER[\"Central_Meridian\",-2.135],PARAMETER[\"Scale_Factor\",0.9999999],PARAMETER[\"Latitude_Of_Origin\",49.225],UNIT[\"Meter\",1.0]]" ) );
+
+  QgsCoordinateReferenceSystem crs = QgsArcGisRestUtils::parseSpatialReference( map );
+  QVERIFY( crs.isValid() );
+  QCOMPARE( crs.toWkt(), QStringLiteral( "PROJCS[\"unnamed\",GEOGCS[\"WGS 84\",DATUM[\"unknown\",SPHEROID[\"WGS84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",49.225],PARAMETER[\"central_meridian\",-2.135],PARAMETER[\"scale_factor\",0.9999999],PARAMETER[\"false_easting\",40000],PARAMETER[\"false_northing\",70000],UNIT[\"Meter\",1]]" ) );
 }
 
 void TestQgsArcGisRestUtils::testMapEsriGeometryType()


### PR DESCRIPTION
Don't treat all unknown projections as WGS84

Fixes #18881

@manisandro What was the original logic behind excluding user projections here?