### PR TITLE
[processing] draw vector icons when available in modeler

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -132,7 +132,7 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
         return QgsApplication.getThemeIcon("/providerGrass.svg")
 
     def svgIconPath(self):
-        return QgsApplication.iconPath("providerGrass.svg")
+        return QgsApplication.iconPath("/providerGrass.svg")
 
     def supportsNonFileBasedOutput(self):
         """

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -75,8 +75,17 @@ class ModelerGraphicItem(QGraphicsItem):
             self.pixmap = None
             self.text = element.name()
         else:
+            if element.algorithm().svgIconPath():
+                svg = QSvgRenderer(element.algorithm().svgIconPath())
+                size = svg.defaultSize()
+                self.picture = QPicture()
+                painter = QPainter(self.picture)
+                painter.scale(16 / size.width(), 16 / size.width())
+                svg.render(painter)
+                self.pixmap = None
+            else:
+                self.pixmap = element.algorithm().icon().pixmap(15, 15)
             self.text = element.description()
-            self.pixmap = element.algorithm().icon().pixmap(15, 15)
         self.arrows = []
         self.setFlag(QGraphicsItem.ItemIsMovable, True)
         self.setFlag(QGraphicsItem.ItemIsSelectable, True)


### PR DESCRIPTION
## Description
This PR updates the modeler to draw algorithm vector icons when available. This avoids pixelated icons when zooming into a model, and allows for resolution-independent icons when a model is exported into PDF and/or SVG.

Before:
![screenshot from 2018-04-30 12-10-13](https://user-images.githubusercontent.com/1728657/39415675-6d16b534-4c70-11e8-875d-51396333c5f5.png)

With PR:
![screenshot from 2018-04-30 12-11-13](https://user-images.githubusercontent.com/1728657/39415681-70f1d08a-4c70-11e8-82b0-b6e69a7ca6f2.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
