### PR TITLE
[processing] add help and clarity to the define current projection algorithm

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -550,3 +550,9 @@ qgis:voronoipolygons: >
 
 qgis:zonalstatistics:
 
+
+qgis:definecurrentprojection: >
+  This algorithm sets an existing layer's projection to the provided CRS. Contrary to the "Assign projection" algorithm, it will not output a new layer.
+
+  For shapefile datasets, the .prj and .qpj files will be overwritten - or created if missing - to match the provided CRS.
+

--- a/python/plugins/processing/algs/qgis/DefineProjection.py
+++ b/python/plugins/processing/algs/qgis/DefineProjection.py
@@ -56,7 +56,7 @@ class DefineProjection(QgisAlgorithm):
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterVectorLayer(self.INPUT,
                                                             self.tr('Input Layer'), types=[QgsProcessing.TypeVectorAnyGeometry]))
-        self.addParameter(QgsProcessingParameterCrs(self.CRS, 'Output CRS'))
+        self.addParameter(QgsProcessingParameterCrs(self.CRS, 'CRS'))
         self.addOutput(QgsProcessingOutputVectorLayer(self.INPUT,
                                                       self.tr('Layer with projection')))
 
@@ -64,7 +64,7 @@ class DefineProjection(QgisAlgorithm):
         return 'definecurrentprojection'
 
     def displayName(self):
-        return self.tr('Define current projection')
+        return self.tr('Define layer projection')
 
     def flags(self):
         return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
@@ -81,14 +81,16 @@ class DefineProjection(QgisAlgorithm):
         if dsPath.lower().endswith('.shp'):
             dsPath = dsPath[:-4]
 
-        wkt = crs.toWkt()
-        with open(dsPath + '.prj', 'w') as f:
-            f.write(wkt)
-
-        qpjFile = dsPath + '.qpj'
-        if os.path.exists(qpjFile):
-            with open(qpjFile, 'w') as f:
+            wkt = crs.toWkt()
+            with open(dsPath + '.prj', 'w') as f:
                 f.write(wkt)
+
+            qpjFile = dsPath + '.qpj'
+            if os.path.exists(qpjFile):
+                with open(qpjFile, 'w') as f:
+                    f.write(wkt)
+        else:
+            feedback.pushConsoleInfo(tr("Data source isn't a shapefile, skipping .prj/.qpj creation"))
 
         layer.setCrs(crs)
         layer.triggerRepaint()


### PR DESCRIPTION
## Description
This PR tries to clarify what the 'define current projection' algorithm really is about:
- the algorithm is renamed to define _layer_ projection
- the CRS parameter is renamed from 'Output CRS' to 'CRS' to better highlight fact that there is no output vector layer created
- an help file is added to help users, and hint/warn that, for shapefiles, the .prj / .qpj files are going to be overwritten

I've also changed the algorithm so it stops creating .prj and .qpj files for non-shapefile datasets.

@nyalldawson , hope this helps taking care of confusions around this algorithm.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
