### PR TITLE
[processing] Refactor Fields algorithm: avoid unnecessary confirmation dialogs

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -325,6 +325,8 @@ class FieldsMappingPanel(BASE, WIDGET):
             delegate)
 
     def setLayer(self, layer):
+        if self.model.layer() == layer:
+            return
         self.model.setLayer(layer)
         if layer is None:
             return

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -154,4 +154,5 @@ def execAlgorithmDialog(algOrName, parameters={}):
         canvas.setMapTool(prevMapTool)
 
     results = dlg.results()
+    dlg.close()
     return results

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -154,5 +154,6 @@ def execAlgorithmDialog(algOrName, parameters={}):
         canvas.setMapTool(prevMapTool)
 
     results = dlg.results()
+    # make sure the dialog is destroyed and not only hidden on pressing Esc
     dlg.close()
     return results


### PR DESCRIPTION
## Description

There is a modal confirmation dialog in Refactor Fields algorithm that is shown even before opening/after closing the algorithm dialog.

[Watch this short video](http://downloads.tuxfamily.org/tuxgis/tmp/ai/gif_refactor_fields_qgis.mp4) of what happens in QGIS.
[Watch this short video](http://downloads.tuxfamily.org/tuxgis/tmp/ai/gif_refactor_fields_plugin.mp4) of what happens when using the `Fields Mapper` widget in a custom model.

This PR avoids opening such confirmation dialog JUST in that couple of situations:

- Before opening the algorithm dialog.
- After closing the algorithm dialog.

Thanks to @m-kuhn for the guidance!

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
