### PR TITLE
Fix crash when unloading multiple layers from a project

### DIFF
--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -186,30 +186,34 @@ void QgsStatisticalSummaryDockWidget::refreshStatistics()
   if ( ok )
   {
     int featureCount = selectedOnly ? mLayer->selectedFeatureCount() : mLayer->featureCount();
-    mGatherer = new QgsStatisticsValueGatherer( mLayer, fit, featureCount, sourceFieldExp );
+    std::unique_ptr< QgsStatisticsValueGatherer > gatherer = qgis::make_unique< QgsStatisticsValueGatherer >( mLayer, fit, featureCount, sourceFieldExp );
     switch ( mFieldType )
     {
       case DataType::Numeric:
-        connect( mGatherer, &QgsStatisticsValueGatherer::taskCompleted, this, &QgsStatisticalSummaryDockWidget::updateNumericStatistics );
+        connect( gatherer.get(), &QgsStatisticsValueGatherer::taskCompleted, this, &QgsStatisticalSummaryDockWidget::updateNumericStatistics );
         break;
       case DataType::String:
-        connect( mGatherer, &QgsStatisticsValueGatherer::taskCompleted, this, &QgsStatisticalSummaryDockWidget::updateStringStatistics );
+        connect( gatherer.get(), &QgsStatisticsValueGatherer::taskCompleted, this, &QgsStatisticalSummaryDockWidget::updateStringStatistics );
         break;
       case DataType::DateTime:
-        connect( mGatherer, &QgsStatisticsValueGatherer::taskCompleted, this, &QgsStatisticalSummaryDockWidget::updateDateTimeStatistics );
+        connect( gatherer.get(), &QgsStatisticsValueGatherer::taskCompleted, this, &QgsStatisticalSummaryDockWidget::updateDateTimeStatistics );
         break;
       default:
-        break;
+        //don't know how to handle stats for this field!
+        mStatisticsTable->setRowCount( 0 );
+        return;
     }
-    connect( mGatherer, &QgsStatisticsValueGatherer::progressChanged, mCalculatingProgressBar, &QProgressBar::setValue );
-    connect( mCancelButton, &QPushButton::clicked, mGatherer, &QgsStatisticsValueGatherer::cancel );
+    connect( gatherer.get(), &QgsStatisticsValueGatherer::progressChanged, mCalculatingProgressBar, &QProgressBar::setValue );
+    connect( gatherer.get(), &QgsStatisticsValueGatherer::taskTerminated, this, &QgsStatisticalSummaryDockWidget::gathererFinished );
+    connect( mCancelButton, &QPushButton::clicked, gatherer.get(), &QgsStatisticsValueGatherer::cancel );
     mCalculatingProgressBar->setMinimum( 0 );
     mCalculatingProgressBar->setMaximum( featureCount > 0 ? 100 : 0 );
     mCalculatingProgressBar->setValue( 0 );
     mCancelButton->show();
     mCalculatingProgressBar->show();
 
-    QgsApplication::taskManager()->addTask( mGatherer );
+    mGatherer = gatherer.get();
+    QgsApplication::taskManager()->addTask( gatherer.release() );
   }
 }
 

--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -219,10 +219,16 @@ void QgsStatisticalSummaryDockWidget::refreshStatistics()
 
 void QgsStatisticalSummaryDockWidget::gathererFinished()
 {
-  mGatherer = nullptr;
-  mCalculatingProgressBar->setValue( -1 );
-  mCancelButton->hide();
-  mCalculatingProgressBar->hide();
+  QgsStatisticsValueGatherer *gatherer = qobject_cast<QgsStatisticsValueGatherer *>( QObject::sender() );
+  // this may have been sent from a gathererer which was canceled previously and we don't care
+  // about it anymore...
+  if ( gatherer == mGatherer )
+  {
+    mGatherer = nullptr;
+    mCalculatingProgressBar->setValue( -1 );
+    mCancelButton->hide();
+    mCalculatingProgressBar->hide();
+  }
 }
 
 void QgsStatisticalSummaryDockWidget::updateNumericStatistics()

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -212,8 +212,11 @@ void QgsTask::setProgress( double progress )
     progress = ( progress + totalProgress ) / ( mSubTasks.count() + 1 );
   }
 
+  // avoid flooding with too many events
+  if ( static_cast< int >( mTotalProgress  * 10 ) != static_cast< int >( progress * 10 ) )
+    emit progressChanged( progress );
+
   mTotalProgress = progress;
-  emit progressChanged( mTotalProgress );
 }
 
 void QgsTask::completed()


### PR DESCRIPTION
The stats dock was holding onto a dangling pointer whenever the statistics gathering task was canceled. This meant that the next time the stats dock tried to start a calculation, it would try to cancel the dangling task pointer and crash.

This was happening frequently when multiple layers were removed from a project (or the project was cleared).

Found while porting Inasafe to QGIS 3 