### PR TITLE
Fix crssync crash during build

### DIFF
--- a/src/core/qgscolorschemeregistry.cpp
+++ b/src/core/qgscolorschemeregistry.cpp
@@ -117,12 +117,15 @@ void QgsColorSchemeRegistry::setRandomStyleColorScheme( QgsColorScheme *scheme )
   {
     mRandomStyleColors = scheme->fetchColors();
 
-    std::random_device rd;
-    std::mt19937 mt( rd() );
-    std::uniform_int_distribution<int> colorDist( 0, mRandomStyleColors.count() - 1 );
-    mNextRandomStyleColorIndex = colorDist( mt );
-    std::uniform_int_distribution<int> colorDir( 0, 1 );
-    mNextRandomStyleColorDirection = colorDir( mt ) == 0 ? -1 : 1;
+    if ( mRandomStyleColors.count() > 0 )
+    {
+      std::random_device rd;
+      std::mt19937 mt( rd() );
+      std::uniform_int_distribution<int> colorDist( 0, mRandomStyleColors.count() - 1 );
+      mNextRandomStyleColorIndex = colorDist( mt );
+      std::uniform_int_distribution<int> colorDir( 0, 1 );
+      mNextRandomStyleColorDirection = colorDir( mt ) == 0 ? -1 : 1;
+    }
   }
   else
   {


### PR DESCRIPTION
On my machine, crssync dies with a core dump during the build of QGIS.
Infinite loop because there is no color defined in the scheme it loads.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
