### PR TITLE
Fix double delete in QgsMeasureTool

### DIFF
--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -26,6 +26,7 @@
 
 class QCloseEvent;
 class QgsMeasureTool;
+class QgsMapCanvas;
 
 class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 {
@@ -92,28 +93,30 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 
     double convertArea( double area, QgsUnitTypes::AreaUnit toUnit ) const;
 
-    double mTotal;
+    double mTotal = 0.0;
 
     //! indicates whether we're measuring distances or areas
-    bool mMeasureArea;
+    bool mMeasureArea = false;
 
     //! Number of decimal places we want.
-    int mDecimalPlaces;
+    int mDecimalPlaces = 3;
 
     //! Current unit for input values
-    QgsUnitTypes::DistanceUnit mCanvasUnits;
+    QgsUnitTypes::DistanceUnit mCanvasUnits = QgsUnitTypes::DistanceUnknownUnit;
 
     //! Current unit for distance values
-    QgsUnitTypes::DistanceUnit mDistanceUnits;
+    QgsUnitTypes::DistanceUnit mDistanceUnits  = QgsUnitTypes::DistanceUnknownUnit;
 
     //! Current unit for area values
-    QgsUnitTypes::AreaUnit mAreaUnits;
+    QgsUnitTypes::AreaUnit mAreaUnits  = QgsUnitTypes::AreaUnknownUnit;
 
     //! Our measurement object
     QgsDistanceArea mDa;
 
     //! pointer to measure tool which owns this dialog
     QgsMeasureTool *mTool = nullptr;
+
+    QgsMapCanvas *mCanvas = nullptr;
 
     QgsPointXY mLastMousePoint;
 

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -56,14 +56,6 @@ QgsMeasureTool::QgsMeasureTool( QgsMapCanvas *canvas, bool measureArea )
   connect( canvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMeasureTool::updateSettings );
 }
 
-QgsMeasureTool::~QgsMeasureTool()
-{
-  delete mDialog;
-  delete mRubberBand;
-  delete mRubberBandPoints;
-}
-
-
 QVector<QgsPointXY> QgsMeasureTool::points()
 {
   return mPoints;

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -34,17 +34,14 @@
 
 QgsMeasureTool::QgsMeasureTool( QgsMapCanvas *canvas, bool measureArea )
   : QgsMapTool( canvas )
-  , mWrongProjectProjection( false )
+  , mMeasureArea( measureArea )
   , mSnapIndicator( new QgsSnapIndicator( canvas ) )
 {
-  mMeasureArea = measureArea;
-
   mRubberBand = new QgsRubberBand( canvas, mMeasureArea ? QgsWkbTypes::PolygonGeometry : QgsWkbTypes::LineGeometry );
   mRubberBandPoints = new QgsRubberBand( canvas, QgsWkbTypes::PointGeometry );
 
   setCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::CrossHair ) );
 
-  mDone = true;
   // Append point we will move
   mPoints.append( QgsPointXY( 0, 0 ) );
   mDestinationCrs = canvas->mapSettings().destinationCrs();
@@ -56,7 +53,14 @@ QgsMeasureTool::QgsMeasureTool( QgsMapCanvas *canvas, bool measureArea )
   connect( canvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMeasureTool::updateSettings );
 }
 
-QVector<QgsPointXY> QgsMeasureTool::points()
+QgsMeasureTool::~QgsMeasureTool()
+{
+  // important - dialog is not parented to this tool (it's parented to the main window)
+  // but we want to clean it up now
+  delete mDialog;
+}
+
+QVector<QgsPointXY> QgsMeasureTool::points() const
 {
   return mPoints;
 }

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -35,13 +35,15 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
 
     QgsMeasureTool( QgsMapCanvas *canvas, bool measureArea );
 
+    ~QgsMeasureTool() override;
+
     Flags flags() const override { return QgsMapTool::AllowZoomRect; }
 
     //! returns whether measuring distance or area
-    bool measureArea() { return mMeasureArea; }
+    bool measureArea() const { return mMeasureArea; }
 
     //! When we have added our last point, and not following
-    bool done() { return mDone; }
+    bool done() const { return mDone; }
 
     //! Reset and start new
     void restart();
@@ -50,29 +52,19 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
     void addPoint( const QgsPointXY &point );
 
     //! Returns reference to array of the points
-    QVector<QgsPointXY> points();
+    QVector<QgsPointXY> points() const;
 
     // Inherited from QgsMapTool
 
-    //! Mouse move event for overriding
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
-
-    //! Mouse press event for overriding
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
-
-    //! Mouse release event for overriding
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
-
-    //! called when set as currently active map tool
     void activate() override;
-
-    //! called when map tool is being deactivated
     void deactivate() override;
-
     void keyPressEvent( QKeyEvent *e ) override;
 
   public slots:
-    //! updates the projections we're using
+    //! Updates the projections we're using
     void updateSettings();
 
   protected:
@@ -87,15 +79,17 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
     //! Rubberband widget tracking the added nodes to line
     QgsRubberBand *mRubberBandPoints = nullptr;
 
-    //! indicates whether we're measuring distances or areas
-    bool mMeasureArea;
+    //! Indicates whether we're measuring distances or areas
+    bool mMeasureArea = false;
 
-    //! indicates whether we've just done a right mouse click
-    bool mDone;
+    //! Indicates whether we've just done a right mouse click
+    bool mDone = true;
 
-    //! indicates whether we've recently warned the user about having the wrong
-    // project projection
-    bool mWrongProjectProjection;
+    /**
+     * Indicates whether we've recently warned the user about having the wrong
+     * project projection.
+     */
+    bool mWrongProjectProjection = false;
 
     //! Destination CoordinateReferenceSystem used by the MapCanvas
     QgsCoordinateReferenceSystem mDestinationCrs;

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -35,8 +35,6 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
 
     QgsMeasureTool( QgsMapCanvas *canvas, bool measureArea );
 
-    ~QgsMeasureTool() override;
-
     Flags flags() const override { return QgsMapTool::AllowZoomRect; }
 
     //! returns whether measuring distance or area


### PR DESCRIPTION
The rubber bands are owned by the canvas - so we shouldn't be deleting them manually here.
