### PR TITLE
[2.18] fix SIP bindings saveStyleToDatabase

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -489,7 +489,7 @@ class QgsVectorLayer : QgsMapLayer
      */
     virtual void saveStyleToDatabase( const QString& name, const QString& description,
                                       bool useAsDefault, const QString& uiFileContent,
-                                      QString &msgError );
+                                      QString &msgError /In,Out/ );
 
     /**
      * Lists all the style in db split into related to the layer and not related to


### PR DESCRIPTION
## Description

I tried on latest QGIS 2.18 and the saveStyleToDatabase is still not working.

I saw this thread @m-kuhn : http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-pyqgis-layer-saveDefaultStyle-for-PostGIS-layers-tp5335606p5335811.html

Can you confirm it's what I'm supposed to do? I'm not compiling QGIS 2 anymore, so I have to wait for the nightly build.

Bug found while I'm working for Guadeloupe National Park

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
