### PR TITLE
fix WFS datetime fields

### DIFF
--- a/qgis-test-travis.ctest
+++ b/qgis-test-travis.ctest
@@ -59,7 +59,7 @@ ctest_build (BUILD "${CTEST_BINARY_DIRECTORY}" RETURN_VALUE BUILDRES NUMBER_WARN
 
 # Create link to test results
 # CDash on OTB requires the date to be set for the search to work and that's the timezone this requires
-SET(ENV{TZ} "UTC-6")
+SET(ENV{TZ} "Etc/GMT+6")
 EXECUTE_PROCESS(COMMAND date +%Y-%m-%d OUTPUT_VARIABLE CDASH_DATE)
 SET(RESULT_LINK "http://dash.orfeo-toolbox.org/index.php?project=QGIS&filtercount=1&showfilters=1&field1=buildname/string&compare1=63&value1=$ENV{TRAVIS_COMMIT}&date=${CDASH_DATE}")
 EXECUTE_PROCESS(COMMAND curl --data-urlencode "url=${RESULT_LINK}" -s http://tinyurl.com/api-create.php

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -1236,9 +1236,20 @@ void QgsWFSFeatureIterator::copyFeature( const QgsFeature& srcFeature, QgsFeatur
         if ( v.type() == fields.at( i ).type() )
           dstFeature.setAttribute( i, v );
         else if ( fields.at( i ).type() == QVariant::DateTime && !v.isNull() )
-          dstFeature.setAttribute( i, QVariant( QDateTime::fromMSecsSinceEpoch( v.toLongLong() ) ) );
+        {
+          QDateTime dt = QDateTime::fromMSecsSinceEpoch( v.toLongLong() );
+          dt.setTimeSpec( Qt::LocalTime );
+          dstFeature.setAttribute( i, QVariant( dt ) );
+        }
         else
           dstFeature.setAttribute( i, QgsVectorDataProvider::convertValue( fields.at( i ).type(), v.toString() ) );
+
+        if ( fields.at( i ).type() == QVariant::DateTime )
+        {
+          QgsDebugMsg( "oops" );
+          QgsDebugMsg( v.toString() );
+          QgsDebugMsg( QgsVectorDataProvider::convertValue( fields.at( i ).type(), v.toString() ).toString() );
+        }
       }
     }
   }
@@ -1250,10 +1261,18 @@ void QgsWFSFeatureIterator::copyFeature( const QgsFeature& srcFeature, QgsFeatur
       if ( idx >= 0 )
       {
         const QVariant &v = srcFeature.attributes().value( idx );
+        if ( fields.at( i ).type() == QVariant::DateTime )
+        {
+          qDebug() << v.toString();
+        }
         if ( v.type() == fields.at( i ).type() )
           dstFeature.setAttribute( i, v );
         else if ( fields.at( i ).type() == QVariant::DateTime && !v.isNull() )
-          dstFeature.setAttribute( i, QVariant( QDateTime::fromMSecsSinceEpoch( v.toLongLong() ) ) );
+        {
+          QDateTime dt = QDateTime::fromMSecsSinceEpoch( v.toLongLong() );
+          dt.setTimeSpec( Qt::LocalTime );
+          dstFeature.setAttribute( i, QVariant( dt ) );
+        }
         else
           dstFeature.setAttribute( i, QgsVectorDataProvider::convertValue( fields.at( i ).type(), v.toString() ) );
       }

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1037,7 +1037,7 @@ QString QgsWFSProvider::convertToXML( const QVariant& value )
       bool negative = true;
       QTime tz = getTimeZoneDiff( dt, negative );
       valueStr = QString( "%1%2%3" )
-                 .arg( dt.toString( "yyyy-MM-ddTHH:mm:ss" ) )
+                 .arg( dt.toString( "yyyy-MM-ddTHH:mm:ss.zzz" ) )
                  .arg( negative ? "-" : "+" )
                  .arg( tz.toString( "HH:mm" ) );
     }
@@ -1113,11 +1113,11 @@ bool QgsWFSProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
       nameElem.appendChild( nameText );
       propertyElem.appendChild( nameElem );
 
-      QDomElement valueElem = transactionDoc.createElementNS( QgsWFSConstants::WFS_NAMESPACE, "Value" );
       if ( attMapIt.value().isValid() && !attMapIt.value().isNull() )
       {
         // WFS does not support :nil='true'
         // if value is NULL, do not add value element
+        QDomElement valueElem = transactionDoc.createElementNS( QgsWFSConstants::WFS_NAMESPACE, "Value" );
         QDomText valueText = transactionDoc.createTextNode( convertToXML( attMapIt.value() ) );
         valueElem.appendChild( valueText );
         propertyElem.appendChild( valueElem );

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -150,6 +150,9 @@ class QgsWFSProvider : public QgsVectorDataProvider
 
     friend class QgsWFSFeatureSource;
 
+    // Q4 has no QDateTime::timeZone()
+    // see http://www.qtcentre.org/threads/22422-Timezone-offset
+    QTime getTimeZoneDiff( const QDateTime &dateTime, bool &isNegative );
   protected:
 
     //! String used to define a subset of the layer

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -332,6 +332,7 @@ void QgsWFSRequest::replyFinished()
     mReply = nullptr;
   }
 
+  QgsDebugMsg( QString::fromAscii( mResponse.data() ) );
   emit downloadFinished();
 }
 

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -776,7 +776,11 @@ bool QgsWFSSharedData::changeAttributeValues( const QgsChangedAttributesMap &att
       int idx = dataProviderFields.indexFromName( mFields.at( siter.key() ).name() );
       Q_ASSERT( idx >= 0 );
       if ( siter.value().type() == QVariant::DateTime && !siter.value().isNull() )
-        newAttrMap[idx] = QVariant( siter.value().toDateTime().toMSecsSinceEpoch() );
+      {
+        QDateTime dt = siter.value().toDateTime();
+        dt.setTimeSpec( Qt::LocalTime );
+        newAttrMap[idx] = QVariant( dt.toMSecsSinceEpoch() );
+      }
       else
         newAttrMap[idx] = siter.value();
     }

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -896,7 +896,11 @@ void QgsWFSSharedData::serializeFeatures( QVector<QgsWFSFeatureGmlIdPair>& featu
       {
         const QVariant &v = gmlFeature.attributes().value( i );
         if ( v.type() == QVariant::DateTime && !v.isNull() )
-          cachedFeature.setAttribute( idx, QVariant( v.toDateTime().toMSecsSinceEpoch() ) );
+        {
+          QDateTime dt = v.toDateTime();
+          dt.setTimeSpec( Qt::LocalTime );
+          cachedFeature.setAttribute( idx, QVariant( dt.toMSecsSinceEpoch() ) );
+        }
         else if ( v.type() !=  dataProviderFields.at( idx ).type() )
           cachedFeature.setAttribute( idx, QgsVectorDataProvider::convertValue( dataProviderFields.at( idx ).type(), v.toString() ) );
         else

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -428,7 +428,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
       <my:GEOMETRY>2</my:GEOMETRY>
       <my:longfield>1234567890123</my:longfield>
       <my:stringfield>foo</my:stringfield>
-      <my:datetimefield>2016-04-10T12:34:56.789Z</my:datetimefield>
+      <my:datetimefield>2016-04-10T12:34:56.789-06:00</my:datetimefield>
     </my:typename>
   </gml:featureMember>
 </wfs:FeatureCollection>""".encode('UTF-8'))
@@ -451,7 +451,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -740,15 +740,15 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
 </wfs:WFS_TransactionResponse>
 """
         # Qt 4 order
-        with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" service="WFS" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml"><Insert xmlns="http://www.opengis.net/wfs"><typename xmlns="http://my"><intfield xmlns="http://my">1</intfield><longfield xmlns="http://my">1234567890123</longfield><stringfield xmlns="http://my">foo</stringfield><datetimefield xmlns="http://my">2016-04-10T12:34:56.789Z</datetimefield><geometryProperty xmlns="http://my"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">2,49</gml:coordinates></gml:Point></geometryProperty></typename></Insert></Transaction>'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" service="WFS" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml"><Insert xmlns="http://www.opengis.net/wfs"><typename xmlns="http://my"><intfield xmlns="http://my">1</intfield><longfield xmlns="http://my">1234567890123</longfield><stringfield xmlns="http://my">foo</stringfield><datetimefield xmlns="http://my">2016-04-10T12:34:56.789-06:00</datetimefield><geometryProperty xmlns="http://my"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">2,49</gml:coordinates></gml:Point></geometryProperty></typename></Insert></Transaction>'), 'wb') as f:
             f.write(response.encode('UTF-8'))
 
         # Qt 5 order
-        with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" service="WFS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" version="1.0.0"><Insert xmlns="http://www.opengis.net/wfs"><typename xmlns="http://my"><intfield xmlns="http://my">1</intfield><longfield xmlns="http://my">1234567890123</longfield><stringfield xmlns="http://my">foo</stringfield><datetimefield xmlns="http://my">2016-04-10T12:34:56.789Z</datetimefield><geometryProperty xmlns="http://my"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">2,49</gml:coordinates></gml:Point></geometryProperty></typename></Insert></Transaction>'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" service="WFS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" version="1.0.0"><Insert xmlns="http://www.opengis.net/wfs"><typename xmlns="http://my"><intfield xmlns="http://my">1</intfield><longfield xmlns="http://my">1234567890123</longfield><stringfield xmlns="http://my">foo</stringfield><datetimefield xmlns="http://my">2016-04-10T12:34:56.789-06:00</datetimefield><geometryProperty xmlns="http://my"><gml:Point srsName="EPSG:4326"><gml:coordinates cs="," ts=" ">2,49</gml:coordinates></gml:Point></geometryProperty></typename></Insert></Transaction>'), 'wb') as f:
             f.write(response.encode('UTF-8'))
 
         f = QgsFeature()
-        f.setAttributes([1, 1234567890123, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))])
+        f.setAttributes([1, 1234567890123, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.LocalTime)])
         f.setGeometry(QgsGeometry.fromWkt('Point (2 49)'))
         (ret, fl) = vl.dataProvider().addFeatures([f])
         assert ret
@@ -766,7 +766,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -807,7 +807,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
 
         # Test changeAttributeValues
         content = """
@@ -820,13 +820,13 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
 </wfs:WFS_TransactionResponse>
 """
         # Qt 4 order
-        with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" service="WFS" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789Z</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" service="WFS" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789-06:00</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>'), 'wb') as f:
             f.write(content.encode('UTF-8'))
         # Qt 5 order
-        with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" service="WFS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" version="1.0.0"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789Z</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" service="WFS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" version="1.0.0"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789-06:00</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>'), 'wb') as f:
             f.write(content.encode('UTF-8'))
 
-        assert vl.dataProvider().changeAttributeValues({1: {0: 2, 1: 3, 2: "bar", 3: QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))}})
+        assert vl.dataProvider().changeAttributeValues({1: {0: 2, 1: 3, 2: "bar", 3: QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.LocalTime)}})
 
         values = [f['intfield'] for f in vl.getFeatures()]
         self.assertEqual(values, [2])
@@ -838,7 +838,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['bar'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))])
+        self.assertEqual(values, [QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -1893,7 +1893,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
       <my:intfield>1</my:intfield>
       <my:longfield>1234567890</my:longfield>
       <my:stringfield>foo</my:stringfield>
-      <my:datetimefield>2016-04-10T12:34:56.789Z</my:datetimefield>
+      <my:datetimefield>2016-04-10T12:34:56.789-06:00</my:datetimefield>
     </my:typename>
   </wfs:member>
   <wfs:member>
@@ -1901,7 +1901,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
       <my:intfield>1</my:intfield>
       <my:longfield>1234567890</my:longfield>
       <my:stringfield>foo</my:stringfield>
-      <my:datetimefield>2016-04-10T12:34:56.789Z</my:datetimefield>
+      <my:datetimefield>2016-04-10T12:34:56.789-06:00</my:datetimefield>
     </my:typename>
   </wfs:member>
   <wfs:member>
@@ -1909,7 +1909,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
       <my:intfield>2</my:intfield> <!-- difference -->
       <my:longfield>1234567890</my:longfield>
       <my:stringfield>foo</my:stringfield>
-      <my:datetimefield>2016-04-10T12:34:56.789Z</my:datetimefield>
+      <my:datetimefield>2016-04-10T12:34:56.789-06:00</my:datetimefield>
     </my:typename>
   </wfs:member>
   <wfs:member>
@@ -1917,7 +1917,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
       <my:intfield>1</my:intfield>
       <my:longfield>1234567891</my:longfield> <!-- difference -->
       <my:stringfield>foo</my:stringfield>
-      <my:datetimefield>2016-04-10T12:34:56.789Z</my:datetimefield>
+      <my:datetimefield>2016-04-10T12:34:56.789-06:00</my:datetimefield>
     </my:typename>
   </wfs:member>
   <wfs:member>
@@ -1925,7 +1925,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
       <my:intfield>1</my:intfield>
       <my:longfield>1234567890</my:longfield>
       <my:stringfield>fop</my:stringfield>  <!-- difference -->
-      <my:datetimefield>2016-04-10T12:34:56.789Z</my:datetimefield>
+      <my:datetimefield>2016-04-10T12:34:56.789-06:00</my:datetimefield>
     </my:typename>
   </wfs:member>
   <wfs:member>
@@ -1933,7 +1933,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
       <my:intfield>1</my:intfield>
       <my:longfield>1234567890</my:longfield>
       <my:stringfield>foo</my:stringfield>
-      <my:datetimefield>2016-04-10T12:34:56.788Z</my:datetimefield> <!-- difference -->
+      <my:datetimefield>2016-04-10T12:34:56.788-06:00</my:datetimefield> <!-- difference -->
     </my:typename>
   </wfs:member>
 </wfs:FeatureCollection>""".encode('UTF-8'))
@@ -1942,11 +1942,13 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         assert vl.isValid()
 
         values = [(f['intfield'], f['longfield'], f['stringfield'], f['datetimefield']) for f in vl.getFeatures()]
-        self.assertEqual(values, [(1, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))),
-                                  (2, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))),
-                                  (1, 1234567891, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))),
-                                  (1, 1234567890, 'fop', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.UTC))),
-                                  (1, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 788, Qt.TimeSpec(Qt.UTC)))])
+        control = [(1, 1234567890, 'foo', QDateTime(2016, 4, 10, 6, 34, 56, 789)),
+                   (2, 1234567890, 'foo', QDateTime(2016, 4, 10, 6, 34, 56, 789)),
+                   (1, 1234567891, 'foo', QDateTime(2016, 4, 10, 6, 34, 56, 789)),
+                   (1, 1234567890, 'fop', QDateTime(2016, 4, 10, 6, 34, 56, 789)),
+                   (1, 1234567890, 'foo', QDateTime(2016, 4, 10, 6, 34, 56, 788))]
+        for i, v in enumerate(values):
+            self.assertEqual(v, control[i], 'failed for value {}\nvalue: {}\nexpected: {}'.format(i, v, control[i]))
 
         vl = QgsVectorLayer(u"url='http://" + endpoint + u"' typename='my:typename' version='2.0.0' sql=SELECT DISTINCT intfield FROM \"my:typename\"", u'test', u'WFS')
         assert vl.isValid()

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -451,7 +451,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -766,7 +766,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -807,7 +807,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))])
 
         # Test changeAttributeValues
         content = """
@@ -838,7 +838,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['bar'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
+        self.assertEqual(values, [QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -1942,11 +1942,11 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         assert vl.isValid()
 
         values = [(f['intfield'], f['longfield'], f['stringfield'], f['datetimefield']) for f in vl.getFeatures()]
-        control = [(1, 1234567890, 'foo', QDateTime(2016, 4, 10, 6, 34, 56, 789)),
-                   (2, 1234567890, 'foo', QDateTime(2016, 4, 10, 6, 34, 56, 789)),
-                   (1, 1234567891, 'foo', QDateTime(2016, 4, 10, 6, 34, 56, 789)),
-                   (1, 1234567890, 'fop', QDateTime(2016, 4, 10, 6, 34, 56, 789)),
-                   (1, 1234567890, 'foo', QDateTime(2016, 4, 10, 6, 34, 56, 788))]
+        control = [(1, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))),
+                   (2, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))),
+                   (1, 1234567891, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))),
+                   (1, 1234567890, 'fop', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))),
+                   (1, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 788, Qt.TimeSpec(Qt.LocalTime)))]
         for i, v in enumerate(values):
             self.assertEqual(v, control[i], 'failed for value {}\nvalue: {}\nexpected: {}'.format(i, v, control[i]))
 

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -451,7 +451,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.OffsetFromUTC))])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -748,7 +748,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
             f.write(response.encode('UTF-8'))
 
         f = QgsFeature()
-        f.setAttributes([1, 1234567890123, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.LocalTime)])
+        f.setAttributes([1, 1234567890123, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)])
         f.setGeometry(QgsGeometry.fromWkt('Point (2 49)'))
         (ret, fl) = vl.dataProvider().addFeatures([f])
         assert ret
@@ -766,7 +766,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.OffsetFromUTC))])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -807,7 +807,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['foo'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))])
+        self.assertEqual(values, [QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.OffsetFromUTC))])
 
         # Test changeAttributeValues
         content = """
@@ -826,7 +826,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         with open(sanitize(endpoint, '?SERVICE=WFS&POSTDATA=<Transaction xmlns="http://www.opengis.net/wfs" service="WFS" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://my http://fake_qgis_http_endpoint?REQUEST=DescribeFeatureType&amp;VERSION=1.0.0&amp;TYPENAME=my:typename" xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" version="1.0.0"><Update xmlns="http://www.opengis.net/wfs" typeName="my:typename"><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">intfield</Name><Value xmlns="http://www.opengis.net/wfs">2</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">longfield</Name><Value xmlns="http://www.opengis.net/wfs">3</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">stringfield</Name><Value xmlns="http://www.opengis.net/wfs">bar</Value></Property><Property xmlns="http://www.opengis.net/wfs"><Name xmlns="http://www.opengis.net/wfs">datetimefield</Name><Value xmlns="http://www.opengis.net/wfs">2015-04-10T12:34:56.789-06:00</Value></Property><Filter xmlns="http://www.opengis.net/ogc"><FeatureId xmlns="http://www.opengis.net/ogc" fid="typename.1"/></Filter></Update></Transaction>'), 'wb') as f:
             f.write(content.encode('UTF-8'))
 
-        assert vl.dataProvider().changeAttributeValues({1: {0: 2, 1: 3, 2: "bar", 3: QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.LocalTime)}})
+        assert vl.dataProvider().changeAttributeValues({1: {0: 2, 1: 3, 2: "bar", 3: QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.OffsetFromUTC)}})
 
         values = [f['intfield'] for f in vl.getFeatures()]
         self.assertEqual(values, [2])
@@ -838,7 +838,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(values, ['bar'])
 
         values = [f['datetimefield'] for f in vl.getFeatures()]
-        self.assertEqual(values, [QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))])
+        self.assertEqual(values, [QDateTime(2015, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.OffsetFromUTC))])
 
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().geometry()
@@ -1942,11 +1942,11 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         assert vl.isValid()
 
         values = [(f['intfield'], f['longfield'], f['stringfield'], f['datetimefield']) for f in vl.getFeatures()]
-        control = [(1, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))),
-                   (2, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))),
-                   (1, 1234567891, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))),
-                   (1, 1234567890, 'fop', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.LocalTime))),
-                   (1, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 788, Qt.TimeSpec(Qt.LocalTime)))]
+        control = [(1, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.OffsetFromUTC))),
+                   (2, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.OffsetFromUTC))),
+                   (1, 1234567891, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.OffsetFromUTC))),
+                   (1, 1234567890, 'fop', QDateTime(2016, 4, 10, 12, 34, 56, 789, Qt.TimeSpec(Qt.OffsetFromUTC))),
+                   (1, 1234567890, 'foo', QDateTime(2016, 4, 10, 12, 34, 56, 788, Qt.TimeSpec(Qt.OffsetFromUTC)))]
         for i, v in enumerate(values):
             self.assertEqual(v, control[i], 'failed for value {}\nvalue: {}\nexpected: {}'.format(i, v, control[i]))
 


### PR DESCRIPTION
issue would occur when destination field in backend doesn't handle timezone
instead of converting to UTC we calculate the offset of zones (incl. daylight)
a proper fix should be introduced in QGIS 3 using QDateTime::timeZone (not available in Qt 4) and should be a bit clearer (no need for extra method for time zone offset)

this also fix issue when modifying existing fields to NULL.
Before they were sent as empty string. Now, value element is removed and this is seen as a NULL by the backend.

Test is made to work on QGIS ctest config which uses UTC -6