### PR TITLE
Relation reference widget value changed signals

### DIFF
--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -394,9 +394,9 @@ QSet<QString> QgsFeatureFilterModel::requestedAttributes() const
   return requestedAttrs;
 }
 
-void QgsFeatureFilterModel::setExtraIdentifierValueIndex( int index )
+void QgsFeatureFilterModel::setExtraIdentifierValueIndex( int index, bool force )
 {
-  if ( mExtraIdentifierValueIndex == index )
+  if ( mExtraIdentifierValueIndex == index && !force )
     return;
 
   mExtraIdentifierValueIndex = index;
@@ -437,7 +437,7 @@ void QgsFeatureFilterModel::setExtraIdentifierValueUnguarded( const QVariant &ex
       mEntries.prepend( Entry( extraIdentifierValue, QStringLiteral( "(%1)" ).arg( extraIdentifierValue.toString() ), QgsFeature() ) );
     endInsertRows();
 
-    setExtraIdentifierValueIndex( 0 );
+    setExtraIdentifierValueIndex( 0, true );
 
     reloadCurrentFeature();
   }
@@ -535,8 +535,16 @@ void QgsFeatureFilterModel::setExtraIdentifierValue( const QVariant &extraIdenti
   if ( extraIdentifierValue == mExtraIdentifierValue && extraIdentifierValue.isNull() == mExtraIdentifierValue.isNull() && mExtraIdentifierValue.isValid() )
     return;
 
-  setExtraIdentifierValueUnguarded( extraIdentifierValue );
+  if ( mIsSettingExtraIdentifierValue )
+    return;
+
+  mIsSettingExtraIdentifierValue = true;
 
   mExtraIdentifierValue = extraIdentifierValue;
+
+  setExtraIdentifierValueUnguarded( extraIdentifierValue );
+
+  mIsSettingExtraIdentifierValue = false;
+
   emit extraIdentifierValueChanged();
 }

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -416,7 +416,9 @@ void QgsFeatureFilterModel::setExtraIdentifierValueUnguarded( const QVariant &ex
   int index = 0;
   for ( const Entry &entry : entries )
   {
-    if ( entry.identifierValue == extraIdentifierValue && entry.identifierValue.isNull() == extraIdentifierValue.isNull() && entry.identifierValue.isValid() == extraIdentifierValue.isValid() )
+    if ( entry.identifierValue == extraIdentifierValue
+         && entry.identifierValue.isNull() == extraIdentifierValue.isNull()
+         && entry.identifierValue.isValid() == extraIdentifierValue.isValid() )
     {
       setExtraIdentifierValueIndex( index );
       break;
@@ -434,6 +436,7 @@ void QgsFeatureFilterModel::setExtraIdentifierValueUnguarded( const QVariant &ex
     else
       mEntries.prepend( Entry( extraIdentifierValue, QStringLiteral( "(%1)" ).arg( extraIdentifierValue.toString() ), QgsFeature() ) );
     endInsertRows();
+
     setExtraIdentifierValueIndex( 0 );
 
     reloadCurrentFeature();

--- a/src/core/qgsfeaturefiltermodel.h
+++ b/src/core/qgsfeaturefiltermodel.h
@@ -261,7 +261,7 @@ class CORE_EXPORT QgsFeatureFilterModel : public QAbstractItemModel
 
   private:
     QSet<QString> requestedAttributes() const;
-    void setExtraIdentifierValueIndex( int index );
+    void setExtraIdentifierValueIndex( int index, bool force = false );
     void setExtraValueDoesNotExist( bool extraValueDoesNotExist );
     void reload();
     void reloadCurrentFeature();
@@ -298,6 +298,7 @@ class CORE_EXPORT QgsFeatureFilterModel : public QAbstractItemModel
     bool mShouldReloadCurrentFeature = false;
     bool mExtraValueDoesNotExist = false;
     bool mAllowNull = false;
+    bool mIsSettingExtraIdentifierValue = false;
 
     QString mIdentifierField;
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1166,7 +1166,6 @@ QString QgsMapLayer::loadNamedProperty( const QString &uri, QgsMapLayer::Propert
 {
   QgsDebugMsgLevel( QString( "uri = %1 myURI = %2" ).arg( uri, publicSource() ), 4 );
 
-  QgsDebugMsg( "loadNamedProperty" );
   resultFlag = false;
 
   QDomDocument myDocument( QStringLiteral( "qgis" ) );

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -345,19 +345,19 @@ void QgsRelation::updateRelationStatus()
   {
     if ( !mReferencedLayer )
     {
-      QgsDebugMsg( QString( "Invalid relation: referenced layer does not exist. ID: %1" ).arg( mReferencedLayerId ) );
+      QgsDebugMsgLevel( QStringLiteral( "Invalid relation: referenced layer does not exist. ID: %1" ).arg( mReferencedLayerId ), 4 );
       mValid = false;
     }
     else if ( !mReferencingLayer )
     {
-      QgsDebugMsg( QString( "Invalid relation: referencing layer does not exist. ID: %2" ).arg( mReferencingLayerId ) );
+      QgsDebugMsgLevel( QStringLiteral( "Invalid relation: referencing layer does not exist. ID: %2" ).arg( mReferencingLayerId ), 4 );
       mValid = false;
     }
     else
     {
       if ( mFieldPairs.count() < 1 )
       {
-        QgsDebugMsg( "Invalid relation: no pair of field is specified." );
+        QgsDebugMsgLevel( "Invalid relation: no pair of field is specified.", 4 );
         mValid = false;
       }
 
@@ -365,13 +365,13 @@ void QgsRelation::updateRelationStatus()
       {
         if ( -1 == mReferencingLayer->fields().lookupField( fieldPair.first ) )
         {
-          QgsDebugMsg( QString( "Invalid relation: field %1 does not exist in referencing layer %2" ).arg( fieldPair.first, mReferencingLayer->name() ) );
+          QgsDebugMsg( QStringLiteral( "Invalid relation: field %1 does not exist in referencing layer %2" ).arg( fieldPair.first, mReferencingLayer->name() ) );
           mValid = false;
           break;
         }
         else if ( -1 == mReferencedLayer->fields().lookupField( fieldPair.second ) )
         {
-          QgsDebugMsg( QString( "Invalid relation: field %1 does not exist in referencedg layer %2" ).arg( fieldPair.second, mReferencedLayer->name() ) );
+          QgsDebugMsg( QStringLiteral( "Invalid relation: field %1 does not exist in referencedg layer %2" ).arg( fieldPair.second, mReferencedLayer->name() ) );
           mValid = false;
           break;
         }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -281,7 +281,8 @@ void QgsRelationReferenceWidget::setForeignKey( const QVariant &value )
   mRemoveFKButton->setEnabled( mIsEditable );
   highlightFeature( mFeature ); // TODO : make this async
   updateAttributeEditorFrame( mFeature );
-  emit foreignKeyChanged( foreignKey() );
+
+  emitForeignKeyChanged( foreignKey() );
 }
 
 void QgsRelationReferenceWidget::deleteForeignKey()
@@ -304,18 +305,16 @@ void QgsRelationReferenceWidget::deleteForeignKey()
       nullText = tr( "%1 (no selection)" ).arg( nullValue );
     }
     mLineEdit->setText( nullText );
-    mForeignKey = QVariant();
+    mForeignKey = QVariant( QVariant::Int );
     mFeature.setValid( false );
   }
   else
   {
-    mComboBox->setIdentifierValue( QVariant() );
-
-
+    mComboBox->setIdentifierValue( QVariant( QVariant::Int ) );
   }
   mRemoveFKButton->setEnabled( false );
   updateAttributeEditorFrame( QgsFeature() );
-  emit foreignKeyChanged( QVariant( QVariant::Int ) );
+  emitForeignKeyChanged( QVariant( QVariant::Int ) );
 }
 
 QgsFeature QgsRelationReferenceWidget::referencedFeature() const
@@ -667,7 +666,8 @@ void QgsRelationReferenceWidget::comboReferenceChanged( int index )
   mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );
   highlightFeature( mFeature );
   updateAttributeEditorFrame( mFeature );
-  emit foreignKeyChanged( mFeature.attribute( mReferencedFieldIdx ) );
+
+  emitForeignKeyChanged( mComboBox->identifierValue() );
 }
 
 void QgsRelationReferenceWidget::updateAttributeEditorFrame( const QgsFeature &feature )
@@ -898,5 +898,14 @@ void QgsRelationReferenceWidget::disableChainedComboBoxes( const QComboBox *scb 
     }
 
     ccb = cb;
+  }
+}
+
+void QgsRelationReferenceWidget::emitForeignKeyChanged( const QVariant &foreignKey )
+{
+  if ( foreignKey != mForeignKey || foreignKey.isNull() != mForeignKey.isNull() )
+  {
+    mForeignKey = foreignKey;
+    emit foreignKeyChanged( foreignKey );
   }
 }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -188,6 +188,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     void highlightFeature( QgsFeature f = QgsFeature(), CanvasExtent canvasExtent = Fixed );
     void updateAttributeEditorFrame( const QgsFeature &feature );
     void disableChainedComboBoxes( const QComboBox *cb );
+    void emitForeignKeyChanged( const QVariant &foreignKey );
 
     // initialized
     QgsAttributeEditorContext mEditorContext;

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -298,14 +298,21 @@ void TestQgsRelationReferenceWidget::testSetGetForeignKey()
   w.setRelation( *mRelation, true );
   w.init();
 
+  QSignalSpy spy( &w, SIGNAL( foreignKeyChanged( QVariant ) ) );
+
   w.setForeignKey( 11 );
   QCOMPARE( w.foreignKey(), QVariant( 11 ) );
+  QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "(11)" ) );
+  QCOMPARE( spy.count(), 1 );
 
   w.setForeignKey( 12 );
   QCOMPARE( w.foreignKey(), QVariant( 12 ) );
+  QCOMPARE( w.mComboBox->currentText(), QStringLiteral( "(12)" ) );
+  QCOMPARE( spy.count(), 2 );
 
   w.setForeignKey( QVariant( QVariant::Int ) );
   Q_ASSERT( w.foreignKey().isNull() );
+  QCOMPARE( spy.count(), 3 );
 }
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )

--- a/tests/src/gui/testqgsrelationreferencewidget.cpp
+++ b/tests/src/gui/testqgsrelationreferencewidget.cpp
@@ -46,6 +46,7 @@ class TestQgsRelationReferenceWidget : public QObject
     void testChainFilterRefreshed();
     void testChainFilterDeleteForeignKey();
     void testInvalidRelation();
+    void testSetGetForeignKey();
 
   private:
     std::unique_ptr<QgsVectorLayer> mLayer1;
@@ -129,6 +130,8 @@ void TestQgsRelationReferenceWidget::init()
 
 void TestQgsRelationReferenceWidget::cleanup()
 {
+  QgsProject::instance()->removeMapLayer( mLayer1.get() );
+  QgsProject::instance()->removeMapLayer( mLayer2.get() );
 }
 
 void TestQgsRelationReferenceWidget::testChainFilter()
@@ -136,7 +139,8 @@ void TestQgsRelationReferenceWidget::testChainFilter()
   // init a relation reference widget
   QStringList filterFields = { "material", "diameter", "raccord" };
 
-  QgsRelationReferenceWidget w( new QWidget() );
+  QWidget parentWidget;
+  QgsRelationReferenceWidget w( &parentWidget );
   w.setChainFilters( true );
   w.setFilterFields( filterFields );
   w.setRelation( *mRelation, true );
@@ -285,6 +289,23 @@ void TestQgsRelationReferenceWidget::testInvalidRelation()
   // initWidget with an invalid relation
   QgsRelationReferenceWidgetWrapper ww( &vl, 10, &editor, &canvas, nullptr, nullptr );
   ww.initWidget( nullptr );
+}
+
+void TestQgsRelationReferenceWidget::testSetGetForeignKey()
+{
+  QWidget parentWidget;
+  QgsRelationReferenceWidget w( &parentWidget );
+  w.setRelation( *mRelation, true );
+  w.init();
+
+  w.setForeignKey( 11 );
+  QCOMPARE( w.foreignKey(), QVariant( 11 ) );
+
+  w.setForeignKey( 12 );
+  QCOMPARE( w.foreignKey(), QVariant( 12 ) );
+
+  w.setForeignKey( QVariant( QVariant::Int ) );
+  Q_ASSERT( w.foreignKey().isNull() );
 }
 
 QGSTEST_MAIN( TestQgsRelationReferenceWidget )


### PR DESCRIPTION
The relation reference widget was sending around value changed signals even when the value was not actually changed (e.g. changing value from 11 to 11 or signalling some internal intermediate values that were never effective).

One effect of this was, that on embedded relation forms, children where listed in red (as modified) even though nothing was modified.

There are unit tests in place to guard this behavior.