### PR TITLE
Delayed update of edit selection

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -342,7 +342,10 @@ void QgsFeatureListView::ensureEditSelection()
          || mModel->mapFromMaster( selectedIndexes.first() ).row() == -1 )
        && mModel->rowCount() )
   {
-    mCurrentEditSelectionModel->select( mModel->mapToMaster( mModel->index( 0, 0 ) ), QItemSelectionModel::Select );
+    QTimer::singleShot( 0, this, [ this ]()
+    {
+      setEditSelection( mModel->mapToMaster( mModel->index( 0, 0 ) ), QItemSelectionModel::ClearAndSelect );
+    } );
   }
 }
 


### PR DESCRIPTION
When the attribute table opens, the first entry is selected. For some
(unknown) reason, the selection does not appear in the feature list on the left.

Posting this to the next run of the event loop with a timer fixes this
problem.