### PR TITLE
Fix crash with uninitialized search widget

### DIFF
--- a/src/gui/qgsattributeformrelationeditorwidget.cpp
+++ b/src/gui/qgsattributeformrelationeditorwidget.cpp
@@ -39,5 +39,9 @@ void QgsAttributeFormRelationEditorWidget::createSearchWidgetWrappers( const Qgs
 
 QString QgsAttributeFormRelationEditorWidget::currentFilterExpression() const
 {
-  return mSearchWidget->expression();
+  QString filterExpression;
+  if ( mSearchWidget )
+    filterExpression = mSearchWidget->expression();
+
+  return filterExpression;
 }


### PR DESCRIPTION
Guard `nullptr` deferencing