### PR TITLE
Widen the diagram Size Legend Preview frame

### DIFF
--- a/src/ui/qgsdatadefinedsizelegendwidget.ui
+++ b/src/ui/qgsdatadefinedsizelegendwidget.ui
@@ -148,6 +148,12 @@
    </item>
    <item>
     <widget class="QTreeView" name="viewLayerTree">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>1</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="headerHidden">
       <bool>true</bool>
      </property>


### PR DESCRIPTION
This should allow more visibility of the previewed symbols and texts.
Also avoids the left part of the dialog to needlessly expand while the information is at right.
I can't test but the aim is to fix https://issues.qgis.org/issues/17065 (and in case it does not, i think it'll still be better)

