### PR TITLE
Optionally add back faces of polygons in tessellator

### DIFF
--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -62,7 +62,7 @@ QgsTessellatedPolygonGeometry::~QgsTessellatedPolygonGeometry()
 
 void QgsTessellatedPolygonGeometry::setPolygons( const QList<QgsPolygon *> &polygons, const QgsPointXY &origin, float extrusionHeight, const QList<float> &extrusionHeightPerPolygon )
 {
-  QgsTessellator tessellator( origin.x(), origin.y(), mWithNormals, mInvertNormals );
+  QgsTessellator tessellator( origin.x(), origin.y(), mWithNormals, mInvertNormals, mAddBackFaces );
   for ( int i = 0; i < polygons.count(); ++i )
   {
     QgsPolygon *polygon = polygons.at( i );

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -46,9 +46,16 @@ class QgsTessellatedPolygonGeometry : public Qt3DRender::QGeometry
     //! Sets whether the normals of triangles will be inverted (useful for fixing clockwise / counter-clockwise face vertex orders)
     void setInvertNormals( bool invert ) { mInvertNormals = invert; }
 
-    //! Returns whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices
+    /**
+     * Returns whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices
+     * \since QGIS 3.2
+     */
     bool addBackFaces() const { return mAddBackFaces; }
-    //! Sets whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices
+
+    /**
+     * Sets whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices
+     * \since QGIS 3.2
+     */
     void setAddBackFaces( bool add ) { mAddBackFaces = add; }
 
     //! Initializes vertex buffer from given polygons. Takes ownership of passed polygon geometries

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -46,6 +46,11 @@ class QgsTessellatedPolygonGeometry : public Qt3DRender::QGeometry
     //! Sets whether the normals of triangles will be inverted (useful for fixing clockwise / counter-clockwise face vertex orders)
     void setInvertNormals( bool invert ) { mInvertNormals = invert; }
 
+    //! Returns whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices
+    bool addBackFaces() const { return mAddBackFaces; }
+    //! Sets whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices
+    void setAddBackFaces( bool add ) { mAddBackFaces = add; }
+
     //! Initializes vertex buffer from given polygons. Takes ownership of passed polygon geometries
     void setPolygons( const QList<QgsPolygon *> &polygons, const QgsPointXY &origin, float extrusionHeight, const QList<float> &extrusionHeightPerPolygon = QList<float>() );
 
@@ -57,6 +62,7 @@ class QgsTessellatedPolygonGeometry : public Qt3DRender::QGeometry
 
     bool mWithNormals = true;
     bool mInvertNormals = false;
+    bool mAddBackFaces = false;
 };
 
 #endif // QGSTESSELLATEDPOLYGONGEOMETRY_H

--- a/src/3d/qgstessellator.cpp
+++ b/src/3d/qgstessellator.cpp
@@ -66,11 +66,12 @@ static void make_quad( float x0, float y0, float z0, float x1, float y1, float z
 }
 
 
-QgsTessellator::QgsTessellator( double originX, double originY, bool addNormals, bool invertNormals )
+QgsTessellator::QgsTessellator( double originX, double originY, bool addNormals, bool invertNormals, bool addBackFaces )
   : mOriginX( originX )
   , mOriginY( originY )
   , mAddNormals( addNormals )
   , mInvertNormals( invertNormals )
+  , mAddBackFaces( addBackFaces )
 {
   mStride = 3 * sizeof( float );
   if ( addNormals )
@@ -358,6 +359,18 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
       if ( mAddNormals )
         mData << pNormal.x() << pNormal.z() << - pNormal.y();
     }
+
+    if ( mAddBackFaces )
+    {
+      // the same triangle with reversed order of coordinates and inverted normal
+      for ( int i = 2; i >= 0; i-- )
+      {
+        exterior->pointAt( i, pt, vt );
+        mData << pt.x() - mOriginX << pt.z() << - pt.y() + mOriginY;
+        if ( mAddNormals )
+          mData << -pNormal.x() << -pNormal.z() << pNormal.y();
+      }
+    }
   }
   else
   {
@@ -465,6 +478,24 @@ void QgsTessellator::addPolygon( const QgsPolygon &polygon, float extrusionHeigh
           mData << fx << fz << -fy;
           if ( mAddNormals )
             mData << pNormal.x() << pNormal.z() << - pNormal.y();
+        }
+
+        if ( mAddBackFaces )
+        {
+          // the same triangle with reversed order of coordinates and inverted normal
+          for ( int j = 2; j >= 0; --j )
+          {
+            p2t::Point *p = t->GetPoint( j );
+            QVector4D pt( p->x, p->y, z[p], 0 );
+            if ( toOldBase )
+              pt = *toOldBase * pt;
+            const double fx = pt.x() - mOriginX + pt0.x();
+            const double fy = pt.y() - mOriginY + pt0.y();
+            const double fz = pt.z() + extrusionHeight + pt0.z();
+            mData << fx << fz << -fy;
+            if ( mAddNormals )
+              mData << -pNormal.x() << -pNormal.z() << pNormal.y();
+          }
         }
       }
     }

--- a/src/3d/qgstessellator.h
+++ b/src/3d/qgstessellator.h
@@ -55,10 +55,10 @@ class _3D_EXPORT QgsTessellator
     std::unique_ptr< QgsMultiPolygon > asMultiPolygon() const;
 
   private:
-    double mOriginX, mOriginY;
-    bool mAddNormals;
-    bool mInvertNormals;
-    bool mAddBackFaces;
+    double mOriginX = 0, mOriginY = 0;
+    bool mAddNormals = false;
+    bool mInvertNormals = false;
+    bool mAddBackFaces = false;
     QVector<float> mData;
     int mStride;
 };

--- a/src/3d/qgstessellator.h
+++ b/src/3d/qgstessellator.h
@@ -39,7 +39,7 @@ class _3D_EXPORT QgsTessellator
 {
   public:
     //! Creates tessellator with a specified origin point of the world (in map coordinates)
-    QgsTessellator( double originX, double originY, bool addNormals, bool invertNormals = false );
+    QgsTessellator( double originX, double originY, bool addNormals, bool invertNormals = false, bool addBackFaces = false );
 
     //! Tessellates a triangle and adds its vertex entries to the output data array
     void addPolygon( const QgsPolygon &polygon, float extrusionHeight );
@@ -58,6 +58,7 @@ class _3D_EXPORT QgsTessellator
     double mOriginX, mOriginY;
     bool mAddNormals;
     bool mInvertNormals;
+    bool mAddBackFaces;
     QVector<float> mData;
     int mStride;
 };

--- a/src/3d/symbols/qgspolygon3dsymbol.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol.cpp
@@ -33,6 +33,7 @@ void QgsPolygon3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext 
   elemDataProperties.setAttribute( QStringLiteral( "extrusion-height" ), mExtrusionHeight );
   elemDataProperties.setAttribute( QStringLiteral( "culling-mode" ), Qgs3DUtils::cullingModeToString( mCullingMode ) );
   elemDataProperties.setAttribute( QStringLiteral( "invert-normals" ), mInvertNormals ? "1" : "0" );
+  elemDataProperties.setAttribute( QStringLiteral( "add-back-faces" ), mAddBackFaces ? "1" : "0" );
   elem.appendChild( elemDataProperties );
 
   QDomElement elemMaterial = doc.createElement( QStringLiteral( "material" ) );
@@ -55,6 +56,7 @@ void QgsPolygon3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteCon
   mExtrusionHeight = elemDataProperties.attribute( QStringLiteral( "extrusion-height" ) ).toFloat();
   mCullingMode = Qgs3DUtils::cullingModeFromString( elemDataProperties.attribute( QStringLiteral( "culling-mode" ) ) );
   mInvertNormals = elemDataProperties.attribute( QStringLiteral( "invert-normals" ) ).toInt();
+  mAddBackFaces = elemDataProperties.attribute( QStringLiteral( "add-back-faces" ) ).toInt();
 
   QDomElement elemMaterial = elem.firstChildElement( QStringLiteral( "material" ) );
   mMaterial.readXml( elemMaterial );

--- a/src/3d/symbols/qgspolygon3dsymbol.h
+++ b/src/3d/symbols/qgspolygon3dsymbol.h
@@ -76,6 +76,18 @@ class _3D_EXPORT QgsPolygon3DSymbol : public QgsAbstract3DSymbol
     //! Sets whether the normals of triangles will be inverted (useful for fixing clockwise / counter-clockwise face vertex orders)
     void setInvertNormals( bool invert ) { mInvertNormals = invert; }
 
+    /**
+     * Returns whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices
+     * \since QGIS 3.2
+     */
+    bool addBackFaces() const { return mAddBackFaces; }
+
+    /**
+     * Sets whether also triangles facing the other side will be created. Useful if input data have inconsistent order of vertices
+     * \since QGIS 3.2
+     */
+    void setAddBackFaces( bool add ) { mAddBackFaces = add; }
+
   private:
     //! how to handle altitude of vector features
     AltitudeClamping mAltClamping = AltClampRelative;
@@ -87,6 +99,7 @@ class _3D_EXPORT QgsPolygon3DSymbol : public QgsAbstract3DSymbol
     QgsPhongMaterialSettings mMaterial;  //!< Defines appearance of objects
     Qt3DRender::QCullFace::CullingMode mCullingMode = Qt3DRender::QCullFace::NoCulling;  //!< Front/back culling mode
     bool mInvertNormals = false;
+    bool mAddBackFaces = false;
 };
 
 

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -200,6 +200,7 @@ Qt3DRender::QGeometryRenderer *QgsPolygon3DSymbolEntityNode::renderer( const Qgs
 
   mGeometry = new QgsTessellatedPolygonGeometry;
   mGeometry->setInvertNormals( symbol.invertNormals() );
+  mGeometry->setAddBackFaces( symbol.addBackFaces() );
   mGeometry->setPolygons( polygons, origin, symbol.extrusionHeight(), extrusionHeightPerPolygon );
 
   Qt3DRender::QGeometryRenderer *renderer = new Qt3DRender::QGeometryRenderer;

--- a/src/app/3d/qgspolygon3dsymbolwidget.cpp
+++ b/src/app/3d/qgspolygon3dsymbolwidget.cpp
@@ -32,6 +32,7 @@ QgsPolygon3DSymbolWidget::QgsPolygon3DSymbolWidget( QWidget *parent )
   connect( cboAltClamping, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPolygon3DSymbolWidget::changed );
   connect( cboAltBinding, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPolygon3DSymbolWidget::changed );
   connect( cboCullingMode, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPolygon3DSymbolWidget::changed );
+  connect( chkAddBackFaces, &QCheckBox::clicked, this, &QgsPolygon3DSymbolWidget::changed );
   connect( chkInvertNormals, &QCheckBox::clicked, this, &QgsPolygon3DSymbolWidget::changed );
   connect( widgetMaterial, &QgsPhongMaterialWidget::changed, this, &QgsPolygon3DSymbolWidget::changed );
   connect( btnHeightDD, &QgsPropertyOverrideButton::changed, this, &QgsPolygon3DSymbolWidget::changed );
@@ -71,6 +72,7 @@ void QgsPolygon3DSymbolWidget::setSymbol( const QgsPolygon3DSymbol &symbol, QgsV
   cboAltClamping->setCurrentIndex( ( int ) symbol.altitudeClamping() );
   cboAltBinding->setCurrentIndex( ( int ) symbol.altitudeBinding() );
   cboCullingMode->setCurrentIndex( _cullingModeToIndex( symbol.cullingMode() ) );
+  chkAddBackFaces->setChecked( symbol.addBackFaces() );
   chkInvertNormals->setChecked( symbol.invertNormals() );
   widgetMaterial->setMaterial( symbol.material() );
 
@@ -86,6 +88,7 @@ QgsPolygon3DSymbol QgsPolygon3DSymbolWidget::symbol() const
   sym.setAltitudeClamping( ( AltitudeClamping ) cboAltClamping->currentIndex() );
   sym.setAltitudeBinding( ( AltitudeBinding ) cboAltBinding->currentIndex() );
   sym.setCullingMode( _cullingModeFromIndex( cboCullingMode->currentIndex() ) );
+  sym.setAddBackFaces( chkAddBackFaces->isChecked() );
   sym.setInvertNormals( chkInvertNormals->isChecked() );
   sym.setMaterial( widgetMaterial->material() );
 

--- a/src/ui/3d/polygon3dsymbolwidget.ui
+++ b/src/ui/3d/polygon3dsymbolwidget.ui
@@ -14,10 +14,92 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_5">
+   <item row="6" column="0" colspan="2">
+    <widget class="QCheckBox" name="chkInvertNormals">
      <property name="text">
-      <string>Culling Mode</string>
+      <string>Invert Normals (Experimental)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QgsPropertyOverrideButton" name="btnHeightDD">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Altitude Binding</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="cboAltBinding">
+     <item>
+      <property name="text">
+       <string>Vertex</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Centroid</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="cboAltClamping">
+     <item>
+      <property name="text">
+       <string>Absolute</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Relative</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Terrain</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Height</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QgsDoubleSpinBox" name="spinExtrusion">
+     <property name="maximum">
+      <double>99999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Extrusion</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Altitude Clamping</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QgsPropertyOverrideButton" name="btnExtrusionDD">
+     <property name="text">
+      <string>...</string>
      </property>
     </widget>
    </item>
@@ -40,26 +122,22 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="2">
-    <widget class="QgsPropertyOverrideButton" name="btnHeightDD">
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>...</string>
+      <string>Culling Mode</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Height</string>
+   <item row="7" column="0" colspan="3">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Altitude Clamping</string>
-     </property>
-    </widget>
+   <item row="8" column="0" colspan="3">
+    <widget class="QgsPhongMaterialWidget" name="widgetMaterial" native="true"/>
    </item>
    <item row="0" column="1">
     <widget class="QgsDoubleSpinBox" name="spinHeight">
@@ -71,81 +149,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="chkAddBackFaces">
      <property name="text">
-      <string>Extrusion</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QgsPropertyOverrideButton" name="btnExtrusionDD">
-     <property name="text">
-      <string>...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="cboAltClamping">
-     <item>
-      <property name="text">
-       <string>Absolute</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Relative</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Terrain</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Altitude Binding</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QgsDoubleSpinBox" name="spinExtrusion">
-     <property name="maximum">
-      <double>99999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="cboAltBinding">
-     <item>
-      <property name="text">
-       <string>Vertex</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Centroid</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="3">
-    <widget class="QgsPhongMaterialWidget" name="widgetMaterial" native="true"/>
-   </item>
-   <item row="6" column="0" colspan="3">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QCheckBox" name="chkInvertNormals">
-     <property name="text">
-      <string>Invert Normals (Experimental)</string>
+      <string>Add back faces</string>
      </property>
     </widget>
    </item>
@@ -176,6 +183,9 @@
   <tabstop>btnExtrusionDD</tabstop>
   <tabstop>cboAltClamping</tabstop>
   <tabstop>cboAltBinding</tabstop>
+  <tabstop>cboCullingMode</tabstop>
+  <tabstop>chkAddBackFaces</tabstop>
+  <tabstop>chkInvertNormals</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/tests/src/3d/testqgstessellator.cpp
+++ b/tests/src/3d/testqgstessellator.cpp
@@ -129,6 +129,7 @@ class TestQgsTessellator : public QObject
 
     void testBasic();
     void testWalls();
+    void testBackEdges();
     void asMultiPolygon();
     void testBadCoordinates();
     void testIssue17745();
@@ -242,6 +243,24 @@ void TestQgsTessellator::testWalls()
   QgsTessellator tZ( 0, 0, false );
   tZ.addPolygon( polygonZ, 10 );
   QVERIFY( checkTriangleOutput( tZ.data(), false, tc ) );
+}
+
+void TestQgsTessellator::testBackEdges()
+{
+  QgsPolygon polygon;
+  polygon.fromWkt( "POLYGON((1 1, 2 1, 3 2, 1 2, 1 1))" );
+
+  QVector3D up( 0, 0, 1 );  // surface normal pointing straight up
+  QVector3D dn( 0, 0, -1 );  // surface normal pointing straight down for back faces
+  QList<TriangleCoords> tcNormals;
+  tcNormals << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 3, 2, 0 ), up, up, up );
+  tcNormals << TriangleCoords( QVector3D( 3, 2, 0 ), QVector3D( 2, 1, 0 ), QVector3D( 1, 2, 0 ), dn, dn, dn );
+  tcNormals << TriangleCoords( QVector3D( 1, 2, 0 ), QVector3D( 1, 1, 0 ), QVector3D( 2, 1, 0 ), up, up, up );
+  tcNormals << TriangleCoords( QVector3D( 2, 1, 0 ), QVector3D( 1, 1, 0 ), QVector3D( 1, 2, 0 ), dn, dn, dn );
+
+  QgsTessellator tN( 0, 0, true, false, true );
+  tN.addPolygon( polygon, 0 );
+  QVERIFY( checkTriangleOutput( tN.data(), true, tcNormals ) );
 }
 
 void TestQgsTessellator::asMultiPolygon()


### PR DESCRIPTION
Often the polygonZ/multipatch data do not have consistent ordering of vertices
(e.g. all clock-wise or counter clock-wise). Disabling culling helps to avoid
seemingly missing surfaces, but the shading is still not correct due to reversed
normals. This new option to add back faces fixes the problem: for each triangle
we create both front and back face with correct normals - at the expense of increased
number of vertex data.
