### PR TITLE
[Processing] Differencing '' and None in string parameter

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -750,7 +750,10 @@ class ParameterString(Parameter):
         if not bool(obj):
             if not self.optional:
                 return False
-            self.value = ''
+            if isinstance(obj, basestring):
+                self.value = obj
+            else:
+                self.value = None
             return True
 
         self.value = unicode(obj).replace(


### PR DESCRIPTION
## Description

This commit enhances:
* [processing] dont set default value in param string, when passed null value d911671b0669d3654d85954b52e38a9f5e952d4a
* [Processing] None is the default value for parameters also for string ac4d776af018a34b8f9e3d67647b5dbcf7c90bf3

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
