### PR TITLE
Fixes Centos7 issues due to old gcc compiler (gcc 4.8.5)

### DIFF
--- a/src/core/layertree/qgslayertreelayer.cpp
+++ b/src/core/layertree/qgslayertreelayer.cpp
@@ -69,8 +69,8 @@ void QgsLayerTreeLayer::attachToLayer()
   if ( !mRef )
     return;
 
-  connect( mRef.layer, &QgsMapLayer::nameChanged, this, &QgsLayerTreeLayer::layerNameChanged );
-  connect( mRef.layer, &QgsMapLayer::willBeDeleted, this, &QgsLayerTreeLayer::layerWillBeDeleted );
+  connect( mRef.layer.data(), &QgsMapLayer::nameChanged, this, &QgsLayerTreeLayer::layerNameChanged );
+  connect( mRef.layer.data(), &QgsMapLayer::willBeDeleted, this, &QgsLayerTreeLayer::layerWillBeDeleted );
 }
 
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1367,7 +1367,7 @@ void QgsLayoutItemMap::connectUpdateSlot()
     } );
 
   }
-  connect( mLayout, &QgsLayout::refreshed, this, &QgsLayoutItemMap::invalidateCache );
+  connect( mLayout.data(), &QgsLayout::refreshed, this, &QgsLayoutItemMap::invalidateCache );
 
   connect( project->mapThemeCollection(), &QgsMapThemeCollection::mapThemeChanged, this, &QgsLayoutItemMap::mapThemeChanged );
 }

--- a/src/core/layout/qgslayoutitemmapoverview.cpp
+++ b/src/core/layout/qgslayoutitemmapoverview.cpp
@@ -217,8 +217,8 @@ void QgsLayoutItemMapOverview::setLinkedMap( QgsLayoutItemMap *map )
   //disconnect old map
   if ( mFrameMap )
   {
-    disconnect( mFrameMap, &QgsLayoutItemMap::extentChanged, this, &QgsLayoutItemMapOverview::overviewExtentChanged );
-    disconnect( mFrameMap, &QgsLayoutItemMap::mapRotationChanged, this, &QgsLayoutItemMapOverview::overviewExtentChanged );
+    disconnect( mFrameMap.data(), &QgsLayoutItemMap::extentChanged, this, &QgsLayoutItemMapOverview::overviewExtentChanged );
+    disconnect( mFrameMap.data(), &QgsLayoutItemMap::mapRotationChanged, this, &QgsLayoutItemMapOverview::overviewExtentChanged );
   }
   mFrameMap = map;
   //connect to new map signals
@@ -240,8 +240,8 @@ void QgsLayoutItemMapOverview::connectSignals()
 
   if ( mFrameMap )
   {
-    connect( mFrameMap, &QgsLayoutItemMap::extentChanged, this, &QgsLayoutItemMapOverview::overviewExtentChanged );
-    connect( mFrameMap, &QgsLayoutItemMap::mapRotationChanged, this, &QgsLayoutItemMapOverview::overviewExtentChanged );
+    connect( mFrameMap.data(), &QgsLayoutItemMap::extentChanged, this, &QgsLayoutItemMapOverview::overviewExtentChanged );
+    connect( mFrameMap.data(), &QgsLayoutItemMap::mapRotationChanged, this, &QgsLayoutItemMapOverview::overviewExtentChanged );
   }
 }
 

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -839,12 +839,12 @@ void QgsLayoutItemPicture::finalizeRestoreFromXml()
   {
     if ( mRotationMap )
     {
-      disconnectMap( mRotationMap );
+      disconnectMap( mRotationMap.data() );
     }
     if ( ( mRotationMap = qobject_cast< QgsLayoutItemMap * >( mLayout->itemByUuid( mRotationMapUuid, true ) ) ) )
     {
-      connect( mRotationMap, &QgsLayoutItemMap::mapRotationChanged, this, &QgsLayoutItemPicture::updateMapRotation );
-      connect( mRotationMap, &QgsLayoutItemMap::extentChanged, this, &QgsLayoutItemPicture::updateMapRotation );
+      connect( mRotationMap.data(), &QgsLayoutItemMap::mapRotationChanged, this, &QgsLayoutItemPicture::updateMapRotation );
+      connect( mRotationMap.data(), &QgsLayoutItemMap::extentChanged, this, &QgsLayoutItemPicture::updateMapRotation );
     }
   }
 

--- a/src/core/layout/qgslayoutobject.cpp
+++ b/src/core/layout/qgslayoutobject.cpp
@@ -93,7 +93,7 @@ QgsLayoutObject::QgsLayoutObject( QgsLayout *layout )
 
   if ( mLayout )
   {
-    connect( mLayout, &QgsLayout::refreshed, this, &QgsLayoutObject::refresh );
+    connect( mLayout.data(), &QgsLayout::refreshed, this, &QgsLayoutObject::refresh );
     connect( &mLayout->reportContext(), &QgsLayoutReportContext::changed, this, &QgsLayoutObject::refresh );
   }
 }

--- a/tests/src/core/testqgstaskmanager.cpp
+++ b/tests/src/core/testqgstaskmanager.cpp
@@ -537,8 +537,8 @@ void TestQgsTaskManager::subTask()
   }
 
   QSignalSpy parentTerminated( parent, &QgsTask::taskTerminated );
-  QSignalSpy subTerminated( subTask, &QgsTask::taskTerminated );
-  QSignalSpy subsubTerminated( subsubTask, &QgsTask::taskTerminated );
+  QSignalSpy subTerminated( subTask.data(), &QgsTask::taskTerminated );
+  QSignalSpy subsubTerminated( subsubTask.data(), &QgsTask::taskTerminated );
 
   subsubTask->terminate();
   while ( subsubTask->status() == QgsTask::Running
@@ -577,8 +577,8 @@ void TestQgsTaskManager::subTask()
   QCOMPARE( ( int )subTask->status(), ( int )QgsTask::Running );
 
   QSignalSpy parentFinished( parent, &QgsTask::taskCompleted );
-  QSignalSpy subFinished( subTask, &QgsTask::taskCompleted );
-  QSignalSpy subsubFinished( subsubTask, &QgsTask::taskCompleted );
+  QSignalSpy subFinished( subTask.data(), &QgsTask::taskCompleted );
+  QSignalSpy subsubFinished( subsubTask.data(), &QgsTask::taskCompleted );
 
   subsubTask->finish();
   while ( subsubTask->status() == QgsTask::Running


### PR DESCRIPTION
## Description
see also https://bugreports.qt.io/browse/QTBUG-48988

CentOS 7.5 (release candidate) has a gcc compiler from 2015 (version 4.8.5) and chokes at several places in the sourcecode, mainly in the layout source files. Fixes according to discussion with @m-kuhn 

If this PR is accepted, it should proably also be applied on Master.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
