### PR TITLE
Wms overwrite parent bounding boxes

### DIFF
--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -896,14 +896,14 @@ void QgsWmsCapabilities::parseLayer( QDomElement const &e, QgsWmsLayerProperty &
           bool inheritedOverwritten = false;
           for ( int i = 0; i < layerProperty.boundingBoxes.size(); i++ )
           {
-              if ( layerProperty.boundingBoxes[i].crs == bbox.crs )
-              {
-                  layerProperty.boundingBoxes[i] = bbox;
-                  inheritedOverwritten = true;
-              }
+            if ( layerProperty.boundingBoxes[i].crs == bbox.crs )
+            {
+              layerProperty.boundingBoxes[i] = bbox;
+              inheritedOverwritten = true;
+            }
           }
           if ( ! inheritedOverwritten )
-              layerProperty.boundingBoxes << bbox;
+            layerProperty.boundingBoxes << bbox;
         }
         else
         {

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -872,7 +872,6 @@ void QgsWmsCapabilities::parseLayer( QDomElement const &e, QgsWmsLayerProperty &
       }
       else if ( tagName == QLatin1String( "BoundingBox" ) )
       {
-        // TODO: overwrite inherited
         QgsWmsBoundingBoxProperty bbox;
         bbox.box = QgsRectangle( e1.attribute( QStringLiteral( "minx" ) ).toDouble(),
                                  e1.attribute( QStringLiteral( "miny" ) ).toDouble(),
@@ -893,7 +892,18 @@ void QgsWmsCapabilities::parseLayer( QDomElement const &e, QgsWmsLayerProperty &
             bbox.box = invAxisBbox;
           }
 
-          layerProperty.boundingBoxes << bbox;
+          // Overwrite existing bounding boxes with identical CRS
+          bool inheritedOverwritten = false;
+          for ( int i = 0; i < layerProperty.boundingBoxes.size(); i++ )
+          {
+              if ( layerProperty.boundingBoxes[i].crs == bbox.crs )
+              {
+                  layerProperty.boundingBoxes[i] = bbox;
+                  inheritedOverwritten = true;
+              }
+          }
+          if ( ! inheritedOverwritten )
+              layerProperty.boundingBoxes << bbox;
         }
         else
         {


### PR DESCRIPTION
Replaces #1934 with prepare-commit applied.
