### PR TITLE
Fix crash when creating spatial index from empty layer

### DIFF
--- a/src/core/qgsspatialindex.cpp
+++ b/src/core/qgsspatialindex.cpp
@@ -220,7 +220,7 @@ class QgsSpatialIndexData : public QSharedData
       // create R-tree
       SpatialIndex::id_type indexId;
 
-      if ( inputStream )
+      if ( inputStream && inputStream->hasNext() )
         mRTree = RTree::createAndBulkLoadNewRTree( RTree::BLM_STR, *inputStream, *mStorage, fillFactor, indexCapacity,
                  leafCapacity, dimension, variant, indexId );
       else

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1371,17 +1371,9 @@ void TestQgsProcessing::createIndex()
   // selected features check, but none selected
   params.insert( QStringLiteral( "layer" ), QVariant::fromValue( QgsProcessingFeatureSourceDefinition( layer->id(), true ) ) );
   source.reset( QgsProcessingParameters::parameterAsSource( def.get(), params, context ) );
-  bool caught = false;
-  try
-  {
-    index = QgsSpatialIndex( *source );
-    ids = index.nearestNeighbor( QgsPointXY( 2.1, 2 ), 1 );
-  }
-  catch ( ... )
-  {
-    caught = true;
-  }
-  QVERIFY( caught );
+  index = QgsSpatialIndex( *source );
+  ids = index.nearestNeighbor( QgsPointXY( 2.1, 2 ), 1 );
+  QCOMPARE( ids, QList<QgsFeatureId>() );
 
   // create selection
   layer->selectByIds( QgsFeatureIds() << 4 << 5 );

--- a/tests/src/core/testqgsspatialindex.cpp
+++ b/tests/src/core/testqgsspatialindex.cpp
@@ -99,6 +99,13 @@ class TestQgsSpatialIndex : public QObject
       QVERIFY( fids2.contains( 3 ) );
     }
 
+    void testInitFromEmptyIterator()
+    {
+      QgsFeatureIterator it;
+      QgsSpatialIndex index( it );
+      // we just test that we survive the above command without exception from libspatialindex raised
+    }
+
     void testCopy()
     {
       QgsSpatialIndex *index = new QgsSpatialIndex;


### PR DESCRIPTION
libspatialindex library throws an exception when trying to bulk load spatial index and it is given an empty input data stream.