### PR TITLE
Assume URL already encoded in web view widget

### DIFF
--- a/src/gui/editorwidgets/qgswebviewwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgswebviewwidgetwrapper.cpp
@@ -39,7 +39,7 @@ void QgsWebViewWidgetWrapper::loadUrl( const QString &url )
     path = QDir( QgsProject::instance()->fileInfo().absolutePath() ).filePath( url );
 
   if ( mWebView )
-    mWebView->load( path );
+    mWebView->load( QUrl::fromEncoded( path.toUtf8() ) );
 }
 
 QVariant QgsWebViewWidgetWrapper::value() const


### PR DESCRIPTION
## Description

Wanted to use QWebView on signed URLs (S3 images) that were already [percent encoded](https://en.wikipedia.org/wiki/Percent-encoding) but it seems `QWebView::Load` will:

* turn **%** -> **%25** breaking the URL signature
* if the url is not encoded does *not*  encode it

If i pass as `QUrl` from a `QUrl::fromEncoded`  call the encoded URL is used to load the image and works.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
