### PR TITLE
[FEATURE] Add DisplayVersion value in Uninstallkey

### DIFF
--- a/ms-windows/QGIS-Installer.nsi
+++ b/ms-windows/QGIS-Installer.nsi
@@ -347,6 +347,7 @@ Section "QGIS" SecQGIS
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${QGIS_BASE}" "HelpLink" "${WIKI_PAGE}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${QGIS_BASE}" "URLInfoAbout" "${WEB_SITE}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${QGIS_BASE}" "Publisher" "${PUBLISHER}"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${QGIS_BASE}" "DisplayVersion" "${VERSION_NUMBER}"
 
 	;Create the Desktop Shortcut
 	SetShellVarContext current


### PR DESCRIPTION
## Description
The DisplayVersion value in Uninstallkey registry hive (Software\Microsoft\Windows\CurrentVersion\Uninstall) is mandatory for deployment software, it allows them to check quickly from standard registry path the currently installed version.

The VersionNumber value is already stored in Software\QGIS (version)\ hive but that's not a standard for deployment solutions.

Example of the render in appwiz.cpl windows component : 
![image](https://user-images.githubusercontent.com/30469328/39820334-d9a1b26c-53a5-11e8-9227-e80116fa6ff4.png)

Sincerly,

Alexandre

