### PR TITLE
[processing][gdal] Do not escape formula because it's not a path!

### DIFF
--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -106,8 +106,7 @@ class gdalcalc(GdalAlgorithm):
             noData = unicode(noData)
 
         arguments = []
-        arguments.append('--calc')
-        arguments.append('"' + formula + '"')
+        arguments.append('--calc "{}"'.format(formula))
         arguments.append('--format')
         arguments.append(GdalUtils.getFormatShortNameFromFilename(out))
         arguments.append('--type')


### PR DESCRIPTION
## Description
numpy formula in gdal_calc processing algoritm is managed as a path and escaped in case having spaces. This escape generate triky error during gdal execution.
Just test the error setting the default formula from "A*2" to "A * 2".

fix promoted inside GeoMove [1] project for Cartolab [2] (A Coruña university)

[1] http://cartolab.udc.es/geomove/
[2] http://cartolab.udc.es

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
