### PR TITLE
[FEATURE] Union algorithm with a single layer

### DIFF
--- a/python/plugins/processing/tests/AlgorithmsTestBase.py
+++ b/python/plugins/processing/tests/AlgorithmsTestBase.py
@@ -283,13 +283,14 @@ class AlgorithmsTest(object):
 
                 compare = expected_result.get('compare', {})
                 pk = expected_result.get('pk', None)
+                topo_equal_check = expected_result.get('topo_equal_check', False)
 
                 if len(expected_lyrs) == 1:
-                    self.assertLayersEqual(expected_lyrs[0], result_lyr, compare=compare, pk=pk)
+                    self.assertLayersEqual(expected_lyrs[0], result_lyr, compare=compare, pk=pk, geometry={'topo_equal_check': topo_equal_check})
                 else:
                     res = False
                     for l in expected_lyrs:
-                        if self.checkLayersEqual(l, result_lyr, compare=compare, pk=pk):
+                        if self.checkLayersEqual(l, result_lyr, compare=compare, pk=pk, geometry={'topo_equal_check': topo_equal_check}):
                             res = True
                             break
                     self.assertTrue(res, 'Could not find matching layer in expected results')
@@ -319,6 +320,7 @@ class AlgorithmsTest(object):
 
 
 class GenericAlgorithmsTest(unittest.TestCase):
+
     """
     General (non-provider specific) algorithm tests
     """

--- a/python/plugins/processing/tests/testdata/custom/overlay0.geojson
+++ b/python/plugins/processing/tests/testdata/custom/overlay0.geojson
@@ -1,0 +1,19 @@
+{
+"type": "FeatureCollection",
+"name": "overlay0",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
+"features": [
+{ "type": "Feature", "properties": { "id_a": "A1" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 1.0, 1.0 ], [ 5.0, 1.0 ], [ 5.0, 5.0 ], [ 1.0, 5.0 ], [ 1.0, 1.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A2" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 2.0, 2.0 ], [ 4.0, 2.0 ], [ 4.0, 4.0 ], [ 2.0, 4.0 ], [ 2.0, 2.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A3" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 7.0, 2.0 ], [ 9.0, 2.0 ], [ 9.0, 4.0 ], [ 7.0, 4.0 ], [ 7.0, 2.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A4" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 6.0, 1.0 ], [ 10.0, 1.0 ], [ 10.0, 5.0 ], [ 6.0, 5.0 ], [ 6.0, 1.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A5" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 1.0, 6.0 ], [ 3.0, 6.0 ], [ 3.0, 10.0 ], [ 1.0, 10.0 ], [ 1.0, 6.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A6" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 3.0, 6.0 ], [ 5.0, 6.0 ], [ 5.0, 10.0 ], [ 3.0, 10.0 ], [ 3.0, 6.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A7" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 6.0, 6.0 ], [ 10.0, 6.0 ], [ 10.0, 10.0 ], [ 6.0, 10.0 ], [ 6.0, 6.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A8" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 1.0, 11.0 ], [ 4.0, 11.0 ], [ 4.0, 14.0 ], [ 1.0, 14.0 ], [ 1.0, 11.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A9" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 1.0, 13.0 ], [ 4.0, 13.0 ], [ 4.0, 16.0 ], [ 1.0, 16.0 ], [ 1.0, 13.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A10" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 2.0, 12.0 ], [ 5.0, 12.0 ], [ 5.0, 15.0 ], [ 2.0, 15.0 ], [ 2.0, 12.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A11" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 6.0, 11.0 ], [ 10.0, 11.0 ], [ 10.0, 12.0 ], [ 7.0, 12.0 ], [ 7.0, 15.0 ], [ 6.0, 15.0 ], [ 6.0, 11.0 ] ] ] } },
+{ "type": "Feature", "properties": { "id_a": "A12" }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 8.0, 13.0 ], [ 10.0, 13.0 ], [ 10.0, 15.0 ], [ 8.0, 15.0 ], [ 8.0, 13.0 ] ] ] } }
+]
+}

--- a/python/plugins/processing/tests/testdata/expected/union0.gml
+++ b/python/plugins/processing/tests/testdata/expected/union0.gml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ union0.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>1</gml:X><gml:Y>1</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>16</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+
+  <gml:featureMember>
+    <ogr:union0 fid="union0.0">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,2 2,4 4,4 4,2 2,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A2</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.1">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,2 2,4 4,4 4,2 2,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A1</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.2">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,1 1,5 5,5 5,1 1,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>2,2 4,2 4,4 2,4 2,2</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A1</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.3">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>7,2 7,4 9,4 9,2 7,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A4</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.4">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>7,2 7,4 9,4 9,2 7,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A3</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.5">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,13 1,13 1,14 2,14 2,13</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A9</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.6">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,13 1,13 1,14 2,14 2,13</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A8</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.7">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 6,5 10,5 10,1 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>7,2 9,2 9,4 7,4 7,2</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A4</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.8">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4,12 2,12 2,13 4,13 4,12</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A10</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.9">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4,12 2,12 2,13 4,13 4,12</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A8</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.10">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,6 3,6 3,10 1,10 1,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A5</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.11">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,13 2,14 4,14 4,13 2,13</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A10</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.12">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,13 2,14 4,14 4,13 2,13</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A9</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.13">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,13 2,14 4,14 4,13 2,13</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A8</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.14">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,6 5,6 5,10 3,10 3,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A6</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.15">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,14 2,15 4,15 4,14 2,14</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A10</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.16">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,14 2,15 4,15 4,14 2,14</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A9</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.17">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,6 10,6 10,10 6,10 6,6</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A7</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.18">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4,12 4,11 1,11 1,13 2,13 2,12 4,12</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A8</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.19">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1,14 1,16 4,16 4,15 2,15 2,14 1,14</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A9</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.20">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4,15 5,15 5,12 4,12 4,13 4,14 4,15</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A10</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.21">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,11 10,11 10,12 7,12 7,15 6,15 6,11</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A11</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:union0 fid="union0.22">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:3857"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>8,13 10,13 10,15 8,15 8,13</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:id_a>A12</ogr:id_a>
+    </ogr:union0>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/union0.xsd
+++ b/python/plugins/processing/tests/testdata/expected/union0.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="union0" type="ogr:union0_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="union0_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:MultiPolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id_a" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="255"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -5331,6 +5331,21 @@ tests:
             fid: skip
 
   - algorithm: native:union
+    name: Test Union of single layer
+    params:
+      INPUT:
+        name: custom/overlay0.geojson
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/union0.gml
+        type: vector
+        compare:
+          unordered: true
+          fields:
+            fid: skip
+
+  - algorithm: native:union
     name: Test Union (basic)
     params:
       INPUT:

--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -199,7 +199,9 @@ class TestCase(_TestCase):
     def checkGeometriesEqual(self, geom0, geom1, geom0_id, geom1_id, use_asserts=False, precision=14, topo_equal_check=False):
         """ Checks whether two geometries are the same - using either a strict check of coordinates (up to given precision)
         or by using topological equality (where e.g. a polygon with clockwise is equal to a polygon with counter-clockwise
-        order of vertices) """
+        order of vertices)
+        .. versionadded:: 3.2
+        """
         if not geom0.isNull() and not geom1.isNull():
             if topo_equal_check:
                 equal = geom0.isGeosEqual(geom1)
@@ -225,7 +227,9 @@ class TestCase(_TestCase):
             return equal
 
     def checkAttributesEqual(self, feat0, feat1, fields_expected, use_asserts, compare):
-        """ Checks whether attributes of two features are the same """
+        """ Checks whether attributes of two features are the same
+        .. versionadded:: 3.2
+        """
 
         for attr_expected, field_expected in zip(feat0.attributes(), fields_expected.toList()):
             try:

--- a/src/analysis/processing/qgsalgorithmunion.cpp
+++ b/src/analysis/processing/qgsalgorithmunion.cpp
@@ -65,7 +65,8 @@ QVariantMap QgsUnionAlgorithm::processAlgorithm( const QVariantMap &parameters, 
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
 
   std::unique_ptr< QgsFeatureSource > sourceB( parameterAsSource( parameters, QStringLiteral( "OVERLAY" ), context ) );
-  // sourceB is optional so we do not throw an error if it is not a valid source
+  if ( parameters.value( QStringLiteral( "OVERLAY" ) ).isValid() && !sourceB )
+    throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "OVERLAY" ) ) );
 
   QgsWkbTypes::Type geomType = QgsWkbTypes::multiType( sourceA->wkbType() );
 

--- a/src/analysis/processing/qgsalgorithmunion.cpp
+++ b/src/analysis/processing/qgsalgorithmunion.cpp
@@ -53,11 +53,10 @@ QgsProcessingAlgorithm *QgsUnionAlgorithm::createInstance() const
 void QgsUnionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Union layer" ) ) );
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Union layer" ), QList< int >(), QVariant(), true ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Union" ) ) );
 }
-
 
 QVariantMap QgsUnionAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
 {
@@ -66,12 +65,11 @@ QVariantMap QgsUnionAlgorithm::processAlgorithm( const QVariantMap &parameters, 
     throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "INPUT" ) ) );
 
   std::unique_ptr< QgsFeatureSource > sourceB( parameterAsSource( parameters, QStringLiteral( "OVERLAY" ), context ) );
-  if ( !sourceB )
-    throw QgsProcessingException( invalidSourceError( parameters, QStringLiteral( "OVERLAY" ) ) );
+  // sourceB is optional so we do not throw an error if it is not a valid source
 
   QgsWkbTypes::Type geomType = QgsWkbTypes::multiType( sourceA->wkbType() );
 
-  QgsFields fields = QgsProcessingUtils::combineFields( sourceA->fields(), sourceB->fields() );
+  QgsFields fields = sourceB ? QgsProcessingUtils::combineFields( sourceA->fields(), sourceB->fields() ) : sourceA->fields();
 
   QString dest;
   std::unique_ptr< QgsFeatureSink > sink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, fields, geomType, sourceA->sourceCrs() ) );
@@ -80,6 +78,13 @@ QVariantMap QgsUnionAlgorithm::processAlgorithm( const QVariantMap &parameters, 
 
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+
+  if ( !sourceB )
+  {
+    // we are doing single layer union
+    QgsOverlayUtils::resolveOverlaps( *sourceA.get(), *sink.get(), feedback );
+    return outputs;
+  }
 
   QList<int> fieldIndicesA = QgsProcessingUtils::fieldNamesToIndices( QStringList(), sourceA->fields() );
   QList<int> fieldIndicesB = QgsProcessingUtils::fieldNamesToIndices( QStringList(), sourceB->fields() );

--- a/src/analysis/processing/qgsoverlayutils.h
+++ b/src/analysis/processing/qgsoverlayutils.h
@@ -50,7 +50,7 @@ namespace QgsOverlayUtils
    * 2. a feature with geometry B - A with B's attributes
    * 3. two features with geometry intersection(A, B) - one with A's attributes, one with B's attributes.
    *
-   * As a result, for all pairs of features in the output, a pair either havs no common interior or their interior is the same.
+   * As a result, for all pairs of features in the output, a pair either has no common interior or their interior is the same.
    */
   void resolveOverlaps( const QgsFeatureSource &source, QgsFeatureSink &sink, QgsProcessingFeedback *feedback );
 }

--- a/src/analysis/processing/qgsoverlayutils.h
+++ b/src/analysis/processing/qgsoverlayutils.h
@@ -43,6 +43,16 @@ namespace QgsOverlayUtils
 
   void intersection( const QgsFeatureSource &sourceA, const QgsFeatureSource &sourceB, QgsFeatureSink &sink, QgsProcessingContext &context, QgsProcessingFeedback *feedback, int &count, int totalCount, const QList<int> &fieldIndicesA, const QList<int> &fieldIndicesB );
 
+  /**
+   * Copies features from the source to the sink and resolves overlaps: for each pair of overlapping features A and B
+   * it will produce:
+   * 1. a feature with geometry A - B with A's attributes
+   * 2. a feature with geometry B - A with B's attributes
+   * 3. two features with geometry intersection(A, B) - one with A's attributes, one with B's attributes.
+   *
+   * As a result, for all pairs of features in the output, a pair either havs no common interior or their interior is the same.
+   */
+  void resolveOverlaps( const QgsFeatureSource &source, QgsFeatureSink &sink, QgsProcessingFeedback *feedback );
 }
 
 ///@endcond PRIVATE


### PR DESCRIPTION
Make Union algorithm support the case of just one input layer - splits features at any intersections with other features. Best described in the following picture:

![single-layer-union](https://user-images.githubusercontent.com/193367/41784551-54b28456-7640-11e8-8497-8f4c72cd1cb9.png)

This should address the rest of https://issues.qgis.org/issues/17131

The PR also improves processing test support - both points needed to make the single layer union tests work:
1. optional geometry tests based on topology equality rather than comparing exact coordinates (with the exact order)
2. optional unordered comparison of features

Finally, we have a beautiful new handcrafted test dataset covering various situations for union:

![overlay0_data](https://user-images.githubusercontent.com/193367/39845689-4656c810-53c5-11e8-92dc-973b2939d7bc.png)

