### PR TITLE
Allow the widget type box to fit its content

### DIFF
--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -169,6 +169,7 @@ void QgsAttributeTypeDialog::setEditorWidgetType( const QString &type )
       QgsDebugMsg( "Oops, couldn't create editor widget config dialog..." );
     }
   }
+  stackedWidget->adjustSize();
 
   //update default expression preview
   defaultExpressionChanged();


### PR DESCRIPTION
Avoid blank space at the bottom of the widget type when selecting eg, "Color" after "Value Relation" widget.
Trying to fix
![attributesform](https://user-images.githubusercontent.com/7983394/37593161-58da0320-2b71-11e8-9e41-648f39b861c5.PNG)