### PR TITLE
add flag to avoid UI prompt if a style already exists in the DB

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -761,6 +761,18 @@ Resolve references to other layers (kept as layer IDs after reading XML) into la
 .. versionadded:: 3.0
 %End
 
+    virtual bool styleExistsInDatabase( const QString &name, QString &msgError /Out/ );
+%Docstring
+Check if the named style exists in the database.
+
+:param name: Name of the style to check.
+:param msgError: A reason why the style might not exist in the DB.
+
+:return: If the style is present or not.
+
+.. versionadded:: 3.2
+%End
+
     virtual void saveStyleToDatabase( const QString &name, const QString &description,
                                       bool useAsDefault, const QString &uiFileContent,
                                       QString &msgError /Out/ );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -931,12 +931,26 @@ void QgsVectorLayerProperties::saveDefaultStyle_clicked()
       case 0:
         return;
       case 2:
+      {
+        QgsDataSourceUri dsUri( mLayer->dataProvider()->uri() );
+        if ( mLayer->styleExistsInDatabase( dsUri.table(), errorMsg ) )
+        {
+          if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
+                                      QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
+                                      .arg( dsUri.table() ),
+                                      QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
+          {
+            return;
+          }
+        }
+        errorMsg = QString();
         mLayer->saveStyleToDatabase( QLatin1String( "" ), QLatin1String( "" ), true, QLatin1String( "" ), errorMsg );
         if ( errorMsg.isNull() )
         {
           return;
         }
         break;
+      }
       default:
         break;
     }
@@ -1137,6 +1151,18 @@ void QgsVectorLayerProperties::saveStyleAs( StyleType styleType )
 
       apply();
 
+      if ( mLayer->styleExistsInDatabase( styleName, msgError ) )
+      {
+        if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
+                                    QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
+                                    .arg( styleName ),
+                                    QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
+        {
+          return;
+        }
+      }
+
+      msgError = QString();
       mLayer->saveStyleToDatabase( styleName, styleDesc, isDefault, uiFileContent, msgError );
 
       if ( !msgError.isNull() )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -110,6 +110,12 @@ typedef bool saveStyle_t(
   QString &errCause
 );
 
+typedef bool styleExistsInDatabase_t(
+  const QString &uri,
+  const QString &styleName,
+  QString &errCause
+);
+
 typedef QString loadStyle_t(
   const QString &uri,
   QString &errCause
@@ -4327,6 +4333,23 @@ bool QgsVectorLayer::deleteStyleFromDatabase( const QString &styleId, QString &m
   return deleteStyleByIdMethod( mDataSource, styleId, msgError );
 }
 
+bool QgsVectorLayer::styleExistsInDatabase( const QString &name, QString &msgError )
+{
+  std::unique_ptr<QLibrary> myLib( QgsProviderRegistry::instance()->createProviderLibrary( mProviderKey ) );
+  if ( !myLib )
+  {
+    msgError = QObject::tr( "Unable to load %1 provider" ).arg( mProviderKey );
+    return false;
+  }
+
+  styleExistsInDatabase_t *styleExistsExternalMethod = reinterpret_cast< styleExistsInDatabase_t * >( cast_to_fptr( myLib->resolve( "styleExists" ) ) );
+  if ( !styleExistsExternalMethod )
+  {
+    msgError = QObject::tr( "Provider %1 has no %2 method" ).arg( mProviderKey, QStringLiteral( "styleExists" ) );
+    return false;
+  }
+  return styleExistsExternalMethod( mDataSource, name, msgError );
+}
 
 void QgsVectorLayer::saveStyleToDatabase( const QString &name, const QString &description,
     bool useAsDefault, const QString &uiFileContent, QString &msgError )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -774,6 +774,15 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void resolveReferences( QgsProject *project ) override;
 
     /**
+     * Check if the named style exists in the database.
+     * \param name Name of the style to check.
+     * \param msgError A reason why the style might not exist in the DB.
+     * \returns If the style is present or not.
+     * \since QGIS 3.2
+     */
+    virtual bool styleExistsInDatabase( const QString &name, QString &msgError SIP_OUT );
+
+    /**
      * Save named and sld style of the layer to the style table in the db.
      * \param name
      * \param description

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -197,12 +197,25 @@ void QgsMapLayerStyleManagerWidget::saveAsDefault()
         case 0:
           return;
         case 2:
+        {
+          QgsDataSourceUri dsUri( layer->dataProvider()->uri() );
+          if ( layer->styleExistsInDatabase( dsUri.table(), errorMsg ) )
+          {
+            if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
+                                        QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
+                                        .arg( dsUri.table() ),
+                                        QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
+            {
+              return;
+            }
+          }
           layer->saveStyleToDatabase( QLatin1String( "" ), QLatin1String( "" ), true, QLatin1String( "" ), errorMsg );
           if ( errorMsg.isNull() )
           {
             return;
           }
           break;
+        }
         default:
           break;
       }

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -67,6 +67,26 @@ static bool tableExists( QgsPostgresConn &conn, const QString &name )
   return res.PQgetvalue( 0, 0 ).toInt() > 0;
 }
 
+static bool createStyleTable( QgsPostgresConn &connection )
+{
+  QgsPostgresResult res( connection.PQexec( "CREATE TABLE layer_styles("
+                         "id SERIAL PRIMARY KEY"
+                         ",f_table_catalog varchar"
+                         ",f_table_schema varchar"
+                         ",f_table_name varchar"
+                         ",f_geometry_column varchar"
+                         ",styleName text"
+                         ",styleQML xml"
+                         ",styleSLD xml"
+                         ",useAsDefault boolean"
+                         ",description text"
+                         ",owner varchar(63)"
+                         ",ui xml"
+                         ",update_time timestamp DEFAULT CURRENT_TIMESTAMP"
+                         ")" ) );
+  return res.PQresultStatus() == PGRES_COMMAND_OK;
+}
+
 QgsPostgresPrimaryKeyType
 QgsPostgresProvider::pkType( const QgsField &f ) const
 {
@@ -4572,6 +4592,51 @@ QGISEXTERN bool deleteSchema( const QString &schema, const QgsDataSourceUri &uri
   return true;
 }
 
+QGISEXTERN bool styleExists( const QString &uri, const QString &styleName, QString &errCause )
+{
+  QgsDataSourceUri dsUri( uri );
+
+  QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  if ( !conn )
+  {
+    errCause = QObject::tr( "Connection to database failed." );
+    return false;
+  }
+
+  if ( !tableExists( *conn, QStringLiteral( "layer_styles" ) ) )
+  {
+    conn->unref();
+    errCause = QObject::tr( "The layer_style table does not exist in the database." );
+    return false;
+  }
+
+  QString defaultStyleName = styleName.isEmpty() ? dsUri.table() : styleName;
+  QString checkQuery = QString( "SELECT styleName"
+                                " FROM layer_styles"
+                                " WHERE f_table_catalog=%1"
+                                " AND f_table_schema=%2"
+                                " AND f_table_name=%3"
+                                " AND f_geometry_column=%4"
+                                " AND styleName=%5" )
+                       .arg( QgsPostgresConn::quotedValue( dsUri.database() ) )
+                       .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
+                       .arg( QgsPostgresConn::quotedValue( dsUri.table() ) )
+                       .arg( QgsPostgresConn::quotedValue( dsUri.geometryColumn() ) )
+                       .arg( QgsPostgresConn::quotedValue( defaultStyleName ) );
+
+  QgsPostgresResult res( conn->PQexec( checkQuery ) );
+  conn->unref();
+  if ( res.PQntuples() > 0 )
+  {
+    return true;
+  }
+  else
+  {
+    errCause = QObject::tr( "The style has not been found in the database." );
+    return false;
+  }
+}
+
 QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QString &sldStyle,
                            const QString &styleName, const QString &styleDescription,
                            const QString &uiFileContent, bool useAsDefault, QString &errCause )
@@ -4587,22 +4652,7 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
 
   if ( !tableExists( *conn, QStringLiteral( "layer_styles" ) ) )
   {
-    QgsPostgresResult res( conn->PQexec( "CREATE TABLE layer_styles("
-                                         "id SERIAL PRIMARY KEY"
-                                         ",f_table_catalog varchar"
-                                         ",f_table_schema varchar"
-                                         ",f_table_name varchar"
-                                         ",f_geometry_column varchar"
-                                         ",styleName text"
-                                         ",styleQML xml"
-                                         ",styleSLD xml"
-                                         ",useAsDefault boolean"
-                                         ",description text"
-                                         ",owner varchar(63)"
-                                         ",ui xml"
-                                         ",update_time timestamp DEFAULT CURRENT_TIMESTAMP"
-                                         ")" ) );
-    if ( res.PQresultStatus() != PGRES_COMMAND_OK )
+    if ( ! createStyleTable( *conn ) )
     {
       errCause = QObject::tr( "Unable to save layer style. It's not possible to create the destination table on the database. Maybe this is due to table permissions (user=%1). Please contact your database admin" ).arg( dsUri.username() );
       conn->unref();
@@ -4623,6 +4673,9 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
     uiFileValue = QStringLiteral( ",XMLPARSE(DOCUMENT %1)" ).arg( QgsPostgresConn::quotedValue( uiFileContent ) );
   }
 
+  QString defaultStyleName = styleName.isEmpty() ? dsUri.table() : styleName;
+  QString defaultStyleDescription = styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription;
+
   // Note: in the construction of the INSERT and UPDATE strings the qmlStyle and sldStyle values
   // can contain user entered strings, which may themselves include %## values that would be
   // replaced by the QString.arg function.  To ensure that the final SQL string is not corrupt these
@@ -4637,9 +4690,9 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
                 .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
                 .arg( QgsPostgresConn::quotedValue( dsUri.table() ) )
                 .arg( QgsPostgresConn::quotedValue( dsUri.geometryColumn() ) )
-                .arg( QgsPostgresConn::quotedValue( styleName.isEmpty() ? dsUri.table() : styleName ) )
+                .arg( QgsPostgresConn::quotedValue( defaultStyleName ) )
                 .arg( useAsDefault ? "true" : "false" )
-                .arg( QgsPostgresConn::quotedValue( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
+                .arg( QgsPostgresConn::quotedValue( defaultStyleDescription ) )
                 .arg( QgsPostgresConn::quotedValue( dsUri.username() ) )
                 .arg( uiFileColumn )
                 .arg( uiFileValue )
@@ -4647,32 +4700,8 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
                 .arg( QgsPostgresConn::quotedValue( qmlStyle ),
                       QgsPostgresConn::quotedValue( sldStyle ) );
 
-  QString checkQuery = QString( "SELECT styleName"
-                                " FROM layer_styles"
-                                " WHERE f_table_catalog=%1"
-                                " AND f_table_schema=%2"
-                                " AND f_table_name=%3"
-                                " AND f_geometry_column=%4"
-                                " AND styleName=%5" )
-                       .arg( QgsPostgresConn::quotedValue( dsUri.database() ) )
-                       .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
-                       .arg( QgsPostgresConn::quotedValue( dsUri.table() ) )
-                       .arg( QgsPostgresConn::quotedValue( dsUri.geometryColumn() ) )
-                       .arg( QgsPostgresConn::quotedValue( styleName.isEmpty() ? dsUri.table() : styleName ) );
-
-  QgsPostgresResult res( conn->PQexec( checkQuery ) );
-  if ( res.PQntuples() > 0 )
+  if ( styleExists( uri, defaultStyleName, errCause ) )
   {
-    if ( QMessageBox::question( nullptr, QObject::tr( "Save style in database" ),
-                                QObject::tr( "A style named \"%1\" already exists in the database for this layer. Do you want to overwrite it?" )
-                                .arg( styleName.isEmpty() ? dsUri.table() : styleName ),
-                                QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
-    {
-      errCause = QObject::tr( "Operation aborted. No changes were made in the database" );
-      conn->unref();
-      return false;
-    }
-
     sql = QString( "UPDATE layer_styles"
                    " SET useAsDefault=%1"
                    ",styleQML=XMLPARSE(DOCUMENT %12)"
@@ -4685,13 +4714,13 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
                    " AND f_geometry_column=%9"
                    " AND styleName=%10" )
           .arg( useAsDefault ? "true" : "false" )
-          .arg( QgsPostgresConn::quotedValue( styleDescription.isEmpty() ? QDateTime::currentDateTime().toString() : styleDescription ) )
+          .arg( QgsPostgresConn::quotedValue( defaultStyleDescription ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.username() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.database() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.schema() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.table() ) )
           .arg( QgsPostgresConn::quotedValue( dsUri.geometryColumn() ) )
-          .arg( QgsPostgresConn::quotedValue( styleName.isEmpty() ? dsUri.table() : styleName ) )
+          .arg( QgsPostgresConn::quotedValue( defaultStyleName ) )
           // Must be the final .arg replacement - see above
           .arg( QgsPostgresConn::quotedValue( qmlStyle ),
                 QgsPostgresConn::quotedValue( sldStyle ) );
@@ -4712,7 +4741,7 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
     sql = QStringLiteral( "BEGIN; %1; %2; COMMIT;" ).arg( removeDefaultSql, sql );
   }
 
-  res = conn->PQexec( sql );
+  QgsPostgresResult res( conn->PQexec( sql ) );
 
   bool saved = res.PQresultStatus() == PGRES_COMMAND_OK;
   if ( !saved )


### PR DESCRIPTION
## Description

Adding a flag to avoid this window when you save styles in DB programmatically:
![screenshot from 2018-05-10 19-38-06](https://user-images.githubusercontent.com/1609292/39899428-ca16fd18-5489-11e8-99c6-6991edbca9cd.png)

I think I'm not doing a API break like this. Is-it fine?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
