### PR TITLE
Reorganise project menu

### DIFF
--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -144,6 +144,9 @@ void QgsActionLocatorFilter::searchActions( const QString &string, QWidget *pare
   {
     searchActions( string, widget, found );
   }
+
+  QRegularExpression extractFromTooltip( QStringLiteral( "<b>(.*)</b>" ) );
+
   Q_FOREACH ( QAction *action, parent->actions() )
   {
     if ( action->menu() )
@@ -159,6 +162,22 @@ void QgsActionLocatorFilter::searchActions( const QString &string, QWidget *pare
 
     QString searchText = action->text();
     searchText.replace( '&', QString() );
+
+    QString tooltip = action->toolTip();
+    QRegularExpressionMatch match = extractFromTooltip.match( tooltip );
+    if ( match.hasMatch() )
+    {
+      tooltip = match.captured( 1 );
+    }
+    tooltip.replace( QStringLiteral( "..." ), QString() );
+    tooltip.replace( QStringLiteral( "…" ), QString() );
+    searchText.replace( QStringLiteral( "..." ), QString() );
+    searchText.replace( QStringLiteral( "…" ), QString() );
+    if ( searchText.trimmed().compare( tooltip.trimmed(), Qt::CaseInsensitive ) != 0 )
+    {
+      searchText += QStringLiteral( " (%1)" ).arg( tooltip.trimmed() );
+    }
+
     if ( stringMatches( searchText, string ) )
     {
       QgsLocatorResult result;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13613,7 +13613,7 @@ void QgisApp::populateProjectStorageMenu( QMenu *menu, bool saving )
     QString name = storage->visibleName();
     if ( name.isEmpty() )
       continue;
-    QAction *action = menu->addAction( name );
+    QAction *action = menu->addAction( QStringLiteral( "%1…" ).arg( name ) );
     if ( saving )
     {
       connect( action, &QAction::triggered, [this, storage]

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -690,6 +690,9 @@
    <property name="text">
     <string>&amp;New</string>
    </property>
+   <property name="toolTip">
+    <string>New Project</string>
+   </property>
    <property name="shortcut">
     <string>Ctrl+N</string>
    </property>
@@ -701,6 +704,9 @@
    </property>
    <property name="text">
     <string>&amp;Open…</string>
+   </property>
+   <property name="toolTip">
+    <string>Open Project</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -714,6 +720,9 @@
    <property name="text">
     <string>&amp;Save</string>
    </property>
+   <property name="toolTip">
+    <string>Save Project</string>
+   </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
    </property>
@@ -725,6 +734,9 @@
    </property>
    <property name="text">
     <string>Save &amp;As…</string>
+   </property>
+   <property name="toolTip">
+    <string>Save Project As</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
@@ -738,6 +750,9 @@
    <property name="text">
     <string>Save Map as &amp;Image…</string>
    </property>
+   <property name="toolTip">
+    <string>Save Map as Image</string>
+   </property>
   </action>
   <action name="mActionSaveMapAsPdf">
    <property name="icon">
@@ -746,6 +761,9 @@
    </property>
    <property name="text">
     <string>Save Map as &amp;PDF…</string>
+   </property>
+   <property name="toolTip">
+    <string>Save Map as PDF</string>
    </property>
   </action>
   <action name="mActionNewMapCanvas">
@@ -1553,6 +1571,9 @@
    <property name="text">
     <string>&amp;Save As...</string>
    </property>
+   <property name="toolTip">
+    <string>Save Layer As</string>
+   </property>
   </action>
   <action name="mActionRemoveLayer">
    <property name="icon">
@@ -1585,6 +1606,9 @@
   <action name="mActionLayerProperties">
    <property name="text">
     <string>&amp;Properties...</string>
+   </property>
+   <property name="toolTip">
+    <string>Layer Properties</string>
    </property>
   </action>
   <action name="mActionLayerSubsetString">
@@ -1686,6 +1710,9 @@
    </property>
    <property name="text">
     <string>&amp;Properties…</string>
+   </property>
+   <property name="toolTip">
+    <string>Project Properties</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+P</string>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -748,7 +748,7 @@
      <normaloff>:/images/themes/default/mActionSaveMapAsImage.svg</normaloff>:/images/themes/default/mActionSaveMapAsImage.svg</iconset>
    </property>
    <property name="text">
-    <string>Save Map as &amp;Image…</string>
+    <string>Export Map to &amp;Image…</string>
    </property>
    <property name="toolTip">
     <string>Save Map as Image</string>
@@ -760,7 +760,7 @@
      <normaloff>:/images/themes/default/mActionSaveAsPDF.svg</normaloff>:/images/themes/default/mActionSaveAsPDF.svg</iconset>
    </property>
    <property name="text">
-    <string>Save Map as &amp;PDF…</string>
+    <string>Export Map to &amp;PDF…</string>
    </property>
    <property name="toolTip">
     <string>Save Map as PDF</string>
@@ -2443,7 +2443,7 @@ Acts on currently active editable layer</string>
   </action>
   <action name="mActionDxfExport">
    <property name="text">
-    <string>Export Map to DXF…</string>
+    <string>Export Project to DXF…</string>
    </property>
   </action>
   <action name="mActionDwgImport">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -52,25 +52,33 @@
       <string>Open from</string>
      </property>
     </widget>
+    <widget class="QMenu" name="menuImport_Export">
+     <property name="title">
+      <string>Import/Export</string>
+     </property>
+     <addaction name="mActionSaveMapAsImage"/>
+     <addaction name="mActionSaveMapAsPdf"/>
+     <addaction name="mActionDxfExport"/>
+     <addaction name="separator"/>
+     <addaction name="mActionDwgImport"/>
+    </widget>
     <addaction name="mActionNewProject"/>
+    <addaction name="mProjectFromTemplateMenu"/>
+    <addaction name="separator"/>
     <addaction name="mActionOpenProject"/>
     <addaction name="mProjectFromStorageMenu"/>
-    <addaction name="mProjectFromTemplateMenu"/>
     <addaction name="mRecentProjectsMenu"/>
-    <addaction name="mActionRevertProject"/>
+    <addaction name="separator"/>
     <addaction name="mActionCloseProject"/>
     <addaction name="separator"/>
     <addaction name="mActionSaveProject"/>
     <addaction name="mActionSaveProjectAs"/>
     <addaction name="mProjectToStorageMenu"/>
-    <addaction name="mActionSaveMapAsImage"/>
-    <addaction name="mActionSaveMapAsPdf"/>
-    <addaction name="mActionDxfExport"/>
-    <addaction name="mActionDwgImport"/>
-    <addaction name="separator"/>
-    <addaction name="mActionSnappingOptions"/>
+    <addaction name="mActionRevertProject"/>
     <addaction name="separator"/>
     <addaction name="mActionProjectProperties"/>
+    <addaction name="mActionSnappingOptions"/>
+    <addaction name="menuImport_Export"/>
     <addaction name="separator"/>
     <addaction name="mActionNewPrintLayout"/>
     <addaction name="mActionNewReport"/>
@@ -692,7 +700,7 @@
      <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
    </property>
    <property name="text">
-    <string>&amp;Open...</string>
+    <string>&amp;Open…</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -716,7 +724,7 @@
      <normaloff>:/images/themes/default/mActionFileSaveAs.svg</normaloff>:/images/themes/default/mActionFileSaveAs.svg</iconset>
    </property>
    <property name="text">
-    <string>Save &amp;As...</string>
+    <string>Save &amp;As…</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+S</string>
@@ -728,7 +736,7 @@
      <normaloff>:/images/themes/default/mActionSaveMapAsImage.svg</normaloff>:/images/themes/default/mActionSaveMapAsImage.svg</iconset>
    </property>
    <property name="text">
-    <string>Save Map as &amp;Image...</string>
+    <string>Save Map as &amp;Image…</string>
    </property>
   </action>
   <action name="mActionSaveMapAsPdf">
@@ -737,7 +745,7 @@
      <normaloff>:/images/themes/default/mActionSaveAsPDF.svg</normaloff>:/images/themes/default/mActionSaveAsPDF.svg</iconset>
    </property>
    <property name="text">
-    <string>Save Map as &amp;PDF...</string>
+    <string>Save Map as &amp;PDF…</string>
    </property>
   </action>
   <action name="mActionNewMapCanvas">
@@ -1022,7 +1030,7 @@
   </action>
   <action name="mActionSnappingOptions">
    <property name="text">
-    <string>&amp;Snapping Options...</string>
+    <string>&amp;Snapping Options…</string>
    </property>
   </action>
   <action name="mActionPan">
@@ -1677,7 +1685,7 @@
      <normaloff>:/images/themes/default/mActionProjectProperties.svg</normaloff>:/images/themes/default/mActionProjectProperties.svg</iconset>
    </property>
    <property name="text">
-    <string>&amp;Project Properties...</string>
+    <string>&amp;Properties…</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+P</string>
@@ -2408,12 +2416,12 @@ Acts on currently active editable layer</string>
   </action>
   <action name="mActionDxfExport">
    <property name="text">
-    <string>DXF Export...</string>
+    <string>Export Map to DXF…</string>
    </property>
   </action>
   <action name="mActionDwgImport">
    <property name="text">
-    <string>DWG/DXF Import...</string>
+    <string>Import Layers from DWG/DXF…</string>
    </property>
   </action>
   <action name="mActionFillRing">
@@ -2969,7 +2977,7 @@ Acts on currently active editable layer</string>
      <normaloff>:/images/themes/default/mActionNewLayout.svg</normaloff>:/images/themes/default/mActionNewLayout.svg</iconset>
    </property>
    <property name="text">
-    <string>New &amp;Print Layout</string>
+    <string>New &amp;Print Layout…</string>
    </property>
    <property name="toolTip">
     <string>New Print Layout</string>
@@ -2984,7 +2992,7 @@ Acts on currently active editable layer</string>
      <normaloff>:/images/themes/default/mActionNewReport.svg</normaloff>:/images/themes/default/mActionNewReport.svg</iconset>
    </property>
    <property name="text">
-    <string>New &amp;Report</string>
+    <string>New &amp;Report…</string>
    </property>
    <property name="toolTip">
     <string>New Report</string>
@@ -2992,7 +3000,7 @@ Acts on currently active editable layer</string>
   </action>
   <action name="mActionCloseProject">
    <property name="text">
-    <string>Close Project</string>
+    <string>Close</string>
    </property>
    <property name="toolTip">
     <string>Close Project</string>
@@ -3000,7 +3008,7 @@ Acts on currently active editable layer</string>
   </action>
   <action name="mActionRevertProject">
    <property name="text">
-    <string>Revert Project…</string>
+    <string>Revert…</string>
    </property>
    <property name="toolTip">
     <string>Revert Project to Saved version</string>


### PR DESCRIPTION
The project menu has become a huge mess of random items in an illogical order:

![before](https://user-images.githubusercontent.com/1829991/39903581-26fa4be2-5517-11e8-8617-efe54461f2cc.png)

This PR cleans it up by:
- grouping similar actions together and using separators more effectively
- moving the import/export actions to a submenu
- adding consistency to action names

After:

![after](https://user-images.githubusercontent.com/1829991/39903596-40ca2cae-5517-11e8-8f3f-d25fd6b3ea0c.png)

I'd like to also move some of the Layouts actions to further reduce clutter. I think the "New Print Layout"  and "New Report" actions should be moved into the "Layouts" submenu. Any objections here?
