### PR TITLE
Fix incorrect snapping when moving features and using advanced ditizing parallel/perpendicular modes

### DIFF
--- a/src/app/qgsmaptoolmovefeature.cpp
+++ b/src/app/qgsmaptoolmovefeature.cpp
@@ -172,7 +172,6 @@ void QgsMapToolMoveFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       mRubberBand = nullptr;
       return;
     }
-    e->snapPoint();
 
     QgsPointXY startPointLayerCoords = toLayerCoordinates( ( QgsMapLayer * )vlayer, mStartPointMapCoords );
     QgsPointXY stopPointLayerCoords = toLayerCoordinates( ( QgsMapLayer * )vlayer, e->mapPoint() );


### PR DESCRIPTION
Refs issue demonstrated in https://www.youtube.com/watch?v=jZYKGrIyVCA at 25:00

