### PR TITLE
Remove the default output value shown in expression builder

### DIFF
--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -344,7 +344,7 @@
                       <number>0</number>
                      </property>
                      <property name="text">
-                      <string>123232</string>
+                      <string/>
                      </property>
                      <property name="scaledContents">
                       <bool>false</bool>


### PR DESCRIPTION
Fixes [#18808](https://issues.qgis.org/issues/18808)