### PR TITLE
[memory] Fix memory provider does not return correct min/max values after adding or editing features

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -402,6 +402,7 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList &flist, Flags )
     mNextFeatureId++;
   }
 
+  clearMinMaxCache();
   return result;
 }
 
@@ -423,6 +424,7 @@ bool QgsMemoryProvider::deleteFeatures( const QgsFeatureIds &id )
   }
 
   updateExtents();
+  clearMinMaxCache();
 
   return true;
 }
@@ -504,6 +506,7 @@ bool QgsMemoryProvider::deleteAttributes( const QgsAttributeIds &attributes )
       f.setAttributes( attr );
     }
   }
+  clearMinMaxCache();
   return true;
 }
 
@@ -519,6 +522,7 @@ bool QgsMemoryProvider::changeAttributeValues( const QgsChangedAttributesMap &at
     for ( QgsAttributeMap::const_iterator it2 = attrs.constBegin(); it2 != attrs.constEnd(); ++it2 )
       fit->setAttribute( it2.key(), it2.value() );
   }
+  clearMinMaxCache();
   return true;
 }
 

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -471,6 +471,8 @@ QVariant QgsVectorDataProvider::aggregate( QgsAggregateCalculator::Aggregate agg
 void QgsVectorDataProvider::clearMinMaxCache()
 {
   mCacheMinMaxDirty = true;
+  mCacheMinValues.clear();
+  mCacheMaxValues.clear();
 }
 
 void QgsVectorDataProvider::fillMinMaxCache() const


### PR DESCRIPTION
The cache was not cleared correctly in this case

Fix sponsored by LINZ
