### PR TITLE
[feature][need-docs] Current feature/current value form context expressions

### DIFF
--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -180,10 +180,11 @@ which is determined at runtime.
 
     QSet<QString> referencedFunctions() const;
 %Docstring
-Return a list of all functions which are used in this expression.
+Return a list of the names of all functions which are used in this expression.
 
 .. versionadded:: 3.2
 %End
+
 
     QSet<int> referencedAttributeIndexes( const QgsFields &fields ) const;
 %Docstring

--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -178,6 +178,13 @@ which is determined at runtime.
 .. versionadded:: 3.0
 %End
 
+    QSet<QString> referencedFunctions() const;
+%Docstring
+Return a list of all functions which are used in this expression.
+
+.. versionadded:: 3.2
+%End
+
     QSet<int> referencedAttributeIndexes( const QgsFields &fields ) const;
 %Docstring
 Return a list of field name indexes obtained from the provided fields.

--- a/python/core/auto_generated/expression/qgsexpressionnode.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnode.sip.in
@@ -198,6 +198,11 @@ to evaluate child nodes.
 Return a set of all variables which are used in this expression.
 %End
 
+    virtual QSet<QString> referencedFunctions() const = 0;
+%Docstring
+Return a set of all functions which are used in this expression.
+%End
+
     virtual bool needsGeometry() const = 0;
 %Docstring
 Abstract virtual method which returns if the geometry is required to evaluate

--- a/python/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
@@ -55,6 +55,8 @@ Returns the node the operator will operate upon.
 
     virtual QSet<QString> referencedVariables() const;
 
+    virtual QSet<QString> referencedFunctions() const;
+
     virtual bool needsGeometry() const;
 
     virtual QgsExpressionNode *clone() const /Factory/;
@@ -154,6 +156,9 @@ Returns the node to the right of the operator.
 
     virtual QSet<QString> referencedVariables() const;
 
+    virtual QSet<QString> referencedFunctions() const;
+
+
     virtual bool needsGeometry() const;
 
     virtual QgsExpressionNode *clone() const /Factory/;
@@ -224,6 +229,8 @@ Returns the list of nodes to search for matching values within.
 
     virtual QSet<QString> referencedVariables() const;
 
+    virtual QSet<QString> referencedFunctions() const;
+
     virtual bool needsGeometry() const;
 
     virtual QgsExpressionNode *clone() const /Factory/;
@@ -275,6 +282,8 @@ Returns a list of arguments specified for the function.
 
     virtual QSet<QString> referencedVariables() const;
 
+    virtual QSet<QString> referencedFunctions() const;
+
     virtual bool needsGeometry() const;
 
     virtual QgsExpressionNode *clone() const /Factory/;
@@ -323,6 +332,8 @@ The value of the literal.
 
     virtual QSet<QString> referencedVariables() const;
 
+    virtual QSet<QString> referencedFunctions() const;
+
     virtual bool needsGeometry() const;
 
     virtual QgsExpressionNode *clone() const /Factory/;
@@ -366,6 +377,8 @@ The name of the column.
     virtual QSet<QString> referencedColumns() const;
 
     virtual QSet<QString> referencedVariables() const;
+
+    virtual QSet<QString> referencedFunctions() const;
 
     virtual bool needsGeometry() const;
 
@@ -465,6 +478,8 @@ The ELSE expression used for the condition.
     virtual QSet<QString> referencedColumns() const;
 
     virtual QSet<QString> referencedVariables() const;
+
+    virtual QSet<QString> referencedFunctions() const;
 
     virtual bool needsGeometry() const;
 

--- a/python/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
+++ b/python/core/auto_generated/expression/qgsexpressionnodeimpl.sip.in
@@ -57,8 +57,6 @@ Returns the node the operator will operate upon.
 
     virtual QSet<QString> referencedFunctions() const;
 
-    virtual bool needsGeometry() const;
-
     virtual QgsExpressionNode *clone() const /Factory/;
 
 
@@ -158,7 +156,6 @@ Returns the node to the right of the operator.
 
     virtual QSet<QString> referencedFunctions() const;
 
-
     virtual bool needsGeometry() const;
 
     virtual QgsExpressionNode *clone() const /Factory/;
@@ -231,8 +228,6 @@ Returns the list of nodes to search for matching values within.
 
     virtual QSet<QString> referencedFunctions() const;
 
-    virtual bool needsGeometry() const;
-
     virtual QgsExpressionNode *clone() const /Factory/;
 
     virtual bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const;
@@ -284,7 +279,6 @@ Returns a list of arguments specified for the function.
 
     virtual QSet<QString> referencedFunctions() const;
 
-    virtual bool needsGeometry() const;
 
     virtual QgsExpressionNode *clone() const /Factory/;
 
@@ -334,7 +328,6 @@ The value of the literal.
 
     virtual QSet<QString> referencedFunctions() const;
 
-    virtual bool needsGeometry() const;
 
     virtual QgsExpressionNode *clone() const /Factory/;
 
@@ -480,6 +473,7 @@ The ELSE expression used for the condition.
     virtual QSet<QString> referencedVariables() const;
 
     virtual QSet<QString> referencedFunctions() const;
+
 
     virtual bool needsGeometry() const;
 

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -118,7 +118,7 @@ Return a list of variables required by the form context ``expression``
 
     static bool expressionIsUsable( const QString &expression, const QgsFeature &feature );
 %Docstring
-Check wether the ``feature`` has all values required by the ``expression``
+Check whether the ``feature`` has all values required by the ``expression``
 
 @return True if the expression can be used
 

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -59,11 +59,7 @@ Constructor for QgsValueRelationFieldFormatter.
 
     static QStringList valueToStringList( const QVariant &value );
 %Docstring
-Utility to convert an array or a string representation of and array ``value`` to a string list
-
-:param value: The value to be converted
-
-:return: A string list
+Utility to convert an array or a string representation of an array ``value`` to a string list
 
 .. versionadded:: 3.2
 %End
@@ -120,12 +116,10 @@ Return a list of variables required by the form context ``expression``
 %Docstring
 Check whether the ``feature`` has all values required by the ``expression``
 
-@return True if the expression can be used
+:return: True if the expression can be used
 
 .. versionadded:: 3.2
 %End
-
-    static QString FORM_SCOPE_FUNCTIONS_RE;
 
 };
 

--- a/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
+++ b/python/core/auto_generated/fieldformatter/qgsvaluerelationfieldformatter.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsValueRelationFieldFormatter : QgsFieldFormatter
 {
 %Docstring
@@ -56,15 +57,6 @@ Constructor for QgsValueRelationFieldFormatter.
     virtual QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const;
 
 
-    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config );
-%Docstring
-Create a cache for a value relation field.
-This can be used to keep the value map in the local memory
-if doing multiple lookups in a loop.
-
-.. versionadded:: 3.0
-%End
-
     static QStringList valueToStringList( const QVariant &value );
 %Docstring
 Utility to convert an array or a string representation of and array ``value`` to a string list
@@ -75,6 +67,66 @@ Utility to convert an array or a string representation of and array ``value`` to
 
 .. versionadded:: 3.2
 %End
+
+    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature() );
+%Docstring
+Create a cache for a value relation field.
+This can be used to keep the value map in the local memory
+if doing multiple lookups in a loop.
+
+:param config: The widget configuration
+:param formFeature: The feature currently being edited with current attribute values
+
+:return: A kvp list of values for the widget
+
+.. versionadded:: 3.0
+%End
+
+    static bool expressionRequiresFormScope( const QString &expression );
+%Docstring
+Check if the ``expression`` requires a form scope (i.e. if it uses fields
+or geometry of the currently edited feature).
+
+:param expression: The widget's filter expression
+
+:return: true if the expression requires a form scope
+
+.. versionadded:: 3.2
+%End
+
+    static QSet<QString> expressionFormAttributes( const QString &expression );
+%Docstring
+Return a list of attributes required by the form context ``expression``
+
+:param expression: Form filter expression
+
+:return: list of attributes required by the expression
+
+.. versionadded:: 3.2
+%End
+
+    static QSet<QString> expressionFormVariables( const QString &expression );
+%Docstring
+Return a list of variables required by the form context ``expression``
+
+:param expression: Form filter expression
+
+:return: list of variables required by the expression
+
+.. versionadded:: 3.2
+%End
+
+    static bool expressionIsUsable( const QString &expression, const QgsFeature &feature );
+%Docstring
+Check wether the ``feature`` has all values required by the ``expression``
+
+@return True if the expression can be used
+
+.. versionadded:: 3.2
+%End
+
+    static QString FORM_SCOPE_FUNCTIONS_RE;
+
 };
 
 

--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -765,6 +765,14 @@ For instance, QGIS version numbers and variables specified through QGIS options.
 .. seealso:: :py:func:`setGlobalVariable`
 %End
 
+    static QgsExpressionContextScope *formScope( const QgsFeature &formFeature = QgsFeature( ) ) /Factory/;
+%Docstring
+Creates a new scope which contains functions and variables from the current attribute form/table feature.
+The variables and values in this scope will reflect the current state of the form/row being edited.
+
+.. versionadded:: 3.2
+%End
+
     static void setGlobalVariable( const QString &name, const QVariant &value );
 %Docstring
 Sets a global context variable. This variable will be contained within scopes retrieved via

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -213,6 +213,7 @@ This will be disabled when the form is not editable.
 .. versionadded:: 3.0
 %End
 
+
   signals:
 
     void valueChanged( const QVariant &value );
@@ -279,8 +280,32 @@ change the visual cue.
 .. versionadded:: 2.16
 %End
 
-  protected:
 
+    QgsFeature formFeature() const;
+%Docstring
+The feature currently being edited, in its current state
+
+:return: the feature currently being edited, in its current state
+
+.. versionadded:: 3.2
+%End
+
+    void setFormFeature( const QgsFeature &feature );
+%Docstring
+Set the feature currently being edited to ``feature``
+
+.. versionadded:: 3.2
+%End
+
+    bool setFormFeatureAttribute( const QString &attributeName, const QVariant &attributeValue );
+%Docstring
+Update the feature currently being edited by changing its
+attribute ``attributeName`` to ``attributeValue``
+
+:return: bool true on success
+
+.. versionadded:: 3.2
+%End
 
 
 };

--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -279,6 +279,10 @@ change the visual cue.
 .. versionadded:: 2.16
 %End
 
+  protected:
+
+
+
 };
 
 

--- a/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -180,7 +180,7 @@ QGIS forms
 
     const QgsAttributeEditorContext *parentContext() const;
 
-    const QgsFeature formFeature() const;
+    QgsFeature formFeature() const;
 %Docstring
 Return current feature from the currently edited form or table row
 

--- a/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
+++ b/python/gui/auto_generated/qgsattributeeditorcontext.sip.in
@@ -180,6 +180,25 @@ QGIS forms
 
     const QgsAttributeEditorContext *parentContext() const;
 
+    const QgsFeature formFeature() const;
+%Docstring
+Return current feature from the currently edited form or table row
+
+.. seealso:: :py:func:`setFormFeature`
+
+.. versionadded:: 3.2
+%End
+
+    void setFormFeature( const QgsFeature &feature );
+%Docstring
+Set current ``feature`` for the currently edited form or table row
+
+.. seealso:: :py:func:`formFeature`
+
+.. versionadded:: 3.2
+%End
+
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -141,7 +141,8 @@ on all attribute widgets.
 
  void attributeChanged( const QString &attribute, const QVariant &value ) /Deprecated/;
 %Docstring
-Notifies about changes of attributes
+Notifies about changes of attributes, this signal is not emitted when the value is set
+back to the original one.
 
 :param attribute: The name of the attribute that changed.
 :param value:     The new value of the attribute.

--- a/resources/function_help/json/current_value
+++ b/resources/function_help/json/current_value
@@ -1,7 +1,7 @@
 {
   "name": "current_value",
   "type": "function",
-  "description": "Returns the current value of a field in the form or table row currently being edited.",
+  "description": "Returns the current, unsaved value of a field in the form or table row currently being edited. This will differ from the feature's actual attribute values for features which are currently being edited or have not yet been added to a layer.",
   "arguments": [ {"arg":"field_name","description":"a field name in the current form or table row"}],
   "examples": [ { "expression":"current_value( 'FIELD_NAME' )","returns":"The current value of field 'FIELD_NAME'."} ]
 }

--- a/resources/function_help/json/get_current_form_field_value.txt
+++ b/resources/function_help/json/get_current_form_field_value.txt
@@ -1,7 +1,7 @@
 {
-  "name": "get_current_form_field_value",
+  "name": "current_value",
   "type": "function",
   "description": "Returns the current value of a field in the form or table row currently being edited.",
   "arguments": [ {"arg":"field_name","description":"a field name in the current form or table row"}],
-  "examples": [ { "expression":"get_current_form_field_value( 'FIELD_NAME' )","returns":"The current value of field 'FIELD_NAME'."} ]
+  "examples": [ { "expression":"current_value( 'FIELD_NAME' )","returns":"The current value of field 'FIELD_NAME'."} ]
 }

--- a/resources/function_help/json/get_current_form_field_value.txt
+++ b/resources/function_help/json/get_current_form_field_value.txt
@@ -1,0 +1,7 @@
+{
+  "name": "get_current_form_field_value",
+  "type": "function",
+  "description": "Returns the current value of a field in the form or table row currently being edited.",
+  "arguments": [ {"arg":"field_name","description":"a field name in the current form or table row"}],
+  "examples": [ { "expression":"get_current_form_field_value( 'FIELD_NAME' )","returns":"The current value of field 'FIELD_NAME'."} ]
+}

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -956,3 +956,14 @@ bool QgsExpression::isField() const
 {
   return d->mRootNode && d->mRootNode->nodeType() == QgsExpressionNode::ntColumnRef;
 }
+
+QList<const QgsExpressionNode *> QgsExpression::nodes() const
+{
+  if ( !d->mRootNode )
+    return QList<const QgsExpressionNode *>();
+
+  return d->mRootNode->nodes();
+}
+
+
+

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -773,7 +773,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "notification_message" ), QCoreApplication::translate( "notification_message", "Content of the notification message sent by the provider (available only for actions triggered by provider notifications)." ) );
 
   //form context variable
-  sVariableHelpTexts.insert( QStringLiteral( "current_form_geometry" ), QCoreApplication::translate( "current_form_geometry", "Represents the geometry of the feature currently being edited in the form or the table row. Can be used for in a form/row context to filter the related features." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "current_geometry" ), QCoreApplication::translate( "current_geometry", "Represents the geometry of the feature currently being edited in the form or the table row. Can be used for in a form/row context to filter the related features." ) );
 }
 
 QString QgsExpression::variableHelpText( const QString &variableName )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -771,6 +771,9 @@ void QgsExpression::initVariableHelp()
 
   //provider notification
   sVariableHelpTexts.insert( QStringLiteral( "notification_message" ), QCoreApplication::translate( "notification_message", "Content of the notification message sent by the provider (available only for actions triggered by provider notifications)." ) );
+
+  //form context variable
+  sVariableHelpTexts.insert( QStringLiteral( "current_form_geometry" ), QCoreApplication::translate( "current_form_geometry", "Represents the geometry of the feature currently being edited in the form or the table row. Can be used for in a form/row context to filter the related features." ) );
 }
 
 QString QgsExpression::variableHelpText( const QString &variableName )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -782,6 +782,7 @@ void QgsExpression::initVariableHelp()
 
   //form context variable
   sVariableHelpTexts.insert( QStringLiteral( "current_geometry" ), QCoreApplication::translate( "current_geometry", "Represents the geometry of the feature currently being edited in the form or the table row. Can be used for in a form/row context to filter the related features." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "current_feature" ), QCoreApplication::translate( "current_feature", "Represents the feature currently being edited in the form or the table row. Can be used for in a form/row context to filter the related features." ) );
 }
 
 QString QgsExpression::variableHelpText( const QString &variableName )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -276,6 +276,14 @@ QSet<QString> QgsExpression::referencedVariables() const
   return d->mRootNode->referencedVariables();
 }
 
+QSet<QString> QgsExpression::referencedFunctions() const
+{
+  if ( !d->mRootNode )
+    return QSet<QString>();
+
+  return d->mRootNode->referencedFunctions();
+}
+
 QSet<int> QgsExpression::referencedAttributeIndexes( const QgsFields &fields ) const
 {
   if ( !d->mRootNode )

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -29,6 +29,7 @@
 #include "qgis.h"
 #include "qgsunittypes.h"
 #include "qgsinterval.h"
+#include "qgsexpressionnode.h"
 
 class QgsFeature;
 class QgsGeometry;
@@ -41,7 +42,6 @@ class QgsDistanceArea;
 class QDomElement;
 class QgsExpressionContext;
 class QgsExpressionPrivate;
-class QgsExpressionNode;
 class QgsExpressionFunction;
 
 /**
@@ -259,11 +259,42 @@ class CORE_EXPORT QgsExpression
     QSet<QString> referencedVariables() const;
 
     /**
-     * Return a list of all functions which are used in this expression.
+     * Return a list of the names of all functions which are used in this expression.
      *
      * \since QGIS 3.2
      */
     QSet<QString> referencedFunctions() const;
+
+#ifndef SIP_RUN
+
+    /**
+     * Return a list of all nodes which are used in this expression
+     *
+     * \note not available in Python bindings
+     * \since QGIS 3.2
+     */
+    QList<const QgsExpressionNode *> nodes( ) const;
+
+    /**
+     * Return a list of all nodes of the given class which are used in this expression
+     *
+     * \note not available in Python bindings
+     * \since QGIS 3.2
+     */
+    template <class T>
+    QList<const T *> findNodes( ) const
+    {
+      QList<const T *> lst;
+      const QList<const QgsExpressionNode *> allNodes( nodes() );
+      for ( const auto &node : allNodes )
+      {
+        const T *n = dynamic_cast<const T *>( node );
+        if ( n )
+          lst << n;
+      }
+      return lst;
+    }
+#endif
 
     /**
      * Return a list of field name indexes obtained from the provided fields.

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -259,6 +259,13 @@ class CORE_EXPORT QgsExpression
     QSet<QString> referencedVariables() const;
 
     /**
+     * Return a list of all functions which are used in this expression.
+     *
+     * \since QGIS 3.2
+     */
+    QSet<QString> referencedFunctions() const;
+
+    /**
      * Return a list of field name indexes obtained from the provided fields.
      *
      * \since QGIS 3.0

--- a/src/core/expression/qgsexpressionnode.cpp
+++ b/src/core/expression/qgsexpressionnode.cpp
@@ -57,3 +57,4 @@ void QgsExpressionNode::cloneTo( QgsExpressionNode *target ) const
   target->parserFirstColumn = parserFirstColumn;
   target->parserFirstLine = parserFirstLine;
 }
+

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -223,6 +223,11 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
     virtual QSet<QString> referencedVariables() const = 0;
 
     /**
+     * Return a set of all functions which are used in this expression.
+     */
+    virtual QSet<QString> referencedFunctions() const = 0;
+
+    /**
      * Abstract virtual method which returns if the geometry is required to evaluate
      * this expression.
      *

--- a/src/core/expression/qgsexpressionnode.h
+++ b/src/core/expression/qgsexpressionnode.h
@@ -228,6 +228,14 @@ class CORE_EXPORT QgsExpressionNode SIP_ABSTRACT
     virtual QSet<QString> referencedFunctions() const = 0;
 
     /**
+     * Return a list of all nodes which are used in this expression.
+     *
+     * \note not available in Python bindings
+     * \since QGIS 3.2
+     */
+    virtual QList<const QgsExpressionNode *> nodes( ) const = 0; SIP_SKIP
+
+    /**
      * Abstract virtual method which returns if the geometry is required to evaluate
      * this expression.
      *

--- a/src/core/expression/qgsexpressionnodeimpl.h
+++ b/src/core/expression/qgsexpressionnodeimpl.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsExpressionNodeUnaryOperator : public QgsExpressionNode
 
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
+    QSet<QString> referencedFunctions() const override;
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
 
@@ -162,6 +163,8 @@ class CORE_EXPORT QgsExpressionNodeBinaryOperator : public QgsExpressionNode
 
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
+    QSet<QString> referencedFunctions() const override;
+
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
@@ -241,6 +244,7 @@ class CORE_EXPORT QgsExpressionNodeInOperator : public QgsExpressionNode
 
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
+    QSet<QString> referencedFunctions() const override;
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
@@ -284,6 +288,7 @@ class CORE_EXPORT QgsExpressionNodeFunction : public QgsExpressionNode
 
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
+    QSet<QString> referencedFunctions() const override;
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
@@ -321,6 +326,7 @@ class CORE_EXPORT QgsExpressionNodeLiteral : public QgsExpressionNode
 
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
+    QSet<QString> referencedFunctions() const override;
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
@@ -356,6 +362,7 @@ class CORE_EXPORT QgsExpressionNodeColumnRef : public QgsExpressionNode
 
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
+    QSet<QString> referencedFunctions() const override;
     bool needsGeometry() const override;
 
     QgsExpressionNode *clone() const override SIP_FACTORY;
@@ -456,6 +463,7 @@ class CORE_EXPORT QgsExpressionNodeCondition : public QgsExpressionNode
 
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
+    QSet<QString> referencedFunctions() const override;
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;

--- a/src/core/expression/qgsexpressionnodeimpl.h
+++ b/src/core/expression/qgsexpressionnodeimpl.h
@@ -65,6 +65,7 @@ class CORE_EXPORT QgsExpressionNodeUnaryOperator : public QgsExpressionNode
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
     QSet<QString> referencedFunctions() const override;
+    QList<const QgsExpressionNode *> nodes() const override; SIP_SKIP
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
 
@@ -164,6 +165,7 @@ class CORE_EXPORT QgsExpressionNodeBinaryOperator : public QgsExpressionNode
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
     QSet<QString> referencedFunctions() const override;
+    QList<const QgsExpressionNode *> nodes( ) const override; SIP_SKIP
 
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
@@ -245,6 +247,7 @@ class CORE_EXPORT QgsExpressionNodeInOperator : public QgsExpressionNode
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
     QSet<QString> referencedFunctions() const override;
+    QList<const QgsExpressionNode *> nodes() const override; SIP_SKIP
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
@@ -289,6 +292,8 @@ class CORE_EXPORT QgsExpressionNodeFunction : public QgsExpressionNode
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
     QSet<QString> referencedFunctions() const override;
+
+    QList<const QgsExpressionNode *> nodes() const override; SIP_SKIP
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
@@ -327,6 +332,8 @@ class CORE_EXPORT QgsExpressionNodeLiteral : public QgsExpressionNode
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
     QSet<QString> referencedFunctions() const override;
+
+    QList<const QgsExpressionNode *> nodes() const override; SIP_SKIP
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;
@@ -363,6 +370,8 @@ class CORE_EXPORT QgsExpressionNodeColumnRef : public QgsExpressionNode
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
     QSet<QString> referencedFunctions() const override;
+    QList<const QgsExpressionNode *> nodes( ) const override; SIP_SKIP
+
     bool needsGeometry() const override;
 
     QgsExpressionNode *clone() const override SIP_FACTORY;
@@ -464,6 +473,9 @@ class CORE_EXPORT QgsExpressionNodeCondition : public QgsExpressionNode
     QSet<QString> referencedColumns() const override;
     QSet<QString> referencedVariables() const override;
     QSet<QString> referencedFunctions() const override;
+
+    QList<const QgsExpressionNode *> nodes() const override; SIP_SKIP
+
     bool needsGeometry() const override;
     QgsExpressionNode *clone() const override SIP_FACTORY;
     bool isStatic( QgsExpression *parent, const QgsExpressionContext *context ) const override;

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -179,11 +179,11 @@ QSet<QString> QgsValueRelationFieldFormatter::expressionFormVariables( const QSt
   const QStringList formVariables( QgsExpressionContextUtils::formScope()->variableNames() );
   QSet<QString> variables;
 
-  for ( auto it = formVariables.constBegin(); it != formVariables.constEnd(); it++ )
+  for ( auto const &variable : formVariables )
   {
-    if ( expression.contains( *it ) )
+    if ( expression.contains( variable ) )
     {
-      variables.insert( *it );
+      variables.insert( variable );
     }
   }
   return variables;

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -66,10 +66,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const override;
 
     /**
-     * Utility to convert an array or a string representation of and array \a value to a string list
-     *
-     * \param value The value to be converted
-     * \return A string list
+     * Utility to convert an array or a string representation of an array \a value to a string list
      * \since QGIS 3.2
      */
     static QStringList valueToStringList( const QVariant &value );
@@ -117,18 +114,10 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     /**
      * Check whether the \a feature has all values required by the \a expression
      *
-     * @return True if the expression can be used
+     * \return True if the expression can be used
      * \since QGIS 3.2
      */
     static bool expressionIsUsable( const QString &expression, const QgsFeature &feature );
-
-    /**
-     * Regular expression to find dynamic filtering based on form field values
-     * \see GetCurrentFormFieldValue()
-     *
-     * \since QGIS 3.2
-     */
-    static QString FORM_SCOPE_FUNCTIONS_RE;
 
 };
 

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -18,9 +18,12 @@
 
 #include "qgis_core.h"
 #include "qgsfieldformatter.h"
+#include "qgsexpression.h"
+#include "qgsexpressioncontext.h"
 
 #include <QVector>
 #include <QVariant>
+
 
 /**
  * \ingroup core
@@ -63,15 +66,6 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     QVariant createCache( QgsVectorLayer *layer, int fieldIndex, const QVariantMap &config ) const override;
 
     /**
-     * Create a cache for a value relation field.
-     * This can be used to keep the value map in the local memory
-     * if doing multiple lookups in a loop.
-     *
-     * \since QGIS 3.0
-     */
-    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config );
-
-    /**
      * Utility to convert an array or a string representation of and array \a value to a string list
      *
      * \param value The value to be converted
@@ -79,6 +73,63 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
      * \since QGIS 3.2
      */
     static QStringList valueToStringList( const QVariant &value );
+
+    /**
+     * Create a cache for a value relation field.
+     * This can be used to keep the value map in the local memory
+     * if doing multiple lookups in a loop.
+     * \param config The widget configuration
+     * \param formFeature The feature currently being edited with current attribute values
+     * \return A kvp list of values for the widget
+     *
+     * \since QGIS 3.0
+     */
+    static QgsValueRelationFieldFormatter::ValueRelationCache createCache( const QVariantMap &config, const QgsFeature &formFeature = QgsFeature() );
+
+    /**
+     * Check if the \a expression requires a form scope (i.e. if it uses fields
+     * or geometry of the currently edited feature).
+     *
+     * \param expression The widget's filter expression
+     * \return true if the expression requires a form scope
+     * \since QGIS 3.2
+     */
+    static bool expressionRequiresFormScope( const QString &expression );
+
+    /**
+     * Return a list of attributes required by the form context \a expression
+     *
+     * \param expression Form filter expression
+     * \return list of attributes required by the expression
+     * \since QGIS 3.2
+     */
+    static QSet<QString> expressionFormAttributes( const QString &expression );
+
+    /**
+     * Return a list of variables required by the form context \a expression
+     *
+     * \param expression Form filter expression
+     * \return list of variables required by the expression
+     * \since QGIS 3.2
+     */
+    static QSet<QString> expressionFormVariables( const QString &expression );
+
+    /**
+     * Check wether the \a feature has all values required by the \a expression
+     *
+     * @return True if the expression can be used
+     * \since QGIS 3.2
+     */
+    static bool expressionIsUsable( const QString &expression, const QgsFeature &feature );
+
+    /**
+     * Regular expression to find dynamic filtering based on form field values
+     * \see GetCurrentFormFieldValue()
+     *
+     * \since QGIS 3.2
+     */
+    static QString FORM_SCOPE_FUNCTIONS_RE;
+
 };
 
 Q_DECLARE_METATYPE( QgsValueRelationFieldFormatter::ValueRelationCache )

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.h
@@ -115,7 +115,7 @@ class CORE_EXPORT QgsValueRelationFieldFormatter : public QgsFieldFormatter
     static QSet<QString> expressionFormVariables( const QString &expression );
 
     /**
-     * Check wether the \a feature has all values required by the \a expression
+     * Check whether the \a feature has all values required by the \a expression
      *
      * @return True if the expression can be used
      * \since QGIS 3.2

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -741,7 +741,7 @@ class GetCurrentFormFieldValue : public QgsScopedExpressionFunction
 {
   public:
     GetCurrentFormFieldValue( )
-      : QgsScopedExpressionFunction( QStringLiteral( "get_current_form_field_value" ), QgsExpressionFunction::ParameterList() << QStringLiteral( "field_name" ), QStringLiteral( "Form" ) )
+      : QgsScopedExpressionFunction( QStringLiteral( "current_value" ), QgsExpressionFunction::ParameterList() << QStringLiteral( "field_name" ), QStringLiteral( "Form" ) )
     {}
 
     QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * ) override
@@ -794,8 +794,8 @@ QgsExpressionContextScope *QgsExpressionContextUtils::formScope( const QgsFeatur
 {
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Form" ) );
   scope->setFeature( formFeature );
-  scope->addFunction( QStringLiteral( "get_current_form_field_value" ), new GetCurrentFormFieldValue( ) );
-  scope->setVariable( QStringLiteral( "current_form_geometry" ), formFeature.geometry( ), true );
+  scope->addFunction( QStringLiteral( "current_value" ), new GetCurrentFormFieldValue( ) );
+  scope->setVariable( QStringLiteral( "current_geometry" ), formFeature.geometry( ), true );
   return scope;
 }
 

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -736,6 +736,33 @@ class GetLayerVisibility : public QgsScopedExpressionFunction
 
 };
 
+
+class GetCurrentFormFieldValue : public QgsScopedExpressionFunction
+{
+  public:
+    GetCurrentFormFieldValue( )
+      : QgsScopedExpressionFunction( QStringLiteral( "get_current_form_field_value" ), QgsExpressionFunction::ParameterList() << QStringLiteral( "field_name" ), QStringLiteral( "Form" ) )
+    {}
+
+    QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * ) override
+    {
+      QString fieldName( values.at( 0 ).toString() );
+      const QgsFeature feat( context->feature() );
+      if ( fieldName.isEmpty() || ! feat.isValid( ) )
+      {
+        return QVariant();
+      }
+      return feat.attribute( fieldName ) ;
+    }
+
+    QgsScopedExpressionFunction *clone() const override
+    {
+      return new GetCurrentFormFieldValue( );
+    }
+
+};
+
+
 class GetProcessingParameterValue : public QgsScopedExpressionFunction
 {
   public:
@@ -761,6 +788,16 @@ class GetProcessingParameterValue : public QgsScopedExpressionFunction
 };
 
 ///@endcond
+
+
+QgsExpressionContextScope *QgsExpressionContextUtils::formScope( const QgsFeature &formFeature )
+{
+  QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Form" ) );
+  scope->setFeature( formFeature );
+  scope->addFunction( QStringLiteral( "get_current_form_field_value" ), new GetCurrentFormFieldValue( ) );
+  scope->setVariable( QStringLiteral( "current_form_geometry" ), formFeature.geometry( ), true );
+  return scope;
+}
 
 QgsExpressionContextScope *QgsExpressionContextUtils::projectScope( const QgsProject *project )
 {
@@ -899,6 +936,7 @@ QList<QgsExpressionContextScope *> QgsExpressionContextUtils::globalProjectLayer
     scopes << layerScope( layer );
   return scopes;
 }
+
 
 void QgsExpressionContextUtils::setLayerVariable( QgsMapLayer *layer, const QString &name, const QVariant &value )
 {
@@ -1256,6 +1294,7 @@ void QgsExpressionContextUtils::registerContextFunctions()
   QgsExpression::registerFunction( new GetLayoutItemVariables( nullptr ) );
   QgsExpression::registerFunction( new GetLayerVisibility( QList<QgsMapLayer *>() ) );
   QgsExpression::registerFunction( new GetProcessingParameterValue( QVariantMap() ) );
+  QgsExpression::registerFunction( new GetCurrentFormFieldValue( ) );
 }
 
 bool QgsScopedExpressionFunction::usesGeometry( const QgsExpressionNodeFunction *node ) const

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -747,7 +747,7 @@ class GetCurrentFormFieldValue : public QgsScopedExpressionFunction
     QVariant func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * ) override
     {
       QString fieldName( values.at( 0 ).toString() );
-      const QgsFeature feat( context->feature() );
+      const QgsFeature feat( context->variable( QStringLiteral( "current_feature" ) ).value<QgsFeature>() );
       if ( fieldName.isEmpty() || ! feat.isValid( ) )
       {
         return QVariant();
@@ -793,9 +793,9 @@ class GetProcessingParameterValue : public QgsScopedExpressionFunction
 QgsExpressionContextScope *QgsExpressionContextUtils::formScope( const QgsFeature &formFeature )
 {
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( QObject::tr( "Form" ) );
-  scope->setFeature( formFeature );
   scope->addFunction( QStringLiteral( "current_value" ), new GetCurrentFormFieldValue( ) );
   scope->setVariable( QStringLiteral( "current_geometry" ), formFeature.geometry( ), true );
+  scope->setVariable( QStringLiteral( "current_feature" ), formFeature, true );
   return scope;
 }
 

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -740,6 +740,13 @@ class CORE_EXPORT QgsExpressionContextUtils
     static QgsExpressionContextScope *globalScope() SIP_FACTORY;
 
     /**
+     * Creates a new scope which contains functions and variables from the current attribute form/table feature.
+     * The variables and values in this scope will reflect the current state of the form/row being edited.
+     * \since QGIS 3.2
+     */
+    static QgsExpressionContextScope *formScope( const QgsFeature &formFeature = QgsFeature( ) ) SIP_FACTORY;
+
+    /**
      * Sets a global context variable. This variable will be contained within scopes retrieved via
      * globalScope().
      * \param name variable name
@@ -823,14 +830,14 @@ class CORE_EXPORT QgsExpressionContextUtils
     static QList<QgsExpressionContextScope *> globalProjectLayerScopes( const QgsMapLayer *layer ) SIP_FACTORY;
 
     /**
-     * Sets a layer context variable. This variable will be contained within scopes retrieved via
-     * layerScope().
-     * \param layer map layer
-     * \param name variable name
-     * \param value variable value
-     * \see setLayerVariables()
-     * \see layerScope()
-     */
+      * Sets a layer context variable. This variable will be contained within scopes retrieved via
+      * layerScope().
+      * \param layer map layer
+      * \param name variable name
+      * \param value variable value
+      * \see setLayerVariables()
+      * \see layerScope()
+      */
     static void setLayerVariable( QgsMapLayer *layer, const QString &name, const QVariant &value );
 
     /**

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -67,8 +67,12 @@ QWidget *QgsAttributeTableDelegate::createEditor( QWidget *parent, const QStyleO
     return nullptr;
 
   int fieldIdx = index.model()->data( index, QgsAttributeTableModel::FieldIndexRole ).toInt();
-
   QgsAttributeEditorContext context( masterModel( index.model() )->editorContext(), QgsAttributeEditorContext::Popup );
+
+  // Update the editor form context with the feature being edited
+  QgsFeatureId fid( index.model()->data( index, QgsAttributeTableModel::FeatureIdRole ).toLongLong() );
+  context.setFormFeature( vl->getFeature( fid ) );
+
   QgsEditorWidgetWrapper *eww = QgsGui::editorWidgetRegistry()->create( vl, fieldIdx, nullptr, parent, context );
   QWidget *w = eww->widget();
 

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -346,7 +346,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     mutable QgsExpressionContext mExpressionContext;
 
     /**
-      * Gets mFieldCount, mAttributes and mValueMaps
+      * Gets mFieldCount, mAttributes
       */
     virtual void loadAttributes();
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -25,9 +25,9 @@
 
 QgsEditorWidgetWrapper::QgsEditorWidgetWrapper( QgsVectorLayer *vl, int fieldIdx, QWidget *editor, QWidget *parent )
   : QgsWidgetWrapper( vl, editor, parent )
+  , mFieldIdx( fieldIdx )
   , mValidConstraint( true )
   , mIsBlockingCommit( false )
-  , mFieldIdx( fieldIdx )
 {
 }
 
@@ -68,7 +68,7 @@ void QgsEditorWidgetWrapper::setEnabled( bool enabled )
 
 void QgsEditorWidgetWrapper::setFeature( const QgsFeature &feature )
 {
-  mFeature = feature;
+  mFormFeature = feature;
   setValue( feature.attribute( mFieldIdx ) );
 }
 
@@ -100,6 +100,11 @@ void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()
         break;
     }
   }
+}
+
+bool QgsEditorWidgetWrapper::setFormFeatureAttribute( const QString &attributeName, const QVariant &attributeValue )
+{
+  return mFormFeature.setAttribute( attributeName, attributeValue );
 }
 
 QgsEditorWidgetWrapper::ConstraintResult QgsEditorWidgetWrapper::constraintResult() const

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -309,7 +309,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     /**
      * mFieldIdx the widget feature field id
      */
-    int mFieldIdx;
+    int mFieldIdx = -1;
 
     /**
      * The feature currently being edited, in its current state

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -213,6 +213,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     void setConstraintResultVisible( bool constraintResultVisible );
 
+
   signals:
 
     /**
@@ -277,7 +278,33 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     virtual void updateConstraintWidgetStatus();
 
-  protected:
+
+    /**
+     * The feature currently being edited, in its current state
+     *
+     * \return the feature currently being edited, in its current state
+     * \since QGIS 3.2
+     */
+    QgsFeature formFeature() const { return mFormFeature; }
+
+    /**
+     * Set the feature currently being edited to \a feature
+     *
+     * \since QGIS 3.2
+     */
+    void setFormFeature( const QgsFeature &feature ) { mFormFeature = feature; }
+
+    /**
+     * Update the feature currently being edited by changing its
+     * attribute \a attributeName to \a attributeValue
+     *
+     * \return bool true on success
+     * \since QGIS 3.2
+     */
+    bool setFormFeatureAttribute( const QString &attributeName, const QVariant &attributeValue );
+
+
+  private:
 
     /**
      * mFieldIdx the widget feature field id
@@ -285,11 +312,9 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     int mFieldIdx;
 
     /**
-     * mFeature the current feature
+     * The feature currently being edited, in its current state
      */
-    QgsFeature mFeature;
-
-  private:
+    QgsFeature mFormFeature;
 
     /**
      * Boolean storing the current validity of the constraint for this widget.

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -277,6 +277,18 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     virtual void updateConstraintWidgetStatus();
 
+  protected:
+
+    /**
+     * mFieldIdx the widget feature field id
+     */
+    int mFieldIdx;
+
+    /**
+     * mFeature the current feature
+     */
+    QgsFeature mFeature;
+
   private:
 
     /**
@@ -296,8 +308,6 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     //! The current constraint result
     bool mConstraintResultVisible = false;
 
-    int mFieldIdx;
-    QgsFeature mFeature;
     mutable QVariant mDefaultValue; // Cache default value, we don't want to retrieve different serial numbers if called repeatedly
 
 };

--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -92,6 +92,7 @@ void QgsValueRelationConfigDlg::editExpression()
     return;
 
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( vl ) );
+  context << QgsExpressionContextUtils::formScope( );
 
   QgsExpressionBuilderDialog dlg( vl, mFilterExpression->toPlainText(), this, QStringLiteral( "generic" ), context );
   dlg.setWindowTitle( tr( "Edit Filter Expression" ) );

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -161,7 +161,6 @@ void QgsValueRelationSearchWidgetWrapper::onValueChanged()
   }
   else
   {
-    QgsSettings settings;
     setExpression( vl.isNull() ? QgsApplication::nullRepresentation() : vl.toString() );
     emit valueChanged();
   }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.h
@@ -68,9 +68,39 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     bool valid() const override;
 
   public slots:
+
     void setValue( const QVariant &value ) override;
 
+    /**
+     * Will be called when a value in the current edited form or table row
+     * changes
+     *
+     * Update widget cache if the value is used in the filter expression and
+     * stores current field values to be used in expression form scope context
+     *
+     * \param attribute The name of the attribute that changed.
+     * \param newValue     The new value of the attribute.
+     * \param attributeChanged If true, it corresponds to an actual change of the feature attribute
+     * \since QGIS 3.2.0
+     */
+    void widgetValueChanged( const QString &attribute, const QVariant &newValue, bool attributeChanged );
+
+    /**
+     * Will be called when the feature changes
+     *
+     * Is forwarded to the slot setValue() and updates the widget cache if
+     * the filter expression context contains values from the current feature
+     *
+     * \param feature The new feature
+     */
+    void setFeature( const QgsFeature &feature ) override;
+
+
   private:
+
+    //! Set the values for the widgets, re-creates the cache when required
+    void populate( );
+
     QComboBox *mComboBox = nullptr;
     QTableWidget *mTableWidget = nullptr;
     QLineEdit *mLineEdit = nullptr;
@@ -79,6 +109,7 @@ class GUI_EXPORT QgsValueRelationWidgetWrapper : public QgsEditorWidgetWrapper
     QgsVectorLayer *mLayer = nullptr;
 
     bool mEnabled = true;
+    QString mExpression;
 
     friend class QgsValueRelationWidgetFactory;
     friend class TestQgsValueRelationWidgetWrapper;

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -63,6 +63,7 @@ class GUI_EXPORT QgsAttributeEditorContext
       , mVectorLayerTools( parentContext.mVectorLayerTools )
       , mMapCanvas( parentContext.mMapCanvas )
       , mDistanceArea( parentContext.mDistanceArea )
+      , mFormFeature( parentContext.mFormFeature )
       , mFormMode( formMode )
     {
       Q_ASSERT( parentContext.vectorLayerTools() );
@@ -189,6 +190,21 @@ class GUI_EXPORT QgsAttributeEditorContext
 
     inline const QgsAttributeEditorContext *parentContext() const { return mParentContext; }
 
+    /**
+     * Return current feature from the currently edited form or table row
+     * \see setFormFeature()
+     * \since QGIS 3.2
+     */
+    const QgsFeature formFeature() const { return mFormFeature; }
+
+    /**
+     * Set current \a feature for the currently edited form or table row
+     * \see formFeature()
+     * \since QGIS 3.2
+     */
+    void setFormFeature( const QgsFeature &feature ) { mFormFeature = feature ; }
+
+
   private:
     const QgsAttributeEditorContext *mParentContext = nullptr;
     QgsVectorLayer *mLayer = nullptr;
@@ -197,6 +213,8 @@ class GUI_EXPORT QgsAttributeEditorContext
     QgsDistanceArea mDistanceArea;
     QgsRelation mRelation;
     RelationMode mRelationMode = Undefined;
+    //! Store the values of the currently edited form or table row
+    QgsFeature mFormFeature;
     FormMode mFormMode = Embed;
     bool mAllowCustomUi = true;
 };

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -195,7 +195,7 @@ class GUI_EXPORT QgsAttributeEditorContext
      * \see setFormFeature()
      * \since QGIS 3.2
      */
-    const QgsFeature formFeature() const { return mFormFeature; }
+    QgsFeature formFeature() const { return mFormFeature; }
 
     /**
      * Set current \a feature for the currently edited form or table row

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -690,6 +690,7 @@ QString QgsAttributeForm::createFilterExpression() const
   return filter;
 }
 
+
 void QgsAttributeForm::onAttributeChanged( const QVariant &value )
 {
   QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( sender() );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -354,8 +354,6 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     QString createFilterExpression() const;
 
-    //void updateWidgetFeature( QgsEditorWidgetWrapper *w );
-
     //! constraints management
     void updateAllConstraints();
     void updateConstraints( QgsEditorWidgetWrapper *w );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -174,7 +174,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
   signals:
 
     /**
-     * Notifies about changes of attributes
+     * Notifies about changes of attributes, this signal is not emitted when the value is set
+     * back to the original one.
      *
      * \param attribute The name of the attribute that changed.
      * \param value     The new value of the attribute.
@@ -352,6 +353,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void runSearchSelect( QgsVectorLayer::SelectBehavior behavior );
 
     QString createFilterExpression() const;
+
+    //void updateWidgetFeature( QgsEditorWidgetWrapper *w );
 
     //! constraints management
     void updateAllConstraints();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1871,13 +1871,48 @@ class TestQgsExpression: public QObject
                         << QStringLiteral( "$geometry" )
                         << QStringLiteral( "buffer" );
 
-      QgsExpression exp( QStringLiteral( "current_value( 'FIELD_NAME' ) = \"A_VALUE\" AND intersects(buffer($geometry, 10), @current_geometry)" ) );
+      QgsExpression exp( QStringLiteral( "current_value( 'FIELD_NAME' ) = 'A_VALUE' AND intersects(buffer($geometry, 10), @current_geometry)" ) );
       QCOMPARE( exp.hasParserError(), false );
       QSet<QString> refVar = exp.referencedFunctions();
 
       QCOMPARE( refVar, expectedFunctions );
     }
 
+    void findNodes()
+    {
+      QSet<QString> expectedFunctions;
+      expectedFunctions << QStringLiteral( "current_value" )
+                        << QStringLiteral( "intersects" )
+                        << QStringLiteral( "var" )
+                        << QStringLiteral( "$geometry" )
+                        << QStringLiteral( "buffer" );
+      QgsExpression exp( QStringLiteral( "current_value( 'FIELD_NAME' ) = 'A_VALUE' AND intersects(buffer($geometry, 10), @current_geometry)" ) );
+      QList<const QgsExpressionNodeFunction *> functionNodes( exp.findNodes<QgsExpressionNodeFunction>() );
+      QCOMPARE( functionNodes.size(), 5 );
+      QgsExpressionFunction *fd;
+      QSet<QString> actualFunctions;
+      for ( const auto &f : functionNodes )
+      {
+        QCOMPARE( f->nodeType(), QgsExpressionNode::NodeType::ntFunction );
+        fd = QgsExpression::QgsExpression::Functions()[f->fnIndex()];
+        actualFunctions << fd->name();
+      }
+      QCOMPARE( actualFunctions, expectedFunctions );
+
+      QSet<QgsExpressionNodeBinaryOperator::BinaryOperator> expectedBinaryOps;
+      expectedBinaryOps << QgsExpressionNodeBinaryOperator::BinaryOperator::boAnd;
+      expectedBinaryOps << QgsExpressionNodeBinaryOperator::BinaryOperator::boEQ;
+      QList<const QgsExpressionNodeBinaryOperator *> binaryOpsNodes( exp.findNodes<QgsExpressionNodeBinaryOperator>() );
+      QCOMPARE( binaryOpsNodes.size(), 2 );
+      QSet<QgsExpressionNodeBinaryOperator::BinaryOperator> actualBinaryOps;
+      for ( const auto &f : binaryOpsNodes )
+      {
+        QCOMPARE( f->nodeType(), QgsExpressionNode::NodeType::ntBinaryOperator );
+        actualBinaryOps << f->op();
+      }
+      QCOMPARE( actualBinaryOps, expectedBinaryOps );
+
+    }
 
     void referenced_columns_all_attributes()
     {

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1861,6 +1861,24 @@ class TestQgsExpression: public QObject
       QCOMPARE( refVar, expectedVars );
     }
 
+
+    void referenced_functions()
+    {
+      QSet<QString> expectedFunctions;
+      expectedFunctions << QStringLiteral( "current_value" )
+                        << QStringLiteral( "var" )
+                        << QStringLiteral( "intersects" )
+                        << QStringLiteral( "$geometry" )
+                        << QStringLiteral( "buffer" );
+
+      QgsExpression exp( QStringLiteral( "current_value( 'FIELD_NAME' ) = \"A_VALUE\" AND intersects(buffer($geometry, 10), @current_geometry)" ) );
+      QCOMPARE( exp.hasParserError(), false );
+      QSet<QString> refVar = exp.referencedFunctions();
+
+      QCOMPARE( refVar, expectedFunctions );
+    }
+
+
     void referenced_columns_all_attributes()
     {
       QgsExpression exp( QStringLiteral( "attribute($currentfeature,'test')" ) );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -3,7 +3,9 @@
      --------------------------------------
     Date                 : 21 07 2017
     Copyright            : (C) 2017 Paul Blottiere
+    Copyright            : (C) 2018 Alessandro Pasotti
     Email                : paul dot blottiere at oslandia dot com
+    Email                : elpaso at itopen dot it
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -24,6 +26,7 @@
 #include "qgseditorwidgetwrapper.h"
 #include <editorwidgets/qgsvaluerelationwidgetwrapper.h>
 #include <QTableWidget>
+#include <QComboBox>
 #include "qgsgui.h"
 
 class TestQgsValueRelationWidgetWrapper : public QObject
@@ -39,6 +42,7 @@ class TestQgsValueRelationWidgetWrapper : public QObject
     void cleanup(); // will be called after every testfunction.
 
     void testScrollBarUnlocked();
+    void testDrillDown();
 };
 
 void TestQgsValueRelationWidgetWrapper::initTestCase()
@@ -108,6 +112,84 @@ void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
   QCOMPARE( w.widget()->isEnabled(), true );
   itemEnabled = w.mTableWidget->item( 0, 0 )->flags() & Qt::ItemIsEnabled;
   QCOMPARE( itemEnabled, true );
+}
+
+void TestQgsValueRelationWidgetWrapper::testDrillDown()
+{
+  // create a vector layer
+  QgsVectorLayer vl1( QStringLiteral( "Polygon?crs=epsg:4326&field=pk:int&field=province:int&field=municipality:string" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
+  QgsVectorLayer vl2( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=fk_province:int&field=fk_municipality:int" ), QStringLiteral( "vl2" ), QStringLiteral( "memory" ) );
+  QgsProject::instance()->addMapLayer( &vl1, false, false );
+  QgsProject::instance()->addMapLayer( &vl2, false, false );
+
+  // insert some features
+  QgsFeature f1( vl1.fields() );
+  f1.setAttribute( QStringLiteral( "pk" ), 1 );
+  f1.setAttribute( QStringLiteral( "province" ), 123 );
+  f1.setAttribute( QStringLiteral( "municipality" ), QStringLiteral( "Some Place By The River" ) );
+  f1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POLYGON(( 0 0, 0 1, 1 1, 1 0, 0 0 ))" ) ) );
+  QVERIFY( f1.isValid() );
+  QgsFeature f2( vl1.fields() );
+  f2.setAttribute( QStringLiteral( "pk" ), 2 );
+  f2.setAttribute( QStringLiteral( "province" ), 245 );
+  f2.setAttribute( QStringLiteral( "municipality" ), QStringLiteral( "Dreamland By The Clouds" ) );
+  f2.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POLYGON(( 1 0, 1 1, 2 1, 2 0, 1 0 ))" ) ) );
+  QVERIFY( f2.isValid() );
+  QVERIFY( vl1.dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 ) );
+
+  QgsFeature f3( vl2.fields() );
+  f3.setAttribute( QStringLiteral( "fk_province" ), 123 );
+  f3.setAttribute( QStringLiteral( "fk_municipality" ), 1 );
+  f3.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POINT( 0.5 0.5)" ) ) );
+  QVERIFY( f3.isValid() );
+  QVERIFY( f3.geometry().isGeosValid() );
+  QVERIFY( vl2.dataProvider()->addFeature( f3 ) );
+
+  // build a value relation widget wrapper for municipality
+  QgsValueRelationWidgetWrapper w_municipality( &vl2, vl2.fields().indexOf( QStringLiteral( "fk_municipality" ) ), nullptr, nullptr );
+  QVariantMap cfg_municipality;
+  cfg_municipality.insert( QStringLiteral( "Layer" ), vl1.id() );
+  cfg_municipality.insert( QStringLiteral( "Key" ),  QStringLiteral( "pk" ) );
+  cfg_municipality.insert( QStringLiteral( "Value" ), QStringLiteral( "municipality" ) );
+  cfg_municipality.insert( QStringLiteral( "AllowMulti" ), false );
+  cfg_municipality.insert( QStringLiteral( "NofColumns" ), 1 );
+  cfg_municipality.insert( QStringLiteral( "AllowNull" ), false );
+  cfg_municipality.insert( QStringLiteral( "OrderByValue" ), true );
+  cfg_municipality.insert( QStringLiteral( "FilterExpression" ), QStringLiteral( "\"province\" =  get_current_form_field_value('fk_province')" ) );
+  cfg_municipality.insert( QStringLiteral( "UseCompleter" ), false );
+  w_municipality.setConfig( cfg_municipality );
+  w_municipality.widget();
+  w_municipality.setEnabled( true );
+
+  QCOMPARE( w_municipality.mCache.size(), 2 );
+  QCOMPARE( w_municipality.mComboBox->count(), 2 );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mCache.size(), 1 );
+
+  QCOMPARE( w_municipality.mComboBox->count(), 1 );
+  QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Some Place By The River" ) );
+
+  // Filter by geometry
+  cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_form_geometry, 1 ), $geometry)" );
+  w_municipality.setConfig( cfg_municipality );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mComboBox->count(), 1 );
+  QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Some Place By The River" ) );
+
+  // Move the point to 1.5 0.5
+  f3.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POINT( 1.5 0.5)" ) ) );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mComboBox->count(), 1 );
+  QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Dreamland By The Clouds" ) );
+
+  // Enlarge the buffer
+  cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_form_geometry, 3 ), $geometry)" );
+  w_municipality.setConfig( cfg_municipality );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mComboBox->count(), 2 );
+  QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Dreamland By The Clouds" ) );
+  QCOMPARE( w_municipality.mComboBox->itemText( 1 ), QStringLiteral( "Some Place By The River" ) );
+
 }
 
 QGSTEST_MAIN( TestQgsValueRelationWidgetWrapper )

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -155,7 +155,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   cfg_municipality.insert( QStringLiteral( "NofColumns" ), 1 );
   cfg_municipality.insert( QStringLiteral( "AllowNull" ), false );
   cfg_municipality.insert( QStringLiteral( "OrderByValue" ), true );
-  cfg_municipality.insert( QStringLiteral( "FilterExpression" ), QStringLiteral( "\"province\" =  get_current_form_field_value('fk_province')" ) );
+  cfg_municipality.insert( QStringLiteral( "FilterExpression" ), QStringLiteral( "\"province\" =  current_value('fk_province')" ) );
   cfg_municipality.insert( QStringLiteral( "UseCompleter" ), false );
   w_municipality.setConfig( cfg_municipality );
   w_municipality.widget();
@@ -170,7 +170,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Some Place By The River" ) );
 
   // Filter by geometry
-  cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_form_geometry, 1 ), $geometry)" );
+  cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_geometry, 1 ), $geometry)" );
   w_municipality.setConfig( cfg_municipality );
   w_municipality.setFeature( f3 );
   QCOMPARE( w_municipality.mComboBox->count(), 1 );
@@ -183,7 +183,7 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Dreamland By The Clouds" ) );
 
   // Enlarge the buffer
-  cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_form_geometry, 3 ), $geometry)" );
+  cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_geometry, 3 ), $geometry)" );
   w_municipality.setConfig( cfg_municipality );
   w_municipality.setFeature( f3 );
   QCOMPARE( w_municipality.mComboBox->count(), 2 );

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -43,6 +43,7 @@ class TestQgsValueRelationWidgetWrapper : public QObject
 
     void testScrollBarUnlocked();
     void testDrillDown();
+    void testDrillDownMulti();
 };
 
 void TestQgsValueRelationWidgetWrapper::initTestCase()
@@ -63,6 +64,7 @@ void TestQgsValueRelationWidgetWrapper::init()
 
 void TestQgsValueRelationWidgetWrapper::cleanup()
 {
+
 }
 
 void TestQgsValueRelationWidgetWrapper::testScrollBarUnlocked()
@@ -166,8 +168,10 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   w_municipality.setFeature( f3 );
   QCOMPARE( w_municipality.mCache.size(), 1 );
 
+  // Check first is selected
   QCOMPARE( w_municipality.mComboBox->count(), 1 );
   QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Some Place By The River" ) );
+  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "1" ) );
 
   // Filter by geometry
   cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_geometry, 1 ), $geometry)" );
@@ -189,6 +193,123 @@ void TestQgsValueRelationWidgetWrapper::testDrillDown()
   QCOMPARE( w_municipality.mComboBox->count(), 2 );
   QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Dreamland By The Clouds" ) );
   QCOMPARE( w_municipality.mComboBox->itemText( 1 ), QStringLiteral( "Some Place By The River" ) );
+
+  // Check with allow null
+  cfg_municipality[QStringLiteral( "AllowNull" )] = true;
+  w_municipality.setConfig( cfg_municipality );
+  w_municipality.setFeature( QgsFeature() );
+
+  // Check null is selected
+  QCOMPARE( w_municipality.mComboBox->count(), 3 );
+  QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "(no selection)" ) );
+  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "" ) );
+
+  // Check order by value false
+  cfg_municipality[QStringLiteral( "AllowNull" )] = false;
+  cfg_municipality[QStringLiteral( "OrderByValue" )] = false;
+  w_municipality.setConfig( cfg_municipality );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mComboBox->itemText( 1 ), QStringLiteral( "Dreamland By The Clouds" ) );
+  QCOMPARE( w_municipality.mComboBox->itemText( 0 ), QStringLiteral( "Some Place By The River" ) );
+
+}
+
+
+void TestQgsValueRelationWidgetWrapper::testDrillDownMulti()
+{
+  // create a vector layer
+  QgsVectorLayer vl1( QStringLiteral( "Polygon?crs=epsg:4326&field=pk:int&field=province:int&field=municipality:string" ), QStringLiteral( "vl1" ), QStringLiteral( "memory" ) );
+  QgsVectorLayer vl2( QStringLiteral( "Point?crs=epsg:4326&field=pk:int&field=fk_province:int&field=fk_municipality:int" ), QStringLiteral( "vl2" ), QStringLiteral( "memory" ) );
+  QgsProject::instance()->addMapLayer( &vl1, false, false );
+  QgsProject::instance()->addMapLayer( &vl2, false, false );
+
+  // insert some features
+  QgsFeature f1( vl1.fields() );
+  f1.setAttribute( QStringLiteral( "pk" ), 1 );
+  f1.setAttribute( QStringLiteral( "province" ), 123 );
+  f1.setAttribute( QStringLiteral( "municipality" ), QStringLiteral( "Some Place By The River" ) );
+  f1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POLYGON(( 0 0, 0 1, 1 1, 1 0, 0 0 ))" ) ) );
+  QVERIFY( f1.isValid() );
+  QgsFeature f2( vl1.fields() );
+  f2.setAttribute( QStringLiteral( "pk" ), 2 );
+  f2.setAttribute( QStringLiteral( "province" ), 245 );
+  f2.setAttribute( QStringLiteral( "municipality" ), QStringLiteral( "Dreamland By The Clouds" ) );
+  f2.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POLYGON(( 1 0, 1 1, 2 1, 2 0, 1 0 ))" ) ) );
+  QVERIFY( f2.isValid() );
+  QVERIFY( vl1.dataProvider()->addFeatures( QgsFeatureList() << f1 << f2 ) );
+
+  QgsFeature f3( vl2.fields() );
+  f3.setAttribute( QStringLiteral( "fk_province" ), 123 );
+  f3.setAttribute( QStringLiteral( "fk_municipality" ), QStringLiteral( "{1}" ) );
+  f3.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POINT( 0.5 0.5)" ) ) );
+  QVERIFY( f3.isValid() );
+  QVERIFY( f3.geometry().isGeosValid() );
+  QVERIFY( vl2.dataProvider()->addFeature( f3 ) );
+
+  // build a value relation widget wrapper for municipality
+  QgsValueRelationWidgetWrapper w_municipality( &vl2, vl2.fields().indexOf( QStringLiteral( "fk_municipality" ) ), nullptr, nullptr );
+  QVariantMap cfg_municipality;
+  cfg_municipality.insert( QStringLiteral( "Layer" ), vl1.id() );
+  cfg_municipality.insert( QStringLiteral( "Key" ),  QStringLiteral( "pk" ) );
+  cfg_municipality.insert( QStringLiteral( "Value" ), QStringLiteral( "municipality" ) );
+  cfg_municipality.insert( QStringLiteral( "AllowMulti" ), true );
+  cfg_municipality.insert( QStringLiteral( "NofColumns" ), 1 );
+  cfg_municipality.insert( QStringLiteral( "AllowNull" ), false );
+  cfg_municipality.insert( QStringLiteral( "OrderByValue" ), true );
+  cfg_municipality.insert( QStringLiteral( "FilterExpression" ), QStringLiteral( "\"province\" =  current_value('fk_province')" ) );
+  cfg_municipality.insert( QStringLiteral( "UseCompleter" ), false );
+  w_municipality.setConfig( cfg_municipality );
+  w_municipality.widget();
+  w_municipality.setEnabled( true );
+
+  QCOMPARE( w_municipality.mCache.size(), 2 );
+  QCOMPARE( w_municipality.mTableWidget->rowCount(), 2 );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mCache.size(), 1 );
+
+  QCOMPARE( w_municipality.mTableWidget->rowCount(), 1 );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
+  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "{1}" ) );
+
+  // Filter by geometry
+  cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_geometry, 1 ), $geometry)" );
+  w_municipality.setConfig( cfg_municipality );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mTableWidget->rowCount(), 1 );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
+
+  // Move the point to 1.5 0.5
+  f3.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "POINT( 1.5 0.5)" ) ) );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mTableWidget->rowCount(), 1 );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Dreamland By The Clouds" ) );
+
+  // Enlarge the buffer
+  cfg_municipality[ QStringLiteral( "FilterExpression" ) ] = QStringLiteral( "contains(buffer(@current_geometry, 3 ), $geometry)" );
+  w_municipality.setConfig( cfg_municipality );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mTableWidget->rowCount(), 2 );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Dreamland By The Clouds" ) );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "2" ) );
+  QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
+  QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->data( Qt::UserRole ).toString(), QStringLiteral( "1" ) );
+  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "{1}" ) );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Unchecked );
+  QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
+  w_municipality.setValue( QStringLiteral( "{1,2}" ) );
+  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "{2,1}" ) );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
+
+  // Check values are checked
+  f3.setAttribute( QStringLiteral( "fk_municipality" ), QStringLiteral( "{1,2}" ) );
+  w_municipality.setFeature( f3 );
+  QCOMPARE( w_municipality.mTableWidget->rowCount(), 2 );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->text(), QStringLiteral( "Dreamland By The Clouds" ) );
+  QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->text(), QStringLiteral( "Some Place By The River" ) );
+  QCOMPARE( w_municipality.mTableWidget->item( 0, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_municipality.mTableWidget->item( 1, 0 )->checkState(), Qt::Checked );
+  QCOMPARE( w_municipality.value().toString(), QStringLiteral( "{2,1}" ) );
 
 }
 

--- a/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
+++ b/tests/src/gui/testqgsvaluerelationwidgetwrapper.cpp
@@ -3,9 +3,7 @@
      --------------------------------------
     Date                 : 21 07 2017
     Copyright            : (C) 2017 Paul Blottiere
-    Copyright            : (C) 2018 Alessandro Pasotti
     Email                : paul dot blottiere at oslandia dot com
-    Email                : elpaso at itopen dot it
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -140,16 +140,16 @@ class TestQgsValueRelationFieldFormatter(unittest.TestCase):
         res = sorted(res)
         self.assertEqual(res, ['ONE', 'TWO'])
 
-        res = list(QgsValueRelationFieldFormatter.expressionFormVariables("current_geometry"))
+        res = list(QgsValueRelationFieldFormatter.expressionFormVariables("@current_geometry"))
         self.assertEqual(res, ['current_geometry'])
 
         self.assertFalse(QgsValueRelationFieldFormatter.expressionRequiresFormScope(""))
         self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("current_value('TWO')"))
         self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("current_value ( 'TWO' )"))
-        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("current_geometry"))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("@current_geometry"))
 
         self.assertTrue(QgsValueRelationFieldFormatter.expressionIsUsable("", QgsFeature()))
-        self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("current_geometry", QgsFeature()))
+        self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("@current_geometry", QgsFeature()))
         self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("current_value ( 'TWO' )", QgsFeature()))
 
         layer = QgsVectorLayer("none?field=pkid:integer&field=decoded:string",

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -136,21 +136,21 @@ class TestQgsValueRelationFieldFormatter(unittest.TestCase):
 
     def test_expressionRequiresFormScope(self):
 
-        res = list(QgsValueRelationFieldFormatter.expressionFormAttributes("get_current_form_field_value('ONE') AND get_current_form_field_value('TWO')"))
+        res = list(QgsValueRelationFieldFormatter.expressionFormAttributes("current_value('ONE') AND current_value('TWO')"))
         res = sorted(res)
         self.assertEqual(res, ['ONE', 'TWO'])
 
-        res = list(QgsValueRelationFieldFormatter.expressionFormVariables("current_form_geometry"))
-        self.assertEqual(res, ['current_form_geometry'])
+        res = list(QgsValueRelationFieldFormatter.expressionFormVariables("current_geometry"))
+        self.assertEqual(res, ['current_geometry'])
 
         self.assertFalse(QgsValueRelationFieldFormatter.expressionRequiresFormScope(""))
-        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("get_current_form_field_value('TWO')"))
-        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("get_current_form_field_value ( 'TWO' )"))
-        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("current_form_geometry"))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("current_value('TWO')"))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("current_value ( 'TWO' )"))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionRequiresFormScope("current_geometry"))
 
         self.assertTrue(QgsValueRelationFieldFormatter.expressionIsUsable("", QgsFeature()))
-        self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("current_form_geometry", QgsFeature()))
-        self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("get_current_form_field_value ( 'TWO' )", QgsFeature()))
+        self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("current_geometry", QgsFeature()))
+        self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("current_value ( 'TWO' )", QgsFeature()))
 
         layer = QgsVectorLayer("none?field=pkid:integer&field=decoded:string",
                                "layer", "memory")
@@ -160,10 +160,10 @@ class TestQgsValueRelationFieldFormatter(unittest.TestCase):
         f.setAttributes([1, 'value'])
         point = QgsGeometry.fromPointXY(QgsPointXY(123, 456))
         f.setGeometry(point)
-        self.assertTrue(QgsValueRelationFieldFormatter.expressionIsUsable("current_form_geometry", f))
-        self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("get_current_form_field_value ( 'TWO' )", f))
-        self.assertTrue(QgsValueRelationFieldFormatter.expressionIsUsable("get_current_form_field_value ( 'pkid' )", f))
-        self.assertTrue(QgsValueRelationFieldFormatter.expressionIsUsable("@current_form_geometry get_current_form_field_value ( 'pkid' )", f))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionIsUsable("current_geometry", f))
+        self.assertFalse(QgsValueRelationFieldFormatter.expressionIsUsable("current_value ( 'TWO' )", f))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionIsUsable("current_value ( 'pkid' )", f))
+        self.assertTrue(QgsValueRelationFieldFormatter.expressionIsUsable("@current_geometry current_value ( 'pkid' )", f))
 
         QgsProject.instance().removeMapLayer(layer.id())
 


### PR DESCRIPTION
## Form/Attribute table context expressions

This PR implements the QEP 20 https://github.com/qgis/QGIS-Enhancement-Proposals/issues/116 (Allow Drill-down (cascade) search in Value Relation Widgets).

A demo  and a detailed explanation can be found here:  https://north-road.com/drill-down-cascading-forms/

### New functions and variables:

This implementation add two new expression func/vars, available in the attribute table and in the feature forms and that can be used in the Value Relation Widget:


```
current_value('FIELD_NAME')
```
Returns the current form/table-row value of the feature currently being edited

```
@current_geometry
```
Returns the current geometry value of the feature currently being edited

## Tests

Tests have been added for the widget behaviors in a C++ test.
A python test contains tests for the logic which handles the dynamic cache by deciding if the expression contains dynamic values (i.e. if it contains any of the form context expressions and if they are valid) and if they can be used, in case the expression does not require the form context the whole dynamic cache is skipped and the system behave exactly as it behaved before this PR.


