### PR TITLE
Port gdalcalc with formula excaping fix

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -70,7 +70,7 @@ from .tri import tri
 from .warp import warp
 
 # from .extractprojection import ExtractProjection
-# from .gdalcalc import gdalcalc
+from .gdalcalc import gdalcalc
 # from .rasterize_over import rasterize_over
 
 from .Buffer import Buffer
@@ -176,7 +176,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             warp(),
             # rasterize(),
             # ExtractProjection(),
-            # gdalcalc(),
+            gdalcalc(),
             # rasterize_over(),
             # ----- OGR tools -----
             Buffer(),

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -45,6 +45,7 @@ from .gdalinfo import gdalinfo
 from .gdal2tiles import gdal2tiles
 from .gdal2xyz import gdal2xyz
 from .gdaladdo import gdaladdo
+from .gdalcalc import gdalcalc
 from .gdaltindex import gdaltindex
 from .GridAverage import GridAverage
 from .GridDataMetrics import GridDataMetrics
@@ -70,7 +71,6 @@ from .tri import tri
 from .warp import warp
 
 # from .extractprojection import ExtractProjection
-from .gdalcalc import gdalcalc
 # from .rasterize_over import rasterize_over
 
 from .Buffer import Buffer
@@ -151,6 +151,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             gdal2tiles(),
             gdal2xyz(),
             gdaladdo(),
+            gdalcalc(),
             gdaltindex(),
             GridAverage(),
             GridDataMetrics(),
@@ -176,7 +177,6 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             warp(),
             # rasterize(),
             # ExtractProjection(),
-            gdalcalc(),
             # rasterize_over(),
             # ----- OGR tools -----
             Buffer(),

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -191,9 +191,6 @@ class gdalcalc(GdalAlgorithm):
         return 'gdal_calc'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
-        if not parameters:
-            raise QgsProcessingException
-
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         extra = self.parameterAsString(parameters, self.EXTRA, context)
         # if extra is not None:

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -274,4 +274,4 @@ class gdalcalc(GdalAlgorithm):
         arguments.append('--outfile')
         arguments.append(out)
 
-        return ['gdal_calc.py', GdalUtils.escapeAndJoin(arguments)]
+        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -197,8 +197,7 @@ class gdalcalc(GdalAlgorithm):
         #     extra = str(extra)
         #debug = self.getParameterValue(parameters, self.DEBUG)
         formula = self.parameterAsString(parameters, self.FORMULA, context)
-        # noData = self.parameterAsDouble(parameters, self.NO_DATA, context)
-        if self.NO_DATA in parameters and parameters[self.NO_DATA] is not None:
+        if self.NO_DATA in parameters and not parameters[self.NO_DATA]:
             noData = self.parameterAsDouble(parameters, self.NO_DATA, context)
         else:
             noData = None
@@ -211,12 +210,12 @@ class gdalcalc(GdalAlgorithm):
         arguments.append(self.TYPE[self.parameterAsEnum(parameters, self.RTYPE, context)])
         if noData is not None:
             arguments.append('--NoDataValue')
-            arguments.append(str(noData)
+            arguments.append(noData)
         if extra and len(extra) > 0:
             arguments.append(extra)
         #if debug:
         #    arguments.append('--debug')
-        layer=self.parameterAsRasterLayer(parameters, self.INPUT_A, context)
+        layer = self.parameterAsRasterLayer(parameters, self.INPUT_A, context)
         if layer is None:
             raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_A))
         arguments.append('-A')
@@ -225,7 +224,7 @@ class gdalcalc(GdalAlgorithm):
             arguments.append('--A_band ' + self.parameterAsString(parameters, self.BAND_A, context))
 
         if self.INPUT_B in parameters and parameters[self.INPUT_B] is not None:
-            layer=self.parameterAsRasterLayer(parameters, self.INPUT_B, context)
+            layer = self.parameterAsRasterLayer(parameters, self.INPUT_B, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_B))
             arguments.append('-B')
@@ -234,7 +233,7 @@ class gdalcalc(GdalAlgorithm):
                 arguments.append('--B_band ' + self.parameterAsString(parameters, self.BAND_B, context))
 
         if self.INPUT_C in parameters and parameters[self.INPUT_C] is not None:
-            layer=self.parameterAsRasterLayer(parameters, self.INPUT_C, context)
+            layer = self.parameterAsRasterLayer(parameters, self.INPUT_C, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_C))
             arguments.append('-C')
@@ -243,7 +242,7 @@ class gdalcalc(GdalAlgorithm):
                 arguments.append('--C_band ' + self.parameterAsString(parameters, self.BAND_C, context))
 
         if self.INPUT_D in parameters and parameters[self.INPUT_D] is not None:
-            layer=self.parameterAsRasterLayer(parameters, self.INPUT_D, context)
+            layer = self.parameterAsRasterLayer(parameters, self.INPUT_D, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_D))
             arguments.append('-D')
@@ -252,7 +251,7 @@ class gdalcalc(GdalAlgorithm):
                 arguments.append('--D_band ' + self.parameterAsString(parameters, self.BAND_D, context))
 
         if self.INPUT_E in parameters and parameters[self.INPUT_E] is not None:
-            layer=self.parameterAsRasterLayer(parameters, self.INPUT_E, context)
+            layer = self.parameterAsRasterLayer(parameters, self.INPUT_E, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_E))
             arguments.append('-E')
@@ -261,7 +260,7 @@ class gdalcalc(GdalAlgorithm):
                 arguments.append('--E_band ' + self.parameterAsString(parameters, self.BAND_E, context))
 
         if self.INPUT_F in parameters and parameters[self.INPUT_F] is not None:
-            layer=self.parameterAsRasterLayer(parameters, self.INPUT_F, context)
+            layer = self.parameterAsRasterLayer(parameters, self.INPUT_F, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_F))
             arguments.append('-F')
@@ -269,7 +268,7 @@ class gdalcalc(GdalAlgorithm):
             if self.parameterAsString(parameters, self.BAND_F, context):
                 arguments.append('--F_band ' + self.parameterAsString(parameters, self.BAND_F, context))
 
-        options=self.parameterAsString(parameters, self.OPTIONS, context)
+        options = self.parameterAsString(parameters, self.OPTIONS, context)
         if options:
             arguments.extend(GdalUtils.parseCreationOptions(options))
 

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -142,7 +142,7 @@ class gdalcalc(GdalAlgorithm):
             QgsProcessingParameterString(
                 self.NO_DATA,
                 self.tr('Set output nodata value'),
-                '',
+                None,
                 optional=True))
         self.addParameter(
             QgsProcessingParameterEnum(
@@ -197,7 +197,7 @@ class gdalcalc(GdalAlgorithm):
         #     extra = str(extra)
         #debug = self.getParameterValue(parameters, self.DEBUG)
         formula = self.parameterAsString(parameters, self.FORMULA, context)
-        if self.NO_DATA in parameters and not parameters[self.NO_DATA]:
+        if self.NO_DATA in parameters and parameters[self.NO_DATA] is not None and parameters[self.NO_DATA] != '':
             noData = self.parameterAsDouble(parameters, self.NO_DATA, context)
         else:
             noData = None

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -43,6 +43,7 @@ from processing.tools.system import isWindows
 
 class gdalcalc(GdalAlgorithm):
 
+    OPTIONS = 'OPTIONS'
     INPUT_A = 'INPUT_A'
     INPUT_B = 'INPUT_B'
     INPUT_C = 'INPUT_C'
@@ -71,100 +72,84 @@ class gdalcalc(GdalAlgorithm):
             QgsProcessingParameterRasterLayer(
                 self.INPUT_A,
                 self.tr('Input layer A'),
-                optional=False)
-        )
+                optional=False))
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_A,
                 self.tr('Number of raster band for A'),
-                parentLayerParameterName=self.INPUT_A)
-        )
+                parentLayerParameterName=self.INPUT_A))
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_B,
                 self.tr('Input layer B'),
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_B,
                 self.tr('Number of raster band for B'),
                 parentLayerParameterName=self.INPUT_B,
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_C,
                 self.tr('Input layer C'),
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
-            QgsProcessingParameterBand(
-                self.BAND_C,
-                self.tr('Number of raster band for C'),
-                parentLayerParameterName=self.INPUT_C,
-                optional=True)
-        )
+            QgsProcessingParameterBand(self.BAND_C,
+                                       self.tr('Number of raster band for C'),
+                                       parentLayerParameterName=self.INPUT_C,
+                                       optional=True))
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_D,
                 self.tr('Input layer D'),
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_D,
                 self.tr('Number of raster band for D'),
                 parentLayerParameterName=self.INPUT_D,
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_E,
                 self.tr('Input layer E'),
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_E,
                 self.tr('Number of raster band for E'),
                 parentLayerParameterName=self.INPUT_E,
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_F,
                 self.tr('Input layer F'),
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_F,
                 self.tr('Number of raster band for F'),
                 parentLayerParameterName=self.INPUT_F,
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterString(
                 self.FORMULA,
                 self.tr('Calculation in gdalnumeric syntax using +-/* or any numpy array functions (i.e. logical_and())'),
                 'A*2',
-                optional=False)
-        )
+                optional=False))
         self.addParameter(
             QgsProcessingParameterString(
                 self.NO_DATA,
                 self.tr('Set output nodata value'),
                 '',
-                optional=True)
-        )
+                optional=True))
         self.addParameter(
             QgsProcessingParameterEnum(
                 self.RTYPE,
                 self.tr('Output raster type'),
                 options=self.TYPE,
-                defaultValue=5)
-        )
+                defaultValue=5))
         #self.addParameter(ParameterBoolean(
         #    self.DEBUG, self.tr('Print debugging information'), False))
         self.addParameter(
@@ -172,13 +157,23 @@ class gdalcalc(GdalAlgorithm):
                 self.EXTRA,
                 self.tr('Additional creation parameters'),
                 '',
-                optional=True)
-        )
+                optional=True))
+
+        # advanced raster params
+        options_param = QgsProcessingParameterString(self.OPTIONS,
+                                                     self.tr('Additional creation parameters'),
+                                                     defaultValue='',
+                                                     optional=True)
+        options_param.setFlags(options_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        options_param.setMetadata({
+            'widget_wrapper': {
+                'class': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}})
+        self.addParameter(options_param)
+
         self.addParameter(
             QgsProcessingParameterRasterDestination(
                 self.OUTPUT,
-                self.tr('Calculated'))
-        )
+                self.tr('Calculated')))
 
     def name(self):
         return 'rastercalculator'
@@ -256,5 +251,9 @@ class gdalcalc(GdalAlgorithm):
                 arguments.append('--F_band ' + self.parameterAsString(parameters, self.BAND_F, context))
         arguments.append('--outfile')
         arguments.append(out)
+
+        options = self.parameterAsString(parameters, self.OPTIONS, context)
+        if options:
+            arguments.extend(GdalUtils.parseCreationOptions(options))
 
         return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -219,11 +219,14 @@ class gdalcalc(GdalAlgorithm):
             arguments.append(extra)
         #if debug:
         #    arguments.append('--debug')
-        if self.parameterAsLayer(parameters, self.INPUT_A, context):
-            arguments.append('-A')
-            arguments.append(self.parameterAsLayer(parameters, self.INPUT_A, context).source())
+        arguments.append('-A')
+        layer_a=self.parameterAsRasterLayer(parameters, self.INPUT_A, context)
+        if layer_a is None:
+            raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_A))
+        arguments.append(layer_a.source())
         if self.parameterAsString(parameters, self.BAND_A, context):
             arguments.append('--A_band ' + self.parameterAsString(parameters, self.BAND_A, context))
+
         if self.parameterAsLayer(parameters, self.INPUT_B, context):
             arguments.append('-B')
             arguments.append(self.parameterAsLayer(parameters, self.INPUT_B, context).source())

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -25,14 +25,12 @@ __copyright__ = '(C) 2015, Giovanni Manghi'
 
 __revision__ = '$Format:%H$'
 
-from qgis.core import (QgsRasterFileWriter,
-                       QgsProcessingException,
+from qgis.core import (QgsProcessingException,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterBand,
-                       QgsProcessingParameterBoolean,
+                       QgsProcessingParameterNumber,
                        QgsProcessingParameterEnum,
-                       QgsProcessingParameterFile,
                        QgsProcessingParameterString,
                        QgsProcessingParameterRasterDestination)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
@@ -139,10 +137,11 @@ class gdalcalc(GdalAlgorithm):
                 'A*2',
                 optional=False))
         self.addParameter(
-            QgsProcessingParameterString(
+            QgsProcessingParameterNumber(
                 self.NO_DATA,
                 self.tr('Set output nodata value'),
-                None,
+                type=QgsProcessingParameterNumber.Double,
+                defaultValue=None,
                 optional=True))
         self.addParameter(
             QgsProcessingParameterEnum(
@@ -197,7 +196,7 @@ class gdalcalc(GdalAlgorithm):
         #     extra = str(extra)
         #debug = self.getParameterValue(parameters, self.DEBUG)
         formula = self.parameterAsString(parameters, self.FORMULA, context)
-        if self.NO_DATA in parameters and parameters[self.NO_DATA] is not None and parameters[self.NO_DATA] != '':
+        if self.NO_DATA in parameters and parameters[self.NO_DATA] is not None:
             noData = self.parameterAsDouble(parameters, self.NO_DATA, context)
         else:
             noData = None

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -179,6 +179,9 @@ class gdalcalc(GdalAlgorithm):
             return 'gdal_calc.py'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
+        if not parameters:
+            raise QgsProcessingException
+
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         extra = self.parameterAsString(parameters, self.EXTRA, context)
         # if extra is not None:

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -71,82 +71,100 @@ class gdalcalc(GdalAlgorithm):
             QgsProcessingParameterRasterLayer(
                 self.INPUT_A,
                 self.tr('Input layer A'),
-                optional=False))
+                optional=False)
+        )
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_A,
                 self.tr('Number of raster band for A'),
-                parentLayerParameterName=self.INPUT_A))
+                parentLayerParameterName=self.INPUT_A)
+        )
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_B,
                 self.tr('Input layer B'),
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_B,
                 self.tr('Number of raster band for B'),
-                parentLayerParameterName=self.INPUT_B, 
-                optional=True))
+                parentLayerParameterName=self.INPUT_B,
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_C,
                 self.tr('Input layer C'),
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
-            QgsProcessingParameterBand(self.BAND_C,
+            QgsProcessingParameterBand(
+                self.BAND_C,
                 self.tr('Number of raster band for C'),
                 parentLayerParameterName=self.INPUT_C,
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_D,
                 self.tr('Input layer D'),
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_D,
                 self.tr('Number of raster band for D'),
                 parentLayerParameterName=self.INPUT_D,
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterRasterLayer(
                 self.INPUT_E,
                 self.tr('Input layer E'),
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_E,
                 self.tr('Number of raster band for E'),
                 parentLayerParameterName=self.INPUT_E,
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterRasterLayer(
-                self.INPUT_F, 
+                self.INPUT_F,
                 self.tr('Input layer F'),
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterBand(
                 self.BAND_F,
                 self.tr('Number of raster band for F'),
                 parentLayerParameterName=self.INPUT_F,
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
-            QgsProcessingParameterString(self.FORMULA,
-                self.tr('Calculation in gdalnumeric syntax using +-/* or any numpy array functions (i.e. logical_and())'), 
-                'A*2', 
-                optional=False))
+            QgsProcessingParameterString(
+                self.FORMULA,
+                self.tr('Calculation in gdalnumeric syntax using +-/* or any numpy array functions (i.e. logical_and())'),
+                'A*2',
+                optional=False)
+        )
         self.addParameter(
-            QgsProcessingParameterString(self.NO_DATA,
+            QgsProcessingParameterString(
+                self.NO_DATA,
                 self.tr('Set output nodata value'),
-                '', 
-                optional=True))
+                '',
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterEnum(
                 self.RTYPE,
                 self.tr('Output raster type'),
                 options=self.TYPE,
-                defaultValue=5))
+                defaultValue=5)
+        )
         #self.addParameter(ParameterBoolean(
         #    self.DEBUG, self.tr('Print debugging information'), False))
         self.addParameter(
@@ -154,11 +172,13 @@ class gdalcalc(GdalAlgorithm):
                 self.EXTRA,
                 self.tr('Additional creation parameters'),
                 '',
-                optional=True))
+                optional=True)
+        )
         self.addParameter(
             QgsProcessingParameterRasterDestination(
                 self.OUTPUT,
-                self.tr('Calculated')))
+                self.tr('Calculated'))
+        )
 
     def name(self):
         return 'rastercalculator'
@@ -193,7 +213,7 @@ class gdalcalc(GdalAlgorithm):
         #     noData = str(noData)
 
         arguments = []
-        arguments.append('--calc "{}"'.format(formula) )
+        arguments.append('--calc "{}"'.format(formula))
         arguments.append('--format')
         arguments.append(GdalUtils.getFormatShortNameFromFilename(out))
         arguments.append('--type')

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -275,4 +275,4 @@ class gdalcalc(GdalAlgorithm):
         arguments.append('--outfile')
         arguments.append(out)
 
-        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]
+        return ['gdal_calc.py', GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -219,8 +219,9 @@ class gdalcalc(GdalAlgorithm):
             arguments.append(extra)
         #if debug:
         #    arguments.append('--debug')
-        arguments.append('-A')
-        arguments.append(self.parameterAsLayer(parameters, self.INPUT_A, context).source())
+        if self.parameterAsLayer(parameters, self.INPUT_A, context):
+            arguments.append('-A')
+            arguments.append(self.parameterAsLayer(parameters, self.INPUT_A, context).source())
         if self.parameterAsString(parameters, self.BAND_A, context):
             arguments.append('--A_band ' + self.parameterAsString(parameters, self.BAND_A, context))
         if self.parameterAsLayer(parameters, self.INPUT_B, context):

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -219,44 +219,64 @@ class gdalcalc(GdalAlgorithm):
             arguments.append(extra)
         #if debug:
         #    arguments.append('--debug')
-        arguments.append('-A')
-        layer_a=self.parameterAsRasterLayer(parameters, self.INPUT_A, context)
-        if layer_a is None:
+        layer=self.parameterAsRasterLayer(parameters, self.INPUT_A, context)
+        if layer is None:
             raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_A))
-        arguments.append(layer_a.source())
+        arguments.append('-A')
+        arguments.append(layer.source())
         if self.parameterAsString(parameters, self.BAND_A, context):
             arguments.append('--A_band ' + self.parameterAsString(parameters, self.BAND_A, context))
 
-        if self.parameterAsLayer(parameters, self.INPUT_B, context):
+        if self.INPUT_B in parameters and parameters[self.INPUT_B] is not None:
+            layer=self.parameterAsRasterLayer(parameters, self.INPUT_B, context)
+            if layer is None:
+                raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_B))
             arguments.append('-B')
-            arguments.append(self.parameterAsLayer(parameters, self.INPUT_B, context).source())
+            arguments.append(layer.source())
             if self.parameterAsString(parameters, self.BAND_B, context):
                 arguments.append('--B_band ' + self.parameterAsString(parameters, self.BAND_B, context))
-        if self.parameterAsLayer(parameters, self.INPUT_C, context):
+
+        if self.INPUT_C in parameters and parameters[self.INPUT_C] is not None:
+            layer=self.parameterAsRasterLayer(parameters, self.INPUT_C, context)
+            if layer is None:
+                raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_C))
             arguments.append('-C')
-            arguments.append(self.parameterAsLayer(parameters, self.INPUT_C, context).source())
+            arguments.append(layer.source())
             if self.parameterAsString(parameters, self.BAND_C, context):
                 arguments.append('--C_band ' + self.parameterAsString(parameters, self.BAND_C, context))
-        if self.parameterAsLayer(parameters, self.INPUT_D, context):
+
+        if self.INPUT_D in parameters and parameters[self.INPUT_D] is not None:
+            layer=self.parameterAsRasterLayer(parameters, self.INPUT_D, context)
+            if layer is None:
+                raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_D))
             arguments.append('-D')
-            arguments.append(self.parameterAsLayer(parameters, self.INPUT_D, context).source())
+            arguments.append(layer.source())
             if self.parameterAsString(parameters, self.BAND_D, context):
                 arguments.append('--D_band ' + self.parameterAsString(parameters, self.BAND_D, context))
-        if self.parameterAsLayer(parameters, self.INPUT_E, context):
+
+        if self.INPUT_E in parameters and parameters[self.INPUT_E] is not None:
+            layer=self.parameterAsRasterLayer(parameters, self.INPUT_E, context)
+            if layer is None:
+                raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_E))
             arguments.append('-E')
-            arguments.append(self.parameterAsLayer(parameters, self.INPUT_E, context).source())
+            arguments.append(layer.source())
             if self.parameterAsString(parameters, self.BAND_E, context):
                 arguments.append('--E_band ' + self.parameterAsString(parameters, self.BAND_E, context))
-        if self.parameterAsLayer(parameters, self.INPUT_F, context):
+
+        if self.INPUT_F in parameters and parameters[self.INPUT_F] is not None:
+            layer=self.parameterAsRasterLayer(parameters, self.INPUT_F, context)
+            if layer is None:
+                raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_F))
             arguments.append('-F')
-            arguments.append(self.parameterAsLayer(parameters, self.INPUT_F, context).source())
+            arguments.append(layer.source())
             if self.parameterAsString(parameters, self.BAND_F, context):
                 arguments.append('--F_band ' + self.parameterAsString(parameters, self.BAND_F, context))
-        arguments.append('--outfile')
-        arguments.append(out)
 
         options=self.parameterAsString(parameters, self.OPTIONS, context)
         if options:
             arguments.extend(GdalUtils.parseCreationOptions(options))
+
+        arguments.append('--outfile')
+        arguments.append(out)
 
         return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -188,10 +188,7 @@ class gdalcalc(GdalAlgorithm):
         return 'rastermiscellaneous'
 
     def commandName(self):
-        if isWindows():
-            return 'gdal_calc'
-        else:
-            return 'gdal_calc.py'
+        return 'gdal_calc'
 
     def getConsoleCommands(self, parameters, context, feedback, executing=True):
         if not parameters:

--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -200,9 +200,11 @@ class gdalcalc(GdalAlgorithm):
         #     extra = str(extra)
         #debug = self.getParameterValue(parameters, self.DEBUG)
         formula = self.parameterAsString(parameters, self.FORMULA, context)
-        noData = self.parameterAsDouble(parameters, self.NO_DATA, context)
-        # if noData is not None:
-        #     noData = str(noData)
+        # noData = self.parameterAsDouble(parameters, self.NO_DATA, context)
+        if self.NO_DATA in parameters and parameters[self.NO_DATA] is not None:
+            noData = self.parameterAsDouble(parameters, self.NO_DATA, context)
+        else:
+            noData = None
 
         arguments = []
         arguments.append('--calc "{}"'.format(formula))
@@ -210,9 +212,9 @@ class gdalcalc(GdalAlgorithm):
         arguments.append(GdalUtils.getFormatShortNameFromFilename(out))
         arguments.append('--type')
         arguments.append(self.TYPE[self.parameterAsEnum(parameters, self.RTYPE, context)])
-        if noData and len(noData) > 0:
+        if noData is not None:
             arguments.append('--NoDataValue')
-            arguments.append(noData)
+            arguments.append(str(noData)
         if extra and len(extra) > 0:
             arguments.append(extra)
         #if debug:
@@ -249,7 +251,7 @@ class gdalcalc(GdalAlgorithm):
         arguments.append('--outfile')
         arguments.append(out)
 
-        options = self.parameterAsString(parameters, self.OPTIONS, context)
+        options=self.parameterAsString(parameters, self.OPTIONS, context)
         if options:
             arguments.extend(GdalUtils.parseCreationOptions(options))
 

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -32,6 +32,7 @@ from processing.algs.gdal.AssignProjection import AssignProjection
 from processing.algs.gdal.ClipRasterByExtent import ClipRasterByExtent
 from processing.algs.gdal.ClipRasterByMask import ClipRasterByMask
 from processing.algs.gdal.gdal2tiles import gdal2tiles
+from processing.algs.gdal.gdalcalc import gdalcalc
 from processing.algs.gdal.gdaltindex import gdaltindex
 from processing.algs.gdal.contour import contour
 from processing.algs.gdal.GridAverage import GridAverage
@@ -45,7 +46,6 @@ from processing.algs.gdal.rasterize import rasterize
 from processing.algs.gdal.retile import retile
 from processing.algs.gdal.translate import translate
 from processing.algs.gdal.warp import warp
-from processing.algs.gdal.gdalcalc import gdalcalc
 
 from qgis.core import (QgsProcessingContext,
                        QgsProcessingFeedback,
@@ -475,47 +475,47 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         formula = 'A*2' # default formula
         self.assertEqual(
             alg.getConsoleCommands({
-                'INPUT_A' : source,
-                'BAND_A' : 1,
-                'FORMULA' : formula,
-                'BAND_D' : -1,
-                'NO_DATA' : '',
-                'BAND_F' : -1,
-                'BAND_B' : -1,
-                'EXTRA' : '',
-                'RTYPE' : 5,
-                'INPUT_F' : None,
-                'BAND_E' : -1,
-                'INPUT_D' : None,
-                'INPUT_B' : None,
-                'BAND_C' : -1,
-                'INPUT_E' : None,
-                'INPUT_C' : None,
-                'OUTPUT' : output}, context, feedback),
-            [alg.commandName(), '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+                'INPUT_A': source,
+                'BAND_A': 1,
+                'FORMULA': formula,
+                'BAND_D': -1,
+                'NO_DATA': '',
+                'BAND_F': -1,
+                'BAND_B': -1,
+                'EXTRA': '',
+                'RTYPE': 5,
+                'INPUT_F': None,
+                'BAND_E': -1,
+                'INPUT_D': None,
+                'INPUT_B': None,
+                'BAND_C': -1,
+                'INPUT_E': None,
+                'INPUT_C': None,
+                'OUTPUT': output}, context, feedback),
+            [alg.commandName(), '--calc "{}" --format GTiff --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
         # check that formula is not escaped and formula is returned as it is
         formula = 'A * 2'  # <--- add spaces in the formula
         self.assertEqual(
             alg.getConsoleCommands({
-                'INPUT_A' : source,
-                'BAND_A' : 1,
-                'FORMULA' : formula,
-                'BAND_D' : -1,
-                'NO_DATA' : '',
-                'BAND_F' : -1,
-                'BAND_B' : -1,
-                'EXTRA' : '',
-                'RTYPE' : 5,
-                'INPUT_F' : None,
-                'BAND_E' : -1,
-                'INPUT_D' : None,
-                'INPUT_B' : None,
-                'BAND_C' : -1,
-                'INPUT_E' : None,
-                'INPUT_C' : None,
-                'OUTPUT' : output}, context, feedback),
-            [alg.commandName(), '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+                'INPUT_A': source,
+                'BAND_A': 1,
+                'FORMULA': formula,
+                'BAND_D': -1,
+                'NO_DATA': '',
+                'BAND_F': -1,
+                'BAND_B': -1,
+                'EXTRA': '',
+                'RTYPE': 5,
+                'INPUT_F': None,
+                'BAND_E': -1,
+                'INPUT_D': None,
+                'INPUT_B': None,
+                'BAND_C': -1,
+                'INPUT_E': None,
+                'INPUT_C': None,
+                'OUTPUT': output}, context, feedback),
+            [alg.commandName(), '--calc "{}" --format GTiff --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
     def testContour(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -462,61 +462,6 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
              mask + ' -crop_to_cutline -dstnodata 0.0 ' + source + ' ' +
              'd:/temp/check.jpg'])
 
-    def testGdalCalc(self):
-        context = QgsProcessingContext()
-        feedback = QgsProcessingFeedback()
-        source = os.path.join(testDataPath, 'dem.tif')
-        alg = gdalcalc()
-        alg.initAlgorithm()
-
-        output = 'd:/temp/check.jpg'
-
-        # default execution
-        formula = 'A*2' # default formula
-        self.assertEqual(
-            alg.getConsoleCommands({
-                'INPUT_A': source,
-                'BAND_A': 1,
-                'FORMULA': formula,
-                'BAND_D': -1,
-                'NO_DATA': '',
-                'BAND_F': -1,
-                'BAND_B': -1,
-                'EXTRA': '',
-                'RTYPE': 5,
-                'INPUT_F': None,
-                'BAND_E': -1,
-                'INPUT_D': None,
-                'INPUT_B': None,
-                'BAND_C': -1,
-                'INPUT_E': None,
-                'INPUT_C': None,
-                'OUTPUT': output}, context, feedback),
-            [alg.commandName(), '--calc "{}" --format GTiff --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
-
-        # check that formula is not escaped and formula is returned as it is
-        formula = 'A * 2'  # <--- add spaces in the formula
-        self.assertEqual(
-            alg.getConsoleCommands({
-                'INPUT_A': source,
-                'BAND_A': 1,
-                'FORMULA': formula,
-                'BAND_D': -1,
-                'NO_DATA': '',
-                'BAND_F': -1,
-                'BAND_B': -1,
-                'EXTRA': '',
-                'RTYPE': 5,
-                'INPUT_F': None,
-                'BAND_E': -1,
-                'INPUT_D': None,
-                'INPUT_B': None,
-                'BAND_C': -1,
-                'INPUT_E': None,
-                'INPUT_C': None,
-                'OUTPUT': output}, context, feedback),
-            [alg.commandName(), '--calc "{}" --format GTiff --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
-
     def testContour(self):
         context = QgsProcessingContext()
         feedback = QgsProcessingFeedback()
@@ -635,6 +580,61 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
              '-p mercator -w all -r average -s EPSG:3111 ' +
              source + ' ' +
              'd:/temp/'])
+
+    def testGdalCalc(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'dem.tif')
+        alg = gdalcalc()
+        alg.initAlgorithm()
+
+        output = 'd:/temp/check.jpg'
+
+        # default execution
+        formula = 'A*2' # default formula
+        self.assertEqual(
+            alg.getConsoleCommands({
+                'INPUT_A': source,
+                'BAND_A': 1,
+                'FORMULA': formula,
+                'BAND_D': -1,
+                'NO_DATA': '',
+                'BAND_F': -1,
+                'BAND_B': -1,
+                'EXTRA': '',
+                'RTYPE': 5,
+                'INPUT_F': None,
+                'BAND_E': -1,
+                'INPUT_D': None,
+                'INPUT_B': None,
+                'BAND_C': -1,
+                'INPUT_E': None,
+                'INPUT_C': None,
+                'OUTPUT': output}, context, feedback),
+            [alg.commandName(), '--calc "{}" --format GTiff --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+
+        # check that formula is not escaped and formula is returned as it is
+        formula = 'A * 2'  # <--- add spaces in the formula
+        self.assertEqual(
+            alg.getConsoleCommands({
+                'INPUT_A': source,
+                'BAND_A': 1,
+                'FORMULA': formula,
+                'BAND_D': -1,
+                'NO_DATA': '',
+                'BAND_F': -1,
+                'BAND_B': -1,
+                'EXTRA': '',
+                'RTYPE': 5,
+                'INPUT_F': None,
+                'BAND_E': -1,
+                'INPUT_D': None,
+                'INPUT_B': None,
+                'BAND_C': -1,
+                'INPUT_E': None,
+                'INPUT_C': None,
+                'OUTPUT': output}, context, feedback),
+            [alg.commandName(), '--calc "{}" --format GTiff --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
     def testGdalTindex(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -45,6 +45,7 @@ from processing.algs.gdal.rasterize import rasterize
 from processing.algs.gdal.retile import retile
 from processing.algs.gdal.translate import translate
 from processing.algs.gdal.warp import warp
+from processing.algs.gdal.gdalcalc import gdalcalc
 
 from qgis.core import (QgsProcessingContext,
                        QgsProcessingFeedback,
@@ -460,6 +461,61 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
              '-ot Float32 -of JPEG -cutline ' +
              mask + ' -crop_to_cutline -dstnodata 0.0 ' + source + ' ' +
              'd:/temp/check.jpg'])
+
+    def testGdalCalc(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'dem.tif')
+        alg = gdalcalc()
+        alg.initAlgorithm()
+
+        output = 'd:/temp/check.jpg'
+
+        # default execution
+        formula = 'A*2' # default formula
+        self.assertEqual(
+            alg.getConsoleCommands({
+                'INPUT_A' : source,
+                'BAND_A' : 1,
+                'FORMULA' : formula,
+                'BAND_D' : -1,
+                'NO_DATA' : '',
+                'BAND_F' : -1,
+                'BAND_B' : -1,
+                'EXTRA' : '',
+                'RTYPE' : 5,
+                'INPUT_F' : None,
+                'BAND_E' : -1,
+                'INPUT_D' : None,
+                'INPUT_B' : None,
+                'BAND_C' : -1,
+                'INPUT_E' : None,
+                'INPUT_C' : None,
+                'OUTPUT' : output}, context, feedback),
+            [alg.commandName(), '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+
+        # check that formula is not escaped and formula is returned as it is
+        formula = 'A * 2'  # <--- add spaces in the formula
+        self.assertEqual(
+            alg.getConsoleCommands({
+                'INPUT_A' : source,
+                'BAND_A' : 1,
+                'FORMULA' : formula,
+                'BAND_D' : -1,
+                'NO_DATA' : '',
+                'BAND_F' : -1,
+                'BAND_B' : -1,
+                'EXTRA' : '',
+                'RTYPE' : 5,
+                'INPUT_F' : None,
+                'BAND_E' : -1,
+                'INPUT_D' : None,
+                'INPUT_B' : None,
+                'BAND_C' : -1,
+                'INPUT_E' : None,
+                'INPUT_C' : None,
+                'OUTPUT' : output}, context, feedback),
+            [alg.commandName(), '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
     def testContour(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -598,7 +598,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                 'BAND_A': 1,
                 'FORMULA': formula,
                 'BAND_D': -1,
-                'NO_DATA': '',
+                'NO_DATA': None,
                 'BAND_F': -1,
                 'BAND_B': -1,
                 'EXTRA': '',
@@ -611,7 +611,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                 'INPUT_E': None,
                 'INPUT_C': None,
                 'OUTPUT': output}, context, feedback),
-            ['gdal_calc.py', '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+            ['gdal_calc', '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
         # check that formula is not escaped and formula is returned as it is
         formula = 'A * 2'  # <--- add spaces in the formula
@@ -621,7 +621,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                 'BAND_A': 1,
                 'FORMULA': formula,
                 'BAND_D': -1,
-                'NO_DATA': '',
+                'NO_DATA': None,
                 'BAND_F': -1,
                 'BAND_B': -1,
                 'EXTRA': '',
@@ -634,7 +634,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                 'INPUT_E': None,
                 'INPUT_C': None,
                 'OUTPUT': output}, context, feedback),
-            ['gdal_calc.py', '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+            ['gdal_calc', '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
     def testGdalTindex(self):
         context = QgsProcessingContext()

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -611,7 +611,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                 'INPUT_E': None,
                 'INPUT_C': None,
                 'OUTPUT': output}, context, feedback),
-            [alg.commandName(), '--calc "{}" --format GTiff --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+            ['gdal_calc.py', '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
         # check that formula is not escaped and formula is returned as it is
         formula = 'A * 2'  # <--- add spaces in the formula
@@ -634,7 +634,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                 'INPUT_E': None,
                 'INPUT_C': None,
                 'OUTPUT': output}, context, feedback),
-            [alg.commandName(), '--calc "{}" --format GTiff --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
+            ['gdal_calc.py', '--calc "{}" --format JPEG --type Float32 -A {} --A_band 1 --outfile {}'.format(formula, source, output)])
 
     def testGdalTindex(self):
         context = QgsProcessingContext()


### PR DESCRIPTION
## Description
Ported missing gdal processing alg gdalcalc (wrapper to wdal_calc) to 3.X. Console tests included.

fix promoted inside GeoMove [1] project for Cartolab [2] (A Coruña university)

[1] http://cartolab.udc.es/geomove/
[2] http://cartolab.udc.es

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
