### PR TITLE
corrections function_help

### DIFF
--- a/resources/function_help/json/array_intersect
+++ b/resources/function_help/json/array_intersect
@@ -1,7 +1,7 @@
 {
   "name": "array_intersect",
   "type": "function",
-  "description": "Returns true if any element of array1 exists in array2.",
+  "description": "Returns true if at least one element of array1 exists in array2.",
   "arguments": [ {"arg":"array1","description":"an array"},
                  {"arg":"array2","description":"another array"}],
   "examples": [ { "expression":"array_intersect(array(1,2,3,4),array(4,0,2,5))", "returns":"true"}]

--- a/resources/function_help/json/make_circle
+++ b/resources/function_help/json/make_circle
@@ -8,7 +8,7 @@
 	{"arg":"radius", "description": "radius of the circle"},
         {"arg":"segment", "description": "optional argument for polygon segmentation. By default this value is 36"}],
   "examples": [ { "expression":"geom_to_wkt(make_circle(make_point(10,10), 5, 4))", "returns":"'Polygon ((10 15, 15 10, 10 5, 5 10, 10 15))'"},
-    { "expression":"geom_to_wkt(make_circle(make_point(10,10,5), 5, 4))", "returns":"'Polygon ((10 15 5, 15 10 5, 10 5 5, 5 10 5, 10 15 5))'"},
-    { "expression":"geom_to_wkt(make_circle(make_point(10,10,5,30), 5, 4))", "returns":"'Polygon ((10 15 5 30, 15 10 5 30, 10 5 5 30, 5 10 5 30, 10 15 5 30))'"}
+    { "expression":"geom_to_wkt(make_circle(make_point(10,10,5), 5, 4))", "returns":"'PolygonZ ((10 15 5, 15 10 5, 10 5 5, 5 10 5, 10 15 5))'"},
+    { "expression":"geom_to_wkt(make_circle(make_point(10,10,5,30), 5, 4))", "returns":"'PolygonZM ((10 15 5 30, 15 10 5 30, 10 5 5 30, 5 10 5 30, 10 15 5 30))'"}
     ]
 }

--- a/resources/function_help/json/make_ellipse
+++ b/resources/function_help/json/make_ellipse
@@ -10,7 +10,7 @@
 	{"arg":"azimuth", "description": "orientation of the ellipse"},
         {"arg":"segment", "description": "optional argument for polygon segmentation. By default this value is 36"}],
   "examples": [ { "expression":"geom_to_wkt(make_ellipse(make_point(10,10), 5, 2, 90, 4))", "returns":"'Polygon ((15 10, 10 8, 5 10, 10 12, 15 10))'"},
-    { "expression":"geom_to_wkt(make_circle(make_point(10,10,5), 5, 2, 90, 4))", "returns":"'Polygon ((15 10 5, 10 8 5, 5 10 5, 10 12 5, 15 10 5))'"},
-    { "expression":"geom_to_wkt(make_circle(make_point(10,10,5,30), 5, 2, 90, 4))", "returns":"'Polygon ((15 10 5 30, 10 8 5 30, 5 10 5 30, 10 12 5 30, 15 10 5 30))'"}
+    { "expression":"geom_to_wkt(make_ellipse(make_point(10,10,5), 5, 2, 90, 4))", "returns":"'PolygonZ ((15 10 5, 10 8 5, 5 10 5, 10 12 5, 15 10 5))'"},
+    { "expression":"geom_to_wkt(make_ellipse(make_point(10,10,5,30), 5, 2, 90, 4))", "returns":"'PolygonZM ((15 10 5 30, 10 8 5 30, 5 10 5 30, 10 12 5 30, 15 10 5 30))'"}
     ]
 }

--- a/resources/function_help/json/num_geometries
+++ b/resources/function_help/json/num_geometries
@@ -3,5 +3,5 @@
   "type": "function",
   "description": "Returns the number of geometries in a geometry collection, or null if the input geometry is not a collection.",
   "arguments": [ {"arg":"geometry","description":"geometry collection"} ],
-  "examples": [ { "expression":"num_geometries(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'))'),3))", "returns":"4"}]
+  "examples": [ { "expression":"num_geometries(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'))", "returns":"4"}]
 }


### PR DESCRIPTION
## sorry for any errors, for me it is the first time

## Description
Corrections on 4 .json files on function_help:
1. num_geometries, "returns" contained extra characters;
![image](https://user-images.githubusercontent.com/7631137/40000907-58a0c888-578d-11e8-9d6b-1689e74741e2.png)
2. make_circle, "returns" was missing Z and ZM in Polygon
![image](https://user-images.githubusercontent.com/7631137/40000849-2a458122-578d-11e8-872d-90ddbb5e6a8a.png)
3. make_ellepse, "expression" contained make_circle instead of make_ellipse and missing Z and ZM in polygon;
![image](https://user-images.githubusercontent.com/7631137/40001046-9f7ade6a-578d-11e8-93b0-8105ec72e4c3.png)
4. array_intersect, "description" replaced 'any' with 'at least one'

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
