### PR TITLE
[executesql] Use parameter's name instead of description to save sql query

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/ExecuteSQLWidget.py
+++ b/python/plugins/processing/algs/qgis/ui/ExecuteSQLWidget.py
@@ -28,20 +28,12 @@ __revision__ = '$Format:%H$'
 import os
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtWidgets import QTreeWidgetItem
-from qgis.PyQt.QtCore import Qt
 
-from qgis.core import (QgsApplication,
-                       QgsExpressionContextScope,
+from qgis.core import (QgsExpressionContextScope,
                        QgsProcessingParameterString,
                        QgsProcessingParameterNumber,
                        QgsExpression,
-                       QgsProcessingModelChildParameterSource,
-                       QgsProcessingParameterFile,
-                       QgsProcessingParameterField,
-                       QgsProcessingOutputString,
-                       QgsProcessingParameterExpression,
-                       QgsProcessingOutputFile)
+                       QgsProcessingModelChildParameterSource)
 
 from qgis.gui import QgsFieldExpressionWidget
 


### PR DESCRIPTION
## Description

The underlying sql query is saved with parameter's name instead of description in the `ExecuteSQL` algorithm.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
