### PR TITLE
Use connection name to avoid closing default connection

### DIFF
--- a/src/core/qgsuserprofile.cpp
+++ b/src/core/qgsuserprofile.cpp
@@ -67,7 +67,7 @@ const QString QgsUserProfile::alias() const
     return name();
   }
 
-  QSqlDatabase db = QSqlDatabase::addDatabase( QStringLiteral( "QSQLITE" ) );
+  QSqlDatabase db = QSqlDatabase::addDatabase( QStringLiteral( "QSQLITE" ), QStringLiteral( "userprofile" ) );
   db.setDatabaseName( qgisDB() );
   if ( !db.open() )
     return name();


### PR DESCRIPTION
No observable bad effects identified but the following warning looks suspicious:

  Warning: QSqlDatabasePrivate::addDatabase: duplicate connection name qt_sql_default_connection, old connection removed.

@NathanW2 ... or did you have a good reason to skip this name?