### PR TITLE
Add title case conversion to QgsStringUtils, use to fix processing HIG violations

### DIFF
--- a/python/core/auto_generated/qgsstringutils.sip.in
+++ b/python/core/auto_generated/qgsstringutils.sip.in
@@ -174,6 +174,7 @@ class QgsStringUtils
       AllUppercase,
       AllLowercase,
       ForceFirstLetterToCapital,
+      TitleCase,
     };
 
     static QString capitalize( const QString &string, Capitalization capitalization );

--- a/python/plugins/db_manager/db_manager_plugin.py
+++ b/python/plugins/db_manager/db_manager_plugin.py
@@ -48,7 +48,7 @@ class DBManagerPlugin(object):
         else:
             self.iface.addToolBarIcon(self.action)
         if hasattr(self.iface, 'addPluginToDatabaseMenu'):
-            self.iface.addPluginToDatabaseMenu(QApplication.translate("DBManagerPlugin", "DB Manager"), self.action)
+            self.iface.addPluginToDatabaseMenu(QApplication.translate("DBManagerPlugin", None), self.action)
         else:
             self.iface.addPluginToMenu(QApplication.translate("DBManagerPlugin", "DB Manager"), self.action)
 
@@ -63,8 +63,8 @@ class DBManagerPlugin(object):
 
     def unload(self):
         # Remove the plugin menu item and icon
-        if hasattr(self.iface, 'removePluginDatabaseMenu'):
-            self.iface.removePluginDatabaseMenu(QApplication.translate("DBManagerPlugin", "DB Manager"), self.action)
+        if hasattr(self.iface, 'databaseMenu'):
+            self.iface.databaseMenu().removeAction(self.action)
         else:
             self.iface.removePluginMenu(QApplication.translate("DBManagerPlugin", "DB Manager"), self.action)
         if hasattr(self.iface, 'removeDatabaseToolBarIcon'):

--- a/python/plugins/db_manager/db_manager_plugin.py
+++ b/python/plugins/db_manager/db_manager_plugin.py
@@ -37,7 +37,7 @@ class DBManagerPlugin(object):
         self.dlg = None
 
     def initGui(self):
-        self.action = QAction(QgsApplication.getThemeIcon('dbmanager.svg'), QApplication.translate("DBManagerPlugin", "DB Manager"),
+        self.action = QAction(QgsApplication.getThemeIcon('dbmanager.svg'), QApplication.translate("DBManagerPlugin", "DB Manager…"),
                               self.iface.mainWindow())
 
         self.action.setObjectName("dbManager")

--- a/python/plugins/db_manager/db_plugins/vlayers/plugin.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/plugin.py
@@ -22,8 +22,9 @@ email                : hugo dot mercier at oslandia dot com
 # this will disable the dbplugin if the connector raise an ImportError
 from .connector import VLayerConnector
 
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtGui import QIcon
-from qgis.core import QgsVectorLayer, QgsProject, QgsVirtualLayerDefinition, QCoreApplication
+from qgis.core import QgsVectorLayer, QgsProject, QgsVirtualLayerDefinition
 
 from ..plugin import DBPlugin, Database, Table, VectorTable, TableField
 

--- a/python/plugins/processing/gui/menus.py
+++ b/python/plugins/processing/gui/menus.py
@@ -32,7 +32,7 @@ from processing.core.ProcessingConfig import ProcessingConfig, Setting
 from processing.gui.MessageDialog import MessageDialog
 from processing.gui.AlgorithmDialog import AlgorithmDialog
 from qgis.utils import iface
-from qgis.core import QgsApplication, QgsMessageLog
+from qgis.core import QgsApplication, QgsMessageLog, QgsStringUtils
 from processing.gui.MessageBarProgress import MessageBarProgress
 from processing.gui.AlgorithmExecutor import execute
 from processing.gui.Postprocessing import handleAlgorithmResults
@@ -182,7 +182,10 @@ def removeMenus():
 
 
 def addAlgorithmEntry(alg, menuName, submenuName, actionText=None, icon=None, addButton=False):
-    action = QAction(icon or alg.icon(), actionText or alg.displayName(), iface.mainWindow())
+    if actionText is None:
+        actionText = QgsStringUtils.capitalize(alg.displayName(), QgsStringUtils.TitleCase) + QCoreApplication.translate('Processing', '…')
+    action = QAction(icon or alg.icon(), actionText, iface.mainWindow())
+    action.setData(alg.id())
     action.triggered.connect(lambda: _executeAlgorithm(alg))
     action.setObjectName("mProcessingUserMenu_%s" % alg.id())
 
@@ -199,11 +202,11 @@ def addAlgorithmEntry(alg, menuName, submenuName, actionText=None, icon=None, ad
         algorithmsToolbar.addAction(action)
 
 
-def removeAlgorithmEntry(alg, menuName, submenuName, actionText=None, delButton=True):
+def removeAlgorithmEntry(alg, menuName, submenuName, delButton=True):
     if menuName:
         menu = getMenu(menuName, iface.mainWindow().menuBar())
         subMenu = getMenu(submenuName, menu)
-        action = findAction(subMenu.actions(), alg, actionText)
+        action = findAction(subMenu.actions(), alg)
         if action is not None:
             subMenu.removeAction(action)
 
@@ -213,7 +216,7 @@ def removeAlgorithmEntry(alg, menuName, submenuName, actionText=None, delButton=
     if delButton:
         global algorithmsToolbar
         if algorithmsToolbar is not None:
-            action = findAction(algorithmsToolbar.actions(), alg, actionText)
+            action = findAction(algorithmsToolbar.actions(), alg)
             if action is not None:
                 algorithmsToolbar.removeAction(action)
 
@@ -260,8 +263,8 @@ def getMenu(name, parent):
         return parent.addMenu(name)
 
 
-def findAction(actions, alg, actionText=None):
+def findAction(actions, alg):
     for action in actions:
-        if action.text() in [actionText, alg.displayName(), alg.name()]:
+        if action.data() == alg.id():
             return action
     return None

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10963,6 +10963,9 @@ void QgisApp::removePluginMenu( const QString &name, QAction *action )
 
 QMenu *QgisApp::getDatabaseMenu( const QString &menuName )
 {
+  if ( menuName.isEmpty() )
+    return mDatabaseMenu;
+
   QString cleanedMenuName = menuName;
 #ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.
@@ -11004,6 +11007,9 @@ QMenu *QgisApp::getDatabaseMenu( const QString &menuName )
 
 QMenu *QgisApp::getRasterMenu( const QString &menuName )
 {
+  if ( menuName.isEmpty() )
+    return mRasterMenu;
+
   QString cleanedMenuName = menuName;
 #ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.
@@ -11055,6 +11061,9 @@ QMenu *QgisApp::getRasterMenu( const QString &menuName )
 
 QMenu *QgisApp::getVectorMenu( const QString &menuName )
 {
+  if ( menuName.isEmpty() )
+    return mVectorMenu;
+
   QString cleanedMenuName = menuName;
 #ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.
@@ -11096,6 +11105,9 @@ QMenu *QgisApp::getVectorMenu( const QString &menuName )
 
 QMenu *QgisApp::getWebMenu( const QString &menuName )
 {
+  if ( menuName.isEmpty() )
+    return mWebMenu;
+
   QString cleanedMenuName = menuName;
 #ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.

--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -56,6 +56,37 @@ QString QgsStringUtils::capitalize( const QString &string, QgsStringUtils::Capit
       return temp;
     }
 
+    case TitleCase:
+    {
+      // yes, this is MASSIVELY simplifying the problem!!
+
+      static QStringList smallWords;
+      if ( smallWords.empty() )
+      {
+        smallWords = QObject::tr( "a|an|and|as|at|but|by|en|for|if|in|nor|of|on|or|per|the|to|vs.|vs|via" ).split( '|' );
+      }
+
+      const QStringList parts = string.split( ' ' );
+      QString result;
+      bool firstWord = true;
+      for ( const QString &word : qgis::as_const( parts ) )
+      {
+        if ( word.isEmpty() )
+        {
+          result += ' ';
+        }
+        else if ( firstWord || !smallWords.contains( word ) )
+        {
+          result += ' ' + word.at( 0 ).toUpper() + word.mid( 1 );
+          firstWord = false;
+        }
+        else
+        {
+          result += ' ' + word;
+        }
+      }
+      return result;
+    }
   }
   // no warnings
   return string;

--- a/src/core/qgsstringutils.h
+++ b/src/core/qgsstringutils.h
@@ -188,6 +188,7 @@ class CORE_EXPORT QgsStringUtils
       AllUppercase = QFont::AllUppercase, //!< Convert all characters to uppercase
       AllLowercase = QFont::AllLowercase,  //!< Convert all characters to lowercase
       ForceFirstLetterToCapital = QFont::Capitalize, //!< Convert just the first letter of each word to uppercase, leave the rest untouched
+      TitleCase = QFont::Capitalize + 1000, //!< Simple title case conversion - does not fully grammatically parse the text and uses simple rules only. Note that this method does not convert any characters to lowercase, it only uppercases required letters. Callers must ensure that input strings are already lowercased.
     };
 
     /**

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -22,6 +22,7 @@
 #include "processing/qgsprocessingprovider.h"
 #include "qgstaskmanager.h"
 #include "processing/qgsprocessingalgrunnertask.h"
+#include "qgsstringutils.h"
 #include <QToolButton>
 #include <QDesktopServices>
 #include <QScrollBar>
@@ -126,7 +127,7 @@ QgsProcessingAlgorithmDialogBase::QgsProcessingAlgorithmDialogBase( QWidget *par
 void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *algorithm )
 {
   mAlgorithm = algorithm;
-  setWindowTitle( mAlgorithm->displayName() );
+  setWindowTitle( QgsStringUtils::capitalize( mAlgorithm->displayName(), QgsStringUtils::TitleCase ) );
 
   QString algHelp = formatHelp( algorithm );
   if ( algHelp.isEmpty() )

--- a/src/plugins/coordinate_capture/coordinatecapture.cpp
+++ b/src/plugins/coordinate_capture/coordinatecapture.cpp
@@ -44,6 +44,7 @@
 #include <QToolButton>
 #include <QFile>
 #include <QLabel>
+#include <QMenu>
 
 static const QString sName = QObject::tr( "Coordinate Capture" );
 static const QString sDescription = QObject::tr( "Capture mouse coordinates in different CRS" );
@@ -97,7 +98,7 @@ void CoordinateCapture::initGui()
   mQActionPointer->setWhatsThis( tr( "Click on the map to view coordinates and capture to clipboard." ) );
   // Connect the action to the run
   connect( mQActionPointer, &QAction::triggered, this, &CoordinateCapture::showOrHide );
-  mQGisIface->addPluginToVectorMenu( tr( "&Coordinate Capture" ), mQActionPointer );
+  mQGisIface->addPluginToVectorMenu( QString(), mQActionPointer );
   mQGisIface->addVectorToolBarIcon( mQActionPointer );
 
   // create our map tool
@@ -249,7 +250,7 @@ void CoordinateCapture::showOrHide()
 void CoordinateCapture::unload()
 {
   // remove the GUI
-  mQGisIface->removePluginVectorMenu( tr( "&Coordinate Capture" ), mQActionPointer );
+  mQGisIface->vectorMenu()->removeAction( mQActionPointer );
   mQGisIface->removeVectorToolBarIcon( mQActionPointer );
   mpMapTool->deactivate();
   delete mpMapTool;

--- a/src/plugins/geometry_checker/qgsgeometrycheckerplugin.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerplugin.cpp
@@ -28,7 +28,7 @@ void QgsGeometryCheckerPlugin::initGui()
 {
   mDialog = new QgsGeometryCheckerDialog( mIface, mIface->mainWindow() );
   mDialog->setWindowModality( Qt::NonModal );
-  mMenuAction = new QAction( QIcon( ":/geometrychecker/icons/geometrychecker.png" ), QApplication::translate( "QgsGeometryCheckerPlugin", "Check Geometries" ), this );
+  mMenuAction = new QAction( QIcon( ":/geometrychecker/icons/geometrychecker.png" ), QApplication::translate( "QgsGeometryCheckerPlugin", "Check Geometries…" ), this );
   connect( mMenuAction, &QAction::triggered, mDialog, &QWidget::show );
   connect( mMenuAction, &QAction::triggered, mDialog, &QWidget::raise );
   mIface->addPluginToVectorMenu( QApplication::translate( "QgsGeometryCheckerPlugin", "G&eometry Tools" ), mMenuAction );

--- a/src/plugins/geometry_checker/qgsgeometrycheckerplugin.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerplugin.cpp
@@ -17,6 +17,7 @@
 #include "qgsgeometrycheckerplugin.h"
 #include "qgisinterface.h"
 #include "qgsgeometrycheckerdialog.h"
+#include <QMenu>
 
 QgsGeometryCheckerPlugin::QgsGeometryCheckerPlugin( QgisInterface *iface )
   : QgisPlugin( sName, sDescription, sCategory, sPluginVersion, sPluginType )
@@ -31,7 +32,7 @@ void QgsGeometryCheckerPlugin::initGui()
   mMenuAction = new QAction( QIcon( ":/geometrychecker/icons/geometrychecker.png" ), QApplication::translate( "QgsGeometryCheckerPlugin", "Check Geometries…" ), this );
   connect( mMenuAction, &QAction::triggered, mDialog, &QWidget::show );
   connect( mMenuAction, &QAction::triggered, mDialog, &QWidget::raise );
-  mIface->addPluginToVectorMenu( QApplication::translate( "QgsGeometryCheckerPlugin", "G&eometry Tools" ), mMenuAction );
+  mIface->addPluginToVectorMenu( QString(), mMenuAction );
 }
 
 void QgsGeometryCheckerPlugin::unload()
@@ -40,7 +41,7 @@ void QgsGeometryCheckerPlugin::unload()
   mDialog = nullptr;
   delete mMenuAction;
   mMenuAction = nullptr;
-  mIface->removePluginVectorMenu( QApplication::translate( "QgsGeometryCheckerPlugin", "G&eometry Tools" ), mMenuAction );
+  mIface->vectorMenu()->removeAction( mMenuAction );
 }
 
 

--- a/src/plugins/georeferencer/qgsgeorefplugin.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugin.cpp
@@ -98,7 +98,7 @@ void QgsGeorefPlugin::initGui()
 
   // Add to the toolbar & menu
   mQGisIface->addRasterToolBarIcon( mActionRunGeoref );
-  mQGisIface->addPluginToRasterMenu( tr( "&Georeferencer" ), mActionRunGeoref );
+  mQGisIface->addPluginToRasterMenu( QString(), mActionRunGeoref );
 }
 
 void QgsGeorefPlugin::run()
@@ -113,7 +113,7 @@ void QgsGeorefPlugin::run()
 void QgsGeorefPlugin::unload()
 {
   // remove the GUI
-  mQGisIface->removePluginRasterMenu( tr( "&Georeferencer" ), mActionRunGeoref );
+  mQGisIface->rasterMenu()->removeAction( mActionRunGeoref );
   mQGisIface->removeRasterToolBarIcon( mActionRunGeoref );
 
   delete mActionRunGeoref;

--- a/src/plugins/gps_importer/qgsgpsplugin.cpp
+++ b/src/plugins/gps_importer/qgsgpsplugin.cpp
@@ -95,7 +95,7 @@ void QgsGpsPlugin::initGui()
 
   mQGisInterface->layerToolBar()->insertAction( nullptr, mCreateGPXAction );
   mQGisInterface->newLayerMenu()->addAction( mCreateGPXAction );
-  mQGisInterface->addPluginToVectorMenu( tr( "&GPS" ), mQActionPointer );
+  mQGisInterface->addPluginToVectorMenu( QString(), mQActionPointer );
   mQGisInterface->addVectorToolBarIcon( mQActionPointer );
 
   // this is called when the icon theme is changed
@@ -200,7 +200,7 @@ void QgsGpsPlugin::unload()
   // remove the GUI
   mQGisInterface->layerToolBar()->removeAction( mCreateGPXAction );
   mQGisInterface->newLayerMenu()->removeAction( mCreateGPXAction );
-  mQGisInterface->removePluginVectorMenu( tr( "&GPS" ), mQActionPointer );
+  mQGisInterface->vectorMenu()->removeAction( mQActionPointer );
   mQGisInterface->removeVectorToolBarIcon( mQActionPointer );
   delete mQActionPointer;
   mQActionPointer = nullptr;

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -51,7 +51,7 @@ void QgsOfflineEditingPlugin::initGui()
   delete mActionConvertProject;
 
   // Create the action for tool
-  mActionConvertProject = new QAction( QIcon( ":/offline_editing/offline_editing_copy.png" ), tr( "Convert to offline project" ), this );
+  mActionConvertProject = new QAction( QIcon( ":/offline_editing/offline_editing_copy.png" ), tr( "Convert to Offline Project…" ), this );
   mActionConvertProject->setObjectName( QStringLiteral( "mActionConvertProject" ) );
   // Set the what's this text
   mActionConvertProject->setWhatsThis( tr( "Create offline copies of selected layers and save as offline project" ) );
@@ -103,7 +103,7 @@ void QgsOfflineEditingPlugin::convertProject()
       return;
     }
 
-    mProgressDialog->setTitle( tr( "Converting to offline project" ) );
+    mProgressDialog->setTitle( tr( "Converting to Offline Project" ) );
     if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected() ) )
     {
       updateActions();
@@ -117,7 +117,7 @@ void QgsOfflineEditingPlugin::convertProject()
 
 void QgsOfflineEditingPlugin::synchronize()
 {
-  mProgressDialog->setTitle( tr( "Synchronizing to remote layers" ) );
+  mProgressDialog->setTitle( tr( "Synchronizing to Remote Layers" ) );
   mOfflineEditing->synchronize();
   updateActions();
 }

--- a/src/plugins/topology/topol.cpp
+++ b/src/plugins/topology/topol.cpp
@@ -26,6 +26,7 @@
 #include <QToolBar>
 #include <QFile>
 #include <QMessageBox>
+#include <QMenu>
 
 #include "topol.h"
 #include "checkDock.h"
@@ -77,7 +78,7 @@ void Topol::initGui()
   connect( mQActionPointer, &QAction::triggered, this, &Topol::showOrHide );
   // Add the icon to the toolbar
   mQGisIface->addVectorToolBarIcon( mQActionPointer );
-  mQGisIface->addPluginToVectorMenu( tr( "&Topology Checker" ), mQActionPointer );
+  mQGisIface->addPluginToVectorMenu( QString(), mQActionPointer );
   //run();
 }
 //method defined in interface
@@ -112,7 +113,7 @@ void Topol::run()
 void Topol::unload()
 {
   // remove the GUI
-  mQGisIface->removePluginVectorMenu( tr( "&Topology Checker" ), mQActionPointer );
+  mQGisIface->vectorMenu()->removeAction( mQActionPointer );
   mQGisIface->removeVectorToolBarIcon( mQActionPointer );
   delete mQActionPointer;
 }

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -44,12 +44,12 @@
     </widget>
     <widget class="QMenu" name="mProjectToStorageMenu">
      <property name="title">
-      <string>Save to</string>
+      <string>Save To</string>
      </property>
     </widget>
     <widget class="QMenu" name="mProjectFromStorageMenu">
      <property name="title">
-      <string>Open from</string>
+      <string>Open From</string>
      </property>
     </widget>
     <widget class="QMenu" name="menuImport_Export">

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -34,6 +34,8 @@ class TestQgsStringUtils : public QObject
     void hammingDistance();
     void soundex();
     void insertLinks();
+    void titleCase_data();
+    void titleCase();
 
 };
 
@@ -152,6 +154,33 @@ void TestQgsStringUtils::insertLinks()
   QVERIFY( found );
   QCOMPARE( QgsStringUtils::insertLinks( QString( "is a@a an email?" ), &found ), QString( "is a@a an email?" ) );
   QVERIFY( !found );
+}
+
+void TestQgsStringUtils::titleCase_data()
+{
+  QTest::addColumn<QString>( "input" );
+  QTest::addColumn<QString>( "expected" );
+
+  // invalid strings
+  QTest::newRow( "empty string" ) << "" << "";
+  QTest::newRow( "single character" ) << "a" << "A";
+  QTest::newRow( "string 1" ) << "follow step-by-step instructions" << "Follow Step-by-Step Instructions";
+  QTest::newRow( "string 2" ) << "this sub-phrase is nice" << "This Sub-Phrase Is Nice";
+  QTest::newRow( "" ) << "catchy title: a subtitle" << "Catchy Title: A Subtitle";
+  QTest::newRow( "string 3" ) << "all words capitalized" << "All Words Capitalized";
+  QTest::newRow( "string 4" ) << "small words are for by and of lowercase" << "Small Words Are for by and of Lowercase";
+  QTest::newRow( "string 5" ) << "a small word starts" << "A Small Word Starts";
+  QTest::newRow( "last word" ) << "a small word it ends on" << "A Small Word It Ends On";
+  QTest::newRow( "last word2" ) << "Ends with small word of" << "Ends With Small Word Of";
+  QTest::newRow( "string 6" ) << "Merge VRT(s)" << "Merge VRT(s)";
+  QTest::newRow( "string 6" ) << "multiple sentences. more than one." << "Multiple Sentences. More Than One.";
+}
+
+void TestQgsStringUtils::titleCase()
+{
+  QFETCH( QString, input );
+  QFETCH( QString, expected );
+  QCOMPARE( QgsStringUtils::capitalize( input, QgsStringUtils::TitleCase ), expected );
 }
 
 


### PR DESCRIPTION
This adds a super-basic title case conversion method to QgsStringUtils. It's not a full grammar parser (which is needed if you want real title case conversion!), but good enough for simple use cases.

Here I've used it to fix some HIG violations in Processing menus. Since algorithm display names are sentence case, we need to convert them to title case when they are shown in menus and for dialog titles (or risk the wrath of the HIG gods).

I've also taken the opportunity to fix another plugin HIG issue with the menu - which is that many core plugins create single-item submenus. E.g. Raster -> Georeferencer -> Georeferencer. This is a HIG violation, and these items should be top-level instead (e.g. just Raster -> Georeferencer). 