### PR TITLE
[processing] Allow algorithms to return a translated short description

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -106,7 +106,20 @@ provider's ID and the algorithms unique name (e.g. "qgis:mergelayers" ).
 Returns the translated algorithm name, which should be used for any user-visible display
 of the algorithm name.
 
+Algorithm display names should be short, e.g. ideally no more than 3 or 4 words.
+The name should use sentence case (e.g. "Raster layer statistics", not "Raster Layer Statistics").
+
 .. seealso:: :py:func:`name`
+
+.. seealso:: :py:func:`shortDescription`
+%End
+
+    virtual QString shortDescription() const;
+%Docstring
+Returns an optional translated short description of the algorithm. This should be
+at most a single sentence, e.g. "Converts 2D features to 3D by sampling a DEM raster."
+
+.. versionadded:: 3.2
 %End
 
     virtual QStringList tags() const;

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -102,6 +102,7 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
         super().__init__()
         self._name = ''
         self._display_name = ''
+        self._short_description = ''
         self._group = ''
         self._groupId = ''
         self.groupIdRegex = re.compile('^[^\s\(]+')
@@ -141,6 +142,9 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
 
     def displayName(self):
         return self._display_name
+
+    def shortDescription(self):
+        return self._short_description
 
     def group(self):
         return self._group
@@ -191,13 +195,12 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
             self.grass7Name = line
             # Second line if the algorithm name in Processing
             line = lines.readline().strip('\n').strip()
-            self._name = line
-            self._display_name = QCoreApplication.translate("GrassAlgorithm", line)
-            if " - " not in self._name:
-                self._name = self.grass7Name + " - " + self._name
-                self._display_name = self.grass7Name + " - " + self._display_name
-
-            self._name = self._name[:self._name.find(' ')].lower()
+            self._short_description = line
+            if " - " not in line:
+                self._name = self.grass7Name
+            else:
+                self._name = line[:line.find(' ')].lower()
+            self._display_name = self._name
             # Read the grass group
             line = lines.readline().strip('\n').strip()
             self._group = QCoreApplication.translate("GrassAlgorithm", line)

--- a/python/plugins/processing/algs/grass7/description/v.drape.txt
+++ b/python/plugins/processing/algs/grass7/description/v.drape.txt
@@ -1,7 +1,7 @@
 v.drape
 Converts 2D vector features to 3D by sampling of elevation raster map.
 Vector (v.*)
-QgsProcessingParameterFeatureSource|input|Iput vector layer|-1|None|False
+QgsProcessingParameterFeatureSource|input|Input vector layer|-1|None|False
 QgsProcessingParameterString|where|WHERE conditions of SQL statement without 'where' keyword|None|True|True
 QgsProcessingParameterEnum|type|Input feature type|point;line;boundary;centroid|True|0,1,3,4|True
 QgsProcessingParameterRasterLayer|elevation|Elevation raster map for height extraction|None|False

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -508,8 +508,9 @@ class TreeAlgorithmItem(QTreeWidgetItem):
         self.setData(0, ProcessingToolbox.TYPE_ROLE, ProcessingToolbox.ALG_ITEM)
 
     def formatAlgorithmTooltip(self, alg):
-        return '<p><b>{}</b></p><p>{}</p>'.format(
+        return '<p><b>{}</b></p>{}<p>{}</p>'.format(
             alg.displayName(),
+            '<p>{}</p>'.format(alg.shortDescription()) if alg.shortDescription() else '',
             QCoreApplication.translate('Toolbox', 'Algorithm ID: ‘{}’').format('<i>{}</i>'.format(alg.id()))
         )
 

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -160,8 +160,10 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
         elif isinstance(item, TreeAlgorithmItem):
             # hide if every part of text is not contained somewhere in either the item text or item user role
             item_text = [item.text(0).lower(), item.data(0, ProcessingToolbox.NAME_ROLE).lower()]
-            item_text.append(item.alg.id())
-            item_text.extend(item.data(0, ProcessingToolbox.TAG_ROLE))
+            item_text.append(item.alg.id().lower())
+            if item.alg.shortDescription():
+                item_text.append(item.alg.shortDescription().lower())
+            item_text.extend([t.lower() for t in item.data(0, ProcessingToolbox.TAG_ROLE)])
 
             hide = bool(text) and not all(
                 any(part in t for t in item_text)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -606,8 +606,10 @@ class ModelerDialog(BASE, WIDGET):
             # hide if every part of text is not contained somewhere in either the item text or item user role
             item_text = [item.text(0).lower(), item.data(0, ModelerDialog.NAME_ROLE).lower()]
             if isinstance(item, TreeAlgorithmItem):
-                item_text.append(item.alg.id())
-                item_text.extend(item.data(0, ModelerDialog.TAG_ROLE))
+                item_text.append(item.alg.id().lower())
+                if item.alg.shortDescription():
+                    item_text.append(item.alg.shortDescription().lower())
+                item_text.extend([t.lower() for t in item.data(0, ModelerDialog.TAG_ROLE)])
 
             hide = bool(text) and not all(
                 any(part in t for t in item_text)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -779,9 +779,10 @@ class TreeAlgorithmItem(QTreeWidgetItem):
         self.setData(0, ModelerDialog.TYPE_ROLE, ModelerDialog.ALG_ITEM)
 
     def formatAlgorithmTooltip(self, alg):
-        return '<p><b>{}</b></p><p>{}</p>'.format(
+        return '<p><b>{}</b></p>{}<p>{}</p>'.format(
             alg.displayName(),
-            QCoreApplication.translate('TreeAlgorithmItem', 'Algorithm ID: ‘{}’').format('<i>{}</i>'.format(alg.id()))
+            '<p>{}</p>'.format(alg.shortDescription()) if alg.shortDescription() else '',
+            QCoreApplication.translate('Toolbox', 'Algorithm ID: ‘{}’').format('<i>{}</i>'.format(alg.id()))
         )
 
 

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -49,7 +49,10 @@ def algorithmHelp(id):
     alg = QgsApplication.processingRegistry().algorithmById(id)
     if alg is not None:
         print('{} ({})\n'.format(alg.displayName(), alg.id()))
-        print(alg.shortHelpString())
+        if alg.shortDescription():
+            print(alg.shortDescription() + '\n')
+        if alg.shortHelpString():
+            print(alg.shortHelpString() + '\n')
         print('\n----------------')
         print('Input parameters')
         print('----------------')

--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -4028,6 +4028,7 @@ invokved:invoked
 invokves:invokes
 invokving:invoking
 involvment:involvement
+iput:input
 irelevent:irrelevant
 iresistable:irresistible
 iresistably:irresistibly

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -49,6 +49,11 @@ QString QgsProcessingAlgorithm::id() const
     return name();
 }
 
+QString QgsProcessingAlgorithm::shortDescription() const
+{
+  return QString();
+}
+
 QString QgsProcessingAlgorithm::shortHelpString() const
 {
   return QString();

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -146,9 +146,21 @@ class CORE_EXPORT QgsProcessingAlgorithm
     /**
      * Returns the translated algorithm name, which should be used for any user-visible display
      * of the algorithm name.
+     *
+     * Algorithm display names should be short, e.g. ideally no more than 3 or 4 words.
+     * The name should use sentence case (e.g. "Raster layer statistics", not "Raster Layer Statistics").
+     *
      * \see name()
+     * \see shortDescription()
      */
     virtual QString displayName() const = 0;
+
+    /**
+     * Returns an optional translated short description of the algorithm. This should be
+     * at most a single sentence, e.g. "Converts 2D features to 3D by sampling a DEM raster."
+     * \since QGIS 3.2
+     */
+    virtual QString shortDescription() const;
 
     /**
      * Returns a list of tags which relate to the algorithm, and are used to assist users in searching

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -485,6 +485,10 @@ QString QgsProcessingAlgorithmDialogBase::formatHelp( QgsProcessingAlgorithm *al
     }
     return QStringLiteral( "<h2>%1</h2>%2" ).arg( algorithm->displayName(), help );
   }
+  else if ( !algorithm->shortDescription().isEmpty() )
+  {
+    return QStringLiteral( "<h2>%1</h2><p>%2</p>" ).arg( algorithm->displayName(), algorithm->shortDescription() );
+  }
   else
     return QString();
 }


### PR DESCRIPTION
This is used in the algorithm's tooltip in the toolbox, and is intended for single sentence description of the algorithm, e.g.
"Converts 2D features to 3D by sampling a DEM raster."

Convert grass algorithms to use short description for the descriptive parts of their names, to cleanup the toolbox and make it more uniform, and avoid the grass algorithms having massive long display names.
