### PR TITLE
[server][wfs] Apply BBOX inside And using filterRect

### DIFF
--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -252,6 +252,33 @@ class TestQgsServerWFS(QgsServerTestBase):
 """
         tests.append(('sortby_post', sortTemplate.format("")))
 
+        andBboxTemplate = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+  <wfs:Query typeName="testlayer" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">
+    <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+      <ogc:And>
+        <ogc:BBOX>
+          <ogc:PropertyName>geometry</ogc:PropertyName>
+          <gml:Envelope xmlns:gml="http://www.opengis.net/gml">
+            <gml:lowerCorner>890555.92634619 5465442.18332275</gml:lowerCorner>
+            <gml:upperCorner>1001875.41713946 5621521.48619207</gml:upperCorner>
+          </gml:Envelope>
+        </ogc:BBOX>
+        <ogc:PropertyIsGreaterThan>
+          <ogc:PropertyName>id</ogc:PropertyName>
+          <ogc:Literal>1</ogc:Literal>
+        </ogc:PropertyIsGreaterThan>
+        <ogc:PropertyIsLessThan>
+          <ogc:PropertyName>id</ogc:PropertyName>
+          <ogc:Literal>3</ogc:Literal>
+        </ogc:PropertyIsLessThan>
+      </ogc:And>
+    </ogc:Filter>
+  </wfs:Query>
+</wfs:GetFeature>
+"""
+        tests.append(('bbox_inside_and_post', andBboxTemplate.format("")))
+
         for id, req in tests:
             self.wfs_getfeature_post_compare(id, req)
 

--- a/tests/testdata/qgis_server/wfs_getfeature_bbox_inside_and_post.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_bbox_inside_and_post.txt
@@ -1,0 +1,26 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SRSNAME=EPSG:3857&amp;SERVICE=WFS&amp;VERSION=1.1.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
+<gml:boundedBy>
+ <gml:Box srsName="EPSG:4326">
+  <gml:coordinates cs="," ts=" ">8,44 9,45</gml:coordinates>
+ </gml:Box>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.1">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">913214.67407005,5606017.87425818 913214.67407005,5606017.87425818</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">913214.67407005,5606017.87425818</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>2</qgs:id>
+  <qgs:name>two</qgs:name>
+  <qgs:utf8nameè>two àò</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
In case of a WFS GetFeature request (or WMS GetMap request with FILTER),
if BBOX is not a direct child of the Filter element,
it is applyed through an intersects_bbox function in the QgsFeatureRequest filterExpression.
This is not compiled by providers like PostgreSQL, causing the whole filter to be interpreted on QGIS side.
When interpreted on QGIS side, the srsname given in the request is not handled properly as geom_from_gml return a geometry object, projection agnostic.
This result in a very long request returning no results.

This is a workaround for this performance and srs issue in the case the BBOX is direct child of an And operator, itself at first level in Filter element.

This is a bug fix and huge optimisation for the case we have an And with a BBOX and another condition.

Note that it may be possible to transmit intersects_bbox as an && to PostgreSQL when compiling expressions, but it does not come without complexity as && is not a function but an operator and Postgis ST_GeomFromGML does not handle Envelope tag.

I've also tried keeping the filter handling on QGIS side, but use of geom_from_gml does not permit to handle the srsname in Envelope or Query elements.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
