### PR TITLE
Fixes syncDb() that improperly sets "Imported from GDAL" as name for all GEOCCS

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1809,7 +1809,7 @@ int QgsCoordinateReferenceSystem::syncDb()
 
       QString name( OSRIsGeographic( crs ) ? OSRGetAttrValue( crs, "GEOGCS", 0 ) : OSRGetAttrValue( crs, "PROJCS", 0 ) );
       if ( name.isEmpty() )
-        name = QObject::tr( "Imported from GDAL" );
+        name = ( OSRIsGeocentric( crs ) ? OSRGetAttrValue( crs, "GEOCCS", 0 ) : QObject::tr( "Imported from GDAL" ) );
 
       sql = QString( "INSERT INTO tbl_srs(description,projection_acronym,ellipsoid_acronym,parameters,srid,auth_name,auth_id,is_geo,deprecated) VALUES (%1,%2,%3,%4,%5,'EPSG',%5,%6,0)" )
             .arg( quotedValue( name ),


### PR DESCRIPTION
Like for PR #6153, this commit allow syncDb() to properly set the name of each Geocentric Coordinate System ("GEOCCS") imported in srs.db from GDAL *.csv support files during postinstall, instead of wrongly setting it to "Imported from GDAL".
**The bug is also in 3.0 and master.**

Fixes [#18968](https://issues.qgis.org/issues/18968)

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
