### PR TITLE
[RPM] Force brp-python-bytecompile to use python3

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -6,6 +6,12 @@
 # - _relver
 # - _timestamp (optional)
 
+# Force the python interpreter to python3:
+# brp-python-bytecompile is unable to identify
+# the proper required version of python for 
+# py files located under /usr/share/qgis/python/plugins
+%global __python %{__python3}
+
 %if %{_timestamp} > 0
 %define builddate %(date -d @%{_timestamp} '+%a %b %d %Y')
 %else


### PR DESCRIPTION
## Description

Current master breaks when building RPM packages: `brp-python-bytecompile` fails compiling `py` files under `/usr/share/qgis/python/plugins/` because `python2` is used instead of `python3`.

`brp-python-bytecompile` is able to identify the correct version of the `python` interpreter, but only for files located under `/usr/lib64/pythonX.Y`; in QGIS we have `py` files also located under `/usr/share/qgis/python/plugins`.

This was working before (by accident) because all `py` files located in the `plugins` folder were syntactically compatible with `python2`; in latest master this is not true anymore:

```python
Compiling /builddir/build/BUILDROOT/qgis-3.1.0-gita0ff2af.fc27.x86_64/usr/share/qgis/python/plugins/processing/algs/gdal/GdalUtils.py ...
  File "/usr/share/qgis/python/plugins/processing/algs/gdal/GdalUtils.py", line 417
    def gdal_crs_string(crs: QgsCoordinateReferenceSystem) -> str:
                           ^
SyntaxError: invalid syntax
```

Refs:
- https://copr-be.cloud.fedoraproject.org/results/dani/qgis-testing/fedora-27-x86_64/00754651-qgis/builder-live.log
- https://fedoraproject.org/wiki/Packaging:Python

New builds:
- https://ci.services.vigano.me/#/builders/2/builds/34
- https://copr.fedorainfracloud.org/coprs/dani/qgis-testing/build/755391/

Would it be possible to cherry-pick/backport the commit also in the `release-3_0` branch?

/cc @m-kuhn 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
