### PR TITLE
Allows syncDB() to correctly import WKTs from esri_extra.wkt and cubewerx_extra.wkt

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1602,12 +1602,12 @@ bool QgsCoordinateReferenceSystem::loadWkts( QHash<int, QString> &wkts, const ch
     {
       int pos = line.indexOf( ',' );
       if ( pos < 0 )
-        return false;
+        continue;
 
       bool ok;
       int epsg = line.left( pos ).toInt( &ok );
       if ( !ok )
-        return false;
+        continue;
 
       wkts.insert( epsg, line.mid( pos + 1 ) );
     }


### PR DESCRIPTION
loadWkts(), that is used by syncDb() to load WKTs in order to update srs.db during postinstall, wrongly handle empty lines eventually present in esri_extra.wkt and cubewerx_extra.wkt.
This commit slightly modifies the for loop in loadWkts() like it is in loadIDs().
**The bug is also in 3.0 and master.**

Fixes [#18969](https://issues.qgis.org/issues/18969)

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
