### PR TITLE
[processing] change 0 to Not set Null values in Gdal Clip

### DIFF
--- a/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
@@ -67,7 +67,7 @@ class ClipRasterByExtent(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.NODATA,
                                                        self.tr('Assign a specified nodata value to output bands'),
                                                        type=QgsProcessingParameterNumber.Double,
-                                                       defaultValue='',
+                                                       defaultValue=None,
                                                        optional=True))
 
         options_param = QgsProcessingParameterString(self.OPTIONS,

--- a/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
@@ -67,7 +67,7 @@ class ClipRasterByExtent(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.NODATA,
                                                        self.tr('Assign a specified nodata value to output bands'),
                                                        type=QgsProcessingParameterNumber.Double,
-                                                       defaultValue=0.0,
+                                                       defaultValue='',
                                                        optional=True))
 
         options_param = QgsProcessingParameterString(self.OPTIONS,

--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -72,7 +72,7 @@ class ClipRasterByMask(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.NODATA,
                                                        self.tr('Assign a specified nodata value to output bands'),
                                                        type=QgsProcessingParameterNumber.Double,
-                                                       defaultValue=0.0,
+                                                       defaultValue='',
                                                        optional=True))
         self.addParameter(QgsProcessingParameterBoolean(self.ALPHA_BAND,
                                                         self.tr('Create an output alpha band'),

--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -72,7 +72,7 @@ class ClipRasterByMask(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.NODATA,
                                                        self.tr('Assign a specified nodata value to output bands'),
                                                        type=QgsProcessingParameterNumber.Double,
-                                                       defaultValue='',
+                                                       defaultValue=None,
                                                        optional=True))
         self.addParameter(QgsProcessingParameterBoolean(self.ALPHA_BAND,
                                                         self.tr('Create an output alpha band'),

--- a/python/plugins/processing/algs/gdal/contour.py
+++ b/python/plugins/processing/algs/gdal/contour.py
@@ -91,7 +91,7 @@ class contour(GdalAlgorithm):
         nodata_param = QgsProcessingParameterNumber(self.NODATA,
                                                     self.tr('Input pixel value to treat as "nodata"'),
                                                     type=QgsProcessingParameterNumber.Double,
-                                                    defaultValue='',
+                                                    defaultValue=None,
                                                     optional=True)
         nodata_param.setFlags(nodata_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(nodata_param)

--- a/python/plugins/processing/algs/gdal/contour.py
+++ b/python/plugins/processing/algs/gdal/contour.py
@@ -91,7 +91,7 @@ class contour(GdalAlgorithm):
         nodata_param = QgsProcessingParameterNumber(self.NODATA,
                                                     self.tr('Input pixel value to treat as "nodata"'),
                                                     type=QgsProcessingParameterNumber.Double,
-                                                    defaultValue=0.0,
+                                                    defaultValue='',
                                                     optional=True)
         nodata_param.setFlags(nodata_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(nodata_param)


### PR DESCRIPTION
## Description
Change the current 0 value to Not set when using Clip by extent, Clip by Mask layer and Contour in gdal. The 0 default values can confuse the users.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
