### PR TITLE
Update currently edited feature in attribute table when selection changes

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -386,7 +386,7 @@ void QgsFeatureListView::ensureEditSelection( bool inSelection )
   else
   {
     // we don't care if the edit selection is in the feature selection?
-    // well then, only update if there is no valid edit selection availble
+    // well then, only update if there is no valid edit selection available
     if ( !validEditSelectionAvailable )
       editSelectionUpdateRequested = true;
   }

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -184,8 +184,11 @@ class GUI_EXPORT QgsFeatureListView : public QListView
 
     /**
      * Make sure, there is an edit selection. If there is none, choose the first item.
+     * If \a inSelection is set to true, the edit selection is done in selected entries if
+     * there is a selected entry visible.
+     *
      */
-    void ensureEditSelection();
+    void ensureEditSelection( bool inSelection = false );
 
   private:
     void selectRow( const QModelIndex &index, bool anchor );


### PR DESCRIPTION
It's a very common pitfall for people to toggle the selection instead of
the edit selection in the form view of the attribute table. I've noticed
clicking people repeatedly on the list because they know it's not
reliably going to give them what they want.

This change updates the active feature in the form view on a selection
change if one of the selected entries is visible in the current filter.