### PR TITLE
QgsFeatureSource::empty() method

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -260,6 +260,9 @@ An optional ``request`` can be used to optimise the returned
 iterator, eg by restricting the returned attributes or geometry.
 %End
 
+    virtual QgsFeatureSource::FeatureAvailability hasFeatures() const;
+
+
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const;
 
     virtual QgsCoordinateReferenceSystem sourceCrs() const;

--- a/python/core/auto_generated/qgsfeaturesource.sip.in
+++ b/python/core/auto_generated/qgsfeaturesource.sip.in
@@ -22,6 +22,12 @@ An interface for objects which provide features via a getFeatures method.
 #include "qgsfeaturesource.h"
 %End
   public:
+    enum FeatureAvailability
+    {
+      NoFeaturesAvailable,
+      FeaturesAvailable,
+      FeaturesMaybeAvailable
+    };
 
     virtual ~QgsFeatureSource();
 
@@ -68,23 +74,9 @@ Returns the number of features contained in the source, or -1
 if the feature count is unknown.
 %End
 
-    virtual bool empty() const;
+    virtual FeatureAvailability hasFeatures() const;
 %Docstring
 Determines if there are any features available in the source.
-
-In case it is not known if there are features available, false is returned.
-Use ``emptyUnknown()`` to determine if this value is reliable.
-
-.. seealso:: :py:func:`QgsVectorDataProvider.empty`
-information.
-
-.. versionadded:: 3.2
-%End
-
-    virtual bool emptyUnknown() const;
-%Docstring
-Returns true if the value returned by ``empty()`` may be wrong.
-This depends on the dataprovider.
 
 .. versionadded:: 3.2
 %End

--- a/python/core/auto_generated/qgsfeaturesource.sip.in
+++ b/python/core/auto_generated/qgsfeaturesource.sip.in
@@ -22,6 +22,7 @@ An interface for objects which provide features via a getFeatures method.
 #include "qgsfeaturesource.h"
 %End
   public:
+
     enum FeatureAvailability
     {
       NoFeaturesAvailable,

--- a/python/core/auto_generated/qgsfeaturesource.sip.in
+++ b/python/core/auto_generated/qgsfeaturesource.sip.in
@@ -68,6 +68,27 @@ Returns the number of features contained in the source, or -1
 if the feature count is unknown.
 %End
 
+    virtual bool empty() const;
+%Docstring
+Determines if there are any features available in the source.
+
+In case it is not known if there are features available, false is returned.
+Use ``emptyUnknown()`` to determine if this value is reliable.
+
+.. seealso:: :py:func:`QgsVectorDataProvider.empty`
+information.
+
+.. versionadded:: 3.2
+%End
+
+    virtual bool emptyUnknown() const;
+%Docstring
+Returns true if the value returned by ``empty()`` may be wrong.
+This depends on the dataprovider.
+
+.. versionadded:: 3.2
+%End
+
     virtual QSet<QVariant> uniqueValues( int fieldIndex, int limit = -1 ) const;
 %Docstring
 Returns the set of unique values contained within the specified ``fieldIndex`` from this source.
@@ -139,7 +160,6 @@ for its ownership.
 
 .. versionadded:: 3.0
 %End
-
 };
 
 

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -131,7 +131,7 @@ Returns true if the layer contains at least one feature.
 .. versionadded:: 3.2
 %End
 
-    virtual QgsFeatureSource::FeatureAvailability hasFeatures() const;
+    virtual QgsFeatureSource::FeatureAvailability hasFeatures() const final;
 %Docstring
 Will always return FeatureAvailability.FeaturesAvailable or
 FeatureAvailability.FeaturesMaybeAvailable.

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -128,7 +128,7 @@ Number of features in the layer
 %Docstring
 Returns true if the layer contains at least one feature.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.4
 %End
 
     virtual QgsFeatureSource::FeatureAvailability hasFeatures() const final;
@@ -139,7 +139,7 @@ FeatureAvailability.NoFeaturesAvailable.
 Calls empty() internally. Providers should override empty()
 instead if they provide an optimized version of this call.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.4
 
 .. seealso:: :py:func:`empty`
 %End

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -131,12 +131,17 @@ Returns true if the layer contains at least one feature.
 .. versionadded:: 3.2
 %End
 
-    virtual bool emptyUnknown() const;
+    virtual QgsFeatureSource::FeatureAvailability hasFeatures() const;
 %Docstring
-For QgsVectorDataProviders this always returns true because
-the provider is actually queried for features.
+Will always return FeatureAvailability.FeaturesAvailable or
+FeatureAvailability.FeaturesMaybeAvailable.
+
+Calls empty() internally. Providers should override empty instead
+if they provide an optimized version of this call.
 
 .. versionadded:: 3.2
+
+.. seealso:: :py:func:`empty`
 %End
 
     virtual QgsFields fields() const = 0;

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -134,10 +134,10 @@ Returns true if the layer contains at least one feature.
     virtual QgsFeatureSource::FeatureAvailability hasFeatures() const final;
 %Docstring
 Will always return FeatureAvailability.FeaturesAvailable or
-FeatureAvailability.FeaturesMaybeAvailable.
+FeatureAvailability.NoFeaturesAvailable.
 
-Calls empty() internally. Providers should override empty instead
-if they provide an optimized version of this call.
+Calls empty() internally. Providers should override empty()
+instead if they provide an optimized version of this call.
 
 .. versionadded:: 3.2
 

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -139,9 +139,9 @@ FeatureAvailability.NoFeaturesAvailable.
 Calls empty() internally. Providers should override empty()
 instead if they provide an optimized version of this call.
 
-.. versionadded:: 3.4
-
 .. seealso:: :py:func:`empty`
+
+.. versionadded:: 3.4
 %End
 
     virtual QgsFields fields() const = 0;

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -124,6 +124,21 @@ Number of features in the layer
 :return: long containing number of features
 %End
 
+    virtual bool empty() const;
+%Docstring
+Returns true if the layer contains at least one feature.
+
+.. versionadded:: 3.2
+%End
+
+    virtual bool emptyUnknown() const;
+%Docstring
+For QgsVectorDataProviders this always returns true because
+the provider is actually queried for features.
+
+.. versionadded:: 3.2
+%End
+
     virtual QgsFields fields() const = 0;
 
 %Docstring

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -939,6 +939,18 @@ calculated by countSymbolFeatures()
 :return: number of features rendered by symbol or -1 if failed or counts are not available
 %End
 
+    virtual bool empty() const;
+
+%Docstring
+Determines if this vector layer is empty.
+A layer is considered empty if either the data provider or
+the edit buffer have features in them.
+This means, in case the data provider contains features which have all
+been deleted in the edit buffer, the result will be false.
+
+.. versionadded:: 3.2
+%End
+
  void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false ) /Deprecated/;
 %Docstring
 Update the data source of the layer. The layer's renderer and legend will be preserved only

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -943,10 +943,14 @@ calculated by countSymbolFeatures()
 
 %Docstring
 Determines if this vector layer is empty.
-A layer is considered empty if either the data provider or
-the edit buffer have features in them.
-This means, in case the data provider contains features which have all
-been deleted in the edit buffer, the result will be false.
+
+.. warning::
+
+   A layer is considered empty if neither the data provider nor
+   the edit buffer have features in them.
+   This means the returned value may be inaccurate for layers with unsaved changes,
+   i.e. in the case of all features from the data provider having been
+   deleted within the edit buffer.
 
 .. versionadded:: 3.2
 %End

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -939,10 +939,10 @@ calculated by countSymbolFeatures()
 :return: number of features rendered by symbol or -1 if failed or counts are not available
 %End
 
-    virtual bool empty() const;
+    virtual FeatureAvailability hasFeatures() const;
 
 %Docstring
-Determines if this vector layer is empty.
+Determines if this vector layer has features.
 
 .. warning::
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -946,13 +946,12 @@ Determines if this vector layer has features.
 
 .. warning::
 
-   A layer is considered empty if neither the data provider nor
-   the edit buffer have features in them.
-   This means the returned value may be inaccurate for layers with unsaved changes,
-   i.e. in the case of all features from the data provider having been
-   deleted within the edit buffer.
+   when a layer is editable and some features
+   have been deleted, this will return
+   QgsFeatureSource.FeatureAvailability.FeaturesMayBeAvailable
+   to avoid a potentially expensive call to the dataprovider.
 
-.. versionadded:: 3.2
+.. versionadded:: 3.4
 %End
 
  void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false ) /Deprecated/;

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -723,10 +723,14 @@ QgsFeatureIterator QgsProcessingFeatureSource::getFeatures( const QgsFeatureRequ
 
 QgsFeatureSource::FeatureAvailability QgsProcessingFeatureSource::hasFeatures() const
 {
-  if ( !mTransformErrorCallback && !mInvalidGeometryCallback && mInvalidGeometryCheck == QgsFeatureRequest::GeometryNoCheck )
-    return mSource->hasFeatures();
+  FeatureAvailability sourceAvailability = mSource->hasFeatures();
+  if ( sourceAvailability == NoFeaturesAvailable )
+    return NoFeaturesAvailable; // never going to be features if underlying source has no features
+  else if ( mInvalidGeometryCheck == QgsFeatureRequest::GeometryNoCheck )
+    return sourceAvailability;
   else
-    return QgsFeatureSource::FeaturesMaybeAvailable;
+    // we don't know... source has features, but these may be filtered out by invalid geometry check
+    return FeaturesMaybeAvailable;
 }
 
 QgsFeatureIterator QgsProcessingFeatureSource::getFeatures( const QgsFeatureRequest &request ) const

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -721,6 +721,14 @@ QgsFeatureIterator QgsProcessingFeatureSource::getFeatures( const QgsFeatureRequ
   return mSource->getFeatures( req );
 }
 
+QgsFeatureSource::FeatureAvailability QgsProcessingFeatureSource::hasFeatures() const
+{
+  if ( !mTransformErrorCallback && !mInvalidGeometryCallback && mInvalidGeometryCheck == QgsFeatureRequest::GeometryNoCheck )
+    return mSource->hasFeatures();
+  else
+    return QgsFeatureSource::FeaturesMaybeAvailable;
+}
+
 QgsFeatureIterator QgsProcessingFeatureSource::getFeatures( const QgsFeatureRequest &request ) const
 {
   QgsFeatureRequest req( request );

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -317,6 +317,8 @@ class CORE_EXPORT QgsProcessingFeatureSource : public QgsFeatureSource
      */
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request, Flags flags ) const;
 
+    QgsFeatureSource::FeatureAvailability hasFeatures() const override;
+
     QgsFeatureIterator getFeatures( const QgsFeatureRequest &request = QgsFeatureRequest() ) const override;
     QgsCoordinateReferenceSystem sourceCrs() const override;
     QgsFields fields() const override;

--- a/src/core/qgsfeaturesource.cpp
+++ b/src/core/qgsfeaturesource.cpp
@@ -23,14 +23,9 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 
-bool QgsFeatureSource::empty() const
+QgsFeatureSource::FeatureAvailability QgsFeatureSource::hasFeatures() const
 {
-  return featureCount();
-}
-
-bool QgsFeatureSource::emptyUnknown() const
-{
-  return featureCount() == -1;
+  return FeaturesMaybeAvailable;
 }
 
 QSet<QVariant> QgsFeatureSource::uniqueValues( int fieldIndex, int limit ) const

--- a/src/core/qgsfeaturesource.cpp
+++ b/src/core/qgsfeaturesource.cpp
@@ -23,6 +23,16 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 
+bool QgsFeatureSource::empty() const
+{
+  return featureCount();
+}
+
+bool QgsFeatureSource::emptyUnknown() const
+{
+  return featureCount() == -1;
+}
+
 QSet<QVariant> QgsFeatureSource::uniqueValues( int fieldIndex, int limit ) const
 {
   if ( fieldIndex < 0 || fieldIndex >= fields().count() )

--- a/src/core/qgsfeaturesource.h
+++ b/src/core/qgsfeaturesource.h
@@ -37,6 +37,12 @@ class QgsFeedback;
 class CORE_EXPORT QgsFeatureSource
 {
   public:
+    enum FeatureAvailability
+    {
+      NoFeaturesAvailable, //!< There are certainly no features available in this source
+      FeaturesAvailable, //!< There is at least one feature available in this source
+      FeaturesMaybeAvailable //!< There may be features available in this source
+    };
 
     virtual ~QgsFeatureSource() = default;
 
@@ -88,23 +94,9 @@ class CORE_EXPORT QgsFeatureSource
     /**
      * Determines if there are any features available in the source.
      *
-     * In case it is not known if there are features available, false is returned.
-     * Use ``emptyUnknown()`` to determine if this value is reliable.
-     *
-     * \see QgsVectorDataProvider::empty() for data provider specific
-     *      information.
-     *
      * \since QGIS 3.2
      */
-    virtual bool empty() const;
-
-    /**
-     * Returns true if the value returned by ``empty()`` may be wrong.
-     * This depends on the dataprovider.
-     *
-     * \since QGIS 3.2
-     */
-    virtual bool emptyUnknown() const;
+    virtual FeatureAvailability hasFeatures() const;
 
     /**
      * Returns the set of unique values contained within the specified \a fieldIndex from this source.

--- a/src/core/qgsfeaturesource.h
+++ b/src/core/qgsfeaturesource.h
@@ -86,6 +86,27 @@ class CORE_EXPORT QgsFeatureSource
     virtual long featureCount() const = 0;
 
     /**
+     * Determines if there are any features available in the source.
+     *
+     * In case it is not known if there are features available, false is returned.
+     * Use ``emptyUnknown()`` to determine if this value is reliable.
+     *
+     * \see QgsVectorDataProvider::empty() for data provider specific
+     *      information.
+     *
+     * \since QGIS 3.2
+     */
+    virtual bool empty() const;
+
+    /**
+     * Returns true if the value returned by ``empty()`` may be wrong.
+     * This depends on the dataprovider.
+     *
+     * \since QGIS 3.2
+     */
+    virtual bool emptyUnknown() const;
+
+    /**
      * Returns the set of unique values contained within the specified \a fieldIndex from this source.
      * If specified, the \a limit option can be used to limit the number of returned values.
      * The base class implementation uses a non-optimised approach of looping through
@@ -150,7 +171,6 @@ class CORE_EXPORT QgsFeatureSource
      */
     QgsVectorLayer *materialize( const QgsFeatureRequest &request,
                                  QgsFeedback *feedback = nullptr ) SIP_FACTORY;
-
 };
 
 Q_DECLARE_METATYPE( QgsFeatureSource * )

--- a/src/core/qgsfeaturesource.h
+++ b/src/core/qgsfeaturesource.h
@@ -37,6 +37,16 @@ class QgsFeedback;
 class CORE_EXPORT QgsFeatureSource
 {
   public:
+
+    /**
+     * Return value for hasFeatures() to determine if a source is empty.
+     * It is implemented as a three-value logic, so it can return if
+     * there are features available for sure, if there are no features
+     * available for sure or if there might be features available but
+     * there is no guarantee for this.
+     *
+     * \since QGIS 3.4
+     */
     enum FeatureAvailability
     {
       NoFeaturesAvailable, //!< There are certainly no features available in this source

--- a/src/core/qgsfeaturesource.h
+++ b/src/core/qgsfeaturesource.h
@@ -39,7 +39,7 @@ class CORE_EXPORT QgsFeatureSource
   public:
 
     /**
-     * Return value for hasFeatures() to determine if a source is empty.
+     * Possible return value for hasFeatures() to determine if a source is empty.
      * It is implemented as a three-value logic, so it can return if
      * there are features available for sure, if there are no features
      * available for sure or if there might be features available but

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -49,7 +49,11 @@ QString QgsVectorDataProvider::storageType() const
 bool QgsVectorDataProvider::empty() const
 {
   QgsFeature f;
-  if ( getFeatures().nextFeature( f ) )
+  QgsFeatureRequest request;
+  request.setSubsetOfAttributes( QgsAttributeList() );
+  request.setFlags( QgsFeatureRequest::NoGeometry );
+  request.setLimit( 1 );
+  if ( getFeatures( request ).nextFeature( f ) )
     return true;
   else
     return false;

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -46,6 +46,20 @@ QString QgsVectorDataProvider::storageType() const
   return QStringLiteral( "Generic vector file" );
 }
 
+bool QgsVectorDataProvider::empty() const
+{
+  QgsFeature f;
+  if ( getFeatures().nextFeature( f ) )
+    return true;
+  else
+    return false;
+}
+
+bool QgsVectorDataProvider::emptyUnknown() const
+{
+  return false;
+}
+
 QgsCoordinateReferenceSystem QgsVectorDataProvider::sourceCrs() const
 {
   return crs();

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -59,9 +59,12 @@ bool QgsVectorDataProvider::empty() const
     return false;
 }
 
-bool QgsVectorDataProvider::emptyUnknown() const
+QgsFeatureSource::FeatureAvailability QgsVectorDataProvider::hasFeatures() const
 {
-  return false;
+  if ( empty() )
+    return QgsFeatureSource::FeatureAvailability::NoFeaturesAvailable;
+  else
+    return QgsFeatureSource::FeatureAvailability::FeaturesAvailable;
 }
 
 QgsCoordinateReferenceSystem QgsVectorDataProvider::sourceCrs() const

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -54,9 +54,9 @@ bool QgsVectorDataProvider::empty() const
   request.setFlags( QgsFeatureRequest::NoGeometry );
   request.setLimit( 1 );
   if ( getFeatures( request ).nextFeature( f ) )
-    return true;
-  else
     return false;
+  else
+    return true;
 }
 
 QgsFeatureSource::FeatureAvailability QgsVectorDataProvider::hasFeatures() const

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -166,7 +166,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
     /**
      * Returns true if the layer contains at least one feature.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.4
      */
     virtual bool empty() const;
 
@@ -177,7 +177,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * Calls empty() internally. Providers should override empty()
      * instead if they provide an optimized version of this call.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.4
      * \see empty()
      */
     virtual QgsFeatureSource::FeatureAvailability hasFeatures() const final;

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -164,6 +164,21 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
     long featureCount() const override = 0;
 
     /**
+     * Returns true if the layer contains at least one feature.
+     *
+     * \since QGIS 3.2
+     */
+    virtual bool empty() const override;
+
+    /**
+     * For QgsVectorDataProviders this always returns true because
+     * the provider is actually queried for features.
+     *
+     * \since QGIS 3.2
+     */
+    virtual bool emptyUnknown() const override;
+
+    /**
      * Returns the fields associated with this data provider.
      */
     QgsFields fields() const override = 0;

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -168,15 +168,19 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      *
      * \since QGIS 3.2
      */
-    virtual bool empty() const override;
+    virtual bool empty() const;
 
     /**
-     * For QgsVectorDataProviders this always returns true because
-     * the provider is actually queried for features.
+     * Will always return FeatureAvailability::FeaturesAvailable or
+     * FeatureAvailability::FeaturesMaybeAvailable.
+     *
+     * Calls empty() internally. Providers should override empty instead
+     * if they provide an optimized version of this call.
      *
      * \since QGIS 3.2
+     * \see empty()
      */
-    virtual bool emptyUnknown() const override;
+    virtual QgsFeatureSource::FeatureAvailability hasFeatures() const override;
 
     /**
      * Returns the fields associated with this data provider.

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -177,8 +177,8 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * Calls empty() internally. Providers should override empty()
      * instead if they provide an optimized version of this call.
      *
-     * \since QGIS 3.4
      * \see empty()
+     * \since QGIS 3.4
      */
     virtual QgsFeatureSource::FeatureAvailability hasFeatures() const final;
 

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -180,7 +180,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * \since QGIS 3.2
      * \see empty()
      */
-    virtual QgsFeatureSource::FeatureAvailability hasFeatures() const override;
+    virtual QgsFeatureSource::FeatureAvailability hasFeatures() const final;
 
     /**
      * Returns the fields associated with this data provider.

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -172,10 +172,10 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
 
     /**
      * Will always return FeatureAvailability::FeaturesAvailable or
-     * FeatureAvailability::FeaturesMaybeAvailable.
+     * FeatureAvailability::NoFeaturesAvailable.
      *
-     * Calls empty() internally. Providers should override empty instead
-     * if they provide an optimized version of this call.
+     * Calls empty() internally. Providers should override empty()
+     * instead if they provide an optimized version of this call.
      *
      * \since QGIS 3.2
      * \see empty()

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2767,8 +2767,8 @@ long QgsVectorLayer::featureCount() const
 
 QgsFeatureSource::FeatureAvailability QgsVectorLayer::hasFeatures() const
 {
-  const QgsFeatureIds deletedFeatures = mEditBuffer->deletedFeatureIds();
-  const QgsFeatureMap addedFeatures = mEditBuffer->addedFeatures();
+  const QgsFeatureIds deletedFeatures( mEditBuffer ? mEditBuffer->deletedFeatureIds() : QgsFeatureIds() );
+  const QgsFeatureMap addedFeatures( mEditBuffer ? mEditBuffer->addedFeatures() : QgsFeatureMap() );
 
   if ( mEditBuffer && !deletedFeatures.empty() )
   {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2767,7 +2767,18 @@ long QgsVectorLayer::featureCount() const
 
 QgsFeatureSource::FeatureAvailability QgsVectorLayer::hasFeatures() const
 {
-  if ( mDataProvider->empty() && ( !mEditBuffer || mEditBuffer->addedFeatures().empty() ) )
+  const QgsFeatureIds deletedFeatures = mEditBuffer->deletedFeatureIds();
+  const QgsFeatureMap addedFeatures = mEditBuffer->addedFeatures();
+
+  if ( mEditBuffer && !deletedFeatures.empty() )
+  {
+    if ( addedFeatures.size() > deletedFeatures.size() )
+      return QgsFeatureSource::FeatureAvailability::FeaturesAvailable;
+    else
+      return QgsFeatureSource::FeatureAvailability::FeaturesMaybeAvailable;
+  }
+
+  if ( ( !mEditBuffer || addedFeatures.empty() ) && mDataProvider->empty() )
     return QgsFeatureSource::FeatureAvailability::NoFeaturesAvailable;
   else
     return QgsFeatureSource::FeatureAvailability::FeaturesAvailable;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -704,6 +704,8 @@ long QgsVectorLayer::featureCount( const QString &legendKey ) const
   return mSymbolFeatureCountMap.value( legendKey );
 }
 
+
+
 QgsVectorLayerFeatureCounter *QgsVectorLayer::countSymbolFeatures()
 {
   if ( mSymbolFeatureCounted || mFeatureCounter )
@@ -2761,6 +2763,11 @@ long QgsVectorLayer::featureCount() const
 {
   return mDataProvider->featureCount() +
          ( mEditBuffer ? mEditBuffer->mAddedFeatures.size() - mEditBuffer->mDeletedFeatureIds.size() : 0 );
+}
+
+bool QgsVectorLayer::empty() const
+{
+  return mDataProvider->empty() && ( !mEditBuffer || mEditBuffer->addedFeatures().empty() );
 }
 
 bool QgsVectorLayer::commitChanges()

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2765,9 +2765,12 @@ long QgsVectorLayer::featureCount() const
          ( mEditBuffer ? mEditBuffer->mAddedFeatures.size() - mEditBuffer->mDeletedFeatureIds.size() : 0 );
 }
 
-bool QgsVectorLayer::empty() const
+QgsFeatureSource::FeatureAvailability QgsVectorLayer::hasFeatures() const
 {
-  return mDataProvider->empty() && ( !mEditBuffer || mEditBuffer->addedFeatures().empty() );
+  if ( mDataProvider->empty() && ( !mEditBuffer || mEditBuffer->addedFeatures().empty() ) )
+    return QgsFeatureSource::FeatureAvailability::NoFeaturesAvailable;
+  else
+    return QgsFeatureSource::FeatureAvailability::FeaturesAvailable;
 }
 
 bool QgsVectorLayer::commitChanges()

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -930,6 +930,17 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     long featureCount( const QString &legendKey ) const;
 
     /**
+     * Determines if this vector layer is empty.
+     * A layer is considered empty if either the data provider or
+     * the edit buffer have features in them.
+     * This means, in case the data provider contains features which have all
+     * been deleted in the edit buffer, the result will be false.
+     *
+     * \since QGIS 3.2
+     */
+    bool empty() const override;
+
+    /**
      * Update the data source of the layer. The layer's renderer and legend will be preserved only
      * if the geometry type of the new data source matches the current geometry type of the layer.
      * \param dataSource new layer data source

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -931,10 +931,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Determines if this vector layer is empty.
-     * A layer is considered empty if either the data provider or
+     *
+     * \warning A layer is considered empty if neither the data provider nor
      * the edit buffer have features in them.
-     * This means, in case the data provider contains features which have all
-     * been deleted in the edit buffer, the result will be false.
+     * This means the returned value may be inaccurate for layers with unsaved changes,
+     * i.e. in the case of all features from the data provider having been
+     * deleted within the edit buffer.
      *
      * \since QGIS 3.2
      */

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -932,13 +932,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Determines if this vector layer has features.
      *
-     * \warning A layer is considered empty if neither the data provider nor
-     * the edit buffer have features in them.
-     * This means the returned value may be inaccurate for layers with unsaved changes,
-     * i.e. in the case of all features from the data provider having been
-     * deleted within the edit buffer.
+     * \warning when a layer is editable and some features
+     * have been deleted, this will return
+     * QgsFeatureSource::FeatureAvailability::FeaturesMayBeAvailable
+     * to avoid a potentially expensive call to the dataprovider.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.4
      */
     FeatureAvailability hasFeatures() const override;
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -930,7 +930,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     long featureCount( const QString &legendKey ) const;
 
     /**
-     * Determines if this vector layer is empty.
+     * Determines if this vector layer has features.
      *
      * \warning A layer is considered empty if neither the data provider nor
      * the edit buffer have features in them.
@@ -940,7 +940,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \since QGIS 3.2
      */
-    bool empty() const override;
+    FeatureAvailability hasFeatures() const override;
 
     /**
      * Update the data source of the layer. The layer's renderer and legend will be preserved only

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3187,6 +3187,19 @@ long QgsPostgresProvider::featureCount() const
   return num;
 }
 
+bool QgsPostgresProvider::empty() const
+{
+  QString sql = QStringLiteral( "SELECT EXISTS (SELECT * FROM %1%2 LIMIT 1)" ).arg( mQuery, filterWhereClause() );
+  QgsPostgresResult res( connectionRO()->PQexec( sql ) );
+  if ( res.PQresultStatus() != PGRES_TUPLES_OK )
+  {
+    pushError( res.PQresultErrorMessage() );
+    return false;
+  }
+
+  return res.PQgetvalue( 0, 0 ) != 't';
+}
+
 QgsRectangle QgsPostgresProvider::extent() const
 {
   if ( mGeometryColumn.isNull() )

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -110,7 +110,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     long featureCount() const override;
 
     /**
-     * Determines if there is at least one feature avaiable on this table.
+     * Determines if there is at least one feature available on this table.
      *
      * \note In contrast to the featureCount() method, this method is not
      *       affected by estimated metadata.

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -110,6 +110,16 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     long featureCount() const override;
 
     /**
+     * Determines if there is at least one feature avaiable on this table.
+     *
+     * \note In contrast to the featureCount() method, this method is not
+     *       affected by estimated metadata.
+     *
+     * \since QGIS 3.2
+     */
+    bool empty() const override;
+
+    /**
      * Returns a string representation of the endian-ness for the layer
      */
     static QString endianString();

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -115,7 +115,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      * \note In contrast to the featureCount() method, this method is not
      *       affected by estimated metadata.
      *
-     * \since QGIS 3.2
+     * \since QGIS 3.4
      */
     bool empty() const override;
 

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1199,6 +1199,27 @@ QString QgsWFSProvider::translateMetadataValue( const QString &mdKey, const QVar
   {
     return value.toString();
   }
+}
+
+bool QgsWFSProvider::empty() const
+{
+  QgsFeature f;
+  QgsFeatureRequest request;
+  request.setSubsetOfAttributes( QgsAttributeList() );
+  request.setFlags( QgsFeatureRequest::NoGeometry );
+
+  // Whoops, the WFS provider returns an empty iterator when we are using
+  // a setLimit call in combination with a subsetString.
+  // Remove this method (and default to the QgsVectorDataProvider one)
+  // once this is fixed
+#if 0
+  request.setLimit( 1 );
+#endif
+  if ( getFeatures( request ).nextFeature( f ) )
+    return false;
+  else
+    return true;
+
 };
 
 bool QgsWFSProvider::describeFeatureType( QString &geometryAttribute, QgsFields &fields, QgsWkbTypes::Type &geomType )

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -111,6 +111,8 @@ class QgsWFSProvider : public QgsVectorDataProvider
     QString translateMetadataKey( const QString &mdKey ) const override;
     QString translateMetadataValue( const QString &mdKey, const QVariant &value ) const override;
 
+    bool empty() const override;
+
   public slots:
 
     void reloadData() override;

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -433,6 +433,26 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.source.setSubsetString(None)
             self.assertFalse(self.source.empty())
 
+        # If the provider supports tests on editable layers
+        if getattr(self, 'getEditableLayer', None):
+            l = self.getEditableLayer()
+            self.assertTrue(l.isValid())
+
+            self.assertEqual(l.hasFeatures(), QgsFeatureSource.FeaturesAvailable)
+
+            # Test that deleting some features in the edit buffer does not
+            # return empty, we accept FeaturesAvailable as well as
+            # MaybeAvailable
+            l.startEditing()
+            l.deleteFeature(next(l.getFeatures()).id())
+            self.assertNotEqual(l.hasFeatures(), QgsFeatureSource.NoFeaturesAvailable)
+            l.rollBack()
+
+            # Call truncate(), we need an empty set now
+            l.dataProvider().truncate()
+            self.assertTrue(l.dataProvider().empty())
+            self.assertEqual(l.dataProvider().hasFeatures(), QgsFeatureSource.NoFeaturesAvailable)
+
     def testGetFeaturesNoGeometry(self):
         """ Test that no geometry is present when fetching features without geometry"""
 

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -28,6 +28,7 @@ from qgis.core import (
     QgsVectorLayerFeatureSource,
     QgsFeatureSink,
     QgsTestUtils,
+    QgsFeatureSource,
     NULL
 )
 
@@ -417,16 +418,18 @@ class ProviderTestCase(FeatureSourceTestCase):
 
     def testEmpty(self):
         self.assertFalse(self.source.empty())
-        self.assertFalse(self.source.emptyUnknown())
+        self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.FeaturesAvailable)
 
         if self.source.supportsSubsetString():
             # Add a subset string and test feature count
             subset = self.getSubsetString()
             self.source.setSubsetString(subset)
             self.assertFalse(self.source.empty())
+            self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.FeaturesAvailable)
             subsetNoMatching = getSubsetStringNoMatching(self)
             self.source.setSubsetString(subsetNoMatching)
             self.assertTrue(self.source.empty())
+            self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.NoFeaturesAvailable)
             self.source.setSubsetString(None)
             self.assertFalse(self.source.empty())
 

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -415,6 +415,21 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.assertEqual(count, 0)
             self.assertEqual(self.source.featureCount(), 5)
 
+    def testEmpty(self):
+        self.assertFalse(self.source.empty())
+        self.assertFalse(self.source.emptyUnknown())
+
+        if self.source.supportsSubsetString():
+            # Add a subset string and test feature count
+            subset = self.getSubsetString()
+            self.source.setSubsetString(subset)
+            self.assertFalse(self.source.empty())
+            subsetNoMatching = getSubsetStringNoMatching(self)
+            self.source.setSubsetString(subsetNoMatching)
+            self.assertTrue(self.source.empty())
+            self.source.setSubsetString(None)
+            self.assertFalse(self.source.empty())
+
     def testGetFeaturesNoGeometry(self):
         """ Test that no geometry is present when fetching features without geometry"""
 

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -421,6 +421,7 @@ class ProviderTestCase(FeatureSourceTestCase):
         self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.FeaturesAvailable)
 
         if self.source.supportsSubsetString():
+            backup = self.source.subsetString()
             # Add a subset string and test feature count
             subset = self.getSubsetString()
             self.source.setSubsetString(subset)
@@ -432,6 +433,7 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.NoFeaturesAvailable)
             self.source.setSubsetString(None)
             self.assertFalse(self.source.empty())
+            self.source.setSubsetString(backup)
 
         # If the provider supports tests on editable layers
         if getattr(self, 'getEditableLayer', None):

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -421,19 +421,20 @@ class ProviderTestCase(FeatureSourceTestCase):
         self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.FeaturesAvailable)
 
         if self.source.supportsSubsetString():
-            backup = self.source.subsetString()
-            # Add a subset string and test feature count
-            subset = self.getSubsetString()
-            self.source.setSubsetString(subset)
+            try:
+                backup = self.source.subsetString()
+                # Add a subset string and test feature count
+                subset = self.getSubsetString()
+                self.source.setSubsetString(subset)
+                self.assertFalse(self.source.empty())
+                self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.FeaturesAvailable)
+                subsetNoMatching = self.getSubsetStringNoMatching()
+                self.source.setSubsetString(subsetNoMatching)
+                self.assertTrue(self.source.empty())
+                self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.NoFeaturesAvailable)
+            finally:
+                self.source.setSubsetString(None)
             self.assertFalse(self.source.empty())
-            self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.FeaturesAvailable)
-            subsetNoMatching = self.getSubsetStringNoMatching()
-            self.source.setSubsetString(subsetNoMatching)
-            self.assertTrue(self.source.empty())
-            self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.NoFeaturesAvailable)
-            self.source.setSubsetString(None)
-            self.assertFalse(self.source.empty())
-            self.source.setSubsetString(backup)
 
         # If the provider supports tests on editable layers
         if getattr(self, 'getEditableLayer', None):

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -426,7 +426,7 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.source.setSubsetString(subset)
             self.assertFalse(self.source.empty())
             self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.FeaturesAvailable)
-            subsetNoMatching = getSubsetStringNoMatching(self)
+            subsetNoMatching = self.getSubsetStringNoMatching()
             self.source.setSubsetString(subsetNoMatching)
             self.assertTrue(self.source.empty())
             self.assertEqual(self.source.hasFeatures(), QgsFeatureSource.NoFeaturesAvailable)


### PR DESCRIPTION
The main reason is

 * It looks nice
 * It's more performant than checking `source.count() == 0`
 * It also works reliably on pg layers with estimated metadata enabled
