### PR TITLE
remove old color key when restoring copyright decorator from pre-3.2 projects

### DIFF
--- a/src/app/qgsdecorationcopyright.cpp
+++ b/src/app/qgsdecorationcopyright.cpp
@@ -81,6 +81,7 @@ void QgsDecorationCopyright::projectRead()
   if ( oldColor.isValid() )
   {
     mTextFormat.setColor( oldColor );
+    QgsProject::instance()->removeEntry( mNameConfig, QStringLiteral( "/Color" ) );
   }
 }
 


### PR DESCRIPTION
## Description
If the key isn't removed, the value remains attached to the project, and always overwrites the color set through the font settings dialog.

@nyalldawson , sounds good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
