### PR TITLE
[processing] Fixes combobox content based on enum in modeler

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -984,9 +984,8 @@ class EnumWidgetWrapper(WidgetWrapper):
                 return widget
         else:
             self.combobox = QComboBox()
-            values = self.dialog.getAvailableValuesOfType(QgsProcessingParameterEnum)
-            for v in values:
-                self.combobox.addItem(self.dialog.resolveValueDescription(v), v)
+            for i, option in enumerate(self.param.options()):
+                self.combobox.addItem(option, i)
             return self.combobox
 
     def setValue(self, value):


### PR DESCRIPTION
## Description

Comboboxes based on enum are not correctly populated (no items) when algorithms are executed from the modeler.

An example with the `Heatmap` algorithm run from the modeler (same behavior with ExecuteSQL, Random Selection, and so on):

![untitled](https://user-images.githubusercontent.com/9266424/40249722-c9b821e2-5acb-11e8-8865-0c844e133d2c.png)

It seems to come from this commit https://github.com/qgis/QGIS/commit/1ba34dcbeaea010ee0d2c32fcde385e6398617ee.

@nyalldawson @alexbruy I'm not very comfortable with the modeler source code, so I'm really not sure it's a good bugfix. Can you take a look? Thanks :).

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
