### PR TITLE
[needs-docs][processing] Open existing script toolbar action

### DIFF
--- a/python/plugins/processing/modeler/AddModelFromFileAction.py
+++ b/python/plugins/processing/modeler/AddModelFromFileAction.py
@@ -42,7 +42,7 @@ pluginPath = os.path.split(os.path.dirname(__file__))[0]
 class AddModelFromFileAction(ToolboxAction):
 
     def __init__(self):
-        self.name = QCoreApplication.translate('AddModelFromFileAction', 'Add Model from File…')
+        self.name = QCoreApplication.translate('AddModelFromFileAction', 'Add Model to Toolbox…')
         self.group = self.tr('Tools')
 
     def getIcon(self):

--- a/python/plugins/processing/script/AddScriptFromFileAction.py
+++ b/python/plugins/processing/script/AddScriptFromFileAction.py
@@ -41,7 +41,7 @@ from processing.script import ScriptUtils
 class AddScriptFromFileAction(ToolboxAction):
 
     def __init__(self):
-        self.name = QCoreApplication.translate("AddScriptFromFileAction", "Add Script from File…")
+        self.name = QCoreApplication.translate("AddScriptFromFileAction", "Add Script to Toolbox…")
         self.group = self.tr("Tools")
 
     def execute(self):

--- a/python/plugins/processing/script/OpenScriptFromFileAction.py
+++ b/python/plugins/processing/script/OpenScriptFromFileAction.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    OpenScriptFromFileAction.py
+    ---------------------
+    Date                 : May 2018
+    Copyright            : (C) 2018 by Mathieu Pellerin
+    Email                : nirvn dot asia at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Nyall Dawson'
+__date__ = 'February 2018'
+__copyright__ = '(C) 2018, Nyall Dawson'
+
+# This will get replaced with a git SHA1 when you do a git archive
+
+__revision__ = '$Format:%H$'
+
+import os
+from qgis.PyQt.QtWidgets import QFileDialog
+from qgis.PyQt.QtCore import QFileInfo, QCoreApplication
+
+from qgis.core import QgsApplication, QgsSettings
+
+from processing.gui.ToolboxAction import ToolboxAction
+from processing.script.ScriptEditorDialog import ScriptEditorDialog
+
+pluginPath = os.path.split(os.path.dirname(__file__))[0]
+
+
+class OpenScriptFromFileAction(ToolboxAction):
+
+    def __init__(self):
+        self.name = QCoreApplication.translate('OpenScriptFromFileAction', 'Open Existing Script…')
+        self.group = self.tr('Tools')
+
+    def getIcon(self):
+        return QgsApplication.getThemeIcon("/processingScript.svg")
+
+    def execute(self):
+        settings = QgsSettings()
+        lastDir = settings.value('Processing/lastScriptsDir', '')
+        filename, selected_filter = QFileDialog.getOpenFileName(self.toolbox,
+                                                                self.tr('Open Script', 'AddScriptFromFileAction'), lastDir,
+                                                                self.tr('Script files (*.py)', 'AddScriptFromFileAction'))
+        if filename:
+            settings.setValue('Processing/lastScriptsDir',
+                              QFileInfo(filename).absoluteDir().absolutePath())
+
+            dlg = ScriptEditorDialog(filePath=filename)
+            dlg.show()

--- a/python/plugins/processing/script/ScriptAlgorithmProvider.py
+++ b/python/plugins/processing/script/ScriptAlgorithmProvider.py
@@ -40,6 +40,7 @@ from processing.script.CreateNewScriptAction import CreateNewScriptAction
 from processing.script.AddScriptFromTemplateAction import AddScriptFromTemplateAction
 from processing.script.DeleteScriptAction import DeleteScriptAction
 from processing.script.EditScriptAction import EditScriptAction
+from processing.script.OpenScriptFromFileAction import OpenScriptFromFileAction
 from processing.script import ScriptUtils
 
 
@@ -51,6 +52,7 @@ class ScriptAlgorithmProvider(QgsProcessingProvider):
         self.folder_algorithms = []
         self.actions = [CreateNewScriptAction(),
                         AddScriptFromTemplateAction(),
+                        OpenScriptFromFileAction(),
                         AddScriptFromFileAction()
                         ]
         self.contextMenuActions = [EditScriptAction(),


### PR DESCRIPTION
## Description
![screenshot from 2018-05-20 17-21-58](https://user-images.githubusercontent.com/1728657/40277965-7faa9160-5c52-11e8-8fc4-5fbc5a015109.png)

It's a must when you are developing a script (prior to its final version, when the add script to toolbox action becomes relevant).

@nyalldawson , that takes care of the final pain I had when developing  a script through the processing script editor. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
