### PR TITLE
Add QgsDataProvider::ProviderOptions struct to data provider constructors 

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -268,7 +268,7 @@ Responsible for reading native mesh data
 #include "qgsmeshdataprovider.h"
 %End
   public:
-    QgsMeshDataProvider( const QString &uri = QString() );
+    QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 %Docstring
 Ctor
 %End

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -77,7 +77,13 @@ is the MDAL connection string. QGIS must be built with MDAL support to allow thi
 %End
   public:
 
-    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory" );
+    struct LayerOptions
+    {
+
+    };
+
+    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
+                           const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );
 %Docstring
 Constructor - creates a mesh layer
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -95,6 +95,7 @@ data.
 parameters used by the data provider as url query items.
 :param baseName: The name used to represent the layer in the legend
 :param providerLib:  The name of the data provider, e.g., "mesh_memory", "mdal"
+:param options: general mesh layer options
 %End
     ~QgsMeshLayer();
 

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -70,7 +70,7 @@ to generic QgsVectorDataProvider's) depends on it.
 
     };
 
-    QgsDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 %Docstring
 Create a new dataprovider with the specified in the ``uri``.
 

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -64,9 +64,17 @@ to generic QgsVectorDataProvider's) depends on it.
       CustomData
     };
 
-    QgsDataProvider( const QString &uri = QString() );
+
+    struct ProviderOptions
+    {
+
+    };
+
+    QgsDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 %Docstring
 Create a new dataprovider with the specified in the ``uri``.
+
+Additional creation options are specified within the ``options`` value.
 %End
 
     virtual QgsCoordinateReferenceSystem crs() const = 0;

--- a/python/core/auto_generated/qgsprovidermetadata.sip.in
+++ b/python/core/auto_generated/qgsprovidermetadata.sip.in
@@ -10,7 +10,6 @@
 
 
 
-
 class QgsProviderMetadata
 {
 %Docstring

--- a/python/core/auto_generated/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/qgsproviderregistry.sip.in
@@ -74,7 +74,7 @@ Set library directory where to search for plugins
 
     QgsDataProvider *createProvider( const QString &providerKey,
                                      const QString &dataSource,
-                                     const QgsDataProvider::ProviderOptions &options ) /Factory/;
+                                     const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() ) /Factory/;
 %Docstring
 Creates a new instance of a provider.
 

--- a/python/core/auto_generated/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/qgsproviderregistry.sip.in
@@ -73,12 +73,14 @@ Set library directory where to search for plugins
 %End
 
     QgsDataProvider *createProvider( const QString &providerKey,
-                                     const QString &dataSource ) /Factory/;
+                                     const QString &dataSource,
+                                     const QgsDataProvider::ProviderOptions &options ) /Factory/;
 %Docstring
 Creates a new instance of a provider.
 
 :param providerKey: identificator of the provider
 :param dataSource:  string containing data source for the provider
+:param options: provider options
 
 :return: new instance of provider or NULL on error
 %End

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -67,7 +67,7 @@ of feature and attribute information from a spatial datasource.
       UnknownCount,
     };
 
-    QgsVectorDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsVectorDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 %Docstring
 Constructor for a vector data provider.
 

--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -67,11 +67,13 @@ of feature and attribute information from a spatial datasource.
       UnknownCount,
     };
 
-    QgsVectorDataProvider( const QString &uri = QString() );
+    QgsVectorDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 %Docstring
-Constructor of the vector provider
+Constructor for a vector data provider.
 
-:param uri:  uniform resource locator (URI) for a dataset
+The ``uri`` argument specifies the uniform resource locator (URI) for the associated dataset.
+
+Additional creation options are specified within the ``options`` value.
 %End
 
     virtual QgsAbstractFeatureSource *featureSource() const = 0 /Factory/;

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -927,7 +927,7 @@ calculated by countSymbolFeatures()
 :return: number of features rendered by symbol or -1 if failed or counts are not available
 %End
 
-    void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false );
+ void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false ) /Deprecated/;
 %Docstring
 Update the data source of the layer. The layer's renderer and legend will be preserved only
 if the geometry type of the new data source matches the current geometry type of the layer.
@@ -939,6 +939,23 @@ if the geometry type of the new data source matches the current geometry type of
 data source
 
 .. versionadded:: 2.10
+
+.. deprecated:: Use version with ProviderOptions argument instead
+%End
+
+    void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, bool loadDefaultStyleFlag = false );
+%Docstring
+Updates the data source of the layer. The layer's renderer and legend will be preserved only
+if the geometry type of the new data source matches the current geometry type of the layer.
+
+:param dataSource: new layer data source
+:param baseName: base name of the layer
+:param provider: provider string
+:param options: provider options
+:param loadDefaultStyleFlag: set to true to reset the layer's style to the default for the
+data source
+
+.. versionadded:: 3.2
 %End
 
     virtual QString loadDefaultStyle( bool &resultFlag /Out/ );

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -82,7 +82,7 @@ Base class for raster data providers.
 
     QgsRasterDataProvider();
 
-    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 %Docstring
 Constructor for QgsRasterDataProvider.
 

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -82,7 +82,15 @@ Base class for raster data providers.
 
     QgsRasterDataProvider();
 
-    QgsRasterDataProvider( const QString &uri );
+    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+%Docstring
+Constructor for QgsRasterDataProvider.
+
+The ``uri`` argument gives a provider-specific uri indicating the underlying data
+source and it's parameters.
+
+The ``options`` argument specifies generic provider options.
+%End
 
     virtual QgsRasterInterface *clone() const = 0;
 

--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -180,9 +180,21 @@ returned in ``retError``.
 Return time stamp for given file name
 %End
 
-    void setDataProvider( const QString &provider );
+ void setDataProvider( const QString &provider ) /Deprecated/;
 %Docstring
-[ data provider interface ] Set the data provider
+Set the data provider.
+
+.. deprecated:: Use the version with ProviderOptions instead.
+%End
+
+    void setDataProvider( const QString &provider, const QgsDataProvider::ProviderOptions &options );
+%Docstring
+Set the data provider.
+
+:param provider: provider key string, must match a valid QgsRasterDataProvider key. E.g. "gdal", "wms", etc.
+:param options: provider options
+
+.. versionadded:: 3.2
 %End
 
     LayerType rasterType();

--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -18,8 +18,8 @@
 #include "qgsmeshdataprovider.h"
 #include "qgis.h"
 
-QgsMeshDataProvider::QgsMeshDataProvider( const QString &uri )
-  : QgsDataProvider( uri )
+QgsMeshDataProvider::QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options )
+  : QgsDataProvider( uri, options )
 {
 }
 

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -254,7 +254,7 @@ class CORE_EXPORT QgsMeshDataProvider: public QgsDataProvider, public QgsMeshDat
 
   public:
     //! Ctor
-    QgsMeshDataProvider( const QString &uri = QString() );
+    QgsMeshDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     /**
      * Returns the extent of the layer

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -30,12 +30,14 @@
 
 QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
                             const QString &baseName,
-                            const QString &providerKey )
+                            const QString &providerKey,
+                            const LayerOptions & )
   : QgsMapLayer( MeshLayer, baseName, meshLayerPath )
   , mProviderKey( providerKey )
 {
   // load data
-  setDataProvider( providerKey );
+  QgsDataProvider::ProviderOptions providerOptions;
+  setDataProvider( providerKey, providerOptions );
 
   // show at least the mesh by default so we render something
   mRendererNativeMeshSettings.setEnabled( true );
@@ -269,7 +271,8 @@ bool QgsMeshLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &con
     mProviderKey = pkeyElt.text();
   }
 
-  if ( !setDataProvider( mProviderKey ) )
+  QgsDataProvider::ProviderOptions providerOptions;
+  if ( !setDataProvider( mProviderKey, providerOptions ) )
   {
     return false;
   }
@@ -304,7 +307,7 @@ bool QgsMeshLayer::writeXml( QDomNode &layer_node, QDomDocument &document, const
   return writeSymbology( layer_node, document, errorMsg, context );
 }
 
-bool QgsMeshLayer::setDataProvider( QString const &provider )
+bool QgsMeshLayer::setDataProvider( QString const &provider, const QgsDataProvider::ProviderOptions &options )
 {
   if ( mDataProvider )
     delete mDataProvider;
@@ -312,7 +315,7 @@ bool QgsMeshLayer::setDataProvider( QString const &provider )
   mProviderKey = provider;
   QString dataSource = mDataSource;
 
-  mDataProvider = qobject_cast<QgsMeshDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, dataSource ) );
+  mDataProvider = qobject_cast<QgsMeshDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, dataSource, options ) );
   if ( !mDataProvider )
   {
     QgsDebugMsgLevel( QStringLiteral( "Unable to get mesh data provider" ), 2 );

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -93,6 +93,14 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
   public:
 
     /**
+     * Setting options for loading mesh layers.
+     */
+    struct LayerOptions
+    {
+
+    };
+
+    /**
      * Constructor - creates a mesh layer
      *
      * The QgsMeshLayer is constructed by instantiating a data provider.  The provider
@@ -104,7 +112,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      * \param baseName The name used to represent the layer in the legend
      * \param providerLib  The name of the data provider, e.g., "mesh_memory", "mdal"
      */
-    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory" );
+    explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
+                           const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );
     ~QgsMeshLayer() override;
 
     //! QgsMeshLayer cannot be copied.
@@ -185,8 +194,9 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     /**
      * Binds layer to a specific data provider
      * \param provider provider key string, must match a valid QgsMeshDataProvider key. E.g. "mesh_memory", etc.
+     * \param options generic provider options
      */
-    bool setDataProvider( QString const &provider );
+    bool setDataProvider( QString const &provider, const QgsDataProvider::ProviderOptions &options );
 
 #ifdef SIP_RUN
     QgsMeshLayer( const QgsMeshLayer &rhs );

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -111,6 +111,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      *               parameters used by the data provider as url query items.
      * \param baseName The name used to represent the layer in the legend
      * \param providerLib  The name of the data provider, e.g., "mesh_memory", "mdal"
+     * \param options general mesh layer options
      */
     explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",
                            const QgsMeshLayer::LayerOptions &options = QgsMeshLayer::LayerOptions() );

--- a/src/core/mesh/qgsmeshmemorydataprovider.cpp
+++ b/src/core/mesh/qgsmeshmemorydataprovider.cpp
@@ -41,8 +41,8 @@ QgsCoordinateReferenceSystem QgsMeshMemoryDataProvider::crs() const
   return QgsCoordinateReferenceSystem();
 }
 
-QgsMeshMemoryDataProvider::QgsMeshMemoryDataProvider( const QString &uri )
-  : QgsMeshDataProvider( uri )
+QgsMeshMemoryDataProvider::QgsMeshMemoryDataProvider( const QString &uri, const ProviderOptions &options )
+  : QgsMeshDataProvider( uri, options )
 {
   mIsValid = splitMeshSections( uri );
 }
@@ -61,9 +61,9 @@ QString QgsMeshMemoryDataProvider::providerDescription()
   return TEXT_PROVIDER_DESCRIPTION;
 }
 
-QgsMeshMemoryDataProvider *QgsMeshMemoryDataProvider::createProvider( const QString &uri )
+QgsMeshMemoryDataProvider *QgsMeshMemoryDataProvider::createProvider( const QString &uri, const ProviderOptions &options )
 {
-  return new QgsMeshMemoryDataProvider( uri );
+  return new QgsMeshMemoryDataProvider( uri, options );
 }
 
 bool QgsMeshMemoryDataProvider::splitMeshSections( const QString &uri )

--- a/src/core/mesh/qgsmeshmemorydataprovider.h
+++ b/src/core/mesh/qgsmeshmemorydataprovider.h
@@ -71,7 +71,7 @@ class QgsMeshMemoryDataProvider: public QgsMeshDataProvider
      *    );
      * \endcode
      */
-    QgsMeshMemoryDataProvider( const QString &uri = QString() );
+    QgsMeshMemoryDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
     ~QgsMeshMemoryDataProvider();
 
     bool isValid() const override;
@@ -119,7 +119,7 @@ class QgsMeshMemoryDataProvider: public QgsMeshDataProvider
     //! Returns the memory provider description
     static QString providerDescription();
     //! Provider factory
-    static QgsMeshMemoryDataProvider *createProvider( const QString &uri );
+    static QgsMeshMemoryDataProvider *createProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
   private:
     bool splitMeshSections( const QString &uri );
     bool addMeshVertices( const QString &def );

--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -31,9 +31,8 @@
 static const QString TEXT_PROVIDER_KEY = QStringLiteral( "memory" );
 static const QString TEXT_PROVIDER_DESCRIPTION = QStringLiteral( "Memory provider" );
 
-QgsMemoryProvider::QgsMemoryProvider( const QString &uri )
-  : QgsVectorDataProvider( uri )
-
+QgsMemoryProvider::QgsMemoryProvider( const QString &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
 {
   // Initialize the geometry with the uri to support old style uri's
   // (ie, just 'point', 'line', 'polygon')
@@ -201,9 +200,9 @@ QString QgsMemoryProvider::providerDescription()
   return TEXT_PROVIDER_DESCRIPTION;
 }
 
-QgsMemoryProvider *QgsMemoryProvider::createProvider( const QString &uri )
+QgsMemoryProvider *QgsMemoryProvider::createProvider( const QString &uri, const ProviderOptions &options )
 {
-  return new QgsMemoryProvider( uri );
+  return new QgsMemoryProvider( uri, options );
 }
 
 QgsAbstractFeatureSource *QgsMemoryProvider::featureSource() const

--- a/src/core/providers/memory/qgsmemoryprovider.h
+++ b/src/core/providers/memory/qgsmemoryprovider.h
@@ -31,7 +31,7 @@ class QgsMemoryProvider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
-    explicit QgsMemoryProvider( const QString &uri = QString() );
+    explicit QgsMemoryProvider( const QString &uri, const QgsVectorDataProvider::ProviderOptions &options );
 
     ~QgsMemoryProvider() override;
 
@@ -40,7 +40,11 @@ class QgsMemoryProvider : public QgsVectorDataProvider
     //! Returns the memory provider description
     static QString providerDescription();
 
-    static QgsMemoryProvider *createProvider( const QString &uri );
+    /**
+     * Creates a new memory provider, with provider properties embedded within the given \a uri and \a options
+     * argument.
+     */
+    static QgsMemoryProvider *createProvider( const QString &uri, const QgsVectorDataProvider::ProviderOptions &options );
 
     /* Implementation of functions from QgsVectorDataProvider */
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -111,7 +111,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      *
      * Additional creation options are specified within the \a options value.
      */
-    QgsDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options )
+    QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() )
       : mDataSourceURI( uri )
     {
       Q_UNUSED( options );

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -96,12 +96,26 @@ class CORE_EXPORT QgsDataProvider : public QObject
       CustomData   = 3000          //!< Custom properties for 3rd party providers or very provider-specific properties which are not expected to be of interest for other providers can be added starting from this value up.
     };
 
+
+    /**
+     * Setting options for creating vector data providers.
+     * \since QGIS 3.2
+     */
+    struct ProviderOptions
+    {
+
+    };
+
     /**
      * Create a new dataprovider with the specified in the \a uri.
+     *
+     * Additional creation options are specified within the \a options value.
      */
-    QgsDataProvider( const QString &uri = QString() )
+    QgsDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options )
       : mDataSourceURI( uri )
-    {}
+    {
+      Q_UNUSED( options );
+    }
 
     /**
      * Returns the coordinate system for the data source.

--- a/src/core/qgspluginlayer.cpp
+++ b/src/core/qgspluginlayer.cpp
@@ -22,7 +22,7 @@ QgsPluginLayer::QgsPluginLayer( const QString &layerType, const QString &layerNa
   : QgsMapLayer( PluginLayer, layerName )
   , mPluginLayerType( layerType )
 {
-  mDataProvider = new QgsPluginLayerDataProvider( layerType );
+  mDataProvider = new QgsPluginLayerDataProvider( layerType, QgsDataProvider::ProviderOptions() );
 }
 
 QgsPluginLayer::~QgsPluginLayer()
@@ -63,8 +63,9 @@ const QgsDataProvider *QgsPluginLayer::dataProvider() const
 // QgsPluginLayerDataProvider
 //
 ///@cond PRIVATE
-QgsPluginLayerDataProvider::QgsPluginLayerDataProvider( const QString &layerType )
-  : mName( layerType )
+QgsPluginLayerDataProvider::QgsPluginLayerDataProvider( const QString &layerType, const ProviderOptions &options )
+  : QgsDataProvider( QString(), options )
+  , mName( layerType )
 {}
 
 QgsCoordinateReferenceSystem QgsPluginLayerDataProvider::crs() const

--- a/src/core/qgspluginlayer.h
+++ b/src/core/qgspluginlayer.h
@@ -74,7 +74,7 @@ class QgsPluginLayerDataProvider : public QgsDataProvider
     Q_OBJECT
 
   public:
-    QgsPluginLayerDataProvider( const QString &layerType );
+    QgsPluginLayerDataProvider( const QString &layerType, const QgsDataProvider::ProviderOptions &options );
     void setExtent( const QgsRectangle &extent ) { mExtent = extent; }
     virtual QgsCoordinateReferenceSystem crs() const override;
     virtual QString name() const override;

--- a/src/core/qgsprovidermetadata.h
+++ b/src/core/qgsprovidermetadata.h
@@ -22,10 +22,9 @@
 
 #include <QString>
 #include "qgis.h"
+#include "qgsdataprovider.h"
 #include "qgis_core.h"
 #include <functional>
-
-class QgsDataProvider;
 
 /**
  * \ingroup core
@@ -52,7 +51,7 @@ class CORE_EXPORT QgsProviderMetadata
      * Typedef for data provider creation function.
      * \since QGIS 3.0
      */
-    SIP_SKIP typedef std::function < QgsDataProvider*( const QString & ) > CreateDataProviderFunction;
+    SIP_SKIP typedef std::function < QgsDataProvider*( const QString &, const QgsDataProvider::ProviderOptions & ) > CreateDataProviderFunction;
 
     QgsProviderMetadata( const QString &_key, const QString &_description, const QString &_library );
 

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -362,7 +362,7 @@ QDir QgsProviderRegistry::libraryDirectory() const
 
 
 // typedef for the QgsDataProvider class factory
-typedef QgsDataProvider *classFactoryFunction_t( const QString * );
+typedef QgsDataProvider *classFactoryFunction_t( const QString *, const QgsDataProvider::ProviderOptions &options );
 
 
 /* Copied from QgsVectorLayer::setDataProvider
@@ -426,7 +426,7 @@ QgsDataProvider *QgsProviderRegistry::createProvider( QString const &providerKey
     return nullptr;
   }
 
-  QgsDataProvider *dataProvider = classFactory( &dataSource );
+  QgsDataProvider *dataProvider = classFactory( &dataSource, options );
   if ( !dataProvider )
   {
     QgsMessageLog::logMessage( QObject::tr( "Unable to instantiate the data provider plugin %1" ).arg( lib ) );

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -372,7 +372,7 @@ typedef QgsDataProvider *classFactoryFunction_t( const QString * );
  *        It seems more sensible to provide the code in one place rather than
  *        in qgsrasterlayer, qgsvectorlayer, serversourceselect, etc.
  */
-QgsDataProvider *QgsProviderRegistry::createProvider( QString const &providerKey, QString const &dataSource )
+QgsDataProvider *QgsProviderRegistry::createProvider( QString const &providerKey, QString const &dataSource, const QgsDataProvider::ProviderOptions &options )
 {
   // XXX should I check for and possibly delete any pre-existing providers?
   // XXX How often will that scenario occur?
@@ -386,7 +386,7 @@ QgsDataProvider *QgsProviderRegistry::createProvider( QString const &providerKey
 
   if ( metadata->createFunction() )
   {
-    return metadata->createFunction()( dataSource );
+    return metadata->createFunction()( dataSource, options );
   }
 
   // load the plugin

--- a/src/core/qgsproviderregistry.h
+++ b/src/core/qgsproviderregistry.h
@@ -98,7 +98,7 @@ class CORE_EXPORT QgsProviderRegistry
      */
     QgsDataProvider *createProvider( const QString &providerKey,
                                      const QString &dataSource,
-                                     const QgsDataProvider::ProviderOptions &options ) SIP_FACTORY;
+                                     const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() ) SIP_FACTORY;
 
     /**
      * Return the provider capabilities

--- a/src/core/qgsproviderregistry.h
+++ b/src/core/qgsproviderregistry.h
@@ -25,11 +25,11 @@
 #include <QLibrary>
 #include <QString>
 
+#include "qgsdataprovider.h"
 #include "qgis_core.h"
 #include "qgis_sip.h"
 
 
-class QgsDataProvider;
 class QgsProviderMetadata;
 class QgsVectorLayer;
 class QgsCoordinateReferenceSystem;
@@ -93,10 +93,12 @@ class CORE_EXPORT QgsProviderRegistry
      * Creates a new instance of a provider.
      * \param providerKey identificator of the provider
      * \param dataSource  string containing data source for the provider
+     * \param options provider options
      * \returns new instance of provider or NULL on error
      */
     QgsDataProvider *createProvider( const QString &providerKey,
-                                     const QString &dataSource ) SIP_FACTORY;
+                                     const QString &dataSource,
+                                     const QgsDataProvider::ProviderOptions &options ) SIP_FACTORY;
 
     /**
      * Return the provider capabilities

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -34,8 +34,8 @@
 #include "qgsmessagelog.h"
 #include "qgssettings.h"
 
-QgsVectorDataProvider::QgsVectorDataProvider( const QString &uri )
-  : QgsDataProvider( uri )
+QgsVectorDataProvider::QgsVectorDataProvider( const QString &uri, const ProviderOptions &options )
+  : QgsDataProvider( uri, options )
 {
   QgsSettings settings;
   setEncoding( settings.value( QStringLiteral( "UI/encoding" ), "System" ).toString() );

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -114,10 +114,13 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
     };
 
     /**
-     * Constructor of the vector provider
-     * \param uri  uniform resource locator (URI) for a dataset
+     * Constructor for a vector data provider.
+     *
+     * The \a uri argument specifies the uniform resource locator (URI) for the associated dataset.
+     *
+     * Additional creation options are specified within the \a options value.
      */
-    QgsVectorDataProvider( const QString &uri = QString() );
+    QgsVectorDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     /**
      * Return feature source object that can be used for querying provider's data. The returned feature source

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -120,7 +120,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      *
      * Additional creation options are specified within the \a options value.
      */
-    QgsVectorDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsVectorDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 
     /**
      * Return feature source object that can be used for querying provider's data. The returned feature source

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -930,8 +930,22 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param loadDefaultStyleFlag set to true to reset the layer's style to the default for the
      * data source
      * \since QGIS 2.10
+     * \deprecated Use version with ProviderOptions argument instead
      */
-    void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false );
+    Q_DECL_DEPRECATED void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, bool loadDefaultStyleFlag = false ) SIP_DEPRECATED;
+
+    /**
+     * Updates the data source of the layer. The layer's renderer and legend will be preserved only
+     * if the geometry type of the new data source matches the current geometry type of the layer.
+     * \param dataSource new layer data source
+     * \param baseName base name of the layer
+     * \param provider provider string
+     * \param options provider options
+     * \param loadDefaultStyleFlag set to true to reset the layer's style to the default for the
+     * data source
+     * \since QGIS 3.2
+     */
+    void setDataSource( const QString &dataSource, const QString &baseName, const QString &provider, const QgsDataProvider::ProviderOptions &options, bool loadDefaultStyleFlag = false );
 
     QString loadDefaultStyle( bool &resultFlag SIP_OUT ) override;
 
@@ -2285,8 +2299,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Bind layer to a specific data provider
      * \param provider provider key string, must match a valid QgsVectorDataProvider key. E.g. "postgres", "ogr", etc.
+     * \param options provider options
      */
-    bool setDataProvider( QString const &provider );
+    bool setDataProvider( QString const &provider, const QgsDataProvider::ProviderOptions &options );
 
     //! Read labeling from SLD
     void readSldLabeling( const QDomNode &node );

--- a/src/core/qgsvectorlayerexporter.cpp
+++ b/src/core/qgsvectorlayerexporter.cpp
@@ -108,7 +108,9 @@ QgsVectorLayerExporter::QgsVectorLayerExporter( const QString &uri,
       uriUpdated += layerName;
     }
   }
-  QgsVectorDataProvider *vectorProvider = dynamic_cast< QgsVectorDataProvider * >( pReg->createProvider( providerKey, uriUpdated ) );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsVectorDataProvider *vectorProvider = dynamic_cast< QgsVectorDataProvider * >( pReg->createProvider( providerKey, uriUpdated, providerOptions ) );
   if ( !vectorProvider || !vectorProvider->isValid() || ( vectorProvider->capabilities() & QgsVectorDataProvider::AddFeatures ) == 0 )
   {
     mError = ErrInvalidLayer;

--- a/src/core/raster/qgsrasterchecker.cpp
+++ b/src/core/raster/qgsrasterchecker.cpp
@@ -43,7 +43,8 @@ bool QgsRasterChecker::runTest( const QString &verifiedKey, QString verifiedUri,
   mReport += QLatin1String( "\n\n" );
 
   //QgsRasterDataProvider* verifiedProvider = QgsRasterLayer::loadProvider( verifiedKey, verifiedUri );
-  QgsRasterDataProvider *verifiedProvider = dynamic_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( verifiedKey, verifiedUri ) );
+  QgsDataProvider::ProviderOptions options;
+  QgsRasterDataProvider *verifiedProvider = dynamic_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( verifiedKey, verifiedUri, options ) );
   if ( !verifiedProvider || !verifiedProvider->isValid() )
   {
     error( QStringLiteral( "Cannot load provider %1 with URI: %2" ).arg( verifiedKey, verifiedUri ), mReport );
@@ -51,7 +52,7 @@ bool QgsRasterChecker::runTest( const QString &verifiedKey, QString verifiedUri,
   }
 
   //QgsRasterDataProvider* expectedProvider = QgsRasterLayer::loadProvider( expectedKey, expectedUri );
-  QgsRasterDataProvider *expectedProvider = dynamic_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( expectedKey, expectedUri ) );
+  QgsRasterDataProvider *expectedProvider = dynamic_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( expectedKey, expectedUri, options ) );
   if ( !expectedProvider || !expectedProvider->isValid() )
   {
     error( QStringLiteral( "Cannot load provider %1 with URI: %2" ).arg( expectedKey, expectedUri ), mReport );

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -206,12 +206,13 @@ QgsRasterBlock *QgsRasterDataProvider::block( int bandNo, QgsRectangle  const &b
 }
 
 QgsRasterDataProvider::QgsRasterDataProvider()
-  : QgsRasterInterface( nullptr )
+  : QgsDataProvider( QString(), QgsDataProvider::ProviderOptions() )
+  , QgsRasterInterface( nullptr )
 {
 }
 
-QgsRasterDataProvider::QgsRasterDataProvider( QString const &uri )
-  : QgsDataProvider( uri )
+QgsRasterDataProvider::QgsRasterDataProvider( const QString &uri, const ProviderOptions &options )
+  : QgsDataProvider( uri, options )
   , QgsRasterInterface( nullptr )
 {
 }

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -104,7 +104,15 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
 
     QgsRasterDataProvider();
 
-    QgsRasterDataProvider( const QString &uri );
+    /**
+     * Constructor for QgsRasterDataProvider.
+     *
+     * The \a uri argument gives a provider-specific uri indicating the underlying data
+     * source and it's parameters.
+     *
+     * The \a options argument specifies generic provider options.
+     */
+    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     QgsRasterInterface *clone() const override = 0;
 

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -112,7 +112,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      *
      * The \a options argument specifies generic provider options.
      */
-    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
+    QgsRasterDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );
 
     QgsRasterInterface *clone() const override = 0;
 

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -716,7 +716,8 @@ void QgsRasterFileWriter::buildPyramids( const QString &filename )
 {
   QgsDebugMsgLevel( "filename = " + filename, 4 );
   // open new dataProvider so we can build pyramids with it
-  QgsRasterDataProvider *destProvider = dynamic_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( mOutputProviderKey, filename ) );
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsRasterDataProvider *destProvider = dynamic_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( mOutputProviderKey, filename, providerOptions ) );
   if ( !destProvider )
   {
     return;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -212,7 +212,7 @@ void QgsRasterLayer::setDataProvider( const QString &provider )
 }
 
 // typedef for the QgsDataProvider class factory
-typedef QgsDataProvider *classFactoryFunction_t( const QString * );
+typedef QgsDataProvider *classFactoryFunction_t( const QString *, const QgsDataProvider::ProviderOptions &options );
 
 //////////////////////////////////////////////////////////
 //

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -119,7 +119,9 @@ QgsRasterLayer::QgsRasterLayer( const QString &uri,
 {
   QgsDebugMsgLevel( "Entered", 4 );
   init();
-  setDataProvider( providerKey );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  setDataProvider( providerKey, providerOptions );
   if ( !mValid ) return;
 
   // load default style
@@ -202,6 +204,11 @@ QDateTime QgsRasterLayer::lastModified( QString const &name )
   QgsDebugMsgLevel( "last modified = " + t.toString(), 4 );
 
   return t;
+}
+
+void QgsRasterLayer::setDataProvider( const QString &provider )
+{
+  setDataProvider( provider, QgsDataProvider::ProviderOptions() );
 }
 
 // typedef for the QgsDataProvider class factory
@@ -571,7 +578,7 @@ void QgsRasterLayer::init()
   mLastViewPort.mHeight = 0;
 }
 
-void QgsRasterLayer::setDataProvider( QString const &provider )
+void QgsRasterLayer::setDataProvider( QString const &provider, const QgsDataProvider::ProviderOptions &options )
 {
   QgsDebugMsgLevel( "Entered", 4 );
   mValid = false; // assume the layer is invalid until we determine otherwise
@@ -591,7 +598,7 @@ void QgsRasterLayer::setDataProvider( QString const &provider )
 
   //mBandCount = 0;
 
-  mDataProvider = dynamic_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( mProviderKey, mDataSource ) );
+  mDataProvider = dynamic_cast< QgsRasterDataProvider * >( QgsProviderRegistry::instance()->createProvider( mProviderKey, mDataSource, options ) );
   if ( !mDataProvider )
   {
     //QgsMessageLog::logMessage( tr( "Cannot instantiate the data provider" ), tr( "Raster" ) );
@@ -1452,7 +1459,8 @@ bool QgsRasterLayer::readXml( const QDomNode &layer_node, QgsReadWriteContext &c
     // <<< BACKWARD COMPATIBILITY < 1.9
   }
 
-  setDataProvider( mProviderKey );
+  QgsDataProvider::ProviderOptions providerOptions;
+  setDataProvider( mProviderKey, providerOptions );
   if ( !mValid ) return false;
 
   QString error;
@@ -1868,7 +1876,8 @@ bool QgsRasterLayer::update()
     QgsDebugMsgLevel( "reload data", 4 );
     closeDataProvider();
     init();
-    setDataProvider( mProviderKey );
+    QgsDataProvider::ProviderOptions providerOptions;
+    setDataProvider( mProviderKey, providerOptions );
     emit dataChanged();
   }
   return mValid;

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -248,8 +248,19 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     //! Return time stamp for given file name
     static QDateTime lastModified( const QString   &name );
 
-    //! [ data provider interface ] Set the data provider
-    void setDataProvider( const QString &provider );
+    /**
+     * Set the data provider.
+     * \deprecated Use the version with ProviderOptions instead.
+     */
+    Q_DECL_DEPRECATED void setDataProvider( const QString &provider ) SIP_DEPRECATED;
+
+    /**
+     * Set the data provider.
+     * \param provider provider key string, must match a valid QgsRasterDataProvider key. E.g. "gdal", "wms", etc.
+     * \param options provider options
+     * \since QGIS 3.2
+     */
+    void setDataProvider( const QString &provider, const QgsDataProvider::ProviderOptions &options );
 
     //! \brief  Accessor for raster layer type (which is a read only property)
     LayerType rasterType() { return mRasterType; }

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -37,10 +37,8 @@
 static const QString TEXT_PROVIDER_KEY = QStringLiteral( "arcgisfeatureserver" );
 static const QString TEXT_PROVIDER_DESCRIPTION = QStringLiteral( "ArcGIS Feature Server data provider" );
 
-QgsAfsProvider::QgsAfsProvider( const QString &uri )
-  : QgsVectorDataProvider( uri )
-  , mValid( false )
-  , mObjectIdFieldIdx( -1 )
+QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
 {
   mSharedData.reset( new QgsAfsSharedData() );
   mSharedData->mGeometryType = QgsWkbTypes::Unknown;

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -36,7 +36,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
 
   public:
 
-    QgsAfsProvider( const QString &uri );
+    QgsAfsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     /* Inherited from QgsVectorDataProvider */
     QgsAbstractFeatureSource *featureSource() const override;
@@ -73,9 +73,9 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QgsFeatureRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const override;
 
   private:
-    bool mValid;
+    bool mValid = false;
     std::shared_ptr<QgsAfsSharedData> mSharedData;
-    int mObjectIdFieldIdx;
+    int mObjectIdFieldIdx = -1;
     QString mLayerName;
     QString mLayerDescription;
     QgsLayerMetadata mLayerMetadata;

--- a/src/providers/arcgisrest/qgsafsproviderextern.cpp
+++ b/src/providers/arcgisrest/qgsafsproviderextern.cpp
@@ -28,9 +28,9 @@ const QString AFS_KEY = QStringLiteral( "arcgisfeatureserver" );
 const QString AFS_DESCRIPTION = QStringLiteral( "ArcGIS Feature Server data provider" );
 
 
-QGISEXTERN QgsAfsProvider *classFactory( const QString *uri )
+QGISEXTERN QgsAfsProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsAfsProvider( *uri );
+  return new QgsAfsProvider( *uri, options );
 }
 
 QGISEXTERN QString providerKey()

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -115,7 +115,8 @@ void QgsAfsSourceSelect::buildQuery( const QgsOwsConnection &connection, const Q
   QString url = ds.param( QStringLiteral( "url" ) ) + "/" + id;
   ds.removeParam( QStringLiteral( "url" ) );
   ds.setParam( QStringLiteral( "url" ), url );
-  QgsAfsProvider provider( ds.uri() );
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsAfsProvider provider( ds.uri(), providerOptions );
   if ( !provider.isValid() )
   {
     return;

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -124,8 +124,8 @@ void QgsAmsLegendFetcher::handleFinished()
 
 ///////////////////////////////////////////////////////////////////////////////
 
-QgsAmsProvider::QgsAmsProvider( const QString &uri )
-  : QgsRasterDataProvider( uri ), mValid( false )
+QgsAmsProvider::QgsAmsProvider( const QString &uri, const ProviderOptions &options )
+  : QgsRasterDataProvider( uri, options )
 {
   mLegendFetcher = new QgsAmsLegendFetcher( this );
 
@@ -209,7 +209,8 @@ void QgsAmsProvider::reloadData()
 
 QgsRasterInterface *QgsAmsProvider::clone() const
 {
-  QgsAmsProvider *provider = new QgsAmsProvider( dataSourceUri() );
+  QgsDataProvider::ProviderOptions options;
+  QgsAmsProvider *provider = new QgsAmsProvider( dataSourceUri(), options );
   provider->copyBaseSettings( *this );
   return provider;
 }

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -54,7 +54,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     Q_OBJECT
 
   public:
-    QgsAmsProvider( const QString &uri );
+    QgsAmsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     /* Inherited from QgsDataProvider */
     bool isValid() const override { return mValid; }
@@ -91,7 +91,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     void draw( const QgsRectangle &viewExtent, int pixelWidth, int pixelHeight );
 
   private:
-    bool mValid;
+    bool mValid = false;
     QgsAmsLegendFetcher *mLegendFetcher = nullptr;
     QVariantMap mServiceInfo;
     QVariantMap mLayerInfo;

--- a/src/providers/arcgisrest/qgsamsproviderextern.cpp
+++ b/src/providers/arcgisrest/qgsamsproviderextern.cpp
@@ -28,9 +28,9 @@ const QString AMS_KEY = QStringLiteral( "arcgismapserver" );
 const QString AMS_DESCRIPTION = QStringLiteral( "ArcGIS Map Server data provider" );
 
 
-QGISEXTERN QgsAmsProvider *classFactory( const QString *uri )
+QGISEXTERN QgsAmsProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsAmsProvider( *uri );
+  return new QgsAmsProvider( *uri, options );
 }
 
 QGISEXTERN QString providerKey()

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -35,8 +35,8 @@ static const QString PROVIDER_DESCRIPTION = QStringLiteral( "DB2 Spatial Extende
 
 int QgsDb2Provider::sConnectionId = 0;
 
-QgsDb2Provider::QgsDb2Provider( const QString &uri )
-  : QgsVectorDataProvider( uri )
+QgsDb2Provider::QgsDb2Provider( const QString &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
   , mEnvironment( ENV_LUW )
 {
   QgsDebugMsg( "uri: " + uri );
@@ -1691,9 +1691,9 @@ QgsAttributeList QgsDb2Provider::pkAttributeIndexes() const
   return list;
 }
 
-QGISEXTERN QgsDb2Provider *classFactory( const QString *uri )
+QGISEXTERN QgsDb2Provider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsDb2Provider( *uri );
+  return new QgsDb2Provider( *uri, options );
 }
 
 QGISEXTERN bool isProvider()

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -34,7 +34,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
-    explicit QgsDb2Provider( const QString &uri = QString() );
+    explicit QgsDb2Provider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     ~QgsDb2Provider() override;
 

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -63,8 +63,8 @@ static const int SUBSET_ID_THRESHOLD_FACTOR = 10;
 QRegExp QgsDelimitedTextProvider::sWktPrefixRegexp( "^\\s*(?:\\d+\\s+|SRID\\=\\d+\\;)", Qt::CaseInsensitive );
 QRegExp QgsDelimitedTextProvider::sCrdDmsRegexp( "^\\s*(?:([-+nsew])\\s*)?(\\d{1,3})(?:[^0-9.]+([0-5]?\\d))?[^0-9.]+([0-5]?\\d(?:\\.\\d+)?)[^0-9.]*([-+nsew])?\\s*$", Qt::CaseInsensitive );
 
-QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri )
-  : QgsVectorDataProvider( uri )
+QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
 {
 
   // Add supported types to enable creating expression fields in field calculator
@@ -1135,9 +1135,9 @@ QString  QgsDelimitedTextProvider::description() const
  * Class factory to return a pointer to a newly created
  * QgsDelimitedTextProvider object
  */
-QGISEXTERN QgsDelimitedTextProvider *classFactory( const QString *uri )
+QGISEXTERN QgsDelimitedTextProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsDelimitedTextProvider( *uri );
+  return new QgsDelimitedTextProvider( *uri, options );
 }
 
 /**

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -75,7 +75,7 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
       GeomAsWkt
     };
 
-    explicit QgsDelimitedTextProvider( const QString &uri = QString() );
+    explicit QgsDelimitedTextProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     ~QgsDelimitedTextProvider() override;
 

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -125,7 +125,7 @@ int CPL_STDCALL progressCallback( double dfComplete,
 }
 
 QgsGdalProvider::QgsGdalProvider( const QString &uri, const QgsError &error )
-  : QgsRasterDataProvider( uri )
+  : QgsRasterDataProvider( uri, QgsDataProvider::ProviderOptions() )
   , mpRefCounter( new QAtomicInt( 1 ) )
   , mpLightRefCounter( new QAtomicInt( 1 ) )
   , mUpdate( false )
@@ -139,8 +139,8 @@ QgsGdalProvider::QgsGdalProvider( const QString &uri, const QgsError &error )
   setError( error );
 }
 
-QgsGdalProvider::QgsGdalProvider( const QString &uri, bool update, GDALDatasetH dataset )
-  : QgsRasterDataProvider( uri )
+QgsGdalProvider::QgsGdalProvider( const QString &uri, const ProviderOptions &options, bool update, GDALDatasetH dataset )
+  : QgsRasterDataProvider( uri, options )
   , mpRefCounter( new QAtomicInt( 1 ) )
   , mpMutex( new QMutex( QMutex::Recursive ) )
   , mpParent( new QgsGdalProvider * ( this ) )
@@ -194,7 +194,7 @@ QgsGdalProvider::QgsGdalProvider( const QString &uri, bool update, GDALDatasetH 
 }
 
 QgsGdalProvider::QgsGdalProvider( const QgsGdalProvider &other )
-  : QgsRasterDataProvider( other.dataSourceUri() )
+  : QgsRasterDataProvider( other.dataSourceUri(), QgsDataProvider::ProviderOptions() )
   , mUpdate( false )
 {
   // The JP2OPENJPEG driver might consume too much memory on large datasets
@@ -2125,9 +2125,9 @@ QStringList QgsGdalProvider::subLayers() const
  * Class factory to return a pointer to a newly created
  * QgsGdalProvider object
  */
-QGISEXTERN QgsGdalProvider *classFactory( const QString *uri )
+QGISEXTERN QgsGdalProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsGdalProvider( *uri );
+  return new QgsGdalProvider( *uri, options );
 }
 
 /**
@@ -3004,7 +3004,8 @@ QGISEXTERN QgsGdalProvider *create(
   GDALSetGeoTransform( dataset.get(), geoTransform );
   GDALSetProjection( dataset.get(), crs.toWkt().toLocal8Bit().data() );
 
-  return new QgsGdalProvider( uri, true, dataset.release() );
+  QgsDataProvider::ProviderOptions providerOptions;
+  return new QgsGdalProvider( uri, providerOptions, true, dataset.release() );
 }
 
 bool QgsGdalProvider::write( void *data, int band, int width, int height, int xOffset, int yOffset )

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -70,10 +70,10 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
      * \param   newDataset  handle of newly created dataset.
      *
      */
-    QgsGdalProvider( QString const &uri = QString(), bool update = false, GDALDatasetH newDataset = nullptr );
+    QgsGdalProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, bool update = false, GDALDatasetH newDataset = nullptr );
 
     //! Create invalid provider with error
-    QgsGdalProvider( QString const &uri, const QgsError &error );
+    QgsGdalProvider( const QString &uri, const QgsError &error );
 
 
     ~QgsGdalProvider() override;

--- a/src/providers/gpx/qgsgpxprovider.cpp
+++ b/src/providers/gpx/qgsgpxprovider.cpp
@@ -67,8 +67,8 @@ const QString GPX_KEY = QStringLiteral( "gpx" );
 const QString GPX_DESCRIPTION = QObject::tr( "GPS eXchange format provider" );
 
 
-QgsGPXProvider::QgsGPXProvider( const QString &uri )
-  : QgsVectorDataProvider( uri )
+QgsGPXProvider::QgsGPXProvider( const QString &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
 {
   // we always use UTF-8
   setEncoding( QStringLiteral( "utf8" ) );
@@ -546,9 +546,9 @@ QgsCoordinateReferenceSystem QgsGPXProvider::crs() const
  * Class factory to return a pointer to a newly created
  * QgsGPXProvider object
  */
-QGISEXTERN QgsGPXProvider *classFactory( const QString *uri )
+QGISEXTERN QgsGPXProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsGPXProvider( *uri );
+  return new QgsGPXProvider( *uri, options );
 }
 
 

--- a/src/providers/gpx/qgsgpxprovider.h
+++ b/src/providers/gpx/qgsgpxprovider.h
@@ -43,7 +43,7 @@ class QgsGPXProvider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
-    explicit QgsGPXProvider( const QString &uri = QString() );
+    explicit QgsGPXProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
     ~QgsGPXProvider() override;
 
     /* Functions inherited from QgsVectorDataProvider */

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -42,8 +42,8 @@ QgsCoordinateReferenceSystem QgsMdalProvider::crs() const
   return QgsCoordinateReferenceSystem();
 }
 
-QgsMdalProvider::QgsMdalProvider( const QString &uri )
-  : QgsMeshDataProvider( uri )
+QgsMdalProvider::QgsMdalProvider( const QString &uri, const ProviderOptions &options )
+  : QgsMeshDataProvider( uri, options )
 {
   QByteArray curi = uri.toAscii();
   mMeshH = MDAL_LoadMesh( curi.constData() );
@@ -184,9 +184,9 @@ void QgsMdalProvider::refreshDatasets()
  * Class factory to return a pointer to a newly created
  * QgsGdalProvider object
  */
-QGISEXTERN QgsMdalProvider *classFactory( const QString *uri )
+QGISEXTERN QgsMdalProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsMdalProvider( *uri );
+  return new QgsMdalProvider( *uri, options );
 }
 
 /**

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -39,11 +39,10 @@ class QgsMdalProvider : public QgsMeshDataProvider
     /**
      * Constructor for the provider.
      *
-     * \param   uri         file name
-     * \param   newDataset  handle of newly created dataset.
-     *
+     * \param uri file name
+     * \param options generic provider options
      */
-    QgsMdalProvider( const QString &uri = QString() );
+    QgsMdalProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
     ~QgsMdalProvider();
 
     bool isValid() const override;

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -56,8 +56,8 @@ static const QString TEXT_PROVIDER_KEY = QStringLiteral( "mssql" );
 static const QString TEXT_PROVIDER_DESCRIPTION = QStringLiteral( "MSSQL spatial data provider" );
 int QgsMssqlProvider::sConnectionId = 0;
 
-QgsMssqlProvider::QgsMssqlProvider( const QString &uri )
-  : QgsVectorDataProvider( uri )
+QgsMssqlProvider::QgsMssqlProvider( const QString &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
 {
   QgsDataSourceUri anUri = QgsDataSourceUri( uri );
 
@@ -1871,7 +1871,9 @@ QgsVectorLayerExporter::ExportError QgsMssqlProvider::createEmptyLayer( const QS
 
   // use the provider to edit the table
   dsUri.setDataSource( schemaName, tableName, geometryColumn, QString(), primaryKey );
-  QgsMssqlProvider *provider = new QgsMssqlProvider( dsUri.uri() );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsMssqlProvider *provider = new QgsMssqlProvider( dsUri.uri(), providerOptions );
   if ( !provider->isValid() )
   {
     if ( errorMessage )
@@ -1938,9 +1940,9 @@ QgsVectorLayerExporter::ExportError QgsMssqlProvider::createEmptyLayer( const QS
  * Class factory to return a pointer to a newly created
  * QgsMssqlProvider object
  */
-QGISEXTERN QgsMssqlProvider *classFactory( const QString *uri )
+QGISEXTERN QgsMssqlProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsMssqlProvider( *uri );
+  return new QgsMssqlProvider( *uri, options );
 }
 
 /**

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -50,7 +50,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     Q_OBJECT
 
   public:
-    explicit QgsMssqlProvider( const QString &uri = QString() );
+    explicit QgsMssqlProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     ~QgsMssqlProvider() override;
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -424,8 +424,8 @@ static QString AnalyzeURI( QString const &uri,
 
 }
 
-QgsOgrProvider::QgsOgrProvider( QString const &uri )
-  : QgsVectorDataProvider( uri )
+QgsOgrProvider::QgsOgrProvider( QString const &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
 {
   QgsApplication::registerOgrDrivers();
 
@@ -2925,9 +2925,9 @@ QGISEXTERN QStringList wildcards()
  * Class factory to return a pointer to a newly created
  * QgsOgrProvider object
  */
-QGISEXTERN QgsOgrProvider *classFactory( const QString *uri )
+QGISEXTERN QgsOgrProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsOgrProvider( *uri );
+  return new QgsOgrProvider( *uri, options );
 }
 
 

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -76,9 +76,11 @@ class QgsOgrProvider : public QgsVectorDataProvider
 
     /**
      * Constructor of the vector provider
-     * \param uri  uniform resource locator (URI) for a dataset
+     * \param uri uniform resource locator (URI) for a dataset
+     * \param options generic data provider options
      */
-    explicit QgsOgrProvider( QString const &uri = QString() );
+    explicit QgsOgrProvider( QString const &uri,
+                             const QgsDataProvider::ProviderOptions &options );
 
     ~QgsOgrProvider() override;
 

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -45,8 +45,8 @@
 const QString ORACLE_KEY = "oracle";
 const QString ORACLE_DESCRIPTION = "Oracle data provider";
 
-QgsOracleProvider::QgsOracleProvider( QString const &uri )
-  : QgsVectorDataProvider( uri )
+QgsOracleProvider::QgsOracleProvider( QString const &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
   , mValid( false )
   , mIsQuery( false )
   , mPrimaryKeyType( PktUnknown )
@@ -2840,7 +2840,9 @@ QgsVectorLayerExporter::ExportError QgsOracleProvider::createEmptyLayer(
 
   // use the provider to edit the table1
   dsUri.setDataSource( ownerName, tableName, geometryColumn, QString(), primaryKey );
-  QgsOracleProvider *provider = new QgsOracleProvider( dsUri.uri() );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsOracleProvider *provider = new QgsOracleProvider( dsUri.uri(), providerOptions );
   if ( !provider->isValid() )
   {
     if ( errorMessage )
@@ -3029,9 +3031,9 @@ QString  QgsOracleProvider::description() const
  * Class factory to return a pointer to a newly created
  * QgsOracleProvider object
  */
-QGISEXTERN QgsOracleProvider *classFactory( const QString *uri )
+QGISEXTERN QgsOracleProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsOracleProvider( *uri );
+  return new QgsOracleProvider( *uri, options );
 }
 
 /**

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -78,8 +78,9 @@ class QgsOracleProvider : public QgsVectorDataProvider
      * host=localhost user=gsherman dbname=test password=xxx table=test.alaska (the_geom)
      * \param uri String containing the required parameters to connect to the database
      * and query the table.
+     * \param options generic data provider options
      */
-    explicit QgsOracleProvider( QString const &uri = "" );
+    explicit QgsOracleProvider( QString const &uri, const QgsDataProvider::ProviderOptions &options );
 
     //! Destructor
     virtual ~QgsOracleProvider();

--- a/src/providers/ows/qgsowsprovider.cpp
+++ b/src/providers/ows/qgsowsprovider.cpp
@@ -24,14 +24,14 @@
 static QString PROVIDER_KEY = QStringLiteral( "ows" );
 static QString PROVIDER_DESCRIPTION = QStringLiteral( "OWS meta provider" );
 
-QgsOwsProvider::QgsOwsProvider( const QString &uri )
-  : QgsDataProvider( uri )
+QgsOwsProvider::QgsOwsProvider( const QString &uri, const ProviderOptions &options )
+  : QgsDataProvider( uri, options )
 {
 }
 
-QGISEXTERN QgsOwsProvider *classFactory( const QString *uri )
+QGISEXTERN QgsOwsProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsOwsProvider( *uri );
+  return new QgsOwsProvider( *uri, options );
 }
 
 QString QgsOwsProvider::name() const

--- a/src/providers/ows/qgsowsprovider.h
+++ b/src/providers/ows/qgsowsprovider.h
@@ -44,9 +44,10 @@ class QgsOwsProvider : public QgsDataProvider
      *
      * \param   uri   HTTP URL of the Web Server.  If needed a proxy will be used
      *                otherwise we contact the host directly.
+     * \param options generic data provider options
      *
      */
-    explicit QgsOwsProvider( const QString &uri = QString() );
+    explicit QgsOwsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
     /* Pure virtuals */
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -89,8 +89,8 @@ QgsPostgresProvider::pkType( const QgsField &f ) const
 
 
 
-QgsPostgresProvider::QgsPostgresProvider( QString const &uri )
-  : QgsVectorDataProvider( uri )
+QgsPostgresProvider::QgsPostgresProvider( QString const &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
   , mShared( new QgsPostgresSharedData )
 {
 
@@ -3935,7 +3935,9 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
 
   // use the provider to edit the table
   dsUri.setDataSource( schemaName, tableName, geometryColumn, QString(), primaryKey );
-  std::unique_ptr< QgsPostgresProvider > provider = qgis::make_unique< QgsPostgresProvider >( dsUri.uri( false ) );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  std::unique_ptr< QgsPostgresProvider > provider = qgis::make_unique< QgsPostgresProvider >( dsUri.uri( false ), providerOptions );
   if ( !provider->isValid() )
   {
     if ( errorMessage )
@@ -4399,9 +4401,9 @@ bool QgsPostgresProvider::hasMetadata() const
  * Class factory to return a pointer to a newly created
  * QgsPostgresProvider object
  */
-QGISEXTERN QgsPostgresProvider *classFactory( const QString *uri )
+QGISEXTERN QgsPostgresProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsPostgresProvider( *uri );
+  return new QgsPostgresProvider( *uri, options );
 }
 
 /**

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -87,8 +87,9 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      * host=localhost dbname=test [user=gsherman [password=xxx] | authcfg=xxx] table=test.alaska (the_geom)
      * \param uri String containing the required parameters to connect to the database
      * and query the table.
+     * \param options generic data provider options
      */
-    explicit QgsPostgresProvider( QString const &uri = QString() );
+    explicit QgsPostgresProvider( QString const &uri, const QgsDataProvider::ProviderOptions &options );
 
 
     ~QgsPostgresProvider() override;

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -357,7 +357,9 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri,
 
   // use the provider to edit the table
   dsUri.setDataSource( QLatin1String( "" ), tableName, geometryColumn, QString(), primaryKey );
-  QgsSpatiaLiteProvider *provider = new QgsSpatiaLiteProvider( dsUri.uri() );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsSpatiaLiteProvider *provider = new QgsSpatiaLiteProvider( dsUri.uri(), providerOptions );
   if ( !provider->isValid() )
   {
     QgsDebugMsg( "The layer " + tableName + " just created is not valid or not supported by the provider." );
@@ -435,8 +437,8 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString &uri,
 }
 
 
-QgsSpatiaLiteProvider::QgsSpatiaLiteProvider( QString const &uri )
-  : QgsVectorDataProvider( uri )
+QgsSpatiaLiteProvider::QgsSpatiaLiteProvider( QString const &uri, const ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
 {
   nDims = GAIA_XY;
   QgsDataSourceUri anUri = QgsDataSourceUri( uri );
@@ -5293,9 +5295,9 @@ void QgsSpatiaLiteProvider::invalidateConnections( const QString &connection )
  * Class factory to return a pointer to a newly created
  * QgsSpatiaLiteProvider object
  */
-QGISEXTERN QgsSpatiaLiteProvider *classFactory( const QString *uri )
+QGISEXTERN QgsSpatiaLiteProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsSpatiaLiteProvider( *uri );
+  return new QgsSpatiaLiteProvider( *uri, options );
 }
 
 /**

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -71,9 +71,10 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
 
     /**
      * Constructor of the vector provider
-     * \param uri  uniform resource locator (URI) for a dataset
+     * \param uri uniform resource locator (URI) for a dataset
+     * \param options generic data provider options
      */
-    explicit QgsSpatiaLiteProvider( QString const &uri = QString() );
+    explicit QgsSpatiaLiteProvider( QString const &uri, const QgsDataProvider::ProviderOptions &options );
 
     ~ QgsSpatiaLiteProvider() override;
 

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -54,8 +54,8 @@ static QString quotedColumn( QString name )
 #define PROVIDER_ERROR( msg ) do { mError = QgsError( msg, VIRTUAL_LAYER_KEY ); QgsDebugMsg( msg ); } while(0)
 
 
-QgsVirtualLayerProvider::QgsVirtualLayerProvider( QString const &uri )
-  : QgsVectorDataProvider( uri )
+QgsVirtualLayerProvider::QgsVirtualLayerProvider( QString const &uri, const QgsDataProvider::ProviderOptions &options )
+  : QgsVectorDataProvider( uri, options )
 {
   mError.clear();
 
@@ -629,9 +629,9 @@ QSet<QgsMapLayerDependency> QgsVirtualLayerProvider::dependencies() const
  * Class factory to return a pointer to a newly created
  * QgsSpatiaLiteProvider object
  */
-QGISEXTERN QgsVirtualLayerProvider *classFactory( const QString *uri )
+QGISEXTERN QgsVirtualLayerProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsVirtualLayerProvider( *uri );
+  return new QgsVirtualLayerProvider( *uri, options );
 }
 
 /**

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -32,9 +32,10 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
 
     /**
      * Constructor of the vector provider
-     * \param uri  uniform resource locator (URI) for a dataset
+     * \param uri uniform resource locator (URI) for a dataset
+     * \param options generic data provider options
      */
-    explicit QgsVirtualLayerProvider( QString const &uri = QString() );
+    explicit QgsVirtualLayerProvider( QString const &uri, const ProviderOptions &options );
 
     QgsAbstractFeatureSource *featureSource() const override;
     QString storageType() const override;

--- a/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
+++ b/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
@@ -116,7 +116,8 @@ struct VTable
       , mCrs( -1 )
       , mValid( true )
     {
-      mProvider = static_cast<QgsVectorDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, source ) );
+      QgsDataProvider::ProviderOptions providerOptions;
+      mProvider = static_cast<QgsVectorDataProvider *>( QgsProviderRegistry::instance()->createProvider( provider, source, providerOptions ) );
       if ( !mProvider )
       {
         throw std::runtime_error( "Invalid provider" );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -65,8 +65,8 @@ static QString DEFAULT_LATLON_CRS = QStringLiteral( "CRS:84" );
 
 // TODO: colortable - use comon baseclass with gdal, mapserver does not support http://trac.osgeo.org/mapserver/ticket/1671
 
-QgsWcsProvider::QgsWcsProvider( const QString &uri )
-  : QgsRasterDataProvider( uri )
+QgsWcsProvider::QgsWcsProvider( const QString &uri, const ProviderOptions &options )
+  : QgsRasterDataProvider( uri, options )
   , mCachedViewExtent( 0 )
 {
   QgsDebugMsg( "constructing with uri '" + mHttpUri + "'." );
@@ -430,7 +430,8 @@ QgsWcsProvider::~QgsWcsProvider()
 
 QgsWcsProvider *QgsWcsProvider::clone() const
 {
-  QgsWcsProvider *provider = new QgsWcsProvider( dataSourceUri() );
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsWcsProvider *provider = new QgsWcsProvider( dataSourceUri(), providerOptions );
   provider->copyBaseSettings( *this );
   return provider;
 }
@@ -1581,9 +1582,9 @@ QMap<QString, QString> QgsWcsProvider::supportedMimes()
   return mimes;
 }
 
-QGISEXTERN QgsWcsProvider *classFactory( const QString *uri )
+QGISEXTERN QgsWcsProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsWcsProvider( *uri );
+  return new QgsWcsProvider( *uri, options );
 }
 
 QGISEXTERN QString providerKey()

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -112,11 +112,11 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     /**
      * Constructor for the provider.
      *
-     * \param   uri   HTTP URL of the Web Server.  If needed a proxy will be used
+     * \param uri HTTP URL of the Web Server.  If needed a proxy will be used
      *                otherwise we contact the host directly.
-     *
+     * \param options generic data provider options
      */
-    explicit QgsWcsProvider( const QString &uri = QString() );
+    explicit QgsWcsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
 
 
     ~QgsWcsProvider() override;

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -56,8 +56,8 @@
 static const QString TEXT_PROVIDER_KEY = QStringLiteral( "WFS" );
 static const QString TEXT_PROVIDER_DESCRIPTION = QStringLiteral( "WFS data provider" );
 
-QgsWFSProvider::QgsWFSProvider( const QString &uri, const QgsWfsCapabilities::Capabilities &caps )
-  : QgsVectorDataProvider( uri )
+QgsWFSProvider::QgsWFSProvider( const QString &uri, const ProviderOptions &options, const QgsWfsCapabilities::Capabilities &caps )
+  : QgsVectorDataProvider( uri, options )
   , mShared( new QgsWFSSharedData( uri ) )
 {
   mShared->mCaps = caps;
@@ -1739,9 +1739,9 @@ void QgsWFSProvider::handleException( const QDomDocument &serverResponse )
   pushError( tr( "Unhandled response: %1" ).arg( exceptionElem.tagName() ) );
 }
 
-QGISEXTERN QgsWFSProvider *classFactory( const QString *uri )
+QGISEXTERN QgsWFSProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsWFSProvider( *uri );
+  return new QgsWFSProvider( *uri, options );
 }
 
 QGISEXTERN QString providerKey()

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -63,7 +63,7 @@ class QgsWFSProvider : public QgsVectorDataProvider
     Q_OBJECT
   public:
 
-    explicit QgsWFSProvider( const QString &uri, const QgsWfsCapabilities::Capabilities &caps = QgsWfsCapabilities::Capabilities() );
+    explicit QgsWFSProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, const QgsWfsCapabilities::Capabilities &caps = QgsWfsCapabilities::Capabilities() );
     ~QgsWFSProvider() override;
 
     /* Inherited from QgsVectorDataProvider */

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -448,8 +448,10 @@ bool QgsWFSSharedData::createCache()
   pragmas << QStringLiteral( "synchronous=OFF" );
   pragmas << QStringLiteral( "journal_mode=WAL" ); // WAL is needed to avoid reader to block writers
   dsURI.setParam( QStringLiteral( "pragma" ), pragmas );
+
+  QgsDataProvider::ProviderOptions providerOptions;
   mCacheDataProvider = ( QgsVectorDataProvider * )( QgsProviderRegistry::instance()->createProvider(
-                         QStringLiteral( "spatialite" ), dsURI.uri() ) );
+                         QStringLiteral( "spatialite" ), dsURI.uri(), providerOptions ) );
   if ( mCacheDataProvider && !mCacheDataProvider->isValid() )
   {
     delete mCacheDataProvider;

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -425,7 +425,9 @@ bool QgsWFSValidatorCallback::isValid( const QString &sqlStr, QString &errorReas
 
   QgsWFSDataSourceURI uri( mURI );
   uri.setSql( sqlStr );
-  QgsWFSProvider p( uri.uri(), mCaps );
+
+  QgsDataProvider::ProviderOptions options;
+  QgsWFSProvider p( uri.uri(), options, mCaps );
   if ( !p.isValid() )
   {
     errorReason = p.processSQLErrorMsg();
@@ -454,7 +456,9 @@ void QgsWFSTableSelectedCallback::tableSelected( const QString &name )
     return;
   QgsWFSDataSourceURI uri( mURI );
   uri.setTypeName( prefixedTypename );
-  QgsWFSProvider p( uri.uri(), mCaps );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsWFSProvider p( uri.uri(), providerOptions, mCaps );
   if ( !p.isValid() )
   {
     return;
@@ -490,7 +494,9 @@ void QgsWFSSourceSelect::buildQuery( const QModelIndex &index )
   QgsWfsConnection connection( cmbConnections->currentText() );
   QgsWFSDataSourceURI uri( connection.uri().uri() );
   uri.setTypeName( typeName );
-  QgsWFSProvider p( uri.uri(), mCaps );
+
+  QgsDataProvider::ProviderOptions providerOptions;
+  QgsWFSProvider p( uri.uri(), providerOptions, mCaps );
   if ( !p.isValid() )
   {
     QMessageBox *box = new QMessageBox( QMessageBox::Critical, tr( "Server exception" ), tr( "DescribeFeatureType failed" ), QMessageBox::Ok, this );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -100,8 +100,8 @@ struct LessThanTileRequest
 };
 
 
-QgsWmsProvider::QgsWmsProvider( QString const &uri, const QgsWmsCapabilities *capabilities )
-  : QgsRasterDataProvider( uri )
+QgsWmsProvider::QgsWmsProvider( QString const &uri, const ProviderOptions &options, const QgsWmsCapabilities *capabilities )
+  : QgsRasterDataProvider( uri, options )
   , mHttpGetLegendGraphicResponse( nullptr )
   , mImageCrs( DEFAULT_LATLON_CRS )
 {
@@ -199,7 +199,8 @@ QgsWmsProvider::~QgsWmsProvider()
 
 QgsWmsProvider *QgsWmsProvider::clone() const
 {
-  QgsWmsProvider *provider = new QgsWmsProvider( dataSourceUri(), mCaps.isValid() ? &mCaps : nullptr );
+  QgsDataProvider::ProviderOptions options;
+  QgsWmsProvider *provider = new QgsWmsProvider( dataSourceUri(), options, mCaps.isValid() ? &mCaps : nullptr );
   provider->copyBaseSettings( *this );
   return provider;
 }
@@ -3522,9 +3523,9 @@ void QgsWmsProvider::getLegendGraphicReplyProgress( qint64 bytesReceived, qint64
  * Class factory to return a pointer to a newly created
  * QgsWmsProvider object
  */
-QGISEXTERN QgsWmsProvider *classFactory( const QString *uri )
+QGISEXTERN QgsWmsProvider *classFactory( const QString *uri, const QgsDataProvider::ProviderOptions &options )
 {
-  return new QgsWmsProvider( *uri );
+  return new QgsWmsProvider( *uri, options );
 }
 
 /**

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -117,12 +117,13 @@ class QgsWmsProvider : public QgsRasterDataProvider
     /**
      * Constructor for the provider.
      *
-     * \param   uri   HTTP URL of the Web Server.  If needed a proxy will be used
+     * \param uri HTTP URL of the Web Server.  If needed a proxy will be used
      *                otherwise we contact the host directly.
-     * \param   capabilities   Optionally existing parsed capabilities for the given URI
+     * \param options generic data provider options
+     * \param capabilities Optionally existing parsed capabilities for the given URI
      *
      */
-    QgsWmsProvider( const QString &uri = QString(), const QgsWmsCapabilities *capabilities = nullptr );
+    QgsWmsProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options, const QgsWmsCapabilities *capabilities = nullptr );
 
 
     ~QgsWmsProvider() override;

--- a/tests/src/providers/testqgsgdalprovider.cpp
+++ b/tests/src/providers/testqgsgdalprovider.cpp
@@ -84,7 +84,7 @@ void TestQgsGdalProvider::cleanupTestCase()
 void TestQgsGdalProvider::scaleDataType()
 {
   QString rasterWithOffset = QStringLiteral( TEST_DATA_DIR ) + "/int_raster_with_scale.tif";
-  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), rasterWithOffset );
+  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), rasterWithOffset, QgsDataProvider::ProviderOptions() );
   QgsRasterDataProvider *rp = dynamic_cast< QgsRasterDataProvider * >( provider );
   QVERIFY( rp );
   //raster is an integer data type, but has a scale < 1, so data type must be float
@@ -96,7 +96,7 @@ void TestQgsGdalProvider::scaleDataType()
 void TestQgsGdalProvider::warpedVrt()
 {
   QString raster = QStringLiteral( TEST_DATA_DIR ) + "/requires_warped_vrt.tif";
-  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), raster );
+  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), raster, QgsDataProvider::ProviderOptions() );
   QgsRasterDataProvider *rp = dynamic_cast< QgsRasterDataProvider * >( provider );
   QVERIFY( rp );
 
@@ -115,7 +115,7 @@ void TestQgsGdalProvider::warpedVrt()
 void TestQgsGdalProvider::noData()
 {
   QString raster = QStringLiteral( TEST_DATA_DIR ) + "/raster/band1_byte_ct_epsg4326.tif";
-  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), raster );
+  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), raster, QgsDataProvider::ProviderOptions() );
   QVERIFY( provider->isValid() );
   QgsRasterDataProvider *rp = dynamic_cast< QgsRasterDataProvider * >( provider );
   QVERIFY( rp );
@@ -129,7 +129,7 @@ void TestQgsGdalProvider::noData()
 void TestQgsGdalProvider::invalidNoDataInSourceIgnored()
 {
   QString raster = QStringLiteral( TEST_DATA_DIR ) + "/raster/byte_with_nan_nodata.tif";
-  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), raster );
+  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), raster, QgsDataProvider::ProviderOptions() );
   QVERIFY( provider->isValid() );
   QgsRasterDataProvider *rp = dynamic_cast< QgsRasterDataProvider * >( provider );
   QVERIFY( rp );
@@ -201,7 +201,7 @@ void TestQgsGdalProvider::isRepresentableValue()
 void TestQgsGdalProvider::mask()
 {
   QString raster = QStringLiteral( TEST_DATA_DIR ) + "/raster/rgb_with_mask.tif";
-  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), raster );
+  QgsDataProvider *provider = QgsProviderRegistry::instance()->createProvider( QStringLiteral( "gdal" ), raster, QgsDataProvider::ProviderOptions() );
   QVERIFY( provider->isValid() );
   QgsRasterDataProvider *rp = dynamic_cast< QgsRasterDataProvider * >( provider );
   QVERIFY( rp );

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -52,26 +52,26 @@ class TestQgsWmsProvider: public QObject
 
     void legendGraphicsWithStyle()
     {
-      QgsWmsProvider provider( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=fb_style&format=image/jpg" ), mCapabilities );
+      QgsWmsProvider provider( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=fb_style&format=image/jpg" ), QgsDataProvider::ProviderOptions(), mCapabilities );
       QCOMPARE( provider.getLegendGraphicUrl(), QString( "http://www.example.com/fb.png?" ) );
     }
 
     void legendGraphicsWithSecondStyle()
     {
-      QgsWmsProvider provider( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=yt_style&format=image/jpg" ), mCapabilities );
+      QgsWmsProvider provider( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=yt_style&format=image/jpg" ), QgsDataProvider::ProviderOptions(), mCapabilities );
       QCOMPARE( provider.getLegendGraphicUrl(), QString( "http://www.example.com/yt.png?" ) );
     }
 
     void legendGraphicsWithoutStyleWithDefault()
     {
-      QgsWmsProvider provider( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=buildings&styles=&format=image/jpg" ), mCapabilities );
+      QgsWmsProvider provider( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=buildings&styles=&format=image/jpg" ), QgsDataProvider::ProviderOptions(), mCapabilities );
       //only one style, can guess default => use it
       QCOMPARE( provider.getLegendGraphicUrl(), QString( "http://www.example.com/buildings.png?" ) );
     }
 
     void legendGraphicsWithoutStyleWithoutDefault()
     {
-      QgsWmsProvider provider( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=&format=image/jpg" ), mCapabilities );
+      QgsWmsProvider provider( QStringLiteral( "http://localhost:8380/mapserv?xxx&layers=agri_zones&styles=&format=image/jpg" ), QgsDataProvider::ProviderOptions(), mCapabilities );
       //two style, cannot guess default => use the WMS GetLegendGraphics
       QCOMPARE( provider.getLegendGraphicUrl(), QString( "http://localhost:8380/mapserv?" ) );
     }


### PR DESCRIPTION
This allows a way to pass generic settings to providers, e.g. passing a datum transform context for use in provider's constructors.

The current driver is to provide a way for map layers to set their data provider's transform context when constructing. This opens the way for map layers to be constructed with the correct transform context handling during the layer/data provider construction stage. This context isn't actually used by any providers (yet), nor is it correctly set for new layers (yet)... but this is a pre-requisite to correctly handling this.

But it also makes the api a bit more future proof, because the provider options struct can have additional members added at a later stage without breaking API. 

(It's important to land this before https://github.com/qgis/QGIS/pull/7012, which causes more of this API becomes locked into the frozen PyQGIS API.)

This relates to the discussion in https://github.com/qgis/QGIS/pull/6681, but does not replace that PR (which also concerns a method for updating the transform context for an existing layer/data provider)