### PR TITLE
Fix invalid polygon rings created by map to pixel simplification

### DIFF
--- a/src/core/qgsmaptopixelgeometrysimplifier.h
+++ b/src/core/qgsmaptopixelgeometrysimplifier.h
@@ -58,7 +58,7 @@ class CORE_EXPORT QgsMapToPixelSimplifier : public QgsAbstractGeometrySimplifier
 
   private:
     //! Simplify the geometry using the specified tolerance
-    static QgsGeometry simplifyGeometry( int simplifyFlags, SimplifyAlgorithm simplifyAlgorithm, QgsWkbTypes::Type wkbType, const QgsAbstractGeometry &geometry, const QgsRectangle &envelope, double map2pixelTol, bool isaLinearRing );
+    static QgsGeometry simplifyGeometry( int simplifyFlags, SimplifyAlgorithm simplifyAlgorithm, const QgsAbstractGeometry &geometry, double map2pixelTol, bool isaLinearRing );
 
   protected:
     //! Current simplification flags

--- a/src/core/qgsmaptopixelgeometrysimplifier.h
+++ b/src/core/qgsmaptopixelgeometrysimplifier.h
@@ -58,7 +58,7 @@ class CORE_EXPORT QgsMapToPixelSimplifier : public QgsAbstractGeometrySimplifier
 
   private:
     //! Simplify the geometry using the specified tolerance
-    static QgsGeometry simplifyGeometry( int simplifyFlags, SimplifyAlgorithm simplifyAlgorithm, const QgsAbstractGeometry &geometry, double map2pixelTol, bool isaLinearRing );
+    static std::unique_ptr<QgsAbstractGeometry> simplifyGeometry( int simplifyFlags, SimplifyAlgorithm simplifyAlgorithm, const QgsAbstractGeometry &geometry, double map2pixelTol, bool isaLinearRing );
 
   protected:
     //! Current simplification flags

--- a/tests/src/core/testqgsmaptopixelgeometrysimplifier.cpp
+++ b/tests/src/core/testqgsmaptopixelgeometrysimplifier.cpp
@@ -76,6 +76,7 @@ class TestQgsMapToPixelGeometrySimplifier : public QObject
     void testWkbDimensionMismatch();
     void testCircularString();
     void testVisvalingam();
+    void testRingValidity();
 
 };
 
@@ -203,6 +204,17 @@ void TestQgsMapToPixelGeometrySimplifier::testVisvalingam()
   QString expectedWkt( QStringLiteral( "LineString (0 0, 40 0, 41 100, 42 0, 50 0)" ) );
 
   QCOMPARE( simplifier.simplify( g ).asWkt(), expectedWkt );
+}
+
+void TestQgsMapToPixelGeometrySimplifier::testRingValidity()
+{
+  QgsGeometry poly = QgsGeometry::fromWkt( QStringLiteral( "Polygon ((0 0, 30 0, 30 30, 0 30, 0 0),(10.0001 10.00002, 10.0005 10.00002, 10.0005 10.00004, 10.00001 10.00004, 10.0001 10.00002 ))" ) );
+
+  int fl = QgsMapToPixelSimplifier::SimplifyGeometry | QgsMapToPixelSimplifier::SimplifyEnvelope;
+  QgsMapToPixelSimplifier simplifier( fl, 5 );
+  QgsGeometry ret = simplifier.simplify( poly );
+  QVERIFY( ret.isGeosValid() );
+
 }
 
 QGSTEST_MAIN( TestQgsMapToPixelGeometrySimplifier )


### PR DESCRIPTION
...when a larger polygon contains a very small ring.

Also optimise map to pixel simplification to avoid some unnecessary geometry cloning.