### PR TITLE
Fix missing color settings for python console / script editor

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -100,13 +100,9 @@ class Editor(QsciScintilla):
         self.setFont(font)
         self.setMarginsFont(font)
         # Margin 0 is used for line numbers
-        # fm = QFontMetrics(font)
         fontmetrics = QFontMetrics(font)
-        self.setMarginsFont(font)
         self.setMarginWidth(0, fontmetrics.width("0000") + 5)
         self.setMarginLineNumbers(0, True)
-        self.setMarginsForegroundColor(QColor("#3E3EE3"))
-        self.setMarginsBackgroundColor(QColor("#f9f9f9"))
         self.setCaretLineVisible(True)
         self.setCaretWidth(2)
 
@@ -117,17 +113,14 @@ class Editor(QsciScintilla):
         # self.setMinimumWidth(300)
 
         self.setBraceMatching(QsciScintilla.SloppyBraceMatch)
-        self.setMatchedBraceBackgroundColor(QColor("#b7f907"))
 
         # Folding
         self.setFolding(QsciScintilla.PlainFoldStyle)
-        self.setFoldMarginColors(QColor("#f4f4f4"), QColor("#f4f4f4"))
         # self.setWrapMode(QsciScintilla.WrapWord)
 
         # Edge Mode
         self.setEdgeMode(QsciScintilla.EdgeLine)
         self.setEdgeColumn(80)
-        self.setEdgeColor(QColor("#FF0000"))
 
         # self.setWrapMode(QsciScintilla.WrapCharacter)
         self.setWhitespaceVisibility(QsciScintilla.WsVisibleAfterIndent)
@@ -182,6 +175,18 @@ class Editor(QsciScintilla):
         self.modificationAttempted.connect(self.fileReadOnly)
 
     def settingsEditor(self):
+        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColorEditor", QColor("#2e3436"))))
+        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColorEditor", QColor("#babdb6"))))
+        self.setMatchedBraceBackgroundColor(QColor(self.settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor("#b7f907"))))
+        self.setMatchedBraceForegroundColor(QColor(self.settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor("#000000"))))
+        self.setMarginsForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3"))))
+        self.setMarginsBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9"))))
+        self.setIndentationGuidesForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3"))))
+        self.setIndentationGuidesBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9"))))
+        self.setEdgeColor(QColor(self.settings.value("pythonConsole/edgeColorEditor", QColor("#FF0000"))))
+        foldColor = QColor(self.settings.value("pythonConsole/foldColorEditor", QColor("#f4f4f4")))
+        self.setFoldMarginColors(foldColor, foldColor)
+
         # Set Python lexer
         self.setLexers()
         threshold = self.settings.value("pythonConsole/autoCompThresholdEditor", 2, type=int)
@@ -234,6 +239,7 @@ class Editor(QsciScintilla):
         self.lexer.setDefaultFont(font)
         self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColorEditor", QColor(Qt.black))))
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColorEditor", QColor(Qt.gray))), 1)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColorEditor", QColor("#4e9a06"))), 2)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColorEditor", QColor(Qt.darkGreen))), 5)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColorEditor", QColor(Qt.blue))), 8)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColorEditor", QColor(Qt.darkGray))), 9)

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -126,8 +126,6 @@ class ShellOutputScintilla(QsciScintilla):
         self.setMarginsFont(font)
         self.setMarginWidth(1, "00000")
         self.setMarginLineNumbers(1, True)
-        self.setMarginsForegroundColor(QColor("#3E3EE3"))
-        self.setMarginsBackgroundColor(QColor("#f9f9f9"))
         self.setCaretLineVisible(True)
         self.setCaretWidth(0)
 
@@ -161,6 +159,11 @@ class ShellOutputScintilla(QsciScintilla):
     def refreshSettingsOutput(self):
         # Set Python lexer
         self.setLexers()
+        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColor", QColor("#2e3436"))))
+        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColor", QColor("#babdb6"))))
+        self.setMatchedBraceBackgroundColor(QColor(self.settings.value("pythonConsole/matchedBraceColor", QColor("#b7f907"))))
+        self.setMarginsForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColor", QColor("#3E3EE3"))))
+        self.setMarginsBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColor", QColor("#f9f9f9"))))
         caretLineColor = self.settings.value("pythonConsole/caretLineColor", QColor("#fcf3ed"))
         cursorColor = self.settings.value("pythonConsole/cursorColor", QColor(Qt.black))
         self.setCaretLineBackgroundColor(caretLineColor)
@@ -181,6 +184,7 @@ class ShellOutputScintilla(QsciScintilla):
         self.lexer.setDefaultFont(font)
         self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColor", QColor(Qt.black))))
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColor", QColor(Qt.gray))), 1)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColorEditor", QColor("#4e9a06"))), 2)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColor", QColor(Qt.darkGreen))), 5)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColor", QColor(Qt.blue))), 8)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColor", QColor(Qt.darkGray))), 9)

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -78,7 +78,6 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         # Brace matching: enable for a brace immediately before or after
         # the current position
         self.setBraceMatching(QsciScintilla.SloppyBraceMatch)
-        self.setMatchedBraceBackgroundColor(QColor("#b7f907"))
 
         # Current line visible with special background color
         self.setCaretWidth(2)
@@ -138,6 +137,10 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
 
         cursorColor = self.settings.value("pythonConsole/cursorColor", QColor(Qt.black))
         self.setCaretForegroundColor(cursorColor)
+        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColor", QColor("#2e3436"))))
+        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColor", QColor("#babdb6"))))
+        self.setMatchedBraceBackgroundColor(QColor(self.settings.value("pythonConsole/matchedBraceBackgroundColor", QColor("#b7f907"))))
+        self.setMatchedBraceForegroundColor(QColor(self.settings.value("pythonConsole/matchedBraceForegroundColor", QColor("#000000"))))
 
         # Sets minimum height for input area based of font metric
         self._setMinimumHeight()
@@ -187,6 +190,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         self.lexer.setDefaultFont(font)
         self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColor", QColor(Qt.black))))
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColor", QColor(Qt.gray))), 1)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColorEditor", QColor("#4e9a06"))), 2)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColor", QColor(Qt.darkGreen))), 5)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColor", QColor(Qt.blue))), 8)
         self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColor", QColor(Qt.darkGray))), 9)

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -199,6 +199,8 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         settings.setValue("pythonConsole/keywordFontColorEditor", self.keywordFontColorEditor.color())
         settings.setValue("pythonConsole/decorFontColor", self.decorFontColor.color())
         settings.setValue("pythonConsole/decorFontColorEditor", self.decorFontColorEditor.color())
+        settings.setValue("pythonConsole/numberFontColor", self.numberFontColor.color())
+        settings.setValue("pythonConsole/numberFontColorEditor", self.numberFontColorEditor.color())
         settings.setValue("pythonConsole/methodFontColor", self.methodFontColor.color())
         settings.setValue("pythonConsole/methodFontColorEditor", self.methodFontColorEditor.color())
         settings.setValue("pythonConsole/commentFontColor", self.commentFontColor.color())
@@ -223,6 +225,20 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         settings.setValue("pythonConsole/tripleDoubleQuoteFontColor", self.tripleDoubleQuoteFontColor.color())
         settings.setValue("pythonConsole/tripleDoubleQuoteFontColorEditor",
                           self.tripleDoubleQuoteFontColorEditor.color())
+        settings.setValue("pythonConsole/edgeColorEditor", self.edgeColorEditor.color())
+        settings.setValue("pythonConsole/marginBackgroundColor", self.marginBackgroundColor.color())
+        settings.setValue("pythonConsole/marginBackgroundColorEditor", self.marginBackgroundColorEditor.color())
+        settings.setValue("pythonConsole/marginForegroundColor", self.marginForegroundColor.color())
+        settings.setValue("pythonConsole/marginForegroundColorEditor", self.marginForegroundColorEditor.color())
+        settings.setValue("pythonConsole/foldColorEditor", self.foldColorEditor.color())
+        settings.setValue("pythonConsole/selectionBackgroundColor", self.selectionBackgroundColor.color())
+        settings.setValue("pythonConsole/selectionBackgroundColorEditor", self.selectionBackgroundColorEditor.color())
+        settings.setValue("pythonConsole/selectionForegroundColor", self.selectionForegroundColor.color())
+        settings.setValue("pythonConsole/selectionForegroundColorEditor", self.selectionForegroundColorEditor.color())
+        settings.setValue("pythonConsole/matchedBraceBackgroundColor", self.matchedBraceBackgroundColor.color())
+        settings.setValue("pythonConsole/matchedBraceBackgroundColorEditor", self.matchedBraceBackgroundColorEditor.color())
+        settings.setValue("pythonConsole/matchedBraceForegroundColor", self.matchedBraceForegroundColor.color())
+        settings.setValue("pythonConsole/matchedBraceForegroundColorEditor", self.matchedBraceForegroundColorEditor.color())
 
     def restoreSettings(self):
         settings = QgsSettings()
@@ -289,7 +305,10 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
             QColor(settings.value("pythonConsole/methodFontColorEditor", QColor(Qt.darkGray))))
         self.decorFontColor.setColor(QColor(settings.value("pythonConsole/decorFontColor", QColor(Qt.darkBlue))))
         self.decorFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/decorFontColorEditor", QColor(Qt.darkBlue))))
+            QColor(settings.value("pythonConsole/decorFontColorEditor", QColor("#4e9a06"))))
+        self.numberFontColor.setColor(QColor(settings.value("pythonConsole/numberFontColor", QColor("#4e9a06"))))
+        self.numberFontColorEditor.setColor(
+            QColor(settings.value("pythonConsole/numberFontColorEditor", QColor(Qt.darkBlue))))
         self.commentFontColor.setColor(QColor(settings.value("pythonConsole/commentFontColor", QColor(Qt.gray))))
         self.commentFontColorEditor.setColor(
             QColor(settings.value("pythonConsole/commentFontColorEditor", QColor(Qt.gray))))
@@ -322,6 +341,20 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
             settings.value("pythonConsole/tripleDoubleQuoteFontColor", QColor(Qt.blue)))
         self.tripleDoubleQuoteFontColorEditor.setColor(
             settings.value("pythonConsole/tripleDoubleQuoteFontColorEditor", QColor(Qt.blue)))
+        self.edgeColorEditor.setColor(settings.value("pythonConsole/edgeColorEditor", QColor("#FF0000")))
+        self.marginBackgroundColor.setColor(settings.value("pythonConsole/marginBackgroundColor", QColor("#f9f9f9")))
+        self.marginBackgroundColorEditor.setColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9")))
+        self.marginForegroundColor.setColor(settings.value("pythonConsole/marginForegroundColor", QColor("#3E3EE3")))
+        self.marginForegroundColorEditor.setColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3")))
+        self.foldColorEditor.setColor(settings.value("pythonConsole/foldColorEditor", QColor("#f4f4f4")))
+        self.selectionForegroundColor.setColor(settings.value("pythonConsole/selectionForegroundColor", QColor("#2e3436")))
+        self.selectionForegroundColorEditor.setColor(settings.value("pythonConsole/selectionForegroundColorEditor", QColor("#2e3436")))
+        self.selectionBackgroundColor.setColor(settings.value("pythonConsole/selectionBackgroundColor", QColor("#babdb6")))
+        self.selectionBackgroundColorEditor.setColor(settings.value("pythonConsole/selectionBackgroundColorEditor", QColor("#babdb6")))
+        self.matchedBraceForegroundColor.setColor(settings.value("pythonConsole/matchedBraceForegroundColor", QColor("#000000")))
+        self.matchedBraceForegroundColorEditor.setColor(settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor("#000000")))
+        self.matchedBraceBackgroundColor.setColor(settings.value("pythonConsole/matchedBraceBackgroundColor", QColor("#b7f907")))
+        self.matchedBraceBackgroundColorEditor.setColor(settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor("#b7f907")))
 
     def _resetFontColor(self):
         self.defaultFontColor.setColor(QColor(Qt.black))
@@ -329,6 +362,7 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         self.classFontColor.setColor(QColor(Qt.blue))
         self.methodFontColor.setColor(QColor(Qt.darkGray))
         self.decorFontColor.setColor(QColor(Qt.darkBlue))
+        self.numFontColor.setColor(QColor("#4e9a06"))
         self.commentFontColor.setColor(QColor(Qt.gray))
         self.commentBlockFontColor.setColor(QColor(Qt.gray))
         self.stderrFontColor.setColor(QColor(Qt.red))
@@ -339,6 +373,12 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         self.doubleQuoteFontColor.setColor(QColor(Qt.blue))
         self.tripleSingleQuoteFontColor.setColor(QColor(Qt.blue))
         self.tripleDoubleQuoteFontColor.setColor(QColor(Qt.blue))
+        self.marginBackgroundColor.setColor(QColor("#f9f9f9"))
+        self.marginForegroundColor.setColor(QColor("#3E3EE3"))
+        self.selectionBackgroundColor.setColor(QColor("#babdb6"))
+        self.selectionForegroundColor.setColor(QColor("#2e3436"))
+        self.matchedBraceBackgroundColor.setColor(QColor("#b7f907"))
+        self.matchedBraceForegroundColor.setColor(QColor("#000000"))
 
     def _resetFontColorEditor(self):
         self.defaultFontColorEditor.setColor(QColor(Qt.black))
@@ -346,6 +386,7 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         self.classFontColorEditor.setColor(QColor(Qt.blue))
         self.methodFontColorEditor.setColor(QColor(Qt.darkGray))
         self.decorFontColorEditor.setColor(QColor(Qt.darkBlue))
+        self.numFontColorEditor.setColor(QColor("#4e9a06"))
         self.commentFontColorEditor.setColor(QColor(Qt.gray))
         self.commentBlockFontColorEditor.setColor(QColor(Qt.gray))
         self.paperBackgroundColorEditor.setColor(QColor(Qt.white))
@@ -355,6 +396,14 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         self.doubleQuoteFontColorEditor.setColor(QColor(Qt.blue))
         self.tripleSingleQuoteFontColorEditor.setColor(QColor(Qt.blue))
         self.tripleDoubleQuoteFontColorEditor.setColor(QColor(Qt.blue))
+        self.edgeColorEditor.setColor(QColor("#FF0000"))
+        self.marginBackgroundColorEditor.setColor(QColor("#f9f9f9"))
+        self.marginForegroundColorEditor.setColor(QColor("#3E3EE3"))
+        self.foldColorEditor.setColor(QColor("#f4f4f4"))
+        self.selectionBackgroundColorEditor.setColor(QColor("#babdb6"))
+        self.selectionForegroundColorEditor.setColor(QColor("#2e3436"))
+        self.matchedBraceBackgroundColorEditor.setColor(QColor("#b7f907"))
+        self.matchedBraceForegroundColorEditor.setColor(QColor("#000000"))
 
     def reject(self):
         self.restoreSettings()

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>995</width>
-    <height>630</height>
+    <width>1055</width>
+    <height>720</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -313,41 +313,55 @@
                  </widget>
                 </item>
                 <item row="1" column="4">
-                 <widget class="QLabel" name="label_19">
+                 <widget class="QLabel" name="label_55">
                   <property name="text">
-                   <string>Comment</string>
+                   <string>Number</string>
                   </property>
                  </widget>
                 </item>
                 <item row="1" column="5">
-                 <widget class="QgsColorButton" name="commentFontColor">
+                 <widget class="QgsColorButton" name="numberFontColor">
                   <property name="text">
                    <string/>
                   </property>
                  </widget>
                 </item>
                 <item row="2" column="0">
-                 <widget class="QLabel" name="label_20">
+                 <widget class="QLabel" name="label_19">
                   <property name="text">
-                   <string>Comment block</string>
+                   <string>Comment</string>
                   </property>
                  </widget>
                 </item>
                 <item row="2" column="1">
-                 <widget class="QgsColorButton" name="commentBlockFontColor">
+                 <widget class="QgsColorButton" name="commentFontColor">
                   <property name="text">
                    <string/>
                   </property>
                  </widget>
                 </item>
                 <item row="2" column="2">
+                 <widget class="QLabel" name="label_20">
+                  <property name="text">
+                   <string>Comment block</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="3">
+                 <widget class="QgsColorButton" name="commentBlockFontColor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="4">
                  <widget class="QLabel" name="label_24">
                   <property name="text">
                    <string>Cursor</string>
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="3">
+                <item row="4" column="5">
                  <widget class="QgsColorButton" name="cursorColor">
                   <property name="text">
                    <string/>
@@ -438,15 +452,99 @@
                   </property>
                  </widget>
                 </item>
-                <item row="4" column="4">
+                <item row="5" column="0">
+                 <widget class="QLabel" name="label_42">
+                  <property name="text">
+                   <string>Margin background</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="1">
+                 <widget class="QgsColorButton" name="marginBackgroundColor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="2">
+                 <widget class="QLabel" name="label_43">
+                  <property name="text">
+                   <string>Margin foreground</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="3">
+                 <widget class="QgsColorButton" name="marginForegroundColor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="4">
                  <widget class="QLabel" name="label_14">
                   <property name="text">
                    <string>Error</string>
                   </property>
                  </widget>
                 </item>
-                <item row="4" column="5">
+                <item row="5" column="5">
                  <widget class="QgsColorButton" name="stderrFontColor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="0">
+                 <widget class="QLabel" name="label_48">
+                  <property name="text">
+                   <string>Selection background</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="1">
+                 <widget class="QgsColorButton" name="selectionBackgroundColor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="2">
+                 <widget class="QLabel" name="label_49">
+                  <property name="text">
+                   <string>Selection foreground</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="3">
+                 <widget class="QgsColorButton" name="selectionForegroundColor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="0">
+                 <widget class="QLabel" name="label_50">
+                  <property name="text">
+                   <string>Brace background</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="1">
+                 <widget class="QgsColorButton" name="matchedBraceBackgroundColor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="2">
+                 <widget class="QLabel" name="label_60">
+                  <property name="text">
+                   <string>Brace foreground</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="3">
+                 <widget class="QgsColorButton" name="matchedBraceForegroundColor">
                   <property name="text">
                    <string/>
                   </property>
@@ -841,41 +939,55 @@
                  </widget>
                 </item>
                 <item row="1" column="4">
-                 <widget class="QLabel" name="label_10">
+                 <widget class="QLabel" name="label_56">
                   <property name="text">
-                   <string>Comment</string>
+                   <string>Number</string>
                   </property>
                  </widget>
                 </item>
                 <item row="1" column="5">
-                 <widget class="QgsColorButton" name="commentFontColorEditor">
+                 <widget class="QgsColorButton" name="numberFontColorEditor">
                   <property name="text">
                    <string/>
                   </property>
                  </widget>
                 </item>
                 <item row="2" column="0">
-                 <widget class="QLabel" name="label_12">
+                 <widget class="QLabel" name="label_10">
                   <property name="text">
-                   <string>Comment block</string>
+                   <string>Comment</string>
                   </property>
                  </widget>
                 </item>
                 <item row="2" column="1">
-                 <widget class="QgsColorButton" name="commentBlockFontColorEditor">
+                 <widget class="QgsColorButton" name="commentFontColorEditor">
                   <property name="text">
                    <string/>
                   </property>
                  </widget>
                 </item>
                 <item row="2" column="2">
+                 <widget class="QLabel" name="label_12">
+                  <property name="text">
+                   <string>Comment block</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="3">
+                 <widget class="QgsColorButton" name="commentBlockFontColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="4" column="4">
                  <widget class="QLabel" name="label_25">
                   <property name="text">
                    <string>Cursor</string>
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="3">
+                <item row="4" column="5">
                  <widget class="QgsColorButton" name="cursorColorEditor">
                   <property name="text">
                    <string/>
@@ -947,6 +1059,118 @@
                 </item>
                 <item row="4" column="3">
                  <widget class="QgsColorButton" name="tripleDoubleQuoteFontColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="4">
+                 <widget class="QLabel" name="label_40">
+                  <property name="text">
+                   <string>Edge</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="5">
+                 <widget class="QgsColorButton" name="edgeColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="0">
+                 <widget class="QLabel" name="label_45">
+                  <property name="text">
+                   <string>Margin background</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="1">
+                 <widget class="QgsColorButton" name="marginBackgroundColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="2">
+                 <widget class="QLabel" name="label_46">
+                  <property name="text">
+                   <string>Margin foreground</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="5" column="3">
+                 <widget class="QgsColorButton" name="marginForegroundColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="4">
+                 <widget class="QLabel" name="label_47">
+                  <property name="text">
+                   <string>Fold guide</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="5">
+                 <widget class="QgsColorButton" name="foldColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="0">
+                 <widget class="QLabel" name="label_51">
+                  <property name="text">
+                   <string>Selection background</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="1">
+                 <widget class="QgsColorButton" name="selectionBackgroundColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="2">
+                 <widget class="QLabel" name="label_52">
+                  <property name="text">
+                   <string>Selection foreground</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="6" column="3">
+                 <widget class="QgsColorButton" name="selectionForegroundColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="0">
+                 <widget class="QLabel" name="label_53">
+                  <property name="text">
+                   <string>Brace background</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="1">
+                 <widget class="QgsColorButton" name="matchedBraceBackgroundColorEditor">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="2">
+                 <widget class="QLabel" name="label_61">
+                  <property name="text">
+                   <string>Brace foreground</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="7" column="3">
+                 <widget class="QgsColorButton" name="matchedBraceForegroundColorEditor">
                   <property name="text">
                    <string/>
                   </property>

--- a/python/plugins/processing/script/ScriptEdit.py
+++ b/python/plugins/processing/script/ScriptEdit.py
@@ -28,7 +28,7 @@ __revision__ = '$Format:%H$'
 import os
 
 from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtGui import QFont, QColor, QKeySequence, QFontDatabase
+from qgis.PyQt.QtGui import QFont, QColor, QKeySequence, QFontDatabase, QFontMetrics
 from qgis.PyQt.QtWidgets import QShortcut
 from qgis.core import QgsApplication, QgsSettings
 
@@ -50,32 +50,34 @@ class ScriptEdit(QsciScintilla):
         # Enable non-ASCII characters
         self.setUtf8(True)
 
+        settings = QgsSettings()
+
         # Default font
-        font = QFont()
-        font.setFamily('Courier')
-        font.setFixedPitch(True)
-        font.setPointSize(20)
+        font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
         self.setFont(font)
         self.setMarginsFont(font)
 
         self.setBraceMatching(QsciScintilla.SloppyBraceMatch)
-        self.setMatchedBraceBackgroundColor(QColor("#b7f907"))
+        self.setMatchedBraceBackgroundColor(QColor(settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor("#b7f907"))))
+        self.setMatchedBraceForegroundColor(QColor(settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor("#000000"))))
 
         #self.setWrapMode(QsciScintilla.WrapWord)
         #self.setWrapVisualFlags(QsciScintilla.WrapFlagByText,
         #                        QsciScintilla.WrapFlagNone, 4)
 
-        self.setSelectionForegroundColor(QColor('#2e3436'))
-        self.setSelectionBackgroundColor(QColor('#babdb6'))
+        self.setSelectionForegroundColor(QColor(settings.value("pythonConsole/selectionForegroundColorEditor", QColor("#2e3436"))))
+        self.setSelectionBackgroundColor(QColor(settings.value("pythonConsole/selectionBackgroundColorEditor", QColor("#babdb6"))))
 
         # Show line numbers
-        self.setMarginWidth(1, '000')
+        fontmetrics = QFontMetrics(font)
+        self.setMarginWidth(1, fontmetrics.width("0000") + 5)
         self.setMarginLineNumbers(1, True)
-        self.setMarginsForegroundColor(QColor("#3E3EE3"))
-        self.setMarginsBackgroundColor(QColor("#f9f9f9"))
+        self.setMarginsForegroundColor(QColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3"))))
+        self.setMarginsBackgroundColor(QColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9"))))
+        self.setIndentationGuidesForegroundColor(QColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3"))))
+        self.setIndentationGuidesBackgroundColor(QColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9"))))
 
         # Highlight current line
-        settings = QgsSettings()
         caretLineColorEditor = settings.value("pythonConsole/caretLineColorEditor", QColor("#fcf3ed"))
         cursorColorEditor = settings.value("pythonConsole/cursorColorEditor", QColor(Qt.black))
         self.setCaretLineVisible(True)
@@ -85,12 +87,13 @@ class ScriptEdit(QsciScintilla):
 
         # Folding
         self.setFolding(QsciScintilla.PlainFoldStyle)
-        self.setFoldMarginColors(QColor("#f4f4f4"), QColor("#f4f4f4"))
+        foldColor = QColor(settings.value("pythonConsole/foldColorEditor", QColor("#f4f4f4")))
+        self.setFoldMarginColors(foldColor, foldColor)
 
         # Mark column 80 with vertical line
         self.setEdgeMode(QsciScintilla.EdgeLine)
         self.setEdgeColumn(80)
-        self.setEdgeColor(QColor("#FF0000"))
+        self.setEdgeColor(QColor(settings.value("pythonConsole/edgeColorEditor", QColor("#FF0000"))))
 
         # Indentation
         self.setAutoIndent(True)
@@ -169,6 +172,7 @@ class ScriptEdit(QsciScintilla):
         self.lexer.setDefaultFont(font)
         self.lexer.setDefaultColor(QColor(settings.value("pythonConsole/defaultFontColorEditor", QColor(Qt.black))))
         self.lexer.setColor(QColor(settings.value("pythonConsole/commentFontColorEditor", QColor(Qt.gray))), 1)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/numberFontColorEditor", QColor(Qt.gray))), 2)
         self.lexer.setColor(QColor(settings.value("pythonConsole/keywordFontColorEditor", QColor(Qt.darkGreen))), 5)
         self.lexer.setColor(QColor(settings.value("pythonConsole/classFontColorEditor", QColor(Qt.blue))), 8)
         self.lexer.setColor(QColor(settings.value("pythonConsole/methodFontColorEditor", QColor(Qt.darkGray))), 9)


### PR DESCRIPTION
## Description
This PR adds missing color settings to fully customize the color scheme for QGIS' python console and processing script editor. This is mostly adding QgsColorButtons to the .ui file.

This fixes dark color schemes having some elements hidden due to using default colors. QGIS can now properly look like this:
![screenshot from 2018-05-22 11-54-40](https://user-images.githubusercontent.com/1728657/40342958-b7499bf0-5db7-11e8-82be-7e4a2963f695.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
