### PR TITLE
Improve default color scheme for python console & script editor

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -77,7 +77,31 @@ class KeyFilter(QObject):
 
 
 class Editor(QsciScintilla):
+
     MARKER_NUM = 6
+    DEFAULT_COLOR = "#4d4d4c"
+    KEYWORD_COLOR = "#8959a8"
+    CLASS_COLOR = "#4271ae"
+    METHOD_COLOR = "#4271ae"
+    DECORATION_COLOR = "#3e999f"
+    NUMBER_COLOR = "#c82829"
+    COMMENT_COLOR = "#8e908c"
+    COMMENT_BLOCK_COLOR = "#8e908c"
+    BACKGROUND_COLOR = "#ffffff"
+    CURSOR_COLOR = "#636363"
+    CARET_LINE_COLOR = "#efefef"
+    SINGLE_QUOTE_COLOR = "#718c00"
+    DOUBLE_QUOTE_COLOR = "#718c00"
+    TRIPLE_SINGLE_QUOTE_COLOR = "#eab700"
+    TRIPLE_DOUBLE_QUOTE_COLOR = "#eab700"
+    MARGIN_BACKGROUND_COLOR = "#efefef"
+    MARGIN_FOREGROUND_COLOR = "#636363"
+    SELECTION_BACKGROUND_COLOR = "#d7d7d7"
+    SELECTION_FOREGROUND_COLOR = "#303030"
+    MATCHED_BRACE_BACKGROUND_COLOR = "#b7f907"
+    MATCHED_BRACE_FOREGROUND_COLOR = "#303030"
+    EDGE_COLOR = "#efefef"
+    FOLD_COLOR = "#efefef"
 
     def __init__(self, parent=None):
         super(Editor, self).__init__(parent)
@@ -175,16 +199,16 @@ class Editor(QsciScintilla):
         self.modificationAttempted.connect(self.fileReadOnly)
 
     def settingsEditor(self):
-        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColorEditor", QColor("#2e3436"))))
-        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColorEditor", QColor("#babdb6"))))
-        self.setMatchedBraceBackgroundColor(QColor(self.settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor("#b7f907"))))
-        self.setMatchedBraceForegroundColor(QColor(self.settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor("#000000"))))
-        self.setMarginsForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3"))))
-        self.setMarginsBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9"))))
-        self.setIndentationGuidesForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3"))))
-        self.setIndentationGuidesBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9"))))
-        self.setEdgeColor(QColor(self.settings.value("pythonConsole/edgeColorEditor", QColor("#FF0000"))))
-        foldColor = QColor(self.settings.value("pythonConsole/foldColorEditor", QColor("#f4f4f4")))
+        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColorEditor", QColor(self.SELECTION_FOREGROUND_COLOR))))
+        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColorEditor", QColor(self.SELECTION_BACKGROUND_COLOR))))
+        self.setMatchedBraceBackgroundColor(QColor(self.settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor(self.MATCHED_BRACE_BACKGROUND_COLOR))))
+        self.setMatchedBraceForegroundColor(QColor(self.settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor(self.MATCHED_BRACE_FOREGROUND_COLOR))))
+        self.setMarginsForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColorEditor", QColor(self.MARGIN_FOREGROUND_COLOR))))
+        self.setMarginsBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColorEditor", QColor(self.MARGIN_BACKGROUND_COLOR))))
+        self.setIndentationGuidesForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColorEditor", QColor(self.MARGIN_FOREGROUND_COLOR))))
+        self.setIndentationGuidesBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColorEditor", QColor(self.MARGIN_BACKGROUND_COLOR))))
+        self.setEdgeColor(QColor(self.settings.value("pythonConsole/edgeColorEditor", QColor(self.EDGE_COLOR))))
+        foldColor = QColor(self.settings.value("pythonConsole/foldColorEditor", QColor(self.FOLD_COLOR)))
         self.setFoldMarginColors(foldColor, foldColor)
 
         # Set Python lexer
@@ -203,8 +227,8 @@ class Editor(QsciScintilla):
         else:
             self.setAutoCompletionSource(self.AcsNone)
 
-        caretLineColorEditor = self.settings.value("pythonConsole/caretLineColorEditor", QColor("#fcf3ed"))
-        cursorColorEditor = self.settings.value("pythonConsole/cursorColorEditor", QColor(Qt.black))
+        caretLineColorEditor = self.settings.value("pythonConsole/caretLineColorEditor", QColor(self.CARET_LINE_COLOR))
+        cursorColorEditor = self.settings.value("pythonConsole/cursorColorEditor", QColor(self.CURSOR_COLOR))
         self.setCaretLineBackgroundColor(caretLineColorEditor)
         self.setCaretForegroundColor(cursorColorEditor)
 
@@ -237,25 +261,25 @@ class Editor(QsciScintilla):
             font.setPointSize(fontSize)
 
         self.lexer.setDefaultFont(font)
-        self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColorEditor", QColor(Qt.black))))
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColorEditor", QColor(Qt.gray))), 1)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColorEditor", QColor("#4e9a06"))), 2)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColorEditor", QColor(Qt.darkGreen))), 5)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColorEditor", QColor(Qt.blue))), 8)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColorEditor", QColor(Qt.darkGray))), 9)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/decorFontColorEditor", QColor(Qt.darkBlue))), 15)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentBlockFontColorEditor", QColor(Qt.gray))), 12)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/singleQuoteFontColorEditor", QColor(Qt.blue))), 4)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/doubleQuoteFontColorEditor", QColor(Qt.blue))), 3)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleSingleQuoteFontColorEditor", QColor(Qt.blue))), 6)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleDoubleQuoteFontColorEditor", QColor(Qt.blue))), 7)
+        self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColorEditor", QColor(self.DEFAULT_COLOR))))
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColorEditor", QColor(self.COMMENT_COLOR))), 1)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColorEditor", QColor(self.NUMBER_COLOR))), 2)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColorEditor", QColor(self.KEYWORD_COLOR))), 5)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColorEditor", QColor(self.CLASS_COLOR))), 8)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColorEditor", QColor(self.METHOD_COLOR))), 9)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/decorFontColorEditor", QColor(self.DECORATION_COLOR))), 15)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentBlockFontColorEditor", QColor(self.COMMENT_BLOCK_COLOR))), 12)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/singleQuoteFontColorEditor", QColor(self.SINGLE_QUOTE_COLOR))), 4)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/doubleQuoteFontColorEditor", QColor(self.DOUBLE_QUOTE_COLOR))), 3)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleSingleQuoteFontColorEditor", QColor(self.TRIPLE_SINGLE_QUOTE_COLOR))), 6)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleDoubleQuoteFontColorEditor", QColor(self.TRIPLE_DOUBLE_QUOTE_COLOR))), 7)
         self.lexer.setFont(font, 1)
         self.lexer.setFont(font, 3)
         self.lexer.setFont(font, 4)
         self.lexer.setFont(font, QsciLexerPython.UnclosedString)
 
         for style in range(0, 33):
-            paperColor = QColor(self.settings.value("pythonConsole/paperBackgroundColorEditor", QColor(Qt.white)))
+            paperColor = QColor(self.settings.value("pythonConsole/paperBackgroundColorEditor", QColor(self.BACKGROUND_COLOR)))
             self.lexer.setPaper(paperColor, style)
 
         self.api = QsciAPIs(self.lexer)

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -30,6 +30,8 @@ import sys
 
 class writeOut(object):
 
+    ERROR_COLOR = "#e31a1c"
+
     def __init__(self, shellOut, out=None, style=None):
         """
         This class allows writing to stdout and stderr
@@ -42,7 +44,7 @@ class writeOut(object):
     def write(self, m):
         if self.style == "_traceback":
             # Show errors in red
-            stderrColor = QColor(self.sO.settings.value("pythonConsole/stderrFontColor", QColor(Qt.red)))
+            stderrColor = QColor(self.sO.settings.value("pythonConsole/stderrFontColor", QColor(self.ERROR_COLOR)))
             self.sO.SendScintilla(QsciScintilla.SCI_STYLESETFORE, 0o01, stderrColor)
             self.sO.SendScintilla(QsciScintilla.SCI_STYLESETITALIC, 0o01, True)
             self.sO.SendScintilla(QsciScintilla.SCI_STYLESETBOLD, 0o01, True)
@@ -85,6 +87,28 @@ class writeOut(object):
 
 
 class ShellOutputScintilla(QsciScintilla):
+
+    DEFAULT_COLOR = "#4d4d4c"
+    KEYWORD_COLOR = "#8959a8"
+    CLASS_COLOR = "#4271ae"
+    METHOD_COLOR = "#4271ae"
+    DECORATION_COLOR = "#3e999f"
+    NUMBER_COLOR = "#c82829"
+    COMMENT_COLOR = "#8e908c"
+    COMMENT_BLOCK_COLOR = "#8e908c"
+    BACKGROUND_COLOR = "#ffffff"
+    CURSOR_COLOR = "#636363"
+    CARET_LINE_COLOR = "#efefef"
+    SINGLE_QUOTE_COLOR = "#718c00"
+    DOUBLE_QUOTE_COLOR = "#718c00"
+    TRIPLE_SINGLE_QUOTE_COLOR = "#eab700"
+    TRIPLE_DOUBLE_QUOTE_COLOR = "#eab700"
+    MARGIN_BACKGROUND_COLOR = "#efefef"
+    MARGIN_FOREGROUND_COLOR = "#636363"
+    SELECTION_BACKGROUND_COLOR = "#d7d7d7"
+    SELECTION_FOREGROUND_COLOR = "#303030"
+    MATCHED_BRACE_BACKGROUND_COLOR = "#b7f907"
+    MATCHED_BRACE_FOREGROUND_COLOR = "#303030"
 
     def __init__(self, parent=None):
         super(ShellOutputScintilla, self).__init__(parent)
@@ -159,13 +183,12 @@ class ShellOutputScintilla(QsciScintilla):
     def refreshSettingsOutput(self):
         # Set Python lexer
         self.setLexers()
-        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColor", QColor("#2e3436"))))
-        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColor", QColor("#babdb6"))))
-        self.setMatchedBraceBackgroundColor(QColor(self.settings.value("pythonConsole/matchedBraceColor", QColor("#b7f907"))))
-        self.setMarginsForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColor", QColor("#3E3EE3"))))
-        self.setMarginsBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColor", QColor("#f9f9f9"))))
-        caretLineColor = self.settings.value("pythonConsole/caretLineColor", QColor("#fcf3ed"))
-        cursorColor = self.settings.value("pythonConsole/cursorColor", QColor(Qt.black))
+        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColor", QColor(self.SELECTION_FOREGROUND_COLOR))))
+        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColor", QColor(self.SELECTION_BACKGROUND_COLOR))))
+        self.setMarginsForegroundColor(QColor(self.settings.value("pythonConsole/marginForegroundColor", QColor(self.MARGIN_FOREGROUND_COLOR))))
+        self.setMarginsBackgroundColor(QColor(self.settings.value("pythonConsole/marginBackgroundColor", QColor(self.MARGIN_BACKGROUND_COLOR))))
+        caretLineColor = self.settings.value("pythonConsole/caretLineColor", QColor(self.CARET_LINE_COLOR))
+        cursorColor = self.settings.value("pythonConsole/cursorColor", QColor(self.CURSOR_COLOR))
         self.setCaretLineBackgroundColor(caretLineColor)
         self.setCaretForegroundColor(cursorColor)
 
@@ -182,18 +205,18 @@ class ShellOutputScintilla(QsciScintilla):
             font.setPointSize(fontSize)
 
         self.lexer.setDefaultFont(font)
-        self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColor", QColor(Qt.black))))
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColor", QColor(Qt.gray))), 1)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColorEditor", QColor("#4e9a06"))), 2)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColor", QColor(Qt.darkGreen))), 5)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColor", QColor(Qt.blue))), 8)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColor", QColor(Qt.darkGray))), 9)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/decorFontColor", QColor(Qt.darkBlue))), 15)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentBlockFontColor", QColor(Qt.gray))), 12)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/singleQuoteFontColor", QColor(Qt.blue))), 4)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/doubleQuoteFontColor", QColor(Qt.blue))), 3)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleSingleQuoteFontColor", QColor(Qt.blue))), 6)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleDoubleQuoteFontColor", QColor(Qt.blue))), 7)
+        self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColor", QColor(self.DEFAULT_COLOR))))
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColor", QColor(self.COMMENT_COLOR))), 1)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColor", QColor(self.NUMBER_COLOR))), 2)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColor", QColor(self.KEYWORD_COLOR))), 5)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColor", QColor(self.CLASS_COLOR))), 8)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColor", QColor(self.METHOD_COLOR))), 9)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/decorFontColor", QColor(self.DECORATION_COLOR))), 15)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentBlockFontColor", QColor(self.COMMENT_BLOCK_COLOR))), 12)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/singleQuoteFontColor", QColor(self.SINGLE_QUOTE_COLOR))), 4)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/doubleQuoteFontColor", QColor(self.DOUBLE_QUOTE_COLOR))), 3)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleSingleQuoteFontColor", QColor(self.TRIPLE_SINGLE_QUOTE_COLOR))), 6)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleDoubleQuoteFontColor", QColor(self.TRIPLE_DOUBLE_QUOTE_COLOR))), 7)
         self.lexer.setColor(QColor(Qt.red), 14)
         self.lexer.setFont(font, 1)
         self.lexer.setFont(font, 2)
@@ -202,7 +225,7 @@ class ShellOutputScintilla(QsciScintilla):
         self.lexer.setFont(font, QsciLexerPython.UnclosedString)
 
         for style in range(0, 33):
-            paperColor = QColor(self.settings.value("pythonConsole/paperBackgroundColor", QColor(Qt.white)))
+            paperColor = QColor(self.settings.value("pythonConsole/paperBackgroundColor", QColor(self.BACKGROUND_COLOR)))
             self.lexer.setPaper(paperColor, style)
 
         self.setLexer(self.lexer)

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -41,6 +41,28 @@ _historyFile = os.path.join(QgsApplication.qgisSettingsDirPath(), "console_histo
 
 class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
 
+    DEFAULT_COLOR = "#4d4d4c"
+    KEYWORD_COLOR = "#8959a8"
+    CLASS_COLOR = "#4271ae"
+    METHOD_COLOR = "#4271ae"
+    DECORATION_COLOR = "#3e999f"
+    NUMBER_COLOR = "#c82829"
+    COMMENT_COLOR = "#8e908c"
+    COMMENT_BLOCK_COLOR = "#8e908c"
+    BACKGROUND_COLOR = "#ffffff"
+    CURSOR_COLOR = "#636363"
+    CARET_LINE_COLOR = "#efefef"
+    SINGLE_QUOTE_COLOR = "#718c00"
+    DOUBLE_QUOTE_COLOR = "#718c00"
+    TRIPLE_SINGLE_QUOTE_COLOR = "#eab700"
+    TRIPLE_DOUBLE_QUOTE_COLOR = "#eab700"
+    MARGIN_BACKGROUND_COLOR = "#efefef"
+    MARGIN_FOREGROUND_COLOR = "#636363"
+    SELECTION_BACKGROUND_COLOR = "#d7d7d7"
+    SELECTION_FOREGROUND_COLOR = "#303030"
+    MATCHED_BRACE_BACKGROUND_COLOR = "#b7f907"
+    MATCHED_BRACE_FOREGROUND_COLOR = "#303030"
+
     def __init__(self, parent=None):
         super(ShellScintilla, self).__init__(parent)
         code.InteractiveInterpreter.__init__(self, locals=None)
@@ -135,12 +157,12 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         else:
             self.setAutoCompletionSource(self.AcsNone)
 
-        cursorColor = self.settings.value("pythonConsole/cursorColor", QColor(Qt.black))
+        cursorColor = self.settings.value("pythonConsole/cursorColor", QColor(self.CURSOR_COLOR))
         self.setCaretForegroundColor(cursorColor)
-        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColor", QColor("#2e3436"))))
-        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColor", QColor("#babdb6"))))
-        self.setMatchedBraceBackgroundColor(QColor(self.settings.value("pythonConsole/matchedBraceBackgroundColor", QColor("#b7f907"))))
-        self.setMatchedBraceForegroundColor(QColor(self.settings.value("pythonConsole/matchedBraceForegroundColor", QColor("#000000"))))
+        self.setSelectionForegroundColor(QColor(self.settings.value("pythonConsole/selectionForegroundColor", QColor(self.SELECTION_FOREGROUND_COLOR))))
+        self.setSelectionBackgroundColor(QColor(self.settings.value("pythonConsole/selectionBackgroundColor", QColor(self.SELECTION_BACKGROUND_COLOR))))
+        self.setMatchedBraceBackgroundColor(QColor(self.settings.value("pythonConsole/matchedBraceBackgroundColor", QColor(self.MATCHED_BRACE_BACKGROUND_COLOR))))
+        self.setMatchedBraceForegroundColor(QColor(self.settings.value("pythonConsole/matchedBraceForegroundColor", QColor(self.MATCHED_BRACE_FOREGROUND_COLOR))))
 
         # Sets minimum height for input area based of font metric
         self._setMinimumHeight()
@@ -188,25 +210,25 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
             font.setPointSize(fontSize)
 
         self.lexer.setDefaultFont(font)
-        self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColor", QColor(Qt.black))))
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColor", QColor(Qt.gray))), 1)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColorEditor", QColor("#4e9a06"))), 2)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColor", QColor(Qt.darkGreen))), 5)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColor", QColor(Qt.blue))), 8)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColor", QColor(Qt.darkGray))), 9)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/decorFontColor", QColor(Qt.darkBlue))), 15)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentBlockFontColor", QColor(Qt.gray))), 12)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/singleQuoteFontColor", QColor(Qt.blue))), 4)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/doubleQuoteFontColor", QColor(Qt.blue))), 3)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleSingleQuoteFontColor", QColor(Qt.blue))), 6)
-        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleDoubleQuoteFontColor", QColor(Qt.blue))), 7)
+        self.lexer.setDefaultColor(QColor(self.settings.value("pythonConsole/defaultFontColor", QColor(self.DEFAULT_COLOR))))
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentFontColor", QColor(self.COMMENT_COLOR))), 1)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/numberFontColor", QColor(self.NUMBER_COLOR))), 2)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/keywordFontColor", QColor(self.KEYWORD_COLOR))), 5)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/classFontColor", QColor(self.CLASS_COLOR))), 8)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/methodFontColor", QColor(self.METHOD_COLOR))), 9)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/decorFontColor", QColor(self.DECORATION_COLOR))), 15)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/commentBlockFontColor", QColor(self.COMMENT_BLOCK_COLOR))), 12)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/singleQuoteFontColor", QColor(self.SINGLE_QUOTE_COLOR))), 4)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/doubleQuoteFontColor", QColor(self.DOUBLE_QUOTE_COLOR))), 3)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleSingleQuoteFontColor", QColor(self.TRIPLE_SINGLE_QUOTE_COLOR))), 6)
+        self.lexer.setColor(QColor(self.settings.value("pythonConsole/tripleDoubleQuoteFontColor", QColor(self.TRIPLE_DOUBLE_QUOTE_COLOR))), 7)
         self.lexer.setFont(font, 1)
         self.lexer.setFont(font, 3)
         self.lexer.setFont(font, 4)
         self.lexer.setFont(font, QsciLexerPython.UnclosedString)
 
         for style in range(0, 33):
-            paperColor = QColor(self.settings.value("pythonConsole/paperBackgroundColor", QColor(Qt.white)))
+            paperColor = QColor(self.settings.value("pythonConsole/paperBackgroundColor", QColor(self.BACKGROUND_COLOR)))
             self.lexer.setPaper(paperColor, style)
 
         self.api = QsciAPIs(self.lexer)

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -31,6 +31,31 @@ from .ui_console_settings import Ui_SettingsDialogPythonConsole
 
 class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
 
+    DEFAULT_COLOR = "#4d4d4c"
+    KEYWORD_COLOR = "#8959a8"
+    CLASS_COLOR = "#4271ae"
+    METHOD_COLOR = "#4271ae"
+    DECORATION_COLOR = "#3e999f"
+    NUMBER_COLOR = "#c82829"
+    COMMENT_COLOR = "#8e908c"
+    COMMENT_BLOCK_COLOR = "#8e908c"
+    BACKGROUND_COLOR = "#ffffff"
+    CURSOR_COLOR = "#636363"
+    CARET_LINE_COLOR = "#efefef"
+    SINGLE_QUOTE_COLOR = "#718c00"
+    DOUBLE_QUOTE_COLOR = "#718c00"
+    TRIPLE_SINGLE_QUOTE_COLOR = "#eab700"
+    TRIPLE_DOUBLE_QUOTE_COLOR = "#eab700"
+    MARGIN_BACKGROUND_COLOR = "#efefef"
+    MARGIN_FOREGROUND_COLOR = "#636363"
+    SELECTION_BACKGROUND_COLOR = "#d7d7d7"
+    SELECTION_FOREGROUND_COLOR = "#303030"
+    MATCHED_BRACE_BACKGROUND_COLOR = "#b7f907"
+    MATCHED_BRACE_FOREGROUND_COLOR = "#303030"
+    EDGE_COLOR = "#efefef"
+    FOLD_COLOR = "#efefef"
+    ERROR_COLOR = "#e31a1c"
+
     def __init__(self, parent):
         QDialog.__init__(self, parent)
         self.setWindowTitle(QCoreApplication.translate(
@@ -291,119 +316,118 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
             self.autoCompFromDocAPIEditor.setChecked(True)
 
         # Setting font lexer color
-        self.defaultFontColor.setColor(QColor(settings.value("pythonConsole/defaultFontColor", QColor(Qt.black))))
+        self.defaultFontColor.setColor(QColor(settings.value("pythonConsole/defaultFontColor", QColor(self.DEFAULT_COLOR))))
         self.defaultFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/defaultFontColorEditor", QColor(Qt.black))))
-        self.keywordFontColor.setColor(QColor(settings.value("pythonConsole/keywordFontColor", QColor(Qt.darkGreen))))
+            QColor(settings.value("pythonConsole/defaultFontColorEditor", QColor(self.DEFAULT_COLOR))))
+        self.keywordFontColor.setColor(QColor(settings.value("pythonConsole/keywordFontColor", QColor(self.KEYWORD_COLOR))))
         self.keywordFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/keywordFontColorEditor", QColor(Qt.darkGreen))))
-        self.classFontColor.setColor(QColor(settings.value("pythonConsole/classFontColor", QColor(Qt.blue))))
+            QColor(settings.value("pythonConsole/keywordFontColorEditor", QColor(self.KEYWORD_COLOR))))
+        self.classFontColor.setColor(QColor(settings.value("pythonConsole/classFontColor", QColor(self.CLASS_COLOR))))
         self.classFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/classFontColorEditor", QColor(Qt.blue))))
-        self.methodFontColor.setColor(QColor(settings.value("pythonConsole/methodFontColor", QColor(Qt.darkGray))))
+            QColor(settings.value("pythonConsole/classFontColorEditor", QColor(self.CLASS_COLOR))))
+        self.methodFontColor.setColor(QColor(settings.value("pythonConsole/methodFontColor", QColor(self.METHOD_COLOR))))
         self.methodFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/methodFontColorEditor", QColor(Qt.darkGray))))
-        self.decorFontColor.setColor(QColor(settings.value("pythonConsole/decorFontColor", QColor(Qt.darkBlue))))
+            QColor(settings.value("pythonConsole/methodFontColorEditor", QColor(self.METHOD_COLOR))))
+        self.decorFontColor.setColor(QColor(settings.value("pythonConsole/decorFontColor", QColor(self.DECORATION_COLOR))))
         self.decorFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/decorFontColorEditor", QColor("#4e9a06"))))
-        self.numberFontColor.setColor(QColor(settings.value("pythonConsole/numberFontColor", QColor("#4e9a06"))))
+            QColor(settings.value("pythonConsole/decorFontColorEditor", QColor(self.DECORATION_COLOR))))
+        self.numberFontColor.setColor(QColor(settings.value("pythonConsole/numberFontColor", QColor(self.NUMBER_COLOR))))
         self.numberFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/numberFontColorEditor", QColor(Qt.darkBlue))))
-        self.commentFontColor.setColor(QColor(settings.value("pythonConsole/commentFontColor", QColor(Qt.gray))))
+            QColor(settings.value("pythonConsole/numberFontColorEditor", QColor(self.NUMBER_COLOR))))
+        self.commentFontColor.setColor(QColor(settings.value("pythonConsole/commentFontColor", QColor(self.COMMENT_COLOR))))
         self.commentFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/commentFontColorEditor", QColor(Qt.gray))))
+            QColor(settings.value("pythonConsole/commentFontColorEditor", QColor(self.COMMENT_COLOR))))
         self.commentBlockFontColor.setColor(
-            QColor(settings.value("pythonConsole/commentBlockFontColor", QColor(Qt.gray))))
+            QColor(settings.value("pythonConsole/commentBlockFontColor", QColor(self.COMMENT_BLOCK_COLOR))))
         self.commentBlockFontColorEditor.setColor(
-            QColor(settings.value("pythonConsole/commentBlockFontColorEditor", QColor(Qt.gray))))
+            QColor(settings.value("pythonConsole/commentBlockFontColorEditor", QColor(self.COMMENT_BLOCK_COLOR))))
         self.paperBackgroundColor.setColor(
-            QColor(settings.value("pythonConsole/paperBackgroundColor", QColor(Qt.white))))
+            QColor(settings.value("pythonConsole/paperBackgroundColor", QColor(self.BACKGROUND_COLOR))))
         self.paperBackgroundColorEditor.setColor(
-            QColor(settings.value("pythonConsole/paperBackgroundColorEditor", QColor(Qt.white))))
-        self.caretLineColor.setColor(QColor(settings.value("pythonConsole/caretLineColor", QColor("#fcf3ed"))))
+            QColor(settings.value("pythonConsole/paperBackgroundColorEditor", QColor(self.BACKGROUND_COLOR))))
+        self.caretLineColor.setColor(QColor(settings.value("pythonConsole/caretLineColor", QColor(self.CARET_LINE_COLOR))))
         self.caretLineColorEditor.setColor(
-            QColor(settings.value("pythonConsole/caretLineColorEditor", QColor("#fcf3ed"))))
-        self.cursorColor.setColor(QColor(settings.value("pythonConsole/cursorColor", QColor(Qt.black))))
-        self.cursorColorEditor.setColor(QColor(settings.value("pythonConsole/cursorColorEditor", QColor(Qt.black))))
-        self.stderrFontColor.setColor(QColor(settings.value("pythonConsole/stderrFontColor", QColor(Qt.red))))
-
-        self.singleQuoteFontColor.setColor(settings.value("pythonConsole/singleQuoteFontColor", QColor(Qt.blue)))
+            QColor(settings.value("pythonConsole/caretLineColorEditor", QColor(self.CARET_LINE_COLOR))))
+        self.cursorColor.setColor(QColor(settings.value("pythonConsole/cursorColor", QColor(self.CURSOR_COLOR))))
+        self.cursorColorEditor.setColor(QColor(settings.value("pythonConsole/cursorColorEditor", QColor(self.CURSOR_COLOR))))
+        self.singleQuoteFontColor.setColor(settings.value("pythonConsole/singleQuoteFontColor", QColor(self.SINGLE_QUOTE_COLOR)))
         self.singleQuoteFontColorEditor.setColor(
-            settings.value("pythonConsole/singleQuoteFontColorEditor", QColor(Qt.blue)))
-        self.doubleQuoteFontColor.setColor(settings.value("pythonConsole/doubleQuoteFontColor", QColor(Qt.blue)))
+            settings.value("pythonConsole/singleQuoteFontColorEditor", QColor(self.SINGLE_QUOTE_COLOR)))
+        self.doubleQuoteFontColor.setColor(settings.value("pythonConsole/doubleQuoteFontColor", QColor(self.DOUBLE_QUOTE_COLOR)))
         self.doubleQuoteFontColorEditor.setColor(
-            settings.value("pythonConsole/doubleQuoteFontColorEditor", QColor(Qt.blue)))
+            settings.value("pythonConsole/doubleQuoteFontColorEditor", QColor(self.DOUBLE_QUOTE_COLOR)))
         self.tripleSingleQuoteFontColor.setColor(
-            settings.value("pythonConsole/tripleSingleQuoteFontColor", QColor(Qt.blue)))
+            settings.value("pythonConsole/tripleSingleQuoteFontColor", QColor(self.TRIPLE_SINGLE_QUOTE_COLOR)))
         self.tripleSingleQuoteFontColorEditor.setColor(
-            settings.value("pythonConsole/tripleSingleQuoteFontColorEditor", QColor(Qt.blue)))
+            settings.value("pythonConsole/tripleSingleQuoteFontColorEditor", QColor(self.TRIPLE_SINGLE_QUOTE_COLOR)))
         self.tripleDoubleQuoteFontColor.setColor(
-            settings.value("pythonConsole/tripleDoubleQuoteFontColor", QColor(Qt.blue)))
+            settings.value("pythonConsole/tripleDoubleQuoteFontColor", QColor(self.TRIPLE_DOUBLE_QUOTE_COLOR)))
         self.tripleDoubleQuoteFontColorEditor.setColor(
-            settings.value("pythonConsole/tripleDoubleQuoteFontColorEditor", QColor(Qt.blue)))
-        self.edgeColorEditor.setColor(settings.value("pythonConsole/edgeColorEditor", QColor("#FF0000")))
-        self.marginBackgroundColor.setColor(settings.value("pythonConsole/marginBackgroundColor", QColor("#f9f9f9")))
-        self.marginBackgroundColorEditor.setColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9")))
-        self.marginForegroundColor.setColor(settings.value("pythonConsole/marginForegroundColor", QColor("#3E3EE3")))
-        self.marginForegroundColorEditor.setColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3")))
-        self.foldColorEditor.setColor(settings.value("pythonConsole/foldColorEditor", QColor("#f4f4f4")))
-        self.selectionForegroundColor.setColor(settings.value("pythonConsole/selectionForegroundColor", QColor("#2e3436")))
-        self.selectionForegroundColorEditor.setColor(settings.value("pythonConsole/selectionForegroundColorEditor", QColor("#2e3436")))
-        self.selectionBackgroundColor.setColor(settings.value("pythonConsole/selectionBackgroundColor", QColor("#babdb6")))
-        self.selectionBackgroundColorEditor.setColor(settings.value("pythonConsole/selectionBackgroundColorEditor", QColor("#babdb6")))
-        self.matchedBraceForegroundColor.setColor(settings.value("pythonConsole/matchedBraceForegroundColor", QColor("#000000")))
-        self.matchedBraceForegroundColorEditor.setColor(settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor("#000000")))
-        self.matchedBraceBackgroundColor.setColor(settings.value("pythonConsole/matchedBraceBackgroundColor", QColor("#b7f907")))
-        self.matchedBraceBackgroundColorEditor.setColor(settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor("#b7f907")))
+            settings.value("pythonConsole/tripleDoubleQuoteFontColorEditor", QColor(self.TRIPLE_DOUBLE_QUOTE_COLOR)))
+        self.marginBackgroundColor.setColor(settings.value("pythonConsole/marginBackgroundColor", QColor(self.MARGIN_BACKGROUND_COLOR)))
+        self.marginBackgroundColorEditor.setColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor(self.MARGIN_BACKGROUND_COLOR)))
+        self.marginForegroundColor.setColor(settings.value("pythonConsole/marginForegroundColor", QColor(self.MARGIN_FOREGROUND_COLOR)))
+        self.marginForegroundColorEditor.setColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor(self.MARGIN_FOREGROUND_COLOR)))
+        self.selectionForegroundColor.setColor(settings.value("pythonConsole/selectionForegroundColor", QColor(self.SELECTION_FOREGROUND_COLOR)))
+        self.selectionForegroundColorEditor.setColor(settings.value("pythonConsole/selectionForegroundColorEditor", QColor(self.SELECTION_FOREGROUND_COLOR)))
+        self.selectionBackgroundColor.setColor(settings.value("pythonConsole/selectionBackgroundColor", QColor(self.SELECTION_BACKGROUND_COLOR)))
+        self.selectionBackgroundColorEditor.setColor(settings.value("pythonConsole/selectionBackgroundColorEditor", QColor(self.SELECTION_BACKGROUND_COLOR)))
+        self.matchedBraceForegroundColor.setColor(settings.value("pythonConsole/matchedBraceForegroundColor", QColor(self.MATCHED_BRACE_FOREGROUND_COLOR)))
+        self.matchedBraceForegroundColorEditor.setColor(settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor(self.MATCHED_BRACE_FOREGROUND_COLOR)))
+        self.matchedBraceBackgroundColor.setColor(settings.value("pythonConsole/matchedBraceBackgroundColor", QColor(self.MATCHED_BRACE_BACKGROUND_COLOR)))
+        self.matchedBraceBackgroundColorEditor.setColor(settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor(self.MATCHED_BRACE_BACKGROUND_COLOR)))
+        self.stderrFontColor.setColor(QColor(settings.value("pythonConsole/stderrFontColor", QColor(self.ERROR_COLOR))))
+        self.edgeColorEditor.setColor(settings.value("pythonConsole/edgeColorEditor", QColor(self.EDGE_COLOR)))
+        self.foldColorEditor.setColor(settings.value("pythonConsole/foldColorEditor", QColor(self.FOLD_COLOR)))
 
     def _resetFontColor(self):
-        self.defaultFontColor.setColor(QColor(Qt.black))
-        self.keywordFontColor.setColor(QColor(Qt.darkGreen))
-        self.classFontColor.setColor(QColor(Qt.blue))
-        self.methodFontColor.setColor(QColor(Qt.darkGray))
-        self.decorFontColor.setColor(QColor(Qt.darkBlue))
-        self.numFontColor.setColor(QColor("#4e9a06"))
-        self.commentFontColor.setColor(QColor(Qt.gray))
-        self.commentBlockFontColor.setColor(QColor(Qt.gray))
-        self.stderrFontColor.setColor(QColor(Qt.red))
-        self.paperBackgroundColor.setColor(QColor(Qt.white))
-        self.cursorColor.setColor(QColor(Qt.black))
-        self.caretLineColor.setColor(QColor("#fcf3ed"))
-        self.singleQuoteFontColor.setColor(QColor(Qt.blue))
-        self.doubleQuoteFontColor.setColor(QColor(Qt.blue))
-        self.tripleSingleQuoteFontColor.setColor(QColor(Qt.blue))
-        self.tripleDoubleQuoteFontColor.setColor(QColor(Qt.blue))
-        self.marginBackgroundColor.setColor(QColor("#f9f9f9"))
-        self.marginForegroundColor.setColor(QColor("#3E3EE3"))
-        self.selectionBackgroundColor.setColor(QColor("#babdb6"))
-        self.selectionForegroundColor.setColor(QColor("#2e3436"))
-        self.matchedBraceBackgroundColor.setColor(QColor("#b7f907"))
-        self.matchedBraceForegroundColor.setColor(QColor("#000000"))
+        self.defaultFontColor.setColor(QColor(self.DEFAULT_COLOR))
+        self.keywordFontColor.setColor(QColor(self.KEYWORD_COLOR))
+        self.classFontColor.setColor(QColor(self.CLASS_COLOR))
+        self.methodFontColor.setColor(QColor(self.METHOD_COLOR))
+        self.decorFontColor.setColor(QColor(self.DECORATION_COLOR))
+        self.numberFontColor.setColor(QColor(self.NUMBER_COLOR))
+        self.commentFontColor.setColor(QColor(self.COMMENT_COLOR))
+        self.commentBlockFontColor.setColor(QColor(self.COMMENT_BLOCK_COLOR))
+        self.paperBackgroundColor.setColor(QColor(self.BACKGROUND_COLOR))
+        self.cursorColor.setColor(QColor(self.CURSOR_COLOR))
+        self.caretLineColor.setColor(QColor(self.CARET_LINE_COLOR))
+        self.singleQuoteFontColor.setColor(QColor(self.SINGLE_QUOTE_COLOR))
+        self.doubleQuoteFontColor.setColor(QColor(self.DOUBLE_QUOTE_COLOR))
+        self.tripleSingleQuoteFontColor.setColor(QColor(self.TRIPLE_SINGLE_QUOTE_COLOR))
+        self.tripleDoubleQuoteFontColor.setColor(QColor(self.TRIPLE_DOUBLE_QUOTE_COLOR))
+        self.marginBackgroundColor.setColor(QColor(self.MARGIN_BACKGROUND_COLOR))
+        self.marginForegroundColor.setColor(QColor(self.MARGIN_FOREGROUND_COLOR))
+        self.selectionBackgroundColor.setColor(QColor(self.SELECTION_BACKGROUND_COLOR))
+        self.selectionForegroundColor.setColor(QColor(self.SELECTION_FOREGROUND_COLOR))
+        self.matchedBraceBackgroundColor.setColor(QColor(self.MATCHED_BRACE_BACKGROUND_COLOR))
+        self.matchedBraceForegroundColor.setColor(QColor(self.MATCHED_BRACE_FOREGROUND_COLOR))
+        self.stderrFontColor.setColor(QColor(self.ERROR_COLOR))
 
     def _resetFontColorEditor(self):
-        self.defaultFontColorEditor.setColor(QColor(Qt.black))
-        self.keywordFontColorEditor.setColor(QColor(Qt.darkGreen))
-        self.classFontColorEditor.setColor(QColor(Qt.blue))
-        self.methodFontColorEditor.setColor(QColor(Qt.darkGray))
-        self.decorFontColorEditor.setColor(QColor(Qt.darkBlue))
-        self.numFontColorEditor.setColor(QColor("#4e9a06"))
-        self.commentFontColorEditor.setColor(QColor(Qt.gray))
-        self.commentBlockFontColorEditor.setColor(QColor(Qt.gray))
-        self.paperBackgroundColorEditor.setColor(QColor(Qt.white))
-        self.cursorColorEditor.setColor(QColor(Qt.black))
-        self.caretLineColorEditor.setColor(QColor("#fcf3ed"))
-        self.singleQuoteFontColorEditor.setColor(QColor(Qt.blue))
-        self.doubleQuoteFontColorEditor.setColor(QColor(Qt.blue))
-        self.tripleSingleQuoteFontColorEditor.setColor(QColor(Qt.blue))
-        self.tripleDoubleQuoteFontColorEditor.setColor(QColor(Qt.blue))
-        self.edgeColorEditor.setColor(QColor("#FF0000"))
-        self.marginBackgroundColorEditor.setColor(QColor("#f9f9f9"))
-        self.marginForegroundColorEditor.setColor(QColor("#3E3EE3"))
-        self.foldColorEditor.setColor(QColor("#f4f4f4"))
-        self.selectionBackgroundColorEditor.setColor(QColor("#babdb6"))
-        self.selectionForegroundColorEditor.setColor(QColor("#2e3436"))
-        self.matchedBraceBackgroundColorEditor.setColor(QColor("#b7f907"))
-        self.matchedBraceForegroundColorEditor.setColor(QColor("#000000"))
+        self.defaultFontColorEditor.setColor(QColor(self.DEFAULT_COLOR))
+        self.keywordFontColorEditor.setColor(QColor(self.KEYWORD_COLOR))
+        self.classFontColorEditor.setColor(QColor(self.CLASS_COLOR))
+        self.methodFontColorEditor.setColor(QColor(self.METHOD_COLOR))
+        self.decorFontColorEditor.setColor(QColor(self.DECORATION_COLOR))
+        self.numberFontColorEditor.setColor(QColor(self.NUMBER_COLOR))
+        self.commentFontColorEditor.setColor(QColor(self.COMMENT_COLOR))
+        self.commentBlockFontColorEditor.setColor(QColor(self.COMMENT_BLOCK_COLOR))
+        self.paperBackgroundColorEditor.setColor(QColor(self.BACKGROUND_COLOR))
+        self.cursorColorEditor.setColor(QColor(self.CURSOR_COLOR))
+        self.caretLineColorEditor.setColor(QColor(self.CARET_LINE_COLOR))
+        self.singleQuoteFontColorEditor.setColor(QColor(self.SINGLE_QUOTE_COLOR))
+        self.doubleQuoteFontColorEditor.setColor(QColor(self.DOUBLE_QUOTE_COLOR))
+        self.tripleSingleQuoteFontColorEditor.setColor(QColor(self.TRIPLE_SINGLE_QUOTE_COLOR))
+        self.tripleDoubleQuoteFontColorEditor.setColor(QColor(self.TRIPLE_DOUBLE_QUOTE_COLOR))
+        self.marginBackgroundColorEditor.setColor(QColor(self.MARGIN_BACKGROUND_COLOR))
+        self.marginForegroundColorEditor.setColor(QColor(self.MARGIN_FOREGROUND_COLOR))
+        self.selectionBackgroundColorEditor.setColor(QColor(self.SELECTION_BACKGROUND_COLOR))
+        self.selectionForegroundColorEditor.setColor(QColor(self.SELECTION_FOREGROUND_COLOR))
+        self.matchedBraceBackgroundColorEditor.setColor(QColor(self.MATCHED_BRACE_BACKGROUND_COLOR))
+        self.matchedBraceForegroundColorEditor.setColor(QColor(self.MATCHED_BRACE_FOREGROUND_COLOR))
+        self.edgeColorEditor.setColor(QColor(self.EDGE_COLOR))
+        self.foldColorEditor.setColor(QColor(self.FOLD_COLOR))
 
     def reject(self):
         self.restoreSettings()

--- a/python/plugins/processing/script/ScriptEdit.py
+++ b/python/plugins/processing/script/ScriptEdit.py
@@ -37,6 +37,30 @@ from qgis.PyQt.Qsci import QsciScintilla, QsciLexerPython, QsciAPIs
 
 class ScriptEdit(QsciScintilla):
 
+    DEFAULT_COLOR = "#4d4d4c"
+    KEYWORD_COLOR = "#8959a8"
+    CLASS_COLOR = "#4271ae"
+    METHOD_COLOR = "#4271ae"
+    DECORATION_COLOR = "#3e999f"
+    NUMBER_COLOR = "#c82829"
+    COMMENT_COLOR = "#8e908c"
+    COMMENT_BLOCK_COLOR = "#8e908c"
+    BACKGROUND_COLOR = "#ffffff"
+    CURSOR_COLOR = "#636363"
+    CARET_LINE_COLOR = "#efefef"
+    SINGLE_QUOTE_COLOR = "#718c00"
+    DOUBLE_QUOTE_COLOR = "#718c00"
+    TRIPLE_SINGLE_QUOTE_COLOR = "#eab700"
+    TRIPLE_DOUBLE_QUOTE_COLOR = "#eab700"
+    MARGIN_BACKGROUND_COLOR = "#efefef"
+    MARGIN_FOREGROUND_COLOR = "#636363"
+    SELECTION_BACKGROUND_COLOR = "#d7d7d7"
+    SELECTION_FOREGROUND_COLOR = "#303030"
+    MATCHED_BRACE_BACKGROUND_COLOR = "#b7f907"
+    MATCHED_BRACE_FOREGROUND_COLOR = "#303030"
+    EDGE_COLOR = "#efefef"
+    FOLD_COLOR = "#efefef"
+
     def __init__(self, parent=None):
         QsciScintilla.__init__(self, parent)
 
@@ -58,28 +82,28 @@ class ScriptEdit(QsciScintilla):
         self.setMarginsFont(font)
 
         self.setBraceMatching(QsciScintilla.SloppyBraceMatch)
-        self.setMatchedBraceBackgroundColor(QColor(settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor("#b7f907"))))
-        self.setMatchedBraceForegroundColor(QColor(settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor("#000000"))))
+        self.setMatchedBraceBackgroundColor(QColor(settings.value("pythonConsole/matchedBraceBackgroundColorEditor", QColor(self.MATCHED_BRACE_BACKGROUND_COLOR))))
+        self.setMatchedBraceForegroundColor(QColor(settings.value("pythonConsole/matchedBraceForegroundColorEditor", QColor(self.MATCHED_BRACE_FOREGROUND_COLOR))))
 
         #self.setWrapMode(QsciScintilla.WrapWord)
         #self.setWrapVisualFlags(QsciScintilla.WrapFlagByText,
         #                        QsciScintilla.WrapFlagNone, 4)
 
-        self.setSelectionForegroundColor(QColor(settings.value("pythonConsole/selectionForegroundColorEditor", QColor("#2e3436"))))
-        self.setSelectionBackgroundColor(QColor(settings.value("pythonConsole/selectionBackgroundColorEditor", QColor("#babdb6"))))
+        self.setSelectionForegroundColor(QColor(settings.value("pythonConsole/selectionForegroundColorEditor", QColor(self.SELECTION_FOREGROUND_COLOR))))
+        self.setSelectionBackgroundColor(QColor(settings.value("pythonConsole/selectionBackgroundColorEditor", QColor(self.SELECTION_BACKGROUND_COLOR))))
 
         # Show line numbers
         fontmetrics = QFontMetrics(font)
         self.setMarginWidth(1, fontmetrics.width("0000") + 5)
         self.setMarginLineNumbers(1, True)
-        self.setMarginsForegroundColor(QColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3"))))
-        self.setMarginsBackgroundColor(QColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9"))))
-        self.setIndentationGuidesForegroundColor(QColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor("#3E3EE3"))))
-        self.setIndentationGuidesBackgroundColor(QColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor("#f9f9f9"))))
+        self.setMarginsForegroundColor(QColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor(self.MARGIN_FOREGROUND_COLOR))))
+        self.setMarginsBackgroundColor(QColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor(self.MARGIN_BACKGROUND_COLOR))))
+        self.setIndentationGuidesForegroundColor(QColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor(self.MARGIN_FOREGROUND_COLOR))))
+        self.setIndentationGuidesBackgroundColor(QColor(settings.value("pythonConsole/marginBackgroundColorEditor", QColor(self.MARGIN_BACKGROUND_COLOR))))
 
         # Highlight current line
-        caretLineColorEditor = settings.value("pythonConsole/caretLineColorEditor", QColor("#fcf3ed"))
-        cursorColorEditor = settings.value("pythonConsole/cursorColorEditor", QColor(Qt.black))
+        caretLineColorEditor = settings.value("pythonConsole/caretLineColorEditor", QColor(self.CARET_LINE_COLOR))
+        cursorColorEditor = settings.value("pythonConsole/cursorColorEditor", QColor(self.CURSOR_COLOR))
         self.setCaretLineVisible(True)
         self.setCaretWidth(2)
         self.setCaretLineBackgroundColor(caretLineColorEditor)
@@ -87,13 +111,13 @@ class ScriptEdit(QsciScintilla):
 
         # Folding
         self.setFolding(QsciScintilla.PlainFoldStyle)
-        foldColor = QColor(settings.value("pythonConsole/foldColorEditor", QColor("#f4f4f4")))
+        foldColor = QColor(settings.value("pythonConsole/foldColorEditor", QColor(self.FOLD_COLOR)))
         self.setFoldMarginColors(foldColor, foldColor)
 
         # Mark column 80 with vertical line
         self.setEdgeMode(QsciScintilla.EdgeLine)
         self.setEdgeColumn(80)
-        self.setEdgeColor(QColor(settings.value("pythonConsole/edgeColorEditor", QColor("#FF0000"))))
+        self.setEdgeColor(QColor(settings.value("pythonConsole/edgeColorEditor", QColor(self.EDGE_COLOR))))
 
         # Indentation
         self.setAutoIndent(True)
@@ -170,24 +194,24 @@ class ScriptEdit(QsciScintilla):
             font.setPointSize(fontSize)
 
         self.lexer.setDefaultFont(font)
-        self.lexer.setDefaultColor(QColor(settings.value("pythonConsole/defaultFontColorEditor", QColor(Qt.black))))
-        self.lexer.setColor(QColor(settings.value("pythonConsole/commentFontColorEditor", QColor(Qt.gray))), 1)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/numberFontColorEditor", QColor(Qt.gray))), 2)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/keywordFontColorEditor", QColor(Qt.darkGreen))), 5)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/classFontColorEditor", QColor(Qt.blue))), 8)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/methodFontColorEditor", QColor(Qt.darkGray))), 9)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/decorFontColorEditor", QColor(Qt.darkBlue))), 15)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/commentBlockFontColorEditor", QColor(Qt.gray))), 12)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/singleQuoteFontColorEditor", QColor(Qt.blue))), 4)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/doubleQuoteFontColorEditor", QColor(Qt.blue))), 3)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/tripleSingleQuoteFontColorEditor", QColor(Qt.blue))), 6)
-        self.lexer.setColor(QColor(settings.value("pythonConsole/tripleDoubleQuoteFontColorEditor", QColor(Qt.blue))), 7)
+        self.lexer.setDefaultColor(QColor(settings.value("pythonConsole/defaultFontColorEditor", QColor(self.DEFAULT_COLOR))))
+        self.lexer.setColor(QColor(settings.value("pythonConsole/commentFontColorEditor", QColor(self.COMMENT_COLOR))), 1)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/numberFontColorEditor", QColor(self.NUMBER_COLOR))), 2)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/keywordFontColorEditor", QColor(self.KEYWORD_COLOR))), 5)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/classFontColorEditor", QColor(self.CLASS_COLOR))), 8)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/methodFontColorEditor", QColor(self.METHOD_COLOR))), 9)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/decorFontColorEditor", QColor(self.DECORATION_COLOR))), 15)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/commentBlockFontColorEditor", QColor(self.COMMENT_BLOCK_COLOR))), 12)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/singleQuoteFontColorEditor", QColor(self.SINGLE_QUOTE_COLOR))), 4)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/doubleQuoteFontColorEditor", QColor(self.DOUBLE_QUOTE_COLOR))), 3)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/tripleSingleQuoteFontColorEditor", QColor(self.TRIPLE_SINGLE_QUOTE_COLOR))), 6)
+        self.lexer.setColor(QColor(settings.value("pythonConsole/tripleDoubleQuoteFontColorEditor", QColor(self.TRIPLE_DOUBLE_QUOTE_COLOR))), 7)
         self.lexer.setFont(font, 1)
         self.lexer.setFont(font, 3)
         self.lexer.setFont(font, 4)
 
         for style in range(0, 33):
-            paperColor = QColor(settings.value("pythonConsole/paperBackgroundColorEditor", QColor(Qt.white)))
+            paperColor = QColor(settings.value("pythonConsole/paperBackgroundColorEditor", QColor(self.BACKGROUND_COLOR)))
             self.lexer.setPaper(paperColor, style)
 
         self.api = QsciAPIs(self.lexer)


### PR DESCRIPTION
## Description
The PR updates the default color scheme for the python console and the script editor to offer a more pleasing experience to the eyes.

Screenshot:
![screenshot from 2018-05-22 17-20-29](https://user-images.githubusercontent.com/1728657/40356961-f092b414-5de4-11e8-9276-2cbfb94f9304.png)

@nyalldawson , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
