### PR TITLE
Disable RenderPartialOutput Setting in printing. It is unused in prin…

### DIFF
--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -236,6 +236,7 @@ QgsMapSettings QgsComposerMap::mapSettings( const QgsRectangle& extent, QSizeF s
   {
     //if outputing composer, disable optimisations like layer simplification
     jobMapSettings.setFlag( QgsMapSettings::UseRenderingOptimization, false );
+    jobMapSettings.setFlag( QgsMapSettings::RenderPartialOutput, false );
   }
 
   QgsExpressionContext* context = createExpressionContext();

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -230,13 +230,13 @@ QgsMapSettings QgsComposerMap::mapSettings( const QgsRectangle& extent, QSizeF s
   jobMapSettings.setCrsTransformEnabled( ms.hasCrsTransformEnabled() );
   jobMapSettings.setFlags( ms.flags() );
   jobMapSettings.setFlag( QgsMapSettings::DrawSelection, false );
+  jobMapSettings.setFlag( QgsMapSettings::RenderPartialOutput, false );
 
   if ( mComposition->plotStyle() == QgsComposition::Print ||
        mComposition->plotStyle() == QgsComposition::Postscript )
   {
     //if outputing composer, disable optimisations like layer simplification
     jobMapSettings.setFlag( QgsMapSettings::UseRenderingOptimization, false );
-    jobMapSettings.setFlag( QgsMapSettings::RenderPartialOutput, false );
   }
 
   QgsExpressionContext* context = createExpressionContext();


### PR DESCRIPTION
2.18: Disable RenderPartialOutput setting in printout. Partial rendering is not used during printout, even worse, it causes the creation of a background QImage and causes a memory problem in large-format printouts (e.g. A0, 1200 dpi).