### PR TITLE
Add compliance test to doxygen test

### DIFF
--- a/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgseditorwidgetwrapper.sip.in
@@ -187,16 +187,17 @@ Add a hint text on the widget
 
     ConstraintResult constraintResult() const;
 %Docstring
-Getter of constraintResult
-It's the current result of the constraint on the widget influencing it's visualization.
+Returns the constraint result, which is the current result of the constraint
+on the widget influencing its visualization.
 
 .. versionadded:: 3.0
 %End
 
     bool constraintResultVisible() const;
 %Docstring
-Getter of constraintResultVisible
-Defines if the constraint result should be visualized on the widget (with color).
+Returns whether the constraint result is visible.
+
+Returns true if the constraint result will be visualized on the widget (with color).
 This will be disabled when the form is not editable.
 
 .. versionadded:: 3.0
@@ -204,15 +205,15 @@ This will be disabled when the form is not editable.
 
     void setConstraintResultVisible( bool constraintResultVisible );
 %Docstring
-Setter of constraintResultVisible
-Defines if the constraint result should be visualized on the widget (with color).
+Sets whether the constraint result is visible.
+
+Controls if the constraint result should be visualized on the widget (with color).
 This will be disabled when the form is not editable.
 
 :param constraintResultVisible: if constraintResult should be displayed (mostly editable status)
 
 .. versionadded:: 3.0
 %End
-
 
   signals:
 

--- a/python/gui/auto_generated/qgsattributetypeloaddialog.sip.in
+++ b/python/gui/auto_generated/qgsattributetypeloaddialog.sip.in
@@ -35,7 +35,7 @@ Sets predefined vector layer for selection of data
 
     QMap<QString, QVariant> &valueMap();
 %Docstring
-Getter to value map which is currently active
+Returns the value map which is currently active.
 
 :return: value map of vlues selected from layer
 %End

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -190,29 +190,33 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     virtual void setHint( const QString &hintText );
 
     /**
-     * Getter of constraintResult
-     * It's the current result of the constraint on the widget influencing it's visualization.
+     * Returns the constraint result, which is the current result of the constraint
+     * on the widget influencing its visualization.
+     *
      * \since QGIS 3.0
      */
     ConstraintResult constraintResult() const;
 
     /**
-     * Getter of constraintResultVisible
-     * Defines if the constraint result should be visualized on the widget (with color).
+     * Returns whether the constraint result is visible.
+     *
+     * Returns true if the constraint result will be visualized on the widget (with color).
      * This will be disabled when the form is not editable.
+     *
      * \since QGIS 3.0
      */
     bool constraintResultVisible() const;
 
     /**
-     * Setter of constraintResultVisible
-     * Defines if the constraint result should be visualized on the widget (with color).
+     * Sets whether the constraint result is visible.
+     *
+     * Controls if the constraint result should be visualized on the widget (with color).
      * This will be disabled when the form is not editable.
+     *
      * \param constraintResultVisible if constraintResult should be displayed (mostly editable status)
      * \since QGIS 3.0
      */
     void setConstraintResultVisible( bool constraintResultVisible );
-
 
   signals:
 

--- a/src/gui/qgsattributetypeloaddialog.h
+++ b/src/gui/qgsattributetypeloaddialog.h
@@ -52,7 +52,8 @@ class GUI_EXPORT QgsAttributeTypeLoadDialog: public QDialog, private Ui::QgsAttr
     void setVectorLayer( QgsVectorLayer *layer );
 
     /**
-     * Getter to value map which is currently active
+     * Returns the value map which is currently active.
+     *
      * \returns value map of vlues selected from layer
      */
     QMap<QString, QVariant> &valueMap();

--- a/tests/code_layout/test_qgsdoccoverage.py
+++ b/tests/code_layout/test_qgsdoccoverage.py
@@ -60,6 +60,13 @@ class TestQgsDocCoverage(unittest.TestCase):
                 for mem in props['missing_members']:
                     print((colored('  "' + mem + '"', 'yellow', attrs=['bold'])))
 
+        if parser.noncompliant_members:
+            for cls, props in list(parser.noncompliant_members.items()):
+                print(('\n\nClass {}, non-compliant members found\n'.format(colored(cls, 'yellow'))))
+                for p in props:
+                    for mem, error in p.items():
+                        print((colored('  ' + mem + ': ' + error, 'yellow', attrs=['bold'])))
+
         # self.assertEquals(len(parser.undocumented_string), 0, 'FAIL: new undocumented members have been introduced, please add documentation for these members')
 
         if parser.classes_missing_group:
@@ -88,6 +95,7 @@ class TestQgsDocCoverage(unittest.TestCase):
         self.assertTrue(not parser.classes_missing_group, 'Classes without \\group tag found')
         self.assertTrue(not parser.classes_missing_version_added, 'Classes without \\since version tag found')
         self.assertTrue(not parser.classes_missing_brief, 'Classes without \\brief description found')
+        self.assertTrue(not parser.noncompliant_members, 'Non compliant members found')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tests for "non-compliant" doxygen strings, e.g. use of
- "getter for..." instead of "returns the..."
- "setter for..." instead of "sets the..."

Will be expanded in future to also test for:
- "return ..." instead of "returns ..."
- "set ..." instead of "sets ..."