### PR TITLE
Avoid running QEventLoop on main thread (in WFS provider)

### DIFF
--- a/.ci/travis/linux/docker-build-test.sh
+++ b/.ci/travis/linux/docker-build-test.sh
@@ -55,6 +55,7 @@ cmake \
  -DWITH_BINDINGS=ON \
  -DWITH_SERVER=ON \
  -DDISABLE_DEPRECATED=ON \
+ -DPYTHON_TEST_WRAPPER="timeout -sSIGSEGV 55s"\
  -DCXX_EXTRA_FLAGS=${CLANG_WARNINGS} ..
 echo "travis_fold:end:cmake"
 

--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -32,7 +32,7 @@ that the fallback proxy should not be used for, then no proxy will be used.
 #include "qgsnetworkaccessmanager.h"
 %End
   public:
-    static QgsNetworkAccessManager *instance();
+    static QgsNetworkAccessManager *instance( Qt::ConnectionType connectionType = Qt::DirectConnection );
 
     QgsNetworkAccessManager( QObject *parent = 0 );
 
@@ -76,7 +76,7 @@ Gets name for QNetworkRequest.CacheLoadControl
 Gets QNetworkRequest.CacheLoadControl from name
 %End
 
-    void setupDefaultProxyAndCache();
+    void setupDefaultProxyAndCache( Qt::ConnectionType connectionType = Qt::BlockingQueuedConnection );
 %Docstring
 Setup the NAM according to the user's settings
 %End

--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -32,7 +32,26 @@ that the fallback proxy should not be used for, then no proxy will be used.
 #include "qgsnetworkaccessmanager.h"
 %End
   public:
-    static QgsNetworkAccessManager *instance( Qt::ConnectionType connectionType = Qt::DirectConnection );
+
+    static QgsNetworkAccessManager *instance( Qt::ConnectionType connectionType = Qt::BlockingQueuedConnection );
+%Docstring
+Returns a pointer to the active QgsNetworkAccessManager
+for the current thread.
+
+With the ``connectionType`` parameter it is possible to setup the default connection
+type that is used to handle signals that might require user interaction and therefore
+need to be handled on the main thread. See in-depth discussion below.
+
+:param connectionType: In most cases the default of using a ``Qt.BlockingQueuedConnection``
+is ok, to make a background thread wait for the main thread to answer such a request is
+fine and anything else is dangerous.
+However, in case the request was started on the main thread, one should execute a
+local event loop in a helper thread and freeze the main thread for the duration of the
+download. In this case, if an authentication request is sent from the background thread
+network access manager, the background thread should be blocked, the main thread be woken
+up, processEvents() executed once, the main thread frozen again and the background thread
+continued.
+%End
 
     QgsNetworkAccessManager( QObject *parent = 0 );
 
@@ -78,7 +97,11 @@ Gets QNetworkRequest.CacheLoadControl from name
 
     void setupDefaultProxyAndCache( Qt::ConnectionType connectionType = Qt::BlockingQueuedConnection );
 %Docstring
-Setup the NAM according to the user's settings
+Setup the QgsNetworkAccessManager (NAM) according to the user's settings.
+The ``connectionType`` sets up the default connection type that is used to
+handle signals that might require user interaction and therefore
+need to be handled on the main thread. See in-depth discussion in the documentation
+for the constructor of this class.
 %End
 
     bool useSystemProxy() const;

--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -43,14 +43,14 @@ type that is used to handle signals that might require user interaction and ther
 need to be handled on the main thread. See in-depth discussion below.
 
 :param connectionType: In most cases the default of using a ``Qt.BlockingQueuedConnection``
-is ok, to make a background thread wait for the main thread to answer such a request is
-fine and anything else is dangerous.
-However, in case the request was started on the main thread, one should execute a
-local event loop in a helper thread and freeze the main thread for the duration of the
-download. In this case, if an authentication request is sent from the background thread
-network access manager, the background thread should be blocked, the main thread be woken
-up, processEvents() executed once, the main thread frozen again and the background thread
-continued.
+                       is ok, to make a background thread wait for the main thread to answer such a request is
+                       fine and anything else is dangerous.
+                       However, in case the request was started on the main thread, one should execute a
+                       local event loop in a helper thread and freeze the main thread for the duration of the
+                       download. In this case, if an authentication request is sent from the background thread
+                       network access manager, the background thread should be blocked, the main thread be woken
+                       up, processEvents() executed once, the main thread frozen again and the background thread
+                       continued.
 %End
 
     QgsNetworkAccessManager( QObject *parent = 0 );

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -102,7 +102,7 @@ class QgsNetworkProxyFactory : public QNetworkProxyFactory
 //
 // Static calls to enforce singleton behavior
 //
-QgsNetworkAccessManager *QgsNetworkAccessManager::instance()
+QgsNetworkAccessManager *QgsNetworkAccessManager::instance( Qt::ConnectionType connectionType )
 {
   static QThreadStorage<QgsNetworkAccessManager> sInstances;
   QgsNetworkAccessManager *nam = &sInstances.localData();
@@ -111,7 +111,7 @@ QgsNetworkAccessManager *QgsNetworkAccessManager::instance()
     sMainNAM = nam;
 
   if ( !nam->mInitialized )
-    nam->setupDefaultProxyAndCache();
+    nam->setupDefaultProxyAndCache( connectionType );
 
   return nam;
 }
@@ -281,7 +281,7 @@ QNetworkRequest::CacheLoadControl QgsNetworkAccessManager::cacheLoadControlFromN
   return QNetworkRequest::PreferNetwork;
 }
 
-void QgsNetworkAccessManager::setupDefaultProxyAndCache()
+void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType connectionType )
 {
   mInitialized = true;
   mUseSystemProxy = false;
@@ -292,11 +292,11 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache()
   {
     connect( this, &QNetworkAccessManager::authenticationRequired,
              sMainNAM, &QNetworkAccessManager::authenticationRequired,
-             Qt::BlockingQueuedConnection );
+             connectionType );
 
     connect( this, &QNetworkAccessManager::proxyAuthenticationRequired,
              sMainNAM, &QNetworkAccessManager::proxyAuthenticationRequired,
-             Qt::BlockingQueuedConnection );
+             connectionType );
 
     connect( this, &QgsNetworkAccessManager::requestTimedOut,
              sMainNAM, &QgsNetworkAccessManager::requestTimedOut );
@@ -304,7 +304,7 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache()
 #ifndef QT_NO_SSL
     connect( this, &QNetworkAccessManager::sslErrors,
              sMainNAM, &QNetworkAccessManager::sslErrors,
-             Qt::BlockingQueuedConnection );
+             connectionType );
 #endif
   }
 

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -49,9 +49,26 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     Q_OBJECT
 
   public:
-    //! returns a pointer to the single instance
-    // and creates that instance on the first call.
-    static QgsNetworkAccessManager *instance( Qt::ConnectionType connectionType = Qt::DirectConnection );
+
+    /**
+     * Returns a pointer to the active QgsNetworkAccessManager
+     * for the current thread.
+     *
+     * With the \a connectionType parameter it is possible to setup the default connection
+     * type that is used to handle signals that might require user interaction and therefore
+     * need to be handled on the main thread. See in-depth discussion below.
+     *
+     * \param connectionType In most cases the default of using a ``Qt::BlockingQueuedConnection``
+     * is ok, to make a background thread wait for the main thread to answer such a request is
+     * fine and anything else is dangerous.
+     * However, in case the request was started on the main thread, one should execute a
+     * local event loop in a helper thread and freeze the main thread for the duration of the
+     * download. In this case, if an authentication request is sent from the background thread
+     * network access manager, the background thread should be blocked, the main thread be woken
+     * up, processEvents() executed once, the main thread frozen again and the background thread
+     * continued.
+     */
+    static QgsNetworkAccessManager *instance( Qt::ConnectionType connectionType = Qt::BlockingQueuedConnection );
 
     QgsNetworkAccessManager( QObject *parent = nullptr );
 
@@ -79,7 +96,13 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     //! Gets QNetworkRequest::CacheLoadControl from name
     static QNetworkRequest::CacheLoadControl cacheLoadControlFromName( const QString &name );
 
-    //! Setup the NAM according to the user's settings
+    /**
+     * Setup the QgsNetworkAccessManager (NAM) according to the user's settings.
+     * The \a connectionType sets up the default connection type that is used to
+     * handle signals that might require user interaction and therefore
+     * need to be handled on the main thread. See in-depth discussion in the documentation
+     * for the constructor of this class.
+     */
     void setupDefaultProxyAndCache( Qt::ConnectionType connectionType = Qt::BlockingQueuedConnection );
 
     //! Returns whether the system proxy should be used

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
   public:
     //! returns a pointer to the single instance
     // and creates that instance on the first call.
-    static QgsNetworkAccessManager *instance();
+    static QgsNetworkAccessManager *instance( Qt::ConnectionType connectionType = Qt::DirectConnection );
 
     QgsNetworkAccessManager( QObject *parent = nullptr );
 
@@ -80,7 +80,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     static QNetworkRequest::CacheLoadControl cacheLoadControlFromName( const QString &name );
 
     //! Setup the NAM according to the user's settings
-    void setupDefaultProxyAndCache();
+    void setupDefaultProxyAndCache( Qt::ConnectionType connectionType = Qt::BlockingQueuedConnection );
 
     //! Returns whether the system proxy should be used
     bool useSystemProxy() const { return mUseSystemProxy; }

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -30,7 +30,11 @@
 QgsWfsCapabilities::QgsWfsCapabilities( const QString &uri )
   : QgsWfsRequest( QgsWFSDataSourceURI( uri ) )
 {
-  connect( this, &QgsWfsRequest::downloadFinished, this, &QgsWfsCapabilities::capabilitiesReplyFinished );
+  // Using Qt::DirectConnection since the download might be running on a different thread.
+  // In this case, the request was sent from the main thread and is executed with the main
+  // thread being blocked in future.waitForFinished() so we can run code on this object which
+  // lives in the main thread without risking havoc.
+  connect( this, &QgsWfsRequest::downloadFinished, this, &QgsWfsCapabilities::capabilitiesReplyFinished, Qt::DirectConnection );
 }
 
 bool QgsWfsCapabilities::requestCapabilities( bool synchronous, bool forceRefresh )

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -132,6 +132,9 @@ bool QgsWfsRequest::sendGET( const QUrl &url, bool synchronous, bool forceRefres
   {
     bool success = true;
     mReply = QgsNetworkAccessManager::instance()->get( request );
+
+    Q_ASSERT( QThread::currentThread() == mReply->thread() );
+
     mReply->setReadBufferSize( READ_BUFFER_SIZE_HINT );
     if ( !mUri.auth().setAuthorizationReply( mReply ) )
     {
@@ -142,13 +145,13 @@ bool QgsWfsRequest::sendGET( const QUrl &url, bool synchronous, bool forceRefres
     }
     else
     {
-      connect( mReply, &QNetworkReply::finished, this, &QgsWfsRequest::replyFinished );
-      connect( mReply, &QNetworkReply::downloadProgress, this, &QgsWfsRequest::replyProgress );
+      connect( mReply, &QNetworkReply::finished, this, &QgsWfsRequest::replyFinished, Qt::DirectConnection );
+      connect( mReply, &QNetworkReply::downloadProgress, this, &QgsWfsRequest::replyProgress, Qt::DirectConnection );
 
       if ( synchronous )
       {
         QEventLoop loop;
-        connect( this, &QgsWfsRequest::downloadFinished, &loop, &QEventLoop::quit );
+        connect( this, &QgsWfsRequest::downloadFinished, &loop, &QEventLoop::quit, Qt::DirectConnection );
         loop.exec();
       }
     }

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -133,8 +133,6 @@ bool QgsWfsRequest::sendGET( const QUrl &url, bool synchronous, bool forceRefres
     bool success = true;
     mReply = QgsNetworkAccessManager::instance()->get( request );
 
-    Q_ASSERT( QThread::currentThread() == mReply->thread() );
-
     mReply->setReadBufferSize( READ_BUFFER_SIZE_HINT );
     if ( !mUri.auth().setAuthorizationReply( mReply ) )
     {
@@ -145,6 +143,9 @@ bool QgsWfsRequest::sendGET( const QUrl &url, bool synchronous, bool forceRefres
     }
     else
     {
+      // We are able to use direct connection here, because we
+      // * either run on the thread mReply lives in, so DirectConnection is standard and safe anyway (if it is not the main thread)
+      // * or the owner thread of mReply is currently not doing anything because it's blocked in future.waitForFinished() (if it is the main thread)
       connect( mReply, &QNetworkReply::finished, this, &QgsWfsRequest::replyFinished, Qt::DirectConnection );
       connect( mReply, &QNetworkReply::downloadProgress, this, &QgsWfsRequest::replyProgress, Qt::DirectConnection );
 

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -133,6 +133,9 @@ bool QgsWfsRequest::sendGET( const QUrl &url, bool synchronous, bool forceRefres
   QMutex mutex;
   std::function<bool()> downloaderFunction = [ this, request, synchronous, &waitCondition ]()
   {
+    if ( QThread::currentThread() != QgsApplication::instance()->thread() )
+      QgsNetworkAccessManager::instance( Qt::DirectConnection );
+
     bool success = true;
     mReply = QgsNetworkAccessManager::instance()->get( request );
 

--- a/src/providers/wfs/qgswfsrequest.h
+++ b/src/providers/wfs/qgswfsrequest.h
@@ -19,6 +19,7 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QUrl>
+#include <QAuthenticator>
 
 #include "qgswfsdatasourceuri.h"
 
@@ -115,6 +116,33 @@ class QgsWfsRequest : public QObject
   private:
     QString errorMessageFailedAuth();
 
+};
+
+
+class DownloaderThread : public QThread
+{
+    Q_OBJECT
+
+  public:
+    DownloaderThread( std::function<bool()> function, QObject *parent = nullptr )
+      : QThread( parent )
+      , mFunction( function )
+    {
+    }
+
+    void run() override
+    {
+      mSuccess = mFunction();
+    }
+
+    bool success() const
+    {
+      return mSuccess;
+    }
+
+  private:
+    std::function<bool()> mFunction;
+    bool mSuccess = false;
 };
 
 #endif // QGSWFSREQUEST_H


### PR DESCRIPTION
This is an alternative approach to running QEventLoops on the main thread.
In case we need an event loop and we are on the main thread, we just run it in a new thread and wait for that thread to be finished.

It would of course be preferable not to block the main thread while we download something, but if that's not (easily) possible this approach is hopefully more stable than running the event loop on the main thread, which I think is responsible for the crashes below.

For reviewers, the [feature counter commit](https://github.com/qgis/QGIS/pull/7055/commits/75d3ff282dfdc79331fa2515efdd300d2a0561c7) is a minimal example of the concept. The other commit just wraps more code in more or less the same approach.


Linux:

```
0x00007fe5b6f62a56 in socketNotifierSourceCheck(_GSource*) () from /lib64/libQt5Core.so.5
[Current thread is 1 (Thread 0x7fe5c3902400 (LWP 6195))]
#0  0x00007fe5b6f62a56 in socketNotifierSourceCheck(_GSource*) () at /lib64/libQt5Core.so.5
#1  0x00007fe5b0e368c9 in g_main_context_check (context=context@entry=0x1618610, max_priority=0, fds=fds@entry=0x1bf2470, n_fds=n_fds@entry=7) at gmain.c:3701
        result = <optimized out>
        check = 0x7fe5b6f62a00 <socketNotifierSourceCheck(_GSource*)>
        source = 0x1739470
        iter = {context = 0x1618610, may_modify = 1, current_list = 0x7fe574003500 = {0x7fe5740034e0, 0x17da0a0}, source = 0x1739470}
        pollrec = <optimized out>
        n_ready = 1
        i = <optimized out>
#2  0x00007fe5b0e36e40 in g_main_context_iterate (context=context@entry=0x1618610, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at gmain.c:3865
        max_priority = 2147483647
        timeout = 14
        some_ready = <optimized out>
        nfds = 7
        allocated_nfds = 7
        fds = 0x1bf2470
#3  0x00007fe5b0e36fac in g_main_context_iteration (context=0x1618610, may_block=1) at gmain.c:3929
        retval = <optimized out>
#4  0x00007fe5b6f62c2f in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib64/libQt5Core.so.5
#5  0x00007fe5b6f1096a in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /lib64/libQt5Core.so.5
#6  0x00007fe55bc85684 in QgsWfsRequest::sendGET(QUrl const&, bool, bool, bool) (this=0x7fff9966dc58, url=..., synchronous=true, forceRefresh=false, cache=true) at /home/mku/dev/qgis/QGIS/src/providers/wfs/qgswfsrequest.cpp:146
        modifiedUrl = {d = 0x4516cd0}
        request = {d = {d = 0x4104340}}
        loop = <incomplete type>
#7  0x00007fe55bc9b098 in QgsWFSFeatureHitsRequest::getFeatureCount(QString const&, QString const&) (this=0x7fff9966dc58, WFSVersion=..., filter=...) at /home/mku/dev/qgis/QGIS/src/providers/wfs/qgswfsshareddata.cpp:1192
        getFeatureUrl = {d = 0x4516cd0}
        buffer = @0x20a5ee0: {d = 0x7fe5c25c9160 <vtable for QgsLayerTreeMapCanvasBridge+16>}
        error = {static null = {<No data fields>}, d = 0x1e9e450}
        domDoc = {<QDomNode> = {impl = 0x0}, <No data fields>}
        doc = {<QDomNode> = {impl = 0x7fff9966dc58}, <No data fields>}
        numberOfFeatures = {static null = {<No data fields>}, d = 0x0}
#8  0x00007fe55bc9abe9 in QgsWFSSharedData::getFeatureCount(bool) (this=0x44891d0, issueRequestIfNeeded=true) at /home/mku/dev/qgis/QGIS/src/providers/wfs/qgswfsshareddata.cpp:1106
        request = {<QgsWfsRequest> = {<QObject> = {<No data fields>}, static staticMetaObject = {d = {superdata = 0x7fe5b7356280 <QObject::staticMetaObject>, stringdata = 0x7fe55bcc6b38 <qt_meta_stringdata_QgsWfsRequest>, data = 0x7fe55bcc6a30 <qt_meta_data_QgsWfsRequest>, static_metacall = 0x7fe55bcbbc00 <QgsWfsRequest::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)>, relatedMetaObjects = 0x0, extradata = 0x0}}, mUri = {mURI = {static staticMetaObject = {d = {superdata = 0x0, stringdata = 0x7fe5bfedde40 <qt_meta_stringdata_QgsDataSourceUri>, data = 0x7fe5bfedddc0 <qt_meta_data_QgsDataSourceUri>, static_metacall = 0x0, relatedMetaObjects = 0x0, extradata = 0x0}}, mHost = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mPort = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mDriver = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mService = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mDatabase = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mSchema = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mTable = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mGeometryColumn = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mSql = {static null = {<No data fields>}, d = 0x7fe5b6fac760}, mAuthConfigId = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mUsername = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mPassword = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mSSLmode = QgsDataSourceUri::SslPrefer, mKeyColumn = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mUseEstimatedMetadata = false, mSelectAtIdDisabled = false, mWkbType = QgsWkbTypes::Unknown, mSrid = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mParams = {d = 0x37bc890}}, mAuth = {mUserName = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mPassword = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mAuthCfg = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}}, mGetEndpoints = {d = 0x442d9d0}, mPostEndpoints = {d = 0x442dae0}}, mReply = 0x361a6f0, mErrorMessage = {static null = {<No data fields>}, d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mErrorCode = QgsWfsRequest::NoError, mResponse = {d = 0x7fe5b6fac7c0 <QArrayData::shared_null>}, mIsAborted = false, mForceRefresh = false, mTimedout = false, mGotNonEmptyResponse = false}, static staticMetaObject = {d = {superdata = 0x7fe55bef6e50 <QgsWfsRequest::staticMetaObject>, stringdata = 0x7fe55bcc6ff0 <qt_meta_stringdata_QgsWFSFeatureHitsRequest>, data = 0x7fe55bcc6e60 <qt_meta_data_QgsWFSFeatureHitsRequest>, static_metacall = 0x7fe55bcbc690 <QgsWFSFeatureHitsRequest::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)>, relatedMetaObjects = 0x0, extradata = 0x0}}}
        featureCount = 32767
#9  0x00007fe55bc3c686 in QgsWFSProvider::featureCount() const (this=0x190b160) at /home/mku/dev/qgis/QGIS/src/providers/wfs/qgswfsprovider.cpp:729
...
```

or

Windows:

```
QIODevice::channelReadyRead :

QIODevice::write :

QNetworkReply::url :

QNetworkReply::uploadProgress :

QObject::event :

QApplicationPrivate::notify_helper :

QApplication::notify :

QgsApplication::notify qgsapplication.cpp:325

QCoreApplication::notifyInternal2 :

QCoreApplicationPrivate::sendPostedEvents :

QEventDispatcherWin32::processEvents :

TranslateMessageEx :

TranslateMessage :

QEventDispatcherWin32::processEvents :

QEventLoop::exec :

QgsWFSFeatureDownloader::run qgswfsfeatureiterator.cpp:482

QgsWFSThreadedFeatureDownloader::run qgswfsfeatureiterator.cpp:804

QThread::start :

BaseThreadInitThunk :

RtlUserThreadStart :
```