### PR TITLE
[WFS provider] Revert to using singular TYPENAME keyword for WFS 2.0 DescribeFeatureType (fixes #18882, refs #17872)

### DIFF
--- a/src/providers/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/providers/wfs/qgswfsdescribefeaturetype.cpp
@@ -21,11 +21,12 @@ QgsWFSDescribeFeatureType::QgsWFSDescribeFeatureType( QgsWFSDataSourceURI &uri )
 }
 
 bool QgsWFSDescribeFeatureType::requestFeatureType( const QString &WFSVersion,
-    const QString &typeName )
+    const QString &typeName, bool bUsePlural )
 {
   QUrl url( mUri.requestUrl( QStringLiteral( "DescribeFeatureType" ) ) );
   url.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
-  url.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
+  url.addQueryItem( bUsePlural ?
+                    QStringLiteral( "TYPENAMES" ) : QStringLiteral( "TYPENAME" ), typeName );
 
   return sendGET( url, true, false );
 }

--- a/src/providers/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/providers/wfs/qgswfsdescribefeaturetype.cpp
@@ -14,7 +14,6 @@
  ***************************************************************************/
 
 #include "qgswfsdescribefeaturetype.h"
-#include "qgswfsutils.h"
 
 QgsWFSDescribeFeatureType::QgsWFSDescribeFeatureType( QgsWFSDataSourceURI &uri )
   : QgsWfsRequest( uri )
@@ -22,16 +21,12 @@ QgsWFSDescribeFeatureType::QgsWFSDescribeFeatureType( QgsWFSDataSourceURI &uri )
 }
 
 bool QgsWFSDescribeFeatureType::requestFeatureType( const QString &WFSVersion,
-    const QString &typeName, bool forceSingularTypeName )
+    const QString &typeName )
 {
   QUrl url( mUri.requestUrl( QStringLiteral( "DescribeFeatureType" ) ) );
   url.addQueryItem( QStringLiteral( "VERSION" ), WFSVersion );
-  // The specs are not consistent: is it singular in 1.0.x and plural in 2.0.0?
-  // see http://docs.opengeospatial.org/is/09-025r2/09-025r2.html#147
-  if ( ! forceSingularTypeName )
-    url.addQueryItem( QgsWFSUtils::typeNameParameterForVersion( WFSVersion ).toUpper( ), typeName );
-  else
-    url.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
+  url.addQueryItem( QStringLiteral( "TYPENAME" ), typeName );
+
   return sendGET( url, true, false );
 }
 

--- a/src/providers/wfs/qgswfsdescribefeaturetype.h
+++ b/src/providers/wfs/qgswfsdescribefeaturetype.h
@@ -25,7 +25,7 @@ class QgsWFSDescribeFeatureType : public QgsWfsRequest
     explicit QgsWFSDescribeFeatureType( QgsWFSDataSourceURI &uri );
 
     //! Issue the request
-    bool requestFeatureType( const QString &WFSVersion, const QString &typeName );
+    bool requestFeatureType( const QString &WFSVersion, const QString &typeName, bool bUsePlural );
 
   protected:
     QString errorMessageWithReason( const QString &reason ) override;

--- a/src/providers/wfs/qgswfsdescribefeaturetype.h
+++ b/src/providers/wfs/qgswfsdescribefeaturetype.h
@@ -25,8 +25,7 @@ class QgsWFSDescribeFeatureType : public QgsWfsRequest
     explicit QgsWFSDescribeFeatureType( QgsWFSDataSourceURI &uri );
 
     //! Issue the request
-    bool requestFeatureType( const QString &WFSVersion, const QString &typeName,
-                             bool forceSingularTypeName = false );
+    bool requestFeatureType( const QString &WFSVersion, const QString &typeName );
 
   protected:
     QString errorMessageWithReason( const QString &reason ) override;

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -919,7 +919,7 @@ bool QgsWFSProvider::deleteFeatures( const QgsFeatureIds &id )
   transactionDoc.appendChild( transactionElem );
   //delete element
   QDomElement deleteElem = transactionDoc.createElementNS( QgsWFSConstants::WFS_NAMESPACE, QStringLiteral( "Delete" ) );
-  deleteElem.setAttribute( QgsWFSUtils::typeNameParameterForVersion( mShared->mWFSVersion ), tname );
+  deleteElem.setAttribute( QStringLiteral( "typeName" ), tname );
   QDomElement filterElem = transactionDoc.createElementNS( QgsWFSConstants::OGC_NAMESPACE, QStringLiteral( "Filter" ) );
 
 
@@ -984,7 +984,7 @@ bool QgsWFSProvider::changeGeometryValues( const QgsGeometryMap &geometry_map )
       continue;
     }
     QDomElement updateElem = transactionDoc.createElementNS( QgsWFSConstants::WFS_NAMESPACE, QStringLiteral( "Update" ) );
-    updateElem.setAttribute( QgsWFSUtils::typeNameParameterForVersion( mShared->mWFSVersion ), tname );
+    updateElem.setAttribute( QStringLiteral( "typeName" ), tname );
     //Property
     QDomElement propertyElem = transactionDoc.createElementNS( QgsWFSConstants::WFS_NAMESPACE, QStringLiteral( "Property" ) );
     QDomElement nameElem = transactionDoc.createElementNS( QgsWFSConstants::WFS_NAMESPACE, QStringLiteral( "Name" ) );
@@ -1040,7 +1040,6 @@ QString QgsWFSProvider::convertToXML( const QVariant &value )
   return valueStr;
 }
 
-
 bool QgsWFSProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_map )
 {
   //find out typename from uri and strip namespace prefix
@@ -1066,7 +1065,7 @@ bool QgsWFSProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
     }
 
     QDomElement updateElem = transactionDoc.createElementNS( QgsWFSConstants::WFS_NAMESPACE, QStringLiteral( "Update" ) );
-    updateElem.setAttribute( QgsWFSUtils::typeNameParameterForVersion( mShared->mWFSVersion ), tname );
+    updateElem.setAttribute( QStringLiteral( "typeName" ), tname );
 
     QgsAttributeMap::const_iterator attMapIt = attIt.value().constBegin();
     for ( ; attMapIt != attIt.value().constEnd(); ++attMapIt )
@@ -1159,18 +1158,15 @@ QString QgsWFSProvider::translateMetadataValue( const QString &mdKey, const QVar
   {
     return value.toString();
   }
-}
+};
 
-bool QgsWFSProvider::describeFeatureType( QString &geometryAttribute,
-    QgsFields &fields,
-    QgsWkbTypes::Type &geomType,
-    bool forceSingularTypeNames )
+bool QgsWFSProvider::describeFeatureType( QString &geometryAttribute, QgsFields &fields, QgsWkbTypes::Type &geomType )
 {
   fields.clear();
 
   QgsWFSDescribeFeatureType describeFeatureType( mShared->mURI );
   if ( !describeFeatureType.requestFeatureType( mShared->mWFSVersion,
-       mShared->mURI.typeName(), forceSingularTypeNames ) )
+       mShared->mURI.typeName() ) )
   {
     QgsMessageLog::logMessage( tr( "DescribeFeatureType network request failed for url %1: %2" ).
                                arg( dataSourceUri(), describeFeatureType.errorMessage() ), tr( "WFS" ) );
@@ -1193,19 +1189,11 @@ bool QgsWFSProvider::describeFeatureType( QString &geometryAttribute,
                                   mShared->mURI.typeName(),
                                   geometryAttribute, fields, geomType, errorMsg ) )
   {
-    // If 2.0.0, let's assume it was a server that only accepted TYPENAME singular form
-    // and try with that ...
-    if ( ! forceSingularTypeNames && mShared->mWFSVersion.startsWith( '2' ) )
-    {
-      return QgsWFSProvider::describeFeatureType( geometryAttribute,
-             fields,
-             geomType,
-             true );
-    }
     QgsMessageLog::logMessage( tr( "Analysis of DescribeFeatureType response failed for url %1: %2" ).
                                arg( dataSourceUri(), errorMsg ), tr( "WFS" ) );
     return false;
   }
+
   return true;
 }
 
@@ -1479,8 +1467,7 @@ QDomElement QgsWFSProvider::createTransactionElement( QDomDocument &doc ) const
     describeFeatureTypeURL.addQueryItem( QStringLiteral( "REQUEST" ), QStringLiteral( "DescribeFeatureType" ) );
   }
   describeFeatureTypeURL.addQueryItem( QStringLiteral( "VERSION" ), QStringLiteral( "1.0.0" ) );
-  //TODO: proper support of 2.0.0, for now hardcoded
-  describeFeatureTypeURL.addQueryItem( QgsWFSUtils::typeNameParameterForVersion( WfsVersion ).toUpper(), mShared->mURI.typeName() );
+  describeFeatureTypeURL.addQueryItem( QStringLiteral( "TYPENAME" ), mShared->mURI.typeName() );
 
   transactionElem.setAttribute( QStringLiteral( "xsi:schemaLocation" ), mApplicationNamespace + ' '
                                 + describeFeatureTypeURL.toEncoded() );

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -151,7 +151,7 @@ class QgsWFSProvider : public QgsVectorDataProvider
        The method gives back the name of
        the geometry attribute and the thematic attributes with their types*/
     bool describeFeatureType( QString &geometryAttribute,
-                              QgsFields &fields, QgsWkbTypes::Type &geomType, bool forceSingularTypeNames = false );
+                              QgsFields &fields, QgsWkbTypes::Type &geomType );
 
     /**
      * For a given typename, reads the name of the geometry attribute, the

--- a/src/providers/wfs/qgswfsutils.cpp
+++ b/src/providers/wfs/qgswfsutils.cpp
@@ -138,19 +138,6 @@ bool QgsWFSUtils::removeDir( const QString &dirName )
   return dir.rmdir( dirName );
 }
 
-QString QgsWFSUtils::typeNameParameterForVersion( const QString &WfsVersion )
-{
-  // WFS 2.0 uses the plural form TYPENAMES
-  if ( WfsVersion.startsWith( '2' ) )
-  {
-    return QString( "typeNames" );
-  }
-  else
-  {
-    return QString( "typeName" );
-  }
-}
-
 
 // We use a keep alive mechanism where every KEEP_ALIVE_DELAY ms we update
 // a shared memory segment with the current timestamp. This way, other QGIS

--- a/src/providers/wfs/qgswfsutils.h
+++ b/src/providers/wfs/qgswfsutils.h
@@ -45,9 +45,6 @@ class QgsWFSUtils
     //! Return a unique identifier made from feature content
     static QString getMD5( const QgsFeature &f );
 
-    //! Return the correct form of typeName(s) according to the specified \a WfsVersion
-    static QString typeNameParameterForVersion( const QString &WfsVersion );
-
   protected:
     friend class QgsWFSUtilsKeepAlive;
     static QSharedMemory *createAndAttachSHM();
@@ -65,7 +62,6 @@ class QgsWFSUtils
 
     //! Remove (recursively) a directory.
     static bool removeDir( const QString &dirName );
-
 };
 
 //! For internal use of QgsWFSUtils

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -15,8 +15,8 @@ __revision__ = '$Format:%H$'
 import hashlib
 import os
 import re
-import tempfile
 import shutil
+import tempfile
 
 # Needed on Qt 5 so that the serialization of XML is consistent among all executions
 os.environ['QT_HASH_SEED'] = '1'
@@ -106,7 +106,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </FeatureTypeList>
 </wfs:WFS_Capabilities>""".encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml/3.2"/>
@@ -998,7 +998,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </FeatureTypeList>
 </wfs:WFS_Capabilities>""".encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml/3.2"/>
@@ -1321,7 +1321,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </FeatureTypeList>
 </wfs:WFS_Capabilities>""".encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml/3.2"/>
@@ -1600,7 +1600,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   <xsd:element name="othertypename" substitutionGroup="gml:_Feature" type="my:othertypenameType"/>
 </xsd:schema>
 """
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename,my:othertypename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename,my:othertypename'), 'wb') as f:
             f.write(schema.encode('UTF-8'))
 
         with open(sanitize(endpoint, """?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename,my:othertypename&SRSNAME=urn:ogc:def:crs:EPSG::4326&FILTER=<fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">
@@ -1666,7 +1666,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
 
         # main table not appearing in first
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:othertypename,my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:othertypename,my:typename'), 'wb') as f:
             f.write(schema.encode('UTF-8'))
 
         vl = QgsVectorLayer("url='http://" + endpoint + "' typename='my:typename' version='2.0.0' sql=SELECT * FROM othertypename o, typename WHERE typename.id = o.main_id AND typename.id > 0 ORDER BY typename.id DESC", 'test', 'WFS')
@@ -1716,7 +1716,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(len(fields), 1, fields)
         self.assertEqual(fields[0].name(), 'id')
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write(schema.encode('UTF-8'))
 
         # Duplicate fields
@@ -1920,7 +1920,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
             f.write(schema.encode('UTF-8'))
         with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=1.1.0&TYPENAME=my:typename'), 'wb') as f:
             f.write(schema.encode('UTF-8'))
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write(schema.encode('UTF-8'))
 
         # Existing function and validation enabled
@@ -1985,7 +1985,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </FeatureTypeList>
 </wfs:WFS_Capabilities>""".encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml"/>
@@ -2102,7 +2102,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </FeatureTypeList>
 </wfs:WFS_Capabilities>""".encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml"/>
@@ -2210,7 +2210,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </FeatureTypeList>
 </wfs:WFS_Capabilities>""".encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml"/>
@@ -2506,7 +2506,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </FeatureTypeList>
 </wfs:WFS_Capabilities>""".encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml/3.2"/>
@@ -2582,7 +2582,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </FeatureTypeList>
 </wfs:WFS_Capabilities>""".format(endpoint=endpoint).encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml/3.2"/>
@@ -2698,7 +2698,7 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
   </wfs:FeatureTypeList>
 </wfs:WFS_Capabilities>""".encode('UTF-8'))
 
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
             f.write("""
 <xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
   <xsd:import namespace="http://www.opengis.net/gml"/>
@@ -2745,337 +2745,6 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         self.assertAlmostEqual(provider_extent.xMaximum(), -65.32, 3)
         self.assertAlmostEqual(provider_extent.yMinimum(), 66.33, 3)
         self.assertAlmostEqual(provider_extent.yMaximum(), 78.3, 3)
-
-    def testWfs20DescribeFeatureTypeSingularForm(self):
-        """Specs are inconsistent and some 2.0 servers use the TYPENAME singular form"""
-
-        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_describefeaturetype_singular_form'
-
-        with open(sanitize(endpoint, '?SERVICE=WFS?REQUEST=GetCapabilities?VERSION=2.0.0'), 'wb') as f:
-            f.write("""
-<wfs:WFS_Capabilities version="2.0.0" xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://schemas.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0">
-  <FeatureTypeList>
-    <FeatureType>
-      <Name>my:typename</Name>
-      <Title>Title</Title>
-      <Abstract>Abstract</Abstract>
-      <DefaultCRS>urn:ogc:def:crs:EPSG::4326</DefaultCRS>
-      <WGS84BoundingBox>
-        <LowerCorner>-71.123 66.33</LowerCorner>
-        <UpperCorner>-65.32 78.3</UpperCorner>
-      </WGS84BoundingBox>
-    </FeatureType>
-  </FeatureTypeList>
-</wfs:WFS_Capabilities>""".encode('UTF-8'))
-
-        # plural form not supported!
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=my:typename'), 'wb') as f:
-            f.write(b"<error></error>")
-
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=my:typename'), 'wb') as f:
-            f.write("""
-<xsd:schema xmlns:my="http://my" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://my">
-  <xsd:import namespace="http://www.opengis.net/gml/3.2"/>
-  <xsd:complexType name="typenameType">
-    <xsd:complexContent>
-      <xsd:extension base="gml:AbstractFeatureType">
-        <xsd:sequence>
-          <!-- add a trailing space to the name to test https://issues.qgis.org/issues/3426 -->
-          <xsd:element maxOccurs="1" minOccurs="0" name="pk  " nillable="true" type="xsd:long"/>
-          <xsd:element maxOccurs="1" minOccurs="0" name="cnt" nillable="true" type="xsd:long"/>
-          <xsd:element maxOccurs="1" minOccurs="0" name="name" nillable="true" type="xsd:string"/>
-          <xsd:element maxOccurs="1" minOccurs="0" name="name2" nillable="true" type="xsd:string"/>
-          <xsd:element maxOccurs="1" minOccurs="0" name="num_char" nillable="true" type="xsd:string"/>
-          <xsd:element maxOccurs="1" minOccurs="0" name="geometryProperty" nillable="true" type="gml:PolygonPropertyType"/>
-          <!-- check that an element with ref without name doesn't confuse the DescribeFeatureType analyzer -->
-          <xsd:element maxOccurs="0" minOccurs="0" ref="my:somethingElseType"/>
-        </xsd:sequence>
-      </xsd:extension>
-    </xsd:complexContent>
-  </xsd:complexType>
-  <xsd:element name="typename" substitutionGroup="gml:_Feature" type="my:typenameType"/>
-  <xsd:complexType name="somethingElseType"/>
-</xsd:schema>
-""".encode('UTF-8'))
-
-        # Create test layer
-        vl = QgsVectorLayer("url='http://" + endpoint + "' version='2.0.0' typename='my:typename'", 'test', 'WFS')
-        self.assertTrue(vl.isValid())
-
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=my:typename&SRSNAME=urn:ogc:def:crs:EPSG::4326'), 'wb') as f:
-            f.write("""
-<wfs:FeatureCollection
-                       xmlns:wfs="http://www.opengis.net/wfs/2.0"
-                       xmlns:gml="http://www.opengis.net/gml/3.2"
-                       xmlns:my="http://my"
-                       numberMatched="5" numberReturned="5" timeStamp="2016-03-25T14:51:48.998Z">
-  <wfs:member>
-    <my:typename gml:id="typename.0">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>66.33 -70.332</gml:lowerCorner><gml:upperCorner>66.33 -70.332</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.0"><gml:pos>66.33 -70.332</gml:pos></gml:Point></my:geometryProperty>
-      <my:pk>1</my:pk>
-      <my:cnt>100</my:cnt>
-      <my:name>Orange</my:name>
-      <my:name2>oranGe</my:name2>
-      <my:num_char>1</my:num_char>
-    </my:typename>
-  </wfs:member>
-  <wfs:member>
-    <my:typename gml:id="typename.1">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>70.8 -68.2</gml:lowerCorner><gml:upperCorner>70.8 -68.2</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.1"><gml:pos>70.8 -68.2</gml:pos></gml:Point></my:geometryProperty>
-      <my:pk>2</my:pk>
-      <my:cnt>200</my:cnt>
-      <my:name>Apple</my:name>
-      <my:name2>Apple</my:name2>
-      <my:num_char>2</my:num_char>
-    </my:typename>
-  </wfs:member>
-  <wfs:member>
-    <my:typename gml:id="typename.2">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.3 -65.32</gml:lowerCorner><gml:upperCorner>78.3 -65.32</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.2"><gml:pos>78.3 -65.32</gml:pos></gml:Point></my:geometryProperty>
-      <my:pk>4</my:pk>
-      <my:cnt>400</my:cnt>
-      <my:name>Honey</my:name>
-      <my:name2>Honey</my:name2>
-      <my:num_char>4</my:num_char>
-    </my:typename>
-  </wfs:member>
-  <wfs:member>
-    <my:typename gml:id="typename.3">
-      <my:pk>3</my:pk>
-      <my:cnt>300</my:cnt>
-      <my:name>Pear</my:name>
-      <my:name2>PEaR</my:name2>
-      <my:num_char>3</my:num_char>
-    </my:typename>
-  </wfs:member>
-  <wfs:member>
-    <my:typename gml:id="typename.4">
-      <gml:boundedBy><gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326"><gml:lowerCorner>78.23 -71.123</gml:lowerCorner><gml:upperCorner>78.23 -71.123</gml:upperCorner></gml:Envelope></gml:boundedBy>
-      <my:geometryProperty><gml:Point srsName="urn:ogc:def:crs:EPSG::4326" gml:id="typename.geom.4"><gml:pos>78.23 -71.123</gml:pos></gml:Point></my:geometryProperty>
-      <my:pk>5</my:pk>
-      <my:cnt>-200</my:cnt>
-      <my:name2>NuLl</my:name2>
-      <my:num_char>5</my:num_char>
-    </my:typename>
-  </wfs:member>
-</wfs:FeatureCollection>""".encode('UTF-8'))
-
-        features = list(vl.getFeatures())
-        self.assertEqual(len(features), 5)
-        geom = features[0].geometry()
-        self.assertAlmostEqual(geom.asPoint().x(), -70.332, 1)
-        self.assertAlmostEqual(geom.asPoint().y(), 66.33, 1)
-
-    def testWfs20SamServer(self):
-        """Unknown russian WFS 2.0.0 http://geoportal.samregion.ru/wfs12"""
-
-        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_sam'
-
-        with open(sanitize(endpoint, '?SERVICE=WFS?REQUEST=GetCapabilities?VERSION=2.0.0'), 'wb') as f:
-            f.write("""<wfs:WFS_Capabilities version="2.0.0" xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://schemas.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0">
-  <FeatureTypeList>
-    <FeatureType>
-      <Name>EC422</Name>
-      <Title>Title</Title>
-      <Abstract>Abstract</Abstract>
-      <DefaultCRS>urn:ogc:def:crs:EPSG::4326</DefaultCRS>
-    </FeatureType>
-  </FeatureTypeList>
-</wfs:WFS_Capabilities>""".encode('UTF-8'))
-
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAMES=EC422'), 'wb') as f:
-            f.write("""<schema xmlns="http://www.w3.org/2001/XMLSchema"
-        xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:gml="http://www.opengis.net/gml/3.2"
-        xmlns:geosmr="http://www.geosamara.ru/wfs/geosmr/namespace"
-        targetNamespace="http://www.geosamara.ru/wfs/geosmr/namespace"
-        elementFormDefault="qualified" version="2.0.0">
-<element name="Feature" type="geosmr:FeatureType" substitutionGroup="gml:AbstractFeature"/>
-<complexType name="FeatureEC422Type">
-    <complexContent>
-        <extension base="gml:AbstractFeatureType">
-            <sequence>
-                <element name="id" type="xs:string"/>
-                <element name="name" type="xs:string"/>
-                <element name="description" type="geosmr:DescriptionType"/>
-                <element name="style" type="xs:string"/>
-                <element name="status" type="xs:string"/>
-                <element name="operations" type="geosmr:OperationsType"/>
-                <element name="transaction" type="geosmr:TransactionType"/>
-                <choice>
-                    <element name="geometry" type="gml:PointPropertyType"/>
-                    <element name="geometry" type="gml:CurvePropertyType"/>
-                    <element name="geometry" type="gml:SurfacePropertyType"/>
-                </choice>
-            </sequence>
-        </extension>
-    </complexContent>
-</complexType>
-<complexType name="DescriptionType">
-    <sequence>
-        <element name="text" type="xs:string"/>
-        <element name="resource" type="xs:anyURI"/>
-        <element name="image" type="xs:string"/>
-        <element name="reestrId" type="xs:string"/>        
-    </sequence>
-</complexType>
-<complexType name="OperationsType">
-    <sequence>
-        <element name="update" type="xs:boolean"/>
-        <element name="delete" type="xs:boolean"/>
-        <element name="moderate" type="xs:boolean"/>
-    </sequence>
-</complexType>
-    <complexType name="TransactionType">
-    <choice minoccurs="0">
-        <element name="mine" type="xs:boolean"/>
-        <element name="locker" type="xs:string"/>
-        <element name="expireIn" type="xs:positiveInteger"/>
-    </choice>
-</complexType>
-</schema>""".encode('UTF-8'))
-
-        feature_content = """<?xml version="1.0"?>
-<wfs:FeatureCollection
-        timeStamp="2010-02-01T22:56:09"
-        numberMatched="8"
-        numberReturned="8"
-        xmlns="http://www.geosamara.ru/wfs/geosmr/namespace"
-        xmlns:wfs="http://www.opengis.net/wfs/2.0"
-        xmlns:gml="http://www.opengis.net/gml/3.2"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.geosamara.ru/wfs/geosmr/style.xsd
-                       http://www.opengis.net/wfs/2.0
-                       http://schemas.opengis.net/wfs/2.0.0/wfs.xsd
-                       http://www.opengis.net/gml/3.2
-                       http://schemas.opengis.net/gml/3.2.1/gml.xsd">
-    
-        <wfs:member>
-            <EC422 gml:id="EC422.13172455">
-                <id>13172455</id>
-                <name><![CDATA[Основной туристический маршрут]]></name>
-                <description>
-                    <text><![CDATA[]]></text>
-                    <additionalInfo><![CDATA[]]></additionalInfo>
-                    <resource><![CDATA[]]></resource>
-                    <image><![CDATA[]]></image>
-                    <audio><![CDATA[]]></audio>
-                    <video><![CDATA[]]></video>
-                    <votes><![CDATA[0]]></votes>
-                    <reestrId><![CDATA[]]></reestrId>
-                    
-                </description>
-                <style>CreatedRoute</style>
-                <status>checked</status>
-                <author>Андрей Чернов</author>
-                <currentUserAuthor>false</currentUserAuthor>
-                <operations>
-                        <update>false</update>
-                        <delete>false</delete>
-                        <moderate>false</moderate>
-                </operations>
-                <transaction>
-                    
-                </transaction>
-                <geometry>
-                	<LineString xmlns="http://www.opengis.net/gml"><posList>9540051.88156246 5997366.8135842243 9539934.21894572 5997127.7749966066 9539822.1483417116 5996862.6127466606 9539504.179093 5996097.3096572906 9539529.9650254529 5996093.5547346519 9539584.6281441431 5996148.1036405731 9539709.8322301712 5996306.1476564864 9539514.2094426583 5996393.6699969191 9539315.5400513224 5996461.6283053206 9539418.05506746 5996708.1687648129 9539601.002140563 5996948.5162237845 9539715.6644945163 5997103.3323533693 9539806.8714339714 5997185.6346932752 9539980.407018993 5997401.3173021814 9540034.9262902886 5997461.1185212145 9540144.520062916 5997647.082066942 9540205.6388517376 5997752.865820759 9540413.93051952 5998022.2412844934 9540636.78114721 5998289.1650444875 9540652.2228743583 5998292.3310790323 9540739.3873799425 5998253.7093249289 9540742.8882315382 5998264.8666193094 9540928.0440610871 5998447.0783388717 9540964.2606249321 5998465.5247420967 9540992.4471577276 5998468.9503919454 9541266.994057592 5998700.44280944 9541489.2456994727 5998870.8459224468 9542015.9473830853 5999245.7052185535 9542481.7197104339 5999585.458734531 9542594.2400093842 5999581.2418252891 9542791.0368823726 5999731.6623752853 9543204.6598267779 6000066.4150706194 9543245.7990274262 6000086.6195615921 9543303.6317887139 6000098.2128836326 9543392.7859923933 6000084.2088917186 9543473.2299142312 6000041.19114427 9543582.34122052 5999959.7280100482 9543796.5102230646 5999788.4518707721 9544237.3357650079 6000148.6245372053 9544242.356376797 6000146.87913009</posList></LineString>
-                </geometry>
-                <creationDate>
-                	
-                </creationDate>
-        </EC422>
-        </wfs:member>
-    
-        <wfs:member>
-            <EC422 gml:id="EC422.13172458">
-                <id>13172458</id>
-                <name><![CDATA[]]></name>
-                <description>
-                    <text><![CDATA[Добавлено 15:44 20 января 2016]]></text>
-                    <additionalInfo><![CDATA[]]></additionalInfo>
-                    <resource><![CDATA[]]></resource>
-                    <image><![CDATA[]]></image>
-                    <audio><![CDATA[]]></audio>
-                    <video><![CDATA[]]></video>
-                    <votes><![CDATA[0]]></votes>
-                    <reestrId><![CDATA[]]></reestrId>
-                    
-                </description>
-                <style>CreatedRoute</style>
-                <status>checked</status>
-                <author>Андрей Чернов</author>
-                <currentUserAuthor>false</currentUserAuthor>
-                <operations>
-                        <update>false</update>
-                        <delete>false</delete>
-                        <moderate>false</moderate>
-                </operations>
-                <transaction>
-                    
-                </transaction>
-                <geometry>
-                	<LineString xmlns="http://www.opengis.net/gml"><posList>9540865.6444970388 5998183.9317809641 9540775.852046784 5997947.0331188506 9540680.5655983184 5997718.6045682346 9540569.58023185 5997466.57064837 9540466.8184371851 5997200.4314374486 9540244.6014337484 5996676.7638938017 9540169.35653367 5996705.7142945267 9540148.0577711649 5996682.1794316517 9540111.4476553015 5996665.8381209867 9540077.9721918479 5996676.0606173435 9540043.4139141534 5996711.499830937 9540043.9248592574 5996752.0983768944 9540045.5009976458 5996766.0802566176 9539966.0914670844 5996797.8834326165 9539818.507223323 5996864.1487550773 9539610.9541244339 5996949.3710925905</posList></LineString>
-                </geometry>
-                <creationDate>
-                	
-                </creationDate>
-        </EC422>
-        </wfs:member>
-    
-        <wfs:member>
-            <EC422 gml:id="EC422.13172454">
-                <id>13172454</id>
-                <name><![CDATA[Основной туристический маршрут]]></name>
-                <description>
-                    <text><![CDATA[]]></text>
-                    <additionalInfo><![CDATA[]]></additionalInfo>
-                    <resource><![CDATA[]]></resource>
-                    <image><![CDATA[]]></image>
-                    <audio><![CDATA[]]></audio>
-                    <video><![CDATA[]]></video>
-                    <votes><![CDATA[0]]></votes>
-                    <reestrId><![CDATA[]]></reestrId>
-                    
-                </description>
-                <style>CreatedRoute</style>
-                <status>checked</status>
-                <author>Андрей Чернов</author>
-                <currentUserAuthor>false</currentUserAuthor>
-                <operations>
-                        <update>false</update>
-                        <delete>false</delete>
-                        <moderate>false</moderate>
-                </operations>
-                <transaction>
-                    
-                </transaction>
-                <geometry>
-                	<LineString xmlns="http://www.opengis.net/gml"><posList>9542485.8345187921 5998971.7039023517 9542453.32676163 5998980.1340847686 9542423.4887301736 5998965.47791457 9541839.9022341352 5998539.8925312571 9541447.9249842446 5998260.2124332683 9541414.5872483123 5998203.50518699 9541330.9900199063 5998001.1229150137 9540804.3199365921 5996757.0503186928 9540212.17485467 5997003.9579582512 9539930.5850430559 5997125.116400606 9539816.1399206612 5997176.6829545 9539806.7162561137 5997183.794419908</posList></LineString>
-                </geometry>
-                <creationDate>
-                	
-                </creationDate>
-        </EC422>
-  </wfs:member>
-</wfs:FeatureCollection>"""
-
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=EC422&COUNT=1&SRSNAME=urn:ogc:def:crs:EPSG::4326'), 'wb') as f:
-            f.write(feature_content.encode('UTF-8'))
-
-        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=EC422&SRSNAME=urn:ogc:def:crs:EPSG::4326'), 'wb') as f:
-            f.write(feature_content.encode('UTF-8'))
-
-        vl = QgsVectorLayer("url='http://" + endpoint + "' version='2.0.0' typename='EC422'", 'test', 'WFS')
-        self.assertTrue(vl.isValid())
-        features = list(vl.getFeatures())
-        self.assertEqual(len(features), 3)
-        geom = features[0].geometry()
-        geom_string = geom.asWkt()
-        geom_string = re.sub(r'\.\d+', '', geom_string)[:100]
-        self.assertEqual(geom_string, "LineString (9540051 5997366, 9539934 5997127, 9539822 5996862, 9539504 5996097, 9539529 5996093, 953")
 
     def testWFS10DCP(self):
         """Test a server with different DCP endpoints"""
@@ -3343,6 +3012,214 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         got_f = [f for f in vl.getFeatures()]
         got = got_f[0].geometry().constGet()
         self.assertEqual((got.x(), got.y()), (3.0, 4.0))
+
+    def testWfs20SamServer(self):
+        """Unknown russian WFS 2.0.0 http://geoportal.samregion.ru/wfs12"""
+
+        endpoint = self.__class__.basetestpath + '/fake_qgis_http_endpoint_sam'
+
+        with open(sanitize(endpoint, '?SERVICE=WFS?REQUEST=GetCapabilities?VERSION=2.0.0'), 'wb') as f:
+            f.write("""<wfs:WFS_Capabilities version="2.0.0" xmlns="http://www.opengis.net/wfs/2.0" xmlns:wfs="http://www.opengis.net/wfs/2.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:gml="http://schemas.opengis.net/gml/3.2" xmlns:fes="http://www.opengis.net/fes/2.0">
+  <FeatureTypeList>
+    <FeatureType>
+      <Name>EC422</Name>
+      <Title>Title</Title>
+      <Abstract>Abstract</Abstract>
+      <DefaultCRS>urn:ogc:def:crs:EPSG::4326</DefaultCRS>
+    </FeatureType>
+  </FeatureTypeList>
+</wfs:WFS_Capabilities>""".encode('UTF-8'))
+
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=EC422'), 'wb') as f:
+            f.write("""<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:geosmr="http://www.geosamara.ru/wfs/geosmr/namespace"
+        targetNamespace="http://www.geosamara.ru/wfs/geosmr/namespace"
+        elementFormDefault="qualified" version="2.0.0">
+<element name="Feature" type="geosmr:FeatureType" substitutionGroup="gml:AbstractFeature"/>
+<complexType name="FeatureEC422Type">
+    <complexContent>
+        <extension base="gml:AbstractFeatureType">
+            <sequence>
+                <element name="id" type="xs:string"/>
+                <element name="name" type="xs:string"/>
+                <element name="description" type="geosmr:DescriptionType"/>
+                <element name="style" type="xs:string"/>
+                <element name="status" type="xs:string"/>
+                <element name="operations" type="geosmr:OperationsType"/>
+                <element name="transaction" type="geosmr:TransactionType"/>
+                <choice>
+                    <element name="geometry" type="gml:PointPropertyType"/>
+                    <element name="geometry" type="gml:CurvePropertyType"/>
+                    <element name="geometry" type="gml:SurfacePropertyType"/>
+                </choice>
+            </sequence>
+        </extension>
+    </complexContent>
+</complexType>
+<complexType name="DescriptionType">
+    <sequence>
+        <element name="text" type="xs:string"/>
+        <element name="resource" type="xs:anyURI"/>
+        <element name="image" type="xs:string"/>
+        <element name="reestrId" type="xs:string"/>
+    </sequence>
+</complexType>
+<complexType name="OperationsType">
+    <sequence>
+        <element name="update" type="xs:boolean"/>
+        <element name="delete" type="xs:boolean"/>
+        <element name="moderate" type="xs:boolean"/>
+    </sequence>
+</complexType>
+    <complexType name="TransactionType">
+    <choice minoccurs="0">
+        <element name="mine" type="xs:boolean"/>
+        <element name="locker" type="xs:string"/>
+        <element name="expireIn" type="xs:positiveInteger"/>
+    </choice>
+</complexType>
+</schema>""".encode('UTF-8'))
+
+        feature_content = """<?xml version="1.0"?>
+<wfs:FeatureCollection
+        timeStamp="2010-02-01T22:56:09"
+        numberMatched="8"
+        numberReturned="8"
+        xmlns="http://www.geosamara.ru/wfs/geosmr/namespace"
+        xmlns:wfs="http://www.opengis.net/wfs/2.0"
+        xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.geosamara.ru/wfs/geosmr/style.xsd
+                       http://www.opengis.net/wfs/2.0
+                       http://schemas.opengis.net/wfs/2.0.0/wfs.xsd
+                       http://www.opengis.net/gml/3.2
+                       http://schemas.opengis.net/gml/3.2.1/gml.xsd">
+
+        <wfs:member>
+            <EC422 gml:id="EC422.13172455">
+                <id>13172455</id>
+                <name><![CDATA[Основной туристический маршрут]]></name>
+                <description>
+                    <text><![CDATA[]]></text>
+                    <additionalInfo><![CDATA[]]></additionalInfo>
+                    <resource><![CDATA[]]></resource>
+                    <image><![CDATA[]]></image>
+                    <audio><![CDATA[]]></audio>
+                    <video><![CDATA[]]></video>
+                    <votes><![CDATA[0]]></votes>
+                    <reestrId><![CDATA[]]></reestrId>
+
+                </description>
+                <style>CreatedRoute</style>
+                <status>checked</status>
+                <author>Андрей Чернов</author>
+                <currentUserAuthor>false</currentUserAuthor>
+                <operations>
+                        <update>false</update>
+                        <delete>false</delete>
+                        <moderate>false</moderate>
+                </operations>
+                <transaction>
+
+                </transaction>
+                <geometry>
+                    <LineString xmlns="http://www.opengis.net/gml"><posList>9540051.88156246 5997366.8135842243 9539934.21894572 5997127.7749966066 9539822.1483417116 5996862.6127466606 9539504.179093 5996097.3096572906 9539529.9650254529 5996093.5547346519 9539584.6281441431 5996148.1036405731 9539709.8322301712 5996306.1476564864 9539514.2094426583 5996393.6699969191 9539315.5400513224 5996461.6283053206 9539418.05506746 5996708.1687648129 9539601.002140563 5996948.5162237845 9539715.6644945163 5997103.3323533693 9539806.8714339714 5997185.6346932752 9539980.407018993 5997401.3173021814 9540034.9262902886 5997461.1185212145 9540144.520062916 5997647.082066942 9540205.6388517376 5997752.865820759 9540413.93051952 5998022.2412844934 9540636.78114721 5998289.1650444875 9540652.2228743583 5998292.3310790323 9540739.3873799425 5998253.7093249289 9540742.8882315382 5998264.8666193094 9540928.0440610871 5998447.0783388717 9540964.2606249321 5998465.5247420967 9540992.4471577276 5998468.9503919454 9541266.994057592 5998700.44280944 9541489.2456994727 5998870.8459224468 9542015.9473830853 5999245.7052185535 9542481.7197104339 5999585.458734531 9542594.2400093842 5999581.2418252891 9542791.0368823726 5999731.6623752853 9543204.6598267779 6000066.4150706194 9543245.7990274262 6000086.6195615921 9543303.6317887139 6000098.2128836326 9543392.7859923933 6000084.2088917186 9543473.2299142312 6000041.19114427 9543582.34122052 5999959.7280100482 9543796.5102230646 5999788.4518707721 9544237.3357650079 6000148.6245372053 9544242.356376797 6000146.87913009</posList></LineString>
+                </geometry>
+                <creationDate>
+
+                </creationDate>
+        </EC422>
+        </wfs:member>
+
+        <wfs:member>
+            <EC422 gml:id="EC422.13172458">
+                <id>13172458</id>
+                <name><![CDATA[]]></name>
+                <description>
+                    <text><![CDATA[Добавлено 15:44 20 января 2016]]></text>
+                    <additionalInfo><![CDATA[]]></additionalInfo>
+                    <resource><![CDATA[]]></resource>
+                    <image><![CDATA[]]></image>
+                    <audio><![CDATA[]]></audio>
+                    <video><![CDATA[]]></video>
+                    <votes><![CDATA[0]]></votes>
+                    <reestrId><![CDATA[]]></reestrId>
+
+                </description>
+                <style>CreatedRoute</style>
+                <status>checked</status>
+                <author>Андрей Чернов</author>
+                <currentUserAuthor>false</currentUserAuthor>
+                <operations>
+                        <update>false</update>
+                        <delete>false</delete>
+                        <moderate>false</moderate>
+                </operations>
+                <transaction>
+
+                </transaction>
+                <geometry>
+                    <LineString xmlns="http://www.opengis.net/gml"><posList>9540865.6444970388 5998183.9317809641 9540775.852046784 5997947.0331188506 9540680.5655983184 5997718.6045682346 9540569.58023185 5997466.57064837 9540466.8184371851 5997200.4314374486 9540244.6014337484 5996676.7638938017 9540169.35653367 5996705.7142945267 9540148.0577711649 5996682.1794316517 9540111.4476553015 5996665.8381209867 9540077.9721918479 5996676.0606173435 9540043.4139141534 5996711.499830937 9540043.9248592574 5996752.0983768944 9540045.5009976458 5996766.0802566176 9539966.0914670844 5996797.8834326165 9539818.507223323 5996864.1487550773 9539610.9541244339 5996949.3710925905</posList></LineString>
+                </geometry>
+                <creationDate>
+
+                </creationDate>
+        </EC422>
+        </wfs:member>
+
+        <wfs:member>
+            <EC422 gml:id="EC422.13172454">
+                <id>13172454</id>
+                <name><![CDATA[Основной туристический маршрут]]></name>
+                <description>
+                    <text><![CDATA[]]></text>
+                    <additionalInfo><![CDATA[]]></additionalInfo>
+                    <resource><![CDATA[]]></resource>
+                    <image><![CDATA[]]></image>
+                    <audio><![CDATA[]]></audio>
+                    <video><![CDATA[]]></video>
+                    <votes><![CDATA[0]]></votes>
+                    <reestrId><![CDATA[]]></reestrId>
+
+                </description>
+                <style>CreatedRoute</style>
+                <status>checked</status>
+                <author>Андрей Чернов</author>
+                <currentUserAuthor>false</currentUserAuthor>
+                <operations>
+                        <update>false</update>
+                        <delete>false</delete>
+                        <moderate>false</moderate>
+                </operations>
+                <transaction>
+
+                </transaction>
+                <geometry>
+                    <LineString xmlns="http://www.opengis.net/gml"><posList>9542485.8345187921 5998971.7039023517 9542453.32676163 5998980.1340847686 9542423.4887301736 5998965.47791457 9541839.9022341352 5998539.8925312571 9541447.9249842446 5998260.2124332683 9541414.5872483123 5998203.50518699 9541330.9900199063 5998001.1229150137 9540804.3199365921 5996757.0503186928 9540212.17485467 5997003.9579582512 9539930.5850430559 5997125.116400606 9539816.1399206612 5997176.6829545 9539806.7162561137 5997183.794419908</posList></LineString>
+                </geometry>
+                <creationDate>
+
+                </creationDate>
+        </EC422>
+  </wfs:member>
+</wfs:FeatureCollection>"""
+
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=EC422&COUNT=1&SRSNAME=urn:ogc:def:crs:EPSG::4326'), 'wb') as f:
+            f.write(feature_content.encode('UTF-8'))
+
+        with open(sanitize(endpoint, '?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=EC422&SRSNAME=urn:ogc:def:crs:EPSG::4326'), 'wb') as f:
+            f.write(feature_content.encode('UTF-8'))
+
+        vl = QgsVectorLayer("url='http://" + endpoint + "' version='2.0.0' typename='EC422'", 'test', 'WFS')
+        self.assertTrue(vl.isValid())
+        features = list(vl.getFeatures())
+        self.assertEqual(len(features), 3)
+        geom = features[0].geometry()
+        geom_string = geom.asWkt()
+        geom_string = re.sub(r'\.\d+', '', geom_string)[:100]
+        self.assertEqual(geom_string, "LineString (9540051 5997366, 9539934 5997127, 9539822 5996862, 9539504 5996097, 9539529 5996093, 953")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reverts partially commit ccb4c80.

The plural form of TYPENAMES is non conformant for the DescribeFeatureType
request of WFS 2.0
The logic of ccb4c80 breaks conformant servers because they ignore the TYPENAMES parameter and thus return a DescribeFeatureType response covering all layers of the service, which can
be extremely time consuming.

Changes related to better geometry handling have been kept.

Some servers like http://geoportal.samregion.ru/wfs12 return an error when issuing a REQUEST=DescribeFeatureType&VERSION=2.0.0&TYPENAME=...
query, which is the conformant way. They expect the plural form TYPENAMES to be passed
As they return an exception when being provided with the singular form, we can automate the retry with TYPENAMES.
