### PR TITLE
clang workaround to fix build: use move on return unique_ptr

### DIFF
--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -108,12 +108,12 @@ static std::unique_ptr< QgsAbstractGeometry > generalizeWkbGeometryByBoundingBox
         << y2
         << y1 );
     if ( geometryType == QgsWkbTypes::LineString )
-      return ext;
+      return std::move( ext );
     else
     {
       std::unique_ptr< QgsPolygon > polygon = qgis::make_unique< QgsPolygon >();
       polygon->setExteriorRing( ext.release() );
-      return polygon;
+      return std::move( polygon );
     }
   }
 }
@@ -305,7 +305,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
       }
     }
 
-    return output;
+    return std::move( output );
   }
   else if ( flatType == QgsWkbTypes::Polygon )
   {
@@ -319,7 +319,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
       std::unique_ptr< QgsAbstractGeometry > ring = simplifyGeometry( simplifyFlags, simplifyAlgorithm, *sub, map2pixelTol, true );
       polygon->addInteriorRing( qgsgeometry_cast<QgsCurve *>( ring.release() ) );
     }
-    return polygon;
+    return std::move( polygon );
   }
   else if ( QgsWkbTypes::isMultiType( flatType ) )
   {
@@ -332,7 +332,7 @@ std::unique_ptr< QgsAbstractGeometry > QgsMapToPixelSimplifier::simplifyGeometry
       std::unique_ptr< QgsAbstractGeometry > part = simplifyGeometry( simplifyFlags, simplifyAlgorithm, *sub, map2pixelTol, false );
       collection->addGeometry( part.release() );
     }
-    return collection;
+    return std::move( collection );
   }
   return std::unique_ptr< QgsAbstractGeometry >( geometry.clone() );
 }


### PR DESCRIPTION
@nyalldawson is this an acceptable change on order to fix build on osx?

build error is here: https://github.com/qgis/QGIS/commit/959d1e930b439e9e06abb5a9ebd34f89019e5f0f#commitcomment-29088440

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
