### PR TITLE
More efficient QgsGeometry::asGeometryCollection() for single part geometries

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2196,7 +2196,7 @@ QVector<QgsGeometry> QgsGeometry::asGeometryCollection() const
   }
   else //a singlepart geometry
   {
-    geometryList.append( QgsGeometry( d->geometry->clone() ) );
+    geometryList.append( *this );
   }
 
   return geometryList;


### PR DESCRIPTION
Avoids an unnecessary geometry clone