### PR TITLE
Fix mdal build warning unused const var

### DIFF
--- a/external/mdal/frmts/mdal_binary_dat.cpp
+++ b/external/mdal/frmts/mdal_binary_dat.cpp
@@ -33,8 +33,10 @@ static const int CT_NUMCELLS  = 180;
 static const int CT_NAME      = 190;
 static const int CT_TS        = 200;
 static const int CT_ENDDS     = 210;
+#if 0
 static const int CT_RT_JULIAN = 240;
 static const int CT_TIMEUNITS = 250;
+#endif
 
 static const int CT_2D_MESHES = 3;
 static const int CT_FLOAT_SIZE = 4;


### PR DESCRIPTION
Fixes build warnings

```
[1592/3180 4.1/sec] Building CXX object src/providers/mdal/CMakeFiles/mdalprovider.dir/__/__/__/external/mdal/frmts/mdal_binary_dat.cpp.o
/home/mku/dev/qgis/QGIS/external/mdal/frmts/mdal_binary_dat.cpp:36:18: warning: unused variable 'CT_RT_JULIAN' [-Wunused-const-variable]
static const int CT_RT_JULIAN = 240;
                 ^
/home/mku/dev/qgis/QGIS/external/mdal/frmts/mdal_binary_dat.cpp:37:18: warning: unused variable 'CT_TIMEUNITS' [-Wunused-const-variable]
static const int CT_TIMEUNITS = 250;
                 ^
2 warnings generated.
```