### PR TITLE
[server] Proper convertion of literals in Filters

### DIFF
--- a/python/core/auto_generated/qgsogcutils.sip.in
+++ b/python/core/auto_generated/qgsogcutils.sip.in
@@ -128,7 +128,7 @@ Exports the rectangle to GML3 Envelope
 Parse XML with OGC fill into QColor
 %End
 
-    static QgsExpression *expressionFromOgcFilter( const QDomElement &element ) /Factory/;
+    static QgsExpression *expressionFromOgcFilter( const QDomElement &element, QgsVectorLayer *layer = 0 ) /Factory/;
 %Docstring
 Parse XML with OGC filter into QGIS expression
 %End

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -37,6 +37,7 @@ class QgsRectangle;
 #include "qgsexpressionnode.h"
 #include "qgsexpressionnodeimpl.h"
 #include "qgssqlstatement.h"
+#include "qgsvectorlayer.h"
 
 /**
  * \ingroup core
@@ -140,7 +141,7 @@ class CORE_EXPORT QgsOgcUtils
     static QColor colorFromOgcFill( const QDomElement &fillElement );
 
     //! Parse XML with OGC filter into QGIS expression
-    static QgsExpression *expressionFromOgcFilter( const QDomElement &element ) SIP_FACTORY;
+    static QgsExpression *expressionFromOgcFilter( const QDomElement &element, QgsVectorLayer *layer = nullptr ) SIP_FACTORY;
 
     /**
      * Creates OGC filter XML element. Supports minimum standard filter
@@ -298,9 +299,9 @@ class CORE_EXPORT QgsOgcUtils
     static QDomElement createGMLPositions( const QgsPolylineXY &points, QDomDocument &doc );
 
     //! handle a generic sub-expression
-    static QgsExpressionNode *nodeFromOgcFilter( QDomElement &element, QString &errorMessage );
+    static QgsExpressionNode *nodeFromOgcFilter( QDomElement &element, QString &errorMessage, QgsVectorLayer *layer = nullptr );
     //! handle a generic binary operator
-    static QgsExpressionNodeBinaryOperator *nodeBinaryOperatorFromOgcFilter( QDomElement &element, QString &errorMessage );
+    static QgsExpressionNodeBinaryOperator *nodeBinaryOperatorFromOgcFilter( QDomElement &element, QString &errorMessage, QgsVectorLayer *layer = nullptr );
     //! handles various spatial operation tags (\verbatim <Intersects> \endverbatim, \verbatim <Touches> \endverbatim etc.)
     static QgsExpressionNodeFunction *nodeSpatialOperatorFromOgcFilter( QDomElement &element, QString &errorMessage );
     //! handle \verbatim <Not> \endverbatim tag
@@ -308,7 +309,7 @@ class CORE_EXPORT QgsOgcUtils
     //! handles \verbatim <Function> \endverbatim tag
     static QgsExpressionNodeFunction *nodeFunctionFromOgcFilter( QDomElement &element, QString &errorMessage );
     //! handles \verbatim <Literal> \endverbatim tag
-    static QgsExpressionNode *nodeLiteralFromOgcFilter( QDomElement &element, QString &errorMessage );
+    static QgsExpressionNode *nodeLiteralFromOgcFilter( QDomElement &element, QString &errorMessage, QgsVectorLayer *layer = nullptr );
     //! handles \verbatim <PropertyName> \endverbatim tag
     static QgsExpressionNodeColumnRef *nodeColumnRefFromOgcFilter( QDomElement &element, QString &errorMessage );
     //! handles \verbatim <PropertyIsBetween> \endverbatim tag

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -20,6 +20,7 @@
 
 #include "qgis_server.h"
 #include "qgsproject.h"
+#include "qgsvectorlayer.h"
 
 #ifdef SIP_RUN
 % ModuleHeaderCode

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -139,10 +139,7 @@ namespace QgsWfs
         continue;
       }
 
-      QString name = layer->name();
-      if ( !layer->shortName().isEmpty() )
-        name = layer->shortName();
-      name = name.replace( ' ', '_' );
+      QString name = layerTypeName( layer );
 
       if ( !typeNameList.isEmpty() && !typeNameList.contains( name ) )
       {
@@ -180,10 +177,7 @@ namespace QgsWfs
       return;
     }
 
-    QString typeName = layer->name();
-    if ( !layer->shortName().isEmpty() )
-      typeName = layer->shortName();
-    typeName = typeName.replace( ' ', '_' );
+    QString typeName = layerTypeName( layer );
 
     //xsd:element
     QDomElement elementElem = doc.createElement( QStringLiteral( "element" )/*xsd:element*/ );

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -438,11 +438,7 @@ namespace QgsWfs
 
       //create Name
       QDomElement nameElem = doc.createElement( QStringLiteral( "Name" ) );
-      QString typeName = layer->name();
-      if ( !layer->shortName().isEmpty() )
-        typeName = layer->shortName();
-      typeName = typeName.replace( QLatin1String( " " ), QLatin1String( "_" ) );
-      QDomText nameText = doc.createTextNode( typeName );
+      QDomText nameText = doc.createTextNode( layerTypeName( layer ) );
       nameElem.appendChild( nameText );
       layerElem.appendChild( nameElem );
 

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -101,11 +101,11 @@ namespace QgsWfs
     if ( doc.setContent( mRequestParameters.value( QStringLiteral( "REQUEST_BODY" ) ), true, &errorMsg ) )
     {
       QDomElement docElem = doc.documentElement();
-      aRequest = parseGetFeatureRequestBody( docElem );
+      aRequest = parseGetFeatureRequestBody( docElem, project );
     }
     else
     {
-      aRequest = parseGetFeatureParameters();
+      aRequest = parseGetFeatureParameters( project );
     }
 
     // store typeName
@@ -141,10 +141,7 @@ namespace QgsWfs
         continue;
       }
 
-      QString name = layer->name();
-      if ( !layer->shortName().isEmpty() )
-        name = layer->shortName();
-      name = name.replace( ' ', '_' );
+      QString name = layerTypeName( layer );
 
       if ( typeNameList.contains( name ) )
       {
@@ -433,7 +430,7 @@ namespace QgsWfs
 
   }
 
-  getFeatureRequest parseGetFeatureParameters()
+  getFeatureRequest parseGetFeatureParameters( const QgsProject *project )
   {
     getFeatureRequest request;
     request.maxFeatures = mWfsParameters.maxFeaturesAsInt();;
@@ -767,7 +764,7 @@ namespace QgsWfs
         }
 
         QDomElement filterElem = filter.firstChildElement();
-        query.featureRequest = parseFilterElement( query.typeName, filterElem );
+        query.featureRequest = parseFilterElement( query.typeName, filterElem, project );
 
         if ( filterIt != filterList.constEnd() )
         {
@@ -821,7 +818,7 @@ namespace QgsWfs
     return request;
   }
 
-  getFeatureRequest parseGetFeatureRequestBody( QDomElement &docElem )
+  getFeatureRequest parseGetFeatureRequestBody( QDomElement &docElem, const QgsProject *project )
   {
     getFeatureRequest request;
     request.maxFeatures = mWfsParameters.maxFeaturesAsInt();;
@@ -833,7 +830,7 @@ namespace QgsWfs
     for ( int i = 0; i < queryNodes.size(); i++ )
     {
       queryElem = queryNodes.at( i ).toElement();
-      getFeatureQuery query = parseQueryElement( queryElem );
+      getFeatureQuery query = parseQueryElement( queryElem, project );
       request.queries.append( query );
     }
     return request;
@@ -887,7 +884,7 @@ namespace QgsWfs
     }
   }
 
-  getFeatureQuery parseQueryElement( QDomElement &queryElem )
+  getFeatureQuery parseQueryElement( QDomElement &queryElem, const QgsProject *project )
   {
     QString typeName = queryElem.attribute( QStringLiteral( "typeName" ), QLatin1String( "" ) );
     if ( typeName.contains( ':' ) )
@@ -923,7 +920,7 @@ namespace QgsWfs
         }
         else if ( queryChildElem.tagName() == QLatin1String( "Filter" ) )
         {
-          featureRequest = parseFilterElement( typeName, queryChildElem );
+          featureRequest = parseFilterElement( typeName, queryChildElem, project );
         }
         else if ( queryChildElem.tagName() == QLatin1String( "SortBy" ) )
         {

--- a/src/server/services/wfs/qgswfsgetfeature.h
+++ b/src/server/services/wfs/qgswfsgetfeature.h
@@ -58,17 +58,17 @@ namespace QgsWfs
   /**
    * Transform Query element to getFeatureQuery
    */
-  getFeatureQuery parseQueryElement( QDomElement &queryElem );
+  getFeatureQuery parseQueryElement( QDomElement &queryElem, const QgsProject *project = nullptr );
 
   /**
    * Transform RequestBody root element to getFeatureRequest
    */
-  getFeatureRequest parseGetFeatureRequestBody( QDomElement &docElem );
+  getFeatureRequest parseGetFeatureRequestBody( QDomElement &docElem, const QgsProject *project = nullptr );
 
   /**
    * Transform parameters to getFeatureRequest
    */
-  getFeatureRequest parseGetFeatureParameters();
+  getFeatureRequest parseGetFeatureParameters( const QgsProject *project = nullptr );
 
   /**
    * Output WFS  GetFeature response

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -259,10 +259,7 @@ namespace QgsWfs
         continue;
       }
 
-      QString name = layer->name();
-      if ( !layer->shortName().isEmpty() )
-        name = layer->shortName();
-      name = name.replace( ' ', '_' );
+      QString name = layerTypeName( layer );
 
       if ( !typeNameList.contains( name ) )
       {

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -242,10 +242,7 @@ namespace QgsWfs
           continue;
         }
 
-        QString name = layer->name();
-        if ( !layer->shortName().isEmpty() )
-          name = layer->shortName();
-        name = name.replace( ' ', '_' );
+        QString name = layerTypeName( layer );
 
         if ( !typeNameList.contains( name ) )
         {

--- a/src/server/services/wfs/qgswfsutils.h
+++ b/src/server/services/wfs/qgswfsutils.h
@@ -48,9 +48,19 @@ namespace QgsWfs
   QString serviceUrl( const QgsServerRequest &request, const QgsProject *project );
 
   /**
+   * Returns typename from vector layer
+   */
+  QString layerTypeName( const QgsMapLayer *layer );
+
+  /**
+   * Retrieve a layer by typename
+   */
+  QgsVectorLayer *layerByTypeName( const QgsProject *project, const QString &typeName );
+
+  /**
    * Transform a Filter element to a feature request
    */
-  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem );
+  QgsFeatureRequest parseFilterElement( const QString &typeName, QDomElement &filterElem, const QgsProject *project = nullptr );
 
   // Define namespaces used in WFS documents
   const QString WFS_NAMESPACE = QStringLiteral( "http://www.opengis.net/wfs" );

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2798,7 +2798,7 @@ namespace QgsWms
                                           QStringLiteral( "error message: %1. The XML string was: %2" ).arg( errorMsg, filter ) );
           }
           QDomElement filterElem = filterXml.firstChildElement();
-          QScopedPointer<QgsExpression> expression( QgsOgcUtils::expressionFromOgcFilter( filterElem ) );
+          QScopedPointer<QgsExpression> expression( QgsOgcUtils::expressionFromOgcFilter( filterElem, filteredLayer ) );
           mFeatureFilter.setFilter( filteredLayer, *expression );
         }
         else

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -21,6 +21,7 @@
 #include <qgsgeometry.h>
 #include <qgsogcutils.h>
 #include "qgsapplication.h"
+#include "qgsvectorlayer.h"
 
 /**
  * \ingroup UnitTests
@@ -368,6 +369,13 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter_data()
                                   "</Intersects>"
                                   "</Filter>" )
                                 << QStringLiteral( "intersects($geometry, geom_from_gml('<Point><coordinates>123,456</coordinates></Point>'))" );
+
+  QTest::newRow( "Literal conversion" ) << QString(
+                                          "<Filter><PropertyIsEqualTo>"
+                                          "<PropertyName>LITERAL</PropertyName>"
+                                          "<Literal>+2</Literal>"
+                                          "</PropertyIsEqualTo></Filter>" )
+                                        << QStringLiteral( "LITERAL = '+2'" );
 }
 
 void TestQgsOgcUtils::testExpressionFromOgcFilter()
@@ -379,7 +387,9 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter()
   QVERIFY( doc.setContent( xmlText, true ) );
   QDomElement rootElem = doc.documentElement();
 
-  std::shared_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem ) );
+  QgsVectorLayer layer( "Point?crs=epsg:4326&field=LITERAL:string(20)", "temp", "memory" );
+
+  std::shared_ptr<QgsExpression> expr( QgsOgcUtils::expressionFromOgcFilter( rootElem, &layer ) );
   QVERIFY( expr.get() );
 
   qDebug( "OGC XML  : %s", xmlText.toAscii().data() );


### PR DESCRIPTION
Convert OGC Filter's literals accordings to field type.
This can have a huge impact on performance in some cases.
For example for a filter like "num_char" = '+2' converted to "num_char" = 2,
this result with PostgreSQL provider in a fallback to client side evaluation for the whole filter,
including the bbox if present.

Side additions : Factorize getting typename from layer object.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
