### PR TITLE
add missing crsChanged signal in QgsProjectionSelectionWidget

### DIFF
--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -256,9 +256,11 @@ void QgsProjectionSelectionWidget::setCrs( const QgsCoordinateReferenceSystem &c
                                  currentCrsOptionText( crs ) );
     }
   }
-  mCrs = crs;
-
-  emit crsChanged( crs );
+  if ( mCrs != crs )
+  {
+    mCrs = crs;
+    emit crsChanged( crs );
+  }
 }
 
 void QgsProjectionSelectionWidget::setLayerCrs( const QgsCoordinateReferenceSystem &crs )

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -257,6 +257,8 @@ void QgsProjectionSelectionWidget::setCrs( const QgsCoordinateReferenceSystem &c
     }
   }
   mCrs = crs;
+
+  emit crsChanged( crs );
 }
 
 void QgsProjectionSelectionWidget::setLayerCrs( const QgsCoordinateReferenceSystem &crs )

--- a/tests/src/python/test_qgsprojectionselectionwidgets.py
+++ b/tests/src/python/test_qgsprojectionselectionwidgets.py
@@ -122,6 +122,8 @@ class TestQgsProjectionSelectionWidgets(unittest.TestCase):
         w.setCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
         self.assertEqual(w.crs().authid(), 'EPSG:3111')
         self.assertEqual(len(spy), 1)
+        self.assertEqual(w.crs().authid(), 'EPSG:3111')
+        self.assertEqual(len(spy), 0)
 
     def testTreeWidgetGettersSetters(self):
         """ basic tests for QgsProjectionSelectionTreeWidget """

--- a/tests/src/python/test_qgsprojectionselectionwidgets.py
+++ b/tests/src/python/test_qgsprojectionselectionwidgets.py
@@ -122,7 +122,8 @@ class TestQgsProjectionSelectionWidgets(unittest.TestCase):
         w.setCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
         self.assertEqual(w.crs().authid(), 'EPSG:3111')
         self.assertEqual(len(spy), 1)
-        self.assertEqual(w.crs().authid(), 'EPSG:3111')
+        # setting the same crs doesn't emit the signal
+        w.setCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
         self.assertEqual(len(spy), 0)
 
     def testTreeWidgetGettersSetters(self):

--- a/tests/src/python/test_qgsprojectionselectionwidgets.py
+++ b/tests/src/python/test_qgsprojectionselectionwidgets.py
@@ -115,6 +115,14 @@ class TestQgsProjectionSelectionWidgets(unittest.TestCase):
         self.assertTrue(w.optionVisible(QgsProjectionSelectionWidget.CurrentCrs))
         self.assertTrue(w.optionVisible(QgsProjectionSelectionWidget.CrsNotSet))
 
+    def testSignal(self):
+        w = QgsProjectionSelectionWidget()
+        w.show()
+        spy = QSignalSpy(w.crsChanged)
+        w.setCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
+        self.assertEqual(w.crs().authid(), 'EPSG:3111')
+        self.assertEqual(len(spy), 1)
+
     def testTreeWidgetGettersSetters(self):
         """ basic tests for QgsProjectionSelectionTreeWidget """
         w = QgsProjectionSelectionTreeWidget()

--- a/tests/src/python/test_qgsprojectionselectionwidgets.py
+++ b/tests/src/python/test_qgsprojectionselectionwidgets.py
@@ -14,6 +14,7 @@ __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
 
+from qgis.PyQt.QtTest import QSignalSpy
 from qgis.gui import (QgsProjectionSelectionWidget,
                       QgsProjectionSelectionTreeWidget,
                       QgsProjectionSelectionDialog)

--- a/tests/src/python/test_qgsprojectionselectionwidgets.py
+++ b/tests/src/python/test_qgsprojectionselectionwidgets.py
@@ -125,7 +125,7 @@ class TestQgsProjectionSelectionWidgets(unittest.TestCase):
         self.assertEqual(len(spy), 1)
         # setting the same crs doesn't emit the signal
         w.setCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
-        self.assertEqual(len(spy), 0)
+        self.assertEqual(len(spy), 1)
 
     def testTreeWidgetGettersSetters(self):
         """ basic tests for QgsProjectionSelectionTreeWidget """


### PR DESCRIPTION
when changed programmatically (i.e. using setCrs)

