### PR TITLE
Fixes #19001: update url for _pyqgis and _api commands

### DIFF
--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -31,7 +31,7 @@ import codecs
 import re
 import traceback
 
-from qgis.core import QgsApplication, QgsSettings
+from qgis.core import QgsApplication, QgsSettings, Qgis
 from .ui_console_history_dlg import Ui_HistoryDialogPythonConsole
 
 _init_commands = ["from qgis.core import *", "from qgis.gui import *", "from qgis.analysis import *", "import processing", "import qgis.utils",
@@ -619,11 +619,14 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         self.writeCMD(cmd)
         import webbrowser
         self.updateHistory(cmd)
-        if cmd in ('_pyqgis', '_api'):
+        version = 'master' if 'master' in Qgis.QGIS_VERSION.lower() else re.findall('^\d.[0-9]*', Qgis.QGIS_VERSION)[0]
+        if cmd in ('_pyqgis', '_api', '_cookbook'):
             if cmd == '_pyqgis':
-                webbrowser.open("http://qgis.org/pyqgis-cookbook/")
+                webbrowser.open("https://qgis.org/pyqgis/{}".format(version))
             elif cmd == '_api':
-                webbrowser.open("http://qgis.org/api/")
+                webbrowser.open("https://qgis.org/api/{}".format(version))
+            elif cmd == '_cookbook':
+                webbrowser.open("http://qgis.org/pyqgis-cookbook/")
             more = False
         else:
             self.buffer.append(cmd)

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -626,7 +626,8 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
             elif cmd == '_api':
                 webbrowser.open("https://qgis.org/api/{}".format(version))
             elif cmd == '_cookbook':
-                webbrowser.open("https://qgis.org/pyqgis-cookbook/")
+                webbrowser.open("https://docs.qgis.org/{}/en/docs/pyqgis_developer_cookbook/".format(
+                    'testing' if version == 'master' else version))
             more = False
         else:
             self.buffer.append(cmd)

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -626,7 +626,7 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
             elif cmd == '_api':
                 webbrowser.open("https://qgis.org/api/{}".format(version))
             elif cmd == '_cookbook':
-                webbrowser.open("http://qgis.org/pyqgis-cookbook/")
+                webbrowser.open("https://qgis.org/pyqgis-cookbook/")
             more = False
         else:
             self.buffer.append(cmd)


### PR DESCRIPTION
## Description
(Original message by @DelazJ ):
_In the Python console type ```_api``` leads to https://qgis.org/api and ```_pyqgis``` to https://docs.qgis.org/testing/en/docs/pyqgis_developer_cookbook.
Now that there's a PyQGIS API dedicated site, better move to there when using ```_pyqgis``` command and find something else for the cookbook_

refs: https://issues.qgis.org/issues/19001 and @m-kuhn :-)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
