### PR TITLE
[ogr] Fix very slow feature requests when filter string set

### DIFF
--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -207,21 +207,6 @@ bool QgsOgrFeatureIterator::fetchFeatureWithId( QgsFeatureId id, QgsFeature &fea
     // filtered layer, not the original layer!
     OGR_L_ResetReading( mOgrOrigLayer );
     fet.reset( OGR_L_GetFeature( mOgrOrigLayer, FID_TO_NUMBER( id ) ) );
-
-    // do a bit of a safety check - make sure that the original fid column value
-    // matches the feature id which we actually requested.
-    OGRFeatureDefnH fdef = OGR_L_GetLayerDefn( mOgrOrigLayer );
-    int lastField = OGR_FD_GetFieldCount( fdef ) - 1;
-    bool foundCorrect = false;
-    if ( lastField >= 0 )
-      foundCorrect = OGR_F_GetFieldAsInteger64( fet.get(), lastField ) == id;
-    else
-      foundCorrect = OGR_F_GetFID( fet.get() ) == id;
-
-    if ( !foundCorrect )
-    {
-      fet.reset();
-    }
   }
   else
   {

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -66,8 +66,8 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   if ( !mSource->mSubsetString.isEmpty() )
   {
     mOgrOrigLayer = mOgrLayer;
-    mOgrLayerWithFid = QgsOgrProviderUtils::setSubsetString( mOgrLayer, mConn->ds, mSource->mEncoding, QString(), mOrigFidAdded );
-    mOgrLayer = QgsOgrProviderUtils::setSubsetString( mOgrLayer, mConn->ds, mSource->mEncoding, mSource->mSubsetString, mOrigFidAdded );
+    mOgrLayerWithFid = QgsOgrProviderUtils::setSubsetString( mOgrLayer, mConn->ds, mSource->mEncoding, QString(), true, &mOrigFidAdded );
+    mOgrLayer = QgsOgrProviderUtils::setSubsetString( mOgrLayer, mConn->ds, mSource->mEncoding, mSource->mSubsetString, true, &mOrigFidAdded );
     if ( !mOgrLayer )
     {
       close();

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -73,8 +73,8 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
 
     QgsOgrConn *mConn = nullptr;
     OGRLayerH mOgrLayer = nullptr;
+    OGRLayerH mOgrOrigLayer = nullptr;
 
-    bool mSubsetStringSet = false;
     bool mOrigFidAdded = false;
 
     //! Sets to true, if geometry is in the requested columns

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -72,15 +72,15 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
     void getFeatureAttribute( OGRFeatureH ogrFet, QgsFeature &f, int attindex ) const;
 
     QgsOgrConn *mConn = nullptr;
-    OGRLayerH ogrLayer = nullptr;
+    OGRLayerH mOgrLayer = nullptr;
 
-    bool mSubsetStringSet;
-    bool mOrigFidAdded;
+    bool mSubsetStringSet = false;
+    bool mOrigFidAdded = false;
 
     //! Sets to true, if geometry is in the requested columns
-    bool mFetchGeometry;
+    bool mFetchGeometry = false;
 
-    bool mExpressionCompiled;
+    bool mExpressionCompiled = false;
     QgsFeatureIds mFilterFids;
     QgsFeatureIds::const_iterator mFilterFidsIt;
 

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -74,6 +74,7 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
     QgsOgrConn *mConn = nullptr;
     OGRLayerH mOgrLayer = nullptr;
     OGRLayerH mOgrOrigLayer = nullptr;
+    OGRLayerH mOgrLayerWithFid = nullptr;
 
     bool mOrigFidAdded = false;
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -3919,8 +3919,9 @@ OGRLayerH QgsOgrProviderUtils::setSubsetString( OGRLayerH layer, GDALDatasetH ds
   else
   {
     QByteArray sqlPart1 = "SELECT *";
-    QByteArray sqlPart3 = " FROM " + quotedIdentifier( layerName, mGDALDriverName )
-                          + " WHERE " + encoding->fromUnicode( subsetString );
+    QByteArray sqlPart3 = " FROM " + quotedIdentifier( layerName, mGDALDriverName );
+    if ( !subsetString.isEmpty() )
+      sqlPart3 += " WHERE " + encoding->fromUnicode( subsetString );
 
     origFidAddAttempted = true;
 

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -373,7 +373,14 @@ class QgsOgrProviderUtils
     static QString expandAuthConfig( const QString &dsName );
 
     static void setRelevantFields( OGRLayerH ogrLayer, int fieldCount, bool fetchGeometry, const QgsAttributeList &fetchAttributes, bool firstAttrIsFid );
-    static OGRLayerH setSubsetString( OGRLayerH layer, GDALDatasetH ds, QTextCodec *encoding, const QString &subsetString, bool &origFidAdded );
+
+    /**
+     * Sets a subset string for an OGR \a layer.
+     *
+     * If \a addOriginalFid is specified, then the original OGR feature ID field will be added. If this is successful,
+     * \a origFidAdded will be set to true.
+     */
+    static OGRLayerH setSubsetString( OGRLayerH layer, GDALDatasetH ds, QTextCodec *encoding, const QString &subsetString, bool addOriginalFid = false, bool *origFidAdded = nullptr );
     static QByteArray quotedIdentifier( QByteArray field, const QString &driverName );
 
     /**

--- a/tests/src/python/test_provider_ogr_sqlite.py
+++ b/tests/src/python/test_provider_ogr_sqlite.py
@@ -254,7 +254,7 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
             it = vl.getFeatures(req)
             f = QgsFeature()
             self.assertTrue(it.nextFeature(f))
-            self.assertTrue(f.id() == 5)
+            self.assertEqual(f.id(), 5)
             self.assertEqual(f.attributes(), [5, NULL, 2, 16])
             self.assertEqual([field.name() for field in f.fields()], ['fid', 'GEOMETRY', 'type', 'value'])
 
@@ -263,7 +263,7 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
             it = vl.getFeatures(req)
             f = QgsFeature()
             self.assertTrue(it.nextFeature(f))
-            self.assertTrue(f.id() == 5)
+            self.assertEqual(f.id(), 5)
             self.assertEqual(f.attributes(), [5, NULL, 2, 16])
             self.assertEqual([field.name() for field in f.fields()], ['fid', 'GEOMETRY', 'type', 'value'])
 
@@ -272,7 +272,7 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
             it = vl.getFeatures(req)
             f = QgsFeature()
             self.assertTrue(it.nextFeature(f))
-            self.assertTrue(f.id() == 5)
+            self.assertEqual(f.id(), 5)
             self.assertEqual(f.attributes(), [5, NULL, 2, 16])
             self.assertEqual([field.name() for field in f.fields()], ['fid', 'GEOMETRY', 'type', 'value'])
 
@@ -283,10 +283,7 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
             ids = []
             while it.nextFeature(f):
                 ids.append(f.id())
-            self.assertTrue(len(ids) == 3)
-            self.assertTrue(3 in ids)
-            self.assertTrue(4 in ids)
-            self.assertTrue(5 in ids)
+            self.assertCountEqual(ids, [3, 4, 5])
 
         run_checks()
         # Check that subset string is correctly set on reload


### PR DESCRIPTION
Follow up 217e7006 - the extra logic in fetchFeatureWithId is not required, because OGR_L_GetFeature works correctly with the feature IDs generated using the original fid column. This avoids the very slow iteration over all layer features to find matching features when a FilterFids request is made.