### PR TITLE
[processing] Show accepted data types for parameters in processing.algorithmHelp

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparametertype.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparametertype.sip.in
@@ -67,6 +67,16 @@ The default implementation returns true.
 Metadata for this parameter type. Can be used for example to define custom widgets.
 The default implementation returns an empty map.
 %End
+
+    virtual QStringList acceptedPythonTypes() const;
+%Docstring
+Returns a list of the Python data types accepted as values for the parameter.
+E.g. "str", ":py:class:`QgsVectorLayer`", ":py:class:`QgsMapLayer`", etc.
+
+These values should should match the Python types exactly
+(e.g. "str" not "string", "bool" not "boolean"). Extra explanatory help can
+be used (which must be translated), eg "str: as comma delimited list of numbers".
+%End
 };
 
 QFlags<QgsProcessingParameterType::ParameterFlag> operator|(QgsProcessingParameterType::ParameterFlag f1, QFlags<QgsProcessingParameterType::ParameterFlag> f2);

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -64,7 +64,16 @@ def algorithmHelp(id):
             if isinstance(p, QgsProcessingParameterEnum):
                 opts = []
                 for i, o in enumerate(p.options()):
-                    opts.append('\t\t{} - {}'.format(i, o))
+                    opts.append('\t\t- {}: {}'.format(i, o))
+                print('\n\tAvailable values:\n{}'.format('\n'.join(opts)))
+
+            parameter_type = QgsApplication.processingRegistry().parameterType(p.type())
+            accepted_types = parameter_type.acceptedPythonTypes() if parameter_type is not None else []
+            if accepted_types:
+                opts = []
+                for t in accepted_types:
+                    opts.append('\t\t- {}'.format(t))
+                print('\n\tAccepted data types:')
                 print('\n'.join(opts))
 
         print('\n----------------')

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -57,9 +57,9 @@ def algorithmHelp(id):
         print('Input parameters')
         print('----------------')
         for p in alg.parameterDefinitions():
-            print('\n{}:  <{}>'.format(p.name(), p.__class__.__name__))
-            if p.description():
-                print('\t' + p.description())
+            print('\n{}: {}'.format(p.name(), p.description()))
+
+            print('\n\tParameter type:\t{}'.format(p.__class__.__name__))
 
             if isinstance(p, QgsProcessingParameterEnum):
                 opts = []

--- a/src/core/processing/qgsprocessingparametertype.cpp
+++ b/src/core/processing/qgsprocessingparametertype.cpp
@@ -26,3 +26,8 @@ QVariantMap QgsProcessingParameterType::metadata() const
 {
   return QVariantMap();
 }
+
+QStringList QgsProcessingParameterType::acceptedPythonTypes() const
+{
+  return QStringList();
+}

--- a/src/core/processing/qgsprocessingparametertype.h
+++ b/src/core/processing/qgsprocessingparametertype.h
@@ -84,6 +84,16 @@ class CORE_EXPORT QgsProcessingParameterType
      * The default implementation returns an empty map.
      */
     virtual QVariantMap metadata() const;
+
+    /**
+     * Returns a list of the Python data types accepted as values for the parameter.
+     * E.g. "str", "QgsVectorLayer", "QgsMapLayer", etc.
+     *
+     * These values should should match the Python types exactly
+     * (e.g. "str" not "string", "bool" not "boolean"). Extra explanatory help can
+     * be used (which must be translated), eg "str: as comma delimited list of numbers".
+     */
+    virtual QStringList acceptedPythonTypes() const;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProcessingParameterType::ParameterFlags )

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -53,6 +53,15 @@ class CORE_EXPORT QgsProcessingParameterTypeRasterLayer : public QgsProcessingPa
     {
       return QStringLiteral( "raster" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: layer ID" )
+             << QObject::tr( "str: layer name" )
+             << QObject::tr( "str: layer source" )
+             << QStringLiteral( "QgsProperty" )
+             << QStringLiteral( "QgsRasterLayer" );
+    }
 };
 
 /**
@@ -82,6 +91,15 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorLayer : public QgsProcessingPa
     QString id() const override
     {
       return QStringLiteral( "vector" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: layer ID" )
+             << QObject::tr( "str: layer name" )
+             << QObject::tr( "str: layer source" )
+             << QStringLiteral( "QgsProperty" )
+             << QStringLiteral( "QgsVectorLayer" );
     }
 };
 
@@ -113,6 +131,17 @@ class CORE_EXPORT QgsProcessingParameterTypeMapLayer : public QgsProcessingParam
     {
       return QStringLiteral( "maplayer" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: layer ID" )
+             << QObject::tr( "str: layer name" )
+             << QObject::tr( "str: layer source" )
+             << QStringLiteral( "QgsMapLayer" )
+             << QStringLiteral( "QgsProperty" )
+             << QStringLiteral( "QgsRasterLayer" )
+             << QStringLiteral( "QgsVectorLayer" );
+    }
 };
 
 /**
@@ -142,6 +171,14 @@ class CORE_EXPORT QgsProcessingParameterTypeBoolean : public QgsProcessingParame
     QString id() const override
     {
       return QStringLiteral( "boolean" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "bool" )
+             << QStringLiteral( "int" )
+             << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" );
     }
 };
 
@@ -173,6 +210,12 @@ class CORE_EXPORT QgsProcessingParameterTypeExpression : public QgsProcessingPar
     {
       return QStringLiteral( "expression" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" );
+    }
 };
 
 /**
@@ -202,6 +245,20 @@ class CORE_EXPORT QgsProcessingParameterTypeCrs : public QgsProcessingParameterT
     QString id() const override
     {
       return QStringLiteral( "crs" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList()
+             << QStringLiteral( "str: 'ProjectCrs'" )
+             << QObject::tr( "str: CRS auth ID (e.g. 'EPSG:3111')" )
+             << QObject::tr( "str: CRS PROJ4 (e.g. 'PROJ4:...')" )
+             << QObject::tr( "str: CRS WKT (e.g. 'WKT:...')" )
+             << QObject::tr( "str: layer ID. CRS of layer is used." )
+             << QObject::tr( "str: layer name. CRS of layer is used." )
+             << QObject::tr( "str: layer source. CRS of layer is used." )
+             << QObject::tr( "QgsMapLayer: CRS of layer is used" )
+             << QStringLiteral( "QgsProperty" );
     }
 };
 
@@ -233,6 +290,14 @@ class CORE_EXPORT QgsProcessingParameterTypeRange : public QgsProcessingParamete
     {
       return QStringLiteral( "range" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "list[float]: list of 2 float values" )
+             << QObject::tr( "list[str]: list of strings representing floats" )
+             << QObject::tr( "str: as two comma delimited floats, e.g. '1,10'" )
+             << QStringLiteral( "QgsProperty" );
+    }
 };
 
 /**
@@ -262,6 +327,14 @@ class CORE_EXPORT QgsProcessingParameterTypePoint : public QgsProcessingParamete
     QString id() const override
     {
       return QStringLiteral( "point" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: as an 'x,y' string, e.g. '1.5,10.1'" )
+             << QStringLiteral( "QgsPointXY" )
+             << QStringLiteral( "QgsProperty" )
+             << QStringLiteral( "QgsReferencedPointXY" );
     }
 };
 
@@ -293,6 +366,13 @@ class CORE_EXPORT QgsProcessingParameterTypeEnum : public QgsProcessingParameter
     {
       return QStringLiteral( "enum" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "int" )
+             << QObject::tr( "str: as string representation of int, e.g. '1'" )
+             << QStringLiteral( "QgsProperty" );
+    }
 };
 
 /**
@@ -322,6 +402,18 @@ class CORE_EXPORT QgsProcessingParameterTypeExtent : public QgsProcessingParamet
     QString id() const override
     {
       return QStringLiteral( "extent" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: as comma delimited list of x min, x max, y min, y max. E.g. '4,10,101,105'" )
+             << QObject::tr( "str: layer ID. Extent of layer is used." )
+             << QObject::tr( "str: layer name. Extent of layer is used." )
+             << QObject::tr( "str: layer source. Extent of layer is used." )
+             << QObject::tr( "QgsMapLayer: Extent of layer is used" )
+             << QStringLiteral( "QgsProperty" )
+             << QStringLiteral( "QgsRectangle" )
+             << QStringLiteral( "QgsReferencedRectangle" );
     }
 };
 
@@ -353,6 +445,13 @@ class CORE_EXPORT QgsProcessingParameterTypeMatrix : public QgsProcessingParamet
     {
       return QStringLiteral( "matrix" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: as comma delimited list of values" )
+             << QStringLiteral( "list" )
+             << QStringLiteral( "QgsProperty" );
+    }
 };
 
 /**
@@ -383,6 +482,12 @@ class CORE_EXPORT QgsProcessingParameterTypeFile : public QgsProcessingParameter
     {
       return QStringLiteral( "file" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" );
+    }
 };
 
 /**
@@ -412,6 +517,12 @@ class CORE_EXPORT QgsProcessingParameterTypeField : public QgsProcessingParamete
     QString id() const override
     {
       return QStringLiteral( "field" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" );
     }
 };
 
@@ -457,6 +568,13 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorDestination : public QgsProces
 
       return flags;
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" )
+             << QStringLiteral( "QgsProcessingOutputLayerDefinition" );
+    }
 };
 
 /**
@@ -500,6 +618,12 @@ class CORE_EXPORT QgsProcessingParameterTypeFileDestination : public QgsProcessi
 #endif
 
       return flags;
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" );
     }
 };
 
@@ -546,6 +670,12 @@ class CORE_EXPORT QgsProcessingParameterTypeFolderDestination : public QgsProces
 
       return flags;
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" );
+    }
 };
 
 /**
@@ -590,6 +720,13 @@ class CORE_EXPORT QgsProcessingParameterTypeRasterDestination : public QgsProces
 
       return flags;
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" )
+             << QStringLiteral( "QgsProcessingOutputLayerDefinition" );
+    }
 };
 
 /**
@@ -619,6 +756,12 @@ class CORE_EXPORT QgsProcessingParameterTypeString : public QgsProcessingParamet
     QString id() const override
     {
       return QStringLiteral( "string" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "str" )
+             << QStringLiteral( "QgsProperty" );
     }
 };
 
@@ -650,6 +793,15 @@ class CORE_EXPORT QgsProcessingParameterTypeMultipleLayers : public QgsProcessin
     {
       return QStringLiteral( "multilayer" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "list[str]: list of layer IDs" )
+             << QObject::tr( "list[str]: list of layer names" )
+             << QObject::tr( "list[str]: list of layer sources" )
+             << QStringLiteral( "list[QgsMapLayer]" )
+             << QStringLiteral( "QgsProperty" );
+    }
 };
 
 /**
@@ -679,6 +831,16 @@ class CORE_EXPORT QgsProcessingParameterTypeFeatureSource : public QgsProcessing
     QString id() const override
     {
       return QStringLiteral( "source" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: layer ID" )
+             << QObject::tr( "str: layer name" )
+             << QObject::tr( "str: layer source" )
+             << QStringLiteral( "QgsProcessingFeatureSourceDefinition" )
+             << QStringLiteral( "QgsProperty" )
+             << QStringLiteral( "QgsVectorLayer" );
     }
 };
 
@@ -710,6 +872,13 @@ class CORE_EXPORT QgsProcessingParameterTypeNumber : public QgsProcessingParamet
     {
       return QStringLiteral( "number" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "int" )
+             << QStringLiteral( "float" )
+             << QStringLiteral( "QgsProperty" );
+    }
 };
 
 /**
@@ -740,6 +909,14 @@ class CORE_EXPORT QgsProcessingParameterTypeDistance : public QgsProcessingParam
     {
       return QStringLiteral( "distance" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "int" )
+             << QStringLiteral( "float" )
+             << QStringLiteral( "QgsProperty" );
+    }
+
 };
 
 /**
@@ -770,6 +947,13 @@ class CORE_EXPORT QgsProcessingParameterTypeBand : public QgsProcessingParameter
     {
       return QStringLiteral( "band" );
     }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QStringLiteral( "int" )
+             << QStringLiteral( "QgsProperty" );
+    }
+
 };
 
 #endif // QGSPROCESSINGPARAMETERTYPEIMPL_H

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -956,4 +956,57 @@ class CORE_EXPORT QgsProcessingParameterTypeBand : public QgsProcessingParameter
 
 };
 
+/**
+ * A feature sink parameter for Processing algorithms.
+ *
+ * \ingroup core
+ * \note No Python bindings available. Get your copy from QgsApplication.processingRegistry().parameterType('band')
+ * \since QGIS 3.2
+ */
+class CORE_EXPORT QgsProcessingParameterTypeFeatureSink : public QgsProcessingParameterType
+{
+    QgsProcessingParameterDefinition *create( const QString &name ) const override SIP_FACTORY
+    {
+      return new QgsProcessingParameterFeatureSink( name );
+    }
+
+    ParameterFlags flags() const override
+    {
+      ParameterFlags flags = QgsProcessingParameterType::flags();
+
+#if QT_VERSION >= 0x50700
+      flags.setFlag( ParameterFlag::ExposeToModeler, false );
+#else
+      flags &= ~ParameterFlag::ExposeToModeler;
+#endif
+
+      return flags;
+    }
+
+    QString description() const override
+    {
+      return QCoreApplication::translate( "Processing", "A feature sink destination parameter." );
+    }
+
+    QString name() const override
+    {
+      return QCoreApplication::translate( "Processing", "Feature Sink" );
+    }
+
+    QString id() const override
+    {
+      return QStringLiteral( "sink" );
+    }
+
+    QStringList acceptedPythonTypes() const override
+    {
+      return QStringList() << QObject::tr( "str: destination vector file, e.g. 'd:/test.shp'" )
+             << QObject::tr( "str: 'memory:' to store result in temporary memory layer" )
+             << QObject::tr( "str: using vector provider ID prefix and destination URI, e.g. 'postgres:...' to store result in PostGIS table" )
+             << QStringLiteral( "QgsProcessingOutputLayerDefinition" )
+             << QStringLiteral( "QgsProperty" );
+    }
+
+};
+
 #endif // QGSPROCESSINGPARAMETERTYPEIMPL_H

--- a/src/core/processing/qgsprocessingregistry.cpp
+++ b/src/core/processing/qgsprocessingregistry.cpp
@@ -45,6 +45,7 @@ QgsProcessingRegistry::QgsProcessingRegistry( QObject *parent SIP_TRANSFERTHIS )
   addParameterType( new QgsProcessingParameterTypeNumber() );
   addParameterType( new QgsProcessingParameterTypeDistance() );
   addParameterType( new QgsProcessingParameterTypeBand() );
+  addParameterType( new QgsProcessingParameterTypeFeatureSink() );
 }
 
 QgsProcessingRegistry::~QgsProcessingRegistry()


### PR DESCRIPTION
This PR improves the processing.algorithmHelp() output to also include a full list of acceptable data types for each parameter for the algorithm.

E.g. The output for `processing.algorithmHelp('gdal:dissolve')` is now:


```
Dissolve (gdal:dissolve)


----------------
Input parameters
----------------

INPUT: Input layer

	Parameter type:	QgsProcessingParameterFeatureSource

	Accepted data types:
		- str: layer ID
		- str: layer name
		- str: layer source
		- QgsProcessingFeatureSourceDefinition
		- QgsProperty
		- QgsVectorLayer

FIELD: Dissolve field

	Parameter type:	QgsProcessingParameterField

	Accepted data types:
		- str
		- QgsProperty

GEOMETRY: Geometry column name

	Parameter type:	QgsProcessingParameterString

	Accepted data types:
		- str
		- QgsProperty

EXPLODE_COLLECTIONS: Produce one feature for each geometry in any kind of geometry collection in the source file

	Parameter type:	QgsProcessingParameterBoolean

	Accepted data types:
		- bool
		- int
		- str
		- QgsProperty

KEEP_ATTRIBUTES: Keep input attributes

	Parameter type:	QgsProcessingParameterBoolean

	Accepted data types:
		- bool
		- int
		- str
		- QgsProperty

COUNT_FEATURES: Count dissolved features

	Parameter type:	QgsProcessingParameterBoolean

	Accepted data types:
		- bool
		- int
		- str
		- QgsProperty

COMPUTE_AREA: Compute area and perimeter of dissolved features

	Parameter type:	QgsProcessingParameterBoolean

	Accepted data types:
		- bool
		- int
		- str
		- QgsProperty

COMPUTE_STATISTICS: Compute min/max/sum/mean for attribute

	Parameter type:	QgsProcessingParameterBoolean

	Accepted data types:
		- bool
		- int
		- str
		- QgsProperty

STATISTICS_ATTRIBUTE: Numeric attribute to calculate statistics on

	Parameter type:	QgsProcessingParameterField

	Accepted data types:
		- str
		- QgsProperty

OPTIONS: Additional creation options

	Parameter type:	QgsProcessingParameterString

	Accepted data types:
		- str
		- QgsProperty

OUTPUT: Dissolved

	Parameter type:	QgsProcessingParameterVectorDestination

	Accepted data types:
		- str
		- QgsProperty
		- QgsProcessingOutputLayerDefinition

----------------
Outputs
----------------

OUTPUT:  <QgsProcessingOutputVectorLayer>
	Dissolved
```