### PR TITLE
[BUGFIX][Processing] Infinite loop in refresh algorithms tree 2.18

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -67,6 +67,8 @@ from processing.preconfigured.PreconfiguredAlgorithmProvider import Preconfigure
 
 class Processing:
 
+    currentlyUpdatingAlgList = False
+
     providers = []
 
     # Same structure as algs in algList
@@ -179,10 +181,14 @@ class Processing:
         requires the list of algorithms to be created again from
         algorithm providers.
         """
+        if Processing.currentlyUpdatingAlgList:
+            return
+        Processing.currentlyUpdatingAlgList = True
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
         for p in Processing.providers:
             Processing.reloadProvider(p.getName())
         QApplication.restoreOverrideCursor()
+        Processing.currentlyUpdatingAlgList = False
 
     @staticmethod
     def reloadProvider(providerName):

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -374,7 +374,6 @@ class TreeProviderItem(QTreeWidgetItem):
 
     def refresh(self):
         self.takeChildren()
-        Processing.updateAlgsList()
         self.populate()
 
     def populate(self):


### PR DESCRIPTION
## Description

When an algorithm provider is refresh, all algorithm providers are reloaded.
But after each reload,the providerReloaded event is emitted and the provider
algorithms tree is refreshed, and all the algorithm providers are reloaded,
and the infinite loop started.

It fixed #18877 *Maximum recursion depth exceeded after adding a model or
script to the Processing algorithm list (since 2.18.18!)* by removing
`updateAlgsList` when refresh provider algorithms tree item.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
