### PR TITLE
Cast left node to text on string comparison

### DIFF
--- a/python/core/auto_generated/qgsfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsfeatureiterator.sip.in
@@ -67,6 +67,14 @@ If you want to check if the iterator successfully completed, better use :py:func
 .. versionadded:: 3.0
 %End
 
+    bool compileFailed() const;
+%Docstring
+Indicator if there was an error when sending the compiled query to the server.
+This indicates that there is something wrong with the expression compiler.
+
+.. versionadded:: 3.2
+%End
+
   protected:
 
     virtual bool fetchFeature( QgsFeature &f ) = 0;
@@ -141,6 +149,7 @@ Add reference
 %Docstring
 Remove reference, delete if refs == 0
 %End
+
 
 
 
@@ -249,6 +258,14 @@ find out whether the iterator is still valid or closed already
 Returns the status of expression compilation for filter expression requests.
 
 .. versionadded:: 2.16
+%End
+
+    bool compileFailed() const;
+%Docstring
+Indicator if there was an error when sending the compiled query to the server.
+This indicates that there is something wrong with the expression compiler.
+
+.. versionadded:: 3.2
 %End
 
 

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -147,6 +147,11 @@ void QgsAbstractFeatureIterator::deref()
     delete this;
 }
 
+bool QgsAbstractFeatureIterator::compileFailed() const
+{
+  return mCompileFailed;
+}
+
 bool QgsAbstractFeatureIterator::prepareSimplification( const QgsSimplifyMethod &simplifyMethod )
 {
   Q_UNUSED( simplifyMethod );

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -83,6 +83,14 @@ class CORE_EXPORT QgsAbstractFeatureIterator
       return mValid;
     }
 
+    /**
+     * Indicator if there was an error when sending the compiled query to the server.
+     * This indicates that there is something wrong with the expression compiler.
+     *
+     * \since QGIS 3.2
+     */
+    bool compileFailed() const;
+
   protected:
 
     /**
@@ -172,6 +180,8 @@ class CORE_EXPORT QgsAbstractFeatureIterator
 
     //! Status of compilation of filter expression
     CompileStatus mCompileStatus = NoCompilation;
+
+    bool mCompileFailed = false;
 
     //! Setup the simplification of geometries to fetch using the specified simplify method
     virtual bool prepareSimplification( const QgsSimplifyMethod &simplifyMethod );
@@ -322,6 +332,14 @@ class CORE_EXPORT QgsFeatureIterator
      * \since QGIS 2.16
      */
     QgsAbstractFeatureIterator::CompileStatus compileStatus() const { return mIter->compileStatus(); }
+
+    /**
+     * Indicator if there was an error when sending the compiled query to the server.
+     * This indicates that there is something wrong with the expression compiler.
+     *
+     * \since QGIS 3.2
+     */
+    bool compileFailed() const { return mIter->compileFailed(); }
 
     friend bool operator== ( const QgsFeatureIterator &fi1, const QgsFeatureIterator &fi2 ) SIP_SKIP;
     friend bool operator!= ( const QgsFeatureIterator &fi1, const QgsFeatureIterator &fi2 ) SIP_SKIP;

--- a/src/core/qgssqlexpressioncompiler.cpp
+++ b/src/core/qgssqlexpressioncompiler.cpp
@@ -38,6 +38,18 @@ QString QgsSqlExpressionCompiler::result()
   return mResult;
 }
 
+bool QgsSqlExpressionCompiler::opIsStringComparison( QgsExpressionNodeBinaryOperator::BinaryOperator op )
+{
+  if ( op == QgsExpressionNodeBinaryOperator::BinaryOperator::boILike ||
+       op == QgsExpressionNodeBinaryOperator::BinaryOperator::boLike ||
+       op == QgsExpressionNodeBinaryOperator::BinaryOperator::boNotILike ||
+       op == QgsExpressionNodeBinaryOperator::BinaryOperator::boNotLike ||
+       op == QgsExpressionNodeBinaryOperator::BinaryOperator::boRegexp )
+    return true;
+  else
+    return false;
+}
+
 QString QgsSqlExpressionCompiler::quotedIdentifier( const QString &identifier )
 {
   QString quoted = identifier;
@@ -253,6 +265,9 @@ QgsSqlExpressionCompiler::Result QgsSqlExpressionCompiler::compileNode( const Qg
       QString left;
       Result lr( compileNode( n->opLeft(), left ) );
 
+      if ( opIsStringComparison( n ->op() ) )
+        left = castToText( left );
+
       QString right;
       Result rr( compileNode( n->opRight(), right ) );
 
@@ -407,6 +422,11 @@ QString QgsSqlExpressionCompiler::castToReal( const QString &value ) const
 {
   Q_UNUSED( value );
   return QString();
+}
+
+QString QgsSqlExpressionCompiler::castToText( const QString &value ) const
+{
+  return value;
 }
 
 QString QgsSqlExpressionCompiler::castToInt( const QString &value ) const

--- a/src/core/qgssqlexpressioncompiler.h
+++ b/src/core/qgssqlexpressioncompiler.h
@@ -20,6 +20,7 @@
 
 #include "qgis_core.h"
 #include "qgsfields.h"
+#include "qgsexpressionnodeimpl.h"
 
 class QgsExpression;
 class QgsExpressionNode;
@@ -80,6 +81,22 @@ class CORE_EXPORT QgsSqlExpressionCompiler
      */
     virtual QString result();
 
+    /**
+     * Returns true if \a op is one of
+     *
+     * - LIKE
+     * - ILIKE
+     * - NOT LIKE
+     * - NOT ILIKE
+     * - ~ (regexp)
+     *
+     * In such cases the left operator will be cast to string to behave equal to
+     * QGIS own expression engine.
+     *
+     * \since QGIS 3.2
+     */
+    bool opIsStringComparison( QgsExpressionNodeBinaryOperator::BinaryOperator op );
+
   protected:
 
     /**
@@ -131,6 +148,23 @@ class CORE_EXPORT QgsSqlExpressionCompiler
      * \since QGIS 3.0
      */
     virtual QString castToReal( const QString &value ) const;
+
+    /**
+     * Casts a value to a text result. Subclasses that support casting to text may implement this function
+     * to get equal behavior to the QGIS expression engine when string comparison operators are applied
+     * on non-string data.
+     *
+     * Example:
+     *
+     *     579 LIKE '5%'
+     *
+     * which on a postgres database needs to be
+     *
+     *     579::text LIKE '5%'
+     *
+     * \since QGIS 3.2
+     */
+    virtual QString castToText( const QString &value ) const;
 
     /**
      * Casts a value to a integer result. Subclasses must reimplement this to cast a numeric value to a integer

--- a/src/core/qgssqliteexpressioncompiler.cpp
+++ b/src/core/qgssqliteexpressioncompiler.cpp
@@ -111,4 +111,9 @@ QString QgsSQLiteExpressionCompiler::castToInt( const QString &value ) const
   return QStringLiteral( "CAST((%1) AS INTEGER)" ).arg( value );
 }
 
+QString QgsSQLiteExpressionCompiler::castToText( const QString &value ) const
+{
+  return QStringLiteral( "CAST((%1) AS TEXT)" ).arg( value );
+}
+
 ///@endcond

--- a/src/core/qgssqliteexpressioncompiler.h
+++ b/src/core/qgssqliteexpressioncompiler.h
@@ -52,6 +52,7 @@ class CORE_EXPORT QgsSQLiteExpressionCompiler : public QgsSqlExpressionCompiler
     QString sqlFunctionFromFunctionName( const QString &fnName ) const override;
     QString castToReal( const QString &value ) const override;
     QString castToInt( const QString &value ) const override;
+    QString castToText( const QString &value ) const override;
 
 };
 

--- a/src/providers/postgres/qgspostgresexpressioncompiler.cpp
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.cpp
@@ -144,6 +144,11 @@ QString QgsPostgresExpressionCompiler::castToInt( const QString &value ) const
   return QStringLiteral( "((%1)::int)" ).arg( value );
 }
 
+QString QgsPostgresExpressionCompiler::castToText( const QString &value ) const
+{
+  return QStringLiteral( "((%1)::text)" ).arg( value );
+}
+
 QgsSqlExpressionCompiler::Result QgsPostgresExpressionCompiler::compileNode( const QgsExpressionNode *node, QString &result )
 {
   switch ( node->nodeType() )

--- a/src/providers/postgres/qgspostgresexpressioncompiler.h
+++ b/src/providers/postgres/qgspostgresexpressioncompiler.h
@@ -36,6 +36,7 @@ class QgsPostgresExpressionCompiler : public QgsSqlExpressionCompiler
     QStringList sqlArgumentsFromFunctionName( const QString &fnName, const QStringList &fnArgs ) const override;
     QString castToReal( const QString &value ) const override;
     QString castToInt( const QString &value ) const override;
+    QString castToText( const QString &value ) const override;
 
     QString mGeometryColumn;
     QgsPostgresGeometryColumnType mSpatialColType;

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -210,7 +210,10 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
       //try with the fallback where clause, e.g., for cases when using compiled expression failed to prepare
       success = declareCursor( fallbackWhereClause, -1, false, orderByParts.join( QStringLiteral( "," ) ) );
       if ( success )
+      {
         mExpressionCompiled = false;
+        mCompileFailed = true;
+      }
     }
 
     if ( !success && !orderByParts.isEmpty() )

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -213,6 +213,7 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
       //try with the fallback where clause, e.g., for cases when using compiled expression failed to prepare
       mExpressionCompiled = false;
       success = prepareStatement( fallbackWhereClause, -1, orderByParts.join( QStringLiteral( "," ) ) );
+      mCompileFailed = true;
     }
 
     if ( !success )

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -817,3 +817,25 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.assertTrue(vl.dataProvider().deleteAttributes([0]))
             self.assertEqual(vl.dataProvider().minimumValue(0), -200)
             self.assertEqual(vl.dataProvider().maximumValue(0), 400)
+
+    def testStringComparison(self):
+        """
+        Test if string comparisons with numbers are cast by the expression
+        compiler (or work fine without doing anything :P)
+        """
+        vl = self.getEditableLayer()
+        for expression in (
+                '5 LIKE \'5\'',
+                '5 ILIKE \'5\'',
+                '15 NOT LIKE \'5\'',
+                '15 NOT ILIKE \'5\'',
+                '5 ~ \'5\''):
+            iterator = vl.dataProvider().getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\''))
+            count = len([f for f in iterator])
+            self.assertEqual(count, 5)
+            self.assertFalse(iterator.compileFailed())
+            self.enableCompiler()
+            iterator = vl.dataProvider().getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\''))
+            self.assertEqual(count, 5)
+            self.assertFalse(iterator.compileFailed())
+            self.disableCompiler()

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -822,19 +822,18 @@ class ProviderTestCase(FeatureSourceTestCase):
         Test if string comparisons with numbers are cast by the expression
         compiler (or work fine without doing anything :P)
         """
-        vl = self.getEditableLayer()
         for expression in (
                 '5 LIKE \'5\'',
                 '5 ILIKE \'5\'',
                 '15 NOT LIKE \'5\'',
                 '15 NOT ILIKE \'5\'',
                 '5 ~ \'5\''):
-            iterator = vl.dataProvider().getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\''))
+            iterator = self.source.getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\''))
             count = len([f for f in iterator])
             self.assertEqual(count, 5)
             self.assertFalse(iterator.compileFailed())
-            self.enableCompiler()
-            iterator = vl.dataProvider().getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\''))
-            self.assertEqual(count, 5)
-            self.assertFalse(iterator.compileFailed())
-            self.disableCompiler()
+            if self.enableCompiler():
+                iterator = self.source.getFeatures(QgsFeatureRequest().setFilterExpression('5 LIKE \'5\''))
+                self.assertEqual(count, 5)
+                self.assertFalse(iterator.compileFailed())
+                self.disableCompiler()

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -52,6 +52,11 @@ class ProviderTestCase(FeatureSourceTestCase):
         cannot be compiled """
         return set()
 
+    def enableCompiler(self):
+        """By default there is no expression compiling available, needs to be overridden in subclass"""
+        print('Provider does not support compiling')
+        return False
+
     def partiallyCompiledFilters(self):
         """ Individual derived provider tests should override this to return a list of expressions which
         should be partially compiled """
@@ -141,14 +146,11 @@ class ProviderTestCase(FeatureSourceTestCase):
             self.runPolyGetFeatureTests(self.poly_provider)
 
     def testGetFeaturesExp(self):
-        try:
-            self.enableCompiler()
+        if self.enableCompiler():
             self.compiled = True
             self.runGetFeatureTests(self.source)
             if hasattr(self, 'poly_provider'):
                 self.runPolyGetFeatureTests(self.poly_provider)
-        except AttributeError:
-            print('Provider does not support compiling')
 
     def testSubsetString(self):
         if not self.source.supportsSubsetString():
@@ -232,11 +234,8 @@ class ProviderTestCase(FeatureSourceTestCase):
         self.runOrderByTests()
 
     def testOrderByCompiled(self):
-        try:
-            self.enableCompiler()
+        if self.enableCompiler():
             self.runOrderByTests()
-        except AttributeError:
-            print('Provider does not support compiling')
 
     def runOrderByTests(self):
         FeatureSourceTestCase.runOrderByTests(self)

--- a/tests/src/python/test_provider_db2.py
+++ b/tests/src/python/test_provider_db2.py
@@ -58,6 +58,7 @@ class TestPyQgsDb2Provider(unittest.TestCase, ProviderTestCase):
 
     def enableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', True)
+        return True
 
     def disableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', False)

--- a/tests/src/python/test_provider_mssql.py
+++ b/tests/src/python/test_provider_mssql.py
@@ -52,6 +52,7 @@ class TestPyQgsMssqlProvider(unittest.TestCase, ProviderTestCase):
 
     def enableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', True)
+        return True
 
     def disableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', False)

--- a/tests/src/python/test_provider_oracle.py
+++ b/tests/src/python/test_provider_oracle.py
@@ -85,6 +85,7 @@ class TestPyQgsOracleProvider(unittest.TestCase, ProviderTestCase):
 
     def enableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', True)
+        return True
 
     def disableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', False)

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -104,6 +104,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
     def enableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', True)
+        return True
 
     def disableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', False)
@@ -1125,6 +1126,7 @@ class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
 
     def enableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', True)
+        return True
 
     def disableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', False)

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -93,6 +93,7 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
 
     def enableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', True)
+        return True
 
     def disableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', False)

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -260,6 +260,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
 
     def enableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', True)
+        return True
 
     def disableCompiler(self):
         QgsSettings().setValue('/qgis/compileExpressions', False)


### PR DESCRIPTION
## Description

Compiling the following expression fails to compile for postgres:

```sql
50 ILIKE '%5'
```

the internal expression engine will implicitly cast the left hand node to text, so we'll let postgres do the same to avoid failing and having to fallback to local evaluation.