### PR TITLE
[SymbolLayerUtils] Using QgsProject::readPath to resolve relative path in symbolNameToPath

### DIFF
--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -3807,9 +3807,8 @@ QString QgsSymbolLayerV2Utils::symbolNameToPath( QString name )
     }
   }
 
-  QFileInfo pfi( QgsProject::instance()->fileName() );
-  QString alternatePath = pfi.canonicalPath() + QDir::separator() + name;
-  if ( pfi.exists() && QFile( alternatePath ).exists() )
+  QString alternatePath = QgsProject::instance()->readPath( name );
+  if ( QFile( alternatePath ).exists() )
   {
     QgsDebugMsg( "Svg found in alternative path" );
     return QFileInfo( alternatePath ).canonicalFilePath();


### PR DESCRIPTION
## Description

In `QgsSymbolLayerV2Utils::symbolNameToPath` the resolution of relative path to
project was not based on `QgsProject::readPath` method.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
