### PR TITLE
[locator] add a way to invalidate results from python API

### DIFF
--- a/python/core/auto_generated/locator/qgslocatorfilter.sip.in
+++ b/python/core/auto_generated/locator/qgslocatorfilter.sip.in
@@ -54,6 +54,11 @@ class QgsLocatorFilter : QObject
 %Docstring
 Abstract base class for filters which collect locator results.
 
+.. note::
+
+   If the configuration of the filter is changed outside of the main application settings,
+   one needs to invalidate current results of the locator widget: see QgisInterface.invalidateLocatorResults
+
 .. versionadded:: 3.0
 %End
 

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1104,6 +1104,15 @@ deregisterLocatorFilter() to deregister their filters upon plugin unload to avoi
 .. versionadded:: 3.0
 %End
 
+    virtual void invalidateLocatorResults() = 0;
+%Docstring
+Invalidate results from the locator filter.
+
+This might be useful if the configuration of the filter changed without going through main application settings.
+
+.. versionadded:: 3.2
+%End
+
     virtual bool askForDatumTransform( QgsCoordinateReferenceSystem sourceCrs, QgsCoordinateReferenceSystem destinationCrs ) = 0;
 %Docstring
 Checks available datum transforms and ask user if several are available and none

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -774,6 +774,11 @@ void QgisAppInterface::deregisterLocatorFilter( QgsLocatorFilter *filter )
   qgis->mLocatorWidget->locator()->deregisterFilter( filter );
 }
 
+void QgisAppInterface::invalidateLocatorResults()
+{
+  qgis->mLocatorWidget->invalidateResults();
+}
+
 bool QgisAppInterface::askForDatumTransform( QgsCoordinateReferenceSystem sourceCrs, QgsCoordinateReferenceSystem destinationCrs )
 {
   return qgis->askUserForDatumTransform( sourceCrs, destinationCrs );

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -544,6 +544,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
 
     void registerLocatorFilter( QgsLocatorFilter *filter ) override;
     void deregisterLocatorFilter( QgsLocatorFilter *filter ) override;
+    void invalidateLocatorResults() override;
 
     bool askForDatumTransform( QgsCoordinateReferenceSystem sourceCrs, QgsCoordinateReferenceSystem destinationCrs ) override;
 

--- a/src/core/locator/qgslocatorfilter.h
+++ b/src/core/locator/qgslocatorfilter.h
@@ -97,6 +97,9 @@ class CORE_EXPORT QgsLocatorResult
  * \class QgsLocatorFilter
  * \ingroup core
  * Abstract base class for filters which collect locator results.
+ *
+ * \note If the configuration of the filter is changed outside of the main application settings,
+ * one needs to invalidate current results of the locator widget: \see QgisInterface::invalidateLocatorResults
  * \since QGIS 3.0
  */
 class CORE_EXPORT QgsLocatorFilter : public QObject

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -903,6 +903,15 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void deregisterLocatorFilter( QgsLocatorFilter *filter ) = 0;
 
     /**
+     * Invalidate results from the locator filter.
+     *
+     * This might be useful if the configuration of the filter changed without going through main application settings.
+     *
+     * \since QGIS 3.2
+     */
+    virtual void invalidateLocatorResults() = 0;
+
+    /**
       * Checks available datum transforms and ask user if several are available and none
       * is chosen. Dialog is shown only if global option is set accordingly.
       * \returns true if a datum transform has been specifically chosen by user or only one is available.


### PR DESCRIPTION
otherwise if you access the config of the filter (or change app settings) from outside the main application settings dialog, results are not invalidate

for instance, if you update a URL of a service, results won't be updated

it could have been possible to create an `invalidateResults()` signal on the filter level and connect it to the locator widget. But I think it involves more lines of codes for no real added value since all the filters will have their results invalidated anyway.