### PR TITLE
QCAMacros.cmake: fix Linux build

### DIFF
--- a/cmake/QCAMacros.cmake
+++ b/cmake/QCAMacros.cmake
@@ -42,14 +42,28 @@ function(FIND_QCAOSSL_PLUGIN_CPP PLUGIN_REQUIRED)
     get_target_property(_QtCore_path Qt5::Core LOCATION)
     set(QCA_LINK_LIBRARIES "-DLINK_LIBRARIES:STRING=${_QtCore_path};${QCA_LIBRARY}")
 
-    try_run(RUN_RESULT COMPILE_RESULT
-      ${CMAKE_BINARY_DIR} ${TESTCPP}
-      CMAKE_FLAGS "-DCMAKE_CXX_STANDARD=11"
-                  "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-                  "${QCA_INCLUDE_DIRECTORIES}"
-                  "${QCA_LINK_LIBRARIES}"
-      COMPILE_OUTPUT_VARIABLE COMPILE_OUTPUT
-    )
+    IF ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
+        # qtglobal.h with GCC doesn't like -fPIE added by CMAKE_POSITION_INDEPENDENT_CODE=ON
+        SET(CMAKE_CXX_FLAGS_BACKUP "${CMAKE_CXX_FLAGS}")
+        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+        try_run(RUN_RESULT COMPILE_RESULT
+                ${CMAKE_BINARY_DIR} ${TESTCPP}
+                CMAKE_FLAGS "-DCMAKE_CXX_STANDARD=11"
+                            "${QCA_INCLUDE_DIRECTORIES}"
+                            "${QCA_LINK_LIBRARIES}"
+                COMPILE_OUTPUT_VARIABLE COMPILE_OUTPUT
+        )
+        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BACKUP}")
+    ELSE()
+        try_run(RUN_RESULT COMPILE_RESULT
+            ${CMAKE_BINARY_DIR} ${TESTCPP}
+            CMAKE_FLAGS "-DCMAKE_CXX_STANDARD=11"
+                        "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+                        "${QCA_INCLUDE_DIRECTORIES}"
+                        "${QCA_LINK_LIBRARIES}"
+            COMPILE_OUTPUT_VARIABLE COMPILE_OUTPUT
+        )
+    ENDIF()
 
     set(_msg "QCA OpenSSL plugin not found (run-time/unit-test dependency)")
 

--- a/cmake/QCAMacros.cmake
+++ b/cmake/QCAMacros.cmake
@@ -12,8 +12,9 @@
 
 function(FIND_QCAOSSL_PLUGIN_CPP PLUGIN_REQUIRED)
 
+  FIND_PACKAGE(Qt5Core QUIET)
   # requires Qt and QCA packages to be found
-  if(QT_INCLUDE_DIR AND QT_QTCORE_INCLUDE_DIR AND Qt5Core_LIBRARIES
+  if(Qt5Core_INCLUDE_DIRS AND Qt5Core_LIBRARIES
      AND QCA_INCLUDE_DIR AND QCA_LIBRARY
      AND NOT CMAKE_CROSSCOMPILING)
 
@@ -106,7 +107,7 @@ function(FIND_QCATOOL TOOL_REQUIRED)
           $ENV{OSGEO4W_ROOT}/bin
       )
     else()
-      find_program(QCATOOL_EXECUTABLE NAMES qcatool qcatool2 qcatool-qt5)
+      find_program(QCATOOL_EXECUTABLE NAMES qcatool-qt5 qcatool2 qcatool)
     endif()
 
     if(NOT QCATOOL_EXECUTABLE)


### PR DESCRIPTION
https://github.com/qgis/QGIS/commit/25ba36180cfbf836b9458beb98e28f62349c4260 causes
build failures on Ubuntu 16.04 and 18.04 with gcc

```
/usr/bin/c++    -I/usr/include/x86_64-linux-gnu/qt5 -I/usr/include/x86_64-linux-gnu/qt5/QtCore -I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++-64 -I/usr/include/Qca-qt5/QtCrypto  -fPIE   -std=gnu++11 -o CMakeFiles/cmTC_3b936.dir/qcaossl.cpp.o -c /home/even/qgis/QGIS/build/CMakeFiles/CMakeTmp/qcaossl.cpp
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qchar.h:37:0,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:41,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/QString:1,
                 from /usr/include/Qca-qt5/QtCrypto/qca_core.h:36,
                 from /usr/include/Qca-qt5/QtCrypto/qca.h:36,
                 from /usr/include/Qca-qt5/QtCrypto/QtCrypto:1,
                 from /home/even/qgis/QGIS/build/CMakeFiles/CMakeTmp/qcaossl.cpp:2:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qglobal.h:1067:4: error: #error "You must build your code with position independent code if Qt was built with -reduce-relocations. " "Compile your code with -fPIC (-fPIE is not enough)."
 #  error "You must build your code with position independent code if Qt was built with -reduce-relocations. "\
    ^
```

qtglobal.h doesn't like -fPIC and -fPIE together

See https://github.com/qgis/QGIS/pull/6093#issuecomment-393518711
