### PR TITLE
Ensure that orig_ogc_fid field is only ever used internally

### DIFF
--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter.txt
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="2" name="id"/>
    <Attribute value="two" name="name"/>
    <Attribute value="two àò" name="utf8nameè"/>
-   <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_width.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_width.txt
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="2" name="id"/>
    <Attribute value="two" name="name"/>
    <Attribute value="two àò" name="utf8nameè"/>
-   <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or.txt
@@ -8,14 +8,12 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="2" name="id"/>
    <Attribute value="two" name="name"/>
    <Attribute value="two àò" name="utf8nameè"/>
-   <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
   <Feature id="2">
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
-   <Attribute value="2" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or_utf8.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_or_utf8.txt
@@ -8,14 +8,12 @@ Content-Type: text/xml; charset=utf-8
    <Attribute value="2" name="id"/>
    <Attribute value="two" name="name"/>
    <Attribute value="two àò" name="utf8nameè"/>
-   <Attribute value="1" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
   </Feature>
   <Feature id="2">
    <Attribute value="3" name="id"/>
    <Attribute value="three" name="name"/>
    <Attribute value="three èé↓" name="utf8nameè"/>
-   <Attribute value="2" name="orig_ogc_fid"/>
    <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
   </Feature>
  </Layer>


### PR DESCRIPTION
We don't want to expose this field to users, or include it in layer exports or copies

And rename internal field to __orig_ogc_fid to avoid clashes with existing datasets which have been exported before this fix and which now contain a orig_ogc_fid field