### PR TITLE
Adds fill/stroke parameters to some North Arrows svg images

### DIFF
--- a/images/svg/arrows/NorthArrow_07.svg
+++ b/images/svg/arrows/NorthArrow_07.svg
@@ -5,7 +5,7 @@
 <path d="m8.7109374 14.40625l1.03125 3.875 1.0000006-3.84375c-.32242.06819-.657325.125-1.0000006.125-.3560508 0-.6972151-.08278-1.03125-.15625z"/>
 <path d="m14.40625 8.7070311c.07347.334035.15625.6751991.15625 1.03125 0 .3568739-.08245.6965049-.15625 1.0312509l3.875-1.0312509z"/>
 </g>
-<g transform="translate(1.6384771 1.1017831)">
+<g fill="param(fill)" transform="translate(1.6384771 1.1017831)">
 <path d="m9.7375003 5.6288655c-2.2685344 0-4.1086348 1.8400992-4.1086348 4.1086348 0 2.2685327 1.8400997 4.1086337 4.1086348 4.1086337 2.2685327 0 4.1086337-1.840101 4.1086337-4.1086337 0-2.2685356-1.840101-4.1086348-4.1086337-4.1086348z" fill="none" overflow="visible" stroke="param(outline)" stroke-width=".42714843"/>
 <text font-family="OPEN SANS" font-size="40" letter-spacing="0" line-height="125%" word-spacing="0" x="8.9161758" xml:space="preserve" y=".32985753"><tspan font-family="arial black" font-size="2" x="8.9161758" y=".32985753">N</tspan></text>
 <text font-family="OPEN SANS" font-size="40" letter-spacing="0" line-height="125%" word-spacing="0" x="9.0205507" xml:space="preserve" y="20.61916"><tspan font-family="arial black" font-size="2" x="9.0205507" y="20.61916">S</tspan></text>

--- a/images/svg/arrows/NorthArrow_07.svg
+++ b/images/svg/arrows/NorthArrow_07.svg
@@ -5,7 +5,7 @@
 <path d="m8.7109374 14.40625l1.03125 3.875 1.0000006-3.84375c-.32242.06819-.657325.125-1.0000006.125-.3560508 0-.6972151-.08278-1.03125-.15625z"/>
 <path d="m14.40625 8.7070311c.07347.334035.15625.6751991.15625 1.03125 0 .3568739-.08245.6965049-.15625 1.0312509l3.875-1.0312509z"/>
 </g>
-<g fill="param(fill)" transform="translate(1.6384771 1.1017831)">
+<g fill="param(fill)" fill-opacity="param(fill-opacity)" transform="translate(1.6384771 1.1017831)">
 <path d="m9.7375003 5.6288655c-2.2685344 0-4.1086348 1.8400992-4.1086348 4.1086348 0 2.2685327 1.8400997 4.1086337 4.1086348 4.1086337 2.2685327 0 4.1086337-1.840101 4.1086337-4.1086337 0-2.2685356-1.840101-4.1086348-4.1086337-4.1086348z" fill="none" overflow="visible" stroke="param(outline)" stroke-width=".42714843"/>
 <text font-family="OPEN SANS" font-size="40" letter-spacing="0" line-height="125%" word-spacing="0" x="8.9161758" xml:space="preserve" y=".32985753"><tspan font-family="arial black" font-size="2" x="8.9161758" y=".32985753">N</tspan></text>
 <text font-family="OPEN SANS" font-size="40" letter-spacing="0" line-height="125%" word-spacing="0" x="9.0205507" xml:space="preserve" y="20.61916"><tspan font-family="arial black" font-size="2" x="9.0205507" y="20.61916">S</tspan></text>

--- a/images/svg/arrows/NorthArrow_08.svg
+++ b/images/svg/arrows/NorthArrow_08.svg
@@ -3,7 +3,7 @@
 <path d="m11.375977 2.4328575v14.3750005-12.781251" fill="none" stroke="param(outline)" stroke-width=".25000001" transform="translate(-1.6384771 -1.1017834)"/>
 <path d="m9.7444051 15.665089l4.2752529-11.7461562" fill="none" stroke="param(outline)" stroke-width=".25"/>
 <path d="m14.013867 3.9912304l.1875.765625" fill="none" stroke="param(outline)" stroke-width=".25"/>
-<path d="m2.784233 10.834283l-.9525351.331101-.020546 1.00823-.6092452-.803599-.96523331.29202.5760008-.827752-.5760008-.827752.96523331.292019.6092452-.8035986.020546 1.0082306z" fill="param(fill)" stroke="param(fill)" stroke-linecap="square" stroke-width=".25" transform="matrix(0 -.5 .5 0 4.3238667 1.1430154)"/>
-<path d="m19.234375 3.6516075a.796875.828125 0 0 1  .285574.055004" fill="none" stroke="param(outline)" stroke-dasharray=".020174 .010087" stroke-width=".010087" transform="matrix(14.870626 0 0 14.870626 -276.30344 -51.140509)"/>
+<path d="m2.784233 10.834283l-.9525351.331101-.020546 1.00823-.6092452-.803599-.96523331.29202.5760008-.827752-.5760008-.827752.96523331.292019.6092452-.8035986.020546 1.0082306z" fill="param(fill)" fill-opacity="param(fill-opacity)" stroke="param(fill)" stroke-opacity="param(fill-opacity)" stroke-linecap="square" stroke-width=".25" transform="matrix(0 -.5 .5 0 4.3238667 1.1430154)"/>
+<path d="m19.234375 3.6516075a.796875.828125 0 0 1  .285574.055004" fill="none" stroke="param(outline)" stroke-opacity="param(outline-opacity)" stroke-dasharray=".020174 .010087" stroke-width=".010087" transform="matrix(14.870626 0 0 14.870626 -276.30344 -51.140509)"/>
 </g>
 </svg>

--- a/images/svg/arrows/NorthArrow_08.svg
+++ b/images/svg/arrows/NorthArrow_08.svg
@@ -3,7 +3,7 @@
 <path d="m11.375977 2.4328575v14.3750005-12.781251" fill="none" stroke="param(outline)" stroke-width=".25000001" transform="translate(-1.6384771 -1.1017834)"/>
 <path d="m9.7444051 15.665089l4.2752529-11.7461562" fill="none" stroke="param(outline)" stroke-width=".25"/>
 <path d="m14.013867 3.9912304l.1875.765625" fill="none" stroke="param(outline)" stroke-width=".25"/>
-<path d="m2.784233 10.834283l-.9525351.331101-.020546 1.00823-.6092452-.803599-.96523331.29202.5760008-.827752-.5760008-.827752.96523331.292019.6092452-.8035986.020546 1.0082306z" fill-rule="evenodd" stroke="#000" stroke-linecap="square" stroke-width=".25" transform="matrix(0 -.5 .5 0 4.3238667 1.1430154)"/>
-<path d="m19.234375 3.6516075a.796875.828125 0 0 1  .285574.055004" fill="none" stroke="#000" stroke-dasharray=".020174 .010087" stroke-width=".010087" transform="matrix(14.870626 0 0 14.870626 -276.30344 -51.140509)"/>
+<path d="m2.784233 10.834283l-.9525351.331101-.020546 1.00823-.6092452-.803599-.96523331.29202.5760008-.827752-.5760008-.827752.96523331.292019.6092452-.8035986.020546 1.0082306z" fill="param(fill)" stroke="param(fill)" stroke-linecap="square" stroke-width=".25" transform="matrix(0 -.5 .5 0 4.3238667 1.1430154)"/>
+<path d="m19.234375 3.6516075a.796875.828125 0 0 1  .285574.055004" fill="none" stroke="param(outline)" stroke-dasharray=".020174 .010087" stroke-width=".010087" transform="matrix(14.870626 0 0 14.870626 -276.30344 -51.140509)"/>
 </g>
 </svg>

--- a/images/svg/arrows/NorthArrow_09.svg
+++ b/images/svg/arrows/NorthArrow_09.svg
@@ -3,7 +3,7 @@
 <path d="m13.59771 1.3310744v14.3749996-12.7812506" fill="none" stroke="param(outline)" stroke-width=".25"/>
 <path d="m13.590804 15.665089l-4.2752526-11.7461566" fill="none" stroke="param(outline)" stroke-width=".25"/>
 <path d="m9.3213424 3.9912304l-.1875.765625" fill="none" stroke="param(outline)" stroke-width=".25"/>
-<path d="m2.784233 10.834283l-.9525351.331101-.020546 1.00823-.6092452-.803599-.96523331.29202.5760008-.827752-.5760008-.827752.96523331.292019.6092452-.8035986.020546 1.0082306z" fill="param(fill)" stroke="param(fill)" stroke-linecap="square" stroke-width=".25" transform="matrix(0 -.5 -.5 0 19.011343 1.1430154)"/>
-<path d="m19.234375 3.6516075c.09763 0 .194429.018644.285574.055004" fill="none" stroke="param(outline)" stroke-dasharray=".020174 .010087" stroke-width=".010087" transform="matrix(-14.870626 0 0 14.870626 299.63865 -51.14051)"/>
+<path d="m2.784233 10.834283l-.9525351.331101-.020546 1.00823-.6092452-.803599-.96523331.29202.5760008-.827752-.5760008-.827752.96523331.292019.6092452-.8035986.020546 1.0082306z" fill="param(fill)" fill-opacity="param(fill-opacity)" stroke="param(fill)" stroke-opacity="param(fill-opacity)" stroke-linecap="square" stroke-width=".25" transform="matrix(0 -.5 -.5 0 19.011343 1.1430154)"/>
+<path d="m19.234375 3.6516075c.09763 0 .194429.018644.285574.055004" fill="none" stroke="param(outline)" stroke-opacity="param(outline-opacity)" stroke-dasharray=".020174 .010087" stroke-width=".010087" transform="matrix(-14.870626 0 0 14.870626 299.63865 -51.14051)"/>
 </g>
 </svg>

--- a/images/svg/arrows/NorthArrow_09.svg
+++ b/images/svg/arrows/NorthArrow_09.svg
@@ -3,7 +3,7 @@
 <path d="m13.59771 1.3310744v14.3749996-12.7812506" fill="none" stroke="param(outline)" stroke-width=".25"/>
 <path d="m13.590804 15.665089l-4.2752526-11.7461566" fill="none" stroke="param(outline)" stroke-width=".25"/>
 <path d="m9.3213424 3.9912304l-.1875.765625" fill="none" stroke="param(outline)" stroke-width=".25"/>
-<path d="m2.784233 10.834283l-.9525351.331101-.020546 1.00823-.6092452-.803599-.96523331.29202.5760008-.827752-.5760008-.827752.96523331.292019.6092452-.8035986.020546 1.0082306z" fill-rule="evenodd" stroke="#000" stroke-linecap="square" stroke-width=".25" transform="matrix(0 -.5 -.5 0 19.011343 1.1430154)"/>
-<path d="m19.234375 3.6516075c.09763 0 .194429.018644.285574.055004" fill="none" stroke="#000" stroke-dasharray=".020174 .010087" stroke-width=".010087" transform="matrix(-14.870626 0 0 14.870626 299.63865 -51.14051)"/>
+<path d="m2.784233 10.834283l-.9525351.331101-.020546 1.00823-.6092452-.803599-.96523331.29202.5760008-.827752-.5760008-.827752.96523331.292019.6092452-.8035986.020546 1.0082306z" fill="param(fill)" stroke="param(fill)" stroke-linecap="square" stroke-width=".25" transform="matrix(0 -.5 -.5 0 19.011343 1.1430154)"/>
+<path d="m19.234375 3.6516075c.09763 0 .194429.018644.285574.055004" fill="none" stroke="param(outline)" stroke-dasharray=".020174 .010087" stroke-width=".010087" transform="matrix(-14.870626 0 0 14.870626 299.63865 -51.14051)"/>
 </g>
 </svg>


### PR DESCRIPTION
## Description
- Adds fill parameter to N,S,E,W letters of NorthArrow_07.svg
- Adds fill/stroke parameters for star and dashed arc of NorthArrow_08.svg
- Adds fill/stroke parameters for star and dashed arc of NorthArrow_09.svg

This allows to change the color of letters, star and dashed arc of the above mentioned north arrow svg images that otherwise remain always black.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
