### PR TITLE
QgsSvgCache::svgAsPicture(): make sure the returned picture is not shared (fixes #18996)

### DIFF
--- a/src/core/symbology/qgssvgcache.cpp
+++ b/src/core/symbology/qgssvgcache.cpp
@@ -182,8 +182,12 @@ QPicture QgsSvgCache::svgAsPicture( const QString &path, double size, const QCol
     trimToMaximumSize();
   }
 
-  QPicture p = *( currentEntry->picture );
-  p.detach();
+  QPicture p;
+  // For some reason p.detach() doesn't seem to always work as intended, at
+  // least with QT 5.5 on Ubuntu 16.04
+  // Serialization/deserialization is a safe way to be ensured we don't
+  // share a copy.
+  p.setData( currentEntry->picture->data(), currentEntry->picture->size() );
   return p;
 }
 


### PR DESCRIPTION
For some reason QPicture.detach() doesn't seem to always work as intented, at
least with QT 5.5 on Ubuntu 16.04
Serialization/deserialization is a safe way to be ensured we don't
share a copy.

Relates to a6eea7205c72a1be837ab43b79aad0c67a92a9b2
