### PR TITLE
Do not set min/max precision for int fields

### DIFF
--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -493,9 +493,16 @@ void QgsFieldCalculator::setPrecisionMinMax()
   int idx = mOutputFieldTypeComboBox->currentIndex();
   int minPrecType = mOutputFieldTypeComboBox->itemData( idx, Qt::UserRole + FTC_MINPREC_IDX ).toInt();
   int maxPrecType = mOutputFieldTypeComboBox->itemData( idx, Qt::UserRole + FTC_MAXPREC_IDX ).toInt();
-  mOutputFieldPrecisionSpinBox->setEnabled( minPrecType < maxPrecType );
-  mOutputFieldPrecisionSpinBox->setMinimum( minPrecType );
-  mOutputFieldPrecisionSpinBox->setMaximum( std::max( minPrecType, std::min( maxPrecType, mOutputFieldWidthSpinBox->value() ) ) );
+  bool precisionIsEnabled = minPrecType < maxPrecType;
+  mOutputFieldPrecisionSpinBox->setEnabled( precisionIsEnabled );
+  // Do not set min/max if it's disabled or we'll loose the default value,
+  // see https://issues.qgis.org/issues/19050 - QGIS saves integer field when
+  // I create a new real field through field calculator (Update field works as intended)
+  if ( precisionIsEnabled )
+  {
+    mOutputFieldPrecisionSpinBox->setMinimum( minPrecType );
+    mOutputFieldPrecisionSpinBox->setMaximum( std::max( minPrecType, std::min( maxPrecType, mOutputFieldWidthSpinBox->value() ) ) );
+  }
 }
 
 void QgsFieldCalculator::showHelp()


### PR DESCRIPTION
Fixes #19050

QGIS saves integer field when I create a new real
field through field calculator (Update field works as intended)

backport required
