### PR TITLE
[ogr] Fix combination of filterrect and filterfids ignores filterrect check

### DIFF
--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -521,6 +521,36 @@ class FeatureSourceTestCase(object):
         for f in self.source.getFeatures():
             self.assertEqual(request.acceptFeature(f), f['pk'] in expected)
 
+    def testRectAndFids(self):
+        """
+        Test the combination of a filter rect along with filterfids
+        """
+
+        # first get feature ids
+        ids = {f['pk']: f.id() for f in self.source.getFeatures()}
+
+        extent = QgsRectangle(-70, 67, -60, 80)
+        request = QgsFeatureRequest().setFilterFids([ids[3], ids[4]]).setFilterRect(extent)
+        result = set([f['pk'] for f in self.source.getFeatures(request)])
+        all_valid = (all(f.isValid() for f in self.source.getFeatures(request)))
+        expected = [4]
+        assert set(expected) == result, 'Expected {} and got {} when testing for combination of filterRect and expression'.format(set(expected), result)
+        self.assertTrue(all_valid)
+
+        # shouldn't matter what order this is done in
+        request = QgsFeatureRequest().setFilterRect(extent).setFilterFids([ids[3], ids[4]])
+        result = set([f['pk'] for f in self.source.getFeatures(request)])
+        all_valid = (all(f.isValid() for f in self.source.getFeatures(request)))
+        expected = [4]
+        assert set(
+            expected) == result, 'Expected {} and got {} when testing for combination of filterRect and expression'.format(
+            set(expected), result)
+        self.assertTrue(all_valid)
+
+        # test that results match QgsFeatureRequest.acceptFeature
+        for f in self.source.getFeatures():
+            self.assertEqual(request.acceptFeature(f), f['pk'] in expected)
+
     def testGetFeaturesDestinationCrs(self):
         request = QgsFeatureRequest().setDestinationCrs(QgsCoordinateReferenceSystem('epsg:3785'), QgsProject.instance().transformContext())
         features = {f['pk']: f for f in self.source.getFeatures(request)}

--- a/tests/src/python/test_provider_ogr_sqlite.py
+++ b/tests/src/python/test_provider_ogr_sqlite.py
@@ -323,6 +323,18 @@ class TestPyQgsOGRProviderSqlite(unittest.TestCase):
             self.assertEqual([field.name() for field in f.fields()], ['fid', 'type', 'value'])
             self.assertEqual(f.geometry().asWkt(), 'Point (5 5)')
 
+            # filter rect and fids
+            req = QgsFeatureRequest()
+            req.setFilterFids([3, 5])
+            req.setFilterRect(QgsRectangle(4.5, 4.5, 5.5, 5.5))
+            it = vl.getFeatures(req)
+            f = QgsFeature()
+            self.assertTrue(it.nextFeature(f))
+            self.assertEqual(f.id(), 5)
+            self.assertEqual(f.attributes(), [5, 2, 16])
+            self.assertEqual([field.name() for field in f.fields()], ['fid', 'type', 'value'])
+            self.assertEqual(f.geometry().asWkt(), 'Point (5 5)')
+
             # Ensure that orig_ogc_fid is still retrieved even if attribute subset is passed
             req = QgsFeatureRequest()
             req.setSubsetOfAttributes([])


### PR DESCRIPTION
Both these conditions must be honored when set, i.e. features
with matching IDs but which fail the rect check should not be
returned.