### PR TITLE
Plugin loading: only load .so files on Linux

### DIFF
--- a/src/app/qgspluginregistry.cpp
+++ b/src/app/qgspluginregistry.cpp
@@ -484,7 +484,7 @@ void QgsPluginRegistry::restoreSessionPlugins( const QString &pluginDirString )
 #elif ANDROID
   QString pluginExt = "*plugin.so";
 #else
-  QString pluginExt = QStringLiteral( "*.so*" );
+  QString pluginExt = QStringLiteral( "*.so" );
 #endif
 
   // check all libs in the current plugin directory and get name and descriptions


### PR DESCRIPTION
I've recently lost some hair chasing mysterious crashes at QGIS exit
and finally figured out this was due to an old version of the GRASS
plugin that was loaded together with the new version, because the
current filter is *.so* . So restrict this to plain *.so extension,
which will be consistent with what QgsProviderRegistry::init() does.

For more context
https://lists.osgeo.org/pipermail/qgis-developer/2018-June/053546.html
