### PR TITLE
Fix use-after-free at QGIS exist, linked to QgsCoordinateTransform cache

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1084,6 +1084,11 @@ void QgsApplication::exitQgis()
 
   delete QgsProviderRegistry::instance();
 
+  // invalidate coordinate cache while the PROJ context held by the thread-locale
+  // QgsProjContextStore object is still alive. Otherwise if this later object
+  // is destroyed before the static variables of the cache, we might use freed memory.
+  QgsCoordinateTransform::invalidateCache();
+
   // tear-down GDAL/OGR
   OGRCleanupAll();
   GDALDestroyDriverManager();


### PR DESCRIPTION
This fixes the following warning
```
==23284== Invalid read of size 4
==23284==    at 0x14911DE5: pj_ctx_get_errno (pj_ctx.c:137)
==23284==    by 0x149104A9: pj_free (pj_malloc.c:188)
==23284==    by 0x88C4DD3: QgsCoordinateTransformPrivate::freeProj() (qgscoordinatetransform_p.cpp:336)
==23284==    by 0x88C29AB: QgsCoordinateTransformPrivate::~QgsCoordinateTransformPrivate() (qgscoordinatetransform_p.cpp:88)
==23284==    by 0x88BEA6E: QExplicitlySharedDataPointer<QgsCoordinateTransformPrivate>::~QExplicitlySharedDataPointer() (qshareddata.h:156)
==23284==    by 0x88B7857: QgsCoordinateTransform::~QgsCoordinateTransform() (qgscoordinatetransform.cpp:139)
==23284==    by 0x88C1827: QHashNode<QPair<QString, QString>, QgsCoordinateTransform>::~QHashNode() (qhash.h:237)
==23284==    by 0x88C18A6: QHash<QPair<QString, QString>, QgsCoordinateTransform>::deleteNode2(QHashData::Node*) (qhash.h:585)
==23284==    by 0xB9CBBF8: QHashData::free_helper(void (*)(QHashData::Node*)) (in /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.5.1)
==23284==    by 0x88C0276: QHash<QPair<QString, QString>, QgsCoordinateTransform>::freeData(QHashData*) (qhash.h:621)
==23284==    by 0x88BF735: QHash<QPair<QString, QString>, QgsCoordinateTransform>::~QHash() (qhash.h:342)
==23284==    by 0x88C1F2B: QMultiHash<QPair<QString, QString>, QgsCoordinateTransform>::~QMultiHash() (qhash.h:994)
==23284==    by 0xC378369: __cxa_finalize (cxa_finalize.c:56)
==23284==    by 0x8110BB2: ??? (in /home/even/qgis/QGIS/build/output/lib/libqgis_core.so.3.1.0)
==23284==    by 0x4010DE6: _dl_fini (dl-fini.c:235)
==23284==    by 0xC377FF7: __run_exit_handlers (exit.c:82)
==23284==    by 0xC378044: exit (exit.c:104)
==23284==    by 0xC35E836: (below main) (libc-start.c:325)
==23284==  Address 0xaed0c6f0 is 0 bytes inside a block of size 32 free'd
==23284==    at 0x4C2ECF0: free (vg_replace_malloc.c:530)
==23284==    by 0x149103FD: pj_dealloc (pj_malloc.c:133)
==23284==    by 0x88C1FB0: QgsProjContextStore::~QgsProjContextStore() (qgscoordinatetransform_p.cpp:45)
==23284==    by 0xBE23DF5: (anonymous namespace)::run(void*) (atexit_thread.cc:71)
==23284==    by 0xC377FF7: __run_exit_handlers (exit.c:82)
==23284==    by 0xC378044: exit (exit.c:104)
==23284==    by 0xC35E836: (below main) (libc-start.c:325)
==23284==  Block was alloc'd at
==23284==    at 0x4C2DBF6: malloc (vg_replace_malloc.c:299)
==23284==    by 0x14911D8A: pj_ctx_alloc (pj_ctx.c:109)
==23284==    by 0x88C1F64: QgsProjContextStore::QgsProjContextStore() (qgscoordinatetransform_p.cpp:40)
==23284==    by 0x88C505B: __tls_init (qgscoordinatetransform_p.cpp:33)
==23284==    by 0x88C5131: TLS wrapper function for QgsCoordinateTransformPrivate::mProjContext (in /home/even/qgis/QGIS/build/output/lib/libqgis_core.so.3.1.0)
==23284==    by 0x88C39F6: QgsCoordinateTransformPrivate::threadLocalProjData() (qgscoordinatetransform_p.cpp:228)
==23284==    by 0x88C33BE: QgsCoordinateTransformPrivate::initialize() (qgscoordinatetransform_p.cpp:162)

```