### PR TITLE
[processing] Force model outputs to respect constraints set by their underlying algorithm's provider

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -1903,6 +1903,19 @@ a value of false indicates that the destination should not be created by default
 .. seealso:: :py:func:`createByDefault`
 %End
 
+  protected:
+
+    QgsProcessingProvider *originalProvider() const;
+%Docstring
+Original (source) provider which this parameter has been derived from.
+In the case of destination parameters which are part of model algorithms, this
+will reflect the child algorithm's provider which actually generates the
+parameter, as opposed to the provider which this parameter belongs to (i.e.
+the model provider)
+
+.. versionadded:: 3.2
+%End
+
 };
 
 
@@ -1947,6 +1960,15 @@ Returns the type name for the parameter class.
 
     virtual QString defaultFileExtension() const;
 
+
+    virtual QStringList supportedOutputVectorLayerExtensions() const;
+%Docstring
+Returns a list of the vector format file extensions supported by this parameter.
+
+.. seealso:: :py:func:`defaultFileExtension`
+
+.. versionadded:: 3.2
+%End
 
     QgsProcessing::SourceType dataType() const;
 %Docstring
@@ -2029,6 +2051,15 @@ Returns the type name for the parameter class.
     virtual QString defaultFileExtension() const;
 
 
+    virtual QStringList supportedOutputVectorLayerExtensions() const;
+%Docstring
+Returns a list of the vector format file extensions supported by this parameter.
+
+.. seealso:: :py:func:`defaultFileExtension`
+
+.. versionadded:: 3.2
+%End
+
     QgsProcessing::SourceType dataType() const;
 %Docstring
 Returns the layer type for this created vector layer.
@@ -2102,6 +2133,15 @@ Returns the type name for the parameter class.
 
     virtual QString defaultFileExtension() const;
 
+
+    virtual QStringList supportedOutputRasterLayerExtensions() const;
+%Docstring
+Returns a list of the raster format file extensions supported for this parameter.
+
+.. seealso:: :py:func:`defaultFileExtension`
+
+.. versionadded:: 3.2
+%End
 
     static QgsProcessingParameterRasterDestination *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
 %Docstring

--- a/python/plugins/processing/gui/ParameterGuiUtils.py
+++ b/python/plugins/processing/gui/ParameterGuiUtils.py
@@ -68,18 +68,12 @@ def getFileFilter(param):
     elif param.type() == 'raster':
         return QgsProviderRegistry.instance().fileRasterFilters()
     elif param.type() == 'rasterDestination':
-        if param.provider() is not None:
-            exts = param.provider().supportedOutputRasterLayerExtensions()
-        else:
-            exts = QgsRasterFileWriter.supportedFormatExtensions()
+        exts = param.supportedOutputRasterLayerExtensions()
         for i in range(len(exts)):
             exts[i] = tr('{0} files (*.{1})', 'ParameterRaster').format(exts[i].upper(), exts[i].lower())
         return ';;'.join(exts) + ';;' + tr('All files (*.*)')
     elif param.type() in ('sink', 'vectorDestination'):
-        if param.provider() is not None:
-            exts = param.provider().supportedOutputVectorLayerExtensions()
-        else:
-            exts = QgsVectorFileWriter.supportedFormatExtensions()
+        exts = param.supportedOutputVectorLayerExtensions()
         for i in range(len(exts)):
             exts[i] = tr('{0} files (*.{1})', 'ParameterVector').format(exts[i].upper(), exts[i].lower())
         return ';;'.join(exts) + ';;' + tr('All files (*.*)')

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -791,7 +791,18 @@ void QgsProcessingModelAlgorithm::updateDestinationParameters()
       param->setName( outputIt->childId() + ':' + outputIt->name() );
       param->setDescription( outputIt->description() );
       param->setDefaultValue( outputIt->defaultValue() );
-      addParameter( param.release() );
+
+      QgsProcessingDestinationParameter *newDestParam = dynamic_cast< QgsProcessingDestinationParameter * >( param.get() );
+      if ( addParameter( param.release() ) && newDestParam )
+      {
+        if ( QgsProcessingProvider *provider = childIt->algorithm()->provider() )
+        {
+          // we need to copy the constraints given by the provider which creates this output across
+          // and replace those which have been set to match the model provider's constraints
+          newDestParam->setSupportsNonFileBasedOutput( provider->supportsNonFileBasedOutput() );
+          newDestParam->mOriginalProvider = provider;
+        }
+      }
     }
   }
 }

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -27,6 +27,7 @@
 #include "qgsreferencedgeometry.h"
 #include "qgsprocessingregistry.h"
 #include "qgsprocessingparametertype.h"
+#include "qgsrasterfilewriter.h"
 #include <functional>
 
 
@@ -3285,7 +3286,11 @@ QgsProcessingOutputDefinition *QgsProcessingParameterFeatureSink::toOutputDefini
 
 QString QgsProcessingParameterFeatureSink::defaultFileExtension() const
 {
-  if ( QgsProcessingProvider *p = provider() )
+  if ( originalProvider() )
+  {
+    return originalProvider()->defaultVectorFileExtension( hasGeometry() );
+  }
+  else if ( QgsProcessingProvider *p = provider() )
   {
     return p->defaultVectorFileExtension( hasGeometry() );
   }
@@ -3300,6 +3305,22 @@ QString QgsProcessingParameterFeatureSink::defaultFileExtension() const
     {
       return QStringLiteral( "dbf" );
     }
+  }
+}
+
+QStringList QgsProcessingParameterFeatureSink::supportedOutputVectorLayerExtensions() const
+{
+  if ( originalProvider() )
+  {
+    return originalProvider()->supportedOutputVectorLayerExtensions();
+  }
+  else if ( QgsProcessingProvider *p = provider() )
+  {
+    return p->supportedOutputVectorLayerExtensions();
+  }
+  else
+  {
+    return QgsVectorFileWriter::supportedFormatExtensions();
   }
 }
 
@@ -3457,7 +3478,11 @@ QgsProcessingOutputDefinition *QgsProcessingParameterRasterDestination::toOutput
 
 QString QgsProcessingParameterRasterDestination::defaultFileExtension() const
 {
-  if ( QgsProcessingProvider *p = provider() )
+  if ( originalProvider() )
+  {
+    return originalProvider()->defaultRasterFileExtension();
+  }
+  else if ( QgsProcessingProvider *p = provider() )
   {
     return p->defaultRasterFileExtension();
   }
@@ -3465,6 +3490,22 @@ QString QgsProcessingParameterRasterDestination::defaultFileExtension() const
   {
     QgsSettings settings;
     return settings.value( QStringLiteral( "Processing/DefaultOutputRasterLayerExt" ), QStringLiteral( "tif" ), QgsSettings::Core ).toString();
+  }
+}
+
+QStringList QgsProcessingParameterRasterDestination::supportedOutputRasterLayerExtensions() const
+{
+  if ( originalProvider() )
+  {
+    return originalProvider()->supportedOutputRasterLayerExtensions();
+  }
+  else if ( QgsProcessingProvider *p = provider() )
+  {
+    return p->supportedOutputRasterLayerExtensions();
+  }
+  else
+  {
+    return QgsRasterFileWriter::supportedFormatExtensions();
   }
 }
 
@@ -3805,7 +3846,11 @@ QgsProcessingOutputDefinition *QgsProcessingParameterVectorDestination::toOutput
 
 QString QgsProcessingParameterVectorDestination::defaultFileExtension() const
 {
-  if ( QgsProcessingProvider *p = provider() )
+  if ( originalProvider() )
+  {
+    return originalProvider()->defaultVectorFileExtension( hasGeometry() );
+  }
+  else if ( QgsProcessingProvider *p = provider() )
   {
     return p->defaultVectorFileExtension( hasGeometry() );
   }
@@ -3820,6 +3865,22 @@ QString QgsProcessingParameterVectorDestination::defaultFileExtension() const
     {
       return QStringLiteral( "dbf" );
     }
+  }
+}
+
+QStringList QgsProcessingParameterVectorDestination::supportedOutputVectorLayerExtensions() const
+{
+  if ( originalProvider() )
+  {
+    return originalProvider()->supportedOutputVectorLayerExtensions();
+  }
+  else if ( QgsProcessingProvider *p = provider() )
+  {
+    return p->supportedOutputVectorLayerExtensions();
+  }
+  else
+  {
+    return QgsVectorFileWriter::supportedFormatExtensions();
   }
 }
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -1831,11 +1831,34 @@ class CORE_EXPORT QgsProcessingDestinationParameter : public QgsProcessingParame
      */
     void setCreateByDefault( bool createByDefault );
 
+  protected:
+
+    /**
+     * Original (source) provider which this parameter has been derived from.
+     * In the case of destination parameters which are part of model algorithms, this
+     * will reflect the child algorithm's provider which actually generates the
+     * parameter, as opposed to the provider which this parameter belongs to (i.e.
+     * the model provider)
+     * \since QGIS 3.2
+     */
+    QgsProcessingProvider *originalProvider() const { return mOriginalProvider; }
+
   private:
+
+    /**
+     * Original (source) provider which this parameter has been derived from.
+     * In the case of destination parameters which are part of model algorithms, this
+     * will reflect the child algorithm's provider which actually generates the
+     * parameter, as opposed to the provider which this parameter belongs to (i.e.
+     * the model provider)
+     */
+    QgsProcessingProvider *mOriginalProvider = nullptr;
 
     bool mSupportsNonFileBasedOutputs = true;
     bool mCreateByDefault = true;
 
+    friend class QgsProcessingModelAlgorithm;
+    friend class TestQgsProcessing;
 };
 
 
@@ -1871,6 +1894,13 @@ class CORE_EXPORT QgsProcessingParameterFeatureSink : public QgsProcessingDestin
     QString asScriptCode() const override;
     QgsProcessingOutputDefinition *toOutputDefinition() const override SIP_FACTORY;
     QString defaultFileExtension() const override;
+
+    /**
+     * Returns a list of the vector format file extensions supported by this parameter.
+     * \see defaultFileExtension()
+     * \since QGIS 3.2
+     */
+    virtual QStringList supportedOutputVectorLayerExtensions() const;
 
     /**
      * Returns the layer type for sinks associated with the parameter.
@@ -1941,6 +1971,13 @@ class CORE_EXPORT QgsProcessingParameterVectorDestination : public QgsProcessing
     QString defaultFileExtension() const override;
 
     /**
+     * Returns a list of the vector format file extensions supported by this parameter.
+     * \see defaultFileExtension()
+     * \since QGIS 3.2
+     */
+    virtual QStringList supportedOutputVectorLayerExtensions() const;
+
+    /**
      * Returns the layer type for this created vector layer.
      * \see setDataType()
      */
@@ -2004,6 +2041,13 @@ class CORE_EXPORT QgsProcessingParameterRasterDestination : public QgsProcessing
     QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const override;
     QgsProcessingOutputDefinition *toOutputDefinition() const override SIP_FACTORY;
     QString defaultFileExtension() const override;
+
+    /**
+     * Returns a list of the raster format file extensions supported for this parameter.
+     * \see defaultFileExtension()
+     * \since QGIS 3.2
+     */
+    virtual QStringList supportedOutputRasterLayerExtensions() const;
 
     /**
      * Creates a new parameter using the definition from a script code.


### PR DESCRIPTION
E.g. for model outputs generated by a saga algorithm, only sdat and shp files are valid outputs. So only give users choices of these instead of all formats. And don't expose the "save to gpkg/save to postgis" options for these outputs, either.

Also fixes temporary file names generated as part of model execution may use formats which are not compatible with the algorithm's provider.

Fixes #18908
