### PR TITLE
Apply clang-tidy readability-avoid-const-params-in-decls fixit

### DIFF
--- a/python/analysis/auto_generated/network/qgsvectorlayerdirector.sip.in
+++ b/python/analysis/auto_generated/network/qgsvectorlayerdirector.sip.in
@@ -35,7 +35,7 @@ Determine making the graph from vector line layer
                             const QString &directDirectionValue,
                             const QString &reverseDirectionValue,
                             const QString &bothDirectionValue,
-                            const Direction defaultDirection
+                            Direction defaultDirection
                           );
 %Docstring
 Default constructor

--- a/python/core/auto_generated/effects/qgseffectstack.sip.in
+++ b/python/core/auto_generated/effects/qgseffectstack.sip.in
@@ -93,7 +93,7 @@ Appends an effect to the end of the stack.
 .. seealso:: :py:func:`insertEffect`
 %End
 
-    bool insertEffect( const int index, QgsPaintEffect *effect /Transfer/ );
+    bool insertEffect( int index, QgsPaintEffect *effect /Transfer/ );
 %Docstring
 Inserts an effect at a specified index within the stack.
 
@@ -104,7 +104,7 @@ Inserts an effect at a specified index within the stack.
 .. seealso:: :py:func:`appendEffect`
 %End
 
-    bool changeEffect( const int index, QgsPaintEffect *effect /Transfer/ );
+    bool changeEffect( int index, QgsPaintEffect *effect /Transfer/ );
 %Docstring
 Replaces the effect at a specified position within the stack.
 
@@ -113,7 +113,7 @@ Replaces the effect at a specified position within the stack.
                transferred to the stack object.
 %End
 
-    QgsPaintEffect *takeEffect( const int index /TransferBack/ );
+    QgsPaintEffect *takeEffect( int index /TransferBack/ );
 %Docstring
 Removes an effect from the stack and returns a pointer to it.
 

--- a/python/core/auto_generated/effects/qgsimageoperation.sip.in
+++ b/python/core/auto_generated/effects/qgsimageoperation.sip.in
@@ -46,7 +46,7 @@ on which is faster for the particular operation.
       FlipVertical
     };
 
-    static void convertToGrayscale( QImage &image, const GrayscaleMode mode = GrayscaleLuminosity );
+    static void convertToGrayscale( QImage &image, GrayscaleMode mode = GrayscaleLuminosity );
 %Docstring
 Convert a QImage to a grayscale image. Alpha channel is preserved.
 
@@ -54,7 +54,7 @@ Convert a QImage to a grayscale image. Alpha channel is preserved.
 :param mode: mode to use during grayscale conversion
 %End
 
-    static void adjustBrightnessContrast( QImage &image, const int brightness, const double contrast );
+    static void adjustBrightnessContrast( QImage &image, int brightness, double contrast );
 %Docstring
 Alter the brightness or contrast of a QImage.
 
@@ -67,8 +67,8 @@ Alter the brightness or contrast of a QImage.
                  contrast of the image.
 %End
 
-    static void adjustHueSaturation( QImage &image, const double saturation, const QColor &colorizeColor = QColor(),
-                                     const double colorizeStrength = 1.0 );
+    static void adjustHueSaturation( QImage &image, double saturation, const QColor &colorizeColor = QColor(),
+                                     double colorizeStrength = 1.0 );
 %Docstring
 Alter the hue or saturation of a QImage.
 
@@ -79,7 +79,7 @@ Alter the hue or saturation of a QImage.
 :param colorizeStrength: double between 0 and 1, where 0 = no colorization and 1.0 = full colorization
 %End
 
-    static void multiplyOpacity( QImage &image, const double factor );
+    static void multiplyOpacity( QImage &image, double factor );
 %Docstring
 Multiplies opacity of image pixel values by a factor.
 
@@ -118,7 +118,7 @@ using a color ramp.
                    for the distance transform operation
 %End
 
-    static void stackBlur( QImage &image, const int radius, const bool alphaOnly = false );
+    static void stackBlur( QImage &image, int radius, bool alphaOnly = false );
 %Docstring
 Performs a stack blur on an image. Stack blur represents a good balance between
 speed and blur quality.
@@ -133,7 +133,7 @@ speed and blur quality.
    alphaOnly is set to false, or ARGB32 if alphaOnly is true
 %End
 
-    static QImage *gaussianBlur( QImage &image, const int radius ) /Factory/;
+    static QImage *gaussianBlur( QImage &image, int radius ) /Factory/;
 %Docstring
 Performs a gaussian blur on an image. Gaussian blur is slower but results in a high
 quality blur.

--- a/python/core/auto_generated/effects/qgspainteffect.sip.in
+++ b/python/core/auto_generated/effects/qgspainteffect.sip.in
@@ -196,7 +196,7 @@ Returns whether the effect is enabled
 .. seealso:: :py:func:`setEnabled`
 %End
 
-    void setEnabled( const bool enabled );
+    void setEnabled( bool enabled );
 %Docstring
 Sets whether the effect is enabled
 
@@ -215,7 +215,7 @@ effect if the paint effect is used in a :py:class:`QgsEffectStack`.
 .. seealso:: :py:func:`setDrawMode`
 %End
 
-    void setDrawMode( const DrawMode drawMode );
+    void setDrawMode( DrawMode drawMode );
 %Docstring
 Sets the draw mode for the effect. This property only has an
 effect if the paint effect is used in a :py:class:`QgsEffectStack`.

--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -388,7 +388,7 @@ This function returns variables in each expression between [% and %].
 .. versionadded:: 3.2
 %End
 
-    static double evaluateToDouble( const QString &text, const double fallbackValue );
+    static double evaluateToDouble( const QString &text, double fallbackValue );
 %Docstring
 Attempts to evaluate a text string as an expression to a resultant double
 value.

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -196,7 +196,7 @@ Note that this method is 2D only and does not consider the z-value of the circle
 
 
 
-    virtual void setSemiMajorAxis( const double semiMajorAxis );
+    virtual void setSemiMajorAxis( double semiMajorAxis );
 
 %Docstring
 Inherited method. Use setRadius instead.
@@ -206,7 +206,7 @@ Inherited method. Use setRadius instead.
 .. seealso:: :py:func:`setRadius`
 %End
 
-    virtual void setSemiMinorAxis( const double semiMinorAxis );
+    virtual void setSemiMinorAxis( double semiMinorAxis );
 
 %Docstring
 Inherited method. Use setRadius instead.

--- a/python/core/auto_generated/geometry/qgsellipse.sip.in
+++ b/python/core/auto_generated/geometry/qgsellipse.sip.in
@@ -34,7 +34,7 @@ Constructor for QgsEllipse.
 
     virtual ~QgsEllipse();
 
-    QgsEllipse( const QgsPoint &center, const double semiMajorAxis, const double semiMinorAxis, const double azimuth = 90 );
+    QgsEllipse( const QgsPoint &center, double semiMajorAxis, double semiMinorAxis, double azimuth = 90 );
 %Docstring
 Constructs an ellipse by defining all the members.
 
@@ -146,21 +146,21 @@ Sets the center point.
 .. seealso:: :py:func:`rcenter`
 %End
 
-    virtual void setSemiMajorAxis( const double semiMajorAxis );
+    virtual void setSemiMajorAxis( double semiMajorAxis );
 %Docstring
 Sets the semi-major axis.
 
 .. seealso:: :py:func:`semiMajorAxis`
 %End
 
-    virtual void setSemiMinorAxis( const double semiMinorAxis );
+    virtual void setSemiMinorAxis( double semiMinorAxis );
 %Docstring
 Sets the semi-minor axis.
 
 .. seealso:: :py:func:`semiMinorAxis`
 %End
 
-    void setAzimuth( const double azimuth );
+    void setAzimuth( double azimuth );
 %Docstring
 Sets the azimuth (orientation).
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1751,7 +1751,7 @@ The 2 types should match.
     }
 %End
 
-    QgsGeometry smooth( const unsigned int iterations = 1, const double offset = 0.25,
+    QgsGeometry smooth( unsigned int iterations = 1, double offset = 0.25,
                         double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 %Docstring
 Smooths a geometry by rounding off corners using the Chaikin algorithm. This operation

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -102,7 +102,7 @@ supported and is retrieved from the first 3D point amongst ``p1`` and
 :return: Whether the lines intersect
 %End
 
-    static bool segmentIntersection( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint &q1, const QgsPoint &q2, QgsPoint &intersectionPoint /Out/, bool &isIntersection /Out/, const double tolerance = 1e-8, bool acceptImproperIntersection = false );
+    static bool segmentIntersection( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint &q1, const QgsPoint &q2, QgsPoint &intersectionPoint /Out/, bool &isIntersection /Out/, double tolerance = 1e-8, bool acceptImproperIntersection = false );
 %Docstring
 Compute the intersection between two segments
 
@@ -140,7 +140,7 @@ Compute the intersection between two segments
        # (True, 'Point (0 0)', True)
 %End
 
-    static bool lineCircleIntersection( const QgsPointXY &center, const double radius,
+    static bool lineCircleIntersection( const QgsPointXY &center, double radius,
                                         const QgsPointXY &linePoint1, const QgsPointXY &linePoint2,
                                         QgsPointXY &intersection /In,Out/ );
 %Docstring

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -220,6 +220,7 @@ segment in the line.
 
     virtual QPolygonF asQPolygonF() const;
 
+
     virtual bool fromWkb( QgsConstWkbPtr &wkb );
 
     virtual bool fromWkt( const QString &wkt );

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -237,13 +237,13 @@ Expand the rectangle so that covers both the original rectangle and the given re
 Expand the rectangle so that covers both the original rectangle and the given point.
 %End
 
-    QgsRectangle operator-( const QgsVector v ) const;
+    QgsRectangle operator-( QgsVector v ) const;
 
-    QgsRectangle operator+( const QgsVector v ) const;
+    QgsRectangle operator+( QgsVector v ) const;
 
-    QgsRectangle &operator-=( const QgsVector v );
+    QgsRectangle &operator-=( QgsVector v );
 
-    QgsRectangle &operator+=( const QgsVector v );
+    QgsRectangle &operator+=( QgsVector v );
 
     bool isEmpty() const;
 %Docstring

--- a/python/core/auto_generated/geometry/qgsregularpolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgsregularpolygon.sip.in
@@ -38,7 +38,7 @@ The regular polygon is defined by a center point with a number of sides/vertices
 Constructor for QgsRegularPolygon.
 %End
 
-    QgsRegularPolygon( const QgsPoint &center, const double radius, const double azimuth, const unsigned int numberSides, const ConstructionOption circle );
+    QgsRegularPolygon( const QgsPoint &center, double radius, double azimuth, unsigned int numberSides, ConstructionOption circle );
 %Docstring
 Constructs a regular polygon by ``center`` and parameters for the first vertex. An empty regular polygon is returned if ``numberSides`` < 3 or ``ConstructionOption`` isn't valid.
 
@@ -49,7 +49,7 @@ Constructs a regular polygon by ``center`` and parameters for the first vertex. 
 :param circle: Option to create the polygon. see ConstructionOption
 %End
 
-    QgsRegularPolygon( const QgsPoint &center, const QgsPoint &pt1, const unsigned int numberSides, const ConstructionOption circle );
+    QgsRegularPolygon( const QgsPoint &center, const QgsPoint &pt1, unsigned int numberSides, ConstructionOption circle );
 %Docstring
 Constructs a regular polygon by ``center`` and another point.
 
@@ -59,7 +59,7 @@ Constructs a regular polygon by ``center`` and another point.
 :param circle: Option to create the polygon inscribed in circle (the radius is the distance between the center and vertices) or circumscribed about circle (the radius is the distance from the center to the midpoints of the sides).
 %End
 
-    QgsRegularPolygon( const QgsPoint &pt1, const QgsPoint &pt2, const unsigned int numberSides );
+    QgsRegularPolygon( const QgsPoint &pt1, const QgsPoint &pt2, unsigned int numberSides );
 %Docstring
 Constructs a regular polygon by two points of the first side.
 
@@ -123,7 +123,7 @@ Radius is unchanged. The first vertex is reprojected from the new center.
 .. seealso:: :py:func:`center`
 %End
 
-    void setRadius( const double radius );
+    void setRadius( double radius );
 %Docstring
 Sets the radius.
 Center is unchanged. The first vertex is reprojected from the center with the new radius.
@@ -139,7 +139,7 @@ Radius is unchanged. The center is reprojected from the new first vertex.
 .. seealso:: :py:func:`firstVertex`
 %End
 
-    void setNumberSides( const unsigned int numberSides );
+    void setNumberSides( unsigned int numberSides );
 %Docstring
 Sets the number of sides.
 If numberSides < 3, the number of sides is unchanged.

--- a/python/core/auto_generated/geometry/qgstriangle.sip.in
+++ b/python/core/auto_generated/geometry/qgstriangle.sip.in
@@ -41,7 +41,7 @@ Construct a QgsTriangle from three :py:class:`QgsPoint`.
 :param p3: third point
 %End
 
-    explicit QgsTriangle( const QPointF p1, const QPointF p2, const QPointF p3 );
+    explicit QgsTriangle( QPointF p1, QPointF p2, QPointF p3 );
 %Docstring
 Construct a QgsTriangle from three QPointF.
 

--- a/python/core/auto_generated/layout/qgslayout.sip.in
+++ b/python/core/auto_generated/layout/qgslayout.sip.in
@@ -88,7 +88,7 @@ Returns the items model attached to the layout.
 
 
 
-    QList<QgsLayoutItem *> selectedLayoutItems( const bool includeLockedItems = true );
+    QList<QgsLayoutItem *> selectedLayoutItems( bool includeLockedItems = true );
 %Docstring
 Returns list of selected layout items.
 
@@ -168,7 +168,7 @@ updating the scene for each one.
 .. seealso:: :py:func:`updateZValues`
 %End
 
-    void updateZValues( const bool addUndoCommands = true );
+    void updateZValues( bool addUndoCommands = true );
 %Docstring
 Resets the z-values of items based on their position in the internal
 z order list. This should be called after any stacking changes
@@ -237,13 +237,13 @@ Note that template UUIDs are only available while a layout is being restored fro
 .. seealso:: :py:func:`itemByUuid`
 %End
 
-    QgsLayoutItem *layoutItemAt( QPointF position, const bool ignoreLocked = false ) const;
+    QgsLayoutItem *layoutItemAt( QPointF position, bool ignoreLocked = false ) const;
 %Docstring
 Returns the topmost layout item at a specified ``position``. Ignores paper items.
 If ``ignoreLocked`` is set to true any locked items will be ignored.
 %End
 
-    QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, const bool ignoreLocked = false ) const;
+    QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, bool ignoreLocked = false ) const;
 %Docstring
 Returns the topmost layout item at a specified ``position`` which is below a specified ``item``. Ignores paper items.
 If ``ignoreLocked`` is set to true any locked items will be ignored.
@@ -301,7 +301,7 @@ Converts a ``point`` into the layout's native units.
 .. seealso:: :py:func:`units`
 %End
 
-    QgsLayoutMeasurement convertFromLayoutUnits( const double length, const QgsUnitTypes::LayoutUnit unit ) const;
+    QgsLayoutMeasurement convertFromLayoutUnits( double length, QgsUnitTypes::LayoutUnit unit ) const;
 %Docstring
 Converts a ``length`` measurement from the layout's native units to a specified target ``unit``.
 
@@ -312,7 +312,7 @@ Converts a ``length`` measurement from the layout's native units to a specified 
 .. seealso:: :py:func:`units`
 %End
 
-    QgsLayoutSize convertFromLayoutUnits( const QSizeF &size, const QgsUnitTypes::LayoutUnit unit ) const;
+    QgsLayoutSize convertFromLayoutUnits( const QSizeF &size, QgsUnitTypes::LayoutUnit unit ) const;
 %Docstring
 Converts a ``size`` from the layout's native units to a specified target ``unit``.
 
@@ -323,7 +323,7 @@ Converts a ``size`` from the layout's native units to a specified target ``unit`
 .. seealso:: :py:func:`units`
 %End
 
-    QgsLayoutPoint convertFromLayoutUnits( const QPointF &point, const QgsUnitTypes::LayoutUnit unit ) const;
+    QgsLayoutPoint convertFromLayoutUnits( const QPointF &point, QgsUnitTypes::LayoutUnit unit ) const;
 %Docstring
 Converts a ``point`` from the layout's native units to a specified target ``unit``.
 

--- a/python/core/auto_generated/layout/qgslayoutframe.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutframe.sip.in
@@ -79,7 +79,7 @@ Returns whether the page should be hidden (ie, not included in layout exports) i
 .. seealso:: :py:func:`setHidePageIfEmpty`
 %End
 
-    void setHidePageIfEmpty( const bool hidePageIfEmpty );
+    void setHidePageIfEmpty( bool hidePageIfEmpty );
 %Docstring
 Sets whether the page should be hidden (ie, not included in layout exports) if this frame is empty
 
@@ -97,7 +97,7 @@ Returns whether the background and frame stroke should be hidden if this frame i
 .. seealso:: :py:func:`setHideBackgroundIfEmpty`
 %End
 
-    void setHideBackgroundIfEmpty( const bool hideBackgroundIfEmpty );
+    void setHideBackgroundIfEmpty( bool hideBackgroundIfEmpty );
 %Docstring
 Sets whether the background and frame stroke should be hidden if this frame is empty
 

--- a/python/core/auto_generated/layout/qgslayoutgridsettings.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutgridsettings.sip.in
@@ -55,7 +55,7 @@ Returns the page/snap grid resolution.
 .. seealso:: :py:func:`offset`
 %End
 
-    void setOffset( const QgsLayoutPoint offset );
+    void setOffset( QgsLayoutPoint offset );
 %Docstring
 Sets the ``offset`` of the page/snap grid.
 

--- a/python/core/auto_generated/layout/qgslayoutitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitem.sip.in
@@ -308,7 +308,7 @@ not, a user-friendly string identifying item type.
 Sets whether the item should be selected.
 %End
 
-    virtual void setVisibility( const bool visible );
+    virtual void setVisibility( bool visible );
 %Docstring
 Sets whether the item is ``visible``.
 
@@ -319,7 +319,7 @@ Sets whether the item is ``visible``.
    the visibility toggle.
 %End
 
-    void setLocked( const bool locked );
+    void setLocked( bool locked );
 %Docstring
 Sets whether the item is ``locked``, preventing mouse interactions with the item.
 
@@ -700,7 +700,7 @@ Returns the join style used for drawing the item's frame.
 .. seealso:: :py:func:`frameStrokeColor`
 %End
 
-    void setFrameJoinStyle( const Qt::PenJoinStyle style );
+    void setFrameJoinStyle( Qt::PenJoinStyle style );
 %Docstring
 Sets the join ``style`` used when drawing the item's frame.
 
@@ -757,7 +757,7 @@ Returns the item's composition blending mode.
 .. seealso:: :py:func:`setBlendMode`
 %End
 
-    void setBlendMode( const QPainter::CompositionMode mode );
+    void setBlendMode( QPainter::CompositionMode mode );
 %Docstring
 Sets the item's composition blending ``mode``.
 
@@ -928,7 +928,7 @@ Forces a deferred update of any cached image the item uses.
 Triggers a redraw (update) of the item.
 %End
 
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 %Docstring
 Refreshes a data defined ``property`` for the item by reevaluating the property's value
 and redrawing the item with this new value. If ``property`` is set to
@@ -948,7 +948,7 @@ If ``adjustPosition`` is false, rotation occurs around the item origin.
 .. seealso:: :py:func:`rotateItem`
 %End
 
-    virtual void rotateItem( const double angle, const QPointF &transformOrigin );
+    virtual void rotateItem( double angle, const QPointF &transformOrigin );
 %Docstring
 Rotates the item by a specified ``angle`` in degrees clockwise around a specified reference point.
 

--- a/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemattributetable.sip.in
@@ -295,7 +295,7 @@ be replaced by a line break.
     virtual void finalizeRestoreFromXml();
 
 
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 
 
   protected:

--- a/python/core/auto_generated/layout/qgslayoutitemgroup.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemgroup.sip.in
@@ -58,7 +58,7 @@ Items remain in the scene but are no longer grouped together
 Returns a list of items contained by the group.
 %End
 
-    virtual void setVisibility( const bool visible );
+    virtual void setVisibility( bool visible );
 
 
     virtual void attemptMove( const QgsLayoutPoint &point, bool useReferencePoint = true, bool includesFrame = false, int page = -1 );

--- a/python/core/auto_generated/layout/qgslayoutitemhtml.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemhtml.sip.in
@@ -200,7 +200,7 @@ overriding the styles specified within the HTML source.
 .. seealso:: :py:func:`userStylesheetEnabled`
 %End
 
-    void setUserStylesheetEnabled( const bool enabled );
+    void setUserStylesheetEnabled( bool enabled );
 %Docstring
 Sets whether user stylesheets are ``enabled`` for the HTML content.
 
@@ -230,7 +230,7 @@ Returns whether user stylesheets are enabled for the HTML content.
 
   public slots:
 
-    void loadHtml( const bool useCache = false, const QgsExpressionContext *context = 0 );
+    void loadHtml( bool useCache = false, const QgsExpressionContext *context = 0 );
 %Docstring
 Reloads the html source from the url and redraws the item.
 
@@ -249,7 +249,7 @@ Reloads the html source from the url and redraws the item.
 Recalculates the frame sizes for the current viewport dimensions
 %End
 
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 
 
   protected:

--- a/python/core/auto_generated/layout/qgslayoutitemlegend.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlegend.sip.in
@@ -491,7 +491,7 @@ Returns the legend's renderer settings object.
 
     virtual void refresh();
 
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 
 
   protected:

--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -380,7 +380,7 @@ is enabled.
 .. seealso:: :py:func:`atlasDriven`
 %End
 
-    double atlasMargin( const QgsLayoutObject::PropertyValueType valueType = QgsLayoutObject::EvaluatedValue );
+    double atlasMargin( QgsLayoutObject::PropertyValueType valueType = QgsLayoutObject::EvaluatedValue );
 %Docstring
 Returns the margin size (percentage) used when the map is in atlas mode.
 
@@ -546,7 +546,7 @@ associated legend items know they should update
 Updates the bounding rect of this item. Call this function before doing any changes related to annotation out of the map rectangle
 %End
 
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 
 
 };

--- a/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -339,7 +339,7 @@ are retrieved through the units() method.
 .. seealso:: :py:func:`intervalX`
 %End
 
-    void setOffsetX( const double offset );
+    void setOffsetX( double offset );
 %Docstring
 Sets the ``offset`` for grid lines in the x-direction. The units
 are controlled through the setUnits method.
@@ -359,7 +359,7 @@ are retrieved through the units() method.
 .. seealso:: :py:func:`offsetY`
 %End
 
-    void setOffsetY( const double offset );
+    void setOffsetY( double offset );
 %Docstring
 Sets the ``offset`` for grid lines in the y-direction. The units
 are controlled through the setUnits method.
@@ -380,7 +380,7 @@ are retrieved through the units() method.
 %End
 
 
-    void setStyle( const GridStyle style );
+    void setStyle( GridStyle style );
 %Docstring
 Sets the grid ``style``, which controls how the grid is drawn
 over the map's contents.
@@ -412,7 +412,7 @@ with QgsLayoutItemMapGrid.Cross styles.
 .. seealso:: :py:func:`setCrossLength`
 %End
 
-    void setGridLineWidth( const double width );
+    void setGridLineWidth( double width );
 %Docstring
 Sets the ``width`` of grid lines (in layout units). This is only used for grids with QgsLayoutItemMapGrid.Solid
 or QgsLayoutItemMapGrid.Cross styles. For more control over grid line appearance, use
@@ -543,7 +543,7 @@ number of decimal places shown when drawing grid annotations.
 .. seealso:: :py:func:`setAnnotationPrecision`
 %End
 
-    void setAnnotationDisplay( const DisplayMode display, const BorderSide border );
+    void setAnnotationDisplay( DisplayMode display, BorderSide border );
 %Docstring
 Sets what types of grid annotations should be drawn for a specified side of the map frame,
 or whether grid annotations should be disabled for the side.
@@ -554,7 +554,7 @@ or whether grid annotations should be disabled for the side.
 .. seealso:: :py:func:`annotationDisplay`
 %End
 
-    DisplayMode annotationDisplay( const BorderSide border ) const;
+    DisplayMode annotationDisplay( BorderSide border ) const;
 %Docstring
 Returns the display mode for the grid annotations on a specified side of the map
 frame. This property also specifies whether annotations have been disabled
@@ -567,7 +567,7 @@ from a side of the map frame.
 .. seealso:: :py:func:`setAnnotationDisplay`
 %End
 
-    void setAnnotationPosition( const AnnotationPosition position, const BorderSide side );
+    void setAnnotationPosition( AnnotationPosition position, BorderSide side );
 %Docstring
 Sets the ``position`` for the grid annotations on a specified ``side`` of the map
 frame.
@@ -575,7 +575,7 @@ frame.
 .. seealso:: :py:func:`annotationPosition`
 %End
 
-    AnnotationPosition annotationPosition( const BorderSide side ) const;
+    AnnotationPosition annotationPosition( BorderSide side ) const;
 %Docstring
 Returns the position for the grid annotations on a specified ``side`` of the map
 frame.
@@ -597,21 +597,21 @@ Returns the distance between the map frame and annotations. Units are in layout 
 .. seealso:: :py:func:`setAnnotationFrameDistance`
 %End
 
-    void setAnnotationDirection( const AnnotationDirection direction, const BorderSide side );
+    void setAnnotationDirection( AnnotationDirection direction, BorderSide side );
 %Docstring
 Sets the ``direction`` for drawing frame annotations for the specified map ``side``.
 
 .. seealso:: :py:func:`annotationDirection`
 %End
 
-    void setAnnotationDirection( const AnnotationDirection direction );
+    void setAnnotationDirection( AnnotationDirection direction );
 %Docstring
 Sets the ``direction`` for drawing all frame annotations.
 
 .. seealso:: :py:func:`annotationDirection`
 %End
 
-    AnnotationDirection annotationDirection( const BorderSide border ) const;
+    AnnotationDirection annotationDirection( BorderSide border ) const;
 %Docstring
 Returns the direction for drawing frame annotations, on the specified ``side``
 of the map.
@@ -664,14 +664,14 @@ Returns the grid frame style.
 .. seealso:: :py:func:`setFrameStyle`
 %End
 
-    void setFrameDivisions( const DisplayMode divisions, const BorderSide side );
+    void setFrameDivisions( DisplayMode divisions, BorderSide side );
 %Docstring
 Sets what type of grid ``divisions`` should be used for frames on a specified ``side`` of the map.
 
 .. seealso:: :py:func:`frameDivisions`
 %End
 
-    DisplayMode frameDivisions( const BorderSide side ) const;
+    DisplayMode frameDivisions( BorderSide side ) const;
 %Docstring
 Returns the type of grid divisions which are used for frames on a specified ``side`` of the map.
 
@@ -690,7 +690,7 @@ of the map item the grid frame is drawn on.
 .. seealso:: :py:func:`testFrameSideFlag`
 %End
 
-    void setFrameSideFlag( const QgsLayoutItemMapGrid::FrameSideFlag flag, bool on = true );
+    void setFrameSideFlag( QgsLayoutItemMapGrid::FrameSideFlag flag, bool on = true );
 %Docstring
 Sets whether the grid frame is drawn for a certain side of the map item.
 
@@ -716,7 +716,7 @@ is drawn on.
 .. seealso:: :py:func:`testFrameSideFlag`
 %End
 
-    bool testFrameSideFlag( const FrameSideFlag flag ) const;
+    bool testFrameSideFlag( FrameSideFlag flag ) const;
 %Docstring
 Tests whether the grid frame should be drawn on a specified side of the map
 item.

--- a/python/core/auto_generated/layout/qgslayoutitemmapoverview.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapoverview.sip.in
@@ -88,7 +88,7 @@ Moves an overview with matching overviewId down the stack, causing it to be rend
 Returns a reference to an overview with matching overviewId within the stack.
 %End
 
-    QgsLayoutItemMapOverview *overview( const int index ) const;
+    QgsLayoutItemMapOverview *overview( int index ) const;
 %Docstring
 Returns a reference to an overview at the specified ``index`` within the stack.
 %End
@@ -175,7 +175,7 @@ Retrieves the blending mode used for drawing the overview.
 .. seealso:: :py:func:`setBlendMode`
 %End
 
-    void setBlendMode( const QPainter::CompositionMode mode );
+    void setBlendMode( QPainter::CompositionMode mode );
 %Docstring
 Sets the blending ``mode`` used for drawing the overview.
 
@@ -190,7 +190,7 @@ the extent of the overview map.
 .. seealso:: :py:func:`setInverted`
 %End
 
-    void setInverted( const bool inverted );
+    void setInverted( bool inverted );
 %Docstring
 Sets whether the overview frame is ``inverted``, ie, whether the shaded area is drawn outside
 the extent of the overview map.
@@ -205,7 +205,7 @@ Returns whether the extent of the map is forced to center on the overview.
 .. seealso:: :py:func:`setCentered`
 %End
 
-    void setCentered( const bool centered );
+    void setCentered( bool centered );
 %Docstring
 Sets whether the extent of the map is forced to center on the overview
 

--- a/python/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemnodeitem.sip.in
@@ -135,12 +135,12 @@ Constructor for a QgsLayoutNodesItem with the given ``polygon`` nodes, attached 
 
 
 
-    virtual bool _addNode( const int nodeIndex, QPointF newNode, const double radius ) = 0;
+    virtual bool _addNode( int nodeIndex, QPointF newNode, double radius ) = 0;
 %Docstring
 Method called in addNode.
 %End
 
-    virtual bool _removeNode( const int nodeIndex ) = 0;
+    virtual bool _removeNode( int nodeIndex ) = 0;
 %Docstring
 Method called in removeNode.
 %End

--- a/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
@@ -284,7 +284,7 @@ and reloads and redraws the picture.
 Forces a recalculation of the picture's frame size
 %End
 
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 
     virtual bool containsAdvancedEffects() const;
 

--- a/python/core/auto_generated/layout/qgslayoutitempolygon.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolygon.sip.in
@@ -64,9 +64,9 @@ Ownership of ``symbol`` is not transferred.
 %End
 
   protected:
-    virtual bool _addNode( const int indexPoint, QPointF newPoint, const double radius );
+    virtual bool _addNode( int indexPoint, QPointF newPoint, double radius );
 
-    virtual bool _removeNode( const int nodeIndex );
+    virtual bool _removeNode( int nodeIndex );
 
     virtual void _draw( QgsLayoutItemRenderContext &context, const QStyleOptionGraphicsItem *itemStyle = 0 );
 

--- a/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
@@ -211,9 +211,9 @@ Returns the pen width in millimeters for the stroke of the arrow head.
 
   protected:
 
-    virtual bool _addNode( const int indexPoint, QPointF newPoint, const double radius );
+    virtual bool _addNode( int indexPoint, QPointF newPoint, double radius );
 
-    virtual bool _removeNode( const int nodeIndex );
+    virtual bool _removeNode( int nodeIndex );
 
     virtual void _draw( QgsLayoutItemRenderContext &context, const QStyleOptionGraphicsItem *itemStyle = 0 );
 

--- a/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemscalebar.sip.in
@@ -505,7 +505,7 @@ Returns the scale bar style name.
 Adjusts the scale bar box size and updates the item.
 %End
 
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 
     virtual void finalizeRestoreFromXml();
 

--- a/python/core/auto_generated/layout/qgslayoutmeasurement.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutmeasurement.sip.in
@@ -26,7 +26,7 @@ using a variety of different measurement units.
 %End
   public:
 
-    explicit QgsLayoutMeasurement( const double length, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutMeasurement( double length, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 %Docstring
 Constructor for QgsLayoutMeasurement.
 
@@ -80,21 +80,21 @@ Decodes a measurement from a ``string``.
     bool operator==( const QgsLayoutMeasurement &other ) const;
     bool operator!=( const QgsLayoutMeasurement &other ) const;
 
-    QgsLayoutMeasurement operator+( const double v ) const;
+    QgsLayoutMeasurement operator+( double v ) const;
 
-    QgsLayoutMeasurement operator+=( const double v );
+    QgsLayoutMeasurement operator+=( double v );
 
-    QgsLayoutMeasurement operator-( const double v ) const;
+    QgsLayoutMeasurement operator-( double v ) const;
 
-    QgsLayoutMeasurement operator-=( const double v );
+    QgsLayoutMeasurement operator-=( double v );
 
-    QgsLayoutMeasurement operator*( const double v ) const;
+    QgsLayoutMeasurement operator*( double v ) const;
 
-    QgsLayoutMeasurement operator*=( const double v );
+    QgsLayoutMeasurement operator*=( double v );
 
-    QgsLayoutMeasurement operator/( const double v ) const;
+    QgsLayoutMeasurement operator/( double v ) const;
 
-    QgsLayoutMeasurement operator/=( const double v );
+    QgsLayoutMeasurement operator/=( double v );
 
 };
 

--- a/python/core/auto_generated/layout/qgslayoutmeasurementconverter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutmeasurementconverter.sip.in
@@ -49,7 +49,7 @@ when converting measurements to and from pixels.
 .. seealso:: :py:func:`setDpi`
 %End
 
-    QgsLayoutMeasurement convert( const QgsLayoutMeasurement &measurement, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+    QgsLayoutMeasurement convert( const QgsLayoutMeasurement &measurement, QgsUnitTypes::LayoutUnit targetUnits ) const;
 %Docstring
 Converts a measurement from one unit to another.
 
@@ -59,7 +59,7 @@ Converts a measurement from one unit to another.
 :return: measurement converted to target units
 %End
 
-    QgsLayoutSize convert( const QgsLayoutSize &size, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+    QgsLayoutSize convert( const QgsLayoutSize &size, QgsUnitTypes::LayoutUnit targetUnits ) const;
 %Docstring
 Converts a layout size from one unit to another.
 
@@ -69,7 +69,7 @@ Converts a layout size from one unit to another.
 :return: size converted to target units
 %End
 
-    QgsLayoutPoint convert( const QgsLayoutPoint &point, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+    QgsLayoutPoint convert( const QgsLayoutPoint &point, QgsUnitTypes::LayoutUnit targetUnits ) const;
 %Docstring
 Converts a layout point from one unit to another.
 

--- a/python/core/auto_generated/layout/qgslayoutmodel.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutmodel.sip.in
@@ -82,7 +82,7 @@ Returns the QgsLayoutItem corresponding to a QModelIndex ``index``, if possible.
 .. seealso:: :py:func:`indexForItem`
 %End
 
-    QModelIndex indexForItem( QgsLayoutItem *item, const int column = 0 );
+    QModelIndex indexForItem( QgsLayoutItem *item, int column = 0 );
 %Docstring
 Returns the QModelIndex corresponding to a :py:class:`QgsLayoutItem` ``item`` and ``column``, if possible.
 

--- a/python/core/auto_generated/layout/qgslayoutmultiframe.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutmultiframe.sip.in
@@ -112,7 +112,7 @@ Returns unique multiframe type id.
 Returns the item's icon.
 %End
 
-    virtual QSizeF fixedFrameSize( const int frameIndex = -1 ) const;
+    virtual QSizeF fixedFrameSize( int frameIndex = -1 ) const;
 %Docstring
 Returns the fixed size for a frame, if desired. If the fixed frame size changes,
 the sizes of all frames can be recalculated by calling recalculateFrameRects().
@@ -128,7 +128,7 @@ the sizes of all frames can be recalculated by calling recalculateFrameRects().
 .. seealso:: :py:func:`recalculateFrameRects`
 %End
 
-    virtual QSizeF minFrameSize( const int frameIndex = -1 ) const;
+    virtual QSizeF minFrameSize( int frameIndex = -1 ) const;
 %Docstring
 Returns the minimum size for a frames, if desired. If the minimum
 size changes, the sizes of all frames can be recalculated by calling
@@ -355,7 +355,7 @@ fixedFrameSize() method.
 .. seealso:: :py:func:`recalculateFrameSizes`
 %End
 
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 %Docstring
 Refreshes a data defined ``property`` for the multi frame by reevaluating the property's value
 and redrawing the item with this new value. If ``property`` is set to

--- a/python/core/auto_generated/layout/qgslayoutpoint.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutpoint.sip.in
@@ -33,17 +33,17 @@ for use in QGIS layouts. Measurement units are stored alongside the position.
 %End
   public:
 
-    QgsLayoutPoint( const double x, const double y, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    QgsLayoutPoint( double x, double y, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 %Docstring
 Constructor for QgsLayoutPoint.
 %End
 
-    explicit QgsLayoutPoint( const QPointF point, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutPoint( QPointF point, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 %Docstring
 Constructor for QgsLayoutPoint.
 %End
 
-    explicit QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutPoint( QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 %Docstring
 Constructor for an empty point, where both x and y are set to 0.
 
@@ -145,13 +145,13 @@ Decodes a point from a ``string``.
     bool operator==( const QgsLayoutPoint &other ) const;
     bool operator!=( const QgsLayoutPoint &other ) const;
 
-    QgsLayoutPoint operator*( const double v ) const;
+    QgsLayoutPoint operator*( double v ) const;
 
-    QgsLayoutPoint operator*=( const double v );
+    QgsLayoutPoint operator*=( double v );
 
-    QgsLayoutPoint operator/( const double v ) const;
+    QgsLayoutPoint operator/( double v ) const;
 
-    QgsLayoutPoint operator/=( const double v );
+    QgsLayoutPoint operator/=( double v );
 
 };
 

--- a/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -38,7 +38,7 @@ Stores information relating to the current rendering settings for a layout.
 Constructor for QgsLayoutRenderContext.
 %End
 
-    void setFlags( const QgsLayoutRenderContext::Flags flags );
+    void setFlags( QgsLayoutRenderContext::Flags flags );
 %Docstring
 Sets the combination of ``flags`` that will be used for rendering the layout.
 
@@ -49,7 +49,7 @@ Sets the combination of ``flags`` that will be used for rendering the layout.
 .. seealso:: :py:func:`testFlag`
 %End
 
-    void setFlag( const QgsLayoutRenderContext::Flag flag, const bool on = true );
+    void setFlag( QgsLayoutRenderContext::Flag flag, bool on = true );
 %Docstring
 Enables or disables a particular rendering ``flag`` for the layout. Other existing
 flags are not affected.
@@ -72,7 +72,7 @@ Returns the current combination of flags used for rendering the layout.
 .. seealso:: :py:func:`testFlag`
 %End
 
-    bool testFlag( const Flag flag ) const;
+    bool testFlag( Flag flag ) const;
 %Docstring
 Check whether a particular rendering ``flag`` is enabled for the layout.
 

--- a/python/core/auto_generated/layout/qgslayoutsize.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutsize.sip.in
@@ -34,7 +34,7 @@ for use in QGIS layouts. Measurement units are stored alongside the size.
 %End
   public:
 
-    QgsLayoutSize( const double width, const double height, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    QgsLayoutSize( double width, double height, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 %Docstring
 Constructor for QgsLayoutSize.
 
@@ -43,12 +43,12 @@ Constructor for QgsLayoutSize.
 :param units: units for width and height
 %End
 
-    explicit QgsLayoutSize( const QSizeF size, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutSize( QSizeF size, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 %Docstring
 Constructor for QgsLayoutSize.
 %End
 
-    explicit QgsLayoutSize( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutSize( QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 %Docstring
 Constructor for an empty layout size
 
@@ -150,13 +150,13 @@ Decodes a size from a ``string``.
     bool operator==( const QgsLayoutSize &other ) const;
     bool operator!=( const QgsLayoutSize &other ) const;
 
-    QgsLayoutSize operator*( const double v ) const;
+    QgsLayoutSize operator*( double v ) const;
 
-    QgsLayoutSize operator*=( const double v );
+    QgsLayoutSize operator*=( double v );
 
-    QgsLayoutSize operator/( const double v ) const;
+    QgsLayoutSize operator/( double v ) const;
 
-    QgsLayoutSize operator/=( const double v );
+    QgsLayoutSize operator/=( double v );
 
 };
 

--- a/python/core/auto_generated/layout/qgslayoutsnapper.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutsnapper.sip.in
@@ -31,7 +31,7 @@ Constructor for QgsLayoutSnapper, attached to the specified ``layout``.
     virtual QgsLayout *layout();
 
 
-    void setSnapTolerance( const int snapTolerance );
+    void setSnapTolerance( int snapTolerance );
 %Docstring
 Sets the snap ``tolerance`` (in pixels) to use when snapping.
 

--- a/python/core/auto_generated/layout/qgslayouttable.sip.in
+++ b/python/core/auto_generated/layout/qgslayouttable.sip.in
@@ -124,7 +124,7 @@ Constructor for QgsLayoutTable, belonging to the specified ``layout``.
 
     ~QgsLayoutTable();
 
-    void setCellMargin( const double margin );
+    void setCellMargin( double margin );
 %Docstring
 Sets the ``margin`` distance in mm between cell borders and their contents.
 
@@ -138,7 +138,7 @@ Returns the margin distance between cell borders and their contents in mm.
 .. seealso:: :py:func:`setCellMargin`
 %End
 
-    void setEmptyTableBehavior( const EmptyTableMode mode );
+    void setEmptyTableBehavior( EmptyTableMode mode );
 %Docstring
 Sets the behavior ``mode`` for empty tables with no content rows.
 
@@ -175,7 +175,7 @@ set to ShowMessage.
 .. seealso:: :py:func:`emptyTableBehavior`
 %End
 
-    void setShowEmptyRows( const bool showEmpty );
+    void setShowEmptyRows( bool showEmpty );
 %Docstring
 Sets whether empty rows should be drawn. Tables default to hiding empty rows.
 
@@ -231,7 +231,7 @@ Returns the color used to draw header text in the table.
 .. seealso:: :py:func:`contentFontColor`
 %End
 
-    void setHeaderHAlignment( const HeaderHAlignment alignment );
+    void setHeaderHAlignment( HeaderHAlignment alignment );
 %Docstring
 Sets the horizontal ``alignment`` for table headers.
 
@@ -245,7 +245,7 @@ Returns the horizontal alignment for table headers.
 .. seealso:: :py:func:`setHeaderHAlignment`
 %End
 
-    void setHeaderMode( const HeaderMode mode );
+    void setHeaderMode( HeaderMode mode );
 %Docstring
 Sets the display ``mode`` for headers in the table. This property controls
 if and where headers are shown in the table.
@@ -301,7 +301,7 @@ Returns the color used to draw text in table body cells.
 .. seealso:: :py:func:`headerFontColor`
 %End
 
-    void setShowGrid( const bool showGrid );
+    void setShowGrid( bool showGrid );
 %Docstring
 Sets whether grid lines should be drawn in the table
 
@@ -325,7 +325,7 @@ Returns whether grid lines are drawn in the table
 .. seealso:: :py:func:`gridColor`
 %End
 
-    void setGridStrokeWidth( const double width );
+    void setGridStrokeWidth( double width );
 %Docstring
 Sets the ``width`` in mm for grid lines in the table.
 
@@ -369,7 +369,7 @@ Returns the color used for grid lines in the table.
 .. seealso:: :py:func:`gridStrokeWidth`
 %End
 
-    void setHorizontalGrid( const bool horizontalGrid );
+    void setHorizontalGrid( bool horizontalGrid );
 %Docstring
 Sets whether the grid's horizontal lines should be drawn in the table
 
@@ -397,7 +397,7 @@ Returns whether the grid's horizontal lines are drawn in the table.
 .. seealso:: :py:func:`setVerticalGrid`
 %End
 
-    void setVerticalGrid( const bool verticalGrid );
+    void setVerticalGrid( bool verticalGrid );
 %Docstring
 Sets whether the grid's vertical lines should be drawn in the table
 
@@ -504,9 +504,9 @@ Fetches the contents used for the cells in the table.
 Returns the current contents of the table. Excludes header cells.
 %End
 
-    virtual QSizeF fixedFrameSize( const int frameIndex = -1 ) const;
+    virtual QSizeF fixedFrameSize( int frameIndex = -1 ) const;
 
-    virtual QSizeF minFrameSize( const int frameIndex = -1 ) const;
+    virtual QSizeF minFrameSize( int frameIndex = -1 ) const;
 
 
     virtual bool writePropertiesToElement( QDomElement &elem, QDomDocument &doc, const QgsReadWriteContext &context ) const;
@@ -599,7 +599,7 @@ Calculates how many content rows are visible within a given frame.
 :return: number of visible content rows (excludes header rows)
 %End
 
-    QPair<int, int> rowRange( const int frameIndex ) const;
+    QPair<int, int> rowRange( int frameIndex ) const;
 %Docstring
 Calculates a range of rows which should be visible in a given frame.
 

--- a/python/core/auto_generated/layout/qgslayoutundostack.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutundostack.sip.in
@@ -124,7 +124,7 @@ Manually pushes a ``command`` to the stack, and takes ownership of the command.
 
   signals:
 
-    void undoRedoOccurredForItems( const QSet< QString > itemUuids );
+    void undoRedoOccurredForItems( QSet< QString > itemUuids );
 %Docstring
 Emitted when an undo or redo action has occurred, which affected a
 set of layout ``itemUuids``.

--- a/python/core/auto_generated/layout/qgslayoututils.sip.in
+++ b/python/core/auto_generated/layout/qgslayoututils.sip.in
@@ -31,7 +31,7 @@ Rotates a point / vector around the origin.
 :param y: in/out: y coordinate before / after the rotation
 %End
 
-    static double normalizedAngle( const double angle, const bool allowNegative = false );
+    static double normalizedAngle( double angle, bool allowNegative = false );
 %Docstring
 Ensures that an ``angle`` (in degrees) is in the range 0 <= angle < 360.
 If ``allowNegative`` is true then angles between (-360, 360) are allowed. If false,
@@ -77,7 +77,7 @@ Resizes a QRectF relative to a resized bounding rectangle.
 :param boundsAfter: QRectF of bounds after resize
 %End
 
-    static double relativePosition( const double position, const double beforeMin, const double beforeMax, const double afterMin, const double afterMax );
+    static double relativePosition( double position, double beforeMin, double beforeMax, double afterMin, double afterMax );
 %Docstring
 Returns a scaled position given a before and after range
 
@@ -187,7 +187,7 @@ If ``color`` is specified, text will be rendered in that color. If not specified
 color will be used instead.
 %End
 
-    static void drawText( QPainter *painter, const QRectF &rectangle, const QString &text, const QFont &font, const QColor &color = QColor(), const Qt::AlignmentFlag halignment = Qt::AlignLeft, const Qt::AlignmentFlag valignment = Qt::AlignTop, const int flags = Qt::TextWordWrap );
+    static void drawText( QPainter *painter, const QRectF &rectangle, const QString &text, const QFont &font, const QColor &color = QColor(), Qt::AlignmentFlag halignment = Qt::AlignLeft, Qt::AlignmentFlag valignment = Qt::AlignTop, int flags = Qt::TextWordWrap );
 %Docstring
 Draws ``text`` on a ``painter`` within a ``rectangle``, taking care of layout specific issues (calculation to pixel,
 scaling of font and painter to work around Qt font bugs).
@@ -201,7 +201,7 @@ arguments.
 The ``flags`` parameter allows for passing Qt.TextFlags to control appearance of rendered text.
 %End
 
-    static QRectF largestRotatedRectWithinBounds( const QRectF &originalRect, const QRectF &boundsRect, const double rotation );
+    static QRectF largestRotatedRectWithinBounds( const QRectF &originalRect, const QRectF &boundsRect, double rotation );
 %Docstring
 Calculates the largest scaled version of ``originalRect`` which fits within ``boundsRect``, when it is rotated by
 the a specified ``rotation`` amount.

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -272,6 +272,7 @@ Ctor
 %End
 
     virtual QgsRectangle extent() const;
+
 %Docstring
 Returns the extent of the layer
 

--- a/python/core/auto_generated/qgscacheindex.sip.in
+++ b/python/core/auto_generated/qgscacheindex.sip.in
@@ -27,7 +27,7 @@ Constructor for QgsAbstractCacheIndex.
 %End
     virtual ~QgsAbstractCacheIndex();
 
-    virtual void flushFeature( const QgsFeatureId fid ) = 0;
+    virtual void flushFeature( QgsFeatureId fid ) = 0;
 %Docstring
 Is called, whenever a feature is removed from the cache. You should update your indexes, so
 they become invalid in case this feature was required to successfully answer a request.

--- a/python/core/auto_generated/qgscacheindexfeatureid.sip.in
+++ b/python/core/auto_generated/qgscacheindexfeatureid.sip.in
@@ -18,7 +18,7 @@ class QgsCacheIndexFeatureId : QgsAbstractCacheIndex
   public:
     QgsCacheIndexFeatureId( QgsVectorLayerCache * );
 
-    virtual void flushFeature( const QgsFeatureId fid );
+    virtual void flushFeature( QgsFeatureId fid );
 
     virtual void flush();
 

--- a/python/core/auto_generated/qgscolorramp.sip.in
+++ b/python/core/auto_generated/qgscolorramp.sip.in
@@ -463,7 +463,7 @@ Constructor for QgsRandomColorRamp.
     virtual QColor color( double value ) const;
 
 
-    virtual void setTotalColorCount( const int colorCount );
+    virtual void setTotalColorCount( int colorCount );
 %Docstring
 Sets the desired total number of unique colors for the resultant ramp. Calling
 this method pregenerates a set of visually distinct colors which are returned

--- a/python/core/auto_generated/qgscolorschemeregistry.sip.in
+++ b/python/core/auto_generated/qgscolorschemeregistry.sip.in
@@ -100,7 +100,7 @@ Returns all color schemes in the registry
 :return: list of color schemes
 %End
 
-    QList<QgsColorScheme *> schemes( const QgsColorScheme::SchemeFlag flag ) const;
+    QList<QgsColorScheme *> schemes( QgsColorScheme::SchemeFlag flag ) const;
 %Docstring
 Returns all color schemes in the registry which have a specified flag set
 

--- a/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
+++ b/python/core/auto_generated/qgscoordinatereferencesystem.sip.in
@@ -194,7 +194,7 @@ If no prefix is specified, WKT definition is assumed.
                    / // TODO QGIS 3: remove "POSTGIS" and "INTERNAL", allow PROJ4 without the prefix
 %End
 
-    explicit QgsCoordinateReferenceSystem( const long id, CrsType type = PostgisCrsId );
+    explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId );
 %Docstring
 Constructor a CRS object using a PostGIS SRID, an EPSG code or an internal QGIS CRS ID.
 
@@ -294,7 +294,7 @@ Creates a CRS from a specified QGIS SRS ID.
 %End
 
 
-    bool createFromId( const long id, CrsType type = PostgisCrsId );
+    bool createFromId( long id, CrsType type = PostgisCrsId );
 %Docstring
 Sets this CRS by lookup of the given ID in the CRS database.
 
@@ -325,7 +325,7 @@ and refer to QGIS internal CRS IDs.
    /     // TODO QGIS 3: remove "QGIS" and "CUSTOM", only support "USER" (also returned by authid())
 %End
 
-    bool createFromSrid( const long srid );
+    bool createFromSrid( long srid );
 %Docstring
 Sets this CRS by lookup of the given PostGIS SRID in the CRS database.
 
@@ -359,7 +359,7 @@ set up the object.
 .. seealso:: :py:func:`fromWkt`
 %End
 
-    bool createFromSrsId( const long srsId );
+    bool createFromSrsId( long srsId );
 %Docstring
 Sets this CRS by lookup of internal QGIS CRS ID in the CRS database.
 

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -191,7 +191,7 @@ otherwise points are transformed from destination to source CRS.
 :return: transformed point
 %End
 
-    QgsPointXY transform( const double x, const double y, TransformDirection direction = ForwardTransform ) const;
+    QgsPointXY transform( double x, double y, TransformDirection direction = ForwardTransform ) const;
 %Docstring
 Transform the point specified by x,y from the source CRS to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,
@@ -204,7 +204,7 @@ otherwise points are transformed from destination to source CRS.
 :return: transformed point
 %End
 
-    QgsRectangle transformBoundingBox( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform, const bool handle180Crossover = false ) const throw( QgsCsException );
+    QgsRectangle transformBoundingBox( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform, bool handle180Crossover = false ) const throw( QgsCsException );
 %Docstring
 Transforms a rectangle from the source CRS to the destination CRS.
 If the direction is ForwardTransform then coordinates are transformed from source to destination,

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1170,7 +1170,7 @@ A ``scale`` of 0 indicates no maximum scale visibility.
 .. seealso:: :py:func:`setScaleBasedVisibility`
 %End
 
-    void setScaleBasedVisibility( const bool enabled );
+    void setScaleBasedVisibility( bool enabled );
 %Docstring
 Sets whether scale based visibility is enabled for the layer.
 

--- a/python/core/auto_generated/qgsmaprenderertask.sip.in
+++ b/python/core/auto_generated/qgsmaprenderertask.sip.in
@@ -33,7 +33,7 @@ task. This can be used to draw maps without blocking the QGIS interface.
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
-                        const bool forceRaster = false );
+                        bool forceRaster = false );
 %Docstring
 Constructor for QgsMapRendererTask to render a map to an image file.
 %End

--- a/python/core/auto_generated/qgsnetworkcontentfetcherregistry.sip.in
+++ b/python/core/auto_generated/qgsnetworkcontentfetcherregistry.sip.in
@@ -111,7 +111,7 @@ Create the registry for temporary downloaded files
 
     ~QgsNetworkContentFetcherRegistry();
 
-    const QgsFetchedContent *fetch( const QString &url, const FetchingMode fetchingMode = DownloadLater );
+    const QgsFetchedContent *fetch( const QString &url, FetchingMode fetchingMode = DownloadLater );
 %Docstring
 Initialize a download for the given URL
 

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -255,7 +255,7 @@ of any rendering operations.
 
     void setSelectionColor( const QColor &color );
 
-    void setShowSelection( const bool showSelection );
+    void setShowSelection( bool showSelection );
 %Docstring
 Sets whether vector selections should be shown in the rendered map
 

--- a/python/core/auto_generated/qgssettings.sip.in
+++ b/python/core/auto_generated/qgssettings.sip.in
@@ -131,7 +131,7 @@ format used by this constructor.
 %End
     ~QgsSettings();
 
-    void beginGroup( const QString &prefix, const QgsSettings::Section section = QgsSettings::NoSection );
+    void beginGroup( const QString &prefix, QgsSettings::Section section = QgsSettings::NoSection );
 %Docstring
 Appends prefix to the current group.
 The current group is automatically prepended to all keys specified to QSettings.
@@ -191,7 +191,7 @@ Sets the current array index to i. Calls to functions such as setValue(), value(
 remove(), and contains() will operate on the array entry at that index.
 %End
 
-    void setValue( const QString &key, const QVariant &value, const QgsSettings::Section section = QgsSettings::NoSection );
+    void setValue( const QString &key, const QVariant &value, QgsSettings::Section section = QgsSettings::NoSection );
 %Docstring
 Sets the value of setting key to value. If the key already exists, the previous value is overwritten.
 An optional Section argument can be used to set a value to a specific Section.
@@ -222,7 +222,7 @@ An optional Section argument can be used to get a value from a specific Section.
 %End
 
 
-    bool contains( const QString &key, const QgsSettings::Section section = QgsSettings::NoSection ) const;
+    bool contains( const QString &key, QgsSettings::Section section = QgsSettings::NoSection ) const;
 %Docstring
 Returns true if there exists a setting called key; returns false otherwise.
 If a group is set using beginGroup(), key is taken to be relative to that group.
@@ -239,11 +239,11 @@ changed in the meantime by another application.
 This function is called automatically from QSettings's destructor and by the event
 loop at regular intervals, so you normally don't need to call it yourself.
 %End
-    void remove( const QString &key, const QgsSettings::Section section = QgsSettings::NoSection );
+    void remove( const QString &key, QgsSettings::Section section = QgsSettings::NoSection );
 %Docstring
 Removes the setting key and any sub-settings of key in a section.
 %End
-    QString prefixedKey( const QString &key, const QgsSettings::Section section ) const;
+    QString prefixedKey( const QString &key, QgsSettings::Section section ) const;
 %Docstring
 Returns the sanitized and prefixed key
 %End

--- a/python/core/auto_generated/qgsunittypes.sip.in
+++ b/python/core/auto_generated/qgsunittypes.sip.in
@@ -438,7 +438,7 @@ Decodes a layout unit from a string.
 .. versionadded:: 3.0
 %End
 
-    static QgsUnitTypes::LayoutUnitType unitType( const QgsUnitTypes::LayoutUnit units );
+    static QgsUnitTypes::LayoutUnitType unitType( QgsUnitTypes::LayoutUnit units );
 %Docstring
 Returns the type for a unit of measurement.
 

--- a/python/core/auto_generated/qgsvector.sip.in
+++ b/python/core/auto_generated/qgsvector.sip.in
@@ -43,11 +43,11 @@ Constructor for QgsVector taking x and y component values.
 
     QgsVector operator+( QgsVector other ) const;
 
-    QgsVector &operator+=( const QgsVector other );
+    QgsVector &operator+=( QgsVector other );
 
-    QgsVector operator-( const QgsVector other ) const;
+    QgsVector operator-( QgsVector other ) const;
 
-    QgsVector &operator-=( const QgsVector other );
+    QgsVector &operator-=( QgsVector other );
 
     double length() const;
 %Docstring

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2224,7 +2224,7 @@ Select features by their ID
 .. seealso:: :py:func:`select`
 %End
 
-    void deselect( const QgsFeatureId featureId );
+    void deselect( QgsFeatureId featureId );
 %Docstring
 Deselect feature by its ID
 
@@ -2276,7 +2276,7 @@ by the backend data provider).
 
   signals:
 
-    void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, const bool clearAndSelect );
+    void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 %Docstring
 This signal is emitted when selection was changed
 

--- a/python/core/auto_generated/qgsvectorlayercache.sip.in
+++ b/python/core/auto_generated/qgsvectorlayercache.sip.in
@@ -151,7 +151,7 @@ Query the layer for the features with the given ids.
 Query the layer for the features which intersect the specified rectangle.
 %End
 
-    bool isFidCached( const QgsFeatureId fid ) const;
+    bool isFidCached( QgsFeatureId fid ) const;
 %Docstring
 Check if a certain feature id is cached.
 

--- a/python/core/auto_generated/raster/qgscolorrampshader.sip.in
+++ b/python/core/auto_generated/raster/qgscolorrampshader.sip.in
@@ -117,7 +117,7 @@ Set the source color ramp. Ownership is transferred to the renderer.
 Sets the color ramp type
 %End
 
-    void classifyColorRamp( const int classes = 0, const int band = -1, const QgsRectangle &extent = QgsRectangle(), QgsRasterInterface *input = 0 );
+    void classifyColorRamp( int classes = 0, int band = -1, const QgsRectangle &extent = QgsRectangle(), QgsRasterInterface *input = 0 );
 %Docstring
 Classify color ramp shader
 
@@ -127,7 +127,7 @@ Classify color ramp shader
 :param input: raster input used in classification (only used in quantile mode)
 %End
 
-    void classifyColorRamp( const int band = -1, const QgsRectangle &extent = QgsRectangle(), QgsRasterInterface *input = 0 ) /PyName=classifyColorRampV2/;
+    void classifyColorRamp( int band = -1, const QgsRectangle &extent = QgsRectangle(), QgsRasterInterface *input = 0 ) /PyName=classifyColorRampV2/;
 %Docstring
 Classify color ramp shader
 

--- a/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
+++ b/python/core/auto_generated/symbology/qgsfillsymbollayer.sip.in
@@ -802,7 +802,7 @@ The path to the raster image used for the fill.
 .. seealso:: :py:func:`setImageFilePath`
 %End
 
-    void setCoordinateMode( const FillCoordinateMode mode );
+    void setCoordinateMode( FillCoordinateMode mode );
 %Docstring
 Set the coordinate mode for fill. Controls how the top left corner of the image
 fill is positioned relative to the feature.
@@ -822,7 +822,7 @@ fill is positioned relative to the feature.
 .. seealso:: :py:func:`setCoordinateMode`
 %End
 
-    void setOpacity( const double opacity );
+    void setOpacity( double opacity );
 %Docstring
 Sets the ``opacity`` for the raster image used in the fill.
 

--- a/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
+++ b/python/core/auto_generated/symbology/qgssymbollayerutils.sip.in
@@ -525,7 +525,7 @@ Attempts to parse mime data as a list of named colors
 .. versionadded:: 2.5
 %End
 
-    static QMimeData *colorListToMimeData( const QgsNamedColorList &colorList, const bool allFormats = true ) /Factory/;
+    static QMimeData *colorListToMimeData( const QgsNamedColorList &colorList, bool allFormats = true ) /Factory/;
 %Docstring
 Creates mime data from a list of named colors
 

--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -247,7 +247,7 @@ Emitted when the form changes mode.
 :param mode: new mode
 %End
 
-    void showContextMenuExternally( QgsActionMenu *menu, const QgsFeatureId fid );
+    void showContextMenuExternally( QgsActionMenu *menu, QgsFeatureId fid );
 %Docstring
 Emitted when selecting context menu on the feature list to create the context menu individually
 

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -27,6 +27,7 @@ Constructor for FeatureInfo.
 %End
 
         bool isNew;
+
         bool isEdited;
     };
 
@@ -44,7 +45,12 @@ Constructor for QgsFeatureListModel
 %End
 
     virtual void setSourceModel( QgsAttributeTableFilterModel *sourceModel );
+
     QgsVectorLayerCache *layerCache();
+%Docstring
+Returns the vector layer cache which is being used to populate the model.
+%End
+
     virtual QVariant data( const QModelIndex &index, int role ) const;
 
     virtual Qt::ItemFlags flags( const QModelIndex &index ) const;
@@ -89,8 +95,20 @@ Returns a detailed message about errors while parsing a :py:class:`QgsExpression
 
     QString displayExpression() const;
     bool featureByIndex( const QModelIndex &index, QgsFeature &feat );
+
     QgsFeatureId idxToFid( const QModelIndex &index ) const;
+%Docstring
+Returns the feature ID corresponding to an ``index`` from the model.
+
+.. seealso:: :py:func:`fidToIdx`
+%End
+
     QModelIndex fidToIdx( QgsFeatureId fid ) const;
+%Docstring
+Returns the model index corresponding to a feature ID.
+
+.. seealso:: :py:func:`idxToFid`
+%End
 
     virtual QModelIndex mapToSource( const QModelIndex &proxyIndex ) const;
 

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistmodel.sip.in
@@ -90,7 +90,7 @@ Returns a detailed message about errors while parsing a :py:class:`QgsExpression
     QString displayExpression() const;
     bool featureByIndex( const QModelIndex &index, QgsFeature &feat );
     QgsFeatureId idxToFid( const QModelIndex &index ) const;
-    QModelIndex fidToIdx( const QgsFeatureId fid ) const;
+    QModelIndex fidToIdx( QgsFeatureId fid ) const;
 
     virtual QModelIndex mapToSource( const QModelIndex &proxyIndex ) const;
 

--- a/python/gui/auto_generated/attributetable/qgsifeatureselectionmanager.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsifeatureselectionmanager.sip.in
@@ -60,7 +60,7 @@ Returns reference to identifiers of selected features
 
   signals:
 
-    void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, const bool clearAndSelect );
+    void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 %Docstring
 This signal is emitted when selection was changed
 

--- a/python/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsdoublespinbox.sip.in
@@ -51,7 +51,7 @@ Constructor for QgsDoubleSpinBox.
 :param parent: parent widget
 %End
 
-    void setShowClearButton( const bool showClearButton );
+    void setShowClearButton( bool showClearButton );
 %Docstring
 Sets whether the widget will show a clear button. The clear button
 allows users to reset the widget to a default or empty state.
@@ -68,7 +68,7 @@ Returns whether the widget is showing a clear button.
 .. seealso:: :py:func:`setShowClearButton`
 %End
 
-    void setExpressionsEnabled( const bool enabled );
+    void setExpressionsEnabled( bool enabled );
 %Docstring
 Sets if the widget will allow entry of simple expressions, which are
 evaluated and then discarded.

--- a/python/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsspinbox.sip.in
@@ -51,7 +51,7 @@ Constructor for QgsSpinBox.
 :param parent: parent widget
 %End
 
-    void setShowClearButton( const bool showClearButton );
+    void setShowClearButton( bool showClearButton );
 %Docstring
 Sets whether the widget will show a clear button. The clear button
 allows users to reset the widget to a default or empty state.
@@ -68,7 +68,7 @@ Returns whether the widget is showing a clear button.
 .. seealso:: :py:func:`setShowClearButton`
 %End
 
-    void setExpressionsEnabled( const bool enabled );
+    void setExpressionsEnabled( bool enabled );
 %Docstring
 Sets if the widget will allow entry of simple expressions, which are
 evaluated and then discarded.

--- a/python/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
@@ -57,7 +57,7 @@ Returns the layout view utilized by the designer.
 Returns the designer's message bar.
 %End
 
-    virtual void selectItems( const QList< QgsLayoutItem * > items ) = 0;
+    virtual void selectItems( QList< QgsLayoutItem * > items ) = 0;
 %Docstring
 Selects the specified ``items``.
 %End

--- a/python/gui/auto_generated/layout/qgslayoutviewrubberband.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutviewrubberband.sip.in
@@ -35,7 +35,7 @@ in various shapes, for use within QgsLayoutView widgets.
 Constructor for QgsLayoutViewRubberBand.
 %End
 
-    virtual ~QgsLayoutViewRubberBand();
+    ~QgsLayoutViewRubberBand();
 
     virtual QgsLayoutViewRubberBand *create( QgsLayoutView *view ) const = 0 /Factory/;
 %Docstring

--- a/python/gui/auto_generated/layout/qgslayoutviewtool.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutviewtool.sip.in
@@ -172,7 +172,7 @@ item and should have its properties displayed in any designer windows.
 
   protected:
 
-    void setFlags( const QgsLayoutViewTool::Flags flags );
+    void setFlags( QgsLayoutViewTool::Flags flags );
 %Docstring
 Sets the combination of ``flags`` that will be used for the tool.
 

--- a/python/gui/auto_generated/processing/qgsprocessingalgorithmconfigurationwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingalgorithmconfigurationwidget.sip.in
@@ -30,7 +30,7 @@ configuration options directly on algorithm level, in addition to parameters.
 %Docstring
 Creates a new QgsProcessingAlgorithmConfigurationWidget
 %End
-    virtual ~QgsProcessingAlgorithmConfigurationWidget();
+    ~QgsProcessingAlgorithmConfigurationWidget();
 
     virtual QVariantMap configuration() const = 0;
 %Docstring

--- a/python/gui/auto_generated/qgsactionmenu.sip.in
+++ b/python/gui/auto_generated/qgsactionmenu.sip.in
@@ -55,7 +55,7 @@ Constructs a new QgsActionMenu
 :param actionScope: The action scope this menu will run in
 %End
 
-    explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeatureId fid, const QString &actionScope, QWidget *parent /TransferThis/ = 0 );
+    explicit QgsActionMenu( QgsVectorLayer *layer, QgsFeatureId fid, const QString &actionScope, QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Constructs a new QgsActionMenu
 
@@ -73,7 +73,7 @@ Change the feature on which actions are performed
                 as long as the menu is displayed and the action is running.
 %End
 
-    void setMode( const QgsAttributeForm::Mode mode );
+    void setMode( QgsAttributeForm::Mode mode );
 %Docstring
 Change the mode of the actions
 

--- a/python/gui/auto_generated/qgscolorbutton.sip.in
+++ b/python/gui/auto_generated/qgscolorbutton.sip.in
@@ -58,7 +58,7 @@ Returns the currently selected color.
 .. seealso:: :py:func:`setColor`
 %End
 
-    void setAllowOpacity( const bool allowOpacity );
+    void setAllowOpacity( bool allowOpacity );
 %Docstring
 Sets whether opacity modification (transparency) is permitted
 for the color. Defaults to false.
@@ -100,7 +100,7 @@ Returns the title for the color chooser dialog window.
 .. seealso:: :py:func:`setColorDialogTitle`
 %End
 
-    void setShowMenu( const bool showMenu );
+    void setShowMenu( bool showMenu );
 %Docstring
 Sets whether the drop-down menu should be shown for the button. The default behavior is to
 show the menu.
@@ -119,7 +119,7 @@ Returns whether the drop-down menu is shown for the button.
 .. seealso:: :py:func:`setShowMenu`
 %End
 
-    void setBehavior( const Behavior behavior );
+    void setBehavior( Behavior behavior );
 %Docstring
 Sets the behavior for when the button is clicked. The default behavior is to show
 a color picker dialog.

--- a/python/gui/auto_generated/qgscolordialog.sip.in
+++ b/python/gui/auto_generated/qgscolordialog.sip.in
@@ -48,7 +48,7 @@ Sets the title for the color dialog
 :param title: title for dialog box
 %End
 
-    void setAllowOpacity( const bool allowOpacity );
+    void setAllowOpacity( bool allowOpacity );
 %Docstring
 Sets whether opacity modification (transparency) is permitted
 for the color dialog. Defaults to true.
@@ -59,7 +59,7 @@ for the color dialog. Defaults to true.
 %End
 
     static QColor getColor( const QColor &initialColor, QWidget *parent, const QString &title = QString(),
-                            const bool allowOpacity = false );
+                            bool allowOpacity = false );
 %Docstring
 Returns a color selection from a color dialog.
 

--- a/python/gui/auto_generated/qgscolorrampbutton.sip.in
+++ b/python/gui/auto_generated/qgscolorrampbutton.sip.in
@@ -81,7 +81,7 @@ that are not undoable on QColorRampDialog cancel.
 .. seealso:: :py:func:`acceptLiveUpdates`
 %End
 
-    void setShowMenu( const bool showMenu );
+    void setShowMenu( bool showMenu );
 %Docstring
 Sets whether the drop-down menu should be shown for the button. The default behavior is to
 show the menu.

--- a/python/gui/auto_generated/qgscolorwidgets.sip.in
+++ b/python/gui/auto_generated/qgscolorwidgets.sip.in
@@ -38,7 +38,7 @@ set to a color with an ambiguous hue (e.g., black or white shades).
       Alpha
     };
 
-    QgsColorWidget( QWidget *parent /TransferThis/ = 0, const ColorComponent component = Multiple );
+    QgsColorWidget( QWidget *parent /TransferThis/ = 0, ColorComponent component = Multiple );
 %Docstring
 Construct a new color widget.
 
@@ -85,7 +85,7 @@ Create an icon for dragging colors
 
   public slots:
 
-    virtual void setColor( const QColor &color, const bool emitSignals = false );
+    virtual void setColor( const QColor &color, bool emitSignals = false );
 %Docstring
 Sets the color for the widget
 
@@ -95,7 +95,7 @@ Sets the color for the widget
 .. seealso:: :py:func:`color`
 %End
 
-    virtual void setComponent( const QgsColorWidget::ColorComponent component );
+    virtual void setComponent( QgsColorWidget::ColorComponent component );
 %Docstring
 Sets the color component which the widget controls
 
@@ -104,7 +104,7 @@ Sets the color component which the widget controls
 .. seealso:: :py:func:`component`
 %End
 
-    virtual void setComponentValue( const int value );
+    virtual void setComponentValue( int value );
 %Docstring
 Alters the widget's color by setting the value for the widget's color component
 
@@ -149,14 +149,14 @@ Returns the range of valid values for the color widget's component
 :return: maximum value allowed for color component, or -1 if widget has multiple components
 %End
 
-    int componentRange( const ColorComponent component ) const;
+    int componentRange( ColorComponent component ) const;
 %Docstring
 Returns the range of valid values a color component
 
 :return: maximum value allowed for color component
 %End
 
-    int componentValue( const ColorComponent component ) const;
+    int componentValue( ColorComponent component ) const;
 %Docstring
 Returns the value of a component of the widget's current color. This method correctly
 handles hue values when the color has an ambiguous hue (e.g., black or white shades)
@@ -176,7 +176,7 @@ as QColor returns a hue of -1 if the color's hue is ambiguous (e.g., if the satu
 :return: explicitly set hue for widget
 %End
 
-    void alterColor( QColor &color, const QgsColorWidget::ColorComponent component, const int newValue ) const;
+    void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) const;
 %Docstring
 Alters a color by modifiying the value of a specific color component
 
@@ -302,7 +302,7 @@ Constructs a new color wheel widget.
 
   public slots:
 
-    virtual void setColor( const QColor &color, const bool emitSignals = false );
+    virtual void setColor( const QColor &color, bool emitSignals = false );
 
 
   protected:
@@ -335,7 +335,7 @@ axis.
 %End
   public:
 
-    QgsColorBox( QWidget *parent /TransferThis/ = 0, const ColorComponent component = Value );
+    QgsColorBox( QWidget *parent /TransferThis/ = 0, ColorComponent component = Value );
 %Docstring
 Construct a new color box widget.
 
@@ -352,11 +352,11 @@ Construct a new color box widget.
     virtual void paintEvent( QPaintEvent *event );
 
 
-    virtual void setComponent( const ColorComponent component );
+    virtual void setComponent( ColorComponent component );
 
 
   public slots:
-    virtual void setColor( const QColor &color, const bool emitSignals = false );
+    virtual void setColor( const QColor &color, bool emitSignals = false );
 
 
   protected:
@@ -393,8 +393,8 @@ its length by a single color component (e.g., varying saturation from 0 to 100%)
     };
 
     QgsColorRampWidget( QWidget *parent /TransferThis/ = 0,
-                        const ColorComponent component = QgsColorWidget::Red,
-                        const Orientation orientation = QgsColorRampWidget::Horizontal );
+                        ColorComponent component = QgsColorWidget::Red,
+                        Orientation orientation = QgsColorRampWidget::Horizontal );
 %Docstring
 Construct a new color ramp widget.
 
@@ -408,7 +408,7 @@ Construct a new color ramp widget.
     virtual void paintEvent( QPaintEvent *event );
 
 
-    void setOrientation( const Orientation orientation );
+    void setOrientation( Orientation orientation );
 %Docstring
 Sets the orientation for the color ramp
 
@@ -426,7 +426,7 @@ Fetches the orientation for the color ramp
 .. seealso:: :py:func:`setOrientation`
 %End
 
-    void setInteriorMargin( const int margin );
+    void setInteriorMargin( int margin );
 %Docstring
 Sets the margin between the edge of the widget and the ramp
 
@@ -444,7 +444,7 @@ Fetches the margin between the edge of the widget and the ramp
 .. seealso:: :py:func:`setInteriorMargin`
 %End
 
-    void setShowFrame( const bool showFrame );
+    void setShowFrame( bool showFrame );
 %Docstring
 Sets whether the ramp should be drawn within a frame
 
@@ -462,7 +462,7 @@ Fetches whether the ramp is drawn within a frame
 .. seealso:: :py:func:`setShowFrame`
 %End
 
-    void setMarkerSize( const int markerSize );
+    void setMarkerSize( int markerSize );
 %Docstring
 Sets the size for drawing the triangular markers on the ramp
 
@@ -471,7 +471,7 @@ Sets the size for drawing the triangular markers on the ramp
 
   signals:
 
-    void valueChanged( const int value );
+    void valueChanged( int value );
 %Docstring
 Emitted when the widget's color component value changes
 
@@ -506,7 +506,7 @@ A composite horizontal color ramp widget and associated spinbox for manual value
 %End
   public:
 
-    QgsColorSliderWidget( QWidget *parent /TransferThis/ = 0, const ColorComponent component = QgsColorWidget::Red );
+    QgsColorSliderWidget( QWidget *parent /TransferThis/ = 0, ColorComponent component = QgsColorWidget::Red );
 %Docstring
 Construct a new color slider widget.
 
@@ -514,11 +514,11 @@ Construct a new color slider widget.
 :param component: color component which is controlled by the slider
 %End
 
-    virtual void setComponent( const ColorComponent component );
+    virtual void setComponent( ColorComponent component );
 
-    virtual void setComponentValue( const int value );
+    virtual void setComponentValue( int value );
 
-    virtual void setColor( const QColor &color, const bool emitSignals = false );
+    virtual void setColor( const QColor &color, bool emitSignals = false );
 
 
 };
@@ -554,7 +554,7 @@ Construct a new color line edit widget.
 :param parent: parent QWidget for the widget
 %End
 
-    virtual void setColor( const QColor &color, const bool emitSignals = false );
+    virtual void setColor( const QColor &color, bool emitSignals = false );
 
 
   protected:

--- a/python/gui/auto_generated/qgscompoundcolorwidget.sip.in
+++ b/python/gui/auto_generated/qgscompoundcolorwidget.sip.in
@@ -47,7 +47,7 @@ Returns the current color for the dialog
 :return: dialog color
 %End
 
-    void setAllowOpacity( const bool allowOpacity );
+    void setAllowOpacity( bool allowOpacity );
 %Docstring
 Sets whether opacity modification (transparency) is permitted
 for the color dialog. Defaults to true.

--- a/python/gui/auto_generated/qgsdetaileditemdata.sip.in
+++ b/python/gui/auto_generated/qgsdetaileditemdata.sip.in
@@ -27,12 +27,53 @@ Constructor for QgsDetailedItemData.
 %End
 
     void setTitle( const QString &title );
+%Docstring
+Sets the ``title`` for the item.
+
+.. seealso:: :py:func:`title`
+%End
+
     void setDetail( const QString &detail );
+%Docstring
+Sets the detailed description for the item.
+
+.. seealso:: :py:func:`detail`
+%End
+
     void setCategory( const QString &category );
+%Docstring
+Sets the item's ``category``.
+
+.. seealso:: :py:func:`category`
+%End
+
     void setIcon( const QPixmap &icon );
+%Docstring
+Sets the item's ``icon``.
+
+.. seealso:: :py:func:`icon`
+%End
+
     void setCheckable( bool flag );
+%Docstring
+Sets whether the item is checkable.
+
+.. seealso:: :py:func:`isCheckable`
+%End
+
     void setChecked( bool flag );
+%Docstring
+Sets whether the item is checked.
+
+.. seealso:: :py:func:`isChecked`
+%End
+
     void setEnabled( bool flag );
+%Docstring
+Sets whether the item is enabled.
+
+.. seealso:: :py:func:`isEnabled`
+%End
 
     void setRenderAsWidget( bool flag );
 %Docstring
@@ -44,16 +85,65 @@ part of the list item.
 
    the delegate may completely ignore this
    depending on the delegate implementation.
+
+.. seealso:: :py:func:`isRenderedAsWidget`
 %End
 
     QString title() const;
+%Docstring
+Returns the item's title.
+
+.. seealso:: :py:func:`setTitle`
+%End
+
     QString detail() const;
+%Docstring
+Returns the detailed description for the item.
+
+.. seealso:: :py:func:`setDetail`
+%End
+
     QString category() const;
+%Docstring
+Returns the item's category.
+
+.. seealso:: :py:func:`setCategory`
+%End
+
     QPixmap icon() const;
+%Docstring
+Returns the item's icon.
+
+.. seealso:: :py:func:`setIcon`
+%End
+
     bool isCheckable() const;
+%Docstring
+Returns true if the item is checkable.
+
+.. seealso:: :py:func:`setCheckable`
+%End
+
     bool isChecked() const;
+%Docstring
+Returns true if the item is checked.
+
+.. seealso:: :py:func:`setChecked`
+%End
+
     bool isEnabled() const;
+%Docstring
+Returns true if the item is enabled.
+
+.. seealso:: :py:func:`setEnabled`
+%End
+
     bool isRenderedAsWidget() const;
+%Docstring
+Returns true if the item will be rendered using a widget.
+
+.. seealso:: :py:func:`setRenderAsWidget`
+%End
 
 };
 

--- a/python/gui/auto_generated/qgsdetaileditemdata.sip.in
+++ b/python/gui/auto_generated/qgsdetaileditemdata.sip.in
@@ -30,8 +30,8 @@ Constructor for QgsDetailedItemData.
     void setDetail( const QString &detail );
     void setCategory( const QString &category );
     void setIcon( const QPixmap &icon );
-    void setCheckable( const bool flag );
-    void setChecked( const bool flag );
+    void setCheckable( bool flag );
+    void setChecked( bool flag );
     void setEnabled( bool flag );
 
     void setRenderAsWidget( bool flag );

--- a/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
+++ b/python/gui/auto_generated/qgsprojectionselectionwidget.sip.in
@@ -46,7 +46,7 @@ Returns the currently selected CRS for the widget
 :return: current CRS
 %End
 
-    void setOptionVisible( const CrsOption option, const bool visible );
+    void setOptionVisible( CrsOption option, bool visible );
 %Docstring
 Sets whether a predefined CRS option should be shown in the widget.
 

--- a/python/gui/auto_generated/qgsratiolockbutton.sip.in
+++ b/python/gui/auto_generated/qgsratiolockbutton.sip.in
@@ -29,7 +29,7 @@ Construct a new ratio lock button.
 Use ``parent`` to attach a parent QWidget to the button.
 %End
 
-    void setLocked( const bool locked );
+    void setLocked( bool locked );
 %Docstring
 Sets whether the button state is locked.
 
@@ -79,7 +79,7 @@ from the current values of the width and height spin boxes.
 
   signals:
 
-    void lockChanged( const bool locked );
+    void lockChanged( bool locked );
 %Docstring
 Emitted whenever the lock state changes.
 %End

--- a/python/server/auto_generated/qgsfeaturefilter.sip.in
+++ b/python/server/auto_generated/qgsfeaturefilter.sip.in
@@ -28,7 +28,8 @@ A feature filter provider allowing to set filter expressions on a per-layer basi
 Constructor
 %End
 
-    void filterFeatures( const QgsVectorLayer *layer, QgsFeatureRequest &filterFeatures ) const;
+    virtual void filterFeatures( const QgsVectorLayer *layer, QgsFeatureRequest &filterFeatures ) const;
+
 %Docstring
 Filter the features of the layer
 
@@ -36,7 +37,8 @@ Filter the features of the layer
 :param filterFeatures: the request to fill
 %End
 
-    QgsFeatureFilterProvider *clone() const /Factory/;
+    virtual QgsFeatureFilterProvider *clone() const /Factory/;
+
 %Docstring
 Returns a clone of the object
 

--- a/python/server/auto_generated/qgsfeaturefilterprovidergroup.sip.in
+++ b/python/server/auto_generated/qgsfeaturefilterprovidergroup.sip.in
@@ -27,7 +27,8 @@ A filter filter provider grouping several filter providers.
 Constructor
 %End
 
-    void filterFeatures( const QgsVectorLayer *layer, QgsFeatureRequest &filterFeatures ) const;
+    virtual void filterFeatures( const QgsVectorLayer *layer, QgsFeatureRequest &filterFeatures ) const;
+
 %Docstring
 Filter the features of the layer
 
@@ -35,7 +36,8 @@ Filter the features of the layer
 :param filterFeatures: the request to fill
 %End
 
-    QgsFeatureFilterProvider *clone() const /Factory/;
+    virtual QgsFeatureFilterProvider *clone() const /Factory/;
+
 %Docstring
 Returns a clone of the object
 

--- a/src/analysis/network/qgsgraphdirector.h
+++ b/src/analysis/network/qgsgraphdirector.h
@@ -56,7 +56,7 @@ class ANALYSIS_EXPORT QgsGraphDirector : public QObject
 
   public:
 
-    ~QgsGraphDirector()
+    ~QgsGraphDirector() override
     {
       qDeleteAll( mStrategies );
     }

--- a/src/analysis/network/qgsvectorlayerdirector.h
+++ b/src/analysis/network/qgsvectorlayerdirector.h
@@ -65,7 +65,7 @@ class ANALYSIS_EXPORT QgsVectorLayerDirector : public QgsGraphDirector
                             const QString &directDirectionValue,
                             const QString &reverseDirectionValue,
                             const QString &bothDirectionValue,
-                            const Direction defaultDirection
+                            Direction defaultDirection
                           );
 
     /*

--- a/src/analysis/processing/qgsalgorithmfilter.h
+++ b/src/analysis/processing/qgsalgorithmfilter.h
@@ -39,7 +39,7 @@ class QgsFilterAlgorithm : public QgsProcessingAlgorithm
 {
   public:
     QgsFilterAlgorithm() = default;
-    ~QgsFilterAlgorithm();
+    ~QgsFilterAlgorithm() override;
 
     void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
     QString name() const override;

--- a/src/analysis/processing/qgsalgorithmtransect.h
+++ b/src/analysis/processing/qgsalgorithmtransect.h
@@ -67,7 +67,7 @@ class QgsTransectAlgorithm : public QgsProcessingAlgorithm
      * \param orientation Orientation of the transect
      * \param angle Angle of the transect relative to the segment [\a p1 - \a p2] (degrees clockwise)
      */
-    QgsGeometry calcTransect( const QgsPoint &point, const double angleAtVertex, const double length, const Side orientation, const double angle );
+    QgsGeometry calcTransect( const QgsPoint &point, double angleAtVertex, double length, Side orientation, double angle );
 };
 
 ///@endcond PRIVATE

--- a/src/analysis/raster/qgskde.h
+++ b/src/analysis/raster/qgskde.h
@@ -137,17 +137,17 @@ class ANALYSIS_EXPORT QgsKernelDensityEstimation
   private:
 
     //! Calculate the value given to a point width a given distance for a specified kernel shape
-    double calculateKernelValue( const double distance, const double bandwidth, const KernelShape shape, const OutputValues outputType ) const;
+    double calculateKernelValue( double distance, double bandwidth, KernelShape shape, OutputValues outputType ) const;
     //! Uniform kernel function
-    double uniformKernel( const double distance, const double bandwidth, const OutputValues outputType ) const;
+    double uniformKernel( double distance, double bandwidth, OutputValues outputType ) const;
     //! Quartic kernel function
-    double quarticKernel( const double distance, const double bandwidth, const OutputValues outputType ) const;
+    double quarticKernel( double distance, double bandwidth, OutputValues outputType ) const;
     //! Triweight kernel function
-    double triweightKernel( const double distance, const double bandwidth, const OutputValues outputType ) const;
+    double triweightKernel( double distance, double bandwidth, OutputValues outputType ) const;
     //! Epanechnikov kernel function
-    double epanechnikovKernel( const double distance, const double bandwidth, const OutputValues outputType ) const;
+    double epanechnikovKernel( double distance, double bandwidth, OutputValues outputType ) const;
     //! Triangular kernel function
-    double triangularKernel( const double distance, const double bandwidth, const OutputValues outputType ) const;
+    double triangularKernel( double distance, double bandwidth, OutputValues outputType ) const;
 
     QgsRectangle calculateBounds() const;
 

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -56,11 +56,11 @@ class Qgs3DMapCanvas : public QWidget
     void setViewFromTop( const QgsPointXY &center, float distance, float rotation = 0 );
 
     //! Saves the current scene as an image
-    void saveAsImage( const QString fileName, const QString fileFormat );
+    void saveAsImage( QString fileName, QString fileFormat );
 
   signals:
     //! Emitted when the 3D map canvas was successfully saved as image
-    void savedAsImage( const QString fileName );
+    void savedAsImage( QString fileName );
 
   protected:
     void resizeEvent( QResizeEvent *ev ) override;

--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -29,7 +29,7 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
     Q_OBJECT
   public:
     QgsDwgImportDialog( QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
-    ~QgsDwgImportDialog();
+    ~QgsDwgImportDialog() override;
 
   private slots:
     void buttonBox_accepted();

--- a/src/app/dwg/qgsdwgimporter.h
+++ b/src/app/dwg/qgsdwgimporter.h
@@ -30,7 +30,7 @@ class QgsDwgImporter : public DRW_Interface
 {
   public:
     QgsDwgImporter( const QString &database, const QgsCoordinateReferenceSystem &crs );
-    ~QgsDwgImporter();
+    ~QgsDwgImporter() override;
 
     bool import( const QString &drawing, QString &error, bool expandInserts, bool useCurves );
 
@@ -57,7 +57,7 @@ class QgsDwgImporter : public DRW_Interface
 
     void addBlock( const DRW_Block &data ) override;
 
-    void setBlock( const int handle ) override;
+    void setBlock( int handle ) override;
 
     //! Called to end the current block
     void endBlock() override;

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -82,7 +82,7 @@ class QgsGpsInformationWidget: public QWidget, private Ui::QgsGpsInformationWidg
     void connectGpsSlot();
     void disconnectGps();
     void populateDevices();
-    void setStatusIndicator( const FixStatus statusValue );
+    void setStatusIndicator( FixStatus statusValue );
     void showStatusBarMessage( const QString &msg );
     QgsGpsConnection *mNmea = nullptr;
     QgsMapCanvas *mpCanvas = nullptr;

--- a/src/app/layout/qgslayoutattributetablewidget.h
+++ b/src/app/layout/qgslayoutattributetablewidget.h
@@ -46,7 +46,7 @@ class QgsLayoutAttributeTableWidget: public QgsLayoutItemBaseWidget, private Ui:
 
     void toggleSourceControls();
 
-    void toggleAtlasSpecificControls( const bool atlasEnabled );
+    void toggleAtlasSpecificControls( bool atlasEnabled );
 
   private slots:
     void mRefreshPushButton_clicked();

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -59,7 +59,7 @@ class QgsAppLayoutDesignerInterface : public QgsLayoutDesignerInterface
     QgsMasterLayoutInterface *masterLayout() override;
     QgsLayoutView *view() override;
     QgsMessageBar *messageBar() override;
-    void selectItems( const QList< QgsLayoutItem * > items ) override;
+    void selectItems( QList< QgsLayoutItem * > items ) override;
 
   public slots:
 
@@ -132,7 +132,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, private Ui::QgsLayoutDesigner
     /**
      * Selects the specified \a items.
      */
-    void selectItems( const QList< QgsLayoutItem * > items );
+    void selectItems( QList< QgsLayoutItem * > items );
 
     /**
      * Returns the designer's message bar.
@@ -309,7 +309,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, private Ui::QgsLayoutDesigner
     void addPages();
     void statusMessageReceived( const QString &message );
     void dockVisibilityChanged( bool visible );
-    void undoRedoOccurredForItems( const QSet< QString > itemUuids );
+    void undoRedoOccurredForItems( QSet< QString > itemUuids );
     void saveAsTemplate();
     void addItemsFromTemplate();
     void duplicate();

--- a/src/app/layout/qgslayoutmapgridwidget.h
+++ b/src/app/layout/qgslayoutmapgridwidget.h
@@ -112,7 +112,7 @@ class QgsLayoutMapGridWidget: public QgsLayoutItemBaseWidget, private Ui::QgsLay
     //! Blocks / unblocks the signals of all GUI elements
     void blockAllSignals( bool b );
 
-    void handleChangedFrameDisplay( QgsLayoutItemMapGrid::BorderSide border, const QgsLayoutItemMapGrid::DisplayMode mode );
+    void handleChangedFrameDisplay( QgsLayoutItemMapGrid::BorderSide border, QgsLayoutItemMapGrid::DisplayMode mode );
     void handleChangedAnnotationDisplay( QgsLayoutItemMapGrid::BorderSide border, const QString &text );
     void handleChangedAnnotationPosition( QgsLayoutItemMapGrid::BorderSide border, const QString &text );
     void handleChangedAnnotationDirection( QgsLayoutItemMapGrid::BorderSide border, QgsLayoutItemMapGrid::AnnotationDirection direction );

--- a/src/app/layout/qgslayoutmapwidget.h
+++ b/src/app/layout/qgslayoutmapwidget.h
@@ -128,7 +128,7 @@ class QgsLayoutMapWidget: public QgsLayoutItemBaseWidget, private Ui::QgsLayoutM
 
     void rotationChanged( double value );
 
-    void handleChangedFrameDisplay( QgsLayoutItemMapGrid::BorderSide border, const QgsLayoutItemMapGrid::DisplayMode mode );
+    void handleChangedFrameDisplay( QgsLayoutItemMapGrid::BorderSide border, QgsLayoutItemMapGrid::DisplayMode mode );
     void handleChangedAnnotationDisplay( QgsLayoutItemMapGrid::BorderSide border, const QString &text );
     void handleChangedAnnotationPosition( QgsLayoutItemMapGrid::BorderSide border, const QString &text );
     void handleChangedAnnotationDirection( QgsLayoutItemMapGrid::BorderSide border, QgsLayoutItemMapGrid::AnnotationDirection direction );

--- a/src/app/qgsattributeactiondialog.h
+++ b/src/app/qgsattributeactiondialog.h
@@ -71,7 +71,7 @@ class APP_EXPORT QgsAttributeActionDialog: public QWidget, private Ui::QgsAttrib
 
   private:
     void insertRow( int row, const QgsAction &action );
-    void insertRow( int row, QgsAction::ActionType type, const QString &name, const QString &actionText, const QString &iconPath, bool capture, const QString &shortTitle, const QSet<QString> &actionScopes, const QString &notificationMessage, const bool isEnabledOnlyWhenEditable = false );
+    void insertRow( int row, QgsAction::ActionType type, const QString &name, const QString &actionText, const QString &iconPath, bool capture, const QString &shortTitle, const QSet<QString> &actionScopes, const QString &notificationMessage, bool isEnabledOnlyWhenEditable = false );
     void swapRows( int row1, int row2 );
     QgsAction rowToAction( int row ) const;
 

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -214,7 +214,7 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
     QString mInitFilePath;
     QString mInitCode;
 
-    QTreeWidgetItem *loadAttributeEditorTreeItem( QgsAttributeEditorElement *const widgetDef, QTreeWidgetItem *parent, DnDTree *tree );
+    QTreeWidgetItem *loadAttributeEditorTreeItem( QgsAttributeEditorElement *widgetDef, QTreeWidgetItem *parent, DnDTree *tree );
 
   private slots:
     void addTabOrGroupButton();
@@ -271,7 +271,7 @@ class DnDTree : public QTreeWidget
     // QTreeWidget interface
   protected:
     QStringList mimeTypes() const override;
-    QMimeData *mimeData( const QList<QTreeWidgetItem *> items ) const override;
+    QMimeData *mimeData( QList<QTreeWidgetItem *> items ) const override;
 
 
   private slots:

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -224,7 +224,7 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     void updateFieldFromExpressionSelected();
     void viewModeChanged( QgsAttributeForm::Mode mode );
     void formFilterSet( const QString &filter, QgsAttributeForm::FilterType type );
-    void showContextMenu( QgsActionMenu *menu, const QgsFeatureId fid );
+    void showContextMenu( QgsActionMenu *menu, QgsFeatureId fid );
 
   private:
     QMenu *mMenuActions = nullptr;
@@ -243,7 +243,7 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     QgsAttributeEditorContext mEditorContext;
 
     void updateMultiEditButtonState();
-    void deleteFeature( const QgsFeatureId fid );
+    void deleteFeature( QgsFeatureId fid );
 
     friend class TestQgsAttributeTable;
 };

--- a/src/app/qgsdatumtransformtablewidget.h
+++ b/src/app/qgsdatumtransformtablewidget.h
@@ -74,7 +74,7 @@ class APP_EXPORT QgsDatumTransformTableWidget : public QWidget, private Ui::QgsD
 
   public:
     explicit QgsDatumTransformTableWidget( QWidget *parent = 0 );
-    ~QgsDatumTransformTableWidget();
+    ~QgsDatumTransformTableWidget() override;
 
     void setTransformContext( const QgsCoordinateTransformContext &context )
     {

--- a/src/app/qgslabelpropertydialog.h
+++ b/src/app/qgslabelpropertydialog.h
@@ -66,8 +66,8 @@ class APP_EXPORT QgsLabelPropertyDialog: public QDialog, private Ui::QgsLabelPro
     void mRotationSpinBox_valueChanged( double d );
     void mFontColorButton_colorChanged( const QColor &color );
     void mBufferColorButton_colorChanged( const QColor &color );
-    void mHaliComboBox_currentIndexChanged( const int index );
-    void mValiComboBox_currentIndexChanged( const int index );
+    void mHaliComboBox_currentIndexChanged( int index );
+    void mValiComboBox_currentIndexChanged( int index );
     void mLabelTextLineEdit_textChanged( const QString &text );
 
   private:

--- a/src/app/qgsmapsavedialog.h
+++ b/src/app/qgsmapsavedialog.h
@@ -83,7 +83,7 @@ class APP_EXPORT QgsMapSaveDialog: public QDialog, private Ui::QgsMapSaveDialog
 
   private:
 
-    void lockChanged( const bool locked );
+    void lockChanged( bool locked );
     void copyToClipboard();
 
     void updateDpi( int dpi );

--- a/src/app/qgsmaptooladdrectangle.h
+++ b/src/app/qgsmaptooladdrectangle.h
@@ -34,7 +34,7 @@ class APP_EXPORT QgsMapToolAddRectangle: public QgsMapToolCapture
     void keyPressEvent( QKeyEvent *e ) override;
     void keyReleaseEvent( QKeyEvent *e ) override;
 
-    void deactivate( const bool isOriented = false );
+    void deactivate( bool isOriented = false );
 
     void activate() override;
     void clean() override;
@@ -55,18 +55,18 @@ class APP_EXPORT QgsMapToolAddRectangle: public QgsMapToolCapture
     QgsBox3d mRectangle;
 
     //! Convenient method to export a QgsRectangle to a LineString
-    QgsLineString *rectangleToLinestring( const bool isOriented = false ) const;
+    QgsLineString *rectangleToLinestring( bool isOriented = false ) const;
     //! Convenient method to export a QgsRectangle to a Polygon
-    QgsPolygon *rectangleToPolygon( const bool isOriented = false ) const;
+    QgsPolygon *rectangleToPolygon( bool isOriented = false ) const;
 
     //! Sets the azimuth. \see mAzimuth
-    void setAzimuth( const double azimuth );
+    void setAzimuth( double azimuth );
     //! Sets the first distance. \see mDistance1
-    void setDistance1( const double distance1 );
+    void setDistance1( double distance1 );
     //! Sets the second distance. \see mDistance2
-    void setDistance2( const double distance2 );
+    void setDistance2( double distance2 );
     //! Sets the side. \see mSide
-    void setSide( const int side );
+    void setSide( int side );
 
     //! Returns the azimuth. \see mAzimuth
     double azimuth( ) const { return mAzimuth; }

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -230,7 +230,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     void initDiagramTab();
 
     //! Adds a new join to mJoinTreeWidget
-    void addJoinToTreeWidget( const QgsVectorLayerJoinInfo &join, const int insertIndex = -1 );
+    void addJoinToTreeWidget( const QgsVectorLayerJoinInfo &join, int insertIndex = -1 );
 
     void updateAuxiliaryStoragePage( bool reset = false );
     void deleteAuxiliaryField( int index );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -203,7 +203,7 @@ class SelectedMatchFilter : public QgsPointLocator::MatchFilter
     explicit SelectedMatchFilter( double tol )
       : mTolerance( tol ) {}
 
-    virtual bool acceptMatch( const QgsPointLocator::Match &match )
+    bool acceptMatch( const QgsPointLocator::Match &match ) override
     {
       if ( match.distance() <= mTolerance && match.layer() && match.layer()->selectedFeatureIds().contains( match.featureId() ) )
       {

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -652,7 +652,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Password helper enabled setter
      * \note not available in Python bindings
      */
-    void setPasswordHelperEnabled( const bool enabled ) SIP_SKIP;
+    void setPasswordHelperEnabled( bool enabled ) SIP_SKIP;
 
     /**
      * Password helper logging enabled getter
@@ -664,7 +664,7 @@ class CORE_EXPORT QgsAuthManager : public QObject
      * Password helper logging enabled setter
      * \note not available in Python bindings
      */
-    void setPasswordHelperLoggingEnabled( const bool enabled ) SIP_SKIP;
+    void setPasswordHelperLoggingEnabled( bool enabled ) SIP_SKIP;
 
     /**
      * Store the password manager into the wallet

--- a/src/core/effects/qgseffectstack.h
+++ b/src/core/effects/qgseffectstack.h
@@ -101,7 +101,7 @@ class CORE_EXPORT QgsEffectStack : public QgsPaintEffect
      * transferred to the stack object.
      * \see appendEffect
      */
-    bool insertEffect( const int index, QgsPaintEffect *effect SIP_TRANSFER );
+    bool insertEffect( int index, QgsPaintEffect *effect SIP_TRANSFER );
 
     /**
      * Replaces the effect at a specified position within the stack.
@@ -109,13 +109,13 @@ class CORE_EXPORT QgsEffectStack : public QgsPaintEffect
      * \param effect QgsPaintEffect to replace with. Ownership of the effect will be
      * transferred to the stack object.
      */
-    bool changeEffect( const int index, QgsPaintEffect *effect SIP_TRANSFER );
+    bool changeEffect( int index, QgsPaintEffect *effect SIP_TRANSFER );
 
     /**
      * Removes an effect from the stack and returns a pointer to it.
      * \param index position of effect to take
      */
-    QgsPaintEffect *takeEffect( const int index SIP_TRANSFERBACK );
+    QgsPaintEffect *takeEffect( int index SIP_TRANSFERBACK );
 
     /**
      * Returns a pointer to the list of effects currently contained by

--- a/src/core/effects/qgsimageoperation.h
+++ b/src/core/effects/qgsimageoperation.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsImageOperation
      * \param image QImage to convert
      * \param mode mode to use during grayscale conversion
      */
-    static void convertToGrayscale( QImage &image, const GrayscaleMode mode = GrayscaleLuminosity );
+    static void convertToGrayscale( QImage &image, GrayscaleMode mode = GrayscaleLuminosity );
 
     /**
      * Alter the brightness or contrast of a QImage.
@@ -83,7 +83,7 @@ class CORE_EXPORT QgsImageOperation
      * to the contrast, a value of 0 represents an image with 0 contrast, and a value > 1.0 will increase the
      * contrast of the image.
      */
-    static void adjustBrightnessContrast( QImage &image, const int brightness, const double contrast );
+    static void adjustBrightnessContrast( QImage &image, int brightness, double contrast );
 
     /**
      * Alter the hue or saturation of a QImage.
@@ -93,15 +93,15 @@ class CORE_EXPORT QgsImageOperation
      * colorization.
      * \param colorizeStrength double between 0 and 1, where 0 = no colorization and 1.0 = full colorization
      */
-    static void adjustHueSaturation( QImage &image, const double saturation, const QColor &colorizeColor = QColor(),
-                                     const double colorizeStrength = 1.0 );
+    static void adjustHueSaturation( QImage &image, double saturation, const QColor &colorizeColor = QColor(),
+                                     double colorizeStrength = 1.0 );
 
     /**
      * Multiplies opacity of image pixel values by a factor.
      * \param image QImage to alter
      * \param factor factor to multiple pixel's opacity by
      */
-    static void multiplyOpacity( QImage &image, const double factor );
+    static void multiplyOpacity( QImage &image, double factor );
 
     /**
      * Overlays a color onto an image. This operation retains the alpha channel of the
@@ -158,7 +158,7 @@ class CORE_EXPORT QgsImageOperation
      * \note for fastest operation, ensure the source image is ARGB32_Premultiplied if
      * alphaOnly is set to false, or ARGB32 if alphaOnly is true
      */
-    static void stackBlur( QImage &image, const int radius, const bool alphaOnly = false );
+    static void stackBlur( QImage &image, int radius, bool alphaOnly = false );
 
     /**
      * Performs a gaussian blur on an image. Gaussian blur is slower but results in a high
@@ -168,7 +168,7 @@ class CORE_EXPORT QgsImageOperation
      * \returns blurred image
      * \note for fastest operation, ensure the source image is ARGB32_Premultiplied
      */
-    static QImage *gaussianBlur( QImage &image, const int radius ) SIP_FACTORY;
+    static QImage *gaussianBlur( QImage &image, int radius ) SIP_FACTORY;
 
     /**
      * Flips an image horizontally or vertically
@@ -294,7 +294,7 @@ class CORE_EXPORT QgsImageOperation
           : mMode( mode )
         {  }
 
-        void operator()( QRgb &rgb, const int x, const int y );
+        void operator()( QRgb &rgb, int x, int y );
 
       private:
         GrayscaleMode mMode;
@@ -312,7 +312,7 @@ class CORE_EXPORT QgsImageOperation
           , mContrast( contrast )
         {  }
 
-        void operator()( QRgb &rgb, const int x, const int y );
+        void operator()( QRgb &rgb, int x, int y );
 
       private:
         int mBrightness;
@@ -333,7 +333,7 @@ class CORE_EXPORT QgsImageOperation
           , mColorizeStrength( colorizeStrength )
         {  }
 
-        void operator()( QRgb &rgb, const int x, const int y );
+        void operator()( QRgb &rgb, int x, int y );
 
       private:
         double mSaturation; // [0, 2], 1 = no change
@@ -352,7 +352,7 @@ class CORE_EXPORT QgsImageOperation
           : mFactor( factor )
         { }
 
-        void operator()( QRgb &rgb, const int x, const int y );
+        void operator()( QRgb &rgb, int x, int y );
 
       private:
         double mFactor;
@@ -368,7 +368,7 @@ class CORE_EXPORT QgsImageOperation
         {
         }
 
-        void operator()( QRgb &rgb, const int x, const int y );
+        void operator()( QRgb &rgb, int x, int y );
 
       private:
         int mWidth;
@@ -389,7 +389,7 @@ class CORE_EXPORT QgsImageOperation
           mSpreadSquared = std::pow( mSpread, 2.0 );
         }
 
-        void operator()( QRgb &rgb, const int x, const int y );
+        void operator()( QRgb &rgb, int x, int y );
 
       private:
         int mWidth;
@@ -400,7 +400,7 @@ class CORE_EXPORT QgsImageOperation
     };
     static void distanceTransform2d( double *im, int width, int height );
     static void distanceTransform1d( double *f, int n, int *v, double *z, double *d );
-    static double maxValueInDistanceTransformArray( const double *array, const unsigned int size );
+    static double maxValueInDistanceTransformArray( const double *array, unsigned int size );
 
 
     class StackBlurLineOperation
@@ -418,7 +418,7 @@ class CORE_EXPORT QgsImageOperation
 
         LineOperationDirection direction() { return mDirection; }
 
-        void operator()( QRgb *startRef, const int lineLength, const int bytesPerLine );
+        void operator()( QRgb *startRef, int lineLength, int bytesPerLine );
 
       private:
         int mAlpha;
@@ -428,7 +428,7 @@ class CORE_EXPORT QgsImageOperation
         int mi2;
     };
 
-    static double *createGaussianKernel( const int radius );
+    static double *createGaussianKernel( int radius );
 
     class GaussianBlurOperation
     {
@@ -452,8 +452,8 @@ class CORE_EXPORT QgsImageOperation
         int mDestImageBpl;
         double *mKernel = nullptr;
 
-        inline QRgb gaussianBlurVertical( const int posy, unsigned char *sourceFirstLine, const int sourceBpl, const int height );
-        inline QRgb gaussianBlurHorizontal( const int posx, unsigned char *sourceFirstLine, const int width );
+        inline QRgb gaussianBlurVertical( int posy, unsigned char *sourceFirstLine, int sourceBpl, int height );
+        inline QRgb gaussianBlurHorizontal( int posx, unsigned char *sourceFirstLine, int width );
     };
 
     //flip
@@ -470,7 +470,7 @@ class CORE_EXPORT QgsImageOperation
 
         LineOperationDirection direction() { return mDirection; }
 
-        void operator()( QRgb *startRef, const int lineLength, const int bytesPerLine );
+        void operator()( QRgb *startRef, int lineLength, int bytesPerLine );
 
       private:
         LineOperationDirection mDirection;

--- a/src/core/effects/qgspainteffect.h
+++ b/src/core/effects/qgspainteffect.h
@@ -201,7 +201,7 @@ class CORE_EXPORT QgsPaintEffect
      * \param enabled set to false to disable the effect
      * \see enabled
      */
-    void setEnabled( const bool enabled );
+    void setEnabled( bool enabled );
 
     /**
      * Returns the draw mode for the effect. This property only has an
@@ -217,7 +217,7 @@ class CORE_EXPORT QgsPaintEffect
      * \param drawMode draw mode for effect
      * \see drawMode
      */
-    void setDrawMode( const DrawMode drawMode );
+    void setDrawMode( DrawMode drawMode );
 
   protected:
 

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -457,7 +457,7 @@ class CORE_EXPORT QgsExpression
      * for one-off evaluations only.
      * \since QGIS 2.7
      */
-    static double evaluateToDouble( const QString &text, const double fallbackValue );
+    static double evaluateToDouble( const QString &text, double fallbackValue );
 
     enum SpatialOperator
     {

--- a/src/core/geometry/qgscircle.h
+++ b/src/core/geometry/qgscircle.h
@@ -208,14 +208,14 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      * \see radius()
      * \see setRadius()
      */
-    void setSemiMajorAxis( const double semiMajorAxis ) override;
+    void setSemiMajorAxis( double semiMajorAxis ) override;
 
     /**
      * Inherited method. Use setRadius instead.
      * \see radius()
      * \see setRadius()
      */
-    void setSemiMinorAxis( const double semiMinorAxis ) override;
+    void setSemiMinorAxis( double semiMinorAxis ) override;
 
     //! Returns the radius of the circle
     double radius() const {return mSemiMajorAxis;}

--- a/src/core/geometry/qgsellipse.h
+++ b/src/core/geometry/qgsellipse.h
@@ -55,7 +55,7 @@ class CORE_EXPORT QgsEllipse
      * \param semiMinorAxis Semi-minor axis of the ellipse.
      * \param azimuth Angle in degrees started from the North to the first quadrant.
      */
-    QgsEllipse( const QgsPoint &center, const double semiMajorAxis, const double semiMinorAxis, const double azimuth = 90 );
+    QgsEllipse( const QgsPoint &center, double semiMajorAxis, double semiMinorAxis, double azimuth = 90 );
 
     /**
      * Constructs an ellipse by foci (\a pt1 and \a pt2) and a point \a pt3.
@@ -158,19 +158,19 @@ class CORE_EXPORT QgsEllipse
      * Sets the semi-major axis.
      * \see semiMajorAxis()
      */
-    virtual void setSemiMajorAxis( const double semiMajorAxis );
+    virtual void setSemiMajorAxis( double semiMajorAxis );
 
     /**
      * Sets the semi-minor axis.
      * \see semiMinorAxis()
      */
-    virtual void setSemiMinorAxis( const double semiMinorAxis );
+    virtual void setSemiMinorAxis( double semiMinorAxis );
 
     /**
      * Sets the azimuth (orientation).
      * \see azimuth()
      */
-    void setAzimuth( const double azimuth );
+    void setAzimuth( double azimuth );
 
     /**
      * The distance between the center and each foci.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1745,7 +1745,7 @@ class CORE_EXPORT QgsGeometry
      * \param maxAngle maximum angle at node (0-180) at which smoothing will be applied
      * \since QGIS 2.9
      */
-    QgsGeometry smooth( const unsigned int iterations = 1, const double offset = 0.25,
+    QgsGeometry smooth( unsigned int iterations = 1, double offset = 0.25,
                         double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 
     /**
@@ -1820,7 +1820,7 @@ class CORE_EXPORT QgsGeometry
      * \param minimumDistance minimum segment length to apply smoothing to
      * \param maxAngle maximum angle at node (0-180) at which smoothing will be applied
     */
-    std::unique_ptr< QgsLineString > smoothLine( const QgsLineString &line, const unsigned int iterations = 1, const double offset = 0.25,
+    std::unique_ptr< QgsLineString > smoothLine( const QgsLineString &line, unsigned int iterations = 1, double offset = 0.25,
         double minimumDistance = -1, double maxAngle = 180.0 ) const;
 
     /**
@@ -1834,7 +1834,7 @@ class CORE_EXPORT QgsGeometry
      * \param minimumDistance minimum segment length to apply smoothing to
      * \param maxAngle maximum angle at node (0-180) at which smoothing will be applied
     */
-    std::unique_ptr< QgsPolygon > smoothPolygon( const QgsPolygon &polygon, const unsigned int iterations = 1, const double offset = 0.25,
+    std::unique_ptr< QgsPolygon > smoothPolygon( const QgsPolygon &polygon, unsigned int iterations = 1, double offset = 0.25,
         double minimumDistance = -1, double maxAngle = 180.0 ) const;
 
 

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsGeometryUtils
      *   # (True, 'Point (0 0)', True)
      * \endcode
      */
-    static bool segmentIntersection( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint &q1, const QgsPoint &q2, QgsPoint &intersectionPoint SIP_OUT, bool &isIntersection SIP_OUT, const double tolerance = 1e-8, bool acceptImproperIntersection = false );
+    static bool segmentIntersection( const QgsPoint &p1, const QgsPoint &p2, const QgsPoint &q1, const QgsPoint &q2, QgsPoint &intersectionPoint SIP_OUT, bool &isIntersection SIP_OUT, double tolerance = 1e-8, bool acceptImproperIntersection = false );
 
     /**
      * \brief Compute the intersection of a line and a circle.
@@ -151,7 +151,7 @@ class CORE_EXPORT QgsGeometryUtils
      * \param intersection the initial point and the returned intersection point
      * \return true if an intersection has been found
      */
-    static bool lineCircleIntersection( const QgsPointXY &center, const double radius,
+    static bool lineCircleIntersection( const QgsPointXY &center, double radius,
                                         const QgsPointXY &linePoint1, const QgsPointXY &linePoint2,
                                         QgsPointXY &intersection SIP_INOUT );
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -230,7 +230,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     bool isEmpty() const override;
     QgsLineString *snappedToGrid( double hSpacing, double vSpacing, double dSpacing = 0, double mSpacing = 0 ) const override SIP_FACTORY;
     bool removeDuplicateNodes( double epsilon = 4 * DBL_EPSILON, bool useZValues = false ) override;
-    virtual QPolygonF asQPolygonF() const override;
+    QPolygonF asQPolygonF() const override;
 
     bool fromWkb( QgsConstWkbPtr &wkb ) override;
     bool fromWkt( const QString &wkt ) override;

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -232,25 +232,25 @@ class CORE_EXPORT QgsRectangle
      * Returns a rectangle offset from this one in the direction of the reversed vector.
      * \since QGIS 3.0
      */
-    QgsRectangle operator-( const QgsVector v ) const;
+    QgsRectangle operator-( QgsVector v ) const;
 
     /**
      * Returns a rectangle offset from this one in the direction of the vector.
      * \since QGIS 3.0
      */
-    QgsRectangle operator+( const QgsVector v ) const;
+    QgsRectangle operator+( QgsVector v ) const;
 
     /**
      * Moves this rectangle in the direction of the reversed vector.
      * \since QGIS 3.0
      */
-    QgsRectangle &operator-=( const QgsVector v );
+    QgsRectangle &operator-=( QgsVector v );
 
     /**
      * Moves this rectangle in the direction of the vector.
      * \since QGIS 3.0
      */
-    QgsRectangle &operator+=( const QgsVector v );
+    QgsRectangle &operator+=( QgsVector v );
 
     /**
      * Returns true if the rectangle is empty.

--- a/src/core/geometry/qgsregularpolygon.h
+++ b/src/core/geometry/qgsregularpolygon.h
@@ -65,7 +65,7 @@ class CORE_EXPORT QgsRegularPolygon
      * \param numberSides Number of sides of the regular polygon.
      * \param circle Option to create the polygon. \see ConstructionOption
      */
-    QgsRegularPolygon( const QgsPoint &center, const double radius, const double azimuth, const unsigned int numberSides, const ConstructionOption circle );
+    QgsRegularPolygon( const QgsPoint &center, double radius, double azimuth, unsigned int numberSides, ConstructionOption circle );
 
     /**
      * Constructs a regular polygon by \a center and another point.
@@ -74,7 +74,7 @@ class CORE_EXPORT QgsRegularPolygon
      * \param numberSides Number of sides of the regular polygon.
      * \param circle Option to create the polygon inscribed in circle (the radius is the distance between the center and vertices) or circumscribed about circle (the radius is the distance from the center to the midpoints of the sides).
      */
-    QgsRegularPolygon( const QgsPoint &center, const QgsPoint &pt1, const unsigned int numberSides, const ConstructionOption circle );
+    QgsRegularPolygon( const QgsPoint &center, const QgsPoint &pt1, unsigned int numberSides, ConstructionOption circle );
 
     /**
      * Constructs a regular polygon by two points of the first side.
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsRegularPolygon
      * \param pt2 The second vertex of the first side.
      * \param numberSides Number of sides of the regular polygon.
      */
-    QgsRegularPolygon( const QgsPoint &pt1, const QgsPoint &pt2, const unsigned int numberSides );
+    QgsRegularPolygon( const QgsPoint &pt1, const QgsPoint &pt2, unsigned int numberSides );
 
     bool operator ==( const QgsRegularPolygon &rp ) const;
     bool operator !=( const QgsRegularPolygon &rp ) const;
@@ -135,7 +135,7 @@ class CORE_EXPORT QgsRegularPolygon
      * Center is unchanged. The first vertex is reprojected from the center with the new radius.
      * \see radius()
      */
-    void setRadius( const double radius );
+    void setRadius( double radius );
 
     /**
      * Sets the first vertex.
@@ -149,7 +149,7 @@ class CORE_EXPORT QgsRegularPolygon
      * If numberSides < 3, the number of sides is unchanged.
      * \see numberSides()
      */
-    void setNumberSides( const unsigned int numberSides );
+    void setNumberSides( unsigned int numberSides );
 
     /**
      * Returns a list including the vertices of the regular polygon.
@@ -231,17 +231,17 @@ class CORE_EXPORT QgsRegularPolygon
     /**
      * Convenient method to convert an apothem to a radius.
      */
-    double apothemToRadius( const double apothem, const unsigned int numberSides ) const;
+    double apothemToRadius( double apothem, unsigned int numberSides ) const;
 
     /**
      * Convenient method for interiorAngle used by constructors.
      */
-    double interiorAngle( const unsigned int nbSides ) const;
+    double interiorAngle( unsigned int nbSides ) const;
 
     /**
      * Convenient method for centralAngle used by constructors.
      */
-    double centralAngle( const unsigned int nbSides ) const;
+    double centralAngle( unsigned int nbSides ) const;
 
 };
 

--- a/src/core/geometry/qgstriangle.h
+++ b/src/core/geometry/qgstriangle.h
@@ -57,7 +57,7 @@ class CORE_EXPORT QgsTriangle : public QgsPolygon
      * \param p2 second point
      * \param p3 third point
      */
-    explicit QgsTriangle( const QPointF p1, const QPointF p2, const QPointF p3 );
+    explicit QgsTriangle( QPointF p1, QPointF p2, QPointF p3 );
 
     bool operator==( const QgsTriangle &other ) const;
     bool operator!=( const QgsTriangle &other ) const;

--- a/src/core/layout/qgscompositionconverter.h
+++ b/src/core/layout/qgscompositionconverter.h
@@ -223,7 +223,7 @@ class CORE_EXPORT QgsCompositionConverter
     static void readOldDataDefinedPropertyMap( const QDomElement &itemElem,
         QgsPropertyCollection &dataDefinedProperties );
 
-    static QgsProperty readOldDataDefinedProperty( const DataDefinedProperty property, const QDomElement &ddElem );
+    static QgsProperty readOldDataDefinedProperty( DataDefinedProperty property, const QDomElement &ddElem );
 
     static void initPropertyDefinitions();
 

--- a/src/core/layout/qgslayout.h
+++ b/src/core/layout/qgslayout.h
@@ -166,7 +166,7 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
      * If \a includeLockedItems is set to true, then locked items will also be included
      * in the returned list.
      */
-    QList<QgsLayoutItem *> selectedLayoutItems( const bool includeLockedItems = true );
+    QList<QgsLayoutItem *> selectedLayoutItems( bool includeLockedItems = true );
 
     /**
      * Clears any selected items and sets \a item as the current selection.
@@ -241,7 +241,7 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
      * z order list. This should be called after any stacking changes
      * which deferred z-order updates.
      */
-    void updateZValues( const bool addUndoCommands = true );
+    void updateZValues( bool addUndoCommands = true );
 
     /**
      * Returns the layout item with matching \a uuid unique identifier, or a nullptr
@@ -304,13 +304,13 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
      * Returns the topmost layout item at a specified \a position. Ignores paper items.
      * If \a ignoreLocked is set to true any locked items will be ignored.
      */
-    QgsLayoutItem *layoutItemAt( QPointF position, const bool ignoreLocked = false ) const;
+    QgsLayoutItem *layoutItemAt( QPointF position, bool ignoreLocked = false ) const;
 
     /**
      * Returns the topmost layout item at a specified \a position which is below a specified \a item. Ignores paper items.
      * If \a ignoreLocked is set to true any locked items will be ignored.
      */
-    QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, const bool ignoreLocked = false ) const;
+    QgsLayoutItem *layoutItemAt( QPointF position, const QgsLayoutItem *belowItem, bool ignoreLocked = false ) const;
 
     /**
      * Sets the native measurement \a units for the layout. These also form the default unit
@@ -357,7 +357,7 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
      * \see convertToLayoutUnits()
      * \see units()
     */
-    QgsLayoutMeasurement convertFromLayoutUnits( const double length, const QgsUnitTypes::LayoutUnit unit ) const;
+    QgsLayoutMeasurement convertFromLayoutUnits( double length, QgsUnitTypes::LayoutUnit unit ) const;
 
     /**
      * Converts a \a size from the layout's native units to a specified target \a unit.
@@ -365,7 +365,7 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
      * \see convertToLayoutUnits()
      * \see units()
     */
-    QgsLayoutSize convertFromLayoutUnits( const QSizeF &size, const QgsUnitTypes::LayoutUnit unit ) const;
+    QgsLayoutSize convertFromLayoutUnits( const QSizeF &size, QgsUnitTypes::LayoutUnit unit ) const;
 
     /**
      * Converts a \a point from the layout's native units to a specified target \a unit.
@@ -373,7 +373,7 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
      * \see convertToLayoutUnits()
      * \see units()
     */
-    QgsLayoutPoint convertFromLayoutUnits( const QPointF &point, const QgsUnitTypes::LayoutUnit unit ) const;
+    QgsLayoutPoint convertFromLayoutUnits( const QPointF &point, QgsUnitTypes::LayoutUnit unit ) const;
 
     /**
      * Returns a reference to the layout's render context, which stores information relating to the

--- a/src/core/layout/qgslayoutframe.h
+++ b/src/core/layout/qgslayoutframe.h
@@ -87,7 +87,7 @@ class CORE_EXPORT QgsLayoutFrame: public QgsLayoutItem
      * \param hidePageIfEmpty set to true if page should be hidden if frame is empty
      * \see hidePageIfEmpty()
      */
-    void setHidePageIfEmpty( const bool hidePageIfEmpty );
+    void setHidePageIfEmpty( bool hidePageIfEmpty );
 
     /**
      * Returns whether the background and frame stroke should be hidden if this frame is empty
@@ -101,7 +101,7 @@ class CORE_EXPORT QgsLayoutFrame: public QgsLayoutItem
      * \param hideBackgroundIfEmpty set to true if background and stroke should be hidden if frame is empty
      * \see hideBackgroundIfEmpty()
      */
-    void setHideBackgroundIfEmpty( const bool hideBackgroundIfEmpty );
+    void setHideBackgroundIfEmpty( bool hideBackgroundIfEmpty );
 
     /**
      * Returns whether the frame is empty.

--- a/src/core/layout/qgslayoutgridsettings.h
+++ b/src/core/layout/qgslayoutgridsettings.h
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsLayoutGridSettings : public QgsLayoutSerializableObject
      * \see offset()
      * \see setResolution()
      */
-    void setOffset( const QgsLayoutPoint offset );
+    void setOffset( QgsLayoutPoint offset );
 
     /**
      * Returns the offset of the page/snap grid.

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -351,14 +351,14 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
      * on a QgsLayoutItem, as some item types (e.g., groups) need to override
      * the visibility toggle.
      */
-    virtual void setVisibility( const bool visible );
+    virtual void setVisibility( bool visible );
 
     /**
      * Sets whether the item is \a locked, preventing mouse interactions with the item.
      * \see isLocked()
      * \see lockChanged()
      */
-    void setLocked( const bool locked );
+    void setLocked( bool locked );
 
     /**
      * Returns true if the item is locked, and cannot be interacted with using the mouse.
@@ -668,7 +668,7 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
      * \see setFrameStrokeWidth()
      * \see setFrameStrokeColor()
      */
-    void setFrameJoinStyle( const Qt::PenJoinStyle style );
+    void setFrameJoinStyle( Qt::PenJoinStyle style );
 
     /**
      * Returns true if the item has a background.
@@ -709,7 +709,7 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
      * Sets the item's composition blending \a mode.
      * \see blendMode()
      */
-    void setBlendMode( const QPainter::CompositionMode mode );
+    void setBlendMode( QPainter::CompositionMode mode );
 
     /**
      * Returns the item's opacity. This method should be used instead of
@@ -861,7 +861,7 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
      * QgsLayoutObject::AllProperties then all data defined properties for the item will be
      * refreshed.
     */
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 
     /**
      * Sets the layout item's \a rotation, in degrees clockwise.
@@ -879,7 +879,7 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
      * \see setItemRotation()
      * \see itemRotation()
     */
-    virtual void rotateItem( const double angle, const QPointF &transformOrigin );
+    virtual void rotateItem( double angle, const QPointF &transformOrigin );
 
   signals:
 
@@ -1134,9 +1134,9 @@ class CORE_EXPORT QgsLayoutItem : public QgsLayoutObject, public QGraphicsRectIt
     QSizeF applyFixedSize( const QSizeF &targetSize );
     QgsLayoutPoint applyDataDefinedPosition( const QgsLayoutPoint &position );
 
-    double applyDataDefinedRotation( const double rotation );
+    double applyDataDefinedRotation( double rotation );
     void updateStoredItemPosition();
-    QPointF itemPositionAtReferencePoint( const ReferencePoint reference, const QSizeF &size ) const;
+    QPointF itemPositionAtReferencePoint( ReferencePoint reference, const QSizeF &size ) const;
     void setScenePos( const QPointF &destinationPos );
     bool shouldBlockUndoCommands() const;
 

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -292,7 +292,7 @@ class CORE_EXPORT QgsLayoutItemAttributeTable: public QgsLayoutTable
     QgsExpressionContext createExpressionContext() const override;
     void finalizeRestoreFromXml() override;
 
-    void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
+    void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
 
   protected:
 

--- a/src/core/layout/qgslayoutitemgroup.h
+++ b/src/core/layout/qgslayoutitemgroup.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsLayoutItemGroup: public QgsLayoutItem
     QList<QgsLayoutItem *> items() const;
 
     //overridden to also hide grouped items
-    void setVisibility( const bool visible ) override;
+    void setVisibility( bool visible ) override;
 
     //overridden to move child items
     void attemptMove( const QgsLayoutPoint &point, bool useReferencePoint = true, bool includesFrame = false, int page = -1 ) override;

--- a/src/core/layout/qgslayoutitemhtml.h
+++ b/src/core/layout/qgslayoutitemhtml.h
@@ -193,7 +193,7 @@ class CORE_EXPORT QgsLayoutItemHtml: public QgsLayoutMultiFrame
      * \see userStylesheetEnabled()
      * \see setUserStylesheet()
      */
-    void setUserStylesheetEnabled( const bool enabled );
+    void setUserStylesheetEnabled( bool enabled );
 
     /**
      * Returns whether user stylesheets are enabled for the HTML content.
@@ -219,12 +219,12 @@ class CORE_EXPORT QgsLayoutItemHtml: public QgsLayoutMultiFrame
      * \see setUrl
      * \see url
      */
-    void loadHtml( const bool useCache = false, const QgsExpressionContext *context = nullptr );
+    void loadHtml( bool useCache = false, const QgsExpressionContext *context = nullptr );
 
     //! Recalculates the frame sizes for the current viewport dimensions
     void recalculateFrameSizes() override;
 
-    void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
+    void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
 
   protected:
 

--- a/src/core/layout/qgslayoutitemlegend.h
+++ b/src/core/layout/qgslayoutitemlegend.h
@@ -439,7 +439,7 @@ class CORE_EXPORT QgsLayoutItemLegend : public QgsLayoutItem
   public slots:
 
     void refresh() override;
-    void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
+    void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
 
   protected:
     void draw( QgsLayoutItemRenderContext &context ) override;

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -358,7 +358,7 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
      * \see atlasScalingMode
      * \see setAtlasMargin
      */
-    double atlasMargin( const QgsLayoutObject::PropertyValueType valueType = QgsLayoutObject::EvaluatedValue );
+    double atlasMargin( QgsLayoutObject::PropertyValueType valueType = QgsLayoutObject::EvaluatedValue );
 
     /**
      * Sets the margin size (percentage) used when the map is in atlas mode.
@@ -474,7 +474,7 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
     //! Updates the bounding rect of this item. Call this function before doing any changes related to annotation out of the map rectangle
     void updateBoundingRect();
 
-    void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
+    void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
 
   private slots:
     void layersAboutToBeRemoved( const QList<QgsMapLayer *> &layers );

--- a/src/core/layout/qgslayoutitemmapgrid.h
+++ b/src/core/layout/qgslayoutitemmapgrid.h
@@ -363,7 +363,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * \see setOffsetY()
      * \see offsetX()
      */
-    void setOffsetX( const double offset );
+    void setOffsetX( double offset );
 
     /**
      * Returns the offset for grid lines in the x-direction. The units
@@ -379,7 +379,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * \see setOffsetX()
      * \see offsetY()
      */
-    void setOffsetY( const double offset );
+    void setOffsetY( double offset );
 
     /**
      * Returns the offset for grid lines in the y-direction. The units
@@ -398,7 +398,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * over the map's contents.
      * \see style()
      */
-    void setStyle( const GridStyle style );
+    void setStyle( GridStyle style );
 
     /**
      * Returns the grid's style, which controls how the grid is drawn
@@ -428,7 +428,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * \see setLineSymbol()
      * \see setGridLineColor()
      */
-    void setGridLineWidth( const double width );
+    void setGridLineWidth( double width );
 
     /**
      * Sets the \a color of grid lines. This is only used for grids with QgsLayoutItemMapGrid::Solid
@@ -558,7 +558,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * \param border side of map for annotations
      * \see annotationDisplay()
      */
-    void setAnnotationDisplay( const DisplayMode display, const BorderSide border );
+    void setAnnotationDisplay( DisplayMode display, BorderSide border );
 
     /**
      * Returns the display mode for the grid annotations on a specified side of the map
@@ -568,21 +568,21 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * \returns display mode for grid annotations
      * \see setAnnotationDisplay()
      */
-    DisplayMode annotationDisplay( const BorderSide border ) const;
+    DisplayMode annotationDisplay( BorderSide border ) const;
 
     /**
      * Sets the \a position for the grid annotations on a specified \a side of the map
      * frame.
      * \see annotationPosition()
      */
-    void setAnnotationPosition( const AnnotationPosition position, const BorderSide side );
+    void setAnnotationPosition( AnnotationPosition position, BorderSide side );
 
     /**
      * Returns the position for the grid annotations on a specified \a side of the map
      * frame.
      * \see setAnnotationPosition()
      */
-    AnnotationPosition annotationPosition( const BorderSide side ) const;
+    AnnotationPosition annotationPosition( BorderSide side ) const;
 
     /**
      * Sets the \a distance between the map frame and annotations. Units are layout units.
@@ -600,20 +600,20 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * Sets the \a direction for drawing frame annotations for the specified map \a side.
      * \see annotationDirection()
      */
-    void setAnnotationDirection( const AnnotationDirection direction, const BorderSide side );
+    void setAnnotationDirection( AnnotationDirection direction, BorderSide side );
 
     /**
      * Sets the \a direction for drawing all frame annotations.
      * \see annotationDirection()
      */
-    void setAnnotationDirection( const AnnotationDirection direction );
+    void setAnnotationDirection( AnnotationDirection direction );
 
     /**
      * Returns the direction for drawing frame annotations, on the specified \a side
      * of the map.
      * \see setAnnotationDirection()
      */
-    AnnotationDirection annotationDirection( const BorderSide border ) const;
+    AnnotationDirection annotationDirection( BorderSide border ) const;
 
     /**
      * Sets the \a format for drawing grid annotations.
@@ -661,13 +661,13 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * Sets what type of grid \a divisions should be used for frames on a specified \a side of the map.
      * \see frameDivisions()
      */
-    void setFrameDivisions( const DisplayMode divisions, const BorderSide side );
+    void setFrameDivisions( DisplayMode divisions, BorderSide side );
 
     /**
      * Returns the type of grid divisions which are used for frames on a specified \a side of the map.
      * \see setFrameDivisions()
      */
-    DisplayMode frameDivisions( const BorderSide side ) const;
+    DisplayMode frameDivisions( BorderSide side ) const;
 
     /**
      * Sets \a flags for grid frame sides. Setting these flags controls which sides
@@ -686,7 +686,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * \see frameSideFlags()
      * \see testFrameSideFlag()
      */
-    void setFrameSideFlag( const QgsLayoutItemMapGrid::FrameSideFlag flag, bool on = true );
+    void setFrameSideFlag( QgsLayoutItemMapGrid::FrameSideFlag flag, bool on = true );
 
     /**
      * Returns the flags which control which sides of the map item the grid frame
@@ -706,7 +706,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * \see setFrameSideFlag()
      * \see frameSideFlags()
      */
-    bool testFrameSideFlag( const FrameSideFlag flag ) const;
+    bool testFrameSideFlag( FrameSideFlag flag ) const;
 
     /**
      * Sets the grid frame \a width (in layout units). This property controls how wide the grid frame is.
@@ -921,7 +921,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * Draw an annotation. If optional extension argument is specified, nothing will be drawn and instead
      * the extension of the annotation outside of the map frame will be stored in this variable.
      */
-    void drawCoordinateAnnotation( QPainter *p, QPointF pos, const QString &annotationString, const AnnotationCoordinate coordinateType, GridExtension *extension = nullptr ) const;
+    void drawCoordinateAnnotation( QPainter *p, QPointF pos, const QString &annotationString, AnnotationCoordinate coordinateType, GridExtension *extension = nullptr ) const;
 
     /**
      * Draws a single annotation
@@ -966,14 +966,14 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
      * \param p point
      * \param coordinateType coordinate type
      */
-    BorderSide borderForLineCoord( QPointF p, const AnnotationCoordinate coordinateType ) const;
+    BorderSide borderForLineCoord( QPointF p, AnnotationCoordinate coordinateType ) const;
 
     //! Gets parameters for drawing grid in CRS different to map CRS
     int crsGridParams( QgsRectangle &crsRect, QgsCoordinateTransform &inverseTransform ) const;
 
     static QList<QPolygonF> trimLinesToMap( const QPolygonF &line, const QgsRectangle &rect );
 
-    QPolygonF scalePolygon( const QPolygonF &polygon, const double scale ) const;
+    QPolygonF scalePolygon( const QPolygonF &polygon, double scale ) const;
 
     //! Draws grid if CRS is different to map CRS
     void drawGridCrsTransform( QgsRenderContext &context, double dotsPerMM, QList< QPair< double, QLineF > > &horizontalLines,

--- a/src/core/layout/qgslayoutitemmapoverview.h
+++ b/src/core/layout/qgslayoutitemmapoverview.h
@@ -92,7 +92,7 @@ class CORE_EXPORT QgsLayoutItemMapOverviewStack : public QgsLayoutItemMapItemSta
     /**
      * Returns a reference to an overview at the specified \a index within the stack.
      */
-    QgsLayoutItemMapOverview *overview( const int index ) const;
+    QgsLayoutItemMapOverview *overview( int index ) const;
 
     /**
      * Returns a reference to an overview at the specified \a index within the stack.
@@ -177,7 +177,7 @@ class CORE_EXPORT QgsLayoutItemMapOverview : public QgsLayoutItemMapItem
      * Sets the blending \a mode used for drawing the overview.
      * \see blendMode()
      */
-    void setBlendMode( const QPainter::CompositionMode mode );
+    void setBlendMode( QPainter::CompositionMode mode );
 
     /**
      * Returns whether the overview frame is inverted, ie, whether the shaded area is drawn outside
@@ -191,7 +191,7 @@ class CORE_EXPORT QgsLayoutItemMapOverview : public QgsLayoutItemMapItem
      * the extent of the overview map.
      * \see inverted()
      */
-    void setInverted( const bool inverted );
+    void setInverted( bool inverted );
 
     /**
      * Returns whether the extent of the map is forced to center on the overview.
@@ -203,7 +203,7 @@ class CORE_EXPORT QgsLayoutItemMapOverview : public QgsLayoutItemMapItem
      * Sets whether the extent of the map is forced to center on the overview
      * \see centered()
      */
-    void setCentered( const bool centered );
+    void setCentered( bool centered );
 
     /**
      * Reconnects signals for overview map, so that overview correctly follows changes to source

--- a/src/core/layout/qgslayoutitemnodeitem.h
+++ b/src/core/layout/qgslayoutitemnodeitem.h
@@ -138,10 +138,10 @@ class CORE_EXPORT QgsLayoutNodesItem: public QgsLayoutItem
     double mMaxSymbolBleed = 0.0;
 
     //! Method called in addNode.
-    virtual bool _addNode( const int nodeIndex, QPointF newNode, const double radius ) = 0;
+    virtual bool _addNode( int nodeIndex, QPointF newNode, double radius ) = 0;
 
     //! Method called in removeNode.
-    virtual bool _removeNode( const int nodeIndex ) = 0;
+    virtual bool _removeNode( int nodeIndex ) = 0;
 
     //! Method called in paint.
     virtual void _draw( QgsLayoutItemRenderContext &context, const QStyleOptionGraphicsItem *itemStyle = nullptr ) = 0;

--- a/src/core/layout/qgslayoutitempicture.h
+++ b/src/core/layout/qgslayoutitempicture.h
@@ -258,7 +258,7 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
      */
     void recalculateSize();
 
-    void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
+    void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
     bool containsAdvancedEffects() const override;
 
   signals:

--- a/src/core/layout/qgslayoutitempolygon.h
+++ b/src/core/layout/qgslayoutitempolygon.h
@@ -69,8 +69,8 @@ class CORE_EXPORT QgsLayoutItemPolygon: public QgsLayoutNodesItem
     void setSymbol( QgsFillSymbol *symbol );
 
   protected:
-    bool _addNode( const int indexPoint, QPointF newPoint, const double radius ) override;
-    bool _removeNode( const int nodeIndex ) override;
+    bool _addNode( int indexPoint, QPointF newPoint, double radius ) override;
+    bool _removeNode( int nodeIndex ) override;
     void _draw( QgsLayoutItemRenderContext &context, const QStyleOptionGraphicsItem *itemStyle = nullptr ) override;
     void _readXmlStyle( const QDomElement &elmt, const QgsReadWriteContext &context ) override;
     void _writeXmlStyle( QDomDocument &doc, QDomElement &elmt, const QgsReadWriteContext &context ) const override;

--- a/src/core/layout/qgslayoutitempolyline.h
+++ b/src/core/layout/qgslayoutitempolyline.h
@@ -187,8 +187,8 @@ class CORE_EXPORT QgsLayoutItemPolyline: public QgsLayoutNodesItem
 
   protected:
 
-    bool _addNode( const int indexPoint, QPointF newPoint, const double radius ) override;
-    bool _removeNode( const int nodeIndex ) override;
+    bool _addNode( int indexPoint, QPointF newPoint, double radius ) override;
+    bool _removeNode( int nodeIndex ) override;
     void _draw( QgsLayoutItemRenderContext &context, const QStyleOptionGraphicsItem *itemStyle = nullptr ) override;
     void _readXmlStyle( const QDomElement &elmt, const QgsReadWriteContext &context ) override;
     void _writeXmlStyle( QDomDocument &doc, QDomElement &elmt, const QgsReadWriteContext &context ) const override;
@@ -255,7 +255,7 @@ class CORE_EXPORT QgsLayoutItemPolyline: public QgsLayoutNodesItem
      * clockwise from pointing vertical upward
      * \param arrowHeadWidth size of arrow head
      */
-    static void drawArrowHead( QPainter *p, const double x, const double y, const double angle, const double arrowHeadWidth );
+    static void drawArrowHead( QPainter *p, double x, double y, double angle, double arrowHeadWidth );
     void drawSvgMarker( QPainter *p, QPointF point, double angle, const QString &markerPath, double height ) const;
 
     double computeMarkerMargin() const;

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -436,7 +436,7 @@ class CORE_EXPORT QgsLayoutItemScaleBar: public QgsLayoutItem
      */
     void update();
 
-    void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
+    void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
     void finalizeRestoreFromXml() override;
   protected:
 

--- a/src/core/layout/qgslayoutmeasurement.h
+++ b/src/core/layout/qgslayoutmeasurement.h
@@ -39,7 +39,7 @@ class CORE_EXPORT QgsLayoutMeasurement
      * \param length measurement length
      * \param units measurement units
     */
-    explicit QgsLayoutMeasurement( const double length, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutMeasurement( double length, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 
     /**
      * Returns the length of the measurement.
@@ -84,42 +84,42 @@ class CORE_EXPORT QgsLayoutMeasurement
     /**
      * Adds a scalar value to the measurement.
      */
-    QgsLayoutMeasurement operator+( const double v ) const;
+    QgsLayoutMeasurement operator+( double v ) const;
 
     /**
      * Adds a scalar value to the measurement.
      */
-    QgsLayoutMeasurement operator+=( const double v );
+    QgsLayoutMeasurement operator+=( double v );
 
     /**
      * Subtracts a scalar value from the measurement.
      */
-    QgsLayoutMeasurement operator-( const double v ) const;
+    QgsLayoutMeasurement operator-( double v ) const;
 
     /**
      * Subtracts a scalar value from the measurement.
      */
-    QgsLayoutMeasurement operator-=( const double v );
+    QgsLayoutMeasurement operator-=( double v );
 
     /**
      * Multiplies the measurement by a scalar value.
      */
-    QgsLayoutMeasurement operator*( const double v ) const;
+    QgsLayoutMeasurement operator*( double v ) const;
 
     /**
      * Multiplies the measurement by a scalar value.
      */
-    QgsLayoutMeasurement operator*=( const double v );
+    QgsLayoutMeasurement operator*=( double v );
 
     /**
      * Divides the measurement by a scalar value.
      */
-    QgsLayoutMeasurement operator/( const double v ) const;
+    QgsLayoutMeasurement operator/( double v ) const;
 
     /**
      * Divides the measurement by a scalar value.
      */
-    QgsLayoutMeasurement operator/=( const double v );
+    QgsLayoutMeasurement operator/=( double v );
 
   private:
 

--- a/src/core/layout/qgslayoutmeasurementconverter.h
+++ b/src/core/layout/qgslayoutmeasurementconverter.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsLayoutMeasurementConverter
      * \param targetUnits units to convert measurement into
      * \returns measurement converted to target units
     */
-    QgsLayoutMeasurement convert( const QgsLayoutMeasurement &measurement, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+    QgsLayoutMeasurement convert( const QgsLayoutMeasurement &measurement, QgsUnitTypes::LayoutUnit targetUnits ) const;
 
     /**
      * Converts a layout size from one unit to another.
@@ -74,7 +74,7 @@ class CORE_EXPORT QgsLayoutMeasurementConverter
      * \param targetUnits units to convert size into
      * \returns size converted to target units
     */
-    QgsLayoutSize convert( const QgsLayoutSize &size, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+    QgsLayoutSize convert( const QgsLayoutSize &size, QgsUnitTypes::LayoutUnit targetUnits ) const;
 
     /**
      * Converts a layout point from one unit to another.
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsLayoutMeasurementConverter
      * \param targetUnits units to convert point into
      * \returns point converted to target units
     */
-    QgsLayoutPoint convert( const QgsLayoutPoint &point, const QgsUnitTypes::LayoutUnit targetUnits ) const;
+    QgsLayoutPoint convert( const QgsLayoutPoint &point, QgsUnitTypes::LayoutUnit targetUnits ) const;
 
   private:
 

--- a/src/core/layout/qgslayoutmodel.h
+++ b/src/core/layout/qgslayoutmodel.h
@@ -249,7 +249,7 @@ class CORE_EXPORT QgsLayoutModel: public QAbstractItemModel
      * Returns the QModelIndex corresponding to a QgsLayoutItem \a item and \a column, if possible.
      * \see itemFromIndex()
      */
-    QModelIndex indexForItem( QgsLayoutItem *item, const int column = 0 );
+    QModelIndex indexForItem( QgsLayoutItem *item, int column = 0 );
 
   public slots:
 

--- a/src/core/layout/qgslayoutmultiframe.h
+++ b/src/core/layout/qgslayoutmultiframe.h
@@ -157,7 +157,7 @@ class CORE_EXPORT QgsLayoutMultiFrame: public QgsLayoutObject, public QgsLayoutU
      * \see minFrameSize()
      * \see recalculateFrameRects()
      */
-    virtual QSizeF fixedFrameSize( const int frameIndex = -1 ) const;
+    virtual QSizeF fixedFrameSize( int frameIndex = -1 ) const;
 
     /**
      * Returns the minimum size for a frames, if desired. If the minimum
@@ -169,7 +169,7 @@ class CORE_EXPORT QgsLayoutMultiFrame: public QgsLayoutObject, public QgsLayoutU
      * \see fixedFrameSize()
      * \see recalculateFrameRects()
      */
-    virtual QSizeF minFrameSize( const int frameIndex = -1 ) const;
+    virtual QSizeF minFrameSize( int frameIndex = -1 ) const;
 
     /**
      * Renders a portion of the multiframe's content into a render \a context.
@@ -358,7 +358,7 @@ class CORE_EXPORT QgsLayoutMultiFrame: public QgsLayoutObject, public QgsLayoutU
      * QgsLayoutObject::AllProperties then all data defined properties for the item will be
      * refreshed.
     */
-    virtual void refreshDataDefinedProperty( const QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
+    virtual void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties );
 
   signals:
 

--- a/src/core/layout/qgslayoutpoint.h
+++ b/src/core/layout/qgslayoutpoint.h
@@ -43,18 +43,18 @@ class CORE_EXPORT QgsLayoutPoint
     /**
      * Constructor for QgsLayoutPoint.
     */
-    QgsLayoutPoint( const double x, const double y, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    QgsLayoutPoint( double x, double y, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 
     /**
      * Constructor for QgsLayoutPoint.
     */
-    explicit QgsLayoutPoint( const QPointF point, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutPoint( QPointF point, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 
     /**
      * Constructor for an empty point, where both x and y are set to 0.
      * \param units units for measurement
     */
-    explicit QgsLayoutPoint( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutPoint( QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 
     /**
      * Sets new x and y coordinates for the point.
@@ -137,22 +137,22 @@ class CORE_EXPORT QgsLayoutPoint
     /**
      * Multiplies the x and y by a scalar value.
      */
-    QgsLayoutPoint operator*( const double v ) const;
+    QgsLayoutPoint operator*( double v ) const;
 
     /**
      * Multiplies the x and y by a scalar value.
      */
-    QgsLayoutPoint operator*=( const double v );
+    QgsLayoutPoint operator*=( double v );
 
     /**
      * Divides the x and y by a scalar value.
      */
-    QgsLayoutPoint operator/( const double v ) const;
+    QgsLayoutPoint operator/( double v ) const;
 
     /**
      * Divides the x and y by a scalar value.
      */
-    QgsLayoutPoint operator/=( const double v );
+    QgsLayoutPoint operator/=( double v );
 
   private:
 

--- a/src/core/layout/qgslayoutrendercontext.h
+++ b/src/core/layout/qgslayoutrendercontext.h
@@ -59,7 +59,7 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
      * \see flags()
      * \see testFlag()
      */
-    void setFlags( const QgsLayoutRenderContext::Flags flags );
+    void setFlags( QgsLayoutRenderContext::Flags flags );
 
     /**
      * Enables or disables a particular rendering \a flag for the layout. Other existing
@@ -68,7 +68,7 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
      * \see flags()
      * \see testFlag()
      */
-    void setFlag( const QgsLayoutRenderContext::Flag flag, const bool on = true );
+    void setFlag( QgsLayoutRenderContext::Flag flag, bool on = true );
 
     /**
      * Returns the current combination of flags used for rendering the layout.
@@ -84,7 +84,7 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
      * \see setFlag()
      * \see flags()
      */
-    bool testFlag( const Flag flag ) const;
+    bool testFlag( Flag flag ) const;
 
     /**
      * Returns the combination of render context flags matched to the layout context's settings.

--- a/src/core/layout/qgslayoutsize.h
+++ b/src/core/layout/qgslayoutsize.h
@@ -47,18 +47,18 @@ class CORE_EXPORT QgsLayoutSize
      * \param height height
      * \param units units for width and height
     */
-    QgsLayoutSize( const double width, const double height, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    QgsLayoutSize( double width, double height, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 
     /**
      * Constructor for QgsLayoutSize.
     */
-    explicit QgsLayoutSize( const QSizeF size, const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutSize( QSizeF size, QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 
     /**
      * Constructor for an empty layout size
      * \param units units for measurement
     */
-    explicit QgsLayoutSize( const QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
+    explicit QgsLayoutSize( QgsUnitTypes::LayoutUnit units = QgsUnitTypes::LayoutMillimeters );
 
     /**
      * Sets new \a width and \a height for the size.
@@ -141,22 +141,22 @@ class CORE_EXPORT QgsLayoutSize
     /**
      * Multiplies the width and height by a scalar value.
      */
-    QgsLayoutSize operator*( const double v ) const;
+    QgsLayoutSize operator*( double v ) const;
 
     /**
      * Multiplies the width and height by a scalar value.
      */
-    QgsLayoutSize operator*=( const double v );
+    QgsLayoutSize operator*=( double v );
 
     /**
      * Divides the width and height by a scalar value.
      */
-    QgsLayoutSize operator/( const double v ) const;
+    QgsLayoutSize operator/( double v ) const;
 
     /**
      * Divides the width and height by a scalar value.
      */
-    QgsLayoutSize operator/=( const double v );
+    QgsLayoutSize operator/=( double v );
 
   private:
 

--- a/src/core/layout/qgslayoutsnapper.h
+++ b/src/core/layout/qgslayoutsnapper.h
@@ -50,7 +50,7 @@ class CORE_EXPORT QgsLayoutSnapper: public QgsLayoutSerializableObject
      * Sets the snap \a tolerance (in pixels) to use when snapping.
      * \see snapTolerance()
      */
-    void setSnapTolerance( const int snapTolerance );
+    void setSnapTolerance( int snapTolerance );
 
     /**
      * Returns the snap tolerance (in pixels) to use when snapping.

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -173,7 +173,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * Sets the \a margin distance in mm between cell borders and their contents.
      * \see cellMargin()
      */
-    void setCellMargin( const double margin );
+    void setCellMargin( double margin );
 
     /**
      * Returns the margin distance between cell borders and their contents in mm.
@@ -185,7 +185,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * Sets the behavior \a mode for empty tables with no content rows.
      * \see emptyTableBehavior()
      */
-    void setEmptyTableBehavior( const EmptyTableMode mode );
+    void setEmptyTableBehavior( EmptyTableMode mode );
 
     /**
      * Returns the behavior mode for empty tables. This property controls
@@ -217,7 +217,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * \param showEmpty set to true to show empty rows in the table
      * \see showEmptyRows()
      */
-    void setShowEmptyRows( const bool showEmpty );
+    void setShowEmptyRows( bool showEmpty );
 
     /**
      * Returns whether empty rows are drawn in the table.
@@ -259,7 +259,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * Sets the horizontal \a alignment for table headers.
      * \see headerHAlignment()
      */
-    void setHeaderHAlignment( const HeaderHAlignment alignment );
+    void setHeaderHAlignment( HeaderHAlignment alignment );
 
     /**
      * Returns the horizontal alignment for table headers.
@@ -272,7 +272,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * if and where headers are shown in the table.
      * \see headerMode()
      */
-    void setHeaderMode( const HeaderMode mode );
+    void setHeaderMode( HeaderMode mode );
 
     /**
      * Returns the display mode for headers in the table. This property controls
@@ -318,7 +318,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * \see setGridStrokeWidth()
      * \see setGridColor()
      */
-    void setShowGrid( const bool showGrid );
+    void setShowGrid( bool showGrid );
 
     /**
      * Returns whether grid lines are drawn in the table
@@ -334,7 +334,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * \see setShowGrid()
      * \see setGridColor()
      */
-    void setGridStrokeWidth( const double width );
+    void setGridStrokeWidth( double width );
 
     /**
      * Returns the width of grid lines in the table in mm.
@@ -368,7 +368,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * \see setGridColor()
      * \see setVerticalGrid()
      */
-    void setHorizontalGrid( const bool horizontalGrid );
+    void setHorizontalGrid( bool horizontalGrid );
 
     /**
      * Returns whether the grid's horizontal lines are drawn in the table.
@@ -387,7 +387,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * \see setGridColor()
      * \see setHorizontalGrid()
      */
-    void setVerticalGrid( const bool verticalGrid );
+    void setVerticalGrid( bool verticalGrid );
 
     /**
      * Returns whether the grid's vertical lines are drawn in the table.
@@ -471,8 +471,8 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      */
     QgsLayoutTableContents &contents() { return mTableContents; }
 
-    QSizeF fixedFrameSize( const int frameIndex = -1 ) const override;
-    QSizeF minFrameSize( const int frameIndex = -1 ) const override;
+    QSizeF fixedFrameSize( int frameIndex = -1 ) const override;
+    QSizeF minFrameSize( int frameIndex = -1 ) const override;
 
     bool writePropertiesToElement( QDomElement &elem, QDomDocument &doc, const QgsReadWriteContext &context ) const override;
     bool readPropertiesFromElement( const QDomElement &itemElem, const QDomDocument &doc, const QgsReadWriteContext &context ) override;
@@ -613,7 +613,7 @@ class CORE_EXPORT QgsLayoutTable: public QgsLayoutMultiFrame
      * \param frameIndex index number for frame
      * \returns row range
      */
-    QPair<int, int> rowRange( const int frameIndex ) const;
+    QPair<int, int> rowRange( int frameIndex ) const;
 
     /**
      * Draws the horizontal grid lines for the table.

--- a/src/core/layout/qgslayoutundostack.h
+++ b/src/core/layout/qgslayoutundostack.h
@@ -137,7 +137,7 @@ class CORE_EXPORT QgsLayoutUndoStack : public QObject
      * Emitted when an undo or redo action has occurred, which affected a
      * set of layout \a itemUuids.
      */
-    void undoRedoOccurredForItems( const QSet< QString > itemUuids );
+    void undoRedoOccurredForItems( QSet< QString > itemUuids );
 
   private slots:
 

--- a/src/core/layout/qgslayoututils.h
+++ b/src/core/layout/qgslayoututils.h
@@ -51,7 +51,7 @@ class CORE_EXPORT QgsLayoutUtils
      * If \a allowNegative is true then angles between (-360, 360) are allowed. If false,
      * angles are converted to positive angles in the range [0, 360).
      */
-    static double normalizedAngle( const double angle, const bool allowNegative = false );
+    static double normalizedAngle( double angle, bool allowNegative = false );
 
     /**
      * Snaps an \a angle (in degrees) to its closest 45 degree angle.
@@ -97,7 +97,7 @@ class CORE_EXPORT QgsLayoutUtils
      * \param afterMax maximum value in after range
      * \returns position scaled to range specified by afterMin and afterMax
      */
-    static double relativePosition( const double position, const double beforeMin, const double beforeMax, const double afterMin, const double afterMax );
+    static double relativePosition( double position, double beforeMin, double beforeMax, double afterMin, double afterMax );
 
     /**
      * Returns a \a font where size is set in points and the size has been upscaled with FONT_WORKAROUND_SCALE
@@ -187,7 +187,7 @@ class CORE_EXPORT QgsLayoutUtils
      *
      * The \a flags parameter allows for passing Qt::TextFlags to control appearance of rendered text.
      */
-    static void drawText( QPainter *painter, const QRectF &rectangle, const QString &text, const QFont &font, const QColor &color = QColor(), const Qt::AlignmentFlag halignment = Qt::AlignLeft, const Qt::AlignmentFlag valignment = Qt::AlignTop, const int flags = Qt::TextWordWrap );
+    static void drawText( QPainter *painter, const QRectF &rectangle, const QString &text, const QFont &font, const QColor &color = QColor(), Qt::AlignmentFlag halignment = Qt::AlignLeft, Qt::AlignmentFlag valignment = Qt::AlignTop, int flags = Qt::TextWordWrap );
 
     /**
      * Calculates the largest scaled version of \a originalRect which fits within \a boundsRect, when it is rotated by
@@ -197,7 +197,7 @@ class CORE_EXPORT QgsLayoutUtils
      * \param rotation the rotation in degrees to be applied to the rectangle
      * \returns largest scaled version of the rectangle possible
      */
-    static QRectF largestRotatedRectWithinBounds( const QRectF &originalRect, const QRectF &boundsRect, const double rotation );
+    static QRectF largestRotatedRectWithinBounds( const QRectF &originalRect, const QRectF &boundsRect, double rotation );
 
     /**
      * Decodes a \a string representing a paper orientation and returns the
@@ -231,13 +231,13 @@ class CORE_EXPORT QgsLayoutUtils
      * Returns the size in mm corresponding to a font \a pointSize.
      * \see mmToPoints()
      */
-    static double pointsToMM( const double pointSize );
+    static double pointsToMM( double pointSize );
 
     /**
      * Returns the size in points corresponding to a font \a mmSize in mm.
      * \see pointsToMM()
      */
-    static double mmToPoints( const double mmSize );
+    static double mmToPoints( double mmSize );
 
     friend class TestQgsLayoutUtils;
 };

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -259,7 +259,7 @@ class CORE_EXPORT QgsMeshDataProvider: public QgsDataProvider, public QgsMeshDat
      * Returns the extent of the layer
      * \returns QgsRectangle containing the extent of the layer
      */
-    virtual QgsRectangle extent() const;
+    QgsRectangle extent() const override;
 };
 
 #endif // QGSMESHDATAPROVIDER_H

--- a/src/core/mesh/qgsmeshmemorydataprovider.h
+++ b/src/core/mesh/qgsmeshmemorydataprovider.h
@@ -72,7 +72,7 @@ class QgsMeshMemoryDataProvider: public QgsMeshDataProvider
      * \endcode
      */
     QgsMeshMemoryDataProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
-    ~QgsMeshMemoryDataProvider();
+    ~QgsMeshMemoryDataProvider() override;
 
     bool isValid() const override;
     QString name() const override;

--- a/src/core/pal/geomfunction.h
+++ b/src/core/pal/geomfunction.h
@@ -86,7 +86,7 @@ namespace pal
        * \param cHull returns the point id (id of id's vector...) whom are parts of the convex hull
        * \returns convexHull's size
        */
-      static int convexHullId( int *id, const double *const x, const double *const y, int n, int *&cHull );
+      static int convexHullId( int *id, const double *x, const double *y, int n, int *&cHull );
 
       /**
        * Returns true if the two segments intersect.

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -372,7 +372,7 @@ class CORE_EXPORT QgsProcessingFeatureSink : public QgsProxyFeatureSink
      * If \a ownsOriginalSink is true, then this object will take ownership of \a originalSink.
      */
     QgsProcessingFeatureSink( QgsFeatureSink *originalSink, const QString &sinkName, QgsProcessingContext &context, bool ownsOriginalSink = false );
-    ~QgsProcessingFeatureSink();
+    ~QgsProcessingFeatureSink() override;
     bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = nullptr ) override;
     bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = nullptr ) override;
     bool addFeatures( QgsFeatureIterator &iterator, QgsFeatureSink::Flags flags = nullptr ) override;

--- a/src/core/qgscacheindex.h
+++ b/src/core/qgscacheindex.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsAbstractCacheIndex
      * Is called, whenever a feature is removed from the cache. You should update your indexes, so
      * they become invalid in case this feature was required to successfully answer a request.
      */
-    virtual void flushFeature( const QgsFeatureId fid ) = 0;
+    virtual void flushFeature( QgsFeatureId fid ) = 0;
 
     /**
      * Sometimes, the whole cache changes its state and its easier to just withdraw everything.

--- a/src/core/qgscacheindexfeatureid.h
+++ b/src/core/qgscacheindexfeatureid.h
@@ -30,7 +30,7 @@ class CORE_EXPORT QgsCacheIndexFeatureId : public QgsAbstractCacheIndex
   public:
     QgsCacheIndexFeatureId( QgsVectorLayerCache * );
 
-    void flushFeature( const QgsFeatureId fid ) override;
+    void flushFeature( QgsFeatureId fid ) override;
     void flush() override;
     void requestCompleted( const QgsFeatureRequest &featureRequest, const QgsFeatureIds &fids ) override;
     bool getCacheIterator( QgsFeatureIterator &featureIterator, const QgsFeatureRequest &featureRequest ) override;

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -125,14 +125,14 @@ class CORE_EXPORT QgsClipper
     static void trimPolygonToBoundary( const QPolygonF &inPts, QPolygonF &outPts, const QgsRectangle &rect, Boundary b, double boundaryValue );
 
     // Determines if a point is inside or outside the given boundary
-    static bool inside( const double x, const double y, Boundary b );
+    static bool inside( double x, double y, Boundary b );
 
     static bool inside( QPointF pt, Boundary b, double val );
 
     // Calculates the intersection point between a line defined by a
     // (x1, y1), and (x2, y2) and the given boundary
-    static QgsPointXY intersect( const double x1, const double y1,
-                                 const double x2, const double y2,
+    static QgsPointXY intersect( double x1, double y1,
+                                 double x2, double y2,
                                  Boundary b );
 
     static QPointF intersectRect( QPointF pt1,

--- a/src/core/qgscolorramp.h
+++ b/src/core/qgscolorramp.h
@@ -446,7 +446,7 @@ class CORE_EXPORT QgsRandomColorRamp: public QgsColorRamp
      * \param colorCount number of unique colors
      * \since QGIS 2.5
      */
-    virtual void setTotalColorCount( const int colorCount );
+    virtual void setTotalColorCount( int colorCount );
 
     QString type() const override;
 

--- a/src/core/qgscolorschemeregistry.h
+++ b/src/core/qgscolorschemeregistry.h
@@ -100,7 +100,7 @@ class CORE_EXPORT QgsColorSchemeRegistry
      * \param flag flag to match
      * \returns list of color schemes with flag set
      */
-    QList<QgsColorScheme *> schemes( const QgsColorScheme::SchemeFlag flag ) const;
+    QList<QgsColorScheme *> schemes( QgsColorScheme::SchemeFlag flag ) const;
 
 
     /**

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -230,7 +230,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \param id The ID valid for the chosen CRS ID type
      * \param type One of the types described in CrsType
      */ // TODO QGIS 3: remove type and always use EPSG code
-    explicit QgsCoordinateReferenceSystem( const long id, CrsType type = PostgisCrsId );
+    explicit QgsCoordinateReferenceSystem( long id, CrsType type = PostgisCrsId );
 
     //! Copy constructor
     QgsCoordinateReferenceSystem( const QgsCoordinateReferenceSystem &srs );
@@ -308,7 +308,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \note We encourage you to use EPSG code, WKT or Proj4 to describe CRS's in your code
      * wherever possible. Internal QGIS CRS IDs are not guaranteed to be permanent / involatile.
      */     // TODO QGIS 3: remove type and always use EPSG code, rename to createFromEpsg
-    bool createFromId( const long id, CrsType type = PostgisCrsId );
+    bool createFromId( long id, CrsType type = PostgisCrsId );
 
     /**
      * Sets this CRS to the given OGC WMS-format Coordinate Reference Systems.
@@ -327,7 +327,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \param srid The PostGIS SRID for the desired spatial reference system.
      * \returns True on success else false
      */     // TODO QGIS 3: remove unless really necessary - let's use EPSG codes instead
-    bool createFromSrid( const long srid );
+    bool createFromSrid( long srid );
 
     /**
      * Sets this CRS using a WKT definition.
@@ -354,7 +354,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \note this method uses an internal cache. Call invalidateCache() to clear the cache.
      * \see fromSrsId()
      */
-    bool createFromSrsId( const long srsId );
+    bool createFromSrsId( long srsId );
 
     /**
      * Sets this CRS by passing it a PROJ style formatted string.
@@ -649,7 +649,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * \param srsId The srsid used for the lookup
      * \returns QString The proj4 string
      */
-    static QString proj4FromSrsId( const int srsId );
+    static QString proj4FromSrsId( int srsId );
 
     /**
      * Set the QGIS SrsId

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -214,7 +214,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * \param direction transform direction (defaults to ForwardTransform)
      * \returns transformed point
      */
-    QgsPointXY transform( const double x, const double y, TransformDirection direction = ForwardTransform ) const;
+    QgsPointXY transform( double x, double y, TransformDirection direction = ForwardTransform ) const;
 
     /**
      * Transforms a rectangle from the source CRS to the destination CRS.
@@ -229,7 +229,7 @@ class CORE_EXPORT QgsCoordinateTransform
      * crossing the 180 degree longitude line is required
      * \returns rectangle in destination CRS
      */
-    QgsRectangle transformBoundingBox( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform, const bool handle180Crossover = false ) const SIP_THROW( QgsCsException );
+    QgsRectangle transformBoundingBox( const QgsRectangle &rectangle, TransformDirection direction = ForwardTransform, bool handle180Crossover = false ) const SIP_THROW( QgsCsException );
 
     /**
      * Transforms an array of x, y and z double coordinates in place, from the source CRS to the destination CRS.

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1029,7 +1029,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * \see setMaximumScale
      * \see hasScaleBasedVisibility
      */
-    void setScaleBasedVisibility( const bool enabled );
+    void setScaleBasedVisibility( bool enabled );
 
     /**
      * Will advise the map canvas (and any other interested party) that this layer requires to be repainted.

--- a/src/core/qgsmaprenderertask.h
+++ b/src/core/qgsmaprenderertask.h
@@ -56,7 +56,7 @@ class CORE_EXPORT QgsMapRendererTask : public QgsTask
     QgsMapRendererTask( const QgsMapSettings &ms,
                         const QString &fileName,
                         const QString &fileFormat = QString( "PNG" ),
-                        const bool forceRaster = false );
+                        bool forceRaster = false );
 
     /**
      * Constructor for QgsMapRendererTask to render a map to a QPainter object.

--- a/src/core/qgsnetworkcontentfetcherregistry.h
+++ b/src/core/qgsnetworkcontentfetcherregistry.h
@@ -61,7 +61,7 @@ class CORE_EXPORT QgsFetchedContent : public QObject
       , mStatus( status )
     {}
 
-    ~QgsFetchedContent()
+    ~QgsFetchedContent() override
     {
       if ( mFile )
         mFile->close();
@@ -139,7 +139,7 @@ class CORE_EXPORT QgsNetworkContentFetcherRegistry : public QObject
     //! Create the registry for temporary downloaded files
     explicit QgsNetworkContentFetcherRegistry();
 
-    ~QgsNetworkContentFetcherRegistry();
+    ~QgsNetworkContentFetcherRegistry() override;
 
     /**
      * \brief Initialize a download for the given URL
@@ -147,7 +147,7 @@ class CORE_EXPORT QgsNetworkContentFetcherRegistry : public QObject
      * \param fetchingMode defines if the download will start immediately or shall be manually triggered
      * \note If the download starts immediately, it will not redownload any already fetched or currently fetching file.
      */
-    const QgsFetchedContent *fetch( const QString &url, const FetchingMode fetchingMode = DownloadLater );
+    const QgsFetchedContent *fetch( const QString &url, FetchingMode fetchingMode = DownloadLater );
 
 #ifndef SIP_RUN
 

--- a/src/core/qgsnetworkcontentfetchertask.h
+++ b/src/core/qgsnetworkcontentfetchertask.h
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsNetworkContentFetcherTask : public QgsTask
      */
     QgsNetworkContentFetcherTask( const QNetworkRequest &request );
 
-    ~QgsNetworkContentFetcherTask();
+    ~QgsNetworkContentFetcherTask() override;
 
     bool run() override;
     void cancel() override;

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -280,7 +280,7 @@ class CORE_EXPORT QgsRenderContext
      * \see setSelectionColor
      * \since QGIS v2.4
      */
-    void setShowSelection( const bool showSelection );
+    void setShowSelection( bool showSelection );
 
     /**
      * Returns true if the rendering optimization (geometry simplification) can be executed

--- a/src/core/qgssettings.h
+++ b/src/core/qgssettings.h
@@ -151,7 +151,7 @@ class CORE_EXPORT QgsSettings : public QObject
      * In addition, query functions such as childGroups(), childKeys(), and allKeys()
      * are based on the group. By default, no group is set.
      */
-    void beginGroup( const QString &prefix, const QgsSettings::Section section = QgsSettings::NoSection );
+    void beginGroup( const QString &prefix, QgsSettings::Section section = QgsSettings::NoSection );
     //! Resets the group to what it was before the corresponding beginGroup() call.
     void endGroup();
     //! Returns a list of all keys, including subkeys, that can be read using the QSettings object.
@@ -188,7 +188,7 @@ class CORE_EXPORT QgsSettings : public QObject
      * Sets the value of setting key to value. If the key already exists, the previous value is overwritten.
      * An optional Section argument can be used to set a value to a specific Section.
      */
-    void setValue( const QString &key, const QVariant &value, const QgsSettings::Section section = QgsSettings::NoSection );
+    void setValue( const QString &key, const QVariant &value, QgsSettings::Section section = QgsSettings::NoSection );
 
     /**
      * Returns the value for setting key. If the setting doesn't exist, it will be
@@ -198,7 +198,7 @@ class CORE_EXPORT QgsSettings : public QObject
      */
 #ifndef SIP_RUN
     QVariant value( const QString &key, const QVariant &defaultValue = QVariant(),
-                    const Section section = NoSection ) const;
+                    Section section = NoSection ) const;
 #else
     SIP_PYOBJECT value( const QString &key, const QVariant &defaultValue = QVariant(),
                         SIP_PYOBJECT type = 0,
@@ -382,7 +382,7 @@ class CORE_EXPORT QgsSettings : public QObject
      * Returns true if there exists a setting called key; returns false otherwise.
      * If a group is set using beginGroup(), key is taken to be relative to that group.
      */
-    bool contains( const QString &key, const QgsSettings::Section section = QgsSettings::NoSection ) const;
+    bool contains( const QString &key, QgsSettings::Section section = QgsSettings::NoSection ) const;
     //! Returns the path where settings written using this QSettings object are stored.
     QString fileName() const;
 
@@ -394,9 +394,9 @@ class CORE_EXPORT QgsSettings : public QObject
      */
     void sync();
     //! Removes the setting key and any sub-settings of key in a section.
-    void remove( const QString &key, const QgsSettings::Section section = QgsSettings::NoSection );
+    void remove( const QString &key, QgsSettings::Section section = QgsSettings::NoSection );
     //! Returns the sanitized and prefixed key
-    QString prefixedKey( const QString &key, const QgsSettings::Section section ) const;
+    QString prefixedKey( const QString &key, QgsSettings::Section section ) const;
     //! Removes all entries in the user settings
     void clear();
 

--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -434,7 +434,7 @@ class CORE_EXPORT QgsUnitTypes
      *
      * \since QGIS 3.0
     */
-    Q_INVOKABLE static QgsUnitTypes::LayoutUnitType unitType( const QgsUnitTypes::LayoutUnit units );
+    Q_INVOKABLE static QgsUnitTypes::LayoutUnitType unitType( QgsUnitTypes::LayoutUnit units );
 
     /**
      * Returns a translated abbreviation representing a layout \a unit (e.g. "mm").

--- a/src/core/qgsvector.h
+++ b/src/core/qgsvector.h
@@ -74,19 +74,19 @@ class CORE_EXPORT QgsVector
      * Adds another vector to this vector in place.
      * \since QGIS 3.0
      */
-    QgsVector &operator+=( const QgsVector other );
+    QgsVector &operator+=( QgsVector other );
 
     /**
      * Subtracts another vector to this vector.
      * \since QGIS 3.0
      */
-    QgsVector operator-( const QgsVector other ) const;
+    QgsVector operator-( QgsVector other ) const;
 
     /**
      * Subtracts another vector to this vector in place.
      * \since QGIS 3.0
      */
-    QgsVector &operator-=( const QgsVector other );
+    QgsVector &operator-=( QgsVector other );
 
     /**
      * Returns the length of the vector.

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2005,7 +2005,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \see deselect(const QgsFeatureIds&)
      */
-    void deselect( const QgsFeatureId featureId );
+    void deselect( QgsFeatureId featureId );
 
     /**
      * Deselect features by their ID
@@ -2056,7 +2056,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * \param deselected      Ids of all features which have previously been selected but are not any more
      * \param clearAndSelect  In case this is set to true, the old selection was dismissed and the new selection corresponds to selected
      */
-    void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, const bool clearAndSelect );
+    void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 
     //! This signal is emitted when modifications has been done on layer
     void layerModified();

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -221,7 +221,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      * \returns True if this id is in the cache
      * \see cachedFeatureIds()
      */
-    bool isFidCached( const QgsFeatureId fid ) const;
+    bool isFidCached( QgsFeatureId fid ) const;
 
     /**
      * Returns the set of feature IDs for features which are cached.

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -140,7 +140,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
      * \param extent extent used in classification (only used in quantile mode)
      * \param input raster input used in classification (only used in quantile mode)
      */
-    void classifyColorRamp( const int classes = 0, const int band = -1, const QgsRectangle &extent = QgsRectangle(), QgsRasterInterface *input = nullptr );
+    void classifyColorRamp( int classes = 0, int band = -1, const QgsRectangle &extent = QgsRectangle(), QgsRasterInterface *input = nullptr );
 
     /**
      * Classify color ramp shader
@@ -148,7 +148,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
      * \param extent extent used in classification (quantile mode only)
      * \param input raster input used in classification (quantile mode only)
      */
-    void classifyColorRamp( const int band = -1, const QgsRectangle &extent = QgsRectangle(), QgsRasterInterface *input = nullptr ) SIP_PYNAME( classifyColorRampV2 );
+    void classifyColorRamp( int band = -1, const QgsRectangle &extent = QgsRectangle(), QgsRasterInterface *input = nullptr ) SIP_PYNAME( classifyColorRampV2 );
 
     //! \brief Generates and new RGB value based on one input value
     bool shade( double value, int *returnRedValue SIP_OUT, int *returnGreenValue SIP_OUT, int *returnBlueValue SIP_OUT, int *returnAlphaValue SIP_OUT ) override;

--- a/src/core/raster/qgscubicrasterresampler.h
+++ b/src/core/raster/qgscubicrasterresampler.h
@@ -57,7 +57,7 @@ class CORE_EXPORT QgsCubicRasterResampler: public QgsRasterResampler
     static inline int lowerN3( int i );
 
     //creates a QRgb by applying bounds checks
-    static inline QRgb createPremultipliedColor( const int r, const int g, const int b, const int a );
+    static inline QRgb createPremultipliedColor( int r, int g, int b, int a );
 
     //control points
 

--- a/src/core/symbology/qgsfillsymbollayer.h
+++ b/src/core/symbology/qgsfillsymbollayer.h
@@ -326,7 +326,7 @@ class CORE_EXPORT QgsGradientFillSymbolLayer : public QgsFillSymbolLayer
     void applyGradient( const QgsSymbolRenderContext &context, QBrush &brush, const QColor &color, const QColor &color2,
                         GradientColorType gradientColorType, QgsColorRamp *gradientRamp, GradientType gradientType,
                         GradientCoordinateMode coordinateMode, GradientSpread gradientSpread,
-                        QPointF referencePoint1, QPointF referencePoint2, const double angle );
+                        QPointF referencePoint1, QPointF referencePoint2, double angle );
 
     //! Rotates a reference point by a specified angle around the point (0.5, 0.5)
     QPointF rotateReferencePoint( QPointF refPoint, double angle );
@@ -747,7 +747,7 @@ class CORE_EXPORT QgsRasterFillSymbolLayer: public QgsImageFillSymbolLayer
      * \param mode coordinate mode
      * \see coordinateMode
      */
-    void setCoordinateMode( const FillCoordinateMode mode );
+    void setCoordinateMode( FillCoordinateMode mode );
 
     /**
      * Coordinate mode for fill. Controls how the top left corner of the image
@@ -762,7 +762,7 @@ class CORE_EXPORT QgsRasterFillSymbolLayer: public QgsImageFillSymbolLayer
      * \param opacity opacity value between 0 (fully transparent) and 1 (fully opaque)
      * \see opacity()
      */
-    void setOpacity( const double opacity );
+    void setOpacity( double opacity );
 
     /**
      * Returns the opacity for the raster image used in the fill.
@@ -901,7 +901,7 @@ class CORE_EXPORT QgsRasterFillSymbolLayer: public QgsImageFillSymbolLayer
   private:
 
     //! Applies the image pattern to the brush
-    void applyPattern( QBrush &brush, const QString &imageFilePath, const double width, const double opacity,
+    void applyPattern( QBrush &brush, const QString &imageFilePath, double width, double opacity,
                        const QgsSymbolRenderContext &context );
 };
 

--- a/src/core/symbology/qgsheatmaprenderer.h
+++ b/src/core/symbology/qgsheatmaprenderer.h
@@ -201,11 +201,11 @@ class CORE_EXPORT QgsHeatmapRenderer : public QgsFeatureRenderer
 
     int mFeaturesRendered = 0;
 
-    double uniformKernel( const double distance, const int bandwidth ) const;
-    double quarticKernel( const double distance, const int bandwidth ) const;
-    double triweightKernel( const double distance, const int bandwidth ) const;
-    double epanechnikovKernel( const double distance, const int bandwidth ) const;
-    double triangularKernel( const double distance, const int bandwidth ) const;
+    double uniformKernel( double distance, int bandwidth ) const;
+    double quarticKernel( double distance, int bandwidth ) const;
+    double triweightKernel( double distance, int bandwidth ) const;
+    double epanechnikovKernel( double distance, int bandwidth ) const;
+    double triangularKernel( double distance, int bandwidth ) const;
 
     QgsMultiPointXY convertToMultipoint( const QgsGeometry *geom );
     void initializeValues( QgsRenderContext &context );

--- a/src/core/symbology/qgssymbollayerutils.h
+++ b/src/core/symbology/qgssymbollayerutils.h
@@ -506,7 +506,7 @@ class CORE_EXPORT QgsSymbolLayerUtils
      * \returns mime data containing encoded colors
      * \since QGIS 2.5
      */
-    static QMimeData *colorListToMimeData( const QgsNamedColorList &colorList, const bool allFormats = true ) SIP_FACTORY;
+    static QMimeData *colorListToMimeData( const QgsNamedColorList &colorList, bool allFormats = true ) SIP_FACTORY;
 
     /**
      * Exports colors to a gpl GIMP palette file

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -274,7 +274,7 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      * \param menu context menu
      * \param fid feature id of the selected feature
      */
-    void showContextMenuExternally( QgsActionMenu *menu, const QgsFeatureId fid );
+    void showContextMenuExternally( QgsActionMenu *menu, QgsFeatureId fid );
 
   protected:
     void hideEvent( QHideEvent *event ) override;

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -103,7 +103,7 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
     QString displayExpression() const;
     bool featureByIndex( const QModelIndex &index, QgsFeature &feat );
     QgsFeatureId idxToFid( const QModelIndex &index ) const;
-    QModelIndex fidToIdx( const QgsFeatureId fid ) const;
+    QModelIndex fidToIdx( QgsFeatureId fid ) const;
 
     QModelIndex mapToSource( const QModelIndex &proxyIndex ) const override;
     QModelIndex mapFromSource( const QModelIndex &sourceIndex ) const override;

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -50,7 +50,10 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
          */
         FeatureInfo() = default;
 
+        //! True if feature is a newly added feature.
         bool isNew = false;
+
+        //! True if feature has been edited.
         bool isEdited = false;
     };
 
@@ -66,7 +69,12 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
     explicit QgsFeatureListModel( QgsAttributeTableFilterModel *sourceModel, QObject *parent SIP_TRANSFERTHIS = nullptr );
 
     virtual void setSourceModel( QgsAttributeTableFilterModel *sourceModel );
+
+    /**
+     * Returns the vector layer cache which is being used to populate the model.
+     */
     QgsVectorLayerCache *layerCache();
+
     QVariant data( const QModelIndex &index, int role ) const override;
     Qt::ItemFlags flags( const QModelIndex &index ) const override;
 
@@ -102,7 +110,17 @@ class GUI_EXPORT QgsFeatureListModel : public QSortFilterProxyModel, public QgsF
 
     QString displayExpression() const;
     bool featureByIndex( const QModelIndex &index, QgsFeature &feat );
+
+    /**
+     * Returns the feature ID corresponding to an \a index from the model.
+     * \see fidToIdx()
+     */
     QgsFeatureId idxToFid( const QModelIndex &index ) const;
+
+    /**
+     * Returns the model index corresponding to a feature ID.
+     * \see idxToFid()
+     */
     QModelIndex fidToIdx( QgsFeatureId fid ) const;
 
     QModelIndex mapToSource( const QModelIndex &proxyIndex ) const override;

--- a/src/gui/attributetable/qgsifeatureselectionmanager.h
+++ b/src/gui/attributetable/qgsifeatureselectionmanager.h
@@ -79,7 +79,7 @@ class GUI_EXPORT QgsIFeatureSelectionManager : public QObject
      * \param deselected      Ids of all features which have previously been selected but are not any more
      * \param clearAndSelect  In case this is set to true, the old selection was dismissed and the new selection corresponds to selected
      */
-    void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, const bool clearAndSelect );
+    void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 };
 
 #endif // QGSIFEATURESELECTIONMANAGER_H

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -78,7 +78,7 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
      * \param showClearButton set to true to show the clear button, or false to hide it
      * \see showClearButton()
      */
-    void setShowClearButton( const bool showClearButton );
+    void setShowClearButton( bool showClearButton );
 
     /**
      * Returns whether the widget is showing a clear button.
@@ -92,7 +92,7 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
      * \param enabled set to true to allow expression entry
      * \since QGIS 2.7
      */
-    void setExpressionsEnabled( const bool enabled );
+    void setExpressionsEnabled( bool enabled );
 
     /**
      * Returns whether the widget will allow entry of simple expressions, which are
@@ -145,7 +145,7 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
 
   private:
     int frameWidth() const;
-    bool shouldShowClearForValue( const double value ) const;
+    bool shouldShowClearForValue( double value ) const;
 
     QgsSpinBoxLineEdit *mLineEdit = nullptr;
 

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -78,7 +78,7 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
      * \param showClearButton set to true to show the clear button, or false to hide it
      * \see showClearButton()
      */
-    void setShowClearButton( const bool showClearButton );
+    void setShowClearButton( bool showClearButton );
 
     /**
      * Returns whether the widget is showing a clear button.
@@ -92,7 +92,7 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
      * \param enabled set to true to allow expression entry
      * \since QGIS 2.7
      */
-    void setExpressionsEnabled( const bool enabled );
+    void setExpressionsEnabled( bool enabled );
 
     /**
      * Returns whether the widget will allow entry of simple expressions, which are
@@ -146,7 +146,7 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
 
   private:
     int frameWidth() const;
-    bool shouldShowClearForValue( const int value ) const;
+    bool shouldShowClearForValue( int value ) const;
 
     QgsSpinBoxLineEdit *mLineEdit = nullptr;
 

--- a/src/gui/effects/qgspainteffectwidget.h
+++ b/src/gui/effects/qgspainteffectwidget.h
@@ -82,7 +82,7 @@ class GUI_EXPORT QgsDrawSourceWidget : public QgsPaintEffectWidget, private Ui::
     QgsDrawSourceEffect *mEffect = nullptr;
 
     void initGui();
-    void blockSignals( const bool block );
+    void blockSignals( bool block );
 
   private slots:
 
@@ -115,7 +115,7 @@ class GUI_EXPORT QgsBlurWidget : public QgsPaintEffectWidget, private Ui::Widget
     QgsBlurEffect *mEffect = nullptr;
 
     void initGui();
-    void blockSignals( const bool block );
+    void blockSignals( bool block );
 
   private slots:
 
@@ -150,7 +150,7 @@ class GUI_EXPORT QgsShadowEffectWidget : public QgsPaintEffectWidget, private Ui
     QgsShadowEffect *mEffect = nullptr;
 
     void initGui();
-    void blockSignals( const bool block );
+    void blockSignals( bool block );
 
   private slots:
     void mShadowOffsetAngleSpnBx_valueChanged( int value );
@@ -186,7 +186,7 @@ class GUI_EXPORT QgsGlowWidget : public QgsPaintEffectWidget, private Ui::Widget
     QgsGlowEffect *mEffect = nullptr;
 
     void initGui();
-    void blockSignals( const bool block );
+    void blockSignals( bool block );
 
   private slots:
     void colorModeChanged();
@@ -222,7 +222,7 @@ class GUI_EXPORT QgsTransformWidget : public QgsPaintEffectWidget, private Ui::W
     QgsTransformEffect *mEffect = nullptr;
 
     void initGui();
-    void blockSignals( const bool block );
+    void blockSignals( bool block );
 
   private slots:
 
@@ -262,8 +262,8 @@ class GUI_EXPORT QgsColorEffectWidget : public QgsPaintEffectWidget, private Ui:
     QgsColorEffect *mEffect = nullptr;
 
     void initGui();
-    void blockSignals( const bool block );
-    void enableColorizeControls( const bool enable );
+    void blockSignals( bool block );
+    void enableColorizeControls( bool enable );
 
   private slots:
 

--- a/src/gui/layout/qgslayoutdesignerinterface.h
+++ b/src/gui/layout/qgslayoutdesignerinterface.h
@@ -76,7 +76,7 @@ class GUI_EXPORT QgsLayoutDesignerInterface: public QObject
     /**
      * Selects the specified \a items.
      */
-    virtual void selectItems( const QList< QgsLayoutItem * > items ) = 0;
+    virtual void selectItems( QList< QgsLayoutItem * > items ) = 0;
 
   public slots:
 

--- a/src/gui/layout/qgslayoutmousehandles.h
+++ b/src/gui/layout/qgslayoutmousehandles.h
@@ -209,7 +209,7 @@ class GUI_EXPORT QgsLayoutMouseHandles: public QObject, public QGraphicsRectItem
     void hideAlignItems();
 
     //! Collects all items from a list of \a items, exploring for any group members and adding them too
-    void collectItems( const QList< QgsLayoutItem * > items, QList< QgsLayoutItem * > &collected );
+    void collectItems( QList< QgsLayoutItem * > items, QList< QgsLayoutItem * > &collected );
 
 };
 

--- a/src/gui/layout/qgslayoutreportsectionlabel.h
+++ b/src/gui/layout/qgslayoutreportsectionlabel.h
@@ -44,7 +44,7 @@ class GUI_EXPORT QgsLayoutReportSectionLabel: public QGraphicsRectItem
      */
     QgsLayoutReportSectionLabel( QgsLayout *layout, QgsLayoutView *view );
 
-    ~QgsLayoutReportSectionLabel();
+    ~QgsLayoutReportSectionLabel() override;
 
     void paint( QPainter *painter, const QStyleOptionGraphicsItem *itemStyle, QWidget *pWidget ) override;
 

--- a/src/gui/layout/qgslayoutview.h
+++ b/src/gui/layout/qgslayoutview.h
@@ -76,7 +76,7 @@ class GUI_EXPORT QgsLayoutView: public QGraphicsView
      */
     QgsLayoutView( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
-    ~QgsLayoutView();
+    ~QgsLayoutView() override;
 
     /**
      * Returns the current layout associated with the view.

--- a/src/gui/layout/qgslayoutviewrubberband.h
+++ b/src/gui/layout/qgslayoutviewrubberband.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsLayoutViewRubberBand : public QObject
      */
     QgsLayoutViewRubberBand( QgsLayoutView *view = nullptr );
 
-    virtual ~QgsLayoutViewRubberBand() = default;
+    ~QgsLayoutViewRubberBand() override = default;
 
     /**
      * Creates a new instance of the QgsLayoutViewRubberBand subclass.

--- a/src/gui/layout/qgslayoutviewtool.h
+++ b/src/gui/layout/qgslayoutviewtool.h
@@ -196,7 +196,7 @@ class GUI_EXPORT QgsLayoutViewTool : public QObject
      * Sets the combination of \a flags that will be used for the tool.
      * \see flags()
      */
-    void setFlags( const QgsLayoutViewTool::Flags flags );
+    void setFlags( QgsLayoutViewTool::Flags flags );
 
     /**
      * Constructor for QgsLayoutViewTool, taking a layout \a view and

--- a/src/gui/processing/qgsprocessingalgorithmconfigurationwidget.h
+++ b/src/gui/processing/qgsprocessingalgorithmconfigurationwidget.h
@@ -45,7 +45,7 @@ class GUI_EXPORT QgsProcessingAlgorithmConfigurationWidget : public QWidget
      * Creates a new QgsProcessingAlgorithmConfigurationWidget
      */
     QgsProcessingAlgorithmConfigurationWidget( QWidget *parent = nullptr );
-    virtual ~QgsProcessingAlgorithmConfigurationWidget() = default;
+    ~QgsProcessingAlgorithmConfigurationWidget() override = default;
 
     /**
      * Read the current configuration from this widget.

--- a/src/gui/qgsactionmenu.h
+++ b/src/gui/qgsactionmenu.h
@@ -82,7 +82,7 @@ class GUI_EXPORT QgsActionMenu : public QMenu
      * \param parent   The usual QWidget parent.
      * \param actionScope The action scope this menu will run in
      */
-    explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeatureId fid, const QString &actionScope, QWidget *parent SIP_TRANSFERTHIS = nullptr );
+    explicit QgsActionMenu( QgsVectorLayer *layer, QgsFeatureId fid, const QString &actionScope, QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     /**
      * Change the feature on which actions are performed
@@ -97,7 +97,7 @@ class GUI_EXPORT QgsActionMenu : public QMenu
      *
      * \param mode The mode of the attribute form
      */
-    void setMode( const QgsAttributeForm::Mode mode );
+    void setMode( QgsAttributeForm::Mode mode );
 
     /**
      * Sets an expression context scope used to resolve underlying actions.

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -95,7 +95,7 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * \see allowOpacity()
      * \since QGIS 3.0
      */
-    void setAllowOpacity( const bool allowOpacity );
+    void setAllowOpacity( bool allowOpacity );
 
     /**
      * Returns whether opacity modification (transparency) is permitted
@@ -126,7 +126,7 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * \param showMenu set to false to hide the drop-down menu
      * \see showMenu
      */
-    void setShowMenu( const bool showMenu );
+    void setShowMenu( bool showMenu );
 
     /**
      * Returns whether the drop-down menu is shown for the button.
@@ -141,7 +141,7 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * \param behavior behavior when button is clicked
      * \see behavior
      */
-    void setBehavior( const Behavior behavior );
+    void setBehavior( Behavior behavior );
 
     /**
      * Returns the behavior for when the button is clicked.
@@ -454,7 +454,7 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * \param showChecks set to true to display a checkboard pattern behind
      * transparent colors
      */
-    QPixmap createMenuIcon( const QColor &color, const bool showChecks = true );
+    QPixmap createMenuIcon( const QColor &color, bool showChecks = true );
 
   private slots:
 

--- a/src/gui/qgscolordialog.h
+++ b/src/gui/qgscolordialog.h
@@ -67,7 +67,7 @@ class GUI_EXPORT QgsColorDialog : public QDialog, private Ui::QgsColorDialogBase
      * \param allowOpacity set to false to disable opacity modification
      * \since QGIS 3.0
      */
-    void setAllowOpacity( const bool allowOpacity );
+    void setAllowOpacity( bool allowOpacity );
 
     /**
      * Returns a color selection from a color dialog.
@@ -78,7 +78,7 @@ class GUI_EXPORT QgsColorDialog : public QDialog, private Ui::QgsColorDialogBase
      * \returns Selected color on accepted() or initialColor on rejected().
      */
     static QColor getColor( const QColor &initialColor, QWidget *parent, const QString &title = QString(),
-                            const bool allowOpacity = false );
+                            bool allowOpacity = false );
 
   signals:
 

--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -97,7 +97,7 @@ class GUI_EXPORT QgsColorRampButton : public QToolButton
      * \param showMenu set to false to hide the drop-down menu
      * \see showMenu
      */
-    void setShowMenu( const bool showMenu );
+    void setShowMenu( bool showMenu );
 
     /**
      * Returns whether the drop-down menu is shown for the button.

--- a/src/gui/qgscolorswatchgrid.h
+++ b/src/gui/qgscolorswatchgrid.h
@@ -168,7 +168,7 @@ class GUI_EXPORT QgsColorSwatchGrid : public QWidget
      * Updates the widget's tooltip for a given color index
      * \param colorIdx color index to use for calculating tooltip
      */
-    void updateTooltip( const int colorIdx );
+    void updateTooltip( int colorIdx );
 
     /**
      * Generates a checkboard pattern for transparent color backgrounds

--- a/src/gui/qgscolorwidgets.h
+++ b/src/gui/qgscolorwidgets.h
@@ -62,7 +62,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * \param parent parent QWidget for the widget
      * \param component color component the widget alters
      */
-    QgsColorWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr, const ColorComponent component = Multiple );
+    QgsColorWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr, ColorComponent component = Multiple );
 
     /**
      * Returns the current color for the widget
@@ -101,14 +101,14 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * \param emitSignals set to true to emit the colorChanged signal after setting color
      * \see color
      */
-    virtual void setColor( const QColor &color, const bool emitSignals = false );
+    virtual void setColor( const QColor &color, bool emitSignals = false );
 
     /**
      * Sets the color component which the widget controls
      * \param component color component for widget
      * \see component
      */
-    virtual void setComponent( const QgsColorWidget::ColorComponent component );
+    virtual void setComponent( QgsColorWidget::ColorComponent component );
 
     /**
      * Alters the widget's color by setting the value for the widget's color component
@@ -119,7 +119,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * \note this method has no effect if the widget is set to the QgsColorWidget::Multiple
      * component
      */
-    virtual void setComponentValue( const int value );
+    virtual void setComponentValue( int value );
 
   signals:
 
@@ -157,7 +157,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * Returns the range of valid values a color component
      * \returns maximum value allowed for color component
      */
-    int componentRange( const ColorComponent component ) const;
+    int componentRange( ColorComponent component ) const;
 
     /**
      * Returns the value of a component of the widget's current color. This method correctly
@@ -166,7 +166,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * \returns value of color component, or -1 if widget has an invalid color set
      * \see hue
      */
-    int componentValue( const ColorComponent component ) const;
+    int componentValue( ColorComponent component ) const;
 
     /**
      * Returns the hue for the widget. This may differ from the hue for the QColor returned by color(),
@@ -182,7 +182,7 @@ class GUI_EXPORT QgsColorWidget : public QWidget
      * \param newValue new value of color component. Values are automatically clipped to a
      * valid range for the color component.
      */
-    void alterColor( QColor &color, const QgsColorWidget::ColorComponent component, const int newValue ) const;
+    void alterColor( QColor &color, QgsColorWidget::ColorComponent component, int newValue ) const;
 
     /**
      * Generates a checkboard pattern pixmap for use as a background to transparent colors
@@ -305,7 +305,7 @@ class GUI_EXPORT QgsColorWheel : public QgsColorWidget
 
   public slots:
 
-    void setColor( const QColor &color, const bool emitSignals = false ) override;
+    void setColor( const QColor &color, bool emitSignals = false ) override;
 
   protected:
 
@@ -354,7 +354,7 @@ class GUI_EXPORT QgsColorWheel : public QgsColorWidget
      * Creates cache images for specified widget size
      * \param size widget size for images
      */
-    void createImages( const QSizeF size );
+    void createImages( QSizeF size );
 
     //! Creates the hue wheel image
     void createWheel();
@@ -366,7 +366,7 @@ class GUI_EXPORT QgsColorWheel : public QgsColorWidget
      * Sets the widget color based on a point in the widget
      * \param pos position for color
      */
-    void setColorFromPos( const QPointF pos );
+    void setColorFromPos( QPointF pos );
 
 };
 
@@ -393,17 +393,17 @@ class GUI_EXPORT QgsColorBox : public QgsColorWidget
      * which vary along the horizontal and vertical axis are automatically assigned
      * based on this constant color component.
      */
-    QgsColorBox( QWidget *parent SIP_TRANSFERTHIS = nullptr, const ColorComponent component = Value );
+    QgsColorBox( QWidget *parent SIP_TRANSFERTHIS = nullptr, ColorComponent component = Value );
 
     ~QgsColorBox() override;
 
     QSize sizeHint() const override;
     void paintEvent( QPaintEvent *event ) override;
 
-    void setComponent( const ColorComponent component ) override;
+    void setComponent( ColorComponent component ) override;
 
   public slots:
-    void setColor( const QColor &color, const bool emitSignals = false ) override;
+    void setColor( const QColor &color, bool emitSignals = false ) override;
 
   protected:
 
@@ -498,8 +498,8 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
      * \param orientation orientation for widget
      */
     QgsColorRampWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr,
-                        const ColorComponent component = QgsColorWidget::Red,
-                        const Orientation orientation = QgsColorRampWidget::Horizontal );
+                        ColorComponent component = QgsColorWidget::Red,
+                        Orientation orientation = QgsColorRampWidget::Horizontal );
 
     QSize sizeHint() const override;
     void paintEvent( QPaintEvent *event ) override;
@@ -509,7 +509,7 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
      * \param orientation new orientation for the ramp
      * \see orientation
      */
-    void setOrientation( const Orientation orientation );
+    void setOrientation( Orientation orientation );
 
     /**
      * Fetches the orientation for the color ramp
@@ -523,7 +523,7 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
      * \param margin margin around the ramp
      * \see interiorMargin
      */
-    void setInteriorMargin( const int margin );
+    void setInteriorMargin( int margin );
 
     /**
      * Fetches the margin between the edge of the widget and the ramp
@@ -537,7 +537,7 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
      * \param showFrame set to true to draw a frame around the ramp
      * \see showFrame
      */
-    void setShowFrame( const bool showFrame );
+    void setShowFrame( bool showFrame );
 
     /**
      * Fetches whether the ramp is drawn within a frame
@@ -550,7 +550,7 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
      * Sets the size for drawing the triangular markers on the ramp
      * \param markerSize marker size in pixels
      */
-    void setMarkerSize( const int markerSize );
+    void setMarkerSize( int markerSize );
 
   signals:
 
@@ -558,7 +558,7 @@ class GUI_EXPORT QgsColorRampWidget : public QgsColorWidget
      * Emitted when the widget's color component value changes
      * \param value new value of color component
      */
-    void valueChanged( const int value );
+    void valueChanged( int value );
 
   protected:
 
@@ -611,11 +611,11 @@ class GUI_EXPORT QgsColorSliderWidget : public QgsColorWidget
      * \param parent parent QWidget for the widget
      * \param component color component which is controlled by the slider
      */
-    QgsColorSliderWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr, const ColorComponent component = QgsColorWidget::Red );
+    QgsColorSliderWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr, ColorComponent component = QgsColorWidget::Red );
 
-    void setComponent( const ColorComponent component ) override;
-    void setComponentValue( const int value ) override;
-    void setColor( const QColor &color, const bool emitSignals = false ) override;
+    void setComponent( ColorComponent component ) override;
+    void setComponentValue( int value ) override;
+    void setColor( const QColor &color, bool emitSignals = false ) override;
 
   private:
 
@@ -632,7 +632,7 @@ class GUI_EXPORT QgsColorSliderWidget : public QgsColorWidget
      * \returns display value of color component
      * \see convertDisplayToReal
      */
-    int convertRealToDisplay( const int realValue ) const;
+    int convertRealToDisplay( int realValue ) const;
 
     /**
      * Converts the display value of a color component to a real value.
@@ -640,7 +640,7 @@ class GUI_EXPORT QgsColorSliderWidget : public QgsColorWidget
      * \returns real value of color component
      * \see convertRealToDisplay
      */
-    int convertDisplayToReal( const int displayValue ) const;
+    int convertDisplayToReal( int displayValue ) const;
 
   private slots:
 
@@ -694,7 +694,7 @@ class GUI_EXPORT QgsColorTextWidget : public QgsColorWidget
      */
     QgsColorTextWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
-    void setColor( const QColor &color, const bool emitSignals = false ) override;
+    void setColor( const QColor &color, bool emitSignals = false ) override;
 
   protected:
     void resizeEvent( QResizeEvent *event ) override;

--- a/src/gui/qgscompoundcolorwidget.h
+++ b/src/gui/qgscompoundcolorwidget.h
@@ -66,7 +66,7 @@ class GUI_EXPORT QgsCompoundColorWidget : public QgsPanelWidget, private Ui::Qgs
      * \param allowOpacity set to false to disable opacity modification
      * \since QGIS 3.0
      */
-    void setAllowOpacity( const bool allowOpacity );
+    void setAllowOpacity( bool allowOpacity );
 
     /**
      * Sets whether the widget's color has been "discarded" and the selected color should not
@@ -194,7 +194,7 @@ class GUI_EXPORT QgsCompoundColorWidget : public QgsPanelWidget, private Ui::Qgs
      * \param takeSample set to true to actually sample the color, false to just cancel
      * the color picking operation
      */
-    void stopPicking( QPoint eventPos, const bool takeSample = true );
+    void stopPicking( QPoint eventPos, bool takeSample = true );
 
     /**
      * Returns the average color from the pixels in an image

--- a/src/gui/qgsdetaileditemdata.h
+++ b/src/gui/qgsdetaileditemdata.h
@@ -37,12 +37,46 @@ class GUI_EXPORT QgsDetailedItemData
      */
     QgsDetailedItemData() = default;
 
+    /**
+     * Sets the \a title for the item.
+     * \see title()
+     */
     void setTitle( const QString &title );
+
+    /**
+     * Sets the detailed description for the item.
+     * \see detail()
+     */
     void setDetail( const QString &detail );
+
+    /**
+     * Sets the item's \a category.
+     * \see category()
+     */
     void setCategory( const QString &category );
+
+    /**
+     * Sets the item's \a icon.
+     * \see icon()
+     */
     void setIcon( const QPixmap &icon );
+
+    /**
+     * Sets whether the item is checkable.
+     * \see isCheckable()
+     */
     void setCheckable( bool flag );
+
+    /**
+     * Sets whether the item is checked.
+     * \see isChecked()
+     */
     void setChecked( bool flag );
+
+    /**
+     * Sets whether the item is enabled.
+     * \see isEnabled()
+     */
     void setEnabled( bool flag );
 
     /**
@@ -51,16 +85,56 @@ class GUI_EXPORT QgsDetailedItemData
      * part of the list item.
      * \note the delegate may completely ignore this
      * depending on the delegate implementation.
+     * \see isRenderedAsWidget()
      */
     void setRenderAsWidget( bool flag );
 
+    /**
+     * Returns the item's title.
+     * \see setTitle()
+     */
     QString title() const;
+
+    /**
+     * Returns the detailed description for the item.
+     * \see setDetail()
+     */
     QString detail() const;
+
+    /**
+     * Returns the item's category.
+     * \see setCategory()
+     */
     QString category() const;
+
+    /**
+     * Returns the item's icon.
+     * \see setIcon()
+     */
     QPixmap icon() const;
+
+    /**
+     * Returns true if the item is checkable.
+     * \see setCheckable()
+     */
     bool isCheckable() const;
+
+    /**
+     * Returns true if the item is checked.
+     * \see setChecked()
+     */
     bool isChecked() const;
+
+    /**
+     * Returns true if the item is enabled.
+     * \see setEnabled()
+     */
     bool isEnabled() const;
+
+    /**
+     * Returns true if the item will be rendered using a widget.
+     * \see setRenderAsWidget()
+     */
     bool isRenderedAsWidget() const;
 
   private:

--- a/src/gui/qgsdetaileditemdata.h
+++ b/src/gui/qgsdetaileditemdata.h
@@ -41,8 +41,8 @@ class GUI_EXPORT QgsDetailedItemData
     void setDetail( const QString &detail );
     void setCategory( const QString &category );
     void setIcon( const QPixmap &icon );
-    void setCheckable( const bool flag );
-    void setChecked( const bool flag );
+    void setCheckable( bool flag );
+    void setChecked( bool flag );
     void setEnabled( bool flag );
 
     /**

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -67,7 +67,7 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
      * \param visible whether the option should be shown
      * \see optionVisible()
      */
-    void setOptionVisible( const CrsOption option, const bool visible );
+    void setOptionVisible( CrsOption option, bool visible );
 
     /**
      * Returns whether the specified CRS option is visible in the widget.
@@ -142,7 +142,7 @@ class GUI_EXPORT QgsProjectionSelectionWidget : public QWidget
     void addCurrentCrsOption();
     QString currentCrsOptionText( const QgsCoordinateReferenceSystem &crs ) const;
     void addRecentCrs();
-    bool crsIsShown( const long srsid ) const;
+    bool crsIsShown( long srsid ) const;
 
     int firstRecentCrsIndex() const;
 

--- a/src/gui/qgsratiolockbutton.h
+++ b/src/gui/qgsratiolockbutton.h
@@ -49,7 +49,7 @@ class GUI_EXPORT QgsRatioLockButton : public QToolButton
      * \param locked locked state
      * \see locked
      */
-    void setLocked( const bool locked );
+    void setLocked( bool locked );
 
     /**
      * Returns whether the button state is locked.
@@ -93,7 +93,7 @@ class GUI_EXPORT QgsRatioLockButton : public QToolButton
     /**
      * Emitted whenever the lock state changes.
      */
-    void lockChanged( const bool locked );
+    void lockChanged( bool locked );
 
   protected:
 

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -148,15 +148,15 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void addFeature();
     void duplicateFeature();
     void linkFeature();
-    void deleteFeature( const QgsFeatureId featureid = QgsFeatureId() );
+    void deleteFeature( QgsFeatureId featureid = QgsFeatureId() );
     void deleteSelectedFeatures();
-    void unlinkFeature( const QgsFeatureId featureid = QgsFeatureId() );
+    void unlinkFeature( QgsFeatureId featureid = QgsFeatureId() );
     void unlinkSelectedFeatures();
     void zoomToSelectedFeatures();
     void saveEdits();
     void toggleEditing( bool state );
     void onCollapsedStateChanged( bool collapsed );
-    void showContextMenu( QgsActionMenu *menu, const QgsFeatureId fid );
+    void showContextMenu( QgsActionMenu *menu, QgsFeatureId fid );
 
   private:
     void updateUi();

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -559,7 +559,7 @@ class GUI_EXPORT QgsSvgMarkerSymbolLayerWidget : public QgsSymbolLayerWidget, pr
     void mVerticalAnchorComboBox_currentIndexChanged( int index );
     void setWidth();
     void setHeight();
-    void lockAspectRatioChanged( const bool locked );
+    void lockAspectRatioChanged( bool locked );
     void setAngle();
     void setOffset();
     void updateAssistantSymbol();

--- a/src/plugins/georeferencer/qgsgeorefplugingui.h
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.h
@@ -57,7 +57,7 @@ class QgsGeorefPluginGui : public QMainWindow, private Ui::QgsGeorefPluginGuiBas
 
   public:
     QgsGeorefPluginGui( QgisInterface *qgisInterface, QWidget *parent = nullptr, Qt::WindowFlags fl = nullptr );
-    ~QgsGeorefPluginGui();
+    ~QgsGeorefPluginGui() override;
 
   protected:
     void closeEvent( QCloseEvent * ) override;

--- a/src/plugins/georeferencer/qgsimagewarper.h
+++ b/src/plugins/georeferencer/qgsimagewarper.h
@@ -98,7 +98,7 @@ class QgsImageWarper
 
     static bool sWarpCanceled;
 
-    GDALResampleAlg toGDALResampleAlg( const ResamplingMethod method ) const;
+    GDALResampleAlg toGDALResampleAlg( ResamplingMethod method ) const;
 };
 
 

--- a/src/plugins/georeferencer/qgsresidualplotitem.h
+++ b/src/plugins/georeferencer/qgsresidualplotitem.h
@@ -66,7 +66,7 @@ class QgsResidualPlotItem: public QgsLayoutItem
      * clockwise from pointing vertical upward
      * \param arrowHeadWidth size of arrow head
      */
-    static void drawArrowHead( QPainter *p, const double x, const double y, const double angle, const double arrowHeadWidth );
+    static void drawArrowHead( QPainter *p, double x, double y, double angle, double arrowHeadWidth );
 
     /**
      * Calculates the angle of the line from p1 to p2 (counter clockwise,

--- a/src/providers/db2/qgsdb2dataitems.h
+++ b/src/providers/db2/qgsdb2dataitems.h
@@ -66,7 +66,7 @@ class QgsDb2ConnectionItem : public QgsDataCollectionItem
   public:
     QgsDb2ConnectionItem( QgsDataItem *parent, QString name, QString path );
 
-    static bool ConnInfoFromSettings( const QString connName,
+    static bool ConnInfoFromSettings( QString connName,
                                       QString &connInfo, QString &errorMsg );
 
     static bool ConnInfoFromParameters(

--- a/src/providers/gdal/qgsgdalproviderbase.h
+++ b/src/providers/gdal/qgsgdalproviderbase.h
@@ -47,9 +47,9 @@ class QgsGdalProviderBase
     static int gdalGetOverviewCount( GDALRasterBandH hBand );
   protected:
 
-    Qgis::DataType dataTypeFromGdal( const GDALDataType gdalDataType ) const;
+    Qgis::DataType dataTypeFromGdal( GDALDataType gdalDataType ) const;
 
-    int colorInterpretationFromGdal( const GDALColorInterp gdalColorInterpretation ) const;
+    int colorInterpretationFromGdal( GDALColorInterp gdalColorInterpretation ) const;
 
     QList<QgsColorRampShader::ColorRampItem> colorTable( GDALDatasetH gdalDataset, int bandNo )const;
 

--- a/src/providers/mdal/qgsmdalprovider.h
+++ b/src/providers/mdal/qgsmdalprovider.h
@@ -43,7 +43,7 @@ class QgsMdalProvider : public QgsMeshDataProvider
      * \param options generic provider options
      */
     QgsMdalProvider( const QString &uri, const QgsDataProvider::ProviderOptions &options );
-    ~QgsMdalProvider();
+    ~QgsMdalProvider() override;
 
     bool isValid() const override;
     QString name() const override;

--- a/src/server/qgsfeaturefilter.h
+++ b/src/server/qgsfeaturefilter.h
@@ -42,13 +42,13 @@ class SERVER_EXPORT QgsFeatureFilter : public QgsFeatureFilterProvider
      * \param layer the layer to control
      * \param filterFeatures the request to fill
      */
-    void filterFeatures( const QgsVectorLayer *layer, QgsFeatureRequest &filterFeatures ) const;
+    void filterFeatures( const QgsVectorLayer *layer, QgsFeatureRequest &filterFeatures ) const override;
 
     /**
      * Returns a clone of the object
      * \returns A clone
      */
-    QgsFeatureFilterProvider *clone() const SIP_FACTORY;
+    QgsFeatureFilterProvider *clone() const override SIP_FACTORY;
 
     /**
      * Set a filter for the given layer.

--- a/src/server/qgsfeaturefilterprovidergroup.h
+++ b/src/server/qgsfeaturefilterprovidergroup.h
@@ -40,13 +40,13 @@ class SERVER_EXPORT QgsFeatureFilterProviderGroup : public QgsFeatureFilterProvi
      * \param layer the layer to control
      * \param filterFeatures the request to fill
      */
-    void filterFeatures( const QgsVectorLayer *layer, QgsFeatureRequest &filterFeatures ) const;
+    void filterFeatures( const QgsVectorLayer *layer, QgsFeatureRequest &filterFeatures ) const override;
 
     /**
      * Returns a clone of the object
      * \returns A clone
      */
-    QgsFeatureFilterProvider *clone() const SIP_FACTORY;
+    QgsFeatureFilterProvider *clone() const override SIP_FACTORY;
 
     /**
      * Add another filter provider to the group

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -410,22 +410,22 @@ class DummyParameterType : public QgsProcessingParameterType
 
     // QgsProcessingParameterType interface
   public:
-    QgsProcessingParameterDefinition *create( const QString &name ) const
+    QgsProcessingParameterDefinition *create( const QString &name ) const override
     {
       return new QgsProcessingParameterString( name );
     }
 
-    QString description() const
+    QString description() const override
     {
       return QStringLiteral( "Description" );
     }
 
-    QString name() const
+    QString name() const override
     {
       return QStringLiteral( "ParamType" );
     }
 
-    QString id() const
+    QString id() const override
     {
       return QStringLiteral( "paramType" );
     }
@@ -764,7 +764,7 @@ class TestPostProcessor : public QgsProcessingLayerPostProcessorInterface
       : deleted( deleted )
     {}
 
-    ~TestPostProcessor()
+    ~TestPostProcessor() override
     {
       *deleted = true;
     }

--- a/tests/src/core/testqgscompositionconverter.cpp
+++ b/tests/src/core/testqgscompositionconverter.cpp
@@ -150,7 +150,7 @@ class TestQgsCompositionConverter: public QObject
 
   private:
 
-    void checkRenderedImage( QgsLayout *layout, const QString &testName, const int pageNumber = 0 );
+    void checkRenderedImage( QgsLayout *layout, const QString &testName, int pageNumber = 0 );
 
     QDomElement loadComposer( const QString &name );
 


### PR DESCRIPTION
Checks whether a function declaration has parameters that are top level const.

const values in declarations do not affect the signature of a function, so they should not be put there.
