### PR TITLE
[python] Don't install error hook by default

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -195,8 +195,12 @@ def qgis_excepthook(type, value, tb):
 
 def installErrorHook():
     """
-    Installs the QGIS application error/warning hook
-    :return:
+    Installs the QGIS application error/warning hook. This causes Python exceptions
+    to be intercepted by the QGIS application and shown in the main window message bar
+    and in custom dialogs.
+
+    Generally you shouldn't call this method - it's automatically called by
+    the QGIS app on startup, and has no use in standalone applications and scripts.
     """
     sys.excepthook = qgis_excepthook
     warnings.showwarning = showWarning

--- a/python/utils.py
+++ b/python/utils.py
@@ -77,10 +77,6 @@ def showWarning(message, category, filename, lineno, file=None, line=None):
     )
 
 
-if not os.environ.get('QGIS_DISABLE_MESSAGE_HOOKS'):
-    warnings.showwarning = showWarning
-
-
 def showException(type, value, tb, msg, messagebar=False):
     if msg is None:
         msg = QCoreApplication.translate('Python', 'An error has occurred while executing Python code:')
@@ -198,16 +194,17 @@ def qgis_excepthook(type, value, tb):
 
 
 def installErrorHook():
+    """
+    Installs the QGIS application error/warning hook
+    :return:
+    """
     sys.excepthook = qgis_excepthook
+    warnings.showwarning = showWarning
 
 
 def uninstallErrorHook():
     sys.excepthook = sys.__excepthook__
 
-
-# install error hook() on module load
-if not os.environ.get('QGIS_DISABLE_MESSAGE_HOOKS'):
-    installErrorHook()
 
 # initialize 'iface' object
 iface = None

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -224,6 +224,7 @@ void QgsPythonUtilsImpl::initPython( QgisInterface *interface )
     return;
   }
   doCustomImports();
+  installErrorHook();
   finish();
 }
 
@@ -264,6 +265,7 @@ bool QgsPythonUtilsImpl::startServerPlugin( QString packageName )
 
 void QgsPythonUtilsImpl::exitPython()
 {
+  uninstallErrorHook();
   Py_Finalize();
   mMainModule = nullptr;
   mMainDict = nullptr;
@@ -285,8 +287,6 @@ void QgsPythonUtilsImpl::uninstallErrorHook()
 {
   runString( QStringLiteral( "qgis.utils.uninstallErrorHook()" ) );
 }
-
-
 
 bool QgsPythonUtilsImpl::runStringUnsafe( const QString &command, bool single )
 {


### PR DESCRIPTION
This error hook should only ever be used from QGIS app, never
from standalone scripts and applications, so we should default
to not using it and only install it when initializing python
from app.

Otherwise default behavior for standalone scripts based on
PyQGIS is to silently swallow exceptions - this leaves script
developers *no clues* to go off to debug their applications,
meaning that errors which would usually take a couple of seconds
to fix become horrible exercises in frustration for those
unaware of QGIS' exception handling and the
QGIS_DISABLE_MESSAGE_HOOKS environment variable.

Refs #19111
