### PR TITLE
Don't use old policy for CMP0040

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -35,12 +35,6 @@ ADD_CUSTOM_TARGET(clean-staged-plugins
   COMMAND ${CMAKE_COMMAND} -E remove_directory "${PYTHON_OUTPUT_DIRECTORY}/plugins"
 )
 
-IF(POLICY CMP0040) # in CMake 3.0.0+
-  # Skip 'TARGET signature of add_custom_command() must exist' warning, triggered by macro expansion
-  CMAKE_POLICY (PUSH) # see POP below (NOTE: must wrap related macros, which record policies)
-  CMAKE_POLICY (SET CMP0040 OLD) # temporary policy for staging/py_compile macros
-ENDIF(POLICY CMP0040)
-
 # Macro to byte-compile a target's staged Python resource(s)
 MACRO(PY_COMPILE TARGET_NAME RESOURCE_PATHS)
   IF(WITH_PY_COMPILE)
@@ -72,10 +66,6 @@ ADD_SUBDIRECTORY(PyQt)
 ADD_SUBDIRECTORY(pyplugin_installer)
 ADD_SUBDIRECTORY(ext-libs)
 ADD_SUBDIRECTORY(testing)
-
-IF(POLICY CMP0040)
-  CMAKE_POLICY (POP) # see PUSH above
-ENDIF(POLICY CMP0040)
 
 INCLUDE_DIRECTORIES(SYSTEM
   ${PYTHON_INCLUDE_PATH}


### PR DESCRIPTION
Silences a cmake warning, and seems no longer required in any case
