### PR TITLE
[processing] Fix missing schemas in postgis destination selection panel

### DIFF
--- a/python/plugins/processing/tools/postgis.py
+++ b/python/plugins/processing/tools/postgis.py
@@ -55,7 +55,10 @@ def uri_from_name(conn_name):
     service, host, port, database, username, password, authcfg = [settings.value(x, "", type=str) for x in settingsList]
 
     useEstimatedMetadata = settings.value("estimatedMetadata", False, type=bool)
-    sslmode = settings.value("sslmode", QgsDataSourceUri.SslPrefer, type=int)
+    try:
+        sslmode = settings.value("sslmode", QgsDataSourceUri.SslPrefer, type=int)
+    except TypeError:
+        sslmode = QgsDataSourceUri.SslPrefer
 
     settings.endGroup()
 


### PR DESCRIPTION
Avoids a "TypeError: unable to convert a QVariant of type 2 to a QMetaType of type 10" exception