### PR TITLE
[ui] do not hide floating panel toolbars for map-only view

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6324,7 +6324,7 @@ void QgisApp::toggleReducedView( bool viewMapOnly )
       // hide also statusbar and menubar and all toolbars
       for ( QToolBar *toolBar : toolBars )
       {
-        if ( toolBar->isVisible() && !toolBar->isFloating() )
+        if ( toolBar->isVisible() && !toolBar->isFloating() && toolBar->parent()->inherits( "QMainWindow" ) )
         {
           // remember the active toolbars
           toolBarsActive << toolBar->windowTitle();


### PR DESCRIPTION
## Description
ATM, all toolbars are hidden when toggling the map-only view (i.e. ctrl+shift+tab), including toolbars within floating panels which are not meant to be hidden (for e.g. a floating bookmarks panel). This PR improves the logic to only hide toolbars parented to the QMainWindow.

@nyalldawson , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
