### PR TITLE
[processing] Correct management of optional rasters in batch mode. Fixes #19115

### DIFF
--- a/python/plugins/processing/gui/BatchInputSelectionPanel.py
+++ b/python/plugins/processing/gui/BatchInputSelectionPanel.py
@@ -183,7 +183,7 @@ class BatchInputSelectionPanel(QWidget):
         self.valueChanged.emit()
 
     def value(self):
-        return self._value
+        return self._value if self._value else None
 
     def setValue(self, value):
         self._value = value


### PR DESCRIPTION
## Description
running most of gdal algs in batch mode set otpional rasters as '' instead of None => this fix this not correct mamagement

fix promoted inside GeoMove [1] project for Cartolab [2] (A Coruña university)

[1] http://cartolab.udc.es/geomove/
[2] http://cartolab.udc.es

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
