### PR TITLE
Removes the words "Toolbar" and "Panel" from sub-menu names [needs-docs]

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13493,14 +13493,6 @@ QMenu *QgisApp::createPopupMenu()
     menu->addAction( panelstitle );
     Q_FOREACH ( QAction *a, panels )
     {
-      if ( !a->property( "fixed_title" ).toBool() )
-      {
-        // append " Panel" to menu text. Only ever do this once, because the actions are not unique to
-        // this single popup menu
-
-        a->setText( tr( "%1 Panel" ).arg( a->text() ) );
-        a->setProperty( "fixed_title", true );
-      }
       menu->addAction( a );
     }
     menu->addSeparator();

--- a/src/ui/layout/qgslayoutdesignerbase.ui
+++ b/src/ui/layout/qgslayoutdesignerbase.ui
@@ -54,10 +54,10 @@
   <widget class="QStatusBar" name="mStatusBar"/>
   <widget class="QToolBar" name="mLayoutToolbar">
    <property name="windowTitle">
-    <string>Layout Toolbar</string>
+    <string>Layout</string>
    </property>
    <property name="toolTip">
-    <string>Layout Toolbar</string>
+    <string>Layout toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -85,7 +85,7 @@
     <string>Toolbox</string>
    </property>
    <property name="toolTip">
-    <string>Toolbox</string>
+    <string>Toolbox toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -101,10 +101,10 @@
   </widget>
   <widget class="QToolBar" name="mNavigationToolbar">
    <property name="windowTitle">
-    <string>Navigation Toolbar</string>
+    <string>Navigation</string>
    </property>
    <property name="toolTip">
-    <string>Navigation Toolbar</string>
+    <string>Navigation toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -120,10 +120,10 @@
   </widget>
   <widget class="QToolBar" name="mActionsToolbar">
    <property name="windowTitle">
-    <string>Actions Toolbar</string>
+    <string>Actions</string>
    </property>
    <property name="toolTip">
-    <string>Actions Toolbar</string>
+    <string>Actions toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -138,10 +138,10 @@
   </widget>
   <widget class="QToolBar" name="mAtlasToolbar">
    <property name="windowTitle">
-    <string>Atlas Toolbar</string>
+    <string>Atlas</string>
    </property>
    <property name="toolTip">
-    <string>Atlas Toolbar</string>
+    <string>Atlas toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -159,10 +159,10 @@
   </widget>
   <widget class="QToolBar" name="mReportToolbar">
    <property name="windowTitle">
-    <string>Report Toolbar</string>
+    <string>Report</string>
    </property>
    <property name="toolTip">
-    <string>Report Toolbar</string>
+    <string>Report toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -21,7 +21,7 @@
     </rect>
    </property>
    <property name="toolTip">
-    <string>Menu Toolbar</string>
+    <string>Menu toolbar</string>
    </property>
    <widget class="QMenu" name="mProjectMenu">
     <property name="title">
@@ -379,10 +379,10 @@
   </widget>
   <widget class="QToolBar" name="mFileToolBar">
    <property name="windowTitle">
-    <string>Project Toolbar</string>
+    <string>Project</string>
    </property>
    <property name="toolTip">
-    <string>Project Toolbar</string>
+    <string>Project toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -399,10 +399,10 @@
   </widget>
   <widget class="QToolBar" name="mLayerToolBar">
    <property name="windowTitle">
-    <string>Manage Layers Toolbar</string>
+    <string>Manage Layers</string>
    </property>
    <property name="toolTip">
-    <string>Manage Layers Toolbar</string>
+    <string>Manage Layers toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -421,10 +421,10 @@
   </widget>
   <widget class="QToolBar" name="mDigitizeToolBar">
    <property name="windowTitle">
-    <string>Digitizing Toolbar</string>
+    <string>Digitizing</string>
    </property>
    <property name="toolTip">
-    <string>Digitizing Toolbar</string>
+    <string>Digitizing toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -447,10 +447,10 @@
   </widget>
   <widget class="QToolBar" name="mAdvancedDigitizeToolBar">
    <property name="windowTitle">
-    <string>Advanced Digitizing Toolbar</string>
+    <string>Advanced Digitizing</string>
    </property>
    <property name="toolTip">
-    <string>Advanced Digitizing Toolbar</string>
+    <string>Advanced Digitizing toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -474,10 +474,10 @@
   </widget>
   <widget class="QToolBar" name="mMapNavToolBar">
    <property name="windowTitle">
-    <string>Map Navigation Toolbar</string>
+    <string>Map Navigation</string>
    </property>
    <property name="toolTip">
-    <string>Map Navigation Toolbar</string>
+    <string>Map Navigation toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -502,10 +502,10 @@
   </widget>
   <widget class="QToolBar" name="mAttributesToolBar">
    <property name="windowTitle">
-    <string>Attributes Toolbar</string>
+    <string>Attributes</string>
    </property>
    <property name="toolTip">
-    <string>Attributes Toolbar</string>
+    <string>Attributes toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -522,10 +522,10 @@
   </widget>
   <widget class="QToolBar" name="mPluginToolBar">
    <property name="windowTitle">
-    <string>Plugins Toolbar</string>
+    <string>Plugins</string>
    </property>
    <property name="toolTip">
-    <string>Plugins Toolbar</string>
+    <string>Plugins toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -537,10 +537,10 @@
   </widget>
   <widget class="QToolBar" name="mHelpToolBar">
    <property name="windowTitle">
-    <string>Help Toolbar</string>
+    <string>Help</string>
    </property>
    <property name="toolTip">
-    <string>Help Toolbar</string>
+    <string>Help toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -552,10 +552,10 @@
   </widget>
   <widget class="QToolBar" name="mRasterToolBar">
    <property name="windowTitle">
-    <string>Raster Toolbar</string>
+    <string>Raster</string>
    </property>
    <property name="toolTip">
-    <string>Raster Toolbar</string>
+    <string>Raster toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -574,10 +574,10 @@
   </widget>
   <widget class="QToolBar" name="mLabelToolBar">
    <property name="windowTitle">
-    <string>Label Toolbar</string>
+    <string>Label</string>
    </property>
    <property name="toolTip">
-    <string>Label Toolbar</string>
+    <string>Label toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -596,10 +596,10 @@
   </widget>
   <widget class="QToolBar" name="mVectorToolBar">
    <property name="windowTitle">
-    <string>Vector Toolbar</string>
+    <string>Vector</string>
    </property>
    <property name="toolTip">
-    <string>Vector Toolbar</string>
+    <string>Vector toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -610,10 +610,10 @@
   </widget>
   <widget class="QToolBar" name="mDatabaseToolBar">
    <property name="windowTitle">
-    <string>Database Toolbar</string>
+    <string>Database</string>
    </property>
    <property name="toolTip">
-    <string>Database Toolbar</string>
+    <string>Database toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -624,10 +624,10 @@
   </widget>
   <widget class="QToolBar" name="mWebToolBar">
    <property name="windowTitle">
-    <string>Web Toolbar</string>
+    <string>Web</string>
    </property>
    <property name="toolTip">
-    <string>Web Toolbar</string>
+    <string>Web toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -638,10 +638,10 @@
   </widget>
   <widget class="QToolBar" name="mSnappingToolBar">
    <property name="windowTitle">
-    <string>Snapping Toolbar</string>
+    <string>Snapping</string>
    </property>
    <property name="toolTip">
-    <string>Snapping Toolbar</string>
+    <string>Snapping toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -652,10 +652,10 @@
   </widget>
   <widget class="QToolBar" name="mDataSourceManagerToolBar">
    <property name="windowTitle">
-    <string>Data Source Manager Toolbar</string>
+    <string>Data Source Manager</string>
    </property>
    <property name="toolTip">
-    <string>Data Source Manager Toolbar</string>
+    <string>Data Source Manager toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>
@@ -671,10 +671,10 @@
   </widget>
   <widget class="QToolBar" name="mShapeDigitizeToolBar">
    <property name="windowTitle">
-    <string>Shape Digitizing Toolbar</string>
+    <string>Shape Digitizing</string>
    </property>
    <property name="toolTip">
-    <string>Shape Digitizing Toolbar</string>
+    <string>Shape Digitizing toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>


### PR DESCRIPTION
## Description

Following the idea of removing the word "Panel" in their titles (e.g., Layers Panel --> Layers), IMHO, there's no reason to have the words "Toolbar" and "Panel" in every sub-menu item.

For the Panel submenu, the word "Panel" is added automatically. I propose to remove that. I removed the Toolbar word manually and changed the tooltip capitalization.

Before

![image](https://user-images.githubusercontent.com/3607161/40988047-081ea892-68e2-11e8-8b97-a9c249365ee1.png)

![image](https://user-images.githubusercontent.com/3607161/40988072-1812c35a-68e2-11e8-8250-e35e7ba5baa0.png)

![image](https://user-images.githubusercontent.com/3607161/40988086-20876888-68e2-11e8-99e1-fdc4b80f81cd.png)

After

![image](https://user-images.githubusercontent.com/3607161/40988105-2e46f3a8-68e2-11e8-80ea-53188711ab52.png)

![image](https://user-images.githubusercontent.com/3607161/40988124-39fb4b40-68e2-11e8-9425-362e31e76022.png)

![image](https://user-images.githubusercontent.com/3607161/40988143-453427f2-68e2-11e8-9bb6-572b78bc4bf2.png)





## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
