### PR TITLE
[Server] Reactivate the capability to print selection with Server 2.18

### DIFF
--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -59,6 +59,7 @@ QgsComposerMap::QgsComposerMap( QgsComposition *composition, int x, int y, int w
     , mUpdatesEnabled( true )
     , mMapCanvas( nullptr )
     , mDrawCanvasItems( true )
+    , mDrawSelection( false )
     , mAtlasDriven( false )
     , mAtlasScalingMode( Auto )
     , mAtlasMargin( 0.10 )
@@ -229,7 +230,7 @@ QgsMapSettings QgsComposerMap::mapSettings( const QgsRectangle& extent, QSizeF s
   jobMapSettings.setDestinationCrs( ms.destinationCrs() );
   jobMapSettings.setCrsTransformEnabled( ms.hasCrsTransformEnabled() );
   jobMapSettings.setFlags( ms.flags() );
-  jobMapSettings.setFlag( QgsMapSettings::DrawSelection, false );
+  jobMapSettings.setFlag( QgsMapSettings::DrawSelection, mDrawSelection );
   jobMapSettings.setFlag( QgsMapSettings::RenderPartialOutput, false );
 
   if ( mComposition->plotStyle() == QgsComposition::Print ||

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -639,6 +639,17 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     void setDrawCanvasItems( bool b ) { mDrawCanvasItems = b; }
     bool drawCanvasItems() const { return mDrawCanvasItems; }
 
+    /** Set the flag to draw selection in map
+     * @note this function was added in version 2.18.21
+     * @note not available in Python bindings
+     */
+    void setDrawSelection( bool b ) { mDrawSelection = b; }
+    /** Get the flag to draw selection in map
+     * @note this function was added in version 2.18.21
+     * @note not available in Python bindings
+     */
+    bool drawSelection() const { return mDrawSelection; }
+
     /** Returns the conversion factor map units -> mm*/
     double mapUnitsToMM() const;
 
@@ -938,6 +949,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     QGraphicsView* mMapCanvas;
     /** True if annotation items, rubber band, etc. from the main canvas should be displayed*/
     bool mDrawCanvasItems;
+
+    /** True if selection has to be drawn. For server only! */
+    bool mDrawSelection;
 
     /** Adjusts an extent rectangle to match the provided item width and height, so that extent
      * center of extent remains the same */

--- a/src/server/qgswmsconfigparser.cpp
+++ b/src/server/qgswmsconfigparser.cpp
@@ -279,6 +279,9 @@ QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& compo
       }
     }
 
+    // Draw Selection
+    currentMap->setDrawSelection( true );
+
     //grid space x / y
     currentMap->grid()->setIntervalX( parameterMap.value( mapId + ":GRID_INTERVAL_X" ).toDouble() );
     currentMap->grid()->setIntervalY( parameterMap.value( mapId + ":GRID_INTERVAL_Y" ).toDouble() );


### PR DESCRIPTION
## Description
The capability to print selection has been removed by the commit aaa7003 to
prevent accidental selections showing in exports from composer.

It is reactivated only for QGIS Server.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
