### PR TITLE
Processing: Fix deprecation errors thrown by regexes

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -105,7 +105,7 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
         self._short_description = ''
         self._group = ''
         self._groupId = ''
-        self.groupIdRegex = re.compile('^[^\s\(]+')
+        self.groupIdRegex = re.compile(r'^[^\s\(]+')
         self.grass7Name = ''
         self.params = []
         self.hardcodedStrings = []

--- a/python/plugins/processing/algs/qgis/DefineProjection.py
+++ b/python/plugins/processing/algs/qgis/DefineProjection.py
@@ -75,7 +75,7 @@ class DefineProjection(QgisAlgorithm):
 
         provider = layer.dataProvider()
         ds = provider.dataSourceUri()
-        p = re.compile('\|.*')
+        p = re.compile(r'\|.*')
         dsPath = p.sub('', ds)
 
         if dsPath.lower().endswith('.shp'):

--- a/python/plugins/processing/tools/spatialite.py
+++ b/python/plugins/processing/tools/spatialite.py
@@ -66,7 +66,7 @@ class GeoDB:
         try:
             self._exec_sql(c, u'SELECT spatialite_version()')
             rep = c.fetchall()
-            v = [int(x) if x.isdigit() else x for x in re.findall("\d+|[a-zA-Z]+", rep[0][0])]
+            v = [int(x) if x.isdigit() else x for x in re.findall(r"\d+|[a-zA-Z]+", rep[0][0])]
 
             # Add SpatiaLite support
             if v >= [4, 1, 0]:


### PR DESCRIPTION
## Description
Processing currently throws some deprecation errors with regular expressions. A side effect of this is flooding of logs when testing. This PR avoids the deprecation errors by making the regexes raw strings.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
