### PR TITLE
[bugfix] Fix double precision I/O in form widgets

### DIFF
--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -199,15 +199,23 @@ bool QgsVertexEditorModel::setData( const QModelIndex &index, const QVariant &va
     return false;
   }
 
-  double x = ( index.column() == 0 ? value.toDouble() : mSelectedFeature->vertexMap().at( index.row() )->point().x() );
-  double y = ( index.column() == 1 ? value.toDouble() : mSelectedFeature->vertexMap().at( index.row() )->point().y() );
+  // Get double value wrt current locale.
+  bool ok;
+  double doubleValue = QLocale().toDouble( value.toString(), &ok );
+  // If not valid and locale's decimal point is not '.' let's try with english locale
+  if ( ! ok && QLocale().decimalPoint() != '.' )
+  {
+    doubleValue = QLocale( QLocale::English ).toDouble( value.toString() );
+  }
+
+  double x = ( index.column() == 0 ? doubleValue : mSelectedFeature->vertexMap().at( index.row() )->point().x() );
+  double y = ( index.column() == 1 ? doubleValue : mSelectedFeature->vertexMap().at( index.row() )->point().y() );
 
   if ( index.column() == mRCol ) // radius modified
   {
     if ( index.row() == 0 || index.row() >= mSelectedFeature->vertexMap().count() - 1 )
       return false;
 
-    double r = value.toDouble();
     double x1 = mSelectedFeature->vertexMap().at( index.row() - 1 )->point().x();
     double y1 = mSelectedFeature->vertexMap().at( index.row() - 1 )->point().y();
     double x2 = x;
@@ -216,7 +224,7 @@ bool QgsVertexEditorModel::setData( const QModelIndex &index, const QVariant &va
     double y3 = mSelectedFeature->vertexMap().at( index.row() + 1 )->point().y();
 
     QgsPoint result;
-    if ( QgsGeometryUtils::segmentMidPoint( QgsPoint( x1, y1 ), QgsPoint( x3, y3 ), result, r, QgsPoint( x2, y2 ) ) )
+    if ( QgsGeometryUtils::segmentMidPoint( QgsPoint( x1, y1 ), QgsPoint( x3, y3 ), result, doubleValue, QgsPoint( x2, y2 ) ) )
     {
       x = result.x();
       y = result.y();

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -244,11 +244,14 @@ QString QgsField::displayString( const QVariant &v ) const
       return QString::number( v.toDouble(), 'f', d->precision );
     }
   }
-  // Other numeric types out of doubles
+  // Other numeric types than doubles
   else if ( isNumeric() &&
             ! QLocale().numberOptions() & QLocale::NumberOption::OmitGroupSeparator )
   {
-    return QLocale().toString( v.toLongLong() );
+    bool ok;
+    qlonglong converted( v.toLongLong( &ok ) );
+    if ( ok )
+      return QLocale().toString( converted );
   }
   // Fallback if special rules do not apply
   return v.toString();
@@ -305,7 +308,7 @@ bool QgsField::convertCompatible( QVariant &v ) const
     QVariant tmp( v );
     if ( d->type == QVariant::Double && !tmp.convert( d->type ) )
     {
-      v = v.toString().replace( ',', '.' );
+      v = v.toString().replace( QLocale().decimalPoint(), '.' );
     }
   }
 

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -22,6 +22,7 @@
 
 #include <QDataStream>
 #include <QIcon>
+#include <QLocale>
 
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
@@ -208,8 +209,30 @@ QString QgsField::displayString( const QVariant &v ) const
     return QgsApplication::nullRepresentation();
   }
 
-  if ( d->type == QVariant::Double && d->precision > 0 )
-    return QString::number( v.toDouble(), 'f', d->precision );
+  if ( d->type == QVariant::Double )
+  {
+    if ( d->precision > 0 )
+    {
+      return QLocale().toString( v.toDouble(), 'f', d->precision );
+    }
+    else
+    {
+      // Precision is not set, let's guess it from the
+      // standard conversion to string
+      QString s( v.toString() );
+      int dotPosition( s.indexOf( '.' ) );
+      int precision;
+      if ( dotPosition < 0 )
+      {
+        precision = 0;
+      }
+      else
+      {
+        precision = s.length() - dotPosition - 1;
+      }
+      return QLocale().toString( v.toDouble(), 'f', precision );
+    }
+  }
 
   return v.toString();
 }

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -281,6 +281,13 @@ bool QgsField::convertCompatible( QVariant &v ) const
     return true;
   }
 
+  // Give it a chance to convert to double since we accept both comma and dot as decimal point
+  QVariant tmp( v );
+  if ( d->type == QVariant::Double && !tmp.convert( d->type ) )
+  {
+    v = v.toString().replace( ',', '.' );
+  }
+
   if ( !v.convert( d->type ) )
   {
     v = QVariant( d->type );

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -217,7 +217,9 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
       v = QgsApplication::nullRepresentation();
   }
   else
-    v = val.toString();
+  {
+    v = field().displayString( val );
+  }
 
   if ( mTextEdit )
   {

--- a/src/gui/qgsfieldvalidator.cpp
+++ b/src/gui/qgsfieldvalidator.cpp
@@ -56,7 +56,16 @@ QgsFieldValidator::QgsFieldValidator( QObject *parent, const QgsField &field, co
     {
       if ( mField.length() > 0 && mField.precision() > 0 )
       {
-        QString re = QStringLiteral( "-?\\d{0,%1}([\\.,]\\d{0,%2})?" ).arg( mField.length() - mField.precision() ).arg( mField.precision() );
+        QString re;
+        // Also accept locale's decimalPoint if it's not a dot
+        if ( QLocale().decimalPoint() != '.' )
+        {
+          re = QStringLiteral( "-?\\d{0,%1}([\\.%2]\\d{0,%3})?" ).arg( mField.length() - mField.precision() ).arg( QLocale().decimalPoint() ).arg( mField.precision() );
+        }
+        else
+        {
+          re = QStringLiteral( "-?\\d{0,%1}([\\.,]\\d{0,%2})?" ).arg( mField.length() - mField.precision() ).arg( mField.precision() );
+        }
         mValidator = new QRegExpValidator( QRegExp( re ), parent );
       }
       else if ( mField.length() > 0 && mField.precision() == 0 )
@@ -66,7 +75,16 @@ QgsFieldValidator::QgsFieldValidator( QObject *parent, const QgsField &field, co
       }
       else if ( mField.precision() > 0 )
       {
-        QString re = QStringLiteral( "-?\\d*([\\.,]\\d{0,%1})?" ).arg( mField.precision() );
+        QString re;
+        // Also accept locale's decimalPoint if it's not a dot
+        if ( QLocale().decimalPoint() != '.' )
+        {
+          re = QStringLiteral( "-?\\d*([\\.%1]\\d{0,%2})?" ).arg( QLocale().decimalPoint(), mField.precision() );
+        }
+        else
+        {
+          re = QStringLiteral( "-?\\d*([\\.]\\d{0,%1})?" ).arg( mField.precision() );
+        }
         mValidator = new QRegExpValidator( QRegExp( re ), parent );
       }
       else

--- a/src/gui/qgsfieldvalidator.cpp
+++ b/src/gui/qgsfieldvalidator.cpp
@@ -56,7 +56,7 @@ QgsFieldValidator::QgsFieldValidator( QObject *parent, const QgsField &field, co
     {
       if ( mField.length() > 0 && mField.precision() > 0 )
       {
-        QString re = QStringLiteral( "-?\\d{0,%1}(\\.\\d{0,%2})?" ).arg( mField.length() - mField.precision() ).arg( mField.precision() );
+        QString re = QStringLiteral( "-?\\d{0,%1}([\\.,]\\d{0,%2})?" ).arg( mField.length() - mField.precision() ).arg( mField.precision() );
         mValidator = new QRegExpValidator( QRegExp( re ), parent );
       }
       else if ( mField.length() > 0 && mField.precision() == 0 )
@@ -66,7 +66,7 @@ QgsFieldValidator::QgsFieldValidator( QObject *parent, const QgsField &field, co
       }
       else if ( mField.precision() > 0 )
       {
-        QString re = QStringLiteral( "-?\\d*(\\.\\d{0,%1})?" ).arg( mField.precision() );
+        QString re = QStringLiteral( "-?\\d*([\\.,]\\d{0,%1})?" ).arg( mField.precision() );
         mValidator = new QRegExpValidator( QRegExp( re ), parent );
       }
       else
@@ -112,12 +112,6 @@ QValidator::State QgsFieldValidator::validate( QString &s, int &i ) const
   // delegate to the child validator if any
   if ( mValidator )
   {
-    // force to use the '.' as a decimal point or in case we are using QDoubleValidator
-    // we can get a valid number with a comma depending on current locale
-    // ... but this will fail subsequently when converted from string to double and
-    // becomes a NULL!
-    if ( mField.type() == QVariant::Double )
-      s = s.replace( ',', '.' );
     QValidator::State result = mValidator->validate( s, i );
     return result;
   }

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -333,7 +333,6 @@ void TestQgsField::displayString()
   QgsField doubleFieldNoPrec( QStringLiteral( "double" ), QVariant::Double, QStringLiteral( "double" ), 10 );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
-  QCOMPARE( QLocale().decimalPoint(), '.' );
   QCOMPARE( QLocale().numberOptions() & QLocale::NumberOption::OmitGroupSeparator, QLocale::NumberOption::DefaultNumberOptions );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599,999,898,999" ) );
 
@@ -514,7 +513,8 @@ void TestQgsField::convertCompatible()
   QCOMPARE( stringVar.type(), QVariant::String );
   QCOMPARE( stringVar.toString(), QString( "lon" ) );
 
-  //double with ',' as decimal separator
+  //double with ',' as decimal separator for German locale
+  QLocale::setDefault( QLocale::German );
   QVariant doubleCommaVar( "1,2345" );
   QVERIFY( doubleField.convertCompatible( doubleCommaVar ) );
   QCOMPARE( doubleCommaVar.type(), QVariant::Double );

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -498,6 +498,44 @@ void TestQgsField::convertCompatible()
   QCOMPARE( longlong.type(), QVariant::LongLong );
   QCOMPARE( longlong, QVariant( 99999999999999999LL ) );
 
+  //string representation of an int
+  QVariant stringInt( "123456" );
+  QVERIFY( intField.convertCompatible( stringInt ) );
+  QCOMPARE( stringInt.type(), QVariant::Int );
+  QCOMPARE( stringInt, QVariant( 123456 ) );
+  // now with group separator for english locale
+  stringInt = QVariant( "123,456" );
+  QVERIFY( intField.convertCompatible( stringInt ) );
+  QCOMPARE( stringInt.type(), QVariant::Int );
+  QCOMPARE( stringInt, QVariant( "123456" ) );
+
+  //string representation of a longlong
+  QVariant stringLong( "99999999999999999" );
+  QVERIFY( longlongField.convertCompatible( stringLong ) );
+  QCOMPARE( stringLong.type(), QVariant::LongLong );
+  QCOMPARE( stringLong, QVariant( 99999999999999999LL ) );
+  // now with group separator for english locale
+  stringLong = QVariant( "99,999,999,999,999,999" );
+  QVERIFY( longlongField.convertCompatible( stringLong ) );
+  QCOMPARE( stringLong.type(), QVariant::LongLong );
+  QCOMPARE( stringLong, QVariant( 99999999999999999LL ) );
+
+
+  //string representation of a double
+  QVariant stringDouble( "123456.012345" );
+  QVERIFY( doubleField.convertCompatible( stringDouble ) );
+  QCOMPARE( stringDouble.type(), QVariant::Double );
+  QCOMPARE( stringDouble, QVariant( 123456.012345 ) );
+  // now with group separator for english locale
+  stringDouble = QVariant( "1,223,456.012345" );
+  QVERIFY( doubleField.convertCompatible( stringDouble ) );
+  QCOMPARE( stringDouble.type(), QVariant::Double );
+  QCOMPARE( stringDouble, QVariant( 1223456.012345 ) );
+  // This should not convert
+  stringDouble = QVariant( "1.223.456,012345" );
+  QVERIFY( ! doubleField.convertCompatible( stringDouble ) );
+
+
   //double with precision
   QgsField doubleWithPrecField( QStringLiteral( "double" ), QVariant::Double, QStringLiteral( "double" ), 10, 3 );
   doubleVar = QVariant( 10.12345678 );
@@ -513,12 +551,61 @@ void TestQgsField::convertCompatible()
   QCOMPARE( stringVar.type(), QVariant::String );
   QCOMPARE( stringVar.toString(), QString( "lon" ) );
 
+
+  /////////////////////////////////////////////////////////
+  // German locale tests
+
   //double with ',' as decimal separator for German locale
   QLocale::setDefault( QLocale::German );
   QVariant doubleCommaVar( "1,2345" );
   QVERIFY( doubleField.convertCompatible( doubleCommaVar ) );
   QCOMPARE( doubleCommaVar.type(), QVariant::Double );
   QCOMPARE( doubleCommaVar.toString(), QString( "1.2345" ) );
+
+  //string representation of an int
+  stringInt = QVariant( "123456" );
+  QVERIFY( intField.convertCompatible( stringInt ) );
+  QCOMPARE( stringInt.type(), QVariant::Int );
+  QCOMPARE( stringInt, QVariant( 123456 ) );
+  // now with group separator for german locale
+  stringInt = QVariant( "123.456" );
+  QVERIFY( intField.convertCompatible( stringInt ) );
+  QCOMPARE( stringInt.type(), QVariant::Int );
+  QCOMPARE( stringInt, QVariant( "123456" ) );
+
+  //string representation of a longlong
+  stringLong = QVariant( "99999999999999999" );
+  QVERIFY( longlongField.convertCompatible( stringLong ) );
+  QCOMPARE( stringLong.type(), QVariant::LongLong );
+  QCOMPARE( stringLong, QVariant( 99999999999999999LL ) );
+  // now with group separator for german locale
+  stringLong = QVariant( "99.999.999.999.999.999" );
+  QVERIFY( longlongField.convertCompatible( stringLong ) );
+  QCOMPARE( stringLong.type(), QVariant::LongLong );
+  QCOMPARE( stringLong, QVariant( 99999999999999999LL ) );
+
+  //string representation of a double
+  stringDouble = QVariant( "123456,012345" );
+  QVERIFY( doubleField.convertCompatible( stringDouble ) );
+  QCOMPARE( stringDouble.type(), QVariant::Double );
+  QCOMPARE( stringDouble, QVariant( 123456.012345 ) );
+  // For doubles we also want to accept dot as a decimal point
+  stringDouble = QVariant( "123456.012345" );
+  QVERIFY( doubleField.convertCompatible( stringDouble ) );
+  QCOMPARE( stringDouble.type(), QVariant::Double );
+  QCOMPARE( stringDouble, QVariant( 123456.012345 ) );
+  // now with group separator for german locale
+  stringDouble = QVariant( "1.223.456,012345" );
+  QVERIFY( doubleField.convertCompatible( stringDouble ) );
+  QCOMPARE( stringDouble.type(), QVariant::Double );
+  QCOMPARE( stringDouble, QVariant( 1223456.012345 ) );
+  // Be are good citizens and we also accept english locale
+  stringDouble = QVariant( "1,223,456.012345" );
+  QVERIFY( doubleField.convertCompatible( stringDouble ) );
+  QCOMPARE( stringDouble.type(), QVariant::Double );
+  QCOMPARE( stringDouble, QVariant( 1223456.012345 ) );
+
+
 }
 
 void TestQgsField::dataStream()

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -316,12 +316,12 @@ void TestQgsField::displayString()
   //test int value in int type
   QgsField intField2( QStringLiteral( "int" ), QVariant::Int, QStringLiteral( "int" ) );
   QCOMPARE( intField2.displayString( 5 ), QString( "5" ) );
-  QCOMPARE( intField2.displayString( 599999898999LL ), QString( "599999898999" ) );
+  QCOMPARE( intField2.displayString( 599999898999LL ), QString( "599,999,898,999" ) );
 
   //test long type
   QgsField longField( QStringLiteral( "long" ), QVariant::LongLong, QStringLiteral( "longlong" ) );
   QCOMPARE( longField.displayString( 5 ), QString( "5" ) );
-  QCOMPARE( longField.displayString( 599999898999LL ), QString( "599999898999" ) );
+  QCOMPARE( longField.displayString( 599999898999LL ), QString( "599,999,898,999" ) );
 
   //test NULL int
   QVariant nullInt = QVariant( QVariant::Int );
@@ -333,6 +333,8 @@ void TestQgsField::displayString()
   QgsField doubleFieldNoPrec( QStringLiteral( "double" ), QVariant::Double, QStringLiteral( "double" ), 10 );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
+  QCOMPARE( QLocale().decimalPoint(), '.' );
+  QCOMPARE( QLocale().numberOptions() & QLocale::NumberOption::OmitGroupSeparator, QLocale::NumberOption::DefaultNumberOptions );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599,999,898,999" ) );
 
   //test NULL double
@@ -345,6 +347,43 @@ void TestQgsField::displayString()
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5,005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5,005005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599.999.898.999" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5.999,123456" ) );
+
+  //test value with custom German locale (OmitGroupSeparator)
+  QLocale customGerman( QLocale::German );
+  customGerman.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
+  QLocale::setDefault( customGerman );
+  QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5,005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5,005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5,005005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599999898999" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5999,123456" ) );
+
+  //test int value in int type with custom German locale (OmitGroupSeparator)
+  QCOMPARE( intField2.displayString( 5 ), QString( "5" ) );
+  QCOMPARE( intField2.displayString( 599999898999LL ), QString( "599999898999" ) );
+
+  //test long type with custom German locale (OmitGroupSeparator)
+  QCOMPARE( longField.displayString( 5 ), QString( "5" ) );
+  QCOMPARE( longField.displayString( 599999898999LL ), QString( "599999898999" ) );
+
+  //test value with custom english locale (OmitGroupSeparator)
+  QLocale customEnglish( QLocale::English );
+  customEnglish.setNumberOptions( QLocale::NumberOption::OmitGroupSeparator );
+  QLocale::setDefault( customEnglish );
+  QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5.005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599999898999" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5999.123456 ), QString( "5999.123456" ) );
+
+  //test int value in int type with custom english locale (OmitGroupSeparator)
+  QCOMPARE( intField2.displayString( 5 ), QString( "5" ) );
+  QCOMPARE( intField2.displayString( 599999898999LL ), QString( "599999898999" ) );
+
+  //test long type with custom english locale (OmitGroupSeparator)
+  QCOMPARE( longField.displayString( 5 ), QString( "5" ) );
+  QCOMPARE( longField.displayString( 599999898999LL ), QString( "599999898999" ) );
 
 }
 

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -346,7 +346,6 @@ void TestQgsField::displayString()
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5,005005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599.999.898.999" ) );
 
-
 }
 
 void TestQgsField::convertCompatible()
@@ -475,6 +474,12 @@ void TestQgsField::convertCompatible()
   QVERIFY( !stringWithLen.convertCompatible( stringVar ) );
   QCOMPARE( stringVar.type(), QVariant::String );
   QCOMPARE( stringVar.toString(), QString( "lon" ) );
+
+  //double with ',' as decimal separator
+  QVariant doubleCommaVar( "1,2345" );
+  QVERIFY( doubleField.convertCompatible( doubleCommaVar ) );
+  QCOMPARE( doubleCommaVar.type(), QVariant::Double );
+  QCOMPARE( doubleCommaVar.toString(), QString( "1.2345" ) );
 }
 
 void TestQgsField::dataStream()

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -17,6 +17,7 @@
 #include <QObject>
 #include <QString>
 #include <QStringList>
+#include <QLocale>
 
 #include <memory>
 
@@ -66,12 +67,12 @@ void TestQgsField::cleanupTestCase()
 
 void TestQgsField::init()
 {
-
+  QLocale::setDefault( QLocale::English );
 }
 
 void TestQgsField::cleanup()
 {
-
+  QLocale::setDefault( QLocale::English );
 }
 
 void TestQgsField::create()
@@ -332,11 +333,19 @@ void TestQgsField::displayString()
   QgsField doubleFieldNoPrec( QStringLiteral( "double" ), QVariant::Double, QStringLiteral( "double" ), 10 );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
-  QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599999898999" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599,999,898,999" ) );
 
   //test NULL double
   QVariant nullDouble = QVariant( QVariant::Double );
   QCOMPARE( doubleField.displayString( nullDouble ), QString( "TEST NULL" ) );
+
+  //test double value with German locale
+  QLocale::setDefault( QLocale::German );
+  QCOMPARE( doubleField.displayString( 5.005005 ), QString( "5,005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5,005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5,005005005" ) );
+  QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599.999.898.999" ) );
+
 
 }
 

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -266,13 +266,13 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
         QCoreApplication.setOrganizationDomain("QGIS_TestPyQgsColorScheme.com")
         QCoreApplication.setApplicationName("QGIS_TestPyQgsColorScheme")
         QgsSettings().clear()
-        QLocale.setDefault(QLocale.c())
+        QLocale.setDefault(QLocale(QLocale.English))
         start_app()
 
     @classmethod
     def tearDownClass(cls):
         """Reset locale"""
-        QLocale.setDefault(QLocale.c())
+        QLocale.setDefault(QLocale(QLocale.English))
 
     def test_representValue(self):
 
@@ -285,19 +285,19 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
 
         # Precision is ignored for integers and longlongs
         self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '123'), '123')
-        self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '123000'), '123000')
-        self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '9999999'), '9999999')  # no scientific notation for integers!
+        self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '123000'), '123,000')
+        self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '9999999'), '9,999,999')  # no scientific notation for integers!
         self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, None), 'NULL')
         self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '123'), '123')
-        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '123000'), '123000')
-        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '9999999'), '9999999')  # no scientific notation for long longs!
+        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '123000'), '123,000')
+        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '9999999'), '9,999,999')  # no scientific notation for long longs!
         self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, None), 'NULL')
 
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 1}, None, None), 'NULL')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 1}, None, '123'), '123.0')
 
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, None), 'NULL')
-        self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '123000'), '123000.00')
+        self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '123000'), '123,000.00')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '0'), '0.00')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '123'), '123.00')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '0.123'), '0.12')
@@ -312,6 +312,7 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 3}, None, '-0.127'), '-0.127')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 3}, None, '-1.27e-1'), '-0.127')
 
+        # Check with Italian locale
         QLocale.setDefault(QLocale('it'))
 
         self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '9999999'),
@@ -336,6 +337,19 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '-0.127'), '-0,13')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 3}, None, '-0.127'), '-0,127')
         self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 3}, None, '-1.27e-1'), '-0,127')
+
+        # Check with custom locale without thousand separator
+
+        custom = QLocale('en')
+        custom.setNumberOptions(QLocale.OmitGroupSeparator)
+        QLocale.setDefault(custom)
+
+        self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '9999999'),
+                         '9999999')  # scientific notation for integers!
+        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '123'), '123')
+        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '123000'), '123000')
+        self.assertEqual(fieldFormatter.representValue(layer, 2, {'Precision': 1}, None, '9999999'), '9999999')  # scientific notation for long longs!
+        self.assertEqual(fieldFormatter.representValue(layer, 1, {'Precision': 2}, None, '123000'), '123000.00')
 
         QgsProject.instance().removeAllMapLayers()
 

--- a/tests/src/python/test_qgsfieldformatters.py
+++ b/tests/src/python/test_qgsfieldformatters.py
@@ -266,7 +266,13 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
         QCoreApplication.setOrganizationDomain("QGIS_TestPyQgsColorScheme.com")
         QCoreApplication.setApplicationName("QGIS_TestPyQgsColorScheme")
         QgsSettings().clear()
+        QLocale.setDefault(QLocale.c())
         start_app()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Reset locale"""
+        QLocale.setDefault(QLocale.c())
 
     def test_representValue(self):
 
@@ -276,8 +282,6 @@ class TestQgsRangeFieldFormatter(unittest.TestCase):
         QgsProject.instance().addMapLayers([layer])
 
         fieldFormatter = QgsRangeFieldFormatter()
-
-        QLocale.setDefault(QLocale.c())
 
         # Precision is ignored for integers and longlongs
         self.assertEqual(fieldFormatter.representValue(layer, 0, {'Precision': 1}, None, '123'), '123')

--- a/tests/src/python/test_qgsfieldvalidator.py
+++ b/tests/src/python/test_qgsfieldvalidator.py
@@ -14,7 +14,7 @@ __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
 
-from qgis.PyQt.QtCore import QVariant
+from qgis.PyQt.QtCore import QVariant, QLocale
 from qgis.PyQt.QtGui import QValidator
 from qgis.core import QgsVectorLayer
 from qgis.gui import QgsFieldValidator
@@ -39,45 +39,41 @@ class TestQgsFieldValidator(unittest.TestCase):
         """Run after each test."""
         pass
 
-    def test_validator(self):
-        # Test the double
-        """ 
+    def _fld_checker(self, field):
+        """
         Expected results from validate
         QValidator::Invalid 0 The string is clearly invalid.
         QValidator::Intermediate 1 The string is a plausible intermediate value.
         QValidator::Acceptable 2 The string is acceptable as a final result; i.e. it is valid.
         """
+        DECIMAL_SEPARATOR = QLocale().decimalPoint()
+        OTHER_SEPARATOR = ',' if DECIMAL_SEPARATOR == '.' else '.'
 
-        double_field = self.vl.fields()[self.vl.fields().indexFromName('double_field')]
-        self.assertEqual(double_field.precision(), 0) # this is what the provider reports :(
-        self.assertEqual(double_field.length(), 0) # not set
-        self.assertEqual(double_field.type(), QVariant.Double)
-
-        validator = QgsFieldValidator(None, double_field, '0.0', '')
+        validator = QgsFieldValidator(None, field, '0.0', '')
 
         def _test(value, expected):
             ret = validator.validate(value, 0)
-            self.assertEqual(ret[0], expected, value)
+            self.assertEqual(ret[0], expected, "%s != %s" % (ret[0], expected))
             if value:
                 self.assertEqual(validator.validate('-' + value, 0)[0], expected, '-' + value)
-            # Check the decimal comma separator has been properly transformed
-            if expected != QValidator.Invalid:
-                self.assertEqual(ret[1], value.replace(',', '.'))
 
         # Valid
         _test('0.1234', QValidator.Acceptable)
         _test('0,1234', QValidator.Acceptable)
-        _test('12345.1234e+123', QValidator.Acceptable)
-        _test('12345.1234e-123', QValidator.Acceptable)
-        _test('12345,1234e+123', QValidator.Acceptable)
-        _test('12345,1234e-123', QValidator.Acceptable)
-        _test('', QValidator.Acceptable)
 
-        # Out of range
-        _test('12345.1234e+823', QValidator.Intermediate)
-        _test('12345.1234e-823', QValidator.Intermediate)
-        _test('12345,1234e+823', QValidator.Intermediate)
-        _test('12345,1234e-823', QValidator.Intermediate)
+        # If precision is > 0, regexp validator is used (and it does not support sci notation)
+        if field.precision() == 0:
+            _test('12345.1234e+123', QValidator.Acceptable)
+            _test('12345.1234e-123', QValidator.Acceptable)
+            _test('12345,1234e+123', QValidator.Acceptable)
+            _test('12345,1234e-123', QValidator.Acceptable)
+            _test('', QValidator.Acceptable)
+
+            # Out of range
+            _test('12345.1234e+823', QValidator.Intermediate)
+            _test('12345.1234e-823', QValidator.Intermediate)
+            _test('12345,1234e+823', QValidator.Intermediate)
+            _test('12345,1234e-823', QValidator.Intermediate)
 
         # Invalid
         _test('12345-1234', QValidator.Invalid)
@@ -97,8 +93,38 @@ class TestQgsFieldValidator(unittest.TestCase):
 
         # Invalid
         _test('12345-1234', QValidator.Invalid)
-        _test('12345.1234', QValidator.Invalid)
+        _test('12345%s1234' % DECIMAL_SEPARATOR, QValidator.Invalid)
         _test('onetwothree', QValidator.Invalid)
+
+    def test_doubleValidator(self):
+        """Test the double with default (system) locale"""
+        field = self.vl.fields()[self.vl.fields().indexFromName('double_field')]
+        self.assertEqual(field.precision(), 0) # this is what the provider reports :(
+        self.assertEqual(field.length(), 0) # not set
+        self.assertEqual(field.type(), QVariant.Double)
+        self._fld_checker(field)
+
+    def test_doubleValidatorCommaLocale(self):
+        """Test the double with german locale"""
+        QLocale.setDefault(QLocale(QLocale.German, QLocale.Germany))
+        assert QLocale().decimalPoint() == ','
+        field = self.vl.fields()[self.vl.fields().indexFromName('double_field')]
+        self._fld_checker(field)
+
+    def test_doubleValidatorDotLocale(self):
+        """Test the double with english locale"""
+        QLocale.setDefault(QLocale(QLocale.English))
+        assert QLocale().decimalPoint() == '.'
+        field = self.vl.fields()[self.vl.fields().indexFromName('double_field')]
+        self._fld_checker(field)
+
+    def test_precision(self):
+        """Test different precision"""
+        QLocale.setDefault(QLocale(QLocale.English))
+        assert QLocale().decimalPoint() == '.'
+        field = self.vl.fields()[self.vl.fields().indexFromName('double_field')]
+        field.setPrecision(4)
+        self._fld_checker(field)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsfieldvalidator.py
+++ b/tests/src/python/test_qgsfieldvalidator.py
@@ -59,21 +59,26 @@ class TestQgsFieldValidator(unittest.TestCase):
 
         # Valid
         _test('0.1234', QValidator.Acceptable)
-        _test('0,1234', QValidator.Acceptable)
+
+        # Apparently we accept comma only when locale say so
+        if DECIMAL_SEPARATOR != '.':
+            _test('0,1234', QValidator.Acceptable)
 
         # If precision is > 0, regexp validator is used (and it does not support sci notation)
         if field.precision() == 0:
             _test('12345.1234e+123', QValidator.Acceptable)
             _test('12345.1234e-123', QValidator.Acceptable)
-            _test('12345,1234e+123', QValidator.Acceptable)
-            _test('12345,1234e-123', QValidator.Acceptable)
+            if DECIMAL_SEPARATOR != '.':
+                _test('12345,1234e+123', QValidator.Acceptable)
+                _test('12345,1234e-123', QValidator.Acceptable)
             _test('', QValidator.Acceptable)
 
             # Out of range
             _test('12345.1234e+823', QValidator.Intermediate)
             _test('12345.1234e-823', QValidator.Intermediate)
-            _test('12345,1234e+823', QValidator.Intermediate)
-            _test('12345,1234e-823', QValidator.Intermediate)
+            if DECIMAL_SEPARATOR != '.':
+                _test('12345,1234e+823', QValidator.Intermediate)
+                _test('12345,1234e-823', QValidator.Intermediate)
 
         # Invalid
         _test('12345-1234', QValidator.Invalid)


### PR DESCRIPTION
## Fix some display inconsistencies with double and integer numbers in forms:

- range widget and text input now display numbers in the same way 
- range widget and text input now display numbers respecting system settings
- accept comma or dot according to locale settings  (on unix it should accept both, on windows only the decimal point reported by the system settings)

Try to fix  https://issues.qgis.org/issues/18963, https://issues.qgis.org/issues/18679

There is a windows build here if someone wants to give this patch a quick try:
http://www.itopen.it/bulk/mxe-release-2018-06-05-18-06-30.zip
