### PR TITLE
Add more common angles into advanceddigitizingdockwidget

### DIFF
--- a/python/core/auto_generated/qgscadutils.sip.in
+++ b/python/core/auto_generated/qgscadutils.sip.in
@@ -55,7 +55,7 @@ The QgsCadUtils class provides routines for CAD editing.
 
       QgsPointLocator::Match edgeMatch;
 
-      int softLockCommonAngle;
+      double softLockCommonAngle;
     };
 
     static QgsCadUtils::AlignMapPointOutput alignMapPoint( const QgsPointXY &originalMapPoint, const QgsCadUtils::AlignMapPointContext &ctx );

--- a/src/core/qgscadutils.h
+++ b/src/core/qgscadutils.h
@@ -96,7 +96,7 @@ class CORE_EXPORT QgsCadUtils
       QgsPointLocator::Match edgeMatch;
 
       //! Angle (in degrees) to which we have soft-locked ourselves (if not set it is -1)
-      int softLockCommonAngle;
+      double softLockCommonAngle;
     };
 
     /**

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -102,13 +102,18 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
   QMenu *menu = new QMenu( this );
   // common angles
   QActionGroup *angleButtonGroup = new QActionGroup( menu ); // actions are exclusive for common angles
-  mCommonAngleActions = QMap<QAction *, int>();
-  QList< QPair< int, QString > > commonAngles;
-  commonAngles << QPair<int, QString>( 0, tr( "Do Not Snap to Common Angles" ) );
-  commonAngles << QPair<int, QString>( 30, tr( "Snap to 30° Angles" ) );
-  commonAngles << QPair<int, QString>( 45, tr( "Snap to 45° Angles" ) );
-  commonAngles << QPair<int, QString>( 90, tr( "Snap to 90° Angles" ) );
-  for ( QList< QPair< int, QString > >::const_iterator it = commonAngles.constBegin(); it != commonAngles.constEnd(); ++it )
+  mCommonAngleActions = QMap<QAction *, double>();
+  QList< QPair< double, QString > > commonAngles;
+  commonAngles << QPair<double, QString>( 0, tr( "Do not snap to common angles" ) );
+  commonAngles << QPair<double, QString>( 5, tr( "Snap to 5° angles" ) );
+  commonAngles << QPair<double, QString>( 10, tr( "Snap to 10° angles" ) );
+  commonAngles << QPair<double, QString>( 15, tr( "Snap to 15° angles" ) );
+  commonAngles << QPair<double, QString>( 18, tr( "Snap to 18° angles" ) );
+  commonAngles << QPair<double, QString>( 22.5, tr( "Snap to 22.5° angles" ) );
+  commonAngles << QPair<double, QString>( 30, tr( "Snap to 30° angles" ) );
+  commonAngles << QPair<double, QString>( 45, tr( "Snap to 45° angles" ) );
+  commonAngles << QPair<double, QString>( 90, tr( "Snap to 90° angles" ) );
+  for ( QList< QPair<double , QString > >::const_iterator it = commonAngles.constBegin(); it != commonAngles.constEnd(); ++it )
   {
     QAction *action = new QAction( it->second, menu );
     action->setCheckable( true );
@@ -242,7 +247,7 @@ void QgsAdvancedDigitizingDockWidget::setConstructionMode( bool enabled )
 void QgsAdvancedDigitizingDockWidget::settingsButtonTriggered( QAction *action )
 {
   // common angles
-  QMap<QAction *, int>::const_iterator ica = mCommonAngleActions.constFind( action );
+  QMap<QAction *, double>::const_iterator ica = mCommonAngleActions.constFind( action );
   if ( ica != mCommonAngleActions.constEnd() )
   {
     ica.key()->setChecked( true );

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -110,15 +110,16 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
   QActionGroup *angleButtonGroup = new QActionGroup( menu ); // actions are exclusive for common angles
   mCommonAngleActions = QMap<QAction *, double>();
   QList< QPair< double, QString > > commonAngles;
-  commonAngles << QPair<double, QString>( 0, tr( "Do not snap to common angles" ) );
-  commonAngles << QPair<double, QString>( 5, tr( "Snap to 5° angles" ) );
-  commonAngles << QPair<double, QString>( 10, tr( "Snap to 10° angles" ) );
-  commonAngles << QPair<double, QString>( 15, tr( "Snap to 15° angles" ) );
-  commonAngles << QPair<double, QString>( 18, tr( "Snap to 18° angles" ) );
-  commonAngles << QPair<double, QString>( 22.5, tr( "Snap to 22.5° angles" ) );
-  commonAngles << QPair<double, QString>( 30, tr( "Snap to 30° angles" ) );
-  commonAngles << QPair<double, QString>( 45, tr( "Snap to 45° angles" ) );
-  commonAngles << QPair<double, QString>( 90, tr( "Snap to 90° angles" ) );
+  QString menuText;
+  QList<double> anglesDouble( { 0.0, 5.0, 10.0, 15.0, 18.0, 22.5, 30.0, 45.0, 90.0} );
+  for ( QList<double>::const_iterator it = anglesDouble.constBegin(); it != anglesDouble.constEnd(); ++it )
+  {
+    if ( *it == 0 )
+      menuText = tr( "Do not snap to common angles" );
+    else
+      menuText = QString( tr( "%1, %2, %3, %4°..." ) ).arg( *it, 0, 'f', 1 ).arg( *it * 2, 0, 'f', 1 ).arg( *it * 3, 0, 'f', 1 ).arg( *it * 4, 0, 'f', 1 );
+    commonAngles << QPair<double, QString>( *it, menuText );
+  }
   for ( QList< QPair<double, QString > >::const_iterator it = commonAngles.constBegin(); it != commonAngles.constEnd(); ++it )
   {
     QAction *action = new QAction( it->second, menu );

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -38,7 +38,13 @@
 QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *canvas, QWidget *parent )
   : QgsDockWidget( parent )
   , mMapCanvas( canvas )
-  , mCommonAngleConstraint( QgsSettings().value( QStringLiteral( "/Cad/CommonAngle" ), 90 ).toInt() )
+  , mCurrentMapToolSupportsCad( false )
+  , mCadEnabled( false )
+  , mConstructionMode( false )
+  , mCommonAngleConstraint( QgsSettings().value( QStringLiteral( "/Cad/CommonAngle" ), 90 ).toDouble() )
+  , mSnappedToVertex( false )
+  , mSessionActive( false )
+  , mErrorMessage( nullptr )
 {
   setupUi( this );
 
@@ -113,7 +119,7 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
   commonAngles << QPair<double, QString>( 30, tr( "Snap to 30° angles" ) );
   commonAngles << QPair<double, QString>( 45, tr( "Snap to 45° angles" ) );
   commonAngles << QPair<double, QString>( 90, tr( "Snap to 90° angles" ) );
-  for ( QList< QPair<double , QString > >::const_iterator it = commonAngles.constBegin(); it != commonAngles.constEnd(); ++it )
+  for ( QList< QPair<double, QString > >::const_iterator it = commonAngles.constBegin(); it != commonAngles.constEnd(); ++it )
   {
     QAction *action = new QAction( it->second, menu );
     action->setCheckable( true );

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -117,7 +117,7 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
     if ( *it == 0 )
       menuText = tr( "Do not snap to common angles" );
     else
-      menuText = QString( tr( "%1, %2, %3, %4°..." ) ).arg( *it, 0, 'f', 1 ).arg( *it * 2, 0, 'f', 1 ).arg( *it * 3, 0, 'f', 1 ).arg( *it * 4, 0, 'f', 1 );
+      menuText = QString( tr( "%1, %2, %3, %4° …" ) ).arg( *it, 0, 'f', 1 ).arg( *it * 2, 0, 'f', 1 ).arg( *it * 3, 0, 'f', 1 ).arg( *it * 4, 0, 'f', 1 );
     commonAngles << QPair<double, QString>( *it, menuText );
   }
   for ( QList< QPair<double, QString > >::const_iterator it = commonAngles.constBegin(); it != commonAngles.constEnd(); ++it )

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -252,7 +252,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     //! Constraint on the Y coordinate
     const CadConstraint *constraintY() const { return mYConstraint.get(); }
     //! Constraint on a common angle
-    bool commonAngleConstraint() const { return mCommonAngleConstraint; }
+    bool commonAngleConstraint() const { return !qgsDoubleNear( mCommonAngleConstraint, 0.0 ); }
 
     /**
      * Removes all points from the CAD point list
@@ -467,7 +467,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     std::unique_ptr< CadConstraint > mXConstraint;
     std::unique_ptr< CadConstraint > mYConstraint;
     AdditionalConstraint mAdditionalConstraint;
-    int mCommonAngleConstraint = 90; // if 0: do not snap to common angles
+    double mCommonAngleConstraint; // if 0: do not snap to common angles
 
     // point list and current snap point / segment
     QList<QgsPointXY> mCadPointList;
@@ -481,7 +481,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
 
     // UI
     QAction *mEnableAction = nullptr;
-    QMap< QAction *, int > mCommonAngleActions; // map the common angle actions with their angle values
+    QMap< QAction *, double > mCommonAngleActions; // map the common angle actions with their angle values
 
   private:
 #ifdef SIP_RUN

--- a/tests/src/core/testqgscadutils.cpp
+++ b/tests/src/core/testqgscadutils.cpp
@@ -207,14 +207,14 @@ void TestQgsCadUtils::testCommonAngle()
   // without common angle
   QgsCadUtils::AlignMapPointOutput res0 = QgsCadUtils::alignMapPoint( QgsPointXY( 40, 20.1 ), context );
   QVERIFY( res0.valid );
-  QCOMPARE( res0.softLockCommonAngle, -1 );
+  QCOMPARE( res0.softLockCommonAngle, -1.0 );
   QCOMPARE( res0.finalMapPoint, QgsPointXY( 40, 20.1 ) );
 
   // common angle
   context.commonAngleConstraint = QgsCadUtils::AlignMapPointConstraint( true, false, 90 );
   QgsCadUtils::AlignMapPointOutput res1 = QgsCadUtils::alignMapPoint( QgsPointXY( 40, 20.1 ), context );
   QVERIFY( res1.valid );
-  QCOMPARE( res1.softLockCommonAngle, 0 );
+  QCOMPARE( res1.softLockCommonAngle, 0.0 );
   QCOMPARE( res1.finalMapPoint, QgsPointXY( 40, 20 ) );
 
   // common angle + angle  (make sure that angle constraint has priority)
@@ -222,7 +222,7 @@ void TestQgsCadUtils::testCommonAngle()
   context.angleConstraint = QgsCadUtils::AlignMapPointConstraint( true, false, 45 );
   QgsCadUtils::AlignMapPointOutput res2 = QgsCadUtils::alignMapPoint( QgsPointXY( 40, 20.1 ), context );
   QVERIFY( res2.valid );
-  QCOMPARE( res2.softLockCommonAngle, -1 );
+  QCOMPARE( res2.softLockCommonAngle, -1.0 );
   QCOMPARE( res2.finalMapPoint, QgsPointXY( 35.05, 25.05 ) );
 
   // common angle rel
@@ -231,7 +231,7 @@ void TestQgsCadUtils::testCommonAngle()
   context.cadPointList[1] = QgsPointXY( 40, 20 );
   QgsCadUtils::AlignMapPointOutput res3 = QgsCadUtils::alignMapPoint( QgsPointXY( 50.1, 29.9 ), context );
   QVERIFY( res3.valid );
-  QCOMPARE( res3.softLockCommonAngle, 90 );
+  QCOMPARE( res3.softLockCommonAngle, 90.0 );
   QCOMPARE( res3.finalMapPoint, QgsPointXY( 50, 30 ) );
 }
 
@@ -242,7 +242,7 @@ void TestQgsCadUtils::testDistance()
   // without distance constraint
   QgsCadUtils::AlignMapPointOutput res0 = QgsCadUtils::alignMapPoint( QgsPointXY( 45, 20 ), context );
   QVERIFY( res0.valid );
-  QCOMPARE( res0.softLockCommonAngle, -1 );
+  QCOMPARE( res0.softLockCommonAngle, -1.0 );
   QCOMPARE( res0.finalMapPoint, QgsPointXY( 45, 20 ) );
 
   // dist


### PR DESCRIPTION
## Description
This PR adds only some other common angles used in CAD tools, like AutoCAD. 
![image](https://user-images.githubusercontent.com/7521540/40986205-f15fe61c-68e5-11e8-915d-6d4bc65aad7d.png)

>@3nids I am a bit reluctant at adding so much. It is still easily achievable through the widget by entering the angle (and eventually locking it).

it was a request from colleagues draftsmen, on the contrary I find it almost more useful to have help on angles "less" obvious than orthogonal

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
