### PR TITLE
[needs-docs] Avoid duplicate use of Ctrl-D shorcut

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1584,7 +1584,7 @@
     <string>Remove Layer/Group</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+D</string>
+    <string>Ctrl+Del</string>
    </property>
   </action>
   <action name="mActionSetLayerCRS">


### PR DESCRIPTION
Fixes [#16702](https://issues.qgis.org/issues/16702)
This shortcut, also used to constrain the distance in the CAD panel, is never triggered in that case and instead tries to save the edits and remove the layer in edit.