### PR TITLE
vertex tool fixes

### DIFF
--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -237,6 +237,13 @@ Expand the rectangle so that covers both the original rectangle and the given re
 Expand the rectangle so that covers both the original rectangle and the given point.
 %End
 
+    void combineExtentWith( const QgsPointXY &point );
+%Docstring
+Expand the rectangle so that covers both the original rectangle and the given point.
+
+.. versionadded:: 3.2
+%End
+
     QgsRectangle operator-( QgsVector v ) const;
 
     QgsRectangle operator+( QgsVector v ) const;

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -229,17 +229,17 @@ Returns true when rectangle contains a point.
 
     void combineExtentWith( const QgsRectangle &rect );
 %Docstring
-Expands the rectangle so that its covers both the original rectangle and the given rectangle.
+Expands the rectangle so that it covers both the original rectangle and the given rectangle.
 %End
 
     void combineExtentWith( double x, double y );
 %Docstring
-Expands the rectangle so that its covers both the original rectangle and the given point.
+Expands the rectangle so that it covers both the original rectangle and the given point.
 %End
 
     void combineExtentWith( const QgsPointXY &point );
 %Docstring
-Expands the rectangle so that its covers both the original rectangle and the given point.
+Expands the rectangle so that it covers both the original rectangle and the given point.
 
 .. versionadded:: 3.2
 %End

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -229,17 +229,17 @@ Returns true when rectangle contains a point.
 
     void combineExtentWith( const QgsRectangle &rect );
 %Docstring
-Expand the rectangle so that covers both the original rectangle and the given rectangle.
+Expands the rectangle so that its covers both the original rectangle and the given rectangle.
 %End
 
     void combineExtentWith( double x, double y );
 %Docstring
-Expand the rectangle so that covers both the original rectangle and the given point.
+Expands the rectangle so that its covers both the original rectangle and the given point.
 %End
 
     void combineExtentWith( const QgsPointXY &point );
 %Docstring
-Expand the rectangle so that covers both the original rectangle and the given point.
+Expands the rectangle so that its covers both the original rectangle and the given point.
 
 .. versionadded:: 3.2
 %End

--- a/src/app/vertextool/qgsselectedfeature.cpp
+++ b/src/app/vertextool/qgsselectedfeature.cpp
@@ -60,7 +60,7 @@ QgsSelectedFeature::~QgsSelectedFeature()
 
 void QgsSelectedFeature::currentLayerChanged( QgsMapLayer *layer )
 {
-  if ( layer == mVlayer )
+  if ( layer == mLayer )
     deleteLater();
 }
 
@@ -71,7 +71,7 @@ void QgsSelectedFeature::updateGeometry( const QgsGeometry *geom )
   if ( !geom )
   {
     QgsFeature f;
-    mVlayer->getFeatures( QgsFeatureRequest().setFilterFid( mFeatureId ) ).nextFeature( f );
+    mLayer->getFeatures( QgsFeatureRequest().setFilterFid( mFeatureId ) ).nextFeature( f );
     if ( f.hasGeometry() )
       mGeometry = new QgsGeometry( f.geometry() );
     else
@@ -83,10 +83,10 @@ void QgsSelectedFeature::updateGeometry( const QgsGeometry *geom )
   }
 }
 
-void QgsSelectedFeature::setSelectedFeature( QgsFeatureId featureId, QgsVectorLayer *vlayer, QgsMapCanvas *canvas )
+void QgsSelectedFeature::setSelectedFeature( QgsFeatureId featureId, QgsVectorLayer *layer, QgsMapCanvas *canvas )
 {
   mFeatureId = featureId;
-  mVlayer = vlayer;
+  mLayer = layer;
   mCanvas = canvas;
 
   delete mGeometry;
@@ -96,24 +96,24 @@ void QgsSelectedFeature::setSelectedFeature( QgsFeatureId featureId, QgsVectorLa
   connect( QgisApp::instance()->layerTreeView(), &QgsLayerTreeView::currentLayerChanged, this, &QgsSelectedFeature::currentLayerChanged );
 
   // feature was deleted
-  connect( mVlayer, &QgsVectorLayer::featureDeleted, this, &QgsSelectedFeature::featureDeleted );
+  connect( mLayer, &QgsVectorLayer::featureDeleted, this, &QgsSelectedFeature::featureDeleted );
 
   // rolling back
-  connect( mVlayer, &QgsVectorLayer::beforeRollBack, this, &QgsSelectedFeature::beforeRollBack );
+  connect( mLayer, &QgsVectorLayer::beforeRollBack, this, &QgsSelectedFeature::beforeRollBack );
 
   // projection or extents changed
   connect( canvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsSelectedFeature::updateVertexMarkersPosition );
   connect( canvas, &QgsMapCanvas::extentsChanged, this, &QgsSelectedFeature::updateVertexMarkersPosition );
 
   // geometry was changed
-  connect( mVlayer, &QgsVectorLayer::geometryChanged, this, &QgsSelectedFeature::geometryChanged );
+  connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsSelectedFeature::geometryChanged );
 
   replaceVertexMap();
 }
 
 void QgsSelectedFeature::beforeRollBack()
 {
-  disconnect( mVlayer, &QgsVectorLayer::geometryChanged, this, &QgsSelectedFeature::geometryChanged );
+  disconnect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsSelectedFeature::geometryChanged );
   deleteVertexMap();
 }
 
@@ -122,7 +122,7 @@ void QgsSelectedFeature::beginGeometryChange()
   Q_ASSERT( !mChangingGeometry );
   mChangingGeometry = true;
 
-  disconnect( mVlayer, &QgsVectorLayer::geometryChanged, this, &QgsSelectedFeature::geometryChanged );
+  disconnect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsSelectedFeature::geometryChanged );
 }
 
 void QgsSelectedFeature::endGeometryChange()
@@ -130,7 +130,7 @@ void QgsSelectedFeature::endGeometryChange()
   Q_ASSERT( mChangingGeometry );
   mChangingGeometry = false;
 
-  connect( mVlayer, &QgsVectorLayer::geometryChanged, this, &QgsSelectedFeature::geometryChanged );
+  connect( mLayer, &QgsVectorLayer::geometryChanged, this, &QgsSelectedFeature::geometryChanged );
 }
 
 void QgsSelectedFeature::canvasLayersChanged()
@@ -148,7 +148,7 @@ void QgsSelectedFeature::geometryChanged( QgsFeatureId fid, const QgsGeometry &g
 {
   QgsDebugCall;
 
-  if ( !mVlayer || fid != mFeatureId )
+  if ( !mLayer || fid != mFeatureId )
     return;
 
   updateGeometry( &geom );
@@ -205,7 +205,7 @@ void QgsSelectedFeature::addError( QgsGeometry::Error e )
   if ( e.hasWhere() )
   {
     QgsVertexMarker *marker = new QgsVertexMarker( mCanvas );
-    marker->setCenter( mCanvas->mapSettings().layerToMapCoordinates( mVlayer, e.where() ) );
+    marker->setCenter( mCanvas->mapSettings().layerToMapCoordinates( mLayer, e.where() ) );
     marker->setIconType( QgsVertexMarker::ICON_X );
     marker->setColor( Qt::green );
     marker->setZValue( marker->zValue() + 1 );
@@ -284,7 +284,7 @@ void QgsSelectedFeature::createVertexMap()
   QgsPoint pt;
   while ( geom->nextVertex( vertexId, pt ) )
   {
-    mVertexMap.append( new QgsVertexEntry( mCanvas, mVlayer, pt, vertexId, tr( "ring %1, vertex %2" ).arg( vertexId.ring ).arg( vertexId.vertex ) ) );
+    mVertexMap.append( new QgsVertexEntry( mCanvas, mLayer, pt, vertexId, tr( "ring %1, vertex %2" ).arg( vertexId.ring ).arg( vertexId.vertex ) ) );
   }
 }
 
@@ -363,7 +363,7 @@ QList<QgsVertexEntry *> &QgsSelectedFeature::vertexMap()
   return mVertexMap;
 }
 
-QgsVectorLayer *QgsSelectedFeature::vlayer()
+QgsVectorLayer *QgsSelectedFeature::layer()
 {
-  return mVlayer;
+  return mLayer;
 }

--- a/src/app/vertextool/qgsselectedfeature.h
+++ b/src/app/vertextool/qgsselectedfeature.h
@@ -52,7 +52,7 @@ class QgsSelectedFeature: public QObject
      * \param vlayer vector layer in which feature is selected
      * \param canvas mapCanvas on which we are working
      */
-    void setSelectedFeature( QgsFeatureId featureId, QgsVectorLayer *vlayer, QgsMapCanvas *canvas );
+    void setSelectedFeature( QgsFeatureId featureId, QgsVectorLayer *layer, QgsMapCanvas *canvas );
 
     /**
      * Function to select vertex with number
@@ -111,7 +111,7 @@ class QgsSelectedFeature: public QObject
      * Gets the layer of the selected feature
      * \returns used vector layer
      */
-    QgsVectorLayer *vlayer();
+    QgsVectorLayer *layer();
 
     /**
      * Getter for the current geometry
@@ -193,7 +193,7 @@ class QgsSelectedFeature: public QObject
     QgsGeometry *mGeometry = nullptr;
     bool mFeatureSelected;
     bool mChangingGeometry;
-    QgsVectorLayer *mVlayer = nullptr;
+    QgsVectorLayer *mLayer = nullptr;
     QList<QgsVertexEntry *> mVertexMap;
     QgsMapCanvas *mCanvas = nullptr;
 

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -107,11 +107,21 @@ QVariant QgsVertexEditorModel::data( const QModelIndex &index, int role ) const
   {
     double r = 0;
     double minRadius = 0;
+    QFont font = mWidgetFont;
+    bool fontChanged = false;
+    if ( vertex->isSelected() )
+    {
+      font.setBold( true );
+      fontChanged = true;
+    }
     if ( calcR( index.row(), r, minRadius ) )
     {
-      QFont curvePointFont = mWidgetFont;
-      curvePointFont.setItalic( true );
-      return curvePointFont;
+      font.setItalic( true );
+      fontChanged = true;;
+    }
+    if ( fontChanged )
+    {
+      return font;
     }
     else
     {

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -293,8 +293,6 @@ QgsVertexEditor::QgsVertexEditor(
 
   setWidget( mTableView );
 
-  connect( mTableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsVertexEditor::updateVertexSelection );
-
   updateEditor( layer, selectedFeature );
 }
 
@@ -311,6 +309,7 @@ void QgsVertexEditor::updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *s
   // TODO We really should just update the model itself.
   mVertexModel = new QgsVertexEditorModel( mLayer, mSelectedFeature, mCanvas, this );
   mTableView->setModel( mVertexModel );
+  connect( mTableView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsVertexEditor::updateVertexSelection );
 
   connect( mSelectedFeature, &QgsSelectedFeature::selectionChanged, this, &QgsVertexEditor::updateTableSelection );
 }

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -93,7 +93,6 @@ class QgsVertexEditor : public QgsDockWidget
   private slots:
     void updateTableSelection();
     void updateVertexSelection( const QItemSelection &selected, const QItemSelection &deselected );
-    void zoomToVertex( int idx );
 
   private:
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1055,7 +1055,7 @@ void QgsVertexTool::showVertexEditor()  //#spellok
     mVertexEditor->updateEditor( m.layer(), mSelectedFeature.get() );
   }
 
-  connect( mSelectedFeature.get()->vlayer(), &QgsVectorLayer::featureDeleted, this, &QgsVertexTool::cleanEditor );
+  connect( mSelectedFeature.get()->layer(), &QgsVectorLayer::featureDeleted, this, &QgsVertexTool::cleanEditor );
 }
 
 void QgsVertexTool::cleanupVertexEditor()
@@ -1095,7 +1095,7 @@ void QgsVertexTool::deleteVertexEditorSelection()
   // make a list of selected vertices
   QList<Vertex> vertices;
   QList<QgsVertexEntry *> &selFeatureVertices = mSelectedFeature->vertexMap();
-  QgsVectorLayer *layer = mSelectedFeature->vlayer();
+  QgsVectorLayer *layer = mSelectedFeature->layer();
   QgsFeatureId fid = mSelectedFeature->featureId();
   QgsGeometry geometry = cachedGeometry( layer, fid );
   for ( QgsVertexEntry *vertex : qgis::as_const( selFeatureVertices ) )
@@ -1123,7 +1123,7 @@ void QgsVertexTool::deleteVertexEditorSelection()
 
     _safeSelectVertex( *mSelectedFeature, nextVertexToSelect );
   }
-  mSelectedFeature->vlayer()->triggerRepaint();
+  mSelectedFeature->layer()->triggerRepaint();
 }
 
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1036,6 +1036,13 @@ void QgsVertexTool::showVertexEditor()  //#spellok
     return;
 
   mSelectedFeature.reset( new QgsSelectedFeature( m.featureId(), m.layer(), mCanvas ) );
+  for ( int i = 0; i < mSelectedVertices.length(); ++i )
+  {
+    if ( mSelectedVertices.at( i ).layer == m.layer() && mSelectedVertices.at( i ).fid == m.featureId() )
+    {
+      mSelectedFeature->selectVertex( mSelectedVertices.at( i ).vertexId );
+    }
+  }
   if ( !mVertexEditor )
   {
     mVertexEditor.reset( new QgsVertexEditor( m.layer(), mSelectedFeature.get(), mCanvas ) );

--- a/src/core/geometry/qgsrectangle.cpp
+++ b/src/core/geometry/qgsrectangle.cpp
@@ -245,6 +245,11 @@ void QgsRectangle::combineExtentWith( double x, double y )
   }
 }
 
+void QgsRectangle::combineExtentWith( const QgsPointXY &point )
+{
+  combineExtentWith( point.x(), point.y() );
+}
+
 QgsRectangle QgsRectangle::operator-( const QgsVector v ) const
 {
   double xmin = mXmin - v.x();

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -219,17 +219,17 @@ class CORE_EXPORT QgsRectangle
     bool contains( const QgsPointXY &p ) const;
 
     /**
-     * Expand the rectangle so that covers both the original rectangle and the given rectangle.
+     * Expands the rectangle so that its covers both the original rectangle and the given rectangle.
      */
     void combineExtentWith( const QgsRectangle &rect );
 
     /**
-     * Expand the rectangle so that covers both the original rectangle and the given point.
+     * Expands the rectangle so that its covers both the original rectangle and the given point.
      */
     void combineExtentWith( double x, double y );
 
     /**
-     * Expand the rectangle so that covers both the original rectangle and the given point.
+     * Expands the rectangle so that its covers both the original rectangle and the given point.
      * \since QGIS 3.2
      */
     void combineExtentWith( const QgsPointXY &point );

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -219,17 +219,17 @@ class CORE_EXPORT QgsRectangle
     bool contains( const QgsPointXY &p ) const;
 
     /**
-     * Expands the rectangle so that its covers both the original rectangle and the given rectangle.
+     * Expands the rectangle so that it covers both the original rectangle and the given rectangle.
      */
     void combineExtentWith( const QgsRectangle &rect );
 
     /**
-     * Expands the rectangle so that its covers both the original rectangle and the given point.
+     * Expands the rectangle so that it covers both the original rectangle and the given point.
      */
     void combineExtentWith( double x, double y );
 
     /**
-     * Expands the rectangle so that its covers both the original rectangle and the given point.
+     * Expands the rectangle so that it covers both the original rectangle and the given point.
      * \since QGIS 3.2
      */
     void combineExtentWith( const QgsPointXY &point );

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -229,6 +229,12 @@ class CORE_EXPORT QgsRectangle
     void combineExtentWith( double x, double y );
 
     /**
+     * Expand the rectangle so that covers both the original rectangle and the given point.
+     * \since QGIS 3.2
+     */
+    void combineExtentWith( const QgsPointXY &point );
+
+    /**
      * Returns a rectangle offset from this one in the direction of the reversed vector.
      * \since QGIS 3.0
      */


### PR DESCRIPTION
fixes #17806

The vertices are now highlighted on the map when selected in the editor.

It is worth mentioning that the selections in the editor and in the tool are not synchronised.

When opening the editor, it now first selects the same vertices than the tool.

Why are they not in sync? Is this because the node editor was brought into the new vertex tool as is or is there a specific reason?
ping @wonder-sk 