### PR TITLE
 [processing] share code between zonal histrogram and zonal stats algs

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -86,6 +86,7 @@ SET(QGIS_ANALYSIS_SRCS
 
   processing/qgsnativealgorithms.cpp
   processing/qgsoverlayutils.cpp
+  processing/qgsrasteranalysisutils.cpp
 
   raster/qgsalignraster.cpp
   raster/qgsninecellfilter.cpp

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
@@ -2,8 +2,8 @@
                          qgsalgorithmrasterlayeruniquevalues.cpp
                          ---------------------
     begin                : April 2017
-    copyright            : (C) 2017 by Nyall Dawson
-    email                : nyall dot dawson at gmail dot com
+    copyright            : (C) 2017 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
  ***************************************************************************/
 
 /***************************************************************************

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.h
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.h
@@ -2,8 +2,8 @@
                          qgsalgorithmrasterlayeruniquevalues.h
                          ---------------------
     begin                : April 2017
-    copyright            : (C) 2017 by Nyall Dawson
-    email                : nyall dot dawson at gmail dot com
+    copyright            : (C) 2017 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
  ***************************************************************************/
 
 /***************************************************************************

--- a/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
@@ -16,7 +16,7 @@
  ***************************************************************************/
 
 #include "qgsalgorithmzonalhistogram.h"
-#include "qgsgeos.h"
+#include "qgsrasteranalysisutils.h"
 #include "qgslogger.h"
 
 ///@cond PRIVATE
@@ -74,20 +74,19 @@ QgsZonalHistogramAlgorithm *QgsZonalHistogramAlgorithm::createInstance() const
 bool QgsZonalHistogramAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
 {
   QgsRasterLayer *layer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT_RASTER" ), context );
-  mBand = parameterAsInt( parameters, QStringLiteral( "RASTER_BAND" ), context );
-
   if ( !layer )
     throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT_RASTER" ) ) );
 
-  mInterface.reset( layer->dataProvider()->clone() );
-  mHasNoDataValue = layer->dataProvider()->sourceHasNoDataValue( mBand );
-  mNodataValue = layer->dataProvider()->sourceNoDataValue( mBand );
-  mExtent = layer->extent();
+  mRasterBand = parameterAsInt( parameters, QStringLiteral( "RASTER_BAND" ), context );
+  mHasNoDataValue = layer->dataProvider()->sourceHasNoDataValue( mRasterBand );
+  mNodataValue = layer->dataProvider()->sourceNoDataValue( mRasterBand );
+  mRasterInterface.reset( layer->dataProvider()->clone() );
+  mRasterExtent = layer->extent();
   mCrs = layer->crs();
-  mRasterUnitsPerPixelX = std::abs( layer->rasterUnitsPerPixelX() );
-  mRasterUnitsPerPixelY = std::abs( layer->rasterUnitsPerPixelX() );
-  mNbCellsXProvider = mInterface->xSize();
-  mNbCellsYProvider = mInterface->ySize();
+  mCellSizeX = std::abs( layer->rasterUnitsPerPixelX() );
+  mCellSizeY = std::abs( layer->rasterUnitsPerPixelX() );
+  mNbCellsXProvider = mRasterInterface->xSize();
+  mNbCellsYProvider = mRasterInterface->ySize();
 
   return true;
 }
@@ -130,41 +129,27 @@ QVariantMap QgsZonalHistogramAlgorithm::processAlgorithm( const QVariantMap &par
     }
 
     QgsGeometry featureGeometry = f.geometry();
-    QgsRectangle intersectRect = featureGeometry.boundingBox().intersect( &mExtent );
-    if ( intersectRect.isEmpty() )
+    QgsRectangle featureRect = featureGeometry.boundingBox().intersect( &mRasterExtent );
+    if ( featureRect.isEmpty() )
     {
       current++;
       continue;
     }
 
-    int offsetX, offsetY, nCellsX, nCellsY;
-    // Get offset in pixels in x- and y- direction
-    offsetX = ( int )( ( intersectRect.xMinimum() - mExtent.xMinimum() ) / mRasterUnitsPerPixelX );
-    offsetY = ( int )( ( mExtent.yMaximum() - intersectRect.yMaximum() ) / mRasterUnitsPerPixelY );
-
-    int maxColumn = ( int )( ( intersectRect.xMaximum() - mExtent.xMinimum() ) / mRasterUnitsPerPixelX ) + 1;
-    int maxRow = ( int )( ( mExtent.yMaximum() - intersectRect.yMinimum() ) / mRasterUnitsPerPixelY ) + 1;
-
-    nCellsX = maxColumn - offsetX;
-    nCellsY = maxRow - offsetY;
-
-    // Avoid access to cells outside of the raster (may occur because of rounding)
-    if ( ( offsetX + nCellsX ) > mNbCellsXProvider )
-    {
-      nCellsX = mNbCellsXProvider - offsetX;
-    }
-    if ( ( offsetY + nCellsY ) > mNbCellsYProvider )
-    {
-      nCellsY = mNbCellsYProvider - offsetY;
-    }
+    int nCellsX, nCellsY;
+    QgsRectangle rasterBlockExtent;
+    QgsRasterAnalysisUtils::cellInfoForBBox( mRasterExtent, featureRect, mCellSizeX, mCellSizeY, nCellsX, nCellsY, mNbCellsXProvider, mNbCellsYProvider, rasterBlockExtent );
 
     QHash< double, qgssize > fUniqueValues;
-    middlePoints( featureGeometry, offsetX, offsetY, nCellsX, nCellsY, fUniqueValues );
+    QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( mRasterInterface.get(), mRasterBand, featureGeometry, nCellsX, nCellsY, mCellSizeX, mCellSizeY,
+    rasterBlockExtent, [ &fUniqueValues]( double value ) { fUniqueValues[value]++; }, false );
 
     if ( fUniqueValues.count() < 1 )
     {
       // The cell resolution is probably larger than the polygon area. We switch to slower precise pixel - polygon intersection in this case
-      preciseIntersection( featureGeometry, offsetX, offsetY, nCellsX, nCellsY, fUniqueValues );
+      // TODO: eventually deal with weight if needed
+      QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( mRasterInterface.get(), mRasterBand, featureGeometry, nCellsX, nCellsY, mCellSizeX, mCellSizeY,
+      rasterBlockExtent, [ &fUniqueValues]( double value, double ) { fUniqueValues[value]++; }, false );
     }
 
     for ( auto it = fUniqueValues.constBegin(); it != fUniqueValues.constEnd(); ++it )
@@ -215,97 +200,6 @@ QVariantMap QgsZonalHistogramAlgorithm::processAlgorithm( const QVariantMap &par
   QVariantMap outputs;
   outputs.insert( QStringLiteral( "OUTPUT" ), dest );
   return outputs;
-}
-
-void QgsZonalHistogramAlgorithm::middlePoints( const QgsGeometry &poly, int pixelOffsetX, int pixelOffsetY, int nCellsX, int nCellsY, QHash< double, qgssize > &uniqueValues )
-{
-  double cellCenterX, cellCenterY;
-
-  cellCenterY = mExtent.yMaximum() - pixelOffsetY * mRasterUnitsPerPixelY - mRasterUnitsPerPixelY / 2;
-
-  geos::unique_ptr polyGeos( QgsGeos::asGeos( poly ) );
-  if ( !polyGeos )
-  {
-    return;
-  }
-
-  GEOSContextHandle_t geosctxt = QgsGeos::getGEOSHandler();
-  geos::prepared_unique_ptr polyGeosPrepared( GEOSPrepare_r( geosctxt, polyGeos.get() ) );
-  if ( !polyGeosPrepared )
-  {
-    return;
-  }
-
-  GEOSCoordSequence *cellCenterCoords = nullptr;
-  geos::unique_ptr currentCellCenter;
-
-  QgsRectangle blockRect( mExtent.xMinimum() + pixelOffsetX * mRasterUnitsPerPixelX,
-                          mExtent.yMaximum() - pixelOffsetY * mRasterUnitsPerPixelY - nCellsY * mRasterUnitsPerPixelY,
-                          mExtent.xMinimum() + pixelOffsetX * mRasterUnitsPerPixelX + nCellsX * mRasterUnitsPerPixelX,
-                          mExtent.yMaximum() - pixelOffsetY * mRasterUnitsPerPixelY );
-  std::unique_ptr< QgsRasterBlock > block( mInterface->block( mBand, blockRect, nCellsX, nCellsY ) );
-  for ( int i = 0; i < nCellsY; ++i )
-  {
-    cellCenterX = mExtent.xMinimum() + pixelOffsetX * mRasterUnitsPerPixelX + mRasterUnitsPerPixelX / 2;
-    for ( int j = 0; j < nCellsX; ++j )
-    {
-      if ( !std::isnan( block->value( i, j ) ) )
-      {
-        cellCenterCoords = GEOSCoordSeq_create_r( geosctxt, 1, 2 );
-        GEOSCoordSeq_setX_r( geosctxt, cellCenterCoords, 0, cellCenterX );
-        GEOSCoordSeq_setY_r( geosctxt, cellCenterCoords, 0, cellCenterY );
-        currentCellCenter.reset( GEOSGeom_createPoint_r( geosctxt, cellCenterCoords ) );
-        if ( GEOSPreparedContains_r( geosctxt, polyGeosPrepared.get(), currentCellCenter.get() ) )
-        {
-          uniqueValues[block->value( i, j )]++;
-        }
-      }
-      cellCenterX += mRasterUnitsPerPixelX;
-    }
-    cellCenterY -= mRasterUnitsPerPixelY;
-  }
-}
-
-void QgsZonalHistogramAlgorithm::preciseIntersection( const QgsGeometry &poly, int pixelOffsetX, int pixelOffsetY, int nCellsX, int nCellsY, QHash< double, qgssize > &uniqueValues )
-{
-  double currentY = mExtent.yMaximum() - pixelOffsetY * mRasterUnitsPerPixelY - mRasterUnitsPerPixelY / 2;
-  QgsGeometry pixelRectGeometry;
-
-  double hCellSizeX = mRasterUnitsPerPixelX / 2.0;
-  double hCellSizeY = mRasterUnitsPerPixelY / 2.0;
-
-  QgsRectangle blockRect( mExtent.xMinimum() + pixelOffsetX * mRasterUnitsPerPixelX,
-                          mExtent.yMaximum() - pixelOffsetY * mRasterUnitsPerPixelY - nCellsY * mRasterUnitsPerPixelY,
-                          mExtent.xMinimum() + pixelOffsetX * mRasterUnitsPerPixelX + nCellsX * mRasterUnitsPerPixelX,
-                          mExtent.yMaximum() - pixelOffsetY * mRasterUnitsPerPixelY );
-  std::unique_ptr< QgsRasterBlock > block( mInterface->block( mBand, blockRect, nCellsX, nCellsY ) );
-  for ( int i = 0; i < nCellsY; ++i )
-  {
-    double currentX = mExtent.xMinimum() + mRasterUnitsPerPixelX / 2.0 + pixelOffsetX * mRasterUnitsPerPixelX;
-    for ( int j = 0; j < nCellsX; ++j )
-    {
-      if ( !std::isnan( block->value( i, j ) ) )
-      {
-        pixelRectGeometry = QgsGeometry::fromRect( QgsRectangle( currentX - hCellSizeX, currentY - hCellSizeY, currentX + hCellSizeX, currentY + hCellSizeY ) );
-        if ( !pixelRectGeometry.isNull() )
-        {
-          //intersection
-          QgsGeometry intersectGeometry = pixelRectGeometry.intersection( poly );
-          if ( !intersectGeometry.isNull() )
-          {
-            double intersectionArea = intersectGeometry.area();
-            if ( intersectionArea >= 0.0 )
-            {
-              uniqueValues[block->value( i, j )]++;
-            }
-          }
-          pixelRectGeometry = QgsGeometry();
-        }
-      }
-      currentX += mRasterUnitsPerPixelX;
-    }
-    currentY -= mRasterUnitsPerPixelY;
-  }
 }
 
 ///@endcond

--- a/src/analysis/processing/qgsalgorithmzonalhistogram.h
+++ b/src/analysis/processing/qgsalgorithmzonalhistogram.h
@@ -49,22 +49,16 @@ class QgsZonalHistogramAlgorithm : public QgsProcessingAlgorithm
     QVariantMap processAlgorithm( const QVariantMap &parameters,
                                   QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
 
-    //! Fetch unique values by considering the pixels where the center point is within the polygon (fast)
-    void middlePoints( const QgsGeometry &poly, int pixelOffsetX, int pixelOffsetY, int nCellsX, int nCellsY, QHash< double, qgssize > &uniqueValues );
-
-    //! Fetch unique values with precise pixel - polygon intersection test (slow)
-    void preciseIntersection( const QgsGeometry &poly, int pixelOffsetX, int pixelOffsetY, int nCellsX, int nCellsY, QHash< double, qgssize > &uniqueValues );
-
   private:
 
-    std::unique_ptr< QgsRasterInterface > mInterface;
-    int mBand;
+    std::unique_ptr< QgsRasterInterface > mRasterInterface;
+    int mRasterBand;
     bool mHasNoDataValue = false;
     float mNodataValue = -1;
-    QgsRectangle mExtent;
+    QgsRectangle mRasterExtent;
     QgsCoordinateReferenceSystem mCrs;
-    double mRasterUnitsPerPixelX;
-    double mRasterUnitsPerPixelY;
+    double mCellSizeX;
+    double mCellSizeY;
     double mNbCellsXProvider;
     double mNbCellsYProvider;
 

--- a/src/analysis/processing/qgsrasteranalysisutils.cpp
+++ b/src/analysis/processing/qgsrasteranalysisutils.cpp
@@ -1,0 +1,175 @@
+/***************************************************************************
+  qgsrasteranalysisutils.cpp
+  ---------------------
+  Date                 : June 2018
+  Copyright            : (C) 2018 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrasteranalysisutils.h"
+
+#include "qgsfeedback.h"
+#include "qgsrasterblock.h"
+#include "qgsrasteriterator.h"
+#include "qgsgeos.h"
+
+///@cond PRIVATE
+
+void QgsRasterAnalysisUtils::cellInfoForBBox( const QgsRectangle &rasterBBox, const QgsRectangle &featureBBox, double cellSizeX, double cellSizeY,
+    int &nCellsX, int &nCellsY, int rasterWidth, int rasterHeight, QgsRectangle &rasterBlockExtent )
+{
+  //get intersecting bbox
+  QgsRectangle intersectBox = rasterBBox.intersect( &featureBBox );
+  if ( intersectBox.isEmpty() )
+  {
+    nCellsX = 0;
+    nCellsY = 0;
+    rasterBlockExtent = QgsRectangle();
+    return;
+  }
+
+  //get offset in pixels in x- and y- direction
+  int offsetX = static_cast< int >( std::floor( ( intersectBox.xMinimum() - rasterBBox.xMinimum() ) / cellSizeX ) );
+  int offsetY = static_cast< int >( std::floor( ( rasterBBox.yMaximum() - intersectBox.yMaximum() ) / cellSizeY ) );
+
+  int maxColumn = static_cast< int >( std::floor( ( intersectBox.xMaximum() - rasterBBox.xMinimum() ) / cellSizeX ) ) + 1;
+  int maxRow = static_cast< int >( std::floor( ( rasterBBox.yMaximum() - intersectBox.yMinimum() ) / cellSizeY ) ) + 1;
+
+  nCellsX = maxColumn - offsetX;
+  nCellsY = maxRow - offsetY;
+
+  //avoid access to cells outside of the raster (may occur because of rounding)
+  nCellsX = std::min( offsetX + nCellsX, rasterWidth ) - offsetX;
+  nCellsY = std::min( offsetY + nCellsY, rasterHeight ) - offsetY;
+
+  rasterBlockExtent = QgsRectangle( rasterBBox.xMinimum() + offsetX * cellSizeX,
+                                    rasterBBox.yMaximum() - offsetY * cellSizeY,
+                                    rasterBBox.xMinimum() + ( nCellsX + offsetX ) * cellSizeX,
+                                    rasterBBox.yMaximum() - ( nCellsY + offsetY ) * cellSizeY );
+}
+
+void QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY, double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox,  const std::function<void( double )> &addValue, bool skipNodata )
+{
+  std::unique_ptr< QgsGeometryEngine > polyEngine( QgsGeometry::createGeometryEngine( poly.constGet( ) ) );
+  if ( !polyEngine )
+  {
+    return;
+  }
+  polyEngine->prepareGeometry();
+
+  const int maxWidth = 4000;
+  const int maxHeight = 4000;
+
+  QgsRasterIterator iter( rasterInterface );
+  iter.setMaximumTileWidth( maxWidth );
+  iter.setMaximumTileHeight( maxHeight );
+  iter.startRasterRead( rasterBand, nCellsX, nCellsY, rasterBBox );
+
+  QgsRasterBlock *block = nullptr;
+  int iterLeft = 0;
+  int iterTop = 0;
+  int iterCols = 0;
+  int iterRows = 0;
+  while ( iter.readNextRasterPart( rasterBand, iterCols, iterRows, &block, iterLeft, iterTop ) )
+  {
+    double cellCenterY = rasterBBox.yMinimum() + ( iterTop + iterRows - 0.5 ) * cellSizeY;
+    for ( int row = 0; row < iterRows; ++row )
+    {
+      double cellCenterX = rasterBBox.xMinimum() + ( iterLeft + 0.5 ) * cellSizeX;
+      for ( int col = 0; col < iterCols; ++col )
+      {
+        double pixelValue = block->value( row, col );
+        if ( validPixel( pixelValue ) && ( !skipNodata || !block->isNoData( row, col ) ) )
+        {
+          QgsPoint cellCenter( cellCenterX, cellCenterY );
+          if ( polyEngine->contains( &cellCenter ) )
+          {
+            addValue( pixelValue );
+          }
+        }
+        cellCenterX += cellSizeX;
+      }
+      cellCenterY -= cellSizeY;
+    }
+    delete block;
+  }
+}
+
+void QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY, double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox,  const std::function<void( double, double )> &addValue, bool skipNodata )
+{
+  QgsGeometry pixelRectGeometry;
+
+  double hCellSizeX = cellSizeX / 2.0;
+  double hCellSizeY = cellSizeY / 2.0;
+  double pixelArea = cellSizeX * cellSizeY;
+  double weight = 0;
+
+  std::unique_ptr< QgsGeometryEngine > polyEngine( QgsGeometry::createGeometryEngine( poly.constGet( ) ) );
+  if ( !polyEngine )
+  {
+    return;
+  }
+  polyEngine->prepareGeometry();
+
+  const int maxWidth = 4000;
+  const int maxHeight = 4000;
+
+  QgsRasterIterator iter( rasterInterface );
+  iter.setMaximumTileWidth( maxWidth );
+  iter.setMaximumTileHeight( maxHeight );
+  iter.startRasterRead( rasterBand, nCellsX, nCellsY, rasterBBox );
+
+  QgsRasterBlock *block = nullptr;
+  int iterLeft = 0;
+  int iterTop = 0;
+  int iterCols = 0;
+  int iterRows = 0;
+  while ( iter.readNextRasterPart( rasterBand, iterCols, iterRows, &block, iterLeft, iterTop ) )
+  {
+    double currentY = rasterBBox.yMinimum() + ( iterTop + iterRows - 0.5 ) * cellSizeY;
+    for ( int row = 0; row < iterRows; ++row )
+    {
+      double currentX = rasterBBox.xMinimum() + ( iterLeft + 0.5 ) * cellSizeX;
+      for ( int col = 0; col < iterCols; ++col )
+      {
+        double pixelValue = block->value( row, col );
+        if ( validPixel( pixelValue ) && ( !skipNodata || !block->isNoData( row, col ) ) )
+        {
+          pixelRectGeometry = QgsGeometry::fromRect( QgsRectangle( currentX - hCellSizeX, currentY - hCellSizeY, currentX + hCellSizeX, currentY + hCellSizeY ) );
+          // GEOS intersects tests on prepared geometry is MAGNITUDES faster than calculating the intersection itself,
+          // so we first test to see if there IS an intersection before doing the actual calculation
+          if ( !pixelRectGeometry.isNull() && polyEngine->intersects( pixelRectGeometry.constGet() ) )
+          {
+            //intersection
+            QgsGeometry intersectGeometry = pixelRectGeometry.intersection( poly );
+            if ( !intersectGeometry.isEmpty() )
+            {
+              double intersectionArea = intersectGeometry.area();
+              if ( intersectionArea > 0.0 )
+              {
+                weight = intersectionArea / pixelArea;
+                addValue( pixelValue, weight );
+              }
+            }
+          }
+        }
+        currentX += cellSizeX;
+      }
+      currentY -= cellSizeY;
+    }
+  }
+}
+
+bool QgsRasterAnalysisUtils::validPixel( double value )
+{
+  return !std::isnan( value );
+}
+
+///@endcond PRIVATE

--- a/src/analysis/processing/qgsrasteranalysisutils.h
+++ b/src/analysis/processing/qgsrasteranalysisutils.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+  qgsrasteranalysisutils.h
+  ---------------------
+  Date                 : June 2018
+  Copyright            : (C) 2018 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRASTERANALYSISUTILS_H
+#define QGSRASTERANALYSISUTILS_H
+
+#include "qgis_analysis.h"
+
+#include <functional>
+
+#define SIP_NO_FILE
+
+///@cond PRIVATE
+
+class QgsRasterInterface;
+class QgsGeometry;
+class QgsRectangle;
+
+namespace QgsRasterAnalysisUtils
+{
+
+  /**
+   * Analyzes which cells need to be considered to completely cover the bounding box of a feature.
+  */
+  void cellInfoForBBox( const QgsRectangle &rasterBBox, const QgsRectangle &featureBBox, double cellSizeX, double cellSizeY, int &nCellsX, int &nCellsY,
+                        int rasterWidth, int rasterHeight,
+                        QgsRectangle &rasterBlockExtent );
+
+  //! Returns statistics by considering the pixels where the center point is within the polygon (fast)
+  void statisticsFromMiddlePointTest( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY,
+                                      double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, const std::function<void( double )> &addValue, bool skipNodata = true );
+
+  //! Returns statistics with precise pixel - polygon intersection test (slow)
+  void statisticsFromPreciseIntersection( QgsRasterInterface *rasterInterface, int rasterBand, const QgsGeometry &poly, int nCellsX, int nCellsY,
+                                          double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, const std::function<void( double, double )> &addValue, bool skipNodata = true );
+
+  //! Tests whether a pixel's value should be included in the result
+  bool validPixel( double value );
+}
+
+///@endcond PRIVATE
+
+#endif // QGSRASTERANALYSISUTILS_H

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -16,16 +16,16 @@
  ***************************************************************************/
 
 #include "qgszonalstatistics.h"
+
 #include "qgsfeatureiterator.h"
 #include "qgsfeedback.h"
 #include "qgsgeometry.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
+#include "processing/qgsrasteranalysisutils.h"
 #include "qgsrasterdataprovider.h"
 #include "qgsrasterlayer.h"
-#include "qgsrasterblock.h"
 #include "qgslogger.h"
-#include "qgsgeos.h"
 #include "qgsproject.h"
 
 #include <QFile>
@@ -252,16 +252,18 @@ int QgsZonalStatistics::calculateStatistics( QgsFeedback *feedback )
 
     int nCellsX, nCellsY;
     QgsRectangle rasterBlockExtent;
-    cellInfoForBBox( rasterBBox, featureRect, mCellSizeX, mCellSizeY, nCellsX, nCellsY, nCellsXProvider, nCellsYProvider, rasterBlockExtent );
+    QgsRasterAnalysisUtils::cellInfoForBBox( rasterBBox, featureRect, mCellSizeX, mCellSizeY, nCellsX, nCellsY, nCellsXProvider, nCellsYProvider, rasterBlockExtent );
 
-    statisticsFromMiddlePointTest( featureGeometry, nCellsX, nCellsY, mCellSizeX, mCellSizeY,
-                                   rasterBlockExtent, featureStats );
+    featureStats.reset();
+    QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( mRasterInterface, mRasterBand, featureGeometry, nCellsX, nCellsY, mCellSizeX, mCellSizeY,
+    rasterBlockExtent, [ &featureStats ]( double value ) { featureStats.addValue( value ); } );
 
     if ( featureStats.count <= 1 )
     {
       //the cell resolution is probably larger than the polygon area. We switch to precise pixel - polygon intersection in this case
-      statisticsFromPreciseIntersection( featureGeometry, nCellsX, nCellsY, mCellSizeX, mCellSizeY,
-                                         rasterBlockExtent, featureStats );
+      featureStats.reset();
+      QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( mRasterInterface, mRasterBand, featureGeometry, nCellsX, nCellsY, mCellSizeX, mCellSizeY,
+      rasterBlockExtent, [ &featureStats ]( double value, double weight ) { featureStats.addValue( value, weight ); } );
     }
 
     //write the statistics value to the vector data provider
@@ -352,160 +354,6 @@ int QgsZonalStatistics::calculateStatistics( QgsFeedback *feedback )
   }
 
   return 0;
-}
-
-void QgsZonalStatistics::cellInfoForBBox( const QgsRectangle &rasterBBox, const QgsRectangle &featureBBox, double cellSizeX, double cellSizeY,
-    int &nCellsX, int &nCellsY, int rasterWidth, int rasterHeight, QgsRectangle &rasterBlockExtent ) const
-{
-  //get intersecting bbox
-  QgsRectangle intersectBox = rasterBBox.intersect( &featureBBox );
-  if ( intersectBox.isEmpty() )
-  {
-    nCellsX = 0;
-    nCellsY = 0;
-    rasterBlockExtent = QgsRectangle();
-    return;
-  }
-
-  //get offset in pixels in x- and y- direction
-  int offsetX = static_cast< int >( std::floor( ( intersectBox.xMinimum() - rasterBBox.xMinimum() ) / cellSizeX ) );
-  int offsetY = static_cast< int >( std::floor( ( rasterBBox.yMaximum() - intersectBox.yMaximum() ) / cellSizeY ) );
-
-  int maxColumn = static_cast< int >( std::floor( ( intersectBox.xMaximum() - rasterBBox.xMinimum() ) / cellSizeX ) ) + 1;
-  int maxRow = static_cast< int >( std::floor( ( rasterBBox.yMaximum() - intersectBox.yMinimum() ) / cellSizeY ) ) + 1;
-
-  nCellsX = maxColumn - offsetX;
-  nCellsY = maxRow - offsetY;
-
-  //avoid access to cells outside of the raster (may occur because of rounding)
-  nCellsX = std::min( offsetX + nCellsX, rasterWidth ) - offsetX;
-  nCellsY = std::min( offsetY + nCellsY, rasterHeight ) - offsetY;
-
-  rasterBlockExtent = QgsRectangle( rasterBBox.xMinimum() + offsetX * cellSizeX,
-                                    rasterBBox.yMaximum() - offsetY * cellSizeY,
-                                    rasterBBox.xMinimum() + ( nCellsX + offsetX ) * cellSizeX,
-                                    rasterBBox.yMaximum() - ( nCellsY + offsetY ) * cellSizeY );
-}
-
-void QgsZonalStatistics::statisticsFromMiddlePointTest( const QgsGeometry &poly, int nCellsX, int nCellsY, double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, FeatureStats &stats )
-{
-  stats.reset();
-
-  std::unique_ptr< QgsGeometryEngine > polyEngine( QgsGeometry::createGeometryEngine( poly.constGet( ) ) );
-  if ( !polyEngine )
-  {
-    return;
-  }
-  polyEngine->prepareGeometry();
-
-  const int maxWidth = 4000;
-  const int maxHeight = 4000;
-
-  QgsRasterIterator iter( mRasterInterface );
-  iter.setMaximumTileWidth( maxWidth );
-  iter.setMaximumTileHeight( maxHeight );
-  iter.startRasterRead( mRasterBand, nCellsX, nCellsY, rasterBBox );
-
-  QgsRasterBlock *block = nullptr;
-  int iterLeft = 0;
-  int iterTop = 0;
-  int iterCols = 0;
-  int iterRows = 0;
-  while ( iter.readNextRasterPart( mRasterBand, iterCols, iterRows, &block, iterLeft, iterTop ) )
-  {
-    double cellCenterY = rasterBBox.yMinimum() + ( iterTop + iterRows - 0.5 ) * cellSizeY;
-    for ( int row = 0; row < iterRows; ++row )
-    {
-      double cellCenterX = rasterBBox.xMinimum() + ( iterLeft + 0.5 ) * cellSizeX;
-      for ( int col = 0; col < iterCols; ++col )
-      {
-        double pixelValue = block->value( row, col );
-        if ( validPixel( pixelValue ) && !block->isNoData( row, col ) )
-        {
-          QgsPoint cellCenter( cellCenterX, cellCenterY );
-          if ( polyEngine->contains( &cellCenter ) )
-          {
-            stats.addValue( pixelValue );
-          }
-        }
-        cellCenterX += cellSizeX;
-      }
-      cellCenterY -= cellSizeY;
-    }
-    delete block;
-  }
-}
-
-void QgsZonalStatistics::statisticsFromPreciseIntersection( const QgsGeometry &poly, int nCellsX, int nCellsY, double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, FeatureStats &stats )
-{
-  stats.reset();
-
-  QgsGeometry pixelRectGeometry;
-
-  double hCellSizeX = cellSizeX / 2.0;
-  double hCellSizeY = cellSizeY / 2.0;
-  double pixelArea = cellSizeX * cellSizeY;
-  double weight = 0;
-
-  std::unique_ptr< QgsGeometryEngine > polyEngine( QgsGeometry::createGeometryEngine( poly.constGet( ) ) );
-  if ( !polyEngine )
-  {
-    return;
-  }
-  polyEngine->prepareGeometry();
-
-  const int maxWidth = 4000;
-  const int maxHeight = 4000;
-
-  QgsRasterIterator iter( mRasterInterface );
-  iter.setMaximumTileWidth( maxWidth );
-  iter.setMaximumTileHeight( maxHeight );
-  iter.startRasterRead( mRasterBand, nCellsX, nCellsY, rasterBBox );
-
-  QgsRasterBlock *block = nullptr;
-  int iterLeft = 0;
-  int iterTop = 0;
-  int iterCols = 0;
-  int iterRows = 0;
-  while ( iter.readNextRasterPart( mRasterBand, iterCols, iterRows, &block, iterLeft, iterTop ) )
-  {
-    double currentY = rasterBBox.yMinimum() + ( iterTop + iterRows - 0.5 ) * cellSizeY;
-    for ( int row = 0; row < iterRows; ++row )
-    {
-      double currentX = rasterBBox.xMinimum() + ( iterLeft + 0.5 ) * cellSizeX;
-      for ( int col = 0; col < iterCols; ++col )
-      {
-        double pixelValue = block->value( row, col );
-        if ( validPixel( pixelValue ) && !block->isNoData( row, col ) )
-        {
-          pixelRectGeometry = QgsGeometry::fromRect( QgsRectangle( currentX - hCellSizeX, currentY - hCellSizeY, currentX + hCellSizeX, currentY + hCellSizeY ) );
-          // GEOS intersects tests on prepared geometry is MAGNITUDES faster than calculating the intersection itself,
-          // so we first test to see if there IS an intersection before doing the actual calculation
-          if ( !pixelRectGeometry.isNull() && polyEngine->intersects( pixelRectGeometry.constGet() ) )
-          {
-            //intersection
-            QgsGeometry intersectGeometry = pixelRectGeometry.intersection( poly );
-            if ( !intersectGeometry.isEmpty() )
-            {
-              double intersectionArea = intersectGeometry.area();
-              if ( intersectionArea > 0.0 )
-              {
-                weight = intersectionArea / pixelArea;
-                stats.addValue( pixelValue, weight );
-              }
-            }
-          }
-        }
-        currentX += cellSizeX;
-      }
-      currentY -= cellSizeY;
-    }
-  }
-}
-
-bool QgsZonalStatistics::validPixel( double value ) const
-{
-  return !std::isnan( value );
 }
 
 QString QgsZonalStatistics::getUniqueFieldName( const QString &fieldName, const QList<QgsField> &newFields )

--- a/src/analysis/vector/qgszonalstatistics.h
+++ b/src/analysis/vector/qgszonalstatistics.h
@@ -171,24 +171,6 @@ class ANALYSIS_EXPORT QgsZonalStatistics
         bool mStoreValueCounts = false;
     };
 
-    /**
-     * Analyzes which cells need to be considered to completely cover the bounding box of a feature.
-    */
-    void cellInfoForBBox( const QgsRectangle &rasterBBox, const QgsRectangle &featureBBox, double cellSizeX, double cellSizeY, int &nCellsX, int &nCellsY,
-                          int rasterWidth, int rasterHeight,
-                          QgsRectangle &rasterBlockExtent ) const;
-
-    //! Returns statistics by considering the pixels where the center point is within the polygon (fast)
-    void statisticsFromMiddlePointTest( const QgsGeometry &poly, int nCellsX, int nCellsY,
-                                        double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, FeatureStats &stats );
-
-    //! Returns statistics with precise pixel - polygon intersection test (slow)
-    void statisticsFromPreciseIntersection( const QgsGeometry &poly, int nCellsX, int nCellsY,
-                                            double cellSizeX, double cellSizeY, const QgsRectangle &rasterBBox, FeatureStats &stats );
-
-    //! Tests whether a pixel's value should be included in the result
-    bool validPixel( double value ) const;
-
     QString getUniqueFieldName( const QString &fieldName, const QList<QgsField> &newFields );
 
     QgsRasterInterface *mRasterInterface = nullptr;


### PR DESCRIPTION
## Description
This PR removes duplicate code shared between the zonal histogram & zonal stats algorithms. This also means the zonal histogram will receive the benefits of @nyalldawson 's recent improvements for the zonal stats, most noticeably the use of a raster iterator.

@nyalldawson , your review welcome and needed.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
