### PR TITLE
[server] Fix BBOX SRS in WFS GetFeature POST with two queries

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -355,10 +355,10 @@ namespace QgsWfs
         outputCrs = QgsCoordinateReferenceSystem::fromOgcWmsCrs( query.srsName );
       }
 
-      if ( onlyOneLayer && !featureRequest.filterRect().isEmpty() )
+      if ( !featureRequest.filterRect().isEmpty() )
       {
         Q_NOWARN_DEPRECATED_PUSH
-        QgsCoordinateTransform transform( outputCrs, requestCrs );
+        QgsCoordinateTransform transform( outputCrs, vlayer->crs() );
         Q_NOWARN_DEPRECATED_POP
         try
         {
@@ -368,8 +368,10 @@ namespace QgsWfs
         {
           Q_UNUSED( cse );
         }
-
-        requestRect = featureRequest.filterRect();
+        if ( onlyOneLayer )
+        {
+          requestRect = featureRequest.filterRect();
+        }
       }
 
       // Iterate through features

--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -229,6 +229,34 @@ class TestQgsServerWFS(QgsServerTestBase):
 """
         tests.append(('srsname_post', srsTemplate.format("")))
 
+        srsTwoLayersTemplate = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
+  <wfs:Query typeName="testlayer" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">
+    <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+      <ogc:BBOX>
+        <ogc:PropertyName>geometry</ogc:PropertyName>
+        <gml:Envelope xmlns:gml="http://www.opengis.net/gml">
+          <gml:lowerCorner>890555.92634619 5465442.18332275</gml:lowerCorner>
+          <gml:upperCorner>1001875.41713946 5621521.48619207</gml:upperCorner>
+        </gml:Envelope>
+      </ogc:BBOX>
+    </ogc:Filter>
+  </wfs:Query>
+  <wfs:Query typeName="testlayer" srsName="EPSG:3857" xmlns:feature="http://www.qgis.org/gml">
+    <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
+      <ogc:BBOX>
+        <ogc:PropertyName>geometry</ogc:PropertyName>
+        <gml:Envelope xmlns:gml="http://www.opengis.net/gml">
+          <gml:lowerCorner>890555.92634619 5465442.18332275</gml:lowerCorner>
+          <gml:upperCorner>1001875.41713946 5621521.48619207</gml:upperCorner>
+        </gml:Envelope>
+      </ogc:BBOX>
+    </ogc:Filter>
+  </wfs:Query>
+</wfs:GetFeature>
+"""
+        tests.append(('srs_two_layers_post', srsTwoLayersTemplate.format("")))
+
         sortTemplate = """<?xml version="1.0" encoding="UTF-8"?>
 <wfs:GetFeature service="WFS" version="1.0.0" {} xmlns:wfs="http://www.opengis.net/wfs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.1.0/wfs.xsd">
   <wfs:Query typeName="testlayer" xmlns:feature="http://www.qgis.org/gml">

--- a/tests/testdata/qgis_server/wfs_getfeature_srs_two_layers_post.txt
+++ b/tests/testdata/qgis_server/wfs_getfeature_srs_two_layers_post.txt
@@ -1,0 +1,111 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/amorvan/dev/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer,testlayer&amp;OUTPUTFORMAT=XMLSCHEMA">
+<gml:boundedBy>
+ <gml:Box srsName="EPSG:4326">
+  <gml:coordinates cs="," ts=" ">8.203459,44.901395 8.203547,44.901483</gml:coordinates>
+ </gml:Box>
+</gml:boundedBy>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.0">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">913209.03579284,5606025.23730414 913209.03579284,5606025.23730414</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">913209.03579284,5606025.23730414</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>1</qgs:id>
+  <qgs:name>one</qgs:name>
+  <qgs:utf8nameè>one èé</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.1">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">913214.67407005,5606017.87425818 913214.67407005,5606017.87425818</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">913214.67407005,5606017.87425818</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>2</qgs:id>
+  <qgs:name>two</qgs:name>
+  <qgs:utf8nameè>two àò</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.2">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">913204.91280263,5606011.45647302 913204.91280263,5606011.45647302</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">913204.91280263,5606011.45647302</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>3</qgs:id>
+  <qgs:name>three</qgs:name>
+  <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.0">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">913209.03579284,5606025.23730414 913209.03579284,5606025.23730414</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">913209.03579284,5606025.23730414</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>1</qgs:id>
+  <qgs:name>one</qgs:name>
+  <qgs:utf8nameè>one èé</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.1">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">913214.67407005,5606017.87425818 913214.67407005,5606017.87425818</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">913214.67407005,5606017.87425818</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>2</qgs:id>
+  <qgs:name>two</qgs:name>
+  <qgs:utf8nameè>two àò</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+<gml:featureMember>
+ <qgs:testlayer fid="testlayer.2">
+  <gml:boundedBy>
+   <gml:Box srsName="EPSG:3857">
+    <gml:coordinates cs="," ts=" ">913204.91280263,5606011.45647302 913204.91280263,5606011.45647302</gml:coordinates>
+   </gml:Box>
+  </gml:boundedBy>
+  <qgs:geometry>
+   <Point xmlns="http://www.opengis.net/gml" srsName="EPSG:3857">
+    <coordinates xmlns="http://www.opengis.net/gml" cs="," ts=" ">913204.91280263,5606011.45647302</coordinates>
+   </Point>
+  </qgs:geometry>
+  <qgs:id>3</qgs:id>
+  <qgs:name>three</qgs:name>
+  <qgs:utf8nameè>three èé↓</qgs:utf8nameè>
+ </qgs:testlayer>
+</gml:featureMember>
+</wfs:FeatureCollection>


### PR DESCRIPTION
## Description

Correctly transform featureRequest.filterRect in WFS POST GetFeature request with multiple Query elements.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
