### PR TITLE
[bugfix] Do not crash when removing a layout legend item

### DIFF
--- a/src/core/layertree/qgslayertree.cpp
+++ b/src/core/layertree/qgslayertree.cpp
@@ -138,6 +138,10 @@ void QgsLayerTree::writeXml( QDomElement &parentElement, const QgsReadWriteConte
 
   Q_FOREACH ( QgsMapLayer *layer, mCustomLayerOrder )
   {
+    // Safety belt, see https://issues.qgis.org/issues/19145
+    // Crash when deleting an item from the layout legend
+    if ( ! layer )
+      continue;
     QDomElement layerElem = doc.createElement( QStringLiteral( "item" ) );
     layerElem.appendChild( doc.createTextNode( layer->id() ) );
     customOrderElem.appendChild( layerElem );


### PR DESCRIPTION
... when the layer was removed from the map, the legend
sync was disabled and the drawind order was enabled ...

Fixes #19145 Crash when deleting an item from the layout legend
