### PR TITLE
[needs-docs] Use an indicator icon for embedded layers

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -686,6 +686,7 @@
         <file>themes/default/mActionIdentifyByPolygon.svg</file>
         <file>themes/default/mActionIdentifyByRadius.svg</file>
         <file>themes/default/mActionIdentifyByRectangle.svg</file>
+        <file>themes/default/mIndicatorEmbedded.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mIndicatorEmbedded.svg
+++ b/images/themes/default/mIndicatorEmbedded.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="mIndicatorEmbedded.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     id="namedview8"
+     showgrid="true"
+     inkscape:zoom="11.313708"
+     inkscape:cx="35.171926"
+     inkscape:cy="8.2554598"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6">
+    <inkscape:grid
+       type="xygrid"
+       id="grid840" />
+  </sodipodi:namedview>
+  <path
+     style="opacity:1;fill:none;stroke:#2c2c2c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.70588235"
+     d="M 6,11.5 H 2.9882619 c -3.27511753,0 -3.35996503,-7 0,-7 H 7.9942708 C 9.7561889,4.4999498 10.484071,6.5889993 10.5,8.000348 L 8.5,8 C 8.4745148,7.2274193 8.1077127,6.5056631 7.4936695,6.5 H 3.4888627 c -1.3460082,0 -1.3209711,3 0,3 H 5"
+     id="path842-5"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+  <path
+     style="opacity:1;fill:none;stroke:#2c2c2c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.70588235"
+     d="m 10.005676,4.5 h 3.011738 c 3.275118,0 3.359965,7 0,7 H 8.0114052 C 6.2494871,11.50005 5.521605,9.4110007 5.505676,7.999652 l 2,3.48e-4 c 0.025485,0.7725807 0.3922873,1.4943369 1.0063305,1.5 h 4.0048065 c 1.346008,0 1.320971,-3 0,-3 h -1.511137"
+     id="path842-5-6"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+</svg>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -52,6 +52,7 @@ SET(QGIS_APP_SRCS
   qgslabelengineconfigdialog.cpp
   qgslabelinggui.cpp
   qgslabelingwidget.cpp
+  qgslayertreeviewembeddedindicator.cpp
   qgslayertreeviewfilterindicator.cpp
   qgsloadstylefromdbdialog.cpp
   qgsmapcanvasdockwidget.cpp
@@ -263,6 +264,7 @@ SET (QGIS_APP_MOC_HDRS
   qgslabelinggui.h
   qgslabelingwidget.h
   qgslabelpropertydialog.h
+  qgslayertreeviewembeddedindicator.h
   qgslayertreeviewfilterindicator.h
   qgsloadstylefromdbdialog.h
   qgsmapcanvasdockwidget.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -202,6 +202,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayertreeutils.h"
 #include "qgslayertreeview.h"
 #include "qgslayertreeviewdefaultactions.h"
+#include "qgslayertreeviewembeddedindicator.h"
 #include "qgslayertreeviewfilterindicator.h"
 #include "qgslayout.h"
 #include "qgslayoutatlas.h"
@@ -3726,6 +3727,7 @@ void QgisApp::initLayerTreeView()
   mLayerTreeView->setModel( model );
   mLayerTreeView->setMenuProvider( new QgsAppLayerTreeViewMenuProvider( mLayerTreeView, mMapCanvas ) );
   new QgsLayerTreeViewFilterIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
+  new QgsLayerTreeViewEmbeddedIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
 
   setupLayerTreeViewFromSettings();
 

--- a/src/app/qgslayertreeviewembeddedindicator.cpp
+++ b/src/app/qgslayertreeviewembeddedindicator.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+  qgslayertreeviewembeddedindicator.h
+  --------------------------------------
+  Date                 : June 2018
+  Copyright            : (C) 2018 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayertreeviewembeddedindicator.h"
+#include "qgslayertree.h"
+#include "qgslayertreemodel.h"
+#include "qgslayertreeview.h"
+
+QgsLayerTreeViewEmbeddedIndicatorProvider::QgsLayerTreeViewEmbeddedIndicatorProvider( QgsLayerTreeView *view )
+  : QObject( view )
+  , mLayerTreeView( view )
+{
+  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorFilter.svg" ) );
+
+  QgsLayerTree *tree = mLayerTreeView->layerTreeModel()->rootGroup();
+  onAddedChildren( tree, 0, tree->children().count() - 1 );
+
+  connect( tree, &QgsLayerTree::addedChildren, this, &QgsLayerTreeViewEmbeddedIndicatorProvider::onAddedChildren );
+}
+
+void QgsLayerTreeViewEmbeddedIndicatorProvider::onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+{
+  // recursively populate indicators
+  QList<QgsLayerTreeNode *> children = node->children();
+  for ( int i = indexFrom; i <= indexTo; ++i )
+  {
+    QgsLayerTreeNode *childNode = children[i];
+
+    if ( QgsLayerTree::isGroup( childNode ) )
+    {
+      onAddedChildren( childNode, 0, childNode->children().count() - 1 );
+    }
+    else if ( QgsLayerTree::isLayer( childNode ) && childNode->customProperty( QStringLiteral( "embedded" ) ).toInt() )
+    {
+      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
+      addIndicatorForEmbeddedLayer( childLayerNode );
+    }
+  }
+}
+
+QgsLayerTreeViewIndicator *QgsLayerTreeViewEmbeddedIndicatorProvider::newIndicator( const QString &project )
+{
+  QgsLayerTreeViewIndicator *indicator = new QgsLayerTreeViewIndicator( this );
+  indicator->setIcon( mIcon );
+  indicator->setToolTip( tr( "Embedded from <b>%1</b>" ).arg( project ) );
+  mIndicators.insert( indicator );
+  return indicator;
+}
+
+void QgsLayerTreeViewEmbeddedIndicatorProvider::addIndicatorForEmbeddedLayer( QgsLayerTreeNode *node )
+{
+  const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
+
+  // maybe the indicator exists already
+  for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
+  {
+    if ( mIndicators.contains( indicator ) )
+    {
+      return;
+    }
+  }
+
+  // it does not exist: need to create a new one
+  mLayerTreeView->addIndicator( node, newIndicator( node->customProperty( QStringLiteral( "embedded_project" ) ).toString() ) );
+}

--- a/src/app/qgslayertreeviewembeddedindicator.cpp
+++ b/src/app/qgslayertreeviewembeddedindicator.cpp
@@ -41,11 +41,14 @@ void QgsLayerTreeViewEmbeddedIndicatorProvider::onAddedChildren( QgsLayerTreeNod
     if ( QgsLayerTree::isGroup( childNode ) )
     {
       onAddedChildren( childNode, 0, childNode->children().count() - 1 );
+      if ( childNode->customProperty( QStringLiteral( "embedded" ) ).toInt() )
+      {
+        addIndicatorForEmbeddedLayer( childNode );
+      }
     }
     else if ( QgsLayerTree::isLayer( childNode ) && childNode->customProperty( QStringLiteral( "embedded" ) ).toInt() )
     {
-      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
-      addIndicatorForEmbeddedLayer( childLayerNode );
+      addIndicatorForEmbeddedLayer( childNode );
     }
   }
 }
@@ -61,6 +64,15 @@ QgsLayerTreeViewIndicator *QgsLayerTreeViewEmbeddedIndicatorProvider::newIndicat
 
 void QgsLayerTreeViewEmbeddedIndicatorProvider::addIndicatorForEmbeddedLayer( QgsLayerTreeNode *node )
 {
+  QString project = node->customProperty( QStringLiteral( "embedded_project" ) ).toString();
+  QgsLayerTreeNode *nextNode = node;
+  while ( project.isEmpty() && nextNode )
+  {
+    nextNode = nextNode->parent();
+    if ( nextNode )
+      project = nextNode->customProperty( QStringLiteral( "embedded_project" ) ).toString();
+  }
+
   const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
 
   // maybe the indicator exists already
@@ -73,5 +85,5 @@ void QgsLayerTreeViewEmbeddedIndicatorProvider::addIndicatorForEmbeddedLayer( Qg
   }
 
   // it does not exist: need to create a new one
-  mLayerTreeView->addIndicator( node, newIndicator( node->customProperty( QStringLiteral( "embedded_project" ) ).toString() ) );
+  mLayerTreeView->addIndicator( node, newIndicator( project ) );
 }

--- a/src/app/qgslayertreeviewembeddedindicator.cpp
+++ b/src/app/qgslayertreeviewembeddedindicator.cpp
@@ -53,12 +53,12 @@ void QgsLayerTreeViewEmbeddedIndicatorProvider::onAddedChildren( QgsLayerTreeNod
   }
 }
 
-QgsLayerTreeViewIndicator *QgsLayerTreeViewEmbeddedIndicatorProvider::newIndicator( const QString &project )
+std::unique_ptr< QgsLayerTreeViewIndicator > QgsLayerTreeViewEmbeddedIndicatorProvider::newIndicator( const QString &project )
 {
-  QgsLayerTreeViewIndicator *indicator = new QgsLayerTreeViewIndicator( this );
+  std::unique_ptr< QgsLayerTreeViewIndicator > indicator = qgis::make_unique< QgsLayerTreeViewIndicator >( this );
   indicator->setIcon( mIcon );
   indicator->setToolTip( tr( "Embedded from <b>%1</b>" ).arg( project ) );
-  mIndicators.insert( indicator );
+  mIndicators.insert( indicator.get() );
   return indicator;
 }
 
@@ -85,5 +85,5 @@ void QgsLayerTreeViewEmbeddedIndicatorProvider::addIndicatorForEmbeddedLayer( Qg
   }
 
   // it does not exist: need to create a new one
-  mLayerTreeView->addIndicator( node, newIndicator( project ) );
+  mLayerTreeView->addIndicator( node, newIndicator( project ).release() );
 }

--- a/src/app/qgslayertreeviewembeddedindicator.cpp
+++ b/src/app/qgslayertreeviewembeddedindicator.cpp
@@ -22,7 +22,7 @@ QgsLayerTreeViewEmbeddedIndicatorProvider::QgsLayerTreeViewEmbeddedIndicatorProv
   : QObject( view )
   , mLayerTreeView( view )
 {
-  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorFilter.svg" ) );
+  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorEmbedded.svg" ) );
 
   QgsLayerTree *tree = mLayerTreeView->layerTreeModel()->rootGroup();
   onAddedChildren( tree, 0, tree->children().count() - 1 );

--- a/src/app/qgslayertreeviewembeddedindicator.h
+++ b/src/app/qgslayertreeviewembeddedindicator.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+  qgslayertreeviewembeddedindicator.h
+  --------------------------------------
+  Date                 : June 2018
+  Copyright            : (C) 2018 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERTREEVIEWEMBEDDEDINDICATOR_H
+#define QGSLAYERTREEVIEWEMBEDDEDINDICATOR_H
+
+#include "qgslayertreeviewindicator.h"
+
+#include <QSet>
+
+class QgsLayerTreeNode;
+class QgsLayerTreeView;
+
+//! Adds indicators showing whether layers are embedded.
+class QgsLayerTreeViewEmbeddedIndicatorProvider : public QObject
+{
+    Q_OBJECT
+  public:
+    explicit QgsLayerTreeViewEmbeddedIndicatorProvider( QgsLayerTreeView *view );
+
+  private slots:
+    //! Connects to signals of layers newly added to the tree
+    void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+
+  private:
+    QgsLayerTreeViewIndicator *newIndicator( const QString &project );
+    void addIndicatorForEmbeddedLayer( QgsLayerTreeNode *node );
+
+  private:
+    QgsLayerTreeView *mLayerTreeView = nullptr;
+    QIcon mIcon;
+    QSet<QgsLayerTreeViewIndicator *> mIndicators;
+};
+
+#endif // QGSLAYERTREEVIEWEMBEDDEDINDICATOR_H

--- a/src/app/qgslayertreeviewembeddedindicator.h
+++ b/src/app/qgslayertreeviewembeddedindicator.h
@@ -19,6 +19,7 @@
 #include "qgslayertreeviewindicator.h"
 
 #include <QSet>
+#include <memory>
 
 class QgsLayerTreeNode;
 class QgsLayerTreeView;
@@ -35,7 +36,7 @@ class QgsLayerTreeViewEmbeddedIndicatorProvider : public QObject
     void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
 
   private:
-    QgsLayerTreeViewIndicator *newIndicator( const QString &project );
+    std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator( const QString &project );
     void addIndicatorForEmbeddedLayer( QgsLayerTreeNode *node );
 
   private:

--- a/src/app/qgslayertreeviewfilterindicator.cpp
+++ b/src/app/qgslayertreeviewfilterindicator.cpp
@@ -175,7 +175,7 @@ void QgsLayerTreeViewFilterIndicatorProvider::addOrRemoveIndicator( QgsLayerTree
     const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
 
     // maybe the indicator exists already
-    foreach ( QgsLayerTreeViewIndicator *indicator, nodeIndicators )
+    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
     {
       if ( mIndicators.contains( indicator ) )
       {
@@ -192,7 +192,7 @@ void QgsLayerTreeViewFilterIndicatorProvider::addOrRemoveIndicator( QgsLayerTree
     const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
 
     // there may be existing indicator we need to get rid of
-    foreach ( QgsLayerTreeViewIndicator *indicator, nodeIndicators )
+    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
     {
       if ( mIndicators.contains( indicator ) )
       {

--- a/src/app/qgslayertreeviewfilterindicator.cpp
+++ b/src/app/qgslayertreeviewfilterindicator.cpp
@@ -151,19 +151,19 @@ void QgsLayerTreeViewFilterIndicatorProvider::onIndicatorClicked( const QModelIn
     vlayer->setSubsetString( qb.sql() );
 }
 
-QgsLayerTreeViewIndicator *QgsLayerTreeViewFilterIndicatorProvider::newIndicator( const QString &filter )
+std::unique_ptr<QgsLayerTreeViewIndicator> QgsLayerTreeViewFilterIndicatorProvider::newIndicator( const QString &filter )
 {
-  QgsLayerTreeViewIndicator *indicator = new QgsLayerTreeViewIndicator( this );
+  std::unique_ptr< QgsLayerTreeViewIndicator > indicator = qgis::make_unique< QgsLayerTreeViewIndicator >( this );
   indicator->setIcon( mIcon );
-  updateIndicator( indicator, filter );
-  connect( indicator, &QgsLayerTreeViewIndicator::clicked, this, &QgsLayerTreeViewFilterIndicatorProvider::onIndicatorClicked );
-  mIndicators.insert( indicator );
+  updateIndicator( indicator.get(), filter );
+  connect( indicator.get(), &QgsLayerTreeViewIndicator::clicked, this, &QgsLayerTreeViewFilterIndicatorProvider::onIndicatorClicked );
+  mIndicators.insert( indicator.get() );
   return indicator;
 }
 
 void QgsLayerTreeViewFilterIndicatorProvider::updateIndicator( QgsLayerTreeViewIndicator *indicator, const QString &filter )
 {
-  indicator->setToolTip( QString( "<b>%1:</b><br>%2" ).arg( tr( "Filter" ) ).arg( filter ) );
+  indicator->setToolTip( QStringLiteral( "<b>%1:</b><br>%2" ).arg( tr( "Filter" ), filter ) );
 }
 
 
@@ -185,7 +185,7 @@ void QgsLayerTreeViewFilterIndicatorProvider::addOrRemoveIndicator( QgsLayerTree
     }
 
     // it does not exist: need to create a new one
-    mLayerTreeView->addIndicator( node, newIndicator( filter ) );
+    mLayerTreeView->addIndicator( node, newIndicator( filter ).release() );
   }
   else
   {

--- a/src/app/qgslayertreeviewfilterindicator.h
+++ b/src/app/qgslayertreeviewfilterindicator.h
@@ -19,6 +19,7 @@
 #include "qgslayertreeviewindicator.h"
 
 #include <QSet>
+#include <memory>
 
 class QgsLayerTreeNode;
 class QgsLayerTreeView;
@@ -45,7 +46,7 @@ class QgsLayerTreeViewFilterIndicatorProvider : public QObject
     void onIndicatorClicked( const QModelIndex &index );
 
   private:
-    QgsLayerTreeViewIndicator *newIndicator( const QString &filter );
+    std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator( const QString &filter );
     void updateIndicator( QgsLayerTreeViewIndicator *indicator, const QString &filter );
     void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsVectorLayer *vlayer );
 

--- a/src/app/qgslayertreeviewfilterindicator.h
+++ b/src/app/qgslayertreeviewfilterindicator.h
@@ -50,7 +50,7 @@ class QgsLayerTreeViewFilterIndicatorProvider : public QObject
     void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsVectorLayer *vlayer );
 
   private:
-    QgsLayerTreeView *mLayerTreeView;
+    QgsLayerTreeView *mLayerTreeView = nullptr;
     QIcon mIcon;
     QSet<QgsLayerTreeViewIndicator *> mIndicators;
 };

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -257,8 +257,6 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
   else if ( role == Qt::FontRole )
   {
     QFont f( QgsLayerTree::isLayer( node ) ? mFontLayer : ( QgsLayerTree::isGroup( node ) ? mFontGroup : QFont() ) );
-    if ( node->customProperty( QStringLiteral( "embedded" ) ).toInt() )
-      f.setItalic( true );
     if ( index == mCurrentIndex )
       f.setUnderline( true );
     return f;


### PR DESCRIPTION
The previous approach of showing these layers with italic text is not obvious for users to understand, and the interface gives little clues as to why a layer cannot be edited. There's also no way to see what project a layer has been embedded from!

(I remember the first time I came across a project with embedded layers... I was super confused for ages trying to work out why some layers were italic and couldn't be changed!!)

So use a new indicator icon in the layer tree to flag embedded layers, with a tooltip showing the path
to the embedded project location.

Needs a nice new icon - @nirvn?
