### PR TITLE
Embed layers UI fixes

### DIFF
--- a/src/app/qgsprojectlayergroupdialog.cpp
+++ b/src/app/qgsprojectlayergroupdialog.cpp
@@ -26,6 +26,24 @@
 #include <QFileInfo>
 #include <QMessageBox>
 
+
+
+
+QgsEmbeddedLayerTreeModel::QgsEmbeddedLayerTreeModel( QgsLayerTree *rootNode, QObject *parent )
+  : QgsLayerTreeModel( rootNode, parent )
+{
+}
+
+QVariant QgsEmbeddedLayerTreeModel::data( const QModelIndex &index, int role ) const
+{
+  if ( role == Qt::ForegroundRole || role == Qt::FontRole )
+    return QVariant();
+
+  return QgsLayerTreeModel::data( index, role );
+}
+
+
+
 QgsProjectLayerGroupDialog::QgsProjectLayerGroupDialog( QWidget *parent, const QString &projectFile, Qt::WindowFlags f )
   : QDialog( parent, f )
   , mRootGroup( new QgsLayerTree )
@@ -180,7 +198,7 @@ void QgsProjectLayerGroupDialog::changeProjectFile()
   if ( !mShowEmbeddedContent )
     removeEmbeddedNodes( mRootGroup );
 
-  QgsLayerTreeModel *model = new QgsLayerTreeModel( mRootGroup, this );
+  QgsEmbeddedLayerTreeModel *model = new QgsEmbeddedLayerTreeModel( mRootGroup, this );
   mTreeView->setModel( model );
 
   connect( mTreeView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsProjectLayerGroupDialog::onTreeViewSelectionChanged );

--- a/src/app/qgsprojectlayergroupdialog.h
+++ b/src/app/qgsprojectlayergroupdialog.h
@@ -18,11 +18,30 @@
 #include "QDialog"
 #include "ui_qgsprojectlayergroupdialogbase.h"
 #include "qgshelp.h"
+#include "qgslayertreemodel.h"
 #include "qgis_app.h"
 
 class QDomElement;
 
 class QgsLayerTree;
+
+/**
+ * Subclass of QgsLayerTreeModel which overrides font styling
+ * from base model.
+ */
+class QgsEmbeddedLayerTreeModel : public QgsLayerTreeModel
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * Construct a new tree model with given layer tree (root node must not be null pointer).
+     * The root node is not transferred by the model.
+     */
+    explicit QgsEmbeddedLayerTreeModel( QgsLayerTree *rootNode, QObject *parent = nullptr );
+
+    QVariant data( const QModelIndex &index, int role = Qt::DisplayRole ) const override;
+};
 
 //! A dialog to select layers and groups from a qgs project
 class APP_EXPORT QgsProjectLayerGroupDialog: public QDialog, private Ui::QgsProjectLayerGroupDialogBase

--- a/src/app/qgsprojectlayergroupdialog.h
+++ b/src/app/qgsprojectlayergroupdialog.h
@@ -60,8 +60,6 @@ class APP_EXPORT QgsProjectLayerGroupDialog: public QDialog, private Ui::QgsProj
     bool isValid() const;
 
   private slots:
-    void mBrowseFileToolButton_clicked();
-    void mProjectFileLineEdit_editingFinished();
     void onTreeViewSelectionChanged();
     void mButtonBox_accepted();
     void showHelp();
@@ -72,6 +70,7 @@ class APP_EXPORT QgsProjectLayerGroupDialog: public QDialog, private Ui::QgsProj
     void deselectChildren( const QModelIndex &index );
     QString mProjectPath;
     bool mShowEmbeddedContent = false;
+    bool mPresetProjectMode = false;
 
     QgsLayerTree *mRootGroup = nullptr;
 };

--- a/src/ui/qgsprojectlayergroupdialogbase.ui
+++ b/src/ui/qgsprojectlayergroupdialogbase.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
      <item>
       <widget class="QLabel" name="mProjectFileLabel">
        <property name="text">
@@ -24,12 +24,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="mProjectFileLineEdit"/>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mBrowseFileToolButton">
-       <property name="text">
-        <string>…</string>
+      <widget class="QgsFileWidget" name="mProjectFileWidget" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
        </property>
       </widget>
      </item>
@@ -63,12 +60,16 @@
    <extends>QTreeView</extends>
    <header>qgslayertreeview.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mProjectFileLineEdit</tabstop>
-  <tabstop>mBrowseFileToolButton</tabstop>
+  <tabstop>mProjectFileWidget</tabstop>
   <tabstop>mTreeView</tabstop>
-  <tabstop>mButtonBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Fixes some UI issues with the embed layers dialog:

- Ignore model font style and color in embed layers dialog, prevents layers from appearing "disabled" if they are unchecked in the original project
- use a qgsfilewidget
- disable ok button when no layers/groups are selected