### PR TITLE
[map themes] fix map renderer ignore theme blend and transparency layer settings

### DIFF
--- a/python/core/auto_generated/qgsmaplayerstylemanager.sip.in
+++ b/python/core/auto_generated/qgsmaplayerstylemanager.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsMapLayerStyle
 {
 %Docstring
@@ -224,6 +223,35 @@ Emitted when the current style has been changed
 
 };
 
+
+class QgsLayerStyleOverride
+{
+%Docstring
+Restore overridden layer style on destruction.
+
+.. versionadded:: 3.2
+%End
+
+%TypeHeaderCode
+#include "qgsmaplayerstylemanager.h"
+%End
+  public:
+
+    QgsLayerStyleOverride( QgsMapLayer *layer );
+%Docstring
+Construct a style override object associated with a map layer.
+The overridden style will be restored upon object destruction.
+%End
+
+    ~QgsLayerStyleOverride();
+
+    void setOverrideStyle( const QString &style );
+%Docstring
+Temporarily apply a different style to the layer. The argument
+can be either a style name or a full QML style definition.
+%End
+
+};
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -979,11 +979,11 @@ void QgsDxfExport::writeEntities()
       continue;
     }
 
-    bool hasStyleOverride = mMapSettings.layerStyleOverrides().contains( vl->id() );
-    if ( hasStyleOverride )
+    QgsLayerStyleOverride styleOverride( vl );
+    if ( mMapSettings.layerStyleOverrides().contains( vl->id() ) )
     {
       QgsDebugMsg( QString( "%1: apply override style" ).arg( vl->id() ) );
-      vl->styleManager()->setOverrideStyle( mMapSettings.layerStyleOverrides().value( vl->id() ) );
+      styleOverride.setOverrideStyle( mMapSettings.layerStyleOverrides().value( vl->id() ) );
     }
     else
     {
@@ -993,8 +993,6 @@ void QgsDxfExport::writeEntities()
     QgsSymbolRenderContext sctx( ctx, QgsUnitTypes::RenderMillimeters, 1.0, false, nullptr, nullptr );
     if ( !vl->renderer() )
     {
-      if ( hasStyleOverride )
-        vl->styleManager()->restoreOverrideStyle();
       continue;
     }
 
@@ -1043,9 +1041,6 @@ void QgsDxfExport::writeEntities()
     {
       writeEntitiesSymbolLevels( vl );
       renderer->stopRender( ctx );
-
-      if ( hasStyleOverride )
-        vl->styleManager()->restoreOverrideStyle();
 
       continue;
     }
@@ -1108,9 +1103,6 @@ void QgsDxfExport::writeEntities()
     }
 
     renderer->stopRender( ctx );
-
-    if ( hasStyleOverride )
-      vl->styleManager()->restoreOverrideStyle();
   }
 
   engine.run( ctx );

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -1188,9 +1188,9 @@ void QgsLayerTreeModel::addLegendToLayer( QgsLayerTreeLayer *nodeL )
   if ( !layerLegend )
     return;
 
-  bool hasStyleOverride = mLayerStyleOverrides.contains( ml->id() );
-  if ( hasStyleOverride )
-    ml->styleManager()->setOverrideStyle( mLayerStyleOverrides.value( ml->id() ) );
+  QgsLayerStyleOverride styleOverride( ml );
+  if ( mLayerStyleOverrides.contains( ml->id() ) )
+    styleOverride.setOverrideStyle( mLayerStyleOverrides.value( ml->id() ) );
 
   QList<QgsLayerTreeModelLegendNode *> lstNew = layerLegend->createLayerTreeModelLegendNodes( nodeL );
 
@@ -1249,9 +1249,6 @@ void QgsLayerTreeModel::addLegendToLayer( QgsLayerTreeLayer *nodeL )
   mLegend[nodeL] = data;
 
   if ( !filteredLstNew.isEmpty() ) endInsertRows();
-
-  if ( hasStyleOverride )
-    ml->styleManager()->restoreOverrideStyle();
 
   // invalidate map based data even if the data is not map-based to make sure
   // the symbol sizes are computed at least once

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -101,9 +101,9 @@ bool QgsMapHitTest::legendKeyVisible( const QString &ruleKey, QgsVectorLayer *la
 
 void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols, SymbolSet &usedSymbolsRuleKey, QgsRenderContext &context )
 {
-  bool hasStyleOverride = mSettings.layerStyleOverrides().contains( vl->id() );
-  if ( hasStyleOverride )
-    vl->styleManager()->setOverrideStyle( mSettings.layerStyleOverrides().value( vl->id() ) );
+  QgsLayerStyleOverride styleOverride( vl );
+  if ( mSettings.layerStyleOverrides().contains( vl->id() ) )
+    styleOverride.setOverrideStyle( mSettings.layerStyleOverrides().value( vl->id() ) );
 
   std::unique_ptr< QgsFeatureRenderer > r( vl->renderer()->clone() );
   bool moreSymbolsPerFeature = r->capabilities() & QgsFeatureRenderer::MoreSymbolsPerFeature;
@@ -199,8 +199,5 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols,
     usedSymbols = lUsedSymbols;
     usedSymbolsRuleKey = lUsedSymbolsRuleKey;
   }
-
-  if ( hasStyleOverride )
-    vl->styleManager()->restoreOverrideStyle();
 }
 

--- a/src/core/qgsmaplayerstylemanager.cpp
+++ b/src/core/qgsmaplayerstylemanager.cpp
@@ -16,7 +16,6 @@
 #include "qgsmaplayerstylemanager.h"
 
 #include "qgslogger.h"
-#include "qgsmaplayer.h"
 
 #include <QDomElement>
 #include <QTextStream>

--- a/src/core/qgsmaplayerstylemanager.h
+++ b/src/core/qgsmaplayerstylemanager.h
@@ -16,16 +16,15 @@
 #ifndef QGSMAPLAYERSTYLEMANAGER_H
 #define QGSMAPLAYERSTYLEMANAGER_H
 
-
-class QgsMapLayer;
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include "qgsmaplayer.h"
 
 #include <QByteArray>
 #include <QMap>
 #include <QStringList>
 #include <QObject>
 
-#include "qgis_core.h"
-#include "qgis_sip.h"
 
 class QDomElement;
 
@@ -195,4 +194,47 @@ class CORE_EXPORT QgsMapLayerStyleManager : public QObject
     QString defaultStyleName() const;
 };
 
+
+/**
+ * \ingroup core
+ * Restore overridden layer style on destruction.
+ *
+ * \since QGIS 3.2
+ */
+class CORE_EXPORT QgsLayerStyleOverride
+{
+  public:
+
+    /**
+     * Construct a style override object associated with a map layer.
+     * The overridden style will be restored upon object destruction.
+     */
+    QgsLayerStyleOverride( QgsMapLayer *layer )
+      : mLayer( layer )
+    {
+    }
+
+    ~QgsLayerStyleOverride()
+    {
+      if ( mLayer && mStyleOverridden )
+        mLayer->styleManager()->restoreOverrideStyle();
+    }
+
+    /**
+     * Temporarily apply a different style to the layer. The argument
+     * can be either a style name or a full QML style definition.
+     */
+    void setOverrideStyle( const QString &style )
+    {
+      if ( mLayer && mStyleOverridden )
+        mLayer->styleManager()->restoreOverrideStyle();
+      mLayer->styleManager()->setOverrideStyle( style );
+      mStyleOverridden = true;
+    }
+
+  private:
+
+    QgsMapLayer *mLayer = nullptr;
+    bool mStyleOverridden = false;
+};
 #endif // QGSMAPLAYERSTYLEMANAGER_H

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -216,8 +216,6 @@ bool QgsMapRendererJob::reprojectToLayerExtent( const QgsMapLayer *ml, const Qgs
   return split;
 }
 
-
-
 LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEngine *labelingEngine2 )
 {
   LayerRenderJobs layerJobs;
@@ -298,9 +296,9 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     if ( mFeatureFilterProvider )
       job.context.setFeatureFilterProvider( mFeatureFilterProvider );
 
-    bool hasStyleOverride = mSettings.layerStyleOverrides().contains( ml->id() );
-    if ( hasStyleOverride )
-      ml->styleManager()->setOverrideStyle( mSettings.layerStyleOverrides().value( ml->id() ) );
+    QgsLayerStyleOverride styleOverride( ml );
+    if ( mSettings.layerStyleOverrides().contains( ml->id() ) )
+      styleOverride.setOverrideStyle( mSettings.layerStyleOverrides().value( ml->id() ) );
 
     job.blendMode = ml->blendMode();
     job.opacity = 1.0;
@@ -312,9 +310,6 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     // if we can use the cache, let's do it and avoid rendering!
     if ( mCache && mCache->hasCacheImage( ml->id() ) )
     {
-      if ( hasStyleOverride )
-        ml->styleManager()->restoreOverrideStyle();
-
       job.cached = true;
       job.imageInitialized = true;
       job.img = new QImage( mCache->cacheImage( ml->id() ) );
@@ -335,9 +330,6 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
                                       mSettings.outputImageFormat() );
       if ( mypFlattenedImage->isNull() )
       {
-        if ( hasStyleOverride )
-          ml->styleManager()->restoreOverrideStyle();
-
         mErrors.append( Error( ml->id(), tr( "Insufficient memory for image %1x%2" ).arg( mSettings.outputSize().width() ).arg( mSettings.outputSize().height() ) ) );
         delete mypFlattenedImage;
         layerJobs.removeLast();
@@ -354,9 +346,6 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     layerTime.start();
     job.renderer = ml->createMapRenderer( job.context );
     job.renderingTime = layerTime.elapsed(); // include job preparation time in layer rendering time
-
-    if ( hasStyleOverride )
-      ml->styleManager()->restoreOverrideStyle();
   } // while (li.hasPrevious())
 
   return layerJobs;

--- a/src/core/qgsmapthemecollection.cpp
+++ b/src/core/qgsmapthemecollection.cpp
@@ -365,7 +365,8 @@ QMap<QString, QString> QgsMapThemeCollection::mapThemeStyleOverrides( const QStr
     if ( layerRec.usingCurrentStyle )
     {
       QgsMapLayer *layer = layerRec.layer();
-      layer->styleManager()->setOverrideStyle( layerRec.currentStyle );
+      QgsLayerStyleOverride styleOverride( layer );
+      styleOverride.setOverrideStyle( layerRec.currentStyle );
 
       // set the checked legend nodes
       applyMapThemeCheckedLegendNodesToLayer( layerRec, layer );
@@ -374,8 +375,6 @@ QMap<QString, QString> QgsMapThemeCollection::mapThemeStyleOverrides( const QStr
       QgsMapLayerStyle layerStyle;
       layerStyle.readFromLayer( layer );
       styleOverrides[layer->id()] = layerStyle.xmlData();
-
-      layer->styleManager()->restoreOverrideStyle();
     }
   }
   return styleOverrides;


### PR DESCRIPTION
## Description
@wonder-sk , @nyalldawson , I stumbled on a serious map theme issue, which went unreported until now. Long story short, the map renderer job doesn't respect map theme's blend and transparency layer settings.

This PR fixes this. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
