### PR TITLE
Avoid signalling repaint / data signals when a setSubsetString doesn't actually change

### DIFF
--- a/src/core/providers/memory/qgsmemoryprovider.cpp
+++ b/src/core/providers/memory/qgsmemoryprovider.cpp
@@ -565,6 +565,9 @@ bool QgsMemoryProvider::setSubsetString( const QString &theSQL, bool updateFeatu
       return false;
   }
 
+  if ( theSQL == mSubsetString )
+    return true;
+
   mSubsetString = theSQL;
   clearMinMaxCache();
   mExtent.setMinimal();

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -890,6 +890,9 @@ bool QgsVectorLayer::setSubsetString( const QString &subset )
     return false;
   }
 
+  if ( subset == mDataProvider->subsetString() )
+    return true;
+
   bool res = mDataProvider->setSubsetString( subset );
 
   // get the updated data source string from the provider

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2095,6 +2095,9 @@ bool QgsOracleProvider::setSubsetString( const QString &theSQL, bool updateFeatu
   if ( !mConnection )
     return false;
 
+  if ( theSQL.trimmed() == mSqlWhereClause )
+    return true;
+
   QString prevWhere = mSqlWhereClause;
 
   mSqlWhereClause = theSQL.trimmed();

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3098,6 +3098,9 @@ QgsVectorDataProvider::Capabilities QgsPostgresProvider::capabilities() const
 
 bool QgsPostgresProvider::setSubsetString( const QString &theSQL, bool updateFeatureCount )
 {
+  if ( theSQL.trimmed() == mSqlWhereClause )
+    return true;
+
   QString prevWhere = mSqlWhereClause;
 
   mSqlWhereClause = theSQL.trimmed();

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3450,6 +3450,9 @@ QString QgsSpatiaLiteProvider::subsetString() const
 
 bool QgsSpatiaLiteProvider::setSubsetString( const QString &theSQL, bool updateFeatureCount )
 {
+  if ( theSQL == mSubsetString )
+    return true;
+
   QString prevSubsetString = mSubsetString;
   mSubsetString = theSQL;
 
@@ -3461,6 +3464,7 @@ bool QgsSpatiaLiteProvider::setSubsetString( const QString &theSQL, bool updateF
   // update feature count and extents
   if ( updateFeatureCount && getTableSummary() )
   {
+    emit dataChanged();
     return true;
   }
 
@@ -3472,8 +3476,6 @@ bool QgsSpatiaLiteProvider::setSubsetString( const QString &theSQL, bool updateF
   setDataSourceUri( uri.uri() );
 
   getTableSummary();
-
-  emit dataChanged();
 
   return false;
 }

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -604,9 +604,10 @@ QgsSpatiaLiteProvider::QgsSpatiaLiteProvider( QString const &uri, const Provider
                   << QgsVectorDataProvider::NativeType( tr( "Array of decimal numbers (double)" ), SPATIALITE_ARRAY_PREFIX.toUpper() + "REAL" + SPATIALITE_ARRAY_SUFFIX.toUpper(), QVariant::List, 0, 0, 0, 0, QVariant::Double )
                   << QgsVectorDataProvider::NativeType( tr( "Array of whole numbers (integer)" ), SPATIALITE_ARRAY_PREFIX.toUpper() + "INTEGER" + SPATIALITE_ARRAY_SUFFIX.toUpper(), QVariant::List, 0, 0, 0, 0, QVariant::LongLong )
                 );
+
   // Update extent and feature count
   if ( ! mSubsetString.isEmpty() )
-    setSubsetString( mSubsetString, true );
+    getTableSummary();
 
   mValid = true;
 }

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -503,10 +503,16 @@ QString QgsVirtualLayerProvider::subsetString() const
 
 bool QgsVirtualLayerProvider::setSubsetString( const QString &subset, bool updateFeatureCount )
 {
+  if ( subset == mSubset )
+    return true;
+
   mSubset = subset;
   clearMinMaxCache();
   if ( updateFeatureCount )
     updateStatistics();
+
+  emit dataChanged();
+
   return true;
 }
 

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -679,6 +679,9 @@ bool QgsWFSProvider::setSubsetString( const QString &theSQL, bool updateFeatureC
 {
   QgsDebugMsg( QString( "theSql = '%1'" ).arg( theSQL ) );
 
+  if ( theSQL == mSubsetString )
+    return true;
+
   // Invalid and cancel current download before altering fields, etc...
   // (crashes might happen if not done at the beginning)
   mShared->invalidateCache();
@@ -710,6 +713,7 @@ bool QgsWFSProvider::setSubsetString( const QString &theSQL, bool updateFeatureC
     mShared->mURI.setSql( QString() );
     mShared->mURI.setFilter( theSQL );
   }
+
   setDataSourceUri( mShared->mURI.uri() );
   QString errorMsg;
   if ( !mShared->computeFilter( errorMsg ) )
@@ -717,6 +721,9 @@ bool QgsWFSProvider::setSubsetString( const QString &theSQL, bool updateFeatureC
   reloadData();
   if ( updateFeatureCount )
     featureCount();
+
+  emit dataChanged();
+
   return true;
 }
 

--- a/tests/src/python/provider_python.py
+++ b/tests/src/python/provider_python.py
@@ -373,10 +373,13 @@ class PyProvider(QgsVectorDataProvider):
         return self._subset_string
 
     def setSubsetString(self, subsetString):
+        if subsetString == self._subset_string:
+            return True
         self._subset_string = subsetString
         self.updateExtents()
         self.clearMinMaxCache()
         self.dataChanged.emit()
+        return True
 
     def supportsSubsetString(self):
         return True

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -30,6 +30,7 @@ from qgis.core import (
     QgsTestUtils,
     NULL
 )
+from qgis.PyQt.QtTest import QSignalSpy
 
 from utilities import compareWkt
 from featuresourcetestbase import FeatureSourceTestCase
@@ -157,9 +158,16 @@ class ProviderTestCase(FeatureSourceTestCase):
             print('Provider does not support subset strings')
             return
 
+        changed_spy = QSignalSpy(self.source.dataChanged)
         subset = self.getSubsetString()
         self.source.setSubsetString(subset)
         self.assertEqual(self.source.subsetString(), subset)
+        self.assertEqual(len(changed_spy), 1)
+
+        # No signal should be emitted if the subset string is not modified
+        self.source.setSubsetString(subset)
+        self.assertEqual(len(changed_spy), 1)
+
         result = set([f['pk'] for f in self.source.getFeatures()])
         all_valid = (all(f.isValid() for f in self.source.getFeatures()))
         self.source.setSubsetString(None)


### PR DESCRIPTION
## Description
Copying what's (rightfully) done in the OGR provider, this PR insures that setSubsetString( string ) doesn't emit signals when the passed string == the previously set subset string.

This fixes at needless repaint when saving a project with the memory layer saver plugin, and just makes sense :)

@nyalldawson , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
