### PR TITLE
[Server] WMS GetFeatureInfo Raster GML: do not add attribute for no data

### DIFF
--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -2582,12 +2582,7 @@ int QgsWMSServer::featureInfoFromRasterLayer( QgsRasterLayer* layer,
     int index = 0;
     Q_FOREACH ( int bandNo, values.keys() )
     {
-      if ( values.value( bandNo ).isNull() )
-      {
-        fields.append( QgsField( layer->bandName( bandNo ), QVariant::String ) );
-        feature.setAttribute( index++, "no data" );
-      }
-      else
+      if ( !values.value( bandNo ).isNull() )
       {
         QVariant value( values.value( bandNo ) );
         fields.append( QgsField( layer->bandName( bandNo ), QVariant::Double ) );


### PR DESCRIPTION
## Description
For WMS GetFeatureInfo request on a raster layer with GML as output, if the
identify value is null, do not ad the band as an attribute.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
