### PR TITLE
[FEATURE] map canvas @canvas_cursor_point variable

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -206,13 +206,6 @@ Gets map center, in geographical coordinates
 .. versionadded:: 2.8
 %End
 
-    QgsPointXY cursorPoint() const;
-%Docstring
-Returns the last cursor position on the canvas in geographical coordinates
-
-.. versionadded:: 3.4
-%End
-
     void zoomToFullExtent();
 %Docstring
 Zoom to the full extent of all layers
@@ -618,6 +611,8 @@ context scope for the canvas.
 
 .. seealso:: :py:func:`expressionContextScope`
 
+.. seealso:: :py:func:`defaultExpressionContextScope`
+
 .. versionadded:: 2.12
 %End
 
@@ -629,13 +624,19 @@ overrides for expression evaluation for the map canvas render.
 
 .. seealso:: :py:func:`setExpressionContextScope`
 
+.. seealso:: :py:func:`defaultExpressionContextScope`
+
 .. versionadded:: 2.12
 %End
 
 
-    QgsExpressionContextScope *scope() /Factory/;
+    QgsExpressionContextScope *defaultExpressionContextScope() /Factory/;
 %Docstring
 Creates a new scope which contains default variables and functions relating to the map canvas.
+
+.. seealso:: :py:func:`expressionContextScope`
+
+.. seealso:: :py:func:`setExpressionContextScope`
 
 .. versionadded:: 3.4
 %End

--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -206,6 +206,13 @@ Gets map center, in geographical coordinates
 .. versionadded:: 2.8
 %End
 
+    QgsPointXY cursorPoint() const;
+%Docstring
+Returns the last cursor position on the canvas in geographical coordinates
+
+.. versionadded:: 3.4
+%End
+
     void zoomToFullExtent();
 %Docstring
 Zoom to the full extent of all layers
@@ -625,6 +632,13 @@ overrides for expression evaluation for the map canvas render.
 .. versionadded:: 2.12
 %End
 
+
+    QgsExpressionContextScope *scope() /Factory/;
+%Docstring
+Creates a new scope which contains default variables and functions relating to the map canvas.
+
+.. versionadded:: 3.4
+%End
 
     void setSegmentationTolerance( double tolerance );
 %Docstring

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -748,6 +748,9 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "grid_number" ), QCoreApplication::translate( "variable_help", "Current grid annotation value." ) );
   sVariableHelpTexts.insert( QStringLiteral( "grid_axis" ), QCoreApplication::translate( "variable_help", "Current grid annotation axis (e.g., 'x' for longitude, 'y' for latitude)." ) );
 
+  // map canvas item variables
+  sVariableHelpTexts.insert( QStringLiteral( "canvas_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the project's geographical coordinates." ) );
+
   // map tool capture variables
   sVariableHelpTexts.insert( QStringLiteral( "snapping_results" ), QCoreApplication::translate( "variable_help",
                              "<p>An array with an item for each snapped point.</p>"

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -466,7 +466,7 @@ QgsMapLayer *QgsMapCanvas::currentLayer()
   return mCurrentLayer;
 }
 
-QgsExpressionContextScope *QgsMapCanvas::scope()
+QgsExpressionContextScope *QgsMapCanvas::defaultExpressionContextScope()
 {
   QgsExpressionContextScope *s = new QgsExpressionContextScope( QObject::tr( "Map Canvas" ) );
   s->setVariable( QStringLiteral( "canvas_cursor_point" ), QgsGeometry::fromPointXY( cursorPoint() ), true );
@@ -517,7 +517,7 @@ void QgsMapCanvas::refreshMap()
                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
                     << QgsExpressionContextUtils::atlasScope( nullptr )
                     << QgsExpressionContextUtils::mapSettingsScope( mSettings )
-                    << scope()
+                    << defaultExpressionContextScope()
                     << new QgsExpressionContextScope( mExpressionContextScope );
 
   mSettings.setExpressionContext( expressionContext );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -466,6 +466,13 @@ QgsMapLayer *QgsMapCanvas::currentLayer()
   return mCurrentLayer;
 }
 
+QgsExpressionContextScope *QgsMapCanvas::scope()
+{
+  QgsExpressionContextScope *s = new QgsExpressionContextScope( QObject::tr( "Map Canvas" ) );
+  s->setVariable( QStringLiteral( "canvas_cursor_point" ), QgsGeometry::fromPointXY( cursorPoint() ), true );
+
+  return s;
+}
 
 void QgsMapCanvas::refresh()
 {
@@ -510,6 +517,7 @@ void QgsMapCanvas::refreshMap()
                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
                     << QgsExpressionContextUtils::atlasScope( nullptr )
                     << QgsExpressionContextUtils::mapSettingsScope( mSettings )
+                    << scope()
                     << new QgsExpressionContextScope( mExpressionContextScope );
 
   mSettings.setExpressionContext( expressionContext );
@@ -862,6 +870,10 @@ QgsPointXY QgsMapCanvas::center() const
   return r.center();
 }
 
+QgsPointXY QgsMapCanvas::cursorPoint() const
+{
+  return mCursorPoint;
+}
 
 double QgsMapCanvas::rotation() const
 {
@@ -1622,9 +1634,8 @@ void QgsMapCanvas::mouseMoveEvent( QMouseEvent *e )
   }
 
   // show x y on status bar
-  QPoint xy = e->pos();
-  QgsPointXY coord = getCoordinateTransform()->toMapCoordinates( xy );
-  emit xyCoordinates( coord );
+  mCursorPoint = getCoordinateTransform()->toMapCoordinates( mCanvasProperties->mouseLastXY );
+  emit xyCoordinates( mCursorPoint );
 }
 
 void QgsMapCanvas::setMapTool( QgsMapTool *tool, bool clean )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -233,12 +233,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      */
     QgsPointXY center() const;
 
-    /**
-     * Returns the last cursor position on the canvas in geographical coordinates
-     * \since QGIS 3.4
-     */
-    QgsPointXY cursorPoint() const;
-
     //! Zoom to the full extent of all layers
     void zoomToFullExtent();
 
@@ -1014,6 +1008,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     bool mUsePreviewJobs = false;
 
     QHash< QString, int > mLastLayerRenderTime;
+
+    /**
+     * Returns the last cursor position on the canvas in geographical coordinates
+     * \since QGIS 3.4
+     */
+    QgsPointXY cursorPoint() const;
 
     /**
      * Force a resize of the map canvas item

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -550,6 +550,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      * context scope for the canvas.
      * \param scope new expression context scope
      * \see expressionContextScope()
+     * \see defaultExpressionContextScope()
      * \since QGIS 2.12
      */
     void setExpressionContextScope( const QgsExpressionContextScope &scope ) { mExpressionContextScope = scope; }
@@ -559,6 +560,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      * into the expression context used for rendering the map, and can be used to apply specific variable
      * overrides for expression evaluation for the map canvas render.
      * \see setExpressionContextScope()
+     * \see defaultExpressionContextScope()
      * \since QGIS 2.12
      */
     QgsExpressionContextScope &expressionContextScope() { return mExpressionContextScope; }
@@ -566,6 +568,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     /**
      * Returns a const reference to the expression context scope for the map canvas.
      * \see setExpressionContextScope()
+     * \see defaultExpressionContextScope()
      * \note not available in Python bindings
      * \since QGIS 2.12
      */
@@ -573,9 +576,11 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     /**
      * Creates a new scope which contains default variables and functions relating to the map canvas.
+     * \see expressionContextScope()
+     * \see setExpressionContextScope()
      * \since QGIS 3.4
      */
-    QgsExpressionContextScope *scope() SIP_FACTORY;
+    QgsExpressionContextScope *defaultExpressionContextScope() SIP_FACTORY;
 
     /**
      * Sets the segmentation tolerance applied when rendering curved geometries

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -233,6 +233,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      */
     QgsPointXY center() const;
 
+    /**
+     * Returns the last cursor position on the canvas in geographical coordinates
+     * \since QGIS 3.4
+     */
+    QgsPointXY cursorPoint() const;
+
     //! Zoom to the full extent of all layers
     void zoomToFullExtent();
 
@@ -564,6 +570,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      * \since QGIS 2.12
      */
     const QgsExpressionContextScope &expressionContextScope() const { return mExpressionContextScope; } SIP_SKIP
+
+    /**
+     * Creates a new scope which contains default variables and functions relating to the map canvas.
+     * \since QGIS 3.4
+     */
+    QgsExpressionContextScope *scope() SIP_FACTORY;
 
     /**
      * Sets the segmentation tolerance applied when rendering curved geometries
@@ -989,6 +1001,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     QMetaObject::Connection mPreviewTimerConnection;
 
     QString mTheme;
+
+    QgsPointXY mCursorPoint;
 
     bool mAnnotationsVisible = true;
 

--- a/src/gui/symbology/qgssymbolwidgetcontext.cpp
+++ b/src/gui/symbology/qgssymbolwidgetcontext.cpp
@@ -83,7 +83,7 @@ QList<QgsExpressionContextScope *> QgsSymbolWidgetContext::globalProjectAtlasMap
   if ( mMapCanvas )
   {
     scopes << QgsExpressionContextUtils::mapSettingsScope( mMapCanvas->mapSettings() )
-           << mMapCanvas->scope()
+           << mMapCanvas->defaultExpressionContextScope()
            << new QgsExpressionContextScope( mMapCanvas->expressionContextScope() );
   }
   else

--- a/src/gui/symbology/qgssymbolwidgetcontext.cpp
+++ b/src/gui/symbology/qgssymbolwidgetcontext.cpp
@@ -83,6 +83,7 @@ QList<QgsExpressionContextScope *> QgsSymbolWidgetContext::globalProjectAtlasMap
   if ( mMapCanvas )
   {
     scopes << QgsExpressionContextUtils::mapSettingsScope( mMapCanvas->mapSettings() )
+           << mMapCanvas->scope()
            << new QgsExpressionContextScope( mMapCanvas->expressionContextScope() );
   }
   else


### PR DESCRIPTION
## Description
This variable returns the last cursor position on the canvas in the project's geographical coordinates.

Using this variable in symbology alongside the layer auto-refresh setting allows users to come up with what's recently been labelled as canvas brushing:
![d](https://user-images.githubusercontent.com/1728657/41282139-84c091f0-6e5d-11e8-9e9a-e729aee80d9b.gif)

Another example, with polygons (using a graduated renderer):
![peek 2018-06-27 10-19](https://user-images.githubusercontent.com/1728657/41951206-e1ebf68e-79f3-11e8-9aea-35b739cf01bf.gif)


This is an extreme scenario, which does show we need more optimization down the line, but it's pretty cool nevertheless. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
