### PR TITLE
Use default QLocale instead of system

### DIFF
--- a/src/app/layout/qgslayoutmapwidget.cpp
+++ b/src/app/layout/qgslayoutmapwidget.cpp
@@ -477,7 +477,7 @@ void QgsLayoutMapWidget::mScaleLineEdit_editingFinished()
   }
 
   bool conversionSuccess = false;
-  double scaleDenominator = QLocale::system().toDouble( mScaleLineEdit->text(), &conversionSuccess );
+  double scaleDenominator = QLocale().toDouble( mScaleLineEdit->text(), &conversionSuccess );
   if ( !conversionSuccess )
   {
     return;
@@ -726,16 +726,16 @@ void QgsLayoutMapWidget::updateComposerExtentFromGui()
   double xmin, ymin, xmax, ymax;
   bool conversionSuccess;
 
-  xmin = QLocale::system().toDouble( mXMinLineEdit->text(), &conversionSuccess );
+  xmin = QLocale().toDouble( mXMinLineEdit->text(), &conversionSuccess );
   if ( !conversionSuccess )
     return;
-  xmax = QLocale::system().toDouble( mXMaxLineEdit->text(), &conversionSuccess );
+  xmax = QLocale().toDouble( mXMaxLineEdit->text(), &conversionSuccess );
   if ( !conversionSuccess )
     return;
-  ymin = QLocale::system().toDouble( mYMinLineEdit->text(), &conversionSuccess );
+  ymin = QLocale().toDouble( mYMinLineEdit->text(), &conversionSuccess );
   if ( !conversionSuccess )
     return;
-  ymax = QLocale::system().toDouble( mYMaxLineEdit->text(), &conversionSuccess );
+  ymax = QLocale().toDouble( mYMaxLineEdit->text(), &conversionSuccess );
   if ( !conversionSuccess )
     return;
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1162,7 +1162,7 @@ int main( int argc, char *argv[] )
   {
     if ( !myLocaleOverrideFlag || myUserLocale.isEmpty() )
     {
-      myTranslationCode = QLocale::system().name();
+      myTranslationCode = QLocale().name();
       //setting the locale/userLocale when the --lang= option is not set will allow third party
       //plugins to always use the same locale as the QGIS, otherwise they can be out of sync
       mySettings.setValue( QStringLiteral( "locale/userLocale" ), myTranslationCode );

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -510,9 +510,9 @@ void QgsCustomProjectionDialog::pbnCalculate_clicked()
       precision = 7;
     }
 
-    tmp = QLocale::system().toString( northing, 'f', precision );
+    tmp = QLocale().toString( northing, 'f', precision );
     projectedX->setText( tmp );
-    tmp = QLocale::system().toString( easting, 'f', precision );
+    tmp = QLocale().toString( easting, 'f', precision );
     projectedY->setText( tmp );
   }
 

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -167,7 +167,7 @@ void QgsMeasureDialog::mouseMove( const QgsPointXY &point )
     QTreeWidgetItem *item = mTable->topLevelItem( mTable->topLevelItemCount() - 1 );
     if ( item )
     {
-      item->setText( 0, QLocale::system().toString( d, 'f', mDecimalPlaces ) );
+      item->setText( 0, QLocale().toString( d, 'f', mDecimalPlaces ) );
     }
   }
 }
@@ -184,7 +184,7 @@ void QgsMeasureDialog::addPoint()
   {
     if ( !mTool->done() )
     {
-      QTreeWidgetItem *item = new QTreeWidgetItem( QStringList( QLocale::system().toString( 0.0, 'f', mDecimalPlaces ) ) );
+      QTreeWidgetItem *item = new QTreeWidgetItem( QStringList( QLocale().toString( 0.0, 'f', mDecimalPlaces ) ) );
       item->setTextAlignment( 0, Qt::AlignRight );
       mTable->addTopLevelItem( item );
       mTable->scrollToItem( item );
@@ -231,7 +231,7 @@ void QgsMeasureDialog::removeLastPoint()
       d = convertLength( d, mDistanceUnits );
 
       QTreeWidgetItem *item = mTable->topLevelItem( mTable->topLevelItemCount() - 1 );
-      item->setText( 0, QLocale::system().toString( d, 'f', mDecimalPlaces ) );
+      item->setText( 0, QLocale().toString( d, 'f', mDecimalPlaces ) );
       editTotal->setText( formatDistance( mTotal + d ) );
     }
     else
@@ -501,7 +501,7 @@ void QgsMeasureDialog::updateUi()
           d = convertLength( d, mDistanceUnits );
         }
 
-        QTreeWidgetItem *item = new QTreeWidgetItem( QStringList( QLocale::system().toString( d, 'f', mDecimalPlaces ) ) );
+        QTreeWidgetItem *item = new QTreeWidgetItem( QStringList( QLocale().toString( d, 'f', mDecimalPlaces ) ) );
         item->setTextAlignment( 0, Qt::AlignRight );
         mTable->addTopLevelItem( item );
         mTable->scrollToItem( item );

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -903,7 +903,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   //
   // Locale settings
   //
-  QString mySystemLocale = QLocale::system().name();
+  QString mySystemLocale = QLocale().name();
   lblSystemLocale->setText( tr( "Detected active locale on your system: %1" ).arg( mySystemLocale ) );
   QString myUserLocale = mSettings->value( QStringLiteral( "locale/userLocale" ), QString() ).toString();
   QStringList myI18nList = i18nList();

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -523,7 +523,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mWMSInspireLanguage->addItem( QIcon( QString( ":/images/flags/%1.png" ).arg( "cy" ) ), QLocale( QStringLiteral( "cy" ) ).nativeLanguageName(), "cym" );
   mWMSInspireLanguage->setCurrentIndex(
     mWMSInspireLanguage->findText(
-      QLocale::system().nativeLanguageName()
+      QLocale().nativeLanguageName()
     )
   );
 
@@ -932,8 +932,8 @@ void QgsProjectProperties::apply()
     if ( leSemiMajor->isModified() || leSemiMinor->isModified() )
     {
       QgsDebugMsgLevel( "Using parameteric major/minor", 4 );
-      major = QLocale::system().toDouble( leSemiMajor->text() );
-      minor = QLocale::system().toDouble( leSemiMinor->text() );
+      major = QLocale().toDouble( leSemiMajor->text() );
+      minor = QLocale().toDouble( leSemiMinor->text() );
     }
     QgsProject::instance()->setEllipsoid( QStringLiteral( "PARAMETER:%1:%2" )
                                           .arg( major, 0, 'g', 17 )
@@ -1980,8 +1980,8 @@ void QgsProjectProperties::updateEllipsoidUI( int newIndex )
   if ( leSemiMajor->isModified() || leSemiMinor->isModified() )
   {
     QgsDebugMsgLevel( "Saving major/minor", 4 );
-    mEllipsoidList[ mEllipsoidIndex ].semiMajor = QLocale::system().toDouble( leSemiMajor->text() );
-    mEllipsoidList[ mEllipsoidIndex ].semiMinor = QLocale::system().toDouble( leSemiMinor->text() );
+    mEllipsoidList[ mEllipsoidIndex ].semiMajor = QLocale().toDouble( leSemiMajor->text() );
+    mEllipsoidList[ mEllipsoidIndex ].semiMinor = QLocale().toDouble( leSemiMinor->text() );
   }
 
   mEllipsoidIndex = newIndex;
@@ -2004,8 +2004,8 @@ void QgsProjectProperties::updateEllipsoidUI( int newIndex )
   }
   if ( mEllipsoidList[ mEllipsoidIndex ].acronym != GEO_NONE )
   {
-    leSemiMajor->setText( QLocale::system().toString( myMajor, 'f', 3 ) );
-    leSemiMinor->setText( QLocale::system().toString( myMinor, 'f', 3 ) );
+    leSemiMajor->setText( QLocale().toString( myMajor, 'f', 3 ) );
+    leSemiMinor->setText( QLocale().toString( myMinor, 'f', 3 ) );
   }
 
   if ( mCrs.isValid() )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -513,7 +513,7 @@ double QgsExpression::evaluateToDouble( const QString &text, const double fallba
   //first test if text is directly convertible to double
   // use system locale: e.g. in German locale, user is presented with numbers "1,23" instead of "1.23" in C locale
   // so we also want to allow user to rewrite it to "5,23" and it is still accepted
-  double convertedValue = QLocale::system().toDouble( text, &ok );
+  double convertedValue = QLocale().toDouble( text, &ok );
   if ( ok )
   {
     return convertedValue;

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -97,15 +97,15 @@ const double Qgis::UI_SCALE_FACTOR = 1;
 double qgsPermissiveToDouble( QString string, bool &ok )
 {
   //remove any thousands separators
-  string.remove( QLocale::system().groupSeparator() );
-  return QLocale::system().toDouble( string, &ok );
+  string.remove( QLocale().groupSeparator() );
+  return QLocale().toDouble( string, &ok );
 }
 
 int qgsPermissiveToInt( QString string, bool &ok )
 {
   //remove any thousands separators
-  string.remove( QLocale::system().groupSeparator() );
-  return QLocale::system().toInt( string, &ok );
+  string.remove( QLocale().groupSeparator() );
+  return QLocale().toInt( string, &ok );
 }
 
 void *qgsMalloc( size_t size )

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -976,7 +976,7 @@ QString QgsApplication::locale()
   }
   else
   {
-    return QLocale::system().name().left( 2 );
+    return QLocale().name().left( 2 );
   }
 }
 

--- a/src/core/qgsexpressionsorter.h
+++ b/src/core/qgsexpressionsorter.h
@@ -30,7 +30,7 @@ class QgsExpressionSorter
         // QString::localeAwareCompare() is case insensitive for common locales,
         // but case sensitive for the C locale. So use an explicit case
         // insensitive comparison in that later case to avoid test failures.
-      , mUseCaseInsensitiveComparison( QLocale::system().name() == QLocale::c().name() )
+      , mUseCaseInsensitiveComparison( QLocale().name() == QLocale::c().name() )
     {}
 
     bool operator()( const QgsIndexedFeature &f1, const QgsIndexedFeature &f2 ) const

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -142,7 +142,7 @@ QgsDateTimeEditConfig::QgsDateTimeEditConfig( QgsVectorLayer *vl, int fieldIdx, 
                       "<td bgcolor=\"#f6f6f6\" style=\"vertical-align:top; padding-left:10; padding-right:10; padding-top:3; padding-bottom:3;\">"
                       "<p><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e; background-color:#f6f6f6;\">" )
     + tr( "the abbreviated localized day name (e.g. 'Mon' to 'Sun'). Uses the system locale to localize the name, i.e. " )
-    + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qlocale.html#system\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">QLocale::system</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">().</span></p>"
+    + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qlocale.html#system\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">QLocale</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">().</span></p>"
                       "</td>"
                       "</tr>"
                       "<tr>"
@@ -154,7 +154,7 @@ QgsDateTimeEditConfig::QgsDateTimeEditConfig( QgsVectorLayer *vl, int fieldIdx, 
     + tr( "the long localized day name (e.g. 'Monday' to '" )
     + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qt.html#DayOfWeek-enum\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">Qt::Sunday</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">')." )
     + tr( "Uses the system locale to localize the name, i.e. " )
-    + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qlocale.html#system\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">QLocale::system</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">().</span></p>"
+    + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qlocale.html#system\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">QLocale</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">().</span></p>"
                       "</td>"
                       "</tr>"
                       "<tr>"
@@ -184,7 +184,7 @@ QgsDateTimeEditConfig::QgsDateTimeEditConfig( QgsVectorLayer *vl, int fieldIdx, 
                       "<td bgcolor=\"#f6f6f6\" style=\"vertical-align:top; padding-left:10; padding-right:10; padding-top:3; padding-bottom:3;\">"
                       "<p><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e; background-color:#f6f6f6;\">" )
     + tr( "the abbreviated localized month name (e.g. 'Jan' to 'Dec'). Uses the system locale to localize the name, i.e." )
-    + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qlocale.html#system\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">QLocale::system</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">().</span></p>"
+    + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qlocale.html#system\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">QLocale</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">().</span></p>"
                       "</td>"
                       "</tr>"
                       "<tr>"
@@ -194,7 +194,7 @@ QgsDateTimeEditConfig::QgsDateTimeEditConfig( QgsVectorLayer *vl, int fieldIdx, 
                       "<td bgcolor=\"#ffffff\" style=\"vertical-align:top; padding-left:10; padding-right:10; padding-top:3; padding-bottom:3;\">"
                       "<p><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e; background-color:#ffffff;\">" )
     + tr( "the long localized month name (e.g. 'January' to 'December'). Uses the system locale to localize the name, i.e." )
-    + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qlocale.html#system\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">QLocale::system</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">().</span></p>"
+    + QStringLiteral( "</span><a href=\"http://qt-project.org/doc/qt-5/qlocale.html#system\"><span style=\"font-family:'Arial,FreeSans,sans-serif'; font-size:12px; font-weight:600; text-decoration: underline; color:#00732f;\">QLocale</span></a><span style=\"font-family:'Open Sans,sans-serif'; font-size:11px; color:#66666e;\">().</span></p>"
                       "</td>"
                       "</tr>"
                       "<tr>"

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -206,7 +206,7 @@ void QgsConfigureShortcutsDialog::loadShortcuts()
   }
   else // use QGIS locale
   {
-    currentLocale = QLocale::system().name();
+    currentLocale = QLocale().name();
   }
 
   if ( root.attribute( QStringLiteral( "locale" ) ) != currentLocale )

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -341,7 +341,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
 
 void QgsMapToolIdentify::closestVertexAttributes( const QgsAbstractGeometry &geometry, QgsVertexId vId, QgsMapLayer *layer, QMap< QString, QString > &derivedAttributes )
 {
-  QString str = QLocale::system().toString( vId.vertex + 1 );
+  QString str = QLocale().toString( vId.vertex + 1 );
   derivedAttributes.insert( tr( "Closest vertex number" ), str );
 
   QgsPoint closestPoint = geometry.vertexAt( vId );
@@ -352,12 +352,12 @@ void QgsMapToolIdentify::closestVertexAttributes( const QgsAbstractGeometry &geo
 
   if ( closestPoint.is3D() )
   {
-    str = QLocale::system().toString( closestPoint.z(), 'g', 10 );
+    str = QLocale().toString( closestPoint.z(), 'g', 10 );
     derivedAttributes.insert( QStringLiteral( "Closest vertex Z" ), str );
   }
   if ( closestPoint.isMeasure() )
   {
-    str = QLocale::system().toString( closestPoint.m(), 'g', 10 );
+    str = QLocale().toString( closestPoint.m(), 'g', 10 );
     derivedAttributes.insert( QStringLiteral( "Closest vertex M" ), str );
   }
 
@@ -370,7 +370,7 @@ void QgsMapToolIdentify::closestVertexAttributes( const QgsAbstractGeometry &geo
     ++vIdAfter.vertex;
     QgsGeometryUtils::circleCenterRadius( geometry.vertexAt( vIdBefore ), geometry.vertexAt( vId ),
                                           geometry.vertexAt( vIdAfter ), radius, centerX, centerY );
-    derivedAttributes.insert( QStringLiteral( "Closest vertex radius" ), QLocale::system().toString( radius ) );
+    derivedAttributes.insert( QStringLiteral( "Closest vertex radius" ), QLocale().toString( radius ) );
   }
 }
 
@@ -419,9 +419,9 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
 
   if ( QgsWkbTypes::isMultiType( wkbType ) )
   {
-    QString str = QLocale::system().toString( static_cast<const QgsGeometryCollection *>( feature.geometry().constGet() )->numGeometries() );
+    QString str = QLocale().toString( static_cast<const QgsGeometryCollection *>( feature.geometry().constGet() )->numGeometries() );
     derivedAttributes.insert( tr( "Parts" ), str );
-    str = QLocale::system().toString( vId.part + 1 );
+    str = QLocale().toString( vId.part + 1 );
     derivedAttributes.insert( tr( "Part number" ), str );
   }
 
@@ -447,7 +447,7 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
     const QgsAbstractGeometry *geom = feature.geometry().constGet();
     if ( geom )
     {
-      str = QLocale::system().toString( geom->nCoordinates() );
+      str = QLocale().toString( geom->nCoordinates() );
       derivedAttributes.insert( tr( "Vertices" ), str );
       //add details of closest vertex to identify point
       closestVertexAttributes( *geom, vId, layer, derivedAttributes );
@@ -493,7 +493,7 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
                           * QgsUnitTypes::fromUnitToUnitFactor( layer->crs().mapUnits(), cartesianDistanceUnits ), cartesianDistanceUnits );
     derivedAttributes.insert( tr( "Perimeter (Cartesian)" ), str );
 
-    str = QLocale::system().toString( feature.geometry().constGet()->nCoordinates() );
+    str = QLocale().toString( feature.geometry().constGet()->nCoordinates() );
     derivedAttributes.insert( tr( "Vertices" ), str );
 
     //add details of closest vertex to identify point
@@ -512,12 +512,12 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
 
       if ( QgsWkbTypes::hasZ( wkbType ) )
       {
-        str = QLocale::system().toString( static_cast<const QgsPoint *>( feature.geometry().constGet() )->z(), 'g', 10 );
+        str = QLocale().toString( static_cast<const QgsPoint *>( feature.geometry().constGet() )->z(), 'g', 10 );
         derivedAttributes.insert( QStringLiteral( "Z" ), str );
       }
       if ( QgsWkbTypes::hasM( wkbType ) )
       {
-        str = QLocale::system().toString( static_cast<const QgsPoint *>( feature.geometry().constGet() )->m(), 'g', 10 );
+        str = QLocale().toString( static_cast<const QgsPoint *>( feature.geometry().constGet() )->m(), 'g', 10 );
         derivedAttributes.insert( QStringLiteral( "M" ), str );
       }
     }

--- a/src/gui/qgsscalecombobox.cpp
+++ b/src/gui/qgsscalecombobox.cpp
@@ -66,7 +66,7 @@ void QgsScaleComboBox::updateScales( const QStringList &scales )
   for ( int i = 0; i < myScalesList.size(); ++i )
   {
     parts = myScalesList[ i ] .split( ':' );
-    denominator = QLocale::system().toDouble( parts[1], &ok );
+    denominator = QLocale().toDouble( parts[1], &ok );
     if ( ok )
     {
       myScalesList[ i ] = toString( denominator );
@@ -185,11 +185,11 @@ QString QgsScaleComboBox::toString( double scale )
   }
   else if ( scale <= 1 )
   {
-    return QStringLiteral( "%1:1" ).arg( QLocale::system().toString( static_cast< int >( std::round( 1.0 / scale ) ) ) );
+    return QStringLiteral( "%1:1" ).arg( QLocale().toString( static_cast< int >( std::round( 1.0 / scale ) ) ) );
   }
   else
   {
-    return QStringLiteral( "1:%1" ).arg( QLocale::system().toString( static_cast< int >( std::round( scale ) ) ) );
+    return QStringLiteral( "1:%1" ).arg( QLocale().toString( static_cast< int >( std::round( scale ) ) ) );
   }
 }
 

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -75,15 +75,15 @@ void TestQgis::permissiveToDouble()
   QVERIFY( ok );
   QCOMPARE( result, 1000.0 );
   ok = false;
-  result = qgsPermissiveToDouble( QStringLiteral( "1" ) + QLocale::system().groupSeparator() + "000", ok );
+  result = qgsPermissiveToDouble( QStringLiteral( "1" ) + QLocale().groupSeparator() + "000", ok );
   QVERIFY( ok );
   QCOMPARE( result, 1000.0 );
   ok = false;
-  result = qgsPermissiveToDouble( QStringLiteral( "5" ) + QLocale::system().decimalPoint() + "5", ok );
+  result = qgsPermissiveToDouble( QStringLiteral( "5" ) + QLocale().decimalPoint() + "5", ok );
   QVERIFY( ok );
   QCOMPARE( result, 5.5 );
   ok = false;
-  result = qgsPermissiveToDouble( QStringLiteral( "1" ) + QLocale::system().groupSeparator() + "000" + QLocale::system().decimalPoint() + "5", ok );
+  result = qgsPermissiveToDouble( QStringLiteral( "1" ) + QLocale().groupSeparator() + "000" + QLocale().decimalPoint() + "5", ok );
   QVERIFY( ok );
   QCOMPARE( result, 1000.5 );
 
@@ -94,11 +94,11 @@ void TestQgis::permissiveToDouble()
 
   //messy input (invalid thousand separator position), should still be converted
   ok = false;
-  result = qgsPermissiveToDouble( QStringLiteral( "10" ) + QLocale::system().groupSeparator() + "00", ok );
+  result = qgsPermissiveToDouble( QStringLiteral( "10" ) + QLocale().groupSeparator() + "00", ok );
   QVERIFY( ok );
   QCOMPARE( result, 1000.0 );
   ok = false;
-  result = qgsPermissiveToDouble( QStringLiteral( "10" ) + QLocale::system().groupSeparator() + "00" + QLocale::system().decimalPoint() + "5", ok );
+  result = qgsPermissiveToDouble( QStringLiteral( "10" ) + QLocale().groupSeparator() + "00" + QLocale().decimalPoint() + "5", ok );
   QVERIFY( ok );
   QCOMPARE( result, 1000.5 );
 }
@@ -111,7 +111,7 @@ void TestQgis::permissiveToInt()
   QVERIFY( ok );
   QCOMPARE( result, 1000 );
   ok = false;
-  result = qgsPermissiveToInt( QStringLiteral( "1%01000" ).arg( QLocale::system().groupSeparator() ), ok );
+  result = qgsPermissiveToInt( QStringLiteral( "1%01000" ).arg( QLocale().groupSeparator() ), ok );
   QVERIFY( ok );
   QCOMPARE( result, 1000 );
 
@@ -122,7 +122,7 @@ void TestQgis::permissiveToInt()
 
   //messy input (invalid thousand separator position), should still be converted
   ok = false;
-  result = qgsPermissiveToInt( QStringLiteral( "10%0100" ).arg( QLocale::system().groupSeparator() ), ok );
+  result = qgsPermissiveToInt( QStringLiteral( "10%0100" ).arg( QLocale().groupSeparator() ), ok );
   QVERIFY( ok );
   QCOMPARE( result, 1000 );
 }

--- a/tests/src/gui/testqgsscalecombobox.cpp
+++ b/tests/src/gui/testqgsscalecombobox.cpp
@@ -70,29 +70,29 @@ void TestQgsScaleComboBox::basic()
 {
   // Testing conversion from "1:nnn".
   enterScale( QStringLiteral( "1:2345" ) );
-  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale::system().toString( 2345 ) ) );
+  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale().toString( 2345 ) ) );
   QCOMPARE( s->scale(), 2345.0 );
 
   // Testing conversion from number to "1:x"
   enterScale( 0.02 );
-  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale::system().toString( 50 ) ) );
+  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale().toString( 50 ) ) );
   QCOMPARE( s->scale(), 1.0 / 0.02 );
 
   // Testing conversion from number to "1:x"
   enterScale( 42 );
-  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale::system().toString( 42 ) ) );
+  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale().toString( 42 ) ) );
   QCOMPARE( s->scale(), 42.0 );
 
   // Testing conversion from number to "1:x,000"
-  QString str = QStringLiteral( "1%01000%01000" ).arg( QLocale::system().groupSeparator() );
+  QString str = QStringLiteral( "1%01000%01000" ).arg( QLocale().groupSeparator() );
   enterScale( str );
   QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( str ) );
   QCOMPARE( s->scale(), 1000000.0 );
 
   // Testing conversion from number to "1:x,000" with wonky separators
   //(e.g., four digits between thousands, which should be fixed automatically)
-  str = QStringLiteral( "1%010000%01000" ).arg( QLocale::system().groupSeparator() );
-  QString fixedStr = QStringLiteral( "10%01000%01000" ).arg( QLocale::system().groupSeparator() );
+  str = QStringLiteral( "1%010000%01000" ).arg( QLocale().groupSeparator() );
+  QString fixedStr = QStringLiteral( "10%01000%01000" ).arg( QLocale().groupSeparator() );
   enterScale( str );
   QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( fixedStr ) );
   QCOMPARE( s->scale(), 10000000.0 );
@@ -102,22 +102,22 @@ void TestQgsScaleComboBox::basic()
   enterScale( 0.24 );
 
   enterScale( QStringLiteral( "1:x:2" ) );
-  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale::system().toString( 4 ) ) );
+  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale().toString( 4 ) ) );
   QCOMPARE( s->scale(), 4.0 );
 
   // Test setting programmatically
   s->setScale( 1.0 / 0.19 );
-  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale::system().toString( 5 ) ) );
+  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale().toString( 5 ) ) );
   QCOMPARE( s->scale(), 5.0 );
 
   // Test setting programmatically
   s->setScaleString( QStringLiteral( "1:240" ) );
-  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale::system().toString( 240 ) ) );
+  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale().toString( 240 ) ) );
   QCOMPARE( s->scale(), 240.0 );
 
   // Test setting programmatically illegal string
-  s->setScaleString( QStringLiteral( "1:2" ) + QLocale::system().decimalPoint() + "4" );
-  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale::system().toString( 240 ) ) );
+  s->setScaleString( QStringLiteral( "1:2" ) + QLocale().decimalPoint() + "4" );
+  QCOMPARE( s->scaleString(), QString( "1:%1" ).arg( QLocale().toString( 240 ) ) );
   QCOMPARE( s->scale(), 240.0 );
 
 }
@@ -196,7 +196,7 @@ void TestQgsScaleComboBox::enterScale( const QString &scale )
 
 void TestQgsScaleComboBox::enterScale( double scale )
 {
-  enterScale( QLocale::system().toString( scale ) );
+  enterScale( QLocale().toString( scale ) );
 }
 
 void TestQgsScaleComboBox::cleanup()


### PR DESCRIPTION
no effect for now, but it makes the locale override
possible through QLocale::setDefault()

This not really a new feature, nor a bugfix (there should be no noticeable effect because the default locale is `::system()` , but I'd like to have it now because of the changes on my previous locales I/O commits, the changes in this PR make it possible to set default locale different than `::system()`, even from a plugin or from the python console. 

The next logical step would be to expose locale override in the QGIS options dialog.
