### PR TITLE
Fix text on symbol disappearing from single symbol renderer

### DIFF
--- a/src/app/qgsvectorlayerlegendwidget.cpp
+++ b/src/app/qgsvectorlayerlegendwidget.cpp
@@ -106,7 +106,7 @@ void QgsVectorLayerLegendWidget::populateLegendTreeView( const QHash<QString, QS
     if ( symbolItem.ruleKey().isEmpty() )
     {
       item1->setEnabled( false );
-      item2->setEnabled( true );
+      item2->setEnabled( false );
     }
     else
     {

--- a/src/core/symbology/qgssinglesymbolrenderer.cpp
+++ b/src/core/symbology/qgssinglesymbolrenderer.cpp
@@ -312,7 +312,7 @@ QgsLegendSymbolList QgsSingleSymbolRenderer::legendSymbolItems() const
   }
 
   QgsLegendSymbolList lst;
-  lst << QgsLegendSymbolItem( mSymbol.get(), QString(), QString() );
+  lst << QgsLegendSymbolItem( mSymbol.get(), QString(), QStringLiteral( "0" ) );
   return lst;
 }
 
@@ -320,7 +320,7 @@ QSet< QString > QgsSingleSymbolRenderer::legendKeysForFeature( const QgsFeature 
 {
   Q_UNUSED( feature );
   Q_UNUSED( context );
-  return QSet< QString >() << QString();
+  return QSet< QString >() << QStringLiteral( "0" );
 }
 
 void QgsSingleSymbolRenderer::setLegendSymbolItem( const QString &key, QgsSymbol *symbol )


### PR DESCRIPTION
Because the single symbol was not having rule key in legend...

cc @ghtmtt 