### PR TITLE
[bugfix] Style Manager - non ascii tags in symbols

### DIFF
--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -192,6 +192,7 @@ SET(TESTS
  testqgsmeshlayer.cpp
  testqgsmeshlayerrenderer.cpp
  testqgslayerdefinition.cpp
+ testqgssqliteutils.cpp
    )
 
 IF(WITH_QTWEBKIT)

--- a/tests/src/core/testqgssqliteutils.cpp
+++ b/tests/src/core/testqgssqliteutils.cpp
@@ -1,0 +1,95 @@
+/***************************************************************************
+     testqgssqliteutils.cpp
+     --------------------------------------
+    Date                 : 2018-06-13
+    Copyright            : (C) 2018 Alessandro Pasotti
+    Email                : elpaso at itopen dot it
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+#include <QStringList>
+#include <QApplication>
+#include <QFileInfo>
+
+//qgis includes...
+#include "qgssqliteutils.h"
+
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test to verify that QgsSqliteUtils are working correctly
+ */
+class TestQgsSqliteUtils : public QObject
+{
+    Q_OBJECT
+
+  public:
+
+    TestQgsSqliteUtils() = default;
+
+
+  private slots:
+
+    // init / cleanup
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {}// will be called before each testfunction is executed.
+    void cleanup() {}// will be called after every testfunction.
+    // void initStyles();
+
+    void testPrintfAscii();
+    void testPrintfUtf8();
+};
+
+
+// slots
+void TestQgsSqliteUtils::initTestCase()
+{
+  // initialize with test settings directory so we don't mess with user's stuff
+  QgsApplication::init( QDir::tempPath() + "/dot-qgis" );
+  QgsApplication::initQgis();
+  QgsApplication::createDatabase();
+
+  // output test environment
+  QgsApplication::showSettings();
+
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+
+
+}
+
+void TestQgsSqliteUtils::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsSqliteUtils::testPrintfAscii()
+{
+  QString tag( "Meteor" );
+  QString query( QgsSqlite3Mprintf( "SELECT id FROM tag WHERE LOWER(name)='%q'", tag.toUtf8().toLower().constData() ) );
+  QCOMPARE( query, QString( "SELECT id FROM tag WHERE LOWER(name)='%1'" ).arg( tag.toLower() ) );
+}
+
+
+void TestQgsSqliteUtils::testPrintfUtf8()
+{
+  QString tag( "МЕТЕОР" );
+  QCOMPARE( tag.toLower(), QString( "метеор" ) );
+  QString lowerTag( tag.toLower() );
+  QString query( QgsSqlite3Mprintf( "SELECT id FROM tag WHERE LOWER(name)='%q'", lowerTag.toUtf8().constData() ) );
+  QCOMPARE( query, QString( "SELECT id FROM tag WHERE LOWER(name)='%1'" ).arg( lowerTag ) );
+}
+
+
+QGSTEST_MAIN( TestQgsSqliteUtils )
+#include "testqgssqliteutils.moc"

--- a/tests/src/core/testqgsstyle.cpp
+++ b/tests/src/core/testqgsstyle.cpp
@@ -291,28 +291,35 @@ void TestStyle::testTags()
   QCOMPARE( id, mStyle->tagId( "purple" ) );
   QCOMPARE( QStringLiteral( "purple" ), mStyle->tag( id ) );
 
+  // Cyrillic
+  id = mStyle->addTag( QStringLiteral( "МЕТЕОР" ) );
+  QCOMPARE( id, mStyle->tagId( "МЕТЕОР" ) );
+
   QStringList tags = mStyle->tags();
-  QCOMPARE( tags.count(), 5 );
+  QCOMPARE( tags.count(), 6 );
   QVERIFY( tags.contains( "red" ) );
   QVERIFY( tags.contains( "starry" ) );
   QVERIFY( tags.contains( "circle" ) );
   QVERIFY( tags.contains( "blue" ) );
   QVERIFY( tags.contains( "purple" ) );
+  QVERIFY( tags.contains( "МЕТЕОР" ) );
 
   //remove tag
   mStyle->remove( QgsStyle::TagEntity, mStyle->tagId( QStringLiteral( "purple" ) ) );
   mStyle->remove( QgsStyle::TagEntity, -999 ); //bad id
   tags = mStyle->tags();
-  QCOMPARE( tags.count(), 4 );
+  QCOMPARE( tags.count(), 5 );
   QVERIFY( !tags.contains( "purple" ) );
 
   //add some symbols
   std::unique_ptr< QgsMarkerSymbol> sym1( QgsMarkerSymbol::createSimple( QgsStringMap() ) );
   std::unique_ptr< QgsMarkerSymbol> sym2( QgsMarkerSymbol::createSimple( QgsStringMap() ) );
   std::unique_ptr< QgsMarkerSymbol> sym3( QgsMarkerSymbol::createSimple( QgsStringMap() ) );
+  std::unique_ptr< QgsMarkerSymbol> sym4( QgsMarkerSymbol::createSimple( QgsStringMap() ) );
   QVERIFY( mStyle->saveSymbol( "symbol1", sym1.get(), false, QStringList() << "red" << "starry" ) );
   mStyle->addSymbol( QStringLiteral( "blue starry" ), sym2.release(), true );
   mStyle->addSymbol( QStringLiteral( "red circle" ), sym3.release(), true );
+  mStyle->addSymbol( QStringLiteral( "МЕТЕОР" ), sym4.release(), true );
 
   //tag them
   QVERIFY( mStyle->tagSymbol( QgsStyle::SymbolEntity, "blue starry", QStringList() << "blue" << "starry" ) );
@@ -323,6 +330,13 @@ void TestStyle::testTags()
   QVERIFY( mStyle->tagSymbol( QgsStyle::SymbolEntity, "red circle", QStringList() << "round" ) );
   tags = mStyle->tags();
   QVERIFY( tags.contains( "round" ) );
+
+  // Cyrillic
+  // Add twice (see issue #18281)
+  QVERIFY( mStyle->tagSymbol( QgsStyle::SymbolEntity, "МЕТЕОР", QStringList() << "МЕТЕОР" ) );
+  tags = mStyle->tags();
+  QVERIFY( tags.contains( "МЕТЕОР" ) );
+  QCOMPARE( tags.filter( "МЕТЕОР" ).count(), 1 );
 
   //check that tags have been applied
   tags = mStyle->tagsOfSymbol( QgsStyle::SymbolEntity, QStringLiteral( "blue starry" ) );
@@ -339,8 +353,13 @@ void TestStyle::testTags()
   QVERIFY( tags.contains( "red" ) );
   QVERIFY( tags.contains( "starry" ) );
 
+  tags = mStyle->tagsOfSymbol( QgsStyle::SymbolEntity, QStringLiteral( "МЕТЕОР" ) );
+  QCOMPARE( tags.count(), 1 );
+  QVERIFY( tags.contains( "МЕТЕОР" ) );
+
   //check that a given tag is attached to a symbol
   QVERIFY( mStyle->symbolHasTag( QgsStyle::SymbolEntity, QStringLiteral( "blue starry" ), QStringLiteral( "blue" ) ) );
+  QVERIFY( mStyle->symbolHasTag( QgsStyle::SymbolEntity, QStringLiteral( "МЕТЕОР" ), QStringLiteral( "МЕТЕОР" ) ) );
 
   //check that a given tag is not attached to a symbol
   QCOMPARE( false, mStyle->symbolHasTag( QgsStyle::SymbolEntity, QStringLiteral( "blue starry" ), QStringLiteral( "notblue" ) ) );
@@ -368,7 +387,9 @@ void TestStyle::testTags()
   QVERIFY( symbols.contains( "red circle" ) );
   symbols = mStyle->symbolsWithTag( QgsStyle::SymbolEntity, mStyle->tagId( QStringLiteral( "round" ) ) );
   QCOMPARE( symbols.count(), 1 );
-  QVERIFY( symbols.contains( "red circle" ) );
+  symbols = mStyle->symbolsWithTag( QgsStyle::SymbolEntity, mStyle->tagId( QStringLiteral( "МЕТЕОР" ) ) );
+  QCOMPARE( symbols.count(), 1 );
+  QVERIFY( symbols.contains( "МЕТЕОР" ) );
   symbols = mStyle->symbolsWithTag( QgsStyle::SymbolEntity, mStyle->tagId( QStringLiteral( "blue" ) ) );
   QVERIFY( symbols.isEmpty() );
   symbols = mStyle->symbolsWithTag( QgsStyle::SymbolEntity, mStyle->tagId( QStringLiteral( "no tag" ) ) );
@@ -392,6 +413,10 @@ void TestStyle::testTags()
   symbols = mStyle->findSymbols( QgsStyle::SymbolEntity, QStringLiteral( "round" ) );
   QCOMPARE( symbols.count(), 1 );
   QVERIFY( symbols.contains( "red circle" ) );
+  symbols = mStyle->findSymbols( QgsStyle::SymbolEntity, QStringLiteral( "МЕТЕОР" ) );
+  QCOMPARE( symbols.count(), 1 );
+  QVERIFY( symbols.contains( "МЕТЕОР" ) );
+
 }
 
 QGSTEST_MAIN( TestStyle )


### PR DESCRIPTION
Fixes #18282 - Style Manager - Impossible to work with non-Latin characters (tag or symbol names)