### PR TITLE
also use 1-dimensional table in modeler dialog (follow up 4b354984e8)

### DIFF
--- a/python/plugins/processing/gui/matrixmodelerwidget.py
+++ b/python/plugins/processing/gui/matrixmodelerwidget.py
@@ -103,26 +103,28 @@ class MatrixModelerWidget(BASE, WIDGET):
             self.tblView.model().setHeaderData(index, Qt.Horizontal, txt)
 
     def value(self):
+        cols = self.tblView.model().columnCount()
+        rows = self.tblView.model().rowCount()
+
         items = []
-        model = self.tblView.model()
-        for i in range(model.rowCount()):
-            row = []
-            for j in range(model.columnCount()):
-                item = model.item(i, j)
-                row.append(item.text())
-            items.append(row)
+        for row in range(rows):
+            for col in range(cols):
+                items.append(str(self.tblView.model().item(row, col).text()))
 
         return items
 
-    def setValue(self, table):
-        cols = len(table[0])
-        rows = len(table)
+    def setValue(self, headers, table):
+        model = self.tblView.model()
+        model.setHorizontalHeaderLabels(headers)
+
+        cols = len(headers)
+        rows = len(table) // cols
         model = QStandardItemModel(rows, cols)
 
-        for i in range(rows):
-            for j in range(cols):
-                item = QStandardItem(str(table[i][j]))
-                model.setItem(i, j, item)
+        for row in range(rows):
+            for col in range(cols):
+                item = QStandardItem(str(table[row * cols + col]))
+                model.setItem(row, col, item)
         self.tblView.setModel(model)
 
     def headers(self):
@@ -132,10 +134,6 @@ class MatrixModelerWidget(BASE, WIDGET):
             headers.append(str(model.headerData(i, Qt.Horizontal)))
 
         return headers
-
-    def setHeaders(self, headers):
-        model = self.tblView.model()
-        model.setHorizontalHeaderLabels(headers)
 
     def fixedRows(self):
         return self.chkFixedRows.isChecked()

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -294,8 +294,7 @@ class ModelerParameterDefinitionDialog(QDialog):
                 isinstance(self.param, QgsProcessingParameterMatrix):
             self.widget = MatrixModelerWidget(self)
             if self.param is not None:
-                self.widget.setValue(self.param.defaultValue())
-                self.widget.setHeaders(self.param.headers())
+                self.widget.setValue(self.param.headers(), self.param.defaultValue())
                 self.widget.setFixedRows(self.param.hasFixedNumberRows())
             self.verticalLayout.addWidget(self.widget)
 


### PR DESCRIPTION
## Description
Fixes modeler parameter definition dialog for matrix parameter to use 1-dimensional tables.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
