### PR TITLE
Make QgsRasterIterator optionally return the exact extent of the current block returned

### DIFF
--- a/src/core/raster/qgsrasteriterator.cpp
+++ b/src/core/raster/qgsrasteriterator.cpp
@@ -70,7 +70,7 @@ bool QgsRasterIterator::readNextRasterPart( int bandNumber,
   return result;
 }
 
-bool QgsRasterIterator::readNextRasterPart( int bandNumber, int &nCols, int &nRows, std::unique_ptr<QgsRasterBlock> &block, int &topLeftCol, int &topLeftRow )
+bool QgsRasterIterator::readNextRasterPart( int bandNumber, int &nCols, int &nRows, std::unique_ptr<QgsRasterBlock> &block, int &topLeftCol, int &topLeftRow, QgsRectangle *blockExtent )
 {
   QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   block.reset();
@@ -111,6 +111,9 @@ bool QgsRasterIterator::readNextRasterPart( int bandNumber, int &nCols, int &nRo
                 viewPortExtent.yMaximum() - ( pInfo.currentRow + nRows ) / static_cast< double >( pInfo.nRows ) * viewPortExtent.height();
   double ymax = viewPortExtent.yMaximum() - pInfo.currentRow / static_cast< double >( pInfo.nRows ) * viewPortExtent.height();
   QgsRectangle blockRect( xmin, ymin, xmax, ymax );
+
+  if ( blockExtent )
+    *blockExtent = blockRect;
 
   block.reset( mInput->block( bandNumber, blockRect, nCols, nRows, mFeedback ) );
   topLeftCol = pInfo.currentCol;

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -70,6 +70,7 @@ class CORE_EXPORT QgsRasterIterator
      * \param block address of block pointer
      * \param topLeftCol top left column
      * \param topLeftRow top left row
+     * \param blockExtent optional storage for exact extent of returned raster block
      * \returns false if the last part was already returned
      * \note Not available in Python bindings
      * \since QGIS 3.2
@@ -77,7 +78,8 @@ class CORE_EXPORT QgsRasterIterator
     bool readNextRasterPart( int bandNumber,
                              int &nCols, int &nRows,
                              std::unique_ptr< QgsRasterBlock > &block,
-                             int &topLeftCol, int &topLeftRow ) SIP_SKIP;
+                             int &topLeftCol, int &topLeftRow,
+                             QgsRectangle *blockExtent = nullptr ) SIP_SKIP;
 
     void stopRasterRead( int bandNumber );
 


### PR DESCRIPTION
...because this is very difficult to calculate exactly outside of the iterator, yet the iterator itself has this knowledge already...