### PR TITLE
[FEATURE][processing] New 'vectorize - Raster to Vector' algorithm

### DIFF
--- a/python/plugins/processing/tests/testdata/expected/vectorize.gml
+++ b/python/plugins/processing/tests/testdata/expected/vectorize.gml
@@ -1,0 +1,734 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ vectorize.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>270746.3040214723</gml:X><gml:Y>4458929.133005036</gml:Y></gml:coord>
+      <gml:coord><gml:X>270869.1443783216</gml:X><gml:Y>4459029.574521748</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4459019.53037008 270756.540717876,4459019.53037008 270756.540717876,4459029.57452175 270746.304021472,4459029.57452175 270746.304021472,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>826.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4459019.53037008 270766.77741428,4459019.53037008 270766.77741428,4459029.57452175 270756.540717876,4459029.57452175 270756.540717876,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>826.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4459019.53037008 270777.014110685,4459019.53037008 270777.014110685,4459029.57452175 270766.777414281,4459029.57452175 270766.777414281,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>837.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4459019.53037008 270787.250807089,4459019.53037008 270787.250807089,4459029.57452175 270777.014110685,4459029.57452175 270777.014110685,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>837.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.4">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4459019.53037008 270797.487503493,4459019.53037008 270797.487503493,4459029.57452175 270787.250807089,4459029.57452175 270787.250807089,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>837.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4459019.53037008 270807.724199897,4459019.53037008 270807.724199897,4459029.57452175 270797.487503493,4459029.57452175 270797.487503493,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>845.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.6">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4459019.53037008 270817.960896301,4459019.53037008 270817.960896301,4459029.57452175 270807.724199897,4459029.57452175 270807.724199897,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>845.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.7">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4459019.53037008 270828.197592705,4459019.53037008 270828.197592705,4459029.57452175 270817.960896301,4459029.57452175 270817.960896301,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>853.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.8">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4459019.53037008 270838.434289109,4459019.53037008 270838.434289109,4459029.57452175 270828.197592705,4459029.57452175 270828.197592705,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>853.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.9">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4459019.53037008 270848.670985513,4459019.53037008 270848.670985513,4459029.57452175 270838.434289109,4459029.57452175 270838.434289109,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>853.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.10">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4459019.53037008 270858.907681917,4459019.53037008 270858.907681917,4459029.57452175 270848.670985513,4459029.57452175 270848.670985513,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>861.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.11">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4459019.53037008 270869.144378322,4459019.53037008 270869.144378322,4459029.57452175 270858.907681918,4459029.57452175 270858.907681918,4459019.53037008</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>861.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.12">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4459009.48621841 270756.540717876,4459009.48621841 270756.540717876,4459019.53037008 270746.304021472,4459019.53037008 270746.304021472,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>826.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.13">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4459009.48621841 270766.77741428,4459009.48621841 270766.77741428,4459019.53037008 270756.540717876,4459019.53037008 270756.540717876,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>826.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.14">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4459009.48621841 270777.014110685,4459009.48621841 270777.014110685,4459019.53037008 270766.777414281,4459019.53037008 270766.777414281,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>837.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.15">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4459009.48621841 270787.250807089,4459009.48621841 270787.250807089,4459019.53037008 270777.014110685,4459019.53037008 270777.014110685,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>837.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.16">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4459009.48621841 270797.487503493,4459009.48621841 270797.487503493,4459019.53037008 270787.250807089,4459019.53037008 270787.250807089,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>837.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.17">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4459009.48621841 270807.724199897,4459009.48621841 270807.724199897,4459019.53037008 270797.487503493,4459019.53037008 270797.487503493,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>845.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.18">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4459009.48621841 270817.960896301,4459009.48621841 270817.960896301,4459019.53037008 270807.724199897,4459019.53037008 270807.724199897,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>845.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.19">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4459009.48621841 270828.197592705,4459009.48621841 270828.197592705,4459019.53037008 270817.960896301,4459019.53037008 270817.960896301,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>853.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.20">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4459009.48621841 270838.434289109,4459009.48621841 270838.434289109,4459019.53037008 270828.197592705,4459019.53037008 270828.197592705,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>853.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.21">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4459009.48621841 270848.670985513,4459009.48621841 270848.670985513,4459019.53037008 270838.434289109,4459019.53037008 270838.434289109,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>853.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.22">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4459009.48621841 270858.907681917,4459009.48621841 270858.907681917,4459019.53037008 270848.670985513,4459019.53037008 270848.670985513,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>861.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.23">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4459009.48621841 270869.144378322,4459009.48621841 270869.144378322,4459019.53037008 270858.907681918,4459019.53037008 270858.907681918,4459009.48621841</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>861.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.24">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4458999.44206673 270756.540717876,4458999.44206673 270756.540717876,4459009.48621841 270746.304021472,4459009.48621841 270746.304021472,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>843.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.25">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4458999.44206673 270766.77741428,4458999.44206673 270766.77741428,4459009.48621841 270756.540717876,4459009.48621841 270756.540717876,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>843.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.26">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4458999.44206673 270777.014110685,4458999.44206673 270777.014110685,4459009.48621841 270766.777414281,4459009.48621841 270766.777414281,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.27">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4458999.44206673 270787.250807089,4458999.44206673 270787.250807089,4459009.48621841 270777.014110685,4459009.48621841 270777.014110685,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.28">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4458999.44206673 270797.487503493,4458999.44206673 270797.487503493,4459009.48621841 270787.250807089,4459009.48621841 270787.250807089,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.29">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4458999.44206673 270807.724199897,4458999.44206673 270807.724199897,4459009.48621841 270797.487503493,4459009.48621841 270797.487503493,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.30">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4458999.44206673 270817.960896301,4458999.44206673 270817.960896301,4459009.48621841 270807.724199897,4459009.48621841 270807.724199897,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.31">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4458999.44206673 270828.197592705,4458999.44206673 270828.197592705,4459009.48621841 270817.960896301,4459009.48621841 270817.960896301,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.32">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4458999.44206673 270838.434289109,4458999.44206673 270838.434289109,4459009.48621841 270828.197592705,4459009.48621841 270828.197592705,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.33">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4458999.44206673 270848.670985513,4458999.44206673 270848.670985513,4459009.48621841 270838.434289109,4459009.48621841 270838.434289109,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.34">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4458999.44206673 270858.907681917,4458999.44206673 270858.907681917,4459009.48621841 270848.670985513,4459009.48621841 270848.670985513,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>878.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.35">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4458999.44206673 270869.144378322,4458999.44206673 270869.144378322,4459009.48621841 270858.907681918,4459009.48621841 270858.907681918,4458999.44206673</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>878.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.36">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4458989.39791506 270756.540717876,4458989.39791506 270756.540717876,4458999.44206673 270746.304021472,4458999.44206673 270746.304021472,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>843.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.37">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4458989.39791506 270766.77741428,4458989.39791506 270766.77741428,4458999.44206673 270756.540717876,4458999.44206673 270756.540717876,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>843.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.38">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4458989.39791506 270777.014110685,4458989.39791506 270777.014110685,4458999.44206673 270766.777414281,4458999.44206673 270766.777414281,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.39">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4458989.39791506 270787.250807089,4458989.39791506 270787.250807089,4458999.44206673 270777.014110685,4458999.44206673 270777.014110685,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.40">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4458989.39791506 270797.487503493,4458989.39791506 270797.487503493,4458999.44206673 270787.250807089,4458999.44206673 270787.250807089,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.41">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4458989.39791506 270807.724199897,4458989.39791506 270807.724199897,4458999.44206673 270797.487503493,4458999.44206673 270797.487503493,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.42">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4458989.39791506 270817.960896301,4458989.39791506 270817.960896301,4458999.44206673 270807.724199897,4458999.44206673 270807.724199897,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.43">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4458989.39791506 270828.197592705,4458989.39791506 270828.197592705,4458999.44206673 270817.960896301,4458999.44206673 270817.960896301,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.44">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4458989.39791506 270838.434289109,4458989.39791506 270838.434289109,4458999.44206673 270828.197592705,4458999.44206673 270828.197592705,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.45">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4458989.39791506 270848.670985513,4458989.39791506 270848.670985513,4458999.44206673 270838.434289109,4458999.44206673 270838.434289109,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.46">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4458989.39791506 270858.907681917,4458989.39791506 270858.907681917,4458999.44206673 270848.670985513,4458999.44206673 270848.670985513,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>878.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.47">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4458989.39791506 270869.144378322,4458989.39791506 270869.144378322,4458999.44206673 270858.907681918,4458999.44206673 270858.907681918,4458989.39791506</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>878.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.48">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4458979.35376339 270756.540717876,4458979.35376339 270756.540717876,4458989.39791506 270746.304021472,4458989.39791506 270746.304021472,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>843.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.49">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4458979.35376339 270766.77741428,4458979.35376339 270766.77741428,4458989.39791506 270756.540717876,4458989.39791506 270756.540717876,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>843.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.50">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4458979.35376339 270777.014110685,4458979.35376339 270777.014110685,4458989.39791506 270766.777414281,4458989.39791506 270766.777414281,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.51">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4458979.35376339 270787.250807089,4458979.35376339 270787.250807089,4458989.39791506 270777.014110685,4458989.39791506 270777.014110685,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.52">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4458979.35376339 270797.487503493,4458979.35376339 270797.487503493,4458989.39791506 270787.250807089,4458989.39791506 270787.250807089,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>851.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.53">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4458979.35376339 270807.724199897,4458979.35376339 270807.724199897,4458989.39791506 270797.487503493,4458989.39791506 270797.487503493,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.54">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4458979.35376339 270817.960896301,4458979.35376339 270817.960896301,4458989.39791506 270807.724199897,4458989.39791506 270807.724199897,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.55">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4458979.35376339 270828.197592705,4458979.35376339 270828.197592705,4458989.39791506 270817.960896301,4458989.39791506 270817.960896301,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.56">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4458979.35376339 270838.434289109,4458979.35376339 270838.434289109,4458989.39791506 270828.197592705,4458989.39791506 270828.197592705,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.57">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4458979.35376339 270848.670985513,4458979.35376339 270848.670985513,4458989.39791506 270838.434289109,4458989.39791506 270838.434289109,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>866.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.58">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4458979.35376339 270858.907681917,4458979.35376339 270858.907681917,4458989.39791506 270848.670985513,4458989.39791506 270848.670985513,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>878.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.59">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4458979.35376339 270869.144378322,4458979.35376339 270869.144378322,4458989.39791506 270858.907681918,4458989.39791506 270858.907681918,4458979.35376339</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>878.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.60">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4458969.30961172 270756.540717876,4458969.30961172 270756.540717876,4458979.35376339 270746.304021472,4458979.35376339 270746.304021472,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.61">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4458969.30961172 270766.77741428,4458969.30961172 270766.77741428,4458979.35376339 270756.540717876,4458979.35376339 270756.540717876,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.62">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4458969.30961172 270777.014110685,4458969.30961172 270777.014110685,4458979.35376339 270766.777414281,4458979.35376339 270766.777414281,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>864.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.63">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4458969.30961172 270787.250807089,4458969.30961172 270787.250807089,4458979.35376339 270777.014110685,4458979.35376339 270777.014110685,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>864.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.64">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4458969.30961172 270797.487503493,4458969.30961172 270797.487503493,4458979.35376339 270787.250807089,4458979.35376339 270787.250807089,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>864.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.65">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4458969.30961172 270807.724199897,4458969.30961172 270807.724199897,4458979.35376339 270797.487503493,4458979.35376339 270797.487503493,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>872.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.66">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4458969.30961172 270817.960896301,4458969.30961172 270817.960896301,4458979.35376339 270807.724199897,4458979.35376339 270807.724199897,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>872.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.67">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4458969.30961172 270828.197592705,4458969.30961172 270828.197592705,4458979.35376339 270817.960896301,4458979.35376339 270817.960896301,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>880.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.68">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4458969.30961172 270838.434289109,4458969.30961172 270838.434289109,4458979.35376339 270828.197592705,4458979.35376339 270828.197592705,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>880.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.69">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4458969.30961172 270848.670985513,4458969.30961172 270848.670985513,4458979.35376339 270838.434289109,4458979.35376339 270838.434289109,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>880.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.70">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4458969.30961172 270858.907681917,4458969.30961172 270858.907681917,4458979.35376339 270848.670985513,4458979.35376339 270848.670985513,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.71">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4458969.30961172 270869.144378322,4458969.30961172 270869.144378322,4458979.35376339 270858.907681918,4458979.35376339 270858.907681918,4458969.30961172</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.72">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4458959.26546005 270756.540717876,4458959.26546005 270756.540717876,4458969.30961172 270746.304021472,4458969.30961172 270746.304021472,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.73">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4458959.26546005 270766.77741428,4458959.26546005 270766.77741428,4458969.30961172 270756.540717876,4458969.30961172 270756.540717876,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>859.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.74">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4458959.26546005 270777.014110685,4458959.26546005 270777.014110685,4458969.30961172 270766.777414281,4458969.30961172 270766.777414281,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>864.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.75">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4458959.26546005 270787.250807089,4458959.26546005 270787.250807089,4458969.30961172 270777.014110685,4458969.30961172 270777.014110685,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>864.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.76">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4458959.26546005 270797.487503493,4458959.26546005 270797.487503493,4458969.30961172 270787.250807089,4458969.30961172 270787.250807089,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>864.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.77">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4458959.26546005 270807.724199897,4458959.26546005 270807.724199897,4458969.30961172 270797.487503493,4458969.30961172 270797.487503493,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>872.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.78">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4458959.26546005 270817.960896301,4458959.26546005 270817.960896301,4458969.30961172 270807.724199897,4458969.30961172 270807.724199897,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>872.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.79">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4458959.26546005 270828.197592705,4458959.26546005 270828.197592705,4458969.30961172 270817.960896301,4458969.30961172 270817.960896301,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>880.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.80">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4458959.26546005 270838.434289109,4458959.26546005 270838.434289109,4458969.30961172 270828.197592705,4458969.30961172 270828.197592705,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>880.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.81">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4458959.26546005 270848.670985513,4458959.26546005 270848.670985513,4458969.30961172 270838.434289109,4458969.30961172 270838.434289109,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>880.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.82">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4458959.26546005 270858.907681917,4458959.26546005 270858.907681917,4458969.30961172 270848.670985513,4458969.30961172 270848.670985513,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.83">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4458959.26546005 270869.144378322,4458959.26546005 270869.144378322,4458969.30961172 270858.907681918,4458969.30961172 270858.907681918,4458959.26546005</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.84">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4458949.22130838 270756.540717876,4458949.22130838 270756.540717876,4458959.26546005 270746.304021472,4458959.26546005 270746.304021472,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>868.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.85">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4458949.22130838 270766.77741428,4458949.22130838 270766.77741428,4458959.26546005 270756.540717876,4458959.26546005 270756.540717876,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>868.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.86">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4458949.22130838 270777.014110685,4458949.22130838 270777.014110685,4458959.26546005 270766.777414281,4458959.26546005 270766.777414281,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.87">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4458949.22130838 270787.250807089,4458949.22130838 270787.250807089,4458959.26546005 270777.014110685,4458959.26546005 270777.014110685,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.88">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4458949.22130838 270797.487503493,4458949.22130838 270797.487503493,4458959.26546005 270787.250807089,4458959.26546005 270787.250807089,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.89">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4458949.22130838 270807.724199897,4458949.22130838 270807.724199897,4458959.26546005 270797.487503493,4458959.26546005 270797.487503493,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>881.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.90">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4458949.22130838 270817.960896301,4458949.22130838 270817.960896301,4458959.26546005 270807.724199897,4458959.26546005 270807.724199897,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>881.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.91">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4458949.22130838 270828.197592705,4458949.22130838 270828.197592705,4458959.26546005 270817.960896301,4458959.26546005 270817.960896301,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.92">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4458949.22130838 270838.434289109,4458949.22130838 270838.434289109,4458959.26546005 270828.197592705,4458959.26546005 270828.197592705,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.93">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4458949.22130838 270848.670985513,4458949.22130838 270848.670985513,4458959.26546005 270838.434289109,4458959.26546005 270838.434289109,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.94">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4458949.22130838 270858.907681917,4458949.22130838 270858.907681917,4458959.26546005 270848.670985513,4458959.26546005 270848.670985513,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>899.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.95">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4458949.22130838 270869.144378322,4458949.22130838 270869.144378322,4458959.26546005 270858.907681918,4458959.26546005 270858.907681918,4458949.22130838</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>899.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.96">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4458939.17715671 270756.540717876,4458939.17715671 270756.540717876,4458949.22130838 270746.304021472,4458949.22130838 270746.304021472,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>868.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.97">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4458939.17715671 270766.77741428,4458939.17715671 270766.77741428,4458949.22130838 270756.540717876,4458949.22130838 270756.540717876,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>868.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.98">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4458939.17715671 270777.014110685,4458939.17715671 270777.014110685,4458949.22130838 270766.777414281,4458949.22130838 270766.777414281,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.99">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4458939.17715671 270787.250807089,4458939.17715671 270787.250807089,4458949.22130838 270777.014110685,4458949.22130838 270777.014110685,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.100">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4458939.17715671 270797.487503493,4458939.17715671 270797.487503493,4458949.22130838 270787.250807089,4458949.22130838 270787.250807089,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.101">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4458939.17715671 270807.724199897,4458939.17715671 270807.724199897,4458949.22130838 270797.487503493,4458949.22130838 270797.487503493,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>881.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.102">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4458939.17715671 270817.960896301,4458939.17715671 270817.960896301,4458949.22130838 270807.724199897,4458949.22130838 270807.724199897,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>881.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.103">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4458939.17715671 270828.197592705,4458939.17715671 270828.197592705,4458949.22130838 270817.960896301,4458949.22130838 270817.960896301,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.104">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4458939.17715671 270838.434289109,4458939.17715671 270838.434289109,4458949.22130838 270828.197592705,4458949.22130838 270828.197592705,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.105">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4458939.17715671 270848.670985513,4458939.17715671 270848.670985513,4458949.22130838 270838.434289109,4458949.22130838 270838.434289109,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.106">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4458939.17715671 270858.907681917,4458939.17715671 270858.907681917,4458949.22130838 270848.670985513,4458949.22130838 270848.670985513,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>899.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.107">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4458939.17715671 270869.144378322,4458939.17715671 270869.144378322,4458949.22130838 270858.907681918,4458949.22130838 270858.907681918,4458939.17715671</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>899.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.108">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270746.304021472,4458929.13300504 270756.540717876,4458929.13300504 270756.540717876,4458939.17715671 270746.304021472,4458939.17715671 270746.304021472,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>868.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.109">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270756.540717876,4458929.13300504 270766.77741428,4458929.13300504 270766.77741428,4458939.17715671 270756.540717876,4458939.17715671 270756.540717876,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>868.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.110">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270766.777414281,4458929.13300504 270777.014110685,4458929.13300504 270777.014110685,4458939.17715671 270766.777414281,4458939.17715671 270766.777414281,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.111">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270777.014110685,4458929.13300504 270787.250807089,4458929.13300504 270787.250807089,4458939.17715671 270777.014110685,4458939.17715671 270777.014110685,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.112">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270787.250807089,4458929.13300504 270797.487503493,4458929.13300504 270797.487503493,4458939.17715671 270787.250807089,4458939.17715671 270787.250807089,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>873.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.113">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270797.487503493,4458929.13300504 270807.724199897,4458929.13300504 270807.724199897,4458939.17715671 270797.487503493,4458939.17715671 270797.487503493,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>881.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.114">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270807.724199897,4458929.13300504 270817.960896301,4458929.13300504 270817.960896301,4458939.17715671 270807.724199897,4458939.17715671 270807.724199897,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>881.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.115">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270817.960896301,4458929.13300504 270828.197592705,4458929.13300504 270828.197592705,4458939.17715671 270817.960896301,4458939.17715671 270817.960896301,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.116">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270828.197592705,4458929.13300504 270838.434289109,4458929.13300504 270838.434289109,4458939.17715671 270828.197592705,4458939.17715671 270828.197592705,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.117">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270838.434289109,4458929.13300504 270848.670985513,4458929.13300504 270848.670985513,4458939.17715671 270838.434289109,4458939.17715671 270838.434289109,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>890.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.118">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270848.670985513,4458929.13300504 270858.907681917,4458929.13300504 270858.907681917,4458939.17715671 270848.670985513,4458939.17715671 270848.670985513,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>899.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:vectorize fid="vectorize.119">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:23030"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>270858.907681918,4458929.13300504 270869.144378322,4458929.13300504 270869.144378322,4458939.17715671 270858.907681918,4458939.17715671 270858.907681918,4458929.13300504</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:pix_val>899.00000000</ogr:pix_val>
+    </ogr:vectorize>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/vectorize.xsd
+++ b/python/plugins/processing/tests/testdata/expected/vectorize.xsd
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="vectorize" type="ogr:vectorize_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="vectorize_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="pix_val" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="8"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -5647,6 +5647,17 @@ tests:
         hash: c29d14f71e8686f7445d53be646fce84702644f159fd0164ac38e861
         type: rasterhash
 
-
+  - algorithm: native:pixelstopolygons
+    name: Pixels to polygons
+    params:
+      FIELD_NAME: pix_val
+      INPUT_RASTER:
+        name: raster.tif
+        type: raster
+      RASTER_BAND: 1
+    results:
+      OUTPUT:
+        name: expected/vectorize.gml
+        type: vector
 
 # See ../README.md for a description of the file format

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -82,6 +82,7 @@ SET(QGIS_ANALYSIS_SRCS
   processing/qgsalgorithmtranslate.cpp
   processing/qgsalgorithmunion.cpp
   processing/qgsalgorithmuniquevalueindex.cpp
+  processing/qgsalgorithmvectorize.cpp
   processing/qgsalgorithmwedgebuffers.cpp
   processing/qgsalgorithmzonalhistogram.cpp
 

--- a/src/analysis/processing/qgsalgorithmvectorize.cpp
+++ b/src/analysis/processing/qgsalgorithmvectorize.cpp
@@ -1,0 +1,167 @@
+/***************************************************************************
+                         qgsalgorithmvectorize.cpp
+                         ---------------------
+    begin                : June, 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmvectorize.h"
+#include "qgis.h"
+#include "qgsprocessing.h"
+
+///@cond PRIVATE
+
+QString QgsVectorizeAlgorithm::name() const
+{
+  return QStringLiteral( "pixelstopolygons" );
+}
+
+QString QgsVectorizeAlgorithm::displayName() const
+{
+  return QObject::tr( "Raster pixels to polygons" );
+}
+
+QStringList QgsVectorizeAlgorithm::tags() const
+{
+  return QObject::tr( "vectorize,polygonize,raster,convert,pixels" ).split( ',' );
+}
+
+QString QgsVectorizeAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "This algorithm converts a raster layer to a vector layer, by creating polygon features for each individual pixel in the raster layer." );
+}
+
+QgsVectorizeAlgorithm *QgsVectorizeAlgorithm::createInstance() const
+{
+  return new QgsVectorizeAlgorithm();
+}
+
+QString QgsVectorizeAlgorithm::group() const
+{
+  return QObject::tr( "Vector creation" );
+}
+
+QString QgsVectorizeAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectorcreation" );
+}
+
+void QgsVectorizeAlgorithm::initAlgorithm( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterRasterLayer( QStringLiteral( "INPUT_RASTER" ),
+                QObject::tr( "Raster layer" ) ) );
+  addParameter( new QgsProcessingParameterBand( QStringLiteral( "RASTER_BAND" ),
+                QObject::tr( "Band number" ), 1, QStringLiteral( "INPUT_RASTER" ) ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "FIELD_NAME" ),
+                QObject::tr( "Field name" ), QStringLiteral( "VALUE" ) ) );
+
+  addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Vectorized layer" ), QgsProcessing::TypeVectorPolygon ) );
+}
+
+bool QgsVectorizeAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  QgsRasterLayer *layer = parameterAsRasterLayer( parameters, QStringLiteral( "INPUT_RASTER" ), context );
+
+  if ( !layer )
+    throw QgsProcessingException( invalidRasterError( parameters, QStringLiteral( "INPUT_RASTER" ) ) );
+
+  mBand = parameterAsInt( parameters, QStringLiteral( "RASTER_BAND" ), context );
+  if ( mBand < 1 || mBand > layer->bandCount() )
+    throw QgsProcessingException( QObject::tr( "Invalid band number for RASTER_BAND (%1): Valid values for input raster are 1 to %2" ).arg( mBand )
+                                  .arg( layer->bandCount() ) );
+
+  mInterface.reset( layer->dataProvider()->clone() );
+  mExtent = layer->extent();
+  mCrs = layer->crs();
+  mRasterUnitsPerPixelX = std::abs( layer->rasterUnitsPerPixelX() );
+  mRasterUnitsPerPixelY = std::abs( layer->rasterUnitsPerPixelY() );
+  mNbCellsXProvider = mInterface->xSize();
+  mNbCellsYProvider = mInterface->ySize();
+  return true;
+}
+
+QVariantMap QgsVectorizeAlgorithm::processAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  const QString fieldName = parameterAsString( parameters, QStringLiteral( "FIELD_NAME" ), context );
+  QgsFields fields;
+  fields.append( QgsField( fieldName, QVariant::Double, QString(), 20, 8 ) );
+
+  QString dest;
+  std::unique_ptr< QgsFeatureSink > sink( parameterAsSink( parameters, QStringLiteral( "OUTPUT" ), context, dest, fields, QgsWkbTypes::Polygon, mCrs ) );
+  if ( !sink )
+    throw QgsProcessingException( invalidSinkError( parameters, QStringLiteral( "OUTPUT" ) ) );
+
+
+  int maxWidth = QgsRasterIterator::DEFAULT_MAXIMUM_TILE_WIDTH;
+  int maxHeight = QgsRasterIterator::DEFAULT_MAXIMUM_TILE_HEIGHT;
+
+  QgsRasterIterator iter( mInterface.get() );
+  iter.startRasterRead( mBand, mNbCellsXProvider, mNbCellsYProvider, mExtent );
+
+  int nbBlocksWidth = static_cast< int >( std::ceil( 1.0 * mNbCellsXProvider / maxWidth ) );
+  int nbBlocksHeight = static_cast< int >( std::ceil( 1.0 * mNbCellsYProvider / maxHeight ) );
+  int nbBlocks = nbBlocksWidth * nbBlocksHeight;
+
+  double hCellSizeX = mRasterUnitsPerPixelX / 2.0;
+  double hCellSizeY = mRasterUnitsPerPixelY / 2.0;
+
+  int iterLeft = 0;
+  int iterTop = 0;
+  int iterCols = 0;
+  int iterRows = 0;
+  std::unique_ptr< QgsRasterBlock > rasterBlock;
+  QgsRectangle blockExtent;
+  while ( iter.readNextRasterPart( mBand, iterCols, iterRows, rasterBlock, iterLeft, iterTop, &blockExtent ) )
+  {
+    if ( feedback )
+      feedback->setProgress( 100 * ( ( iterTop / maxHeight * nbBlocksWidth ) + iterLeft / maxWidth ) / nbBlocks );
+    if ( feedback && feedback->isCanceled() )
+      break;
+
+    double currentY = blockExtent.yMaximum() - 0.5 * mRasterUnitsPerPixelY;
+
+    for ( int row = 0; row < iterRows; row++ )
+    {
+      if ( feedback && feedback->isCanceled() )
+        break;
+
+      double currentX = blockExtent.xMinimum() + 0.5 * mRasterUnitsPerPixelX;
+
+      for ( int column = 0; column < iterCols; column++ )
+      {
+        if ( !rasterBlock->isNoData( row, column ) )
+        {
+
+          QgsGeometry pixelRectGeometry = QgsGeometry::fromRect( QgsRectangle( currentX - hCellSizeX, currentY - hCellSizeY, currentX + hCellSizeX, currentY + hCellSizeY ) );
+
+          double value = rasterBlock->value( row, column );
+
+          QgsFeature f;
+          f.setGeometry( pixelRectGeometry );
+          f.setAttributes( QgsAttributes() << value );
+          sink->addFeature( f, QgsFeatureSink::FastInsert );
+        }
+        currentX += mRasterUnitsPerPixelX;
+      }
+      currentY -= mRasterUnitsPerPixelY;
+    }
+  }
+
+  QVariantMap outputs;
+  outputs.insert( QStringLiteral( "OUTPUT" ), dest );
+  return outputs;
+}
+
+///@endcond
+
+

--- a/src/analysis/processing/qgsalgorithmvectorize.h
+++ b/src/analysis/processing/qgsalgorithmvectorize.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+                         qgsalgorithmvectorize.h
+                         ---------------------
+    begin                : June, 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMVECTORIZE_H
+#define QGSALGORITHMVECTORIZE_H
+
+#define SIP_NO_FILE
+
+#include "qgis.h"
+#include "qgsprocessingalgorithm.h"
+#include "qgsreclassifyutils.h"
+
+///@cond PRIVATE
+
+/**
+ * Native vectorize algorithm
+ */
+class QgsVectorizeAlgorithm : public QgsProcessingAlgorithm
+{
+  public:
+
+    QgsVectorizeAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString shortHelpString() const override;
+    QgsVectorizeAlgorithm *createInstance() const override SIP_FACTORY;
+    QString group() const override final;
+    QString groupId() const override final;
+    void initAlgorithm( const QVariantMap &configuration = QVariantMap() ) override;
+
+  protected:
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+    QVariantMap processAlgorithm( const QVariantMap &parameters,
+                                  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+
+    std::unique_ptr< QgsRasterInterface > mInterface;
+
+    Qgis::DataType mDataType = Qgis::Float32;
+    double mNoDataValue = -9999;
+    int mBand = 1;
+    QgsRectangle mExtent;
+    QgsCoordinateReferenceSystem mCrs;
+    double mRasterUnitsPerPixelX = 0;
+    double mRasterUnitsPerPixelY = 0;
+    int mNbCellsXProvider = 0;
+    int mNbCellsYProvider = 0;
+    QgsReclassifyUtils::RasterClass::BoundsType mBoundsType = QgsReclassifyUtils::RasterClass::IncludeMax;
+    bool mUseNoDataForMissingValues = false;
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMVECTORIZE_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -79,6 +79,7 @@
 #include "qgsalgorithmtranslate.h"
 #include "qgsalgorithmunion.h"
 #include "qgsalgorithmuniquevalueindex.h"
+#include "qgsalgorithmvectorize.h"
 #include "qgsalgorithmwedgebuffers.h"
 #include "qgsalgorithmzonalhistogram.h"
 
@@ -189,6 +190,7 @@ void QgsNativeAlgorithms::loadAlgorithms()
   addAlgorithm( new QgsTranslateAlgorithm() );
   addAlgorithm( new QgsUnionAlgorithm() );
   addAlgorithm( new QgsVariableWidthBufferByMAlgorithm() );
+  addAlgorithm( new QgsVectorizeAlgorithm() );
   addAlgorithm( new QgsWedgeBuffersAlgorithm() );
   addAlgorithm( new QgsZonalHistogramAlgorithm() );
 }


### PR DESCRIPTION
Converts a raster layer into a vector layer, with a polygon feature corresponding to each pixel from the raster and a single field containing the band value from the raster.

Sponsored by SMEC/SJ

## Notes

This doesn't duplicate the existing GDAL Polygonize algorithm - that one automatically dissolves adjacent pixels of the same value into a single feature, and works with assumptions based on this approach (e.g. pixel values are rounded to integers). In contrast this algorithm keeps one feature per pixel (with an attribute of the original untouched pixel value). 
