### PR TITLE
[bugfix] Crash on undo layout legend item on deleted item

### DIFF
--- a/src/core/layertree/qgslayertreelayer.cpp
+++ b/src/core/layertree/qgslayertreelayer.cpp
@@ -164,12 +164,13 @@ void QgsLayerTreeLayer::layerWillBeDeleted()
 {
   Q_ASSERT( mRef );
 
+  emit layerWillBeUnloaded();
+
   mLayerName = mRef->name();
   // in theory we do not even need to do this - the weak ref should clear itself
   mRef.layer.clear();
   // layerId stays in the reference
 
-  emit layerWillBeUnloaded();
 }
 
 

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -884,13 +884,13 @@ void QgsLayerTreeModel::disconnectFromLayer( QgsLayerTreeLayer *nodeLayer )
 {
   disconnect( nodeLayer, nullptr, this, nullptr ); // disconnect from delayed load of layer
 
+  if ( !nodeLayer->layer() )
+    return; // we were never connected
+
   if ( testFlag( ShowLegend ) )
   {
     removeLegendFromLayer( nodeLayer );
   }
-
-  if ( !nodeLayer->layer() )
-    return; // we were never connected
 
   if ( _numLayerCount( mRootNode, nodeLayer->layerId() ) == 1 )
   {

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -884,13 +884,13 @@ void QgsLayerTreeModel::disconnectFromLayer( QgsLayerTreeLayer *nodeLayer )
 {
   disconnect( nodeLayer, nullptr, this, nullptr ); // disconnect from delayed load of layer
 
-  if ( !nodeLayer->layer() )
-    return; // we were never connected
-
   if ( testFlag( ShowLegend ) )
   {
     removeLegendFromLayer( nodeLayer );
   }
+
+  if ( !nodeLayer->layer() )
+    return; // we were never connected
 
   if ( _numLayerCount( mRootNode, nodeLayer->layerId() ) == 1 )
   {

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -47,6 +47,7 @@ class TestQgsLayerTree : public QObject
     void testLegendSymbolRuleBased();
     void testResolveReferences();
     void testEmbeddedGroup();
+    void testLayerDeleted();
 
   private:
 
@@ -586,6 +587,29 @@ void TestQgsLayerTree::testEmbeddedGroup()
   {
     QVERIFY( QgsLayerTree::toLayer( child )->layer() );
   }
+}
+
+void TestQgsLayerTree::testLayerDeleted()
+{
+  //new memory layer
+  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  QVERIFY( vl->isValid() );
+
+  QgsProject project;
+  project.addMapLayer( vl );
+
+  QgsLayerTree root;
+  QgsLayerTreeModel model( &root );
+
+  root.addLayer( vl );
+  QgsLayerTreeLayer *tl( root.findLayer( vl->id() ) );
+  QCOMPARE( tl->layer(), vl );
+
+  QCOMPARE( model.layerLegendNodes( tl ).count(), 1 );
+
+  project.removeMapLayer( vl );
+
+  QCOMPARE( model.layerLegendNodes( tl ).count(), 0 );
 }
 
 


### PR DESCRIPTION
Fixes #19155

@wonder-sk please have a look: I think it's a safe move since `layer()` is not accessed in  `removeLegendFromLayer()`
