### PR TITLE
[OGR provider] [FEATURE] Add support for transactions on GPKG databases

### DIFF
--- a/python/core/auto_generated/qgstransaction.sip.in
+++ b/python/core/auto_generated/qgstransaction.sip.in
@@ -146,6 +146,7 @@ returns the last created savepoint
 .. versionadded:: 3.0
 %End
 
+
   signals:
 
     void afterRollback();

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -51,7 +51,7 @@ QgsTransaction *QgsTransaction::create( const QSet<QgsVectorLayer *> &layers )
 
   QgsVectorLayer *firstLayer = *layers.constBegin();
 
-  QString connStr = QgsDataSourceUri( firstLayer->source() ).connectionInfo( false );
+  QString connStr = connectionString( firstLayer->source() );
   QString providerKey = firstLayer->dataProvider()->name();
   std::unique_ptr<QgsTransaction> transaction( QgsTransaction::create( connStr, providerKey ) );
   if ( transaction )
@@ -81,6 +81,46 @@ QgsTransaction::~QgsTransaction()
   setLayerTransactionIds( nullptr );
 }
 
+// For the needs of the OGR provider with GeoPackage datasources, remove
+// any reference to layers in the connection string
+QString QgsTransaction::removeLayerIdOrName( const QString &str )
+{
+  QString res( str );
+
+  for ( int i = 0; i < 2; i++ )
+  {
+    int pos = res.indexOf( i == 0 ? QLatin1String( "|layername=" ) :  QLatin1String( "|layerid=" ) );
+    if ( pos >= 0 )
+    {
+      int end = res.indexOf( '|', pos + 1 );
+      if ( end >= 0 )
+      {
+        res = res.mid( 0, pos ) + res.mid( end );
+      }
+      else
+      {
+        res = res.mid( 0, pos );
+      }
+    }
+  }
+  return res;
+}
+
+///@cond PRIVATE
+QString QgsTransaction::connectionString( const QString &layerName )
+{
+  QString connString = QgsDataSourceUri( layerName ).connectionInfo( false );
+  // In the case of a OGR datasource, connectionInfo() will return an empty
+  // string. In that case, use the layer->source() itself, and strip any
+  // reference to layers from it.
+  if ( connString.isEmpty() )
+  {
+    connString = removeLayerIdOrName( layerName );
+  }
+  return connString;
+}
+///@endcond
+
 bool QgsTransaction::addLayer( QgsVectorLayer *layer )
 {
   if ( !layer )
@@ -90,17 +130,18 @@ bool QgsTransaction::addLayer( QgsVectorLayer *layer )
     return false;
 
   //test if provider supports transactions
-  if ( !layer->dataProvider() || ( layer->dataProvider()->capabilities() & QgsVectorDataProvider::TransactionSupport ) == 0 )
+  if ( !supportsTransaction( layer ) )
     return false;
 
   if ( layer->dataProvider()->transaction() )
     return false;
 
   //connection string not compatible
-  if ( QgsDataSourceUri( layer->source() ).connectionInfo( false ) != mConnString )
+
+  if ( connectionString( layer->source() ) != mConnString )
   {
     QgsDebugMsg( QString( "Couldn't start transaction because connection string for layer %1 : '%2' does not match '%3'" ).arg(
-                   layer->id(), QgsDataSourceUri( layer->source() ).connectionInfo( false ), mConnString ) );
+                   layer->id(), connectionString( layer->source() ), mConnString ) );
     return false;
   }
 
@@ -162,11 +203,11 @@ bool QgsTransaction::rollback( QString &errorMsg )
 
 bool QgsTransaction::supportsTransaction( const QgsVectorLayer *layer )
 {
-  std::unique_ptr< QLibrary > lib( QgsProviderRegistry::instance()->createProviderLibrary( layer->providerType() ) );
-  if ( !lib )
+  //test if provider supports transactions
+  if ( !layer->dataProvider() || ( layer->dataProvider()->capabilities() & QgsVectorDataProvider::TransactionSupport ) == 0 )
     return false;
 
-  return lib->resolve( "createTransaction" );
+  return true;
 }
 
 void QgsTransaction::onLayerDeleted()

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -158,6 +158,11 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
      */
     bool lastSavePointIsDirty() const { return mLastSavePointIsDirty; }
 
+///@cond PRIVATE
+    // For internal use only, or by QgsTransactionGroup
+    static QString connectionString( const QString &layerName ) SIP_SKIP;
+///@endcond
+
   signals:
 
     /**
@@ -187,6 +192,8 @@ class CORE_EXPORT QgsTransaction : public QObject SIP_ABSTRACT
     bool mLastSavePointIsDirty;
 
     void setLayerTransactionIds( QgsTransaction *transaction );
+
+    static QString removeLayerIdOrName( const QString &str );
 
     virtual bool beginTransaction( QString &error, int statementTimeout ) = 0;
     virtual bool commitTransaction( QString &error ) = 0;

--- a/src/core/qgstransactiongroup.cpp
+++ b/src/core/qgstransactiongroup.cpp
@@ -33,8 +33,7 @@ bool QgsTransactionGroup::addLayer( QgsVectorLayer *layer )
   if ( !QgsTransaction::supportsTransaction( layer ) )
     return false;
 
-  QString connString = QgsDataSourceUri( layer->source() ).connectionInfo();
-
+  QString connString = QgsTransaction::connectionString( layer->source() );
   if ( mConnString.isEmpty() )
   {
     mConnString = connString;
@@ -74,6 +73,8 @@ void QgsTransactionGroup::onEditingStarted()
     return;
 
   mTransaction.reset( QgsTransaction::create( mConnString, mProviderKey ) );
+  if ( !mTransaction )
+    return;
 
   QString errorMsg;
   mTransaction->begin( errorMsg );

--- a/src/providers/ogr/CMakeLists.txt
+++ b/src/providers/ogr/CMakeLists.txt
@@ -9,6 +9,7 @@ SET (OGR_SRCS
     qgsgeopackagerasterwritertask.cpp
     qgsogrdbconnection.cpp
     qgsogrdbtablemodel.cpp
+    qgsogrtransaction.cpp
 )
 
 SET(OGR_MOC_HDRS
@@ -19,6 +20,7 @@ SET(OGR_MOC_HDRS
     qgsgeopackagerasterwritertask.h
     qgsogrdbconnection.h
     qgsogrdbtablemodel.h
+    qgsogrtransaction.h
 )
 
 IF (WITH_GUI)

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -21,8 +21,12 @@
 
 #include <ogr_api.h>
 
+#include <memory>
+
 class QgsOgrFeatureIterator;
 class QgsOgrProvider;
+class QgsOgrDataset;
+using QgsOgrDatasetSharedPtr = std::shared_ptr< QgsOgrDataset>;
 
 class QgsOgrFeatureSource : public QgsAbstractFeatureSource
 {
@@ -45,6 +49,7 @@ class QgsOgrFeatureSource : public QgsAbstractFeatureSource
     QString mDriverName;
     QgsCoordinateReferenceSystem mCrs;
     QgsWkbTypes::Type mWkbType = QgsWkbTypes::Unknown;
+    QgsOgrDatasetSharedPtr mSharedDS = nullptr;
 
     friend class QgsOgrFeatureIterator;
     friend class QgsOgrExpressionCompiler;
@@ -87,6 +92,7 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsOgr
 
     QgsRectangle mFilterRect;
     QgsCoordinateTransform mTransform;
+    QgsOgrDatasetSharedPtr mSharedDS = nullptr;
 
     bool fetchFeatureWithId( QgsFeatureId id, QgsFeature &feature ) const;
 };

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -33,6 +33,7 @@ class QgsOgrFeatureIterator;
 #include <gdal.h>
 
 class QgsOgrLayer;
+class QgsOgrTransaction;
 
 /**
  * Releases a QgsOgrLayer
@@ -146,6 +147,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
 
     QString name() const override;
     QString description() const override;
+    QgsTransaction *transaction() const override;
     bool doesStrictFeatureTypeCheck() const override;
 
     //! Returns OGR geometry type
@@ -317,7 +319,19 @@ class QgsOgrProvider : public QgsVectorDataProvider
     void setupProxy();
 #endif
 
+    QgsOgrTransaction *mTransaction = nullptr;
+
+    void setTransaction( QgsTransaction *transaction ) override;
+
 };
+
+class QgsOgrDataset;
+
+/**
+ * Scoped QgsOgrDataset.
+ */
+using QgsOgrDatasetSharedPtr = std::shared_ptr< QgsOgrDataset>;
+
 
 /**
   \class QgsOgrProviderUtils
@@ -325,6 +339,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
   */
 class QgsOgrProviderUtils
 {
+    friend class QgsOgrDataset;
     friend class QgsOgrLayer;
 
     //! Identifies a dataset by name, updateMode and options
@@ -370,6 +385,10 @@ class QgsOgrProviderUtils
 
     static bool canUseOpenedDatasets( const QString &dsName );
 
+    static void releaseInternal( const DatasetIdentification &ident,
+                                 DatasetWithLayers *ds,
+                                 bool removeFromDatasetList );
+
   public:
 
     //! Inject credentials into the dsName (if any)
@@ -396,6 +415,9 @@ class QgsOgrProviderUtils
 
     //! Wrapper for GDALClose()
     static void GDALCloseWrapper( GDALDatasetH mhDS );
+
+    //! Return a QgsOgrDataset wrapping an already opened GDALDataset. Typical use: by QgsOgrTransaction
+    static QgsOgrDatasetSharedPtr getAlreadyOpenedDataset( const QString &dsName );
 
     //! Open a layer given by name, potentially reusing an existing GDALDatasetH if it doesn't already use that layer.
     static QgsOgrLayerUniquePtr getLayer( const QString &dsName,
@@ -430,6 +452,9 @@ class QgsOgrProviderUtils
     //! Release a QgsOgrLayer*
     static void release( QgsOgrLayer *&layer );
 
+    //! Release a QgsOgrDataset*
+    static void releaseDataset( QgsOgrDataset *&ds );
+
     //! Make sure that the existing pool of opened datasets on dsName is not accessible for new getLayer() attempts
     static void invalidateCachedDatasets( const QString &dsName );
 
@@ -445,6 +470,34 @@ class QgsOgrProviderUtils
     //! Converts a OGR WKB type to the corresponding QGIS wkb type
     static QgsWkbTypes::Type qgisTypeFromOgrType( OGRwkbGeometryType type );
 
+};
+
+
+/**
+  \class QgsOgrDataset
+  \brief Wrap a GDALDatasetH object in a thread-safe way
+  */
+class QgsOgrDataset
+{
+    friend class QgsOgrProviderUtils;
+    QgsOgrProviderUtils::DatasetIdentification mIdent;
+    QgsOgrProviderUtils::DatasetWithLayers *mDs;
+
+    QgsOgrDataset() = default;
+    ~QgsOgrDataset() = default;
+
+  public:
+
+    static QgsOgrDatasetSharedPtr create( const QgsOgrProviderUtils::DatasetIdentification &ident,
+                                          QgsOgrProviderUtils::DatasetWithLayers *ds );
+
+    QMutex &mutex() { return mDs->mutex; }
+
+    bool executeSQLNoReturn( const QString &sql );
+
+    OGRLayerH createSQLResultLayer( QTextCodec *encoding, const QString &layerName, int layerIndex );
+
+    void releaseResultSet( OGRLayerH hSqlLayer );
 };
 
 
@@ -502,7 +555,7 @@ class QgsOgrLayer
     QgsOgrProviderUtils::DatasetIdentification ident;
     bool isSqlLayer = false;
     QString layerName;
-    QString sql;
+    QString sql; // not really used. Just set at QgsOgrLayer::CreateForLayer() time
     QgsOgrProviderUtils::DatasetWithLayers *ds = nullptr;
     OGRLayerH hLayer = nullptr;
     QgsOgrFeatureDefn oFDefn;
@@ -622,7 +675,7 @@ class QgsOgrLayer
     //! Wrapper of GDALDatasetReleaseResultSet( GDALDatasetExecuteSQL( ... ) )
     void ExecuteSQLNoReturn( const QByteArray &sql );
 
-    //! Wrapper of GDALDatasetExecuteSQL(). Returned layer must be released with QgsOgrProviderUtils::release()
+    //! Wrapper of GDALDatasetExecuteSQL().
     QgsOgrLayerUniquePtr ExecuteSQL( const QByteArray &sql );
 };
 

--- a/src/providers/ogr/qgsogrtransaction.cpp
+++ b/src/providers/ogr/qgsogrtransaction.cpp
@@ -1,0 +1,85 @@
+/***************************************************************************
+    QgsOgrTransaction.cpp -  Transaction support for OGR layers
+                             -------------------
+    begin                : June 13, 2018
+    copyright            : (C) 2018 by Even Rouault
+    email                : even.rouault @ spatialys.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgsogrtransaction.h"
+#include "qgsogrprovider.h"
+#include "qgslogger.h"
+#include "qgis.h"
+
+QgsOgrTransaction::QgsOgrTransaction( const QString &connString, QgsOgrDatasetSharedPtr ds )
+  : QgsTransaction( connString ), mSharedDS( ds )
+
+{
+  Q_ASSERT( mSharedDS );
+}
+
+bool QgsOgrTransaction::beginTransaction( QString &error, int /* statementTimeout */ )
+{
+  return executeSql( QStringLiteral( "BEGIN" ), error );
+}
+
+bool QgsOgrTransaction::commitTransaction( QString &error )
+{
+  if ( executeSql( QStringLiteral( "COMMIT" ), error ) )
+  {
+    return true;
+  }
+  return false;
+}
+
+bool QgsOgrTransaction::rollbackTransaction( QString &error )
+{
+  if ( executeSql( QStringLiteral( "ROLLBACK" ), error ) )
+  {
+    return true;
+  }
+  return false;
+}
+
+bool QgsOgrTransaction::executeSql( const QString &sql, QString &errorMsg, bool isDirty, const QString &name )
+{
+
+  QString err;
+  if ( isDirty )
+  {
+    createSavepoint( err );
+  }
+
+  QgsDebugMsg( QString( "Transaction sql: %1" ).arg( sql ) );
+  if ( !mSharedDS->executeSQLNoReturn( sql ) )
+  {
+    errorMsg = CPLGetLastErrorMsg();
+    QgsDebugMsg( errorMsg );
+
+    if ( isDirty )
+    {
+      rollbackToSavepoint( savePoints().last(), err );
+    }
+
+    return false;
+  }
+
+  if ( isDirty )
+  {
+    dirtyLastSavePoint();
+    emit dirtied( sql, name );
+  }
+
+  QgsDebugMsg( QString( "... ok" ) );
+  return true;
+}

--- a/src/providers/ogr/qgsogrtransaction.h
+++ b/src/providers/ogr/qgsogrtransaction.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+    qgsogrtransaction.h  -  Transaction support for OGR layers
+                             -------------------
+    begin                : June 13, 2018
+    copyright            : (C) 2018 by Even Rouault
+    email                : even.rouault @ spatialys.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSOGRTRANSACTION_H
+#define QGSOGRTRANSACTION_H
+
+#include "qgstransaction.h"
+#include "qgsogrprovider.h"
+
+class QgsOgrTransaction : public QgsTransaction
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsOgrTransaction( const QString &connString, QgsOgrDatasetSharedPtr ds );
+
+    /**
+     * Executes the SQL query in database.
+     *
+     * \param sql The SQL query to execute
+     * \param error The error or an empty string if none
+     * \param isDirty True to add an undo/redo command in the edition buffer, false otherwise
+     * \param name Name of the operation ( only used if `isDirty` is true)
+     */
+    bool executeSql( const QString &sql, QString &error, bool isDirty = false, const QString &name = QString() ) override;
+
+    QgsOgrDatasetSharedPtr sharedDS() const { return mSharedDS; }
+
+  private:
+
+    QgsOgrDatasetSharedPtr mSharedDS = nullptr;
+
+    bool beginTransaction( QString &error, int statementTimeout ) override;
+    bool commitTransaction( QString &error ) override;
+    bool rollbackTransaction( QString &error ) override;
+
+};
+
+#endif // QGSOGRTRANSACTION_H

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -983,6 +983,76 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         self.assertTrue(QgsGeometry.compare(provider_extent.asPolygon()[0], reference.asPolygon()[0], 0.00001),
                         provider_extent.asPolygon()[0])
 
+    def testTransaction(self):
+
+        tmpfile = os.path.join(self.basetestpath, 'testTransaction.gpkg')
+        ds = ogr.GetDriverByName('GPKG').CreateDataSource(tmpfile)
+        lyr = ds.CreateLayer('lyr1', geom_type=ogr.wkbPoint)
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(0 1)'))
+        lyr.CreateFeature(f)
+        lyr = ds.CreateLayer('lyr2', geom_type=ogr.wkbPoint)
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(2 3)'))
+        lyr.CreateFeature(f)
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(4 5)'))
+        lyr.CreateFeature(f)
+        ds = None
+
+        vl1 = QgsVectorLayer(u'{}'.format(tmpfile) + "|layername=" + "lyr1", 'test', u'ogr')
+        self.assertTrue(vl1.isValid())
+        vl2 = QgsVectorLayer(u'{}'.format(tmpfile) + "|layername=" + "lyr2", 'test', u'ogr')
+        self.assertTrue(vl2.isValid())
+
+        # prepare a project with transactions enabled
+        p = QgsProject()
+        p.setAutoTransaction(True)
+        p.addMapLayers([vl1, vl2])
+
+        self.assertTrue(vl1.startEditing())
+        self.assertIsNotNone(vl1.dataProvider().transaction())
+        self.assertTrue(vl1.deleteFeature(1))
+
+        # An iterator opened on the layer should see the feature deleted
+        self.assertEqual(len([f for f in vl1.getFeatures(QgsFeatureRequest())]), 0)
+
+        # But not if opened from another connection
+        vl1_external = QgsVectorLayer(u'{}'.format(tmpfile) + "|layername=" + "lyr1", 'test', u'ogr')
+        self.assertTrue(vl1_external.isValid())
+        self.assertEqual(len([f for f in vl1_external.getFeatures(QgsFeatureRequest())]), 1)
+        del vl1_external
+
+        self.assertTrue(vl1.commitChanges())
+
+        # Should still get zero features on vl1
+        self.assertEqual(len([f for f in vl1.getFeatures(QgsFeatureRequest())]), 0)
+        self.assertEqual(len([f for f in vl2.getFeatures(QgsFeatureRequest())]), 2)
+
+        # Test undo/redo
+        self.assertTrue(vl2.startEditing())
+        self.assertIsNotNone(vl2.dataProvider().transaction())
+        self.assertTrue(vl2.editBuffer().deleteFeature(1))
+        self.assertEqual(len([f for f in vl2.getFeatures(QgsFeatureRequest())]), 1)
+        self.assertTrue(vl2.editBuffer().deleteFeature(2))
+        self.assertEqual(len([f for f in vl2.getFeatures(QgsFeatureRequest())]), 0)
+        vl2.undoStack().undo()
+        self.assertEqual(len([f for f in vl2.getFeatures(QgsFeatureRequest())]), 1)
+        vl2.undoStack().undo()
+        self.assertEqual(len([f for f in vl2.getFeatures(QgsFeatureRequest())]), 2)
+        vl2.undoStack().redo()
+        self.assertEqual(len([f for f in vl2.getFeatures(QgsFeatureRequest())]), 1)
+        self.assertTrue(vl2.commitChanges())
+
+        self.assertEqual(len([f for f in vl2.getFeatures(QgsFeatureRequest())]), 1)
+        del vl1
+        del vl2
+
+        vl2_external = QgsVectorLayer(u'{}'.format(tmpfile) + "|layername=" + "lyr2", 'test', u'ogr')
+        self.assertTrue(vl2_external.isValid())
+        self.assertEqual(len([f for f in vl2_external.getFeatures(QgsFeatureRequest())]), 1)
+        del vl2_external
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For complete support, it requires two GDAL fixes:
- One to avoid feature count to be invalid when using ROLLBACK TO SAVEPOINT
  https://github.com/OSGeo/gdal/commit/f73ec8cd1dac08e66845397f59e47e4304f110d4

- Another one to avoid nasty issues, at least on Linux, with the POSIX
  advisory locks used by libsqlite that could be invalidated due to how GDAL
  could open files behind the back of libsqlite. The consequence of this
  could be the deletion of -wal and -shm files, which caused issues in QGIS
  (non working iterators when the edit is finished, and later edits in the
  same session not working). Those issues could appear for example if doing
  ogrinfo on the .gpkg opened by QGIS, or if opening two QGIS session on the
  .gpkg

Both fixes are queued for GDAL 2.3.1
