### PR TITLE
[layouts] insure that legend item widget's list has properly sized icons

### DIFF
--- a/src/app/layout/qgslayoutlegendwidget.h
+++ b/src/app/layout/qgslayoutlegendwidget.h
@@ -93,6 +93,8 @@ class QgsLayoutLegendWidget: public QgsLayoutItemBaseWidget, private Ui::QgsLayo
 
     void setCurrentNodeStyleFromAction();
 
+    void setLegendMapViewData();
+
   private slots:
     //! Sets GUI according to state of mLegend
     void setGuiElements();

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -386,6 +386,8 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     layer->setItemVisibilityChecked( dependencySources.contains( layer->layerId() ) );
   }
 
+  QgsMapSettings ms = QgisApp::instance()->mapCanvas()->mapSettings();
+  mLayersDependenciesTreeModel->setLegendMapViewData( QgisApp::instance()->mapCanvas()->mapUnitsPerPixel(), ms.outputDpi(), ms.scale() );
   mLayersDependenciesTreeView->setModel( mLayersDependenciesTreeModel.get() );
 
   connect( mRefreshLayerCheckBox, &QCheckBox::toggled, mRefreshLayerIntervalSpinBox, &QDoubleSpinBox::setEnabled );


### PR DESCRIPTION
## Description
This PR improves legend icons for the layout legend item widget's legend list embedded in properties panel, by passing some context so that map unit-based symbols are rendered to match the linked map's scale.

Before:
![image](https://user-images.githubusercontent.com/1728657/41449070-0fd0df34-7089-11e8-8da7-c1555adff2f6.png)

PR:
![image](https://user-images.githubusercontent.com/1728657/41450654-535740c2-7093-11e8-8c48-d1d30d908788.png)

@nyalldawson , ~~while I haven't been able to get a perfect match with the map canvas / (100% zoom level) layout, it's a significant improvement already.~~ All good, awaiting your green light.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
