### PR TITLE
QgsProject is no longer a singleton

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -804,6 +804,20 @@ Set a single custom expression variable.
     bool x11EventFilter( XEvent *event );
 %End
 
+    static QgsProject *activeProject();
+%Docstring
+Returns the active QGIS project.
+
+.. versionadded:: 3.2
+%End
+
+    static void setActiveProject( QgsProject *activeProject );
+%Docstring
+Change the active QGIS project.
+
+.. versionadded:: 3.2
+%End
+
   signals:
 
     void customVariablesChanged();
@@ -817,6 +831,13 @@ Emitted whenever a custom global variable changes.
     void nullRepresentationChanged();
 %Docstring
 \copydoc nullRepresentation()
+%End
+
+    void activeProjectChanged();
+%Docstring
+Signal emitted whenever the active project changes.
+
+.. versionadded:: 3.2
 %End
 
 };

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -32,9 +32,13 @@ properties.
 #include "qgsproject.h"
 %End
   public:
+
     static QgsProject *instance();
 %Docstring
-Returns the QgsProject singleton instance
+Returns the active QGIS project.
+Alias for ``QgsApplication.activeProject()``
+
+.. deprecated:: since QGIS 3.2 use QgsApplication.activeProject() instead.
 %End
 
     explicit QgsProject( QObject *parent /TransferThis/ = 0 );

--- a/python/core/auto_generated/qgsproject.sip.in
+++ b/python/core/auto_generated/qgsproject.sip.in
@@ -45,7 +45,7 @@ Alias for ``QgsApplication.activeProject()``
 %Docstring
 Create a new QgsProject.
 
-Most of the time you want to use QgsProject.instance() instead as many components of QGIS work with the singleton.
+Most of the time you want to use QgsApplication.activeProject() instead as many components of QGIS work with the singleton.
 %End
 
     ~QgsProject();

--- a/src/3d/symbols/qgspolygon3dsymbol_p.cpp
+++ b/src/3d/symbols/qgspolygon3dsymbol_p.cpp
@@ -33,7 +33,7 @@ static QgsExpressionContext _expressionContext3D()
 {
   QgsExpressionContext ctx;
   ctx << QgsExpressionContextUtils::globalScope()
-      << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+      << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
   return ctx;
 }
 

--- a/src/analysis/network/qgsgraphbuilderinterface.h
+++ b/src/analysis/network/qgsgraphbuilderinterface.h
@@ -63,7 +63,7 @@ class ANALYSIS_EXPORT QgsGraphBuilderInterface
       , mCtfEnabled( ctfEnabled )
       , mTopologyTolerance( topologyTolerance )
     {
-      mDa.setSourceCrs( mCrs, QgsProject::instance()->transformContext() );
+      mDa.setSourceCrs( mCrs, QgsApplication::activeProject()->transformContext() );
       mDa.setEllipsoid( ellipsoidID );
     }
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
@@ -144,7 +144,7 @@ bool QgsGeometryChecker::fixError( QgsGeometryCheckError *error, int method, boo
   {
     const QMap<QgsFeatureId, QList<QgsGeometryCheck::Change>> &layerChanges = it.value();
     QgsFeaturePool *featurePool = mContext->featurePools[it.key()];
-    QgsCoordinateTransform t( featurePool->getLayer()->crs(), mContext->mapCrs, QgsProject::instance() );
+    QgsCoordinateTransform t( featurePool->getLayer()->crs(), mContext->mapCrs, QgsApplication::activeProject() );
     for ( auto layerChangeIt = layerChanges.constBegin(); layerChangeIt != layerChanges.constEnd(); ++layerChangeIt )
     {
       bool removed = false;
@@ -183,7 +183,7 @@ bool QgsGeometryChecker::fixError( QgsGeometryCheckError *error, int method, boo
   for ( const QString &layerId : mContext->featurePools.keys() )
   {
     QgsFeaturePool *featurePool = mContext->featurePools[layerId];
-    QgsCoordinateTransform t( mContext->mapCrs, featurePool->getLayer()->crs(), QgsProject::instance() );
+    QgsCoordinateTransform t( mContext->mapCrs, featurePool->getLayer()->crs(), QgsApplication::activeProject() );
     recheckAreaFeatures[layerId] = featurePool->getIntersects( t.transform( recheckArea ) );
   }
 

--- a/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
@@ -49,7 +49,7 @@ void QgsGeometryFollowBoundariesCheck::collectErrors( QList<QgsGeometryCheckErro
     const QgsAbstractGeometry *geom = layerFeature.geometry();
 
     // The geometry to crs of the check layer
-    QgsCoordinateTransform crst( layerFeature.layer().crs(), mCheckLayer->crs(), QgsProject::instance() );
+    QgsCoordinateTransform crst( layerFeature.layer().crs(), mCheckLayer->crs(), QgsApplication::activeProject() );
     QgsGeometry geomt( geom->clone() );
     geomt.transform( crst );
 

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -210,7 +210,7 @@ int QgsZonalStatistics::calculateStatistics( QgsFeedback *feedback )
   //iterate over each polygon
   QgsFeatureRequest request;
   request.setSubsetOfAttributes( QgsAttributeList() );
-  request.setDestinationCrs( mRasterCrs, QgsProject::instance()->transformContext() );
+  request.setDestinationCrs( mRasterCrs, QgsApplication::activeProject()->transformContext() );
   QgsFeatureIterator fi = vectorProvider->getFeatures( request );
   QgsFeature f;
 

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -138,7 +138,7 @@ void Qgs3DMapCanvasDockWidget::configure()
   QgsVector3D p = Qgs3DUtils::transformWorldCoordinates(
                     oldLookingAt,
                     oldOrigin, oldCrs,
-                    map->origin(), map->crs(), QgsProject::instance()->transformContext() );
+                    map->origin(), map->crs(), QgsApplication::activeProject()->transformContext() );
 
   if ( p != oldLookingAt )
   {

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -90,7 +90,7 @@ void Qgs3DMapConfigWidget::apply()
     if ( tGenNeedsUpdate )
     {
       QgsDemTerrainGenerator *demTerrainGen = new QgsDemTerrainGenerator;
-      demTerrainGen->setCrs( mMap->crs(), QgsProject::instance()->transformContext() );
+      demTerrainGen->setCrs( mMap->crs(), QgsApplication::activeProject()->transformContext() );
       demTerrainGen->setLayer( demLayer );
       demTerrainGen->setResolution( spinTerrainResolution->value() );
       demTerrainGen->setSkirtHeight( spinTerrainSkirtHeight->value() );
@@ -111,7 +111,7 @@ void Qgs3DMapConfigWidget::apply()
   {
     // reproject terrain's extent to map CRS
     QgsRectangle te = mMap->terrainGenerator()->extent();
-    QgsCoordinateTransform terrainToMapTransform( mMap->terrainGenerator()->crs(), mMap->crs(), QgsProject::instance() );
+    QgsCoordinateTransform terrainToMapTransform( mMap->terrainGenerator()->crs(), mMap->crs(), QgsApplication::activeProject() );
     te = terrainToMapTransform.transformBoundingBox( te );
 
     QgsPointXY center = te.center();
@@ -140,7 +140,7 @@ void Qgs3DMapConfigWidget::updateMaxZoomLevel()
   if ( demLayer )
   {
     QgsDemTerrainGenerator *demTerrainGen = new QgsDemTerrainGenerator;
-    demTerrainGen->setCrs( mMap->crs(), QgsProject::instance()->transformContext() );
+    demTerrainGen->setCrs( mMap->crs(), QgsApplication::activeProject()->transformContext() );
     demTerrainGen->setLayer( demLayer );
     demTerrainGen->setResolution( spinTerrainResolution->value() );
     tGen.reset( demTerrainGen );

--- a/src/app/dwg/qgsdwgimportdialog.cpp
+++ b/src/app/dwg/qgsdwgimportdialog.cpp
@@ -71,7 +71,7 @@ QgsDwgImportDialog::QgsDwgImportDialog( QWidget *parent, Qt::WindowFlags f )
   pbImportDrawing->setHidden( true );
   lblMessage->setHidden( true );
 
-  int crsid = s.value( QStringLiteral( "/DwgImport/lastCrs" ), QString::number( QgsProject::instance()->crs().srsid() ) ).toInt();
+  int crsid = s.value( QStringLiteral( "/DwgImport/lastCrs" ), QString::number( QgsApplication::activeProject()->crs().srsid() ) ).toInt();
 
   QgsCoordinateReferenceSystem crs( crsid, QgsCoordinateReferenceSystem::InternalCrsId );
   mCrsSelector->setCrs( crs );
@@ -277,7 +277,7 @@ QgsVectorLayer *QgsDwgImportDialog::layer( QgsLayerTreeGroup *layerGroup, const 
     return nullptr;
   }
 
-  QgsProject::instance()->addMapLayer( l, false );
+  QgsApplication::activeProject()->addMapLayer( l, false );
   layerGroup->addLayer( l );
   return l;
 }

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -684,7 +684,7 @@ void QgsGpsInformationWidget::displayGPSInformation( const QgsGpsInformation &in
     if ( radRecenterMap->isChecked() || radRecenterWhenNeeded->isChecked() )
     {
       QgsCoordinateReferenceSystem mypSRS = mpCanvas->mapSettings().destinationCrs();
-      QgsCoordinateTransform myTransform( mWgs84CRS, mypSRS, QgsProject::instance() ); // use existing WGS84 CRS
+      QgsCoordinateTransform myTransform( mWgs84CRS, mypSRS, QgsApplication::activeProject() ); // use existing WGS84 CRS
 
       QgsPointXY myPoint = myTransform.transform( myNewCenter );
       //keep the extent the same just center the map canvas in the display so our feature is in the middle
@@ -758,7 +758,7 @@ void QgsGpsInformationWidget::addVertex()
   QgsPointXY myPoint;
   if ( mpCanvas )
   {
-    QgsCoordinateTransform t( mWgs84CRS, mpCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+    QgsCoordinateTransform t( mWgs84CRS, mpCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
     myPoint = t.transform( mLastGpsPosition );
   }
   else
@@ -809,7 +809,7 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
   {
     QgsFeature *f = new QgsFeature( 0 );
 
-    QgsCoordinateTransform t( mWgs84CRS, vlayer->crs(), QgsProject::instance() );
+    QgsCoordinateTransform t( mWgs84CRS, vlayer->crs(), QgsApplication::activeProject() );
     QgsPointXY myPoint = t.transform( mLastGpsPosition );
     double x = myPoint.x();
     double y = myPoint.y();
@@ -864,7 +864,7 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
       {
         QgsPointXY savePoint = *it;
         // transform the gps point into the layer crs
-        QgsCoordinateTransform t( mWgs84CRS, vlayer->crs(), QgsProject::instance() );
+        QgsCoordinateTransform t( mWgs84CRS, vlayer->crs(), QgsApplication::activeProject() );
         QgsPointXY myPoint = t.transform( savePoint );
 
         wkbPtr << myPoint.x() << myPoint.y();
@@ -887,7 +887,7 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
       {
         QgsPointXY savePoint = *it;
         // transform the gps point into the layer crs
-        QgsCoordinateTransform t( mWgs84CRS, vlayer->crs(), QgsProject::instance() );
+        QgsCoordinateTransform t( mWgs84CRS, vlayer->crs(), QgsApplication::activeProject() );
         QgsPointXY myPoint = t.transform( savePoint );
         wkbPtr << myPoint.x() << myPoint.y();
       }
@@ -902,7 +902,7 @@ void QgsGpsInformationWidget::mBtnCloseFeature_clicked()
       f->setGeometry( g );
 
       QgsGeometry featGeom = f->geometry();
-      int avoidIntersectionsReturn = featGeom.avoidIntersections( QgsProject::instance()->avoidIntersectionsLayers() );
+      int avoidIntersectionsReturn = featGeom.avoidIntersections( QgsApplication::activeProject()->avoidIntersectionsLayers() );
       f->setGeometry( featGeom );
       if ( avoidIntersectionsReturn == 1 )
       {

--- a/src/app/gps/qgsgpsmarker.cpp
+++ b/src/app/gps/qgsgpsmarker.cpp
@@ -43,7 +43,7 @@ void QgsGpsMarker::setCenter( const QgsPointXY &point )
   //transform to map crs
   if ( mMapCanvas )
   {
-    QgsCoordinateTransform t( mWgs84CRS, mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+    QgsCoordinateTransform t( mWgs84CRS, mMapCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
     try
     {
       mCenter = t.transform( point );

--- a/src/app/layout/qgslayoutapputils.cpp
+++ b/src/app/layout/qgslayoutapputils.cpp
@@ -80,9 +80,9 @@ void QgsLayoutAppUtils::registerGuiForKnownItemTypes()
     Q_ASSERT( map );
 
     //get the color for map canvas background and set map background color accordingly
-    int bgRedInt = QgsProject::instance()->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorRedPart" ), 255 );
-    int bgGreenInt = QgsProject::instance()->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), 255 );
-    int bgBlueInt = QgsProject::instance()->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), 255 );
+    int bgRedInt = QgsApplication::activeProject()->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorRedPart" ), 255 );
+    int bgGreenInt = QgsApplication::activeProject()->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorGreenPart" ), 255 );
+    int bgBlueInt = QgsApplication::activeProject()->readNumEntry( QStringLiteral( "Gui" ), QStringLiteral( "/CanvasColorBluePart" ), 255 );
     map->setBackgroundColor( QColor( bgRedInt, bgGreenInt, bgBlueInt ) );
 
     if ( QgisApp::instance()->mapCanvas() )

--- a/src/app/layout/qgslayoutattributetablewidget.cpp
+++ b/src/app/layout/qgslayoutattributetablewidget.cpp
@@ -92,7 +92,7 @@ QgsLayoutAttributeTableWidget::QgsLayoutAttributeTableWidget( QgsLayoutFrame *fr
   toggleAtlasSpecificControls( atlasEnabled );
 
   //update relations combo when relations modified in project
-  connect( QgsProject::instance()->relationManager(), &QgsRelationManager::changed, this, &QgsLayoutAttributeTableWidget::updateRelationsCombo );
+  connect( QgsApplication::activeProject()->relationManager(), &QgsRelationManager::changed, this, &QgsLayoutAttributeTableWidget::updateRelationsCombo );
 
   mLayerComboBox->setFilters( QgsMapLayerProxyModel::VectorLayer );
   connect( mLayerComboBox, &QgsMapLayerComboBox::layerChanged, this, &QgsLayoutAttributeTableWidget::changeLayer );
@@ -513,7 +513,7 @@ void QgsLayoutAttributeTableWidget::updateRelationsCombo()
   QgsVectorLayer *atlasLayer = coverageLayer();
   if ( atlasLayer )
   {
-    const QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencedRelations( atlasLayer );
+    const QList<QgsRelation> relations = QgsApplication::activeProject()->relationManager()->referencedRelations( atlasLayer );
     for ( const QgsRelation &relation : relations )
     {
       mRelationsComboBox->addItem( relation.name(), relation.id() );

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -751,7 +751,7 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   //listen out to status bar updates from the view
   connect( mView, &QgsLayoutView::statusMessage, this, &QgsLayoutDesignerDialog::statusMessageReceived );
 
-  connect( QgsProject::instance(), &QgsProject::isDirtyChanged, this, &QgsLayoutDesignerDialog::updateWindowTitle );
+  connect( QgsApplication::activeProject(), &QgsProject::isDirtyChanged, this, &QgsLayoutDesignerDialog::updateWindowTitle );
 }
 
 QgsAppLayoutDesignerInterface *QgsLayoutDesignerDialog::iface()
@@ -1592,7 +1592,7 @@ void QgsLayoutDesignerDialog::saveAsTemplate()
   settings.setValue( QStringLiteral( "lastComposerTemplateDir" ), saveFileInfo.absolutePath(), QgsSettings::App );
 
   QgsReadWriteContext context;
-  context.setPathResolver( QgsProject::instance()->pathResolver() );
+  context.setPathResolver( QgsApplication::activeProject()->pathResolver() );
   if ( !currentLayout()->saveAsTemplate( saveFileName, context ) )
   {
     QMessageBox::warning( this, tr( "Save Template" ), tr( "Error creating template file." ) );
@@ -1625,7 +1625,7 @@ void QgsLayoutDesignerDialog::addItemsFromTemplate()
 
   QDomDocument templateDoc;
   QgsReadWriteContext context;
-  context.setPathResolver( QgsProject::instance()->pathResolver() );
+  context.setPathResolver( QgsApplication::activeProject()->pathResolver() );
   if ( templateDoc.setContent( &templateFile ) )
   {
     bool ok = false;
@@ -4159,7 +4159,7 @@ void QgsLayoutDesignerDialog::updateWindowTitle()
   else
     title = QStringLiteral( "%1 - %2" ).arg( mTitle, mSectionTitle );
 
-  if ( QgsProject::instance()->isDirty() )
+  if ( QgsApplication::activeProject()->isDirty() )
     title.prepend( '*' );
 
   setWindowTitle( title );

--- a/src/app/layout/qgslayoutmanagerdialog.cpp
+++ b/src/app/layout/qgslayoutmanagerdialog.cpp
@@ -65,7 +65,7 @@ QgsLayoutManagerDialog::QgsLayoutManagerDialog( QWidget *parent, Qt::WindowFlags
     settings.setValue( QStringLiteral( "lastComposerTemplateDir" ), tmplFileInfo.absolutePath(), QgsSettings::App );
   } );
 
-  mModel = new QgsLayoutManagerModel( QgsProject::instance()->layoutManager(),
+  mModel = new QgsLayoutManagerModel( QgsApplication::activeProject()->layoutManager(),
                                       this );
   mProxyModel = new QgsLayoutManagerProxyModel( mLayoutListView );
   mProxyModel->setSourceModel( mModel );
@@ -249,10 +249,10 @@ void QgsLayoutManagerDialog::mAddButton_clicked()
 
     if ( title.isEmpty() )
     {
-      title = QgsProject::instance()->layoutManager()->generateUniqueTitle( QgsMasterLayoutInterface::PrintLayout );
+      title = QgsApplication::activeProject()->layoutManager()->generateUniqueTitle( QgsMasterLayoutInterface::PrintLayout );
     }
 
-    std::unique_ptr< QgsPrintLayout > layout = qgis::make_unique< QgsPrintLayout >( QgsProject::instance() );
+    std::unique_ptr< QgsPrintLayout > layout = qgis::make_unique< QgsPrintLayout >( QgsApplication::activeProject() );
     if ( loadingTemplate )
     {
       bool loadedOK = false;
@@ -272,7 +272,7 @@ void QgsLayoutManagerDialog::mAddButton_clicked()
     {
       layout->setName( title );
       QgisApp::instance()->openLayoutDesignerDialog( layout.get() );
-      QgsProject::instance()->layoutManager()->addLayout( layout.release() );
+      QgsApplication::activeProject()->layoutManager()->addLayout( layout.release() );
     }
   }
 }
@@ -303,19 +303,19 @@ void QgsLayoutManagerDialog::createReport()
 
   if ( title.isEmpty() )
   {
-    title = QgsProject::instance()->layoutManager()->generateUniqueTitle( QgsMasterLayoutInterface::Report );
+    title = QgsApplication::activeProject()->layoutManager()->generateUniqueTitle( QgsMasterLayoutInterface::Report );
   }
 
-  std::unique_ptr< QgsReport > report = qgis::make_unique< QgsReport >( QgsProject::instance() );
+  std::unique_ptr< QgsReport > report = qgis::make_unique< QgsReport >( QgsApplication::activeProject() );
   report->setName( title );
 
-  std::unique_ptr< QgsLayout > header = qgis::make_unique< QgsLayout >( QgsProject::instance() );
+  std::unique_ptr< QgsLayout > header = qgis::make_unique< QgsLayout >( QgsApplication::activeProject() );
   header->initializeDefaults();
   report->setHeader( header.release() );
   report->setHeaderEnabled( true );
 
   QgisApp::instance()->openLayoutDesignerDialog( report.get() );
-  QgsProject::instance()->layoutManager()->addLayout( report.release() );
+  QgsApplication::activeProject()->layoutManager()->addLayout( report.release() );
 }
 
 void QgsLayoutManagerDialog::openLocalDirectory( const QString &localDirPath )
@@ -399,7 +399,7 @@ void QgsLayoutManagerDialog::removeClicked()
   // Once we have the layout list, we can delete all of them !
   for ( QgsMasterLayoutInterface *l : qgis::as_const( layoutList ) )
   {
-    QgsProject::instance()->layoutManager()->removeLayout( l );
+    QgsApplication::activeProject()->layoutManager()->removeLayout( l );
   }
 }
 
@@ -566,7 +566,7 @@ bool QgsLayoutManagerModel::setData( const QModelIndex &index, const QVariant &v
 
   //check if name already exists
   QStringList layoutNames;
-  const QList< QgsMasterLayoutInterface * > layouts = QgsProject::instance()->layoutManager()->layouts();
+  const QList< QgsMasterLayoutInterface * > layouts = QgsApplication::activeProject()->layoutManager()->layouts();
   for ( QgsMasterLayoutInterface *l : layouts )
   {
     layoutNames << l->name();

--- a/src/app/layout/qgslayoutmapgridwidget.cpp
+++ b/src/app/layout/qgslayoutmapgridwidget.cpp
@@ -429,8 +429,8 @@ void QgsLayoutMapGridWidget::initAnnotationDirectionBox( QComboBox *c, QgsLayout
 bool QgsLayoutMapGridWidget::hasPredefinedScales() const
 {
   // first look at project's scales
-  QStringList scales( QgsProject::instance()->readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) ) );
-  bool hasProjectScales( QgsProject::instance()->readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) ) );
+  QStringList scales( QgsApplication::activeProject()->readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) ) );
+  bool hasProjectScales( QgsApplication::activeProject()->readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) ) );
   if ( !hasProjectScales || scales.isEmpty() )
   {
     // default to global map tool scales

--- a/src/app/layout/qgslayoutmapwidget.cpp
+++ b/src/app/layout/qgslayoutmapwidget.cpp
@@ -99,7 +99,7 @@ QgsLayoutMapWidget::QgsLayoutMapWidget( QgsLayoutItemMap *item )
   // follow preset combo
   mFollowVisibilityPresetCombo->setModel( new QStringListModel( mFollowVisibilityPresetCombo ) );
   connect( mFollowVisibilityPresetCombo, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLayoutMapWidget::followVisibilityPresetSelected );
-  connect( QgsProject::instance()->mapThemeCollection(), &QgsMapThemeCollection::mapThemesChanged,
+  connect( QgsApplication::activeProject()->mapThemeCollection(), &QgsMapThemeCollection::mapThemesChanged,
            this, &QgsLayoutMapWidget::onMapThemesChanged );
   onMapThemesChanged();
 
@@ -223,7 +223,7 @@ void QgsLayoutMapWidget::aboutToShowKeepLayersVisibilityPresetsMenu()
     return;
 
   menu->clear();
-  Q_FOREACH ( const QString &presetName, QgsProject::instance()->mapThemeCollection()->mapThemes() )
+  Q_FOREACH ( const QString &presetName, QgsApplication::activeProject()->mapThemeCollection()->mapThemes() )
   {
     menu->addAction( presetName, this, SLOT( keepLayersVisibilityPresetSelected() ) );
   }
@@ -273,7 +273,7 @@ void QgsLayoutMapWidget::keepLayersVisibilityPresetSelected()
     mKeepLayerStylesCheckBox->setChecked( true );
 
     mMapItem->layout()->undoStack()->beginCommand( mMapItem, tr( "Change Map Preset" ) );
-    mMapItem->setLayerStyleOverrides( QgsProject::instance()->mapThemeCollection()->mapThemeStyleOverrides( presetName ) );
+    mMapItem->setLayerStyleOverrides( QgsApplication::activeProject()->mapThemeCollection()->mapThemeStyleOverrides( presetName ) );
     mMapItem->layout()->undoStack()->endCommand();
 
     mMapItem->invalidateCache();
@@ -286,7 +286,7 @@ void QgsLayoutMapWidget::onMapThemesChanged()
   {
     QStringList lst;
     lst.append( tr( "(none)" ) );
-    lst += QgsProject::instance()->mapThemeCollection()->mapThemes();
+    lst += QgsApplication::activeProject()->mapThemeCollection()->mapThemes();
     model->setStringList( lst );
 
     // select the previously selected item again
@@ -314,7 +314,7 @@ void QgsLayoutMapWidget::mapCrsChanged( const QgsCoordinateReferenceSystem &crs 
   QgsRectangle newExtent;
   try
   {
-    QgsCoordinateTransform xForm( oldCrs, crs.isValid() ? crs : QgsProject::instance()->crs(), QgsProject::instance() );
+    QgsCoordinateTransform xForm( oldCrs, crs.isValid() ? crs : QgsApplication::activeProject()->crs(), QgsApplication::activeProject() );
     QgsRectangle prevExtent = mMapItem->extent();
     newExtent = xForm.transformBoundingBox( prevExtent );
     updateExtent = true;
@@ -520,7 +520,7 @@ void QgsLayoutMapWidget::mSetToMapCanvasExtentButton_clicked()
     try
     {
       QgsCoordinateTransform xForm( QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs(),
-                                    mMapItem->crs(), QgsProject::instance() );
+                                    mMapItem->crs(), QgsApplication::activeProject() );
       newExtent = xForm.transformBoundingBox( newExtent );
     }
     catch ( QgsCsException & )
@@ -553,7 +553,7 @@ void QgsLayoutMapWidget::mViewExtentInCanvasButton_clicked()
       try
       {
         QgsCoordinateTransform xForm( mMapItem->crs(),
-                                      QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs(), QgsProject::instance() );
+                                      QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs(), QgsApplication::activeProject() );
         currentMapExtent = xForm.transformBoundingBox( currentMapExtent );
       }
       catch ( QgsCsException & )
@@ -1067,8 +1067,8 @@ void QgsLayoutMapWidget::atlasLayerChanged( QgsVectorLayer *layer )
 bool QgsLayoutMapWidget::hasPredefinedScales() const
 {
   // first look at project's scales
-  QStringList scales( QgsProject::instance()->readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) ) );
-  bool hasProjectScales( QgsProject::instance()->readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) ) );
+  QStringList scales( QgsApplication::activeProject()->readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) ) );
+  bool hasProjectScales( QgsApplication::activeProject()->readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) ) );
   if ( !hasProjectScales || scales.isEmpty() )
   {
     // default to global map tool scales

--- a/src/app/layout/qgslayoutpropertieswidget.cpp
+++ b/src/app/layout/qgslayoutpropertieswidget.cpp
@@ -90,7 +90,7 @@ QgsLayoutPropertiesWidget::QgsLayoutPropertiesWidget( QWidget *parent, QgsLayout
   connect( mVariableEditor, &QgsVariableEditorWidget::scopeChanged, this, &QgsLayoutPropertiesWidget::variablesChanged );
   // listen out for variable edits
   connect( QgsApplication::instance(), &QgsApplication::customVariablesChanged, this, &QgsLayoutPropertiesWidget::updateVariables );
-  connect( QgsProject::instance(), &QgsProject::customVariablesChanged, this, &QgsLayoutPropertiesWidget::updateVariables );
+  connect( QgsApplication::activeProject(), &QgsProject::customVariablesChanged, this, &QgsLayoutPropertiesWidget::updateVariables );
 
   updateGui();
 }
@@ -245,7 +245,7 @@ void QgsLayoutPropertiesWidget::updateVariables()
 {
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
-          << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+          << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
           << QgsExpressionContextUtils::layoutScope( mLayout );
   mVariableEditor->setContext( &context );
   mVariableEditor->setEditableScopeIndex( 2 );

--- a/src/app/layout/qgslayoutqptdrophandler.cpp
+++ b/src/app/layout/qgslayoutqptdrophandler.cpp
@@ -42,7 +42,7 @@ bool QgsLayoutQptDropHandler::handleFileDrop( QgsLayoutDesignerInterface *iface,
 
   QDomDocument templateDoc;
   QgsReadWriteContext context;
-  context.setPathResolver( QgsProject::instance()->pathResolver() );
+  context.setPathResolver( QgsApplication::activeProject()->pathResolver() );
   if ( templateDoc.setContent( &templateFile ) )
   {
     bool ok = false;

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -39,7 +39,7 @@ QgsLayerTreeLocatorFilter *QgsLayerTreeLocatorFilter::clone() const
 
 void QgsLayerTreeLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback * )
 {
-  QgsLayerTree *tree = QgsProject::instance()->layerTreeRoot();
+  QgsLayerTree *tree = QgsApplication::activeProject()->layerTreeRoot();
   const QList<QgsLayerTreeLayer *> layers = tree->findLayers();
   for ( QgsLayerTreeLayer *layer : layers )
   {
@@ -58,7 +58,7 @@ void QgsLayerTreeLocatorFilter::fetchResults( const QString &string, const QgsLo
 void QgsLayerTreeLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
   QString layerId = result.userData.toString();
-  QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId );
+  QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( layerId );
   QgisApp::instance()->setActiveLayer( layer );
 }
 
@@ -77,7 +77,7 @@ QgsLayoutLocatorFilter *QgsLayoutLocatorFilter::clone() const
 
 void QgsLayoutLocatorFilter::fetchResults( const QString &string, const QgsLocatorContext &context, QgsFeedback * )
 {
-  const QList< QgsMasterLayoutInterface * > layouts = QgsProject::instance()->layoutManager()->layouts();
+  const QList< QgsMasterLayoutInterface * > layouts = QgsApplication::activeProject()->layoutManager()->layouts();
   for ( QgsMasterLayoutInterface *layout : layouts )
   {
     if ( layout && ( stringMatches( layout->name(), string ) || ( context.usingPrefix && string.isEmpty() ) ) )
@@ -95,7 +95,7 @@ void QgsLayoutLocatorFilter::fetchResults( const QString &string, const QgsLocat
 void QgsLayoutLocatorFilter::triggerResult( const QgsLocatorResult &result )
 {
   QString layoutName = result.userData.toString();
-  QgsMasterLayoutInterface *layout = QgsProject::instance()->layoutManager()->layoutByName( layoutName );
+  QgsMasterLayoutInterface *layout = QgsApplication::activeProject()->layoutManager()->layoutByName( layoutName );
   if ( !layout )
     return;
 
@@ -291,7 +291,7 @@ void QgsActiveLayerFeaturesLocatorFilter::triggerResult( const QgsLocatorResult 
   QVariantList dataList = result.userData.toList();
   QgsFeatureId id = dataList.at( 0 ).toLongLong();
   QString layerId = dataList.at( 1 ).toString();
-  QgsVectorLayer *layer = qobject_cast< QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+  QgsVectorLayer *layer = qobject_cast< QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( layerId ) );
   if ( !layer )
     return;
 
@@ -316,7 +316,7 @@ void QgsExpressionCalculatorLocatorFilter::fetchResults( const QString &string, 
 {
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
-          << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+          << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
 
   QString error;
   if ( QgsExpression::checkExpression( string, &context, error ) )

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1359,7 +1359,7 @@ int main( int argc, char *argv[] )
     QList< QgsDxfExport::DxfLayer > layers;
     if ( !dxfMapTheme.isEmpty() )
     {
-      Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->mapThemeCollection()->mapThemeVisibleLayers( dxfMapTheme ) )
+      Q_FOREACH ( QgsMapLayer *layer, QgsApplication::activeProject()->mapThemeCollection()->mapThemeVisibleLayers( dxfMapTheme ) )
       {
         QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
         if ( !vl )
@@ -1370,7 +1370,7 @@ int main( int argc, char *argv[] )
     }
     else
     {
-      Q_FOREACH ( QgsMapLayer *ml, QgsProject::instance()->mapLayers() )
+      Q_FOREACH ( QgsMapLayer *ml, QgsApplication::activeProject()->mapLayers() )
       {
         QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( ml );
         if ( !vl )
@@ -1411,7 +1411,7 @@ int main( int argc, char *argv[] )
   }
 
   // make sure we don't have a dirty blank project after launch
-  QgsProject::instance()->setDirty( false );
+  QgsApplication::activeProject()->setDirty( false );
 
   /////////////////////////////////////////////////////////////////////
   // Continue on to interactive gui...

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -729,8 +729,8 @@ QgsAttributeDialog *QgisAppInterface::getFeatureForm( QgsVectorLayer *l, QgsFeat
 {
   QgsDistanceArea myDa;
 
-  myDa.setSourceCrs( l->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( l->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
 
   QgsAttributeEditorContext context;
   context.setDistanceArea( myDa );

--- a/src/app/qgsalignrasterdialog.cpp
+++ b/src/app/qgsalignrasterdialog.cpp
@@ -35,7 +35,7 @@
 
 static QgsMapLayer *_rasterLayer( const QString &filename )
 {
-  QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();
+  QMap<QString, QgsMapLayer *> layers = QgsApplication::activeProject()->mapLayers();
   Q_FOREACH ( QgsMapLayer *layer, layers )
   {
     if ( layer->type() == QgsMapLayer::RasterLayer && layer->source() == filename )
@@ -369,7 +369,7 @@ void QgsAlignRasterDialog::runAlign()
       {
         QgsRasterLayer *layer = new QgsRasterLayer( item.outputFilename, QFileInfo( item.outputFilename ).baseName() );
         if ( layer->isValid() )
-          QgsProject::instance()->addMapLayer( layer );
+          QgsApplication::activeProject()->addMapLayer( layer );
         else
           delete layer;
       }

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -371,7 +371,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         }
       }
 
-      if ( layer && QgsProject::instance()->layerIsEmbedded( layer->id() ).isEmpty() )
+      if ( layer && QgsApplication::activeProject()->layerIsEmbedded( layer->id() ).isEmpty() )
         menu->addAction( tr( "&Properties…" ), QgisApp::instance(), SLOT( layerProperties() ) );
     }
   }
@@ -584,7 +584,7 @@ void QgsAppLayerTreeViewMenuProvider::editVectorSymbol()
     return;
 
   QString layerId = action->property( "layerId" ).toString();
-  QgsVectorLayer *layer = dynamic_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+  QgsVectorLayer *layer = dynamic_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( layerId ) );
   if ( !layer )
     return;
 
@@ -613,7 +613,7 @@ void QgsAppLayerTreeViewMenuProvider::setVectorSymbolColor( const QColor &color 
     return;
 
   QString layerId = action->property( "layerId" ).toString();
-  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( layerId ) );
   if ( !layer )
     return;
 
@@ -705,7 +705,7 @@ void QgsAppLayerTreeViewMenuProvider::setSymbolLegendNodeColor( const QColor &co
   QgsSymbol *newSymbol = originalSymbol->clone();
   newSymbol->setColor( color );
   node->setSymbol( newSymbol );
-  if ( QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) ) )
+  if ( QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( layerId ) ) )
   {
     layer->emitStyleChanged();
   }
@@ -714,7 +714,7 @@ void QgsAppLayerTreeViewMenuProvider::setSymbolLegendNodeColor( const QColor &co
 bool QgsAppLayerTreeViewMenuProvider::removeActionEnabled()
 {
   const QList<QgsLayerTreeLayer *> selectedLayers = mView->selectedLayerNodes();
-  const QSet<QgsMapLayer *> requiredLayers = QgsProject::instance()->requiredLayers();
+  const QSet<QgsMapLayer *> requiredLayers = QgsApplication::activeProject()->requiredLayers();
   for ( QgsLayerTreeLayer *nodeLayer : selectedLayers )
   {
     if ( requiredLayers.contains( nodeLayer->layer() ) )

--- a/src/app/qgsattributeactionpropertiesdialog.cpp
+++ b/src/app/qgsattributeactionpropertiesdialog.cpp
@@ -213,8 +213,8 @@ void QgsAttributeActionPropertiesDialog::init( const QSet<QString> &actionScopes
   }
 
   QgsDistanceArea myDa;
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
 
   mFieldExpression->setLayer( mLayer );
   mFieldExpression->setGeomCalculator( myDa );

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -112,7 +112,7 @@ void QgsAttributesFormProperties::initAvailableWidgetsTree()
   catItemData = DnDTreeItemData( DnDTreeItemData::Container, "Relations", "Relations" );
   catitem = mAvailableWidgetsTree->addItem( mAvailableWidgetsTree->invisibleRootItem(), catItemData );
 
-  const QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencedRelations( mLayer );
+  const QList<QgsRelation> relations = QgsApplication::activeProject()->relationManager()->referencedRelations( mLayer );
 
   for ( const QgsRelation &relation : relations )
   {
@@ -335,9 +335,9 @@ void QgsAttributesFormProperties::loadAttributeRelationEdit()
 
     mAttributeRelationEdit->setCardinalityCombo( tr( "Many to one relation" ) );
 
-    QgsRelation relation = QgsProject::instance()->relationManager()->relation( currentItem->data( 0, FieldNameRole ).toString() );
+    QgsRelation relation = QgsApplication::activeProject()->relationManager()->relation( currentItem->data( 0, FieldNameRole ).toString() );
 
-    Q_FOREACH ( const QgsRelation &nmrel, QgsProject::instance()->relationManager()->referencingRelations( relation.referencingLayer() ) )
+    Q_FOREACH ( const QgsRelation &nmrel, QgsApplication::activeProject()->relationManager()->referencingRelations( relation.referencingLayer() ) )
     {
       if ( nmrel.fieldPairs().at( 0 ).referencingField() != relation.fieldPairs().at( 0 ).referencingField() )
         mAttributeRelationEdit->setCardinalityCombo( QStringLiteral( "%1 (%2)" ).arg( nmrel.referencedLayer()->name(), nmrel.fieldPairs().at( 0 ).referencedField() ), nmrel.id() );
@@ -531,7 +531,7 @@ QgsAttributeEditorElement *QgsAttributesFormProperties::createAttributeEditorWid
 
     case DnDTreeItemData::Relation:
     {
-      QgsRelation relation = QgsProject::instance()->relationManager()->relation( itemData.name() );
+      QgsRelation relation = QgsApplication::activeProject()->relationManager()->relation( itemData.name() );
       QgsAttributeEditorRelation *relDef = new QgsAttributeEditorRelation( relation, parent );
       relDef->setShowLinkButton( itemData.relationEditorConfiguration().showLinkButton );
       relDef->setShowUnlinkButton( itemData.relationEditorConfiguration().showUnlinkButton );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -55,7 +55,7 @@ QgsExpressionContext QgsAttributeTableDialog::createExpressionContext() const
 {
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
 
   if ( mLayer )
     expContext << QgsExpressionContextUtils::layerScope( mLayer );
@@ -144,8 +144,8 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
 
   myDa = new QgsDistanceArea();
 
-  myDa->setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa->setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa->setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa->setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
 
   mEditorContext.setDistanceArea( *myDa );
   mEditorContext.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );
@@ -498,8 +498,8 @@ void QgsAttributeTableDialog::runFieldCalculation( QgsVectorLayer *layer, const 
 
   QgsExpression exp( expression );
   exp.setGeomCalculator( myDa );
-  exp.setDistanceUnits( QgsProject::instance()->distanceUnits() );
-  exp.setAreaUnits( QgsProject::instance()->areaUnits() );
+  exp.setDistanceUnits( QgsApplication::activeProject()->distanceUnits() );
+  exp.setAreaUnits( QgsApplication::activeProject()->areaUnits() );
   bool useGeometry = exp.needsGeometry();
 
   QgsFeatureRequest request( mMainView->masterModel()->request() );
@@ -628,8 +628,8 @@ void QgsAttributeTableDialog::filterExpressionBuilder()
   dlg.setWindowTitle( tr( "Expression Based Filter" ) );
 
   QgsDistanceArea myDa;
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
   dlg.setGeomCalculator( myDa );
 
   if ( dlg.exec() == QDialog::Accepted )
@@ -1018,8 +1018,8 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
   QgsFeatureIds filteredFeatures;
   QgsDistanceArea myDa;
 
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
 
   // parse search string and build parsed tree
   QgsExpression filterExpression( filter );
@@ -1041,8 +1041,8 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
   QApplication::setOverrideCursor( Qt::WaitCursor );
 
   filterExpression.setGeomCalculator( &myDa );
-  filterExpression.setDistanceUnits( QgsProject::instance()->distanceUnits() );
-  filterExpression.setAreaUnits( QgsProject::instance()->areaUnits() );
+  filterExpression.setDistanceUnits( QgsApplication::activeProject()->distanceUnits() );
+  filterExpression.setAreaUnits( QgsApplication::activeProject()->areaUnits() );
   QgsFeatureRequest request( mMainView->masterModel()->request() );
   request.setSubsetOfAttributes( filterExpression.referencedColumns(), mLayer->fields() );
   if ( !fetchGeom )

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -296,7 +296,7 @@ QgsExpressionContext QgsAttributeTypeDialog::createExpressionContext() const
   QgsExpressionContext context;
   context
       << QgsExpressionContextUtils::globalScope()
-      << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+      << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
       << QgsExpressionContextUtils::layerScope( mLayer )
       << QgsExpressionContextUtils::mapToolCaptureScope( QList<QgsPointLocator::Match>() );
 

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -156,15 +156,15 @@ void QgsBookmarks::addClicked()
   Q_ASSERT( canvas );
 
   QString projStr( QLatin1String( "" ) );
-  if ( QgsProject::instance() )
+  if ( QgsApplication::activeProject() )
   {
-    if ( !QgsProject::instance()->title().isEmpty() )
+    if ( !QgsApplication::activeProject()->title().isEmpty() )
     {
-      projStr = QgsProject::instance()->title();
+      projStr = QgsApplication::activeProject()->title();
     }
-    else if ( !QgsProject::instance()->fileName().isEmpty() )
+    else if ( !QgsApplication::activeProject()->fileName().isEmpty() )
     {
-      QFileInfo fi( QgsProject::instance()->fileName() );
+      QFileInfo fi( QgsApplication::activeProject()->fileName() );
       projStr = fi.exists() ? fi.fileName() : QLatin1String( "" );
     }
   }
@@ -254,7 +254,7 @@ void  QgsBookmarks::zoomToBookmarkIndex( const QModelIndex &index )
        authid != QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs().authid() )
   {
     QgsCoordinateTransform ct( QgsCoordinateReferenceSystem::fromOgcWmsCrs( authid ),
-                               QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs(), QgsProject::instance() );
+                               QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs(), QgsApplication::activeProject() );
     rect = ct.transform( rect );
     if ( rect.isEmpty() )
     {
@@ -461,7 +461,7 @@ QgsProjectBookmarksTableModel::QgsProjectBookmarksTableModel( QObject *parent )
 int QgsProjectBookmarksTableModel::rowCount( const QModelIndex &parent ) const
 {
   Q_UNUSED( parent );
-  return QgsProject::instance()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ) );
+  return QgsApplication::activeProject()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ) );
 }
 
 int QgsProjectBookmarksTableModel::columnCount( const QModelIndex &parent ) const
@@ -480,19 +480,19 @@ QVariant QgsProjectBookmarksTableModel::data( const QModelIndex &index, int role
   switch ( index.column() )
   {
     case 1:
-      return QgsProject::instance()->readEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/Name" ).arg( index.row() ) );
+      return QgsApplication::activeProject()->readEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/Name" ).arg( index.row() ) );
     case 2:
-      return QgsProject::instance()->readEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/Project" ).arg( index.row() ) );
+      return QgsApplication::activeProject()->readEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/Project" ).arg( index.row() ) );
     case 3:
-      return QgsProject::instance()->readDoubleEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MinX" ).arg( index.row() ) );
+      return QgsApplication::activeProject()->readDoubleEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MinX" ).arg( index.row() ) );
     case 4:
-      return QgsProject::instance()->readDoubleEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MinY" ).arg( index.row() ) );
+      return QgsApplication::activeProject()->readDoubleEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MinY" ).arg( index.row() ) );
     case 5:
-      return QgsProject::instance()->readDoubleEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MaxX" ).arg( index.row() ) );
+      return QgsApplication::activeProject()->readDoubleEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MaxX" ).arg( index.row() ) );
     case 6:
-      return QgsProject::instance()->readDoubleEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MaxY" ).arg( index.row() ) );
+      return QgsApplication::activeProject()->readDoubleEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MaxY" ).arg( index.row() ) );
     case 7:
-      return  QgsProject::instance()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/SRID" ).arg( index.row() ) );
+      return  QgsApplication::activeProject()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/SRID" ).arg( index.row() ) );
     default:
       return QVariant();
   }
@@ -506,25 +506,25 @@ bool QgsProjectBookmarksTableModel::setData( const QModelIndex &index, const QVa
   switch ( index.column() )
   {
     case 1:
-      QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/Name" ).arg( index.row() ), value.toString() );
+      QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/Name" ).arg( index.row() ), value.toString() );
       return true;
     case 2:
-      QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/Project" ).arg( index.row() ), value.toString() );
+      QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/Project" ).arg( index.row() ), value.toString() );
       return true;
     case 3:
-      QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MinX" ).arg( index.row() ), value.toDouble() );
+      QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MinX" ).arg( index.row() ), value.toDouble() );
       return true;
     case 4:
-      QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MinY" ).arg( index.row() ), value.toDouble() );
+      QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MinY" ).arg( index.row() ), value.toDouble() );
       return true;
     case 5:
-      QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MaxX" ).arg( index.row() ), value.toDouble() );
+      QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MaxX" ).arg( index.row() ), value.toDouble() );
       return true;
     case 6:
-      QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MaxY" ).arg( index.row() ), value.toDouble() );
+      QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/MaxY" ).arg( index.row() ), value.toDouble() );
       return true;
     case 7:
-      QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/SRID" ).arg( index.row() ), value.toInt() );
+      QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1/SRID" ).arg( index.row() ), value.toInt() );
       return true;
     default:
       return false;
@@ -536,9 +536,9 @@ bool QgsProjectBookmarksTableModel::insertRows( int row, int count, const QModel
   Q_UNUSED( parent );
   Q_UNUSED( row );
   // append
-  int oldCount = QgsProject::instance()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ) );
+  int oldCount = QgsApplication::activeProject()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ) );
   beginInsertRows( parent, oldCount, oldCount + count );
-  bool result = QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ), oldCount + count );
+  bool result = QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ), oldCount + count );
   endInsertRows();
   return result;
 }
@@ -556,10 +556,10 @@ bool QgsProjectBookmarksTableModel::removeRows( int row, int count, const QModel
   }
   for ( int newRow = rowCount() - count ; newRow < rowCount() ; newRow++ )
   {
-    QgsProject::instance()->removeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1" ).arg( newRow ) );
+    QgsApplication::activeProject()->removeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/Row-%1" ).arg( newRow ) );
   }
 
-  QgsProject::instance()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ), QgsProject::instance()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ) ) - count );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ), QgsApplication::activeProject()->readNumEntry( QStringLiteral( "Bookmarks" ), QStringLiteral( "/count" ) ) - count );
   endRemoveRows();
   return true;
 }
@@ -750,7 +750,7 @@ QAbstractTableModel *QgsMergedBookmarksTableModel::qgisModel()
 
 bool QgsMergedBookmarksTableModel::projectAvailable() const
 {
-  return ! QgsProject::instance()->fileName().isEmpty();
+  return ! QgsApplication::activeProject()->fileName().isEmpty();
 }
 
 void QgsMergedBookmarksTableModel::moveBookmark( QAbstractTableModel &modelFrom, QAbstractTableModel &modelTo, int row )

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -292,7 +292,7 @@ QgsFeatureList QgsClipboard::transformedCopyOf( const QgsCoordinateReferenceSyst
   QgsFeatureList featureList = copyOf( fields );
 
   QgisApp::instance()->askUserForDatumTransform( crs(), destCRS );
-  QgsCoordinateTransform ct = QgsCoordinateTransform( crs(), destCRS, QgsProject::instance() );
+  QgsCoordinateTransform ct = QgsCoordinateTransform( crs(), destCRS, QgsApplication::activeProject() );
 
   QgsDebugMsg( "transforming clipboard." );
   for ( QgsFeatureList::iterator iter = featureList.begin(); iter != featureList.end(); ++iter )

--- a/src/app/qgscrashhandler.cpp
+++ b/src/app/qgscrashhandler.cpp
@@ -60,7 +60,7 @@ LONG WINAPI QgsCrashHandler::handle( LPEXCEPTION_POINTERS exception )
   arguments = QCoreApplication::arguments();
   // TODO In future this needs to be moved out into a "session state" file because we can't trust this is valid in
   // a crash.
-  arguments << QgsProject::instance()->fileName();
+  arguments << QgsApplication::activeProject()->fileName();
 
   QStringList reportData;
   reportData.append( QStringLiteral( "QGIS Version: %1" ).arg( Qgis::QGIS_VERSION ) );

--- a/src/app/qgsdecorationcopyright.cpp
+++ b/src/app/qgsdecorationcopyright.cpp
@@ -60,44 +60,44 @@ void QgsDecorationCopyright::projectRead()
 {
   QgsDecorationItem::projectRead();
 
-  mLabelText = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Label" ), QString() );
-  mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
-  mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
+  mLabelText = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/Label" ), QString() );
+  mMarginHorizontal = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
+  mMarginVertical = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
 
   QDomDocument doc;
   QDomElement elem;
-  QString textXml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Font" ) );
+  QString textXml = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/Font" ) );
   if ( !textXml.isEmpty() )
   {
     doc.setContent( textXml );
     elem = doc.documentElement();
     QgsReadWriteContext rwContext;
-    rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+    rwContext.setPathResolver( QgsApplication::activeProject()->pathResolver() );
     mTextFormat.readXml( elem, rwContext );
   }
 
   // Migratation for pre QGIS 3.2 settings
-  QColor oldColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ) ) );
+  QColor oldColor = QgsSymbolLayerUtils::decodeColor( QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/Color" ) ) );
   if ( oldColor.isValid() )
   {
     mTextFormat.setColor( oldColor );
-    QgsProject::instance()->removeEntry( mNameConfig, QStringLiteral( "/Color" ) );
+    QgsApplication::activeProject()->removeEntry( mNameConfig, QStringLiteral( "/Color" ) );
   }
 }
 
 void QgsDecorationCopyright::saveToProject()
 {
   QgsDecorationItem::saveToProject();
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Label" ), mLabelText );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Label" ), mLabelText );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
 
   QDomDocument textDoc;
   QgsReadWriteContext rwContext;
-  rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+  rwContext.setPathResolver( QgsApplication::activeProject()->pathResolver() );
   QDomElement textElem = mTextFormat.writeXml( textDoc, rwContext );
   textDoc.appendChild( textElem );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Font" ), textDoc.toString() );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Font" ), textDoc.toString() );
 }
 
 // Slot called when the buffer menu item is activated

--- a/src/app/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/qgsdecorationcopyrightdialog.cpp
@@ -51,7 +51,7 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   if ( !mDeco.enabled() && mDeco.mLabelText.isEmpty() )
   {
     QDate now = QDate::currentDate();
-    QString defaultString = QString( "%1 %2 %3" ).arg( QChar( 0x00A9 ), QgsProject::instance()->metadata().author(), now.toString( QStringLiteral( "yyyy" ) ) );
+    QString defaultString = QString( "%1 %2 %3" ).arg( QChar( 0x00A9 ), QgsApplication::activeProject()->metadata().author(), now.toString( QStringLiteral( "yyyy" ) ) );
     txtCopyrightText->setPlainText( defaultString );
   }
   else

--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -94,23 +94,23 @@ void QgsDecorationGrid::projectRead()
 {
   QgsDecorationItem::projectRead();
 
-  mEnabled = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/Enabled" ), false );
-  mMapUnits = static_cast< QgsUnitTypes::DistanceUnit >( QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MapUnits" ),
+  mEnabled = QgsApplication::activeProject()->readBoolEntry( mNameConfig, QStringLiteral( "/Enabled" ), false );
+  mMapUnits = static_cast< QgsUnitTypes::DistanceUnit >( QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/MapUnits" ),
               QgsUnitTypes::DistanceUnknownUnit ) );
-  mGridStyle = static_cast< GridStyle >( QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/Style" ),
+  mGridStyle = static_cast< GridStyle >( QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/Style" ),
                                          QgsDecorationGrid::Line ) );
-  mGridIntervalX = QgsProject::instance()->readDoubleEntry( mNameConfig, QStringLiteral( "/IntervalX" ), 10 );
-  mGridIntervalY = QgsProject::instance()->readDoubleEntry( mNameConfig, QStringLiteral( "/IntervalY" ), 10 );
-  mGridOffsetX = QgsProject::instance()->readDoubleEntry( mNameConfig, QStringLiteral( "/OffsetX" ), 0 );
-  mGridOffsetY = QgsProject::instance()->readDoubleEntry( mNameConfig, QStringLiteral( "/OffsetY" ), 0 );
-  // mCrossLength = QgsProject::instance()->readDoubleEntry( mNameConfig, "/CrossLength", 3 );
-  mShowGridAnnotation = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/ShowAnnotation" ), false );
-  // mGridAnnotationPosition = ( GridAnnotationPosition ) QgsProject::instance()->readNumEntry( mNameConfig,
+  mGridIntervalX = QgsApplication::activeProject()->readDoubleEntry( mNameConfig, QStringLiteral( "/IntervalX" ), 10 );
+  mGridIntervalY = QgsApplication::activeProject()->readDoubleEntry( mNameConfig, QStringLiteral( "/IntervalY" ), 10 );
+  mGridOffsetX = QgsApplication::activeProject()->readDoubleEntry( mNameConfig, QStringLiteral( "/OffsetX" ), 0 );
+  mGridOffsetY = QgsApplication::activeProject()->readDoubleEntry( mNameConfig, QStringLiteral( "/OffsetY" ), 0 );
+  // mCrossLength = QgsApplication::activeProject()->readDoubleEntry( mNameConfig, "/CrossLength", 3 );
+  mShowGridAnnotation = QgsApplication::activeProject()->readBoolEntry( mNameConfig, QStringLiteral( "/ShowAnnotation" ), false );
+  // mGridAnnotationPosition = ( GridAnnotationPosition ) QgsApplication::activeProject()->readNumEntry( mNameConfig,
   //                           "/AnnotationPosition", 0 );
   mGridAnnotationPosition = InsideMapFrame; // don't allow outside frame, doesn't make sense
-  mGridAnnotationDirection = static_cast< GridAnnotationDirection >( QgsProject::instance()->readNumEntry( mNameConfig,
+  mGridAnnotationDirection = static_cast< GridAnnotationDirection >( QgsApplication::activeProject()->readNumEntry( mNameConfig,
                              QStringLiteral( "/AnnotationDirection" ), 0 ) );
-  QString fontStr = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/AnnotationFont" ), QString() );
+  QString fontStr = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/AnnotationFont" ), QString() );
   if ( !fontStr.isEmpty() )
   {
     mGridAnnotationFont.fromString( fontStr );
@@ -121,19 +121,19 @@ void QgsDecorationGrid::projectRead()
     // TODO fix font scaling problem - put a slightly large font for now
     mGridAnnotationFont.setPointSize( 16 );
   }
-  mAnnotationFrameDistance = QgsProject::instance()->readDoubleEntry( mNameConfig, QStringLiteral( "/AnnotationFrameDistance" ), 0 );
-  mGridAnnotationPrecision = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/AnnotationPrecision" ), 0 );
+  mAnnotationFrameDistance = QgsApplication::activeProject()->readDoubleEntry( mNameConfig, QStringLiteral( "/AnnotationFrameDistance" ), 0 );
+  mGridAnnotationPrecision = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/AnnotationPrecision" ), 0 );
 
   // read symbol info from xml
   QDomDocument doc;
   QDomElement elem;
   QString xml;
   QgsReadWriteContext rwContext;
-  rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+  rwContext.setPathResolver( QgsApplication::activeProject()->pathResolver() );
 
   if ( mLineSymbol )
     setLineSymbol( nullptr );
-  xml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/LineSymbol" ) );
+  xml = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/LineSymbol" ) );
   if ( !xml.isEmpty() )
   {
     doc.setContent( xml );
@@ -145,7 +145,7 @@ void QgsDecorationGrid::projectRead()
 
   if ( mMarkerSymbol )
     setMarkerSymbol( nullptr );
-  xml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/MarkerSymbol" ) );
+  xml = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/MarkerSymbol" ) );
   if ( !xml.isEmpty() )
   {
     doc.setContent( xml );
@@ -165,40 +165,40 @@ void QgsDecorationGrid::projectRead()
 void QgsDecorationGrid::saveToProject()
 {
   QgsDecorationItem::saveToProject();
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Enabled" ), mEnabled );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MapUnits" ), static_cast< int >( mMapUnits ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Style" ), static_cast< int >( mGridStyle ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/IntervalX" ), mGridIntervalX );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/IntervalY" ), mGridIntervalY );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OffsetX" ), mGridOffsetX );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OffsetY" ), mGridOffsetY );
-  // QgsProject::instance()->writeEntry( mNameConfig, "/CrossLength", mCrossLength );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Enabled" ), mEnabled );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MapUnits" ), static_cast< int >( mMapUnits ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Style" ), static_cast< int >( mGridStyle ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/IntervalX" ), mGridIntervalX );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/IntervalY" ), mGridIntervalY );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/OffsetX" ), mGridOffsetX );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/OffsetY" ), mGridOffsetY );
+  // QgsApplication::activeProject()->writeEntry( mNameConfig, "/CrossLength", mCrossLength );
   // missing mGridPen, but should use styles anyway
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/ShowAnnotation" ), mShowGridAnnotation );
-  // QgsProject::instance()->writeEntry( mNameConfig, "/AnnotationPosition", ( int ) mGridAnnotationPosition );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/AnnotationDirection" ), static_cast< int >( mGridAnnotationDirection ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/AnnotationFont" ), mGridAnnotationFont.toString() );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/AnnotationFrameDistance" ), mAnnotationFrameDistance );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/AnnotationPrecision" ), mGridAnnotationPrecision );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/ShowAnnotation" ), mShowGridAnnotation );
+  // QgsApplication::activeProject()->writeEntry( mNameConfig, "/AnnotationPosition", ( int ) mGridAnnotationPosition );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/AnnotationDirection" ), static_cast< int >( mGridAnnotationDirection ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/AnnotationFont" ), mGridAnnotationFont.toString() );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/AnnotationFrameDistance" ), mAnnotationFrameDistance );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/AnnotationPrecision" ), mGridAnnotationPrecision );
 
   // write symbol info to xml
   QDomDocument doc;
   QDomElement elem;
   QgsReadWriteContext rwContext;
-  rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+  rwContext.setPathResolver( QgsApplication::activeProject()->pathResolver() );
   if ( mLineSymbol )
   {
     elem = QgsSymbolLayerUtils::saveSymbol( QStringLiteral( "line symbol" ), mLineSymbol, doc, rwContext );
     doc.appendChild( elem );
     // FIXME this works, but XML will not be valid as < is replaced by &lt;
-    QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/LineSymbol" ), doc.toString() );
+    QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/LineSymbol" ), doc.toString() );
   }
   if ( mMarkerSymbol )
   {
     doc.setContent( QString() );
     elem = QgsSymbolLayerUtils::saveSymbol( QStringLiteral( "marker symbol" ), mMarkerSymbol, doc, rwContext );
     doc.appendChild( elem );
-    QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarkerSymbol" ), doc.toString() );
+    QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MarkerSymbol" ), doc.toString() );
   }
 
 }

--- a/src/app/qgsdecorationitem.cpp
+++ b/src/app/qgsdecorationitem.cpp
@@ -57,16 +57,16 @@ void QgsDecorationItem::update()
 
 void QgsDecorationItem::projectRead()
 {
-  mEnabled = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/Enabled" ), false );
-  mPlacement = static_cast< Placement >( QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/Placement" ), static_cast< int >( mPlacement ) ) );
-  mMarginUnit = QgsUnitTypes::decodeRenderUnit( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/MarginUnit" ), QgsUnitTypes::encodeUnit( mMarginUnit ) ) );
+  mEnabled = QgsApplication::activeProject()->readBoolEntry( mNameConfig, QStringLiteral( "/Enabled" ), false );
+  mPlacement = static_cast< Placement >( QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/Placement" ), static_cast< int >( mPlacement ) ) );
+  mMarginUnit = QgsUnitTypes::decodeRenderUnit( QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/MarginUnit" ), QgsUnitTypes::encodeUnit( mMarginUnit ) ) );
 }
 
 void QgsDecorationItem::saveToProject()
 {
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Enabled" ), mEnabled );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Placement" ), static_cast< int >( mPlacement ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginUnit" ), QgsUnitTypes::encodeUnit( mMarginUnit ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Enabled" ), mEnabled );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Placement" ), static_cast< int >( mPlacement ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MarginUnit" ), QgsUnitTypes::encodeUnit( mMarginUnit ) );
 }
 
 void QgsDecorationItem::setName( const char *name )

--- a/src/app/qgsdecorationlayoutextent.cpp
+++ b/src/app/qgsdecorationlayoutextent.cpp
@@ -53,8 +53,8 @@ void QgsDecorationLayoutExtent::projectRead()
   QDomDocument doc;
   QDomElement elem;
   QgsReadWriteContext rwContext;
-  rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
-  QString xml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Symbol" ) );
+  rwContext.setPathResolver( QgsApplication::activeProject()->pathResolver() );
+  QString xml = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/Symbol" ) );
   mSymbol.reset( nullptr );
   if ( !xml.isEmpty() )
   {
@@ -69,14 +69,14 @@ void QgsDecorationLayoutExtent::projectRead()
     mSymbol->changeSymbolLayer( 0, layer );
   }
 
-  QString textXml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Font" ) );
+  QString textXml = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/Font" ) );
   if ( !textXml.isEmpty() )
   {
     doc.setContent( textXml );
     elem = doc.documentElement();
     mTextFormat.readXml( elem, rwContext );
   }
-  mLabelExtents = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/Labels" ), true );
+  mLabelExtents = QgsApplication::activeProject()->readBoolEntry( mNameConfig, QStringLiteral( "/Labels" ), true );
 }
 
 void QgsDecorationLayoutExtent::saveToProject()
@@ -86,20 +86,20 @@ void QgsDecorationLayoutExtent::saveToProject()
   QDomDocument doc;
   QDomElement elem;
   QgsReadWriteContext rwContext;
-  rwContext.setPathResolver( QgsProject::instance()->pathResolver() );
+  rwContext.setPathResolver( QgsApplication::activeProject()->pathResolver() );
   if ( mSymbol )
   {
     elem = QgsSymbolLayerUtils::saveSymbol( QStringLiteral( "Symbol" ), mSymbol.get(), doc, rwContext );
     doc.appendChild( elem );
     // FIXME this works, but XML will not be valid as < is replaced by &lt;
-    QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Symbol" ), doc.toString() );
+    QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Symbol" ), doc.toString() );
   }
 
   QDomDocument textDoc;
   QDomElement textElem = mTextFormat.writeXml( textDoc, rwContext );
   textDoc.appendChild( textElem );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Font" ), textDoc.toString() );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Labels" ), mLabelExtents );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Font" ), textDoc.toString() );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Labels" ), mLabelExtents );
 }
 
 void QgsDecorationLayoutExtent::run()
@@ -143,7 +143,7 @@ void QgsDecorationLayoutExtent::render( const QgsMapSettings &mapSettings, QgsRe
       {
         // reproject extent
         QgsCoordinateTransform ct( map->crs(),
-                                   mapSettings.destinationCrs(), QgsProject::instance() );
+                                   mapSettings.destinationCrs(), QgsApplication::activeProject() );
         g = g.densifyByCount( 20 );
         try
         {

--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -62,26 +62,26 @@ QgsDecorationNorthArrow::QgsDecorationNorthArrow( QObject *parent )
 void QgsDecorationNorthArrow::projectRead()
 {
   QgsDecorationItem::projectRead();
-  mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
-  mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
-  mSize = QgsProject::instance()->readDoubleEntry( mNameConfig, QStringLiteral( "/Size" ), 16.0 );
-  mSvgPath = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/SvgPath" ), QString() );
-  mRotationInt = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/Rotation" ), 0 );
-  mAutomatic = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/Automatic" ), true );
-  mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
-  mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
+  mColor = QgsSymbolLayerUtils::decodeColor( QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
+  mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
+  mSize = QgsApplication::activeProject()->readDoubleEntry( mNameConfig, QStringLiteral( "/Size" ), 16.0 );
+  mSvgPath = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/SvgPath" ), QString() );
+  mRotationInt = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/Rotation" ), 0 );
+  mAutomatic = QgsApplication::activeProject()->readBoolEntry( mNameConfig, QStringLiteral( "/Automatic" ), true );
+  mMarginHorizontal = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
+  mMarginVertical = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
 }
 
 void QgsDecorationNorthArrow::saveToProject()
 {
   QgsDecorationItem::saveToProject();
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Size" ), mSize );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/SvgPath" ), mSvgPath );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Automatic" ), mAutomatic );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Size" ), mSize );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/SvgPath" ), mSvgPath );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Automatic" ), mAutomatic );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
 }
 
 // Slot called when the buffer menu item is activated
@@ -95,7 +95,7 @@ QString QgsDecorationNorthArrow::svgPath()
 {
   if ( !mSvgPath.isEmpty() )
   {
-    QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( mSvgPath, QgsProject::instance()->pathResolver() );
+    QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( mSvgPath, QgsApplication::activeProject()->pathResolver() );
     bool validSvg = QFileInfo::exists( resolvedPath );
     if ( validSvg )
     {

--- a/src/app/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/qgsdecorationnortharrowdialog.cpp
@@ -163,7 +163,7 @@ void QgsDecorationNorthArrowDialog::updateSvgPath( const QString &svgPath )
   }
   mDeco.mSvgPath = svgPath;
 
-  QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( svgPath, QgsProject::instance()->pathResolver() );
+  QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( svgPath, QgsApplication::activeProject()->pathResolver() );
   bool validSvg = QFileInfo::exists( resolvedPath );
 
   // draw red text for path field if invalid (path can't be resolved)

--- a/src/app/qgsdecorationscalebar.cpp
+++ b/src/app/qgsdecorationscalebar.cpp
@@ -75,28 +75,28 @@ QgsDecorationScaleBar::QgsDecorationScaleBar( QObject *parent )
 void QgsDecorationScaleBar::projectRead()
 {
   QgsDecorationItem::projectRead();
-  mPreferredSize = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/PreferredSize" ), 30 );
-  mStyleIndex = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/Style" ), 0 );
-  mSnapping = QgsProject::instance()->readBoolEntry( mNameConfig, QStringLiteral( "/Snapping" ), true );
-  mColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
-  mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
-  mMarginHorizontal = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
-  mMarginVertical = QgsProject::instance()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
+  mPreferredSize = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/PreferredSize" ), 30 );
+  mStyleIndex = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/Style" ), 0 );
+  mSnapping = QgsApplication::activeProject()->readBoolEntry( mNameConfig, QStringLiteral( "/Snapping" ), true );
+  mColor = QgsSymbolLayerUtils::decodeColor( QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/Color" ), QStringLiteral( "#000000" ) ) );
+  mOutlineColor = QgsSymbolLayerUtils::decodeColor( QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QStringLiteral( "#FFFFFF" ) ) );
+  mMarginHorizontal = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/MarginH" ), 0 );
+  mMarginVertical = QgsApplication::activeProject()->readNumEntry( mNameConfig, QStringLiteral( "/MarginV" ), 0 );
 
   QDomDocument doc;
   QDomElement elem;
-  QString textFormatXml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/TextFormat" ) );
+  QString textFormatXml = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/TextFormat" ) );
   if ( !textFormatXml.isEmpty() )
   {
     doc.setContent( textFormatXml );
     elem = doc.documentElement();
     QgsReadWriteContext context;
-    context.setPathResolver( QgsProject::instance()->pathResolver() );
+    context.setPathResolver( QgsApplication::activeProject()->pathResolver() );
     mTextFormat.readXml( elem, context );
   }
   else
   {
-    QString fontXml = QgsProject::instance()->readEntry( mNameConfig, QStringLiteral( "/Font" ) );
+    QString fontXml = QgsApplication::activeProject()->readEntry( mNameConfig, QStringLiteral( "/Font" ) );
     if ( !fontXml.isEmpty() )
     {
       doc.setContent( fontXml );
@@ -118,21 +118,21 @@ void QgsDecorationScaleBar::projectRead()
 void QgsDecorationScaleBar::saveToProject()
 {
   QgsDecorationItem::saveToProject();
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/PreferredSize" ), mPreferredSize );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Snapping" ), mSnapping );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Style" ), mStyleIndex );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/PreferredSize" ), mPreferredSize );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Snapping" ), mSnapping );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Style" ), mStyleIndex );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/Color" ), QgsSymbolLayerUtils::encodeColor( mColor ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/OutlineColor" ), QgsSymbolLayerUtils::encodeColor( mOutlineColor ) );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MarginH" ), mMarginHorizontal );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/MarginV" ), mMarginVertical );
 
   QDomDocument fontDoc;
   QgsReadWriteContext context;
-  context.setPathResolver( QgsProject::instance()->pathResolver() );
+  context.setPathResolver( QgsApplication::activeProject()->pathResolver() );
   QDomElement textElem = mTextFormat.writeXml( fontDoc, context );
   fontDoc.appendChild( textElem );
 
-  QgsProject::instance()->writeEntry( mNameConfig, QStringLiteral( "/TextFormat" ), fontDoc.toString() );
+  QgsApplication::activeProject()->writeEntry( mNameConfig, QStringLiteral( "/TextFormat" ), fontDoc.toString() );
 }
 
 

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -51,7 +51,7 @@ QgsExpressionContext QgsDiagramProperties::createExpressionContext() const
 {
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
              << QgsExpressionContextUtils::atlasScope( nullptr )
              << QgsExpressionContextUtils::mapSettingsScope( mMapCanvas->mapSettings() )
              << QgsExpressionContextUtils::layerScope( mLayer );
@@ -207,8 +207,8 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer *layer, QWidget *pare
   // field combo and expression button
   mSizeFieldExpressionWidget->setLayer( mLayer );
   QgsDistanceArea myDa;
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
   mSizeFieldExpressionWidget->setGeomCalculator( myDa );
 
   //insert all attributes into the combo boxes
@@ -641,7 +641,7 @@ void QgsDiagramProperties::mFindMaximumValueButton_clicked()
     QgsExpression exp( sizeFieldNameOrExp );
     QgsExpressionContext context;
     context << QgsExpressionContextUtils::globalScope()
-            << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+            << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
             << QgsExpressionContextUtils::mapSettingsScope( mMapCanvas->mapSettings() )
             << QgsExpressionContextUtils::layerScope( mLayer );
 
@@ -922,7 +922,7 @@ void QgsDiagramProperties::apply()
   mLayer->setDiagramLayerSettings( dls );
 
   // refresh
-  QgsProject::instance()->setDirty( true );
+  QgsApplication::activeProject()->setDirty( true );
   mLayer->triggerRepaint();
 }
 
@@ -930,7 +930,7 @@ QString QgsDiagramProperties::showExpressionBuilder( const QString &initialExpre
 {
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
-          << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+          << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
           << QgsExpressionContextUtils::atlasScope( nullptr )
           << QgsExpressionContextUtils::mapSettingsScope( mMapCanvas->mapSettings() )
           << QgsExpressionContextUtils::layerScope( mLayer );
@@ -939,8 +939,8 @@ QString QgsDiagramProperties::showExpressionBuilder( const QString &initialExpre
   dlg.setWindowTitle( tr( "Expression Based Attribute" ) );
 
   QgsDistanceArea myDa;
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
   dlg.setGeomCalculator( myDa );
 
   if ( dlg.exec() == QDialog::Accepted )

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -348,7 +348,7 @@ void QgsVectorLayerAndAttributeModel::applyVisibilityPreset( const QString &name
   }
   else
   {
-    visibleLayers = QgsProject::instance()->mapThemeCollection()->mapThemeVisibleLayerIds( name ).toSet();
+    visibleLayers = QgsApplication::activeProject()->mapThemeCollection()->mapThemeVisibleLayerIds( name ).toSet();
   }
 
   if ( visibleLayers.isEmpty() )
@@ -430,7 +430,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
 
   QgsSettings settings;
 
-  mLayerTreeGroup = QgsProject::instance()->layerTreeRoot()->clone();
+  mLayerTreeGroup = QgsApplication::activeProject()->layerTreeRoot()->clone();
   cleanGroup( mLayerTreeGroup );
 
   mFieldSelectorDelegate = new FieldSelectorDelegate( this );
@@ -463,27 +463,27 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
   } );
 
   //last dxf symbology mode
-  mSymbologyModeComboBox->setCurrentIndex( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfSymbologyMode" ), settings.value( QStringLiteral( "qgis/lastDxfSymbologyMode" ), "2" ).toString() ).toInt() );
+  mSymbologyModeComboBox->setCurrentIndex( QgsApplication::activeProject()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfSymbologyMode" ), settings.value( QStringLiteral( "qgis/lastDxfSymbologyMode" ), "2" ).toString() ).toInt() );
 
   //last symbol scale
   mScaleWidget->setMapCanvas( QgisApp::instance()->mapCanvas() );
-  double oldScale = QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastSymbologyExportScale" ), settings.value( QStringLiteral( "qgis/lastSymbologyExportScale" ), "1/50000" ).toString() ).toDouble();
+  double oldScale = QgsApplication::activeProject()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastSymbologyExportScale" ), settings.value( QStringLiteral( "qgis/lastSymbologyExportScale" ), "1/50000" ).toString() ).toDouble();
   if ( oldScale != 0.0 )
     mScaleWidget->setScale( 1.0 / oldScale );
-  mLayerTitleAsName->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfLayerTitleAsName" ), settings.value( QStringLiteral( "qgis/lastDxfLayerTitleAsName" ), "false" ).toString() ) != QLatin1String( "false" ) );
-  mMapExtentCheckBox->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfMapRectangle" ), settings.value( QStringLiteral( "qgis/lastDxfMapRectangle" ), "false" ).toString() ) != QLatin1String( "false" ) );
-  mMTextCheckBox->setChecked( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfUseMText" ), settings.value( QStringLiteral( "qgis/lastDxfUseMText" ), "true" ).toString() ) != QLatin1String( "false" ) );
+  mLayerTitleAsName->setChecked( QgsApplication::activeProject()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfLayerTitleAsName" ), settings.value( QStringLiteral( "qgis/lastDxfLayerTitleAsName" ), "false" ).toString() ) != QLatin1String( "false" ) );
+  mMapExtentCheckBox->setChecked( QgsApplication::activeProject()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfMapRectangle" ), settings.value( QStringLiteral( "qgis/lastDxfMapRectangle" ), "false" ).toString() ) != QLatin1String( "false" ) );
+  mMTextCheckBox->setChecked( QgsApplication::activeProject()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfUseMText" ), settings.value( QStringLiteral( "qgis/lastDxfUseMText" ), "true" ).toString() ) != QLatin1String( "false" ) );
 
-  QStringList ids = QgsProject::instance()->mapThemeCollection()->mapThemes();
+  QStringList ids = QgsApplication::activeProject()->mapThemeCollection()->mapThemes();
   ids.prepend( QLatin1String( "" ) );
   mVisibilityPresets->addItems( ids );
-  mVisibilityPresets->setCurrentIndex( mVisibilityPresets->findText( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastVisibliltyPreset" ), QLatin1String( "" ) ) ) );
+  mVisibilityPresets->setCurrentIndex( mVisibilityPresets->findText( QgsApplication::activeProject()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastVisibliltyPreset" ), QLatin1String( "" ) ) ) );
 
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
 
-  long crsid = QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfCrs" ),
-               settings.value( QStringLiteral( "qgis/lastDxfCrs" ), QString::number( QgsProject::instance()->crs().srsid() ) ).toString()
-                                                ).toLong();
+  long crsid = QgsApplication::activeProject()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfCrs" ),
+               settings.value( QStringLiteral( "qgis/lastDxfCrs" ), QString::number( QgsApplication::activeProject()->crs().srsid() ) ).toString()
+                                                         ).toLong();
   mCRS = QgsCoordinateReferenceSystem::fromSrsId( crsid );
   mCrsSelector->setCrs( mCRS );
   mCrsSelector->setLayerCrs( mCRS );
@@ -491,7 +491,7 @@ QgsDxfExportDialog::QgsDxfExportDialog( QWidget *parent, Qt::WindowFlags f )
                                 "The data points will be transformed from the layer coordinate reference system." ) );
 
   mEncoding->addItems( QgsDxfExport::encodings() );
-  mEncoding->setCurrentIndex( mEncoding->findText( QgsProject::instance()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfEncoding" ), settings.value( QStringLiteral( "qgis/lastDxfEncoding" ), "CP1252" ).toString() ) ) );
+  mEncoding->setCurrentIndex( mEncoding->findText( QgsApplication::activeProject()->readEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfEncoding" ), settings.value( QStringLiteral( "qgis/lastDxfEncoding" ), "CP1252" ).toString() ) ) );
 }
 
 
@@ -631,14 +631,14 @@ void QgsDxfExportDialog::saveSettings()
   settings.setValue( QStringLiteral( "qgis/lastDxfCrs" ), QString::number( mCRS.srsid() ) );
   settings.setValue( QStringLiteral( "qgis/lastDxfUseMText" ), mMTextCheckBox->isChecked() );
 
-  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfSymbologyMode" ), mSymbologyModeComboBox->currentIndex() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastSymbologyExportScale" ), mScaleWidget->scale() != 0 ? 1.0 / mScaleWidget->scale() : 0 );
-  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfLayerTitleAsName" ), mLayerTitleAsName->isChecked() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfMapRectangle" ), mMapExtentCheckBox->isChecked() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfEncoding" ), mEncoding->currentText() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastVisibilityPreset" ), mVisibilityPresets->currentText() );
-  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfCrs" ), QString::number( mCRS.srsid() ) );
-  QgsProject::instance()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfUseMText" ), mMTextCheckBox->isChecked() );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfSymbologyMode" ), mSymbologyModeComboBox->currentIndex() );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastSymbologyExportScale" ), mScaleWidget->scale() != 0 ? 1.0 / mScaleWidget->scale() : 0 );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfLayerTitleAsName" ), mLayerTitleAsName->isChecked() );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfMapRectangle" ), mMapExtentCheckBox->isChecked() );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfEncoding" ), mEncoding->currentText() );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastVisibilityPreset" ), mVisibilityPresets->currentText() );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfCrs" ), QString::number( mCRS.srsid() ) );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "dxf" ), QStringLiteral( "/lastDxfUseMText" ), mMTextCheckBox->isChecked() );
 }
 
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -57,8 +57,8 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
 
   QgsDistanceArea myDa;
 
-  myDa.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
 
   context.setDistanceArea( myDa );
   context.setVectorLayerTools( QgisApp::instance()->vectorLayerTools() );

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -70,8 +70,8 @@ QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer *vl, QWidget *parent )
   connect( mButtonBox, &QDialogButtonBox::helpRequested, this, &QgsFieldCalculator::showHelp );
 
   QgsDistanceArea myDa;
-  myDa.setSourceCrs( vl->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( vl->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
   builder->setGeomCalculator( myDa );
 
   //default values for field width and precision
@@ -169,14 +169,14 @@ void QgsFieldCalculator::accept()
   // Set up QgsDistanceArea each time we (re-)calculate
   QgsDistanceArea myDa;
 
-  myDa.setSourceCrs( mVectorLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  myDa.setSourceCrs( mVectorLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  myDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
 
   QString calcString = builder->expressionText();
   QgsExpression exp( calcString );
   exp.setGeomCalculator( &myDa );
-  exp.setDistanceUnits( QgsProject::instance()->distanceUnits() );
-  exp.setAreaUnits( QgsProject::instance()->areaUnits() );
+  exp.setDistanceUnits( QgsApplication::activeProject()->distanceUnits() );
+  exp.setAreaUnits( QgsApplication::activeProject()->areaUnits() );
 
   QgsExpressionContext expContext( QgsExpressionContextUtils::globalProjectLayerScopes( mVectorLayer ) );
 

--- a/src/app/qgsformannotationdialog.cpp
+++ b/src/app/qgsformannotationdialog.cpp
@@ -82,7 +82,7 @@ void QgsFormAnnotationDialog::mBrowseToolButton_clicked()
 void QgsFormAnnotationDialog::deleteItem()
 {
   if ( mItem && mItem->annotation() )
-    QgsProject::instance()->annotationManager()->removeAnnotation( mItem->annotation() );
+    QgsApplication::activeProject()->annotationManager()->removeAnnotation( mItem->annotation() );
   mItem = nullptr;
 }
 

--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -362,7 +362,7 @@ void QgsHandleBadLayers::apply()
     QString datasource = item->text();
 
     node.namedItem( QStringLiteral( "datasource" ) ).toElement().firstChild().toText().setData( datasource );
-    if ( QgsProject::instance()->readLayer( node ) )
+    if ( QgsApplication::activeProject()->readLayer( node ) )
     {
       mLayerList->removeRow( i-- );
     }

--- a/src/app/qgshtmlannotationdialog.cpp
+++ b/src/app/qgshtmlannotationdialog.cpp
@@ -87,7 +87,7 @@ void QgsHtmlAnnotationDialog::mBrowseToolButton_clicked()
 void QgsHtmlAnnotationDialog::deleteItem()
 {
   if ( mItem && mItem->annotation() )
-    QgsProject::instance()->annotationManager()->removeAnnotation( mItem->annotation() );
+    QgsApplication::activeProject()->annotationManager()->removeAnnotation( mItem->annotation() );
   mItem = nullptr;
 }
 

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1102,7 +1102,7 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent *event )
   mActionPopup->addAction( tr( "Clear Highlights" ), this, SLOT( clearHighlights() ) );
   mActionPopup->addAction( tr( "Highlight All" ), this, SLOT( highlightAll() ) );
   mActionPopup->addAction( tr( "Highlight Layer" ), this, SLOT( highlightLayer() ) );
-  if ( layer && QgsProject::instance()->layerIsEmbedded( layer->id() ).isEmpty() )
+  if ( layer && QgsApplication::activeProject()->layerIsEmbedded( layer->id() ).isEmpty() )
   {
     mActionPopup->addAction( tr( "Activate Layer" ), this, SLOT( activateLayer() ) );
     mActionPopup->addAction( tr( "Layer Properties…" ), this, SLOT( layerProperties() ) );

--- a/src/app/qgslabelengineconfigdialog.cpp
+++ b/src/app/qgslabelengineconfigdialog.cpp
@@ -31,7 +31,7 @@ QgsLabelEngineConfigDialog::QgsLabelEngineConfigDialog( QWidget *parent )
   connect( buttonBox->button( QDialogButtonBox::RestoreDefaults ), &QAbstractButton::clicked,
            this, &QgsLabelEngineConfigDialog::setDefaults );
 
-  QgsLabelingEngineSettings engineSettings = QgsProject::instance()->labelingEngineSettings();
+  QgsLabelingEngineSettings engineSettings = QgsApplication::activeProject()->labelingEngineSettings();
 
   // search method
   cboSearchMethod->setCurrentIndex( engineSettings.searchMethod() );
@@ -65,7 +65,7 @@ void QgsLabelEngineConfigDialog::onOK()
   engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, chkShowPartialsLabels->isChecked() );
   engineSettings.setFlag( QgsLabelingEngineSettings::RenderOutlineLabels, mDrawOutlinesChkBox->isChecked() );
 
-  QgsProject::instance()->setLabelingEngineSettings( engineSettings );
+  QgsApplication::activeProject()->setLabelingEngineSettings( engineSettings );
 
   accept();
 }

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -30,7 +30,7 @@ QgsExpressionContext QgsLabelingGui::createExpressionContext() const
 {
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
              << QgsExpressionContextUtils::atlasScope( nullptr )
              << QgsExpressionContextUtils::mapSettingsScope( QgisApp::instance()->mapCanvas()->mapSettings() );
 
@@ -115,8 +115,8 @@ void QgsLabelingGui::setLayer( QgsMapLayer *mapLayer )
 
   mFieldExpressionWidget->setLayer( mLayer );
   QgsDistanceArea da;
-  da.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
-  da.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  da.setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
+  da.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
   mFieldExpressionWidget->setGeomCalculator( da );
 
   // set placement methods page based on geometry type

--- a/src/app/qgslabelpropertydialog.cpp
+++ b/src/app/qgslabelpropertydialog.cpp
@@ -93,7 +93,7 @@ void QgsLabelPropertyDialog::buttonBox_clicked( QAbstractButton *button )
 void QgsLabelPropertyDialog::init( const QString &layerId, const QString &providerId, int featureId, const QString &labelText )
 {
   //get feature attributes
-  QgsVectorLayer *vlayer = dynamic_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+  QgsVectorLayer *vlayer = dynamic_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( layerId ) );
   if ( !vlayer )
   {
     return;
@@ -254,7 +254,7 @@ void QgsLabelPropertyDialog::setDataDefinedValues( QgsVectorLayer *vlayer )
 
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
-          << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+          << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
           << QgsExpressionContextUtils::atlasScope( nullptr )
           << QgsExpressionContextUtils::mapSettingsScope( QgisApp::instance()->mapCanvas()->mapSettings() )
           << QgsExpressionContextUtils::layerScope( vlayer );

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -60,7 +60,7 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, const QList<
 {
   setupUi( this );
 
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) > ( &QgsProject::layerWillBeRemoved ), this, &QgsLayerStylingWidget::layerAboutToBeRemoved );
+  connect( QgsApplication::activeProject(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) > ( &QgsProject::layerWillBeRemoved ), this, &QgsLayerStylingWidget::layerAboutToBeRemoved );
 
   QgsSettings settings;
   mLiveApplyCheck->setChecked( settings.value( QStringLiteral( "UI/autoApplyStyling" ), true ).toBool() );
@@ -275,7 +275,7 @@ void QgsLayerStylingWidget::apply()
   if ( styleWasChanged )
   {
     emit styleChanged( mCurrentLayer );
-    QgsProject::instance()->setDirty( true );
+    QgsApplication::activeProject()->setDirty( true );
     mCurrentLayer->triggerRepaint();
   }
   connect( mCurrentLayer, &QgsMapLayer::styleChanged, this, &QgsLayerStylingWidget::updateCurrentWidgetLayer );

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -349,7 +349,7 @@ void QgsMapCanvasDockWidget::syncViewCenter( QgsMapCanvas *sourceCanvas )
 
   // reproject extent
   QgsCoordinateTransform ct( sourceCanvas->mapSettings().destinationCrs(),
-                             destCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+                             destCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
   try
   {
     destCanvas->setCenter( ct.transform( sourceCanvas->center() ) );
@@ -408,7 +408,7 @@ void QgsMapCanvasDockWidget::menuAboutToShow()
 
   QAction *actionFollowMain = new QAction( tr( "(default)" ), mMenu );
   actionFollowMain->setCheckable( true );
-  if ( currentTheme.isEmpty() || !QgsProject::instance()->mapThemeCollection()->hasMapTheme( currentTheme ) )
+  if ( currentTheme.isEmpty() || !QgsApplication::activeProject()->mapThemeCollection()->hasMapTheme( currentTheme ) )
   {
     actionFollowMain->setChecked( true );
   }
@@ -419,7 +419,7 @@ void QgsMapCanvasDockWidget::menuAboutToShow()
   } );
   mMenuPresetActions.append( actionFollowMain );
 
-  Q_FOREACH ( const QString &grpName, QgsProject::instance()->mapThemeCollection()->mapThemes() )
+  Q_FOREACH ( const QString &grpName, QgsApplication::activeProject()->mapThemeCollection()->mapThemes() )
   {
     QAction *a = new QAction( grpName, mMenu );
     a->setCheckable( true );
@@ -449,7 +449,7 @@ void QgsMapCanvasDockWidget::syncMarker( const QgsPointXY &p )
 
   // reproject point
   QgsCoordinateTransform ct( mMainCanvas->mapSettings().destinationCrs(),
-                             mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+                             mMapCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
   QgsPointXY t = p;
   try
   {
@@ -487,7 +487,7 @@ void QgsMapCanvasDockWidget::updateExtentRect()
   {
     // reproject extent
     QgsCoordinateTransform ct( mMainCanvas->mapSettings().destinationCrs(),
-                               mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+                               mMapCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
     g = g.densifyByCount( 5 );
     try
     {

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -296,13 +296,13 @@ void QgsMapSaveDialog::applyMapSettings( QgsMapSettings &mapSettings )
   mapSettings.setRotation( mMapCanvas->rotation() );
   mapSettings.setLayers( mMapCanvas->layers() );
   mapSettings.setLabelingEngineSettings( mMapCanvas->mapSettings().labelingEngineSettings() );
-  mapSettings.setTransformContext( QgsProject::instance()->transformContext() );
-  mapSettings.setPathResolver( QgsProject::instance()->pathResolver() );
+  mapSettings.setTransformContext( QgsApplication::activeProject()->transformContext() );
+  mapSettings.setPathResolver( QgsApplication::activeProject()->pathResolver() );
 
   //build the expression context
   QgsExpressionContext expressionContext;
   expressionContext << QgsExpressionContextUtils::globalScope()
-                    << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+                    << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
                     << QgsExpressionContextUtils::mapSettingsScope( mapSettings );
 
   mapSettings.setExpressionContext( expressionContext );

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -58,7 +58,7 @@ QgsMapThemes::QgsMapThemes()
 
 QgsMapThemeCollection::MapThemeRecord QgsMapThemes::currentState()
 {
-  QgsLayerTreeGroup *root = QgsProject::instance()->layerTreeRoot();
+  QgsLayerTreeGroup *root = QgsApplication::activeProject()->layerTreeRoot();
   QgsLayerTreeModel *model = QgisApp::instance()->layerTreeView()->layerTreeModel();
   return QgsMapThemeCollection::createThemeFromCurrentState( root, model );
 }
@@ -73,21 +73,21 @@ QgsMapThemes *QgsMapThemes::instance()
 
 void QgsMapThemes::addPreset( const QString &name )
 {
-  QgsProject::instance()->mapThemeCollection()->insert( name, currentState() );
+  QgsApplication::activeProject()->mapThemeCollection()->insert( name, currentState() );
 }
 
 void QgsMapThemes::updatePreset( const QString &name )
 {
-  QgsProject::instance()->mapThemeCollection()->update( name, currentState() );
+  QgsApplication::activeProject()->mapThemeCollection()->update( name, currentState() );
 }
 
 QList<QgsMapLayer *> QgsMapThemes::orderedPresetVisibleLayers( const QString &name ) const
 {
-  QStringList visibleIds = QgsProject::instance()->mapThemeCollection()->mapThemeVisibleLayerIds( name );
+  QStringList visibleIds = QgsApplication::activeProject()->mapThemeCollection()->mapThemeVisibleLayerIds( name );
 
   // also make sure to order the layers according to map canvas order
   QList<QgsMapLayer *> lst;
-  Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->layerTreeRoot()->layerOrder() )
+  Q_FOREACH ( QgsMapLayer *layer, QgsApplication::activeProject()->layerTreeRoot()->layerOrder() )
   {
     if ( visibleIds.contains( layer->id() ) )
     {
@@ -105,7 +105,7 @@ QMenu *QgsMapThemes::menu()
 
 void QgsMapThemes::addPreset()
 {
-  QStringList existingNames = QgsProject::instance()->mapThemeCollection()->mapThemes();
+  QStringList existingNames = QgsApplication::activeProject()->mapThemeCollection()->mapThemes();
   QgsNewNameDialog dlg( tr( "theme" ), tr( "Theme" ), QStringList(), existingNames, QRegExp(), Qt::CaseInsensitive, mMenu );
   dlg.setWindowTitle( tr( "Map Themes" ) );
   dlg.setHintString( tr( "Name of the new theme" ) );
@@ -146,12 +146,12 @@ void QgsMapThemes::replaceTriggered()
 
 void QgsMapThemes::applyState( const QString &presetName )
 {
-  if ( !QgsProject::instance()->mapThemeCollection()->hasMapTheme( presetName ) )
+  if ( !QgsApplication::activeProject()->mapThemeCollection()->hasMapTheme( presetName ) )
     return;
 
-  QgsLayerTreeGroup *root = QgsProject::instance()->layerTreeRoot();
+  QgsLayerTreeGroup *root = QgsApplication::activeProject()->layerTreeRoot();
   QgsLayerTreeModel *model = QgisApp::instance()->layerTreeView()->layerTreeModel();
-  QgsProject::instance()->mapThemeCollection()->applyTheme( presetName, root, model );
+  QgsApplication::activeProject()->mapThemeCollection()->applyTheme( presetName, root, model );
 }
 
 void QgsMapThemes::removeCurrentPreset()
@@ -164,7 +164,7 @@ void QgsMapThemes::removeCurrentPreset()
                                        tr( "Are you sure you want to remove the existing theme “%1”?" ).arg( actionPreset->text() ),
                                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No );
       if ( res == QMessageBox::Yes )
-        QgsProject::instance()->mapThemeCollection()->removeMapTheme( actionPreset->text() );
+        QgsApplication::activeProject()->mapThemeCollection()->removeMapTheme( actionPreset->text() );
       break;
     }
   }
@@ -181,11 +181,11 @@ void QgsMapThemes::menuAboutToShow()
   QgsMapThemeCollection::MapThemeRecord rec = currentState();
   bool hasCurrent = false;
 
-  Q_FOREACH ( const QString &grpName, QgsProject::instance()->mapThemeCollection()->mapThemes() )
+  Q_FOREACH ( const QString &grpName, QgsApplication::activeProject()->mapThemeCollection()->mapThemes() )
   {
     QAction *a = new QAction( grpName, mMenu );
     a->setCheckable( true );
-    if ( !hasCurrent && rec == QgsProject::instance()->mapThemeCollection()->mapThemeState( grpName ) )
+    if ( !hasCurrent && rec == QgsApplication::activeProject()->mapThemeCollection()->mapThemeState( grpName ) )
     {
       a->setChecked( true );
       hasCurrent = true;

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -63,11 +63,11 @@ void QgsMapToolAddFeature::digitized( QgsFeature &f )
   if ( res && ( mode() == CaptureLine || mode() == CapturePolygon ) )
   {
     //add points to other features to keep topology up-to-date
-    bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+    bool topologicalEditing = QgsApplication::activeProject()->topologicalEditing();
 
     //use always topological editing for avoidIntersection.
     //Otherwise, no way to guarantee the geometries don't have a small gap in between.
-    QList<QgsVectorLayer *> intersectionLayers = QgsProject::instance()->avoidIntersectionsLayers();
+    QList<QgsVectorLayer *> intersectionLayers = QgsApplication::activeProject()->avoidIntersectionsLayers();
     bool avoidIntersection = !intersectionLayers.isEmpty();
     if ( avoidIntersection ) //try to add topological points also to background layers
     {

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -159,7 +159,7 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         QgsCurvePolygon *cp = new QgsCurvePolygon();
         cp->setExteriorRing( curveToAdd );
         QgsGeometry *geom = new QgsGeometry( cp );
-        geom->avoidIntersections( QgsProject::instance()->avoidIntersectionsLayers() );
+        geom->avoidIntersections( QgsApplication::activeProject()->avoidIntersectionsLayers() );
 
         const QgsCurvePolygon *cpGeom = qgsgeometry_cast<const QgsCurvePolygon *>( geom->constGet() );
         if ( !cpGeom )
@@ -195,7 +195,7 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
       emit messageDiscarded();
 
       //add points to other features to keep topology up-to-date
-      bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+      bool topologicalEditing = QgsApplication::activeProject()->topologicalEditing();
       if ( topologicalEditing )
       {
         addTopologicalPoints( points() );

--- a/src/app/qgsmaptoolannotation.cpp
+++ b/src/app/qgsmaptoolannotation.cpp
@@ -124,7 +124,7 @@ void QgsMapToolAnnotation::canvasPressEvent( QgsMapMouseEvent *e )
                                          e->pos().y() / mCanvas->height() ) );
         annotation->setFrameSize( QSizeF( 200, 100 ) );
 
-        QgsProject::instance()->annotationManager()->addAnnotation( annotation );
+        QgsApplication::activeProject()->annotationManager()->addAnnotation( annotation );
 
         // select newly added item
         Q_FOREACH ( QGraphicsItem *item, mCanvas->items() )
@@ -156,7 +156,7 @@ void QgsMapToolAnnotation::keyPressEvent( QKeyEvent *e )
     if ( e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Delete )
     {
       QCursor neutralCursor( item->cursorShapeForAction( QgsMapCanvasAnnotationItem::NoAction ) );
-      QgsProject::instance()->annotationManager()->removeAnnotation( item->annotation() );
+      QgsApplication::activeProject()->annotationManager()->removeAnnotation( item->annotation() );
       if ( mCanvas )
       {
         mCanvas->setCursor( neutralCursor );
@@ -183,7 +183,7 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent *e )
       annotation->setRelativePosition( QPointF( e->pos().x() / mCanvas->width(),
                                        e->pos().y() / mCanvas->height() ) );
       item->update();
-      QgsProject::instance()->setDirty( true );
+      QgsApplication::activeProject()->setDirty( true );
     }
     else if ( mCurrentMoveAction == QgsMapCanvasAnnotationItem::MoveFramePosition )
     {
@@ -202,7 +202,7 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent *e )
                                          newCanvasPos.y() / mCanvas->height() ) );
       }
       item->update();
-      QgsProject::instance()->setDirty( true );
+      QgsApplication::activeProject()->setDirty( true );
     }
     else if ( mCurrentMoveAction != QgsMapCanvasAnnotationItem::NoAction )
     {
@@ -261,7 +261,7 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent *e )
       annotation->setFrameSize( QSizeF( xmax - xmin, ymax - ymin ) );
       annotation->setRelativePosition( QPointF( relPosX, relPosY ) );
       item->update();
-      QgsProject::instance()->setDirty( true );
+      QgsApplication::activeProject()->setDirty( true );
     }
   }
   else if ( item )
@@ -286,7 +286,7 @@ void QgsMapToolAnnotation::canvasDoubleClickEvent( QgsMapMouseEvent *e )
   if ( itemEditor )
   {
     if ( itemEditor->exec() )
-      QgsProject::instance()->setDirty( true );
+      QgsApplication::activeProject()->setDirty( true );
     delete itemEditor;
   }
 }
@@ -359,7 +359,7 @@ QgsPointXY QgsMapToolAnnotation::transformCanvasToAnnotation( QgsPointXY p, QgsA
 {
   if ( annotation->mapPositionCrs() != mCanvas->mapSettings().destinationCrs() )
   {
-    QgsCoordinateTransform transform( mCanvas->mapSettings().destinationCrs(), annotation->mapPositionCrs(), QgsProject::instance() );
+    QgsCoordinateTransform transform( mCanvas->mapSettings().destinationCrs(), annotation->mapPositionCrs(), QgsApplication::activeProject() );
     try
     {
       p = transform.transform( p );

--- a/src/app/qgsmaptooldigitizefeature.cpp
+++ b/src/app/qgsmaptooldigitizefeature.cpp
@@ -309,7 +309,7 @@ void QgsMapToolDigitizeFeature::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
         f->setGeometry( g );
 
         QgsGeometry featGeom = f->geometry();
-        int avoidIntersectionsReturn = featGeom.avoidIntersections( QgsProject::instance()->avoidIntersectionsLayers() );
+        int avoidIntersectionsReturn = featGeom.avoidIntersections( QgsApplication::activeProject()->avoidIntersectionsLayers() );
         f->setGeometry( featGeom );
         if ( avoidIntersectionsReturn == 1 )
         {

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -132,7 +132,7 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
       // define custom substitutions: layer id and clicked coords
       QgsExpressionContext context;
       context << QgsExpressionContextUtils::globalScope()
-              << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+              << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
               << QgsExpressionContextUtils::mapSettingsScope( mCanvas->mapSettings() );
       QgsExpressionContextScope *actionScope = new QgsExpressionContextScope();
       actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "click_x" ), point.x(), true ) );

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -206,12 +206,12 @@ void QgsMapToolIdentifyAction::deactivate()
 
 QgsUnitTypes::DistanceUnit QgsMapToolIdentifyAction::displayDistanceUnits() const
 {
-  return QgsProject::instance()->distanceUnits();
+  return QgsApplication::activeProject()->distanceUnits();
 }
 
 QgsUnitTypes::AreaUnit QgsMapToolIdentifyAction::displayAreaUnits() const
 {
-  return QgsProject::instance()->areaUnits();
+  return QgsApplication::activeProject()->areaUnits();
 }
 
 void QgsMapToolIdentifyAction::handleCopyToClipboard( QgsFeatureStore &featureStore )

--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -690,7 +690,7 @@ bool QgsMapToolLabel::diagramCanShowHide( QgsVectorLayer *vlayer, int &showCol )
 QgsMapToolLabel::LabelDetails::LabelDetails( const QgsLabelPosition &p )
   : pos( p )
 {
-  layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( pos.layerID ) );
+  layer = qobject_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( pos.layerID ) );
   if ( layer && layer->labelsEnabled() && !p.isDiagram )
   {
     settings = layer->labeling()->settings( pos.providerID );

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -180,7 +180,7 @@ void QgsMapToolMeasureAngle::updateSettings()
 
 void QgsMapToolMeasureAngle::configureDistanceArea()
 {
-  QString ellipsoidId = QgsProject::instance()->ellipsoid();
-  mDa.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
+  QString ellipsoidId = QgsApplication::activeProject()->ellipsoid();
+  mDa.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject()->transformContext() );
   mDa.setEllipsoid( ellipsoidId );
 }

--- a/src/app/qgsmaptooloffsetpointsymbol.cpp
+++ b/src/app/qgsmaptooloffsetpointsymbol.cpp
@@ -251,7 +251,7 @@ QPointF QgsMapToolOffsetPointSymbol::calculateOffset( const QgsPointXY &startPoi
     case QgsUnitTypes::RenderMetersInMapUnits:
     {
       QgsDistanceArea distanceArea;
-      distanceArea.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
+      distanceArea.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject()->transformContext() );
       distanceArea.setEllipsoid( mCanvas->mapSettings().ellipsoid() );
       // factor=1.0 / 1 meter in MapUnits
       factor = 1.0 / distanceArea.measureLineProjected( startPoint );

--- a/src/app/qgsmaptoolpinlabels.cpp
+++ b/src/app/qgsmaptoolpinlabels.cpp
@@ -198,7 +198,7 @@ void QgsMapToolPinLabels::highlightPinnedLabels()
       }
 
       QColor lblcolor = QColor( 54, 129, 255, 63 );
-      QgsMapLayer *layer = QgsProject::instance()->mapLayer( pos.layerID );
+      QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( pos.layerID );
       if ( !layer )
       {
         continue;

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -156,7 +156,7 @@ void QgsMapToolReshape::reshape( QgsVectorLayer *vlayer )
           QHash<QgsVectorLayer *, QSet<QgsFeatureId> > ignoreFeatures;
           ignoreFeatures.insert( vlayer, vlayer->allFeatureIds() );
 
-          if ( geom.avoidIntersections( QgsProject::instance()->avoidIntersectionsLayers(), ignoreFeatures ) != 0 )
+          if ( geom.avoidIntersections( QgsApplication::activeProject()->avoidIntersectionsLayers(), ignoreFeatures ) != 0 )
           {
             emit messageEmitted( tr( "An error was reported during intersection removal" ), Qgis::Critical );
             vlayer->destroyEditCommand();

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -177,7 +177,7 @@ QgsFeatureIds QgsMapToolSelectUtils::getMatchingFeatures( QgsMapCanvas *canvas, 
 
   try
   {
-    QgsCoordinateTransform ct( canvas->mapSettings().destinationCrs(), vlayer->crs(), QgsProject::instance() );
+    QgsCoordinateTransform ct( canvas->mapSettings().destinationCrs(), vlayer->crs(), QgsApplication::activeProject() );
 
     if ( !ct.isShortCircuited() && selectGeomTrans.type() == QgsWkbTypes::PolygonGeometry )
     {

--- a/src/app/qgsmaptoolshowhidelabels.cpp
+++ b/src/app/qgsmaptoolshowhidelabels.cpp
@@ -199,7 +199,7 @@ bool QgsMapToolShowHideLabels::selectedFeatures( QgsVectorLayer *vlayer,
 
   try
   {
-    QgsCoordinateTransform ct( mCanvas->mapSettings().destinationCrs(), vlayer->crs(), QgsProject::instance() );
+    QgsCoordinateTransform ct( mCanvas->mapSettings().destinationCrs(), vlayer->crs(), QgsApplication::activeProject() );
     selectGeomTrans.transform( ct );
   }
   catch ( QgsCsException &cse )

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -91,7 +91,7 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     deleteTempRubberBand();
 
     //bring up dialog if a split was not possible (polygon) or only done once (line)
-    int topologicalEditing = QgsProject::instance()->topologicalEditing();
+    int topologicalEditing = QgsApplication::activeProject()->topologicalEditing();
     vlayer->beginEditCommand( tr( "Features split" ) );
     QgsGeometry::OperationResult returnCode = vlayer->splitFeatures( points(), topologicalEditing );
     vlayer->endEditCommand();

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -89,7 +89,7 @@ void QgsMapToolSplitParts::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     deleteTempRubberBand();
 
     //bring up dialog if a split was not possible (polygon) or only done once (line)
-    bool topologicalEditing = QgsProject::instance()->topologicalEditing();
+    bool topologicalEditing = QgsApplication::activeProject()->topologicalEditing();
     vlayer->beginEditCommand( tr( "Parts split" ) );
     QgsGeometry::OperationResult returnCode = vlayer->splitParts( points(), topologicalEditing );
     vlayer->endEditCommand();

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -51,9 +51,9 @@ QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f )
 
   repopulateComboBoxUnits( mMeasureArea );
   if ( mMeasureArea )
-    mUnitsCombo->setCurrentIndex( mUnitsCombo->findData( QgsProject::instance()->areaUnits() ) );
+    mUnitsCombo->setCurrentIndex( mUnitsCombo->findData( QgsApplication::activeProject()->areaUnits() ) );
   else
-    mUnitsCombo->setCurrentIndex( mUnitsCombo->findData( QgsProject::instance()->distanceUnits() ) );
+    mUnitsCombo->setCurrentIndex( mUnitsCombo->findData( QgsApplication::activeProject()->distanceUnits() ) );
 
   if ( !mCanvas->mapSettings().destinationCrs().isValid() )
   {
@@ -102,10 +102,10 @@ void QgsMeasureDialog::updateSettings()
   mDecimalPlaces = settings.value( QStringLiteral( "qgis/measure/decimalplaces" ), "3" ).toInt();
   mCanvasUnits = mCanvas->mapUnits();
   // Configure QgsDistanceArea
-  mDistanceUnits = QgsProject::instance()->distanceUnits();
-  mAreaUnits = QgsProject::instance()->areaUnits();
-  mDa.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
-  mDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  mDistanceUnits = QgsApplication::activeProject()->distanceUnits();
+  mAreaUnits = QgsApplication::activeProject()->areaUnits();
+  mDa.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject()->transformContext() );
+  mDa.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
 
   mTable->clear();
   mTotal = 0;

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -132,7 +132,7 @@ void QgsMeasureTool::updateSettings()
 
     mDialog->restart();
     mDone = lastDone;
-    QgsCoordinateTransform ct( mDestinationCrs, mCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+    QgsCoordinateTransform ct( mDestinationCrs, mCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
 
     Q_FOREACH ( const QgsPointXY &previousPoint, points )
     {

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -469,7 +469,7 @@ bool QgsNewSpatialiteLayerDialog::apply()
     myList << layer;
     //addMapLayers returns a list of all successfully added layers
     //so we compare that to our original list.
-    if ( myList == QgsProject::instance()->addMapLayers( myList ) )
+    if ( myList == QgsApplication::activeProject()->addMapLayers( myList ) )
       return true;
   }
   else

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1117,7 +1117,7 @@ void QgsOptions::cbxProjectDefaultNew_toggled( bool checked )
 void QgsOptions::setCurrentProjectDefault()
 {
   QString fileName = QgsApplication::qgisSettingsDirPath() + QStringLiteral( "project_default.qgs" );
-  if ( QgsProject::instance()->write( fileName ) )
+  if ( QgsApplication::activeProject()->write( fileName ) )
   {
     QMessageBox::information( nullptr, tr( "Save Default Project" ), tr( "Current project saved as default" ) );
   }

--- a/src/app/qgspointmarkeritem.cpp
+++ b/src/app/qgspointmarkeritem.cpp
@@ -32,7 +32,7 @@ QgsRenderContext QgsPointMarkerItem::renderContext( QPainter *painter )
 {
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
-          << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+          << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
           << QgsExpressionContextUtils::atlasScope( nullptr );
   if ( mMapCanvas )
   {

--- a/src/app/qgsprojectlayergroupdialog.cpp
+++ b/src/app/qgsprojectlayergroupdialog.cpp
@@ -152,7 +152,7 @@ void QgsProjectLayerGroupDialog::changeProjectFile()
   }
 
   //check we are not embedding from/to the same project
-  if ( mProjectFileWidget->isVisible() && mProjectFileWidget->filePath() == QgsProject::instance()->fileName() )
+  if ( mProjectFileWidget->isVisible() && mProjectFileWidget->filePath() == QgsApplication::activeProject()->fileName() )
   {
     QMessageBox::critical( nullptr, tr( "Embed Layers and Groups" ), tr( "Recursive embedding is not supported. It is not possible to embed layers / groups from the current project." ) );
     return;

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -165,7 +165,7 @@ void QgsRasterCalcDialog::setExtentSize( int width, int height, QgsRectangle bbo
 
 void QgsRasterCalcDialog::insertAvailableRasterBands()
 {
-  const QMap<QString, QgsMapLayer *> &layers = QgsProject::instance()->mapLayers();
+  const QMap<QString, QgsMapLayer *> &layers = QgsApplication::activeProject()->mapLayers();
   QMap<QString, QgsMapLayer *>::const_iterator layerIt = layers.constBegin();
 
   for ( ; layerIt != layers.constEnd(); ++layerIt )

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1052,7 +1052,7 @@ void QgsRasterLayerProperties::apply()
   mRasterLayer->triggerRepaint();
 
   // notify the project we've made a change
-  QgsProject::instance()->setDirty( true );
+  QgsApplication::activeProject()->setDirty( true );
 }//apply
 
 void QgsRasterLayerProperties::mLayerOrigNameLineEd_textEdited( const QString &text )
@@ -1229,7 +1229,7 @@ void QgsRasterLayerProperties::pbnAddValuesManually_clicked()
 
 void QgsRasterLayerProperties::mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs )
 {
-  QgisApp::instance()->askUserForDatumTransform( crs, QgsProject::instance()->crs() );
+  QgisApp::instance()->askUserForDatumTransform( crs, QgsApplication::activeProject()->crs() );
   mRasterLayer->setCrs( crs );
   mMetadataWidget->crsChanged();
 }

--- a/src/app/qgsrulebasedlabelingwidget.cpp
+++ b/src/app/qgsrulebasedlabelingwidget.cpp
@@ -35,7 +35,7 @@ static QList<QgsExpressionContextScope *> _globalProjectAtlasMapLayerScopes( Qgs
 {
   QList<QgsExpressionContextScope *> scopes;
   scopes << QgsExpressionContextUtils::globalScope()
-         << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+         << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
          << QgsExpressionContextUtils::atlasScope( nullptr );
   if ( mapCanvas )
   {

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -75,7 +75,7 @@ QWidget *QgsSnappingLayerDelegate::createEditor( QWidget *parent, const QStyleOp
   {
     QComboBox *w = new QComboBox( parent );
     w->addItem( tr( "px" ), QgsTolerance::Pixels );
-    w->addItem( QgsUnitTypes::toString( QgsProject::instance()->distanceUnits() ), QgsTolerance::ProjectUnits );
+    w->addItem( QgsUnitTypes::toString( QgsApplication::activeProject()->distanceUnits() ), QgsTolerance::ProjectUnits );
     return w;
   }
 
@@ -474,7 +474,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
           case QgsTolerance::Pixels:
             return tr( "pixels" );
           case QgsTolerance::ProjectUnits:
-            return QgsUnitTypes::toString( QgsProject::instance()->distanceUnits() );
+            return QgsUnitTypes::toString( QgsApplication::activeProject()->distanceUnits() );
           default:
             return QVariant();
         }

--- a/src/app/qgssourcefieldsproperties.cpp
+++ b/src/app/qgssourcefieldsproperties.cpp
@@ -119,7 +119,7 @@ void QgsSourceFieldsProperties::updateExpression()
 
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
-          << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+          << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
 
   QgsExpressionBuilderDialog dlg( mLayer, exp, nullptr, QStringLiteral( "generic" ), context );
 

--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -66,7 +66,7 @@ QgsExpressionContext QgsStatisticalSummaryDockWidget::createExpressionContext() 
 {
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
              << QgsExpressionContextUtils::mapSettingsScope( QgisApp::instance()->mapCanvas()->mapSettings() )
              << QgsExpressionContextUtils::layerScope( mLayer );
 
@@ -97,7 +97,7 @@ QgsStatisticalSummaryDockWidget::QgsStatisticalSummaryDockWidget( QWidget *paren
   connect( mSelectedOnlyCheckBox, &QAbstractButton::toggled, this, &QgsStatisticalSummaryDockWidget::refreshStatistics );
   connect( mButtonCopy, &QAbstractButton::clicked, this, &QgsStatisticalSummaryDockWidget::copyStatistics );
   connect( mButtonRefresh, &QAbstractButton::clicked, this, &QgsStatisticalSummaryDockWidget::refreshStatistics );
-  connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsStatisticalSummaryDockWidget::layersRemoved );
+  connect( QgsApplication::activeProject(), static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsStatisticalSummaryDockWidget::layersRemoved );
 
   mStatisticsMenu = new QMenu( mOptionsToolButton );
   mOptionsToolButton->setMenu( mStatisticsMenu );

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -231,7 +231,7 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPointXY &p )
     return;
   }
 
-  mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( QgsProject::instance(), p, mMapCanvas->mapSettings().destinationCrs(),
+  mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( QgsApplication::activeProject(), p, mMapCanvas->mapSettings().destinationCrs(),
                       mMousePrecisionDecimalPlaces ) );
 
   ensureCoordinatesVisible();

--- a/src/app/qgssvgannotationdialog.cpp
+++ b/src/app/qgssvgannotationdialog.cpp
@@ -85,7 +85,7 @@ void QgsSvgAnnotationDialog::applySettingsToItem()
 void QgsSvgAnnotationDialog::deleteItem()
 {
   if ( mItem && mItem->annotation() )
-    QgsProject::instance()->annotationManager()->removeAnnotation( mItem->annotation() );
+    QgsApplication::activeProject()->annotationManager()->removeAnnotation( mItem->annotation() );
   mItem = nullptr;
 }
 

--- a/src/app/qgstextannotationdialog.cpp
+++ b/src/app/qgstextannotationdialog.cpp
@@ -164,7 +164,7 @@ void QgsTextAnnotationDialog::blockAllSignals( bool block )
 void QgsTextAnnotationDialog::deleteItem()
 {
   if ( mItem && mItem->annotation() )
-    QgsProject::instance()->annotationManager()->removeAnnotation( mItem->annotation() );
+    QgsApplication::activeProject()->annotationManager()->removeAnnotation( mItem->annotation() );
   mItem = nullptr;
 }
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -139,7 +139,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   connect( this, &QDialog::rejected, this, &QgsVectorLayerProperties::onCancel );
 
   mContext << QgsExpressionContextUtils::globalScope()
-           << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+           << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
            << QgsExpressionContextUtils::atlasScope( nullptr )
            << QgsExpressionContextUtils::mapSettingsScope( QgisApp::instance()->mapCanvas()->mapSettings() )
            << QgsExpressionContextUtils::layerScope( mLayer );
@@ -364,7 +364,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     title += QStringLiteral( " (%1)" ).arg( mLayer->styleManager()->currentStyle() );
   restoreOptionsBaseUi( title );
 
-  mLayersDependenciesTreeGroup.reset( QgsProject::instance()->layerTreeRoot()->clone() );
+  mLayersDependenciesTreeGroup.reset( QgsApplication::activeProject()->layerTreeRoot()->clone() );
   QgsLayerTreeLayer *layer = mLayersDependenciesTreeGroup->findLayer( mLayer->id() );
   if ( layer )
   {
@@ -759,7 +759,7 @@ void QgsVectorLayerProperties::apply()
 
   mLayer->triggerRepaint();
   // notify the project we've made a change
-  QgsProject::instance()->setDirty( true );
+  QgsApplication::activeProject()->setDirty( true );
 }
 
 void QgsVectorLayerProperties::onCancel()
@@ -851,7 +851,7 @@ void QgsVectorLayerProperties::mLayerOrigNameLineEdit_textEdited( const QString 
 
 void QgsVectorLayerProperties::mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem &crs )
 {
-  QgisApp::instance()->askUserForDatumTransform( crs, QgsProject::instance()->crs() );
+  QgisApp::instance()->askUserForDatumTransform( crs, QgsApplication::activeProject()->crs() );
   mLayer->setCrs( crs );
   mMetadataFilled = false;
   mMetadataWidget->crsChanged();
@@ -1631,7 +1631,7 @@ void QgsVectorLayerProperties::updateVariableEditor()
   QgsExpressionContext context;
   mVariableEditor->setContext( &context );
   mVariableEditor->context()->appendScope( QgsExpressionContextUtils::globalScope() );
-  mVariableEditor->context()->appendScope( QgsExpressionContextUtils::projectScope( QgsProject::instance() ) );
+  mVariableEditor->context()->appendScope( QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() ) );
   mVariableEditor->context()->appendScope( QgsExpressionContextUtils::layerScope( mLayer ) );
   mVariableEditor->reloadContext();
   mVariableEditor->setEditableScopeIndex( 2 );

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -370,7 +370,7 @@ void QgsVertexEditor::updateVertexSelection( const QItemSelection &selected, con
 
   mSelectedFeature->deselectAllVertices();
 
-  QgsCoordinateTransform t( mLayer->crs(), mCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+  QgsCoordinateTransform t( mLayer->crs(), mCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
   std::unique_ptr<QgsRectangle> bbox;
   QModelIndexList indexList = selected.indexes();
   for ( int i = 0; i < indexList.length(); ++i )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -654,7 +654,7 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
   QgsPointXY mapPoint = toMapCoordinates( e->pos() );
   double tol = QgsTolerance::vertexSearchRadius( canvas()->mapSettings() );
 
-  QgsSnappingConfig config( QgsProject::instance() );
+  QgsSnappingConfig config( QgsApplication::activeProject() );
   config.setEnabled( true );
   config.setMode( QgsSnappingConfig::AdvancedConfiguration );
   config.setIntersectionSnapping( false );  // only snap to layers
@@ -1194,7 +1194,7 @@ void QgsVertexTool::startDraggingMoveVertex( const QgsPointLocator::Match &m )
 
   cadDockWidget()->setPoints( QList<QgsPointXY>() << m.point() << m.point() );
 
-  if ( QgsProject::instance()->topologicalEditing() )
+  if ( QgsApplication::activeProject()->topologicalEditing() )
   {
     // support for topo editing - find extra features
     // that have coincident point with the vertex being dragged
@@ -1560,7 +1560,7 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
 
   applyEditsToLayers( edits );
 
-  if ( QgsProject::instance()->topologicalEditing() && mapPointMatch->hasEdge() && mapPointMatch->layer() )
+  if ( QgsApplication::activeProject()->topologicalEditing() && mapPointMatch->hasEdge() && mapPointMatch->layer() )
   {
     // topo editing: add vertex to existing segments when moving/adding a vertex to such segment.
     // this requires that the snapping match is to a segment and the segment layer's CRS
@@ -1657,7 +1657,7 @@ void QgsVertexTool::deleteVertex()
   stopDragging();
   setHighlightedVertices( QList<Vertex>() ); // reset selection
 
-  if ( QgsProject::instance()->topologicalEditing() )
+  if ( QgsApplication::activeProject()->topologicalEditing() )
   {
     // if topo editing is enabled, delete all the vertices that are on the same location
     QSet<Vertex> topoVerticesToDelete;

--- a/src/core/annotations/qgsannotation.cpp
+++ b/src/core/annotations/qgsannotation.cpp
@@ -387,7 +387,7 @@ void QgsAnnotation::_readXml( const QDomElement &annotationElem, const QgsReadWr
   mVisible = annotationElem.attribute( QStringLiteral( "visible" ), QStringLiteral( "1" ) ).toInt();
   if ( annotationElem.hasAttribute( QStringLiteral( "mapLayer" ) ) )
   {
-    mMapLayer = QgsProject::instance()->mapLayer( annotationElem.attribute( QStringLiteral( "mapLayer" ) ) );
+    mMapLayer = QgsApplication::activeProject()->mapLayer( annotationElem.attribute( QStringLiteral( "mapLayer" ) ) );
   }
 
   //marker symbol

--- a/src/core/annotations/qgshtmlannotation.cpp
+++ b/src/core/annotations/qgshtmlannotation.cpp
@@ -121,7 +121,7 @@ void QgsHtmlAnnotation::readXml( const QDomElement &itemElem, const QgsReadWrite
   // upgrade old layer
   if ( !mapLayer() && itemElem.hasAttribute( QStringLiteral( "vectorLayer" ) ) )
   {
-    setMapLayer( QgsProject::instance()->mapLayer( itemElem.attribute( QStringLiteral( "vectorLayer" ) ) ) );
+    setMapLayer( QgsApplication::activeProject()->mapLayer( itemElem.attribute( QStringLiteral( "vectorLayer" ) ) ) );
   }
 
   if ( mWebPage )

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -524,7 +524,7 @@ double QgsExpression::evaluateToDouble( const QString &text, const double fallba
 
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
-          << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+          << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
 
   QVariant result = expr.evaluate( &context );
   convertedValue = result.toDouble( &ok );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -582,11 +582,11 @@ static QVariant fcnAggregateRelation( const QVariantList &values, const QgsExpre
   ENSURE_NO_EVAL_ERROR;
   QString relationId = value.toString();
   // check relation exists
-  QgsRelation relation = QgsProject::instance()->relationManager()->relation( relationId );
+  QgsRelation relation = QgsApplication::activeProject()->relationManager()->relation( relationId );
   if ( !relation.isValid() || relation.referencedLayer() != vl )
   {
     // check for relations by name
-    QList< QgsRelation > relations = QgsProject::instance()->relationManager()->relationsByName( relationId );
+    QList< QgsRelation > relations = QgsApplication::activeProject()->relationManager()->relationsByName( relationId );
     if ( relations.isEmpty() || relations.at( 0 ).referencedLayer() != vl )
     {
       parent->setEvalErrorString( QObject::tr( "Cannot find relation with id '%1'" ).arg( relationId ) );
@@ -3726,10 +3726,10 @@ static QVariant fcnGetRasterBandStat( const QVariantList &values, const QgsExpre
   QString layerIdOrName = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
 
   //try to find a matching layer by name
-  QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerIdOrName ); //search by id first
+  QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( layerIdOrName ); //search by id first
   if ( !layer )
   {
-    QList<QgsMapLayer *> layersByName = QgsProject::instance()->mapLayersByName( layerIdOrName );
+    QList<QgsMapLayer *> layersByName = QgsApplication::activeProject()->mapLayersByName( layerIdOrName );
     if ( !layersByName.isEmpty() )
     {
       layer = layersByName.at( 0 );

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -337,7 +337,7 @@ class QgsExpressionUtils
     {
       // First check if we already received a layer pointer
       QgsMapLayer *ml = value.value< QgsWeakMapLayerPointer >().data();
-      QgsProject *project = QgsProject::instance();
+      QgsProject *project = QgsApplication::activeProject();
 
       // No pointer yet, maybe it's a layer id?
       if ( !ml )

--- a/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrelationreferencefieldformatter.cpp
@@ -37,7 +37,7 @@ QString QgsRelationReferenceFieldFormatter::representValue( QgsVectorLayer *laye
     QgsMessageLog::logMessage( QObject::tr( "Missing Relation in configuration" ) );
     return value.toString();
   }
-  QgsRelation relation = QgsProject::instance()->relationManager()->relation( config[QStringLiteral( "Relation" )].toString() );
+  QgsRelation relation = QgsApplication::activeProject()->relationManager()->relation( config[QStringLiteral( "Relation" )].toString() );
   if ( !relation.isValid() )
   {
     QgsMessageLog::logMessage( QObject::tr( "Invalid relation" ) );

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -104,7 +104,7 @@ QgsValueRelationFieldFormatter::ValueRelationCache QgsValueRelationFieldFormatte
 {
   ValueRelationCache cache;
 
-  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( config.value( QStringLiteral( "Layer" ) ).toString() ) );
+  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( config.value( QStringLiteral( "Layer" ) ).toString() ) );
 
   if ( !layer )
     return cache;

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -1047,7 +1047,7 @@ bool QgsLayerTreeModel::dropMimeData( const QMimeData *data, Qt::DropAction acti
   QDomElement elem = rootElem.firstChildElement();
   while ( !elem.isNull() )
   {
-    QgsLayerTreeNode *node = QgsLayerTreeNode::readXml( elem, QgsProject::instance() );
+    QgsLayerTreeNode *node = QgsLayerTreeNode::readXml( elem, QgsApplication::activeProject() );
     if ( node )
       nodes << node;
 

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -236,7 +236,7 @@ QgsMemoryFeatureSource::QgsMemoryFeatureSource( const QgsMemoryProvider *p )
   , mCrs( p->mCrs )
 {
   mExpressionContext << QgsExpressionContextUtils::globalScope()
-                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+                     << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
   mExpressionContext.setFields( mFields );
 }
 

--- a/src/core/qgsactionmanager.cpp
+++ b/src/core/qgsactionmanager.cpp
@@ -213,7 +213,7 @@ QgsExpressionContext QgsActionManager::createExpressionContext() const
 {
   QgsExpressionContext context;
   context << QgsExpressionContextUtils::globalScope()
-          << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+          << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
   if ( mLayer )
     context << QgsExpressionContextUtils::layerScope( mLayer );
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -134,9 +134,6 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
 
 void QgsApplication::init( QString profileFolder )
 {
-  instance()->mApplicationMembers->mActiveProject = new QgsProject();
-  instance()->mApplicationMembers->mActiveProject->setParent( instance() );
-
   if ( profileFolder.isEmpty() )
   {
     if ( getenv( "QGIS_CUSTOM_CONFIG_PATH" ) )

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1413,6 +1413,22 @@ void QgsApplication::copyPath( const QString &src, const QString &dst )
   }
 }
 
+QgsProject *QgsApplication::activeProject()
+{
+  return instance()->ABISYM( mActiveProject );
+}
+
+void QgsApplication::setActiveProject( QgsProject *activeProject )
+{
+  QgsApplication *app = instance();
+
+  if ( app->ABISYM( mActiveProject ) == activeProject )
+    return;
+
+  app->ABISYM( mActiveProject ) = activeProject;
+  emit app->activeProjectChanged();
+}
+
 QVariantMap QgsApplication::customVariables()
 {
   //read values from QgsSettings

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -134,6 +134,9 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
 
 void QgsApplication::init( QString profileFolder )
 {
+  mApplicationMembers->mActiveProject = new QgsProject();
+  mApplicationMembers->mActiveProject->setParent( this );
+
   if ( profileFolder.isEmpty() )
   {
     if ( getenv( "QGIS_CUSTOM_CONFIG_PATH" ) )
@@ -289,6 +292,9 @@ void QgsApplication::init( QString profileFolder )
 
 QgsApplication::~QgsApplication()
 {
+  if ( mApplicationMembers->mActiveProject && mApplicationMembers->mActiveProject->parent() == this )
+    delete mApplicationMembers->mActiveProject;
+
   delete mDataItemProviderRegistry;
   delete mApplicationMembers;
 }
@@ -1415,17 +1421,20 @@ void QgsApplication::copyPath( const QString &src, const QString &dst )
 
 QgsProject *QgsApplication::activeProject()
 {
-  return instance()->ABISYM( mActiveProject );
+  return instance()->mApplicationMembers->mActiveProject;
 }
 
 void QgsApplication::setActiveProject( QgsProject *activeProject )
 {
   QgsApplication *app = instance();
 
-  if ( app->ABISYM( mActiveProject ) == activeProject )
+  if ( app->mApplicationMembers->mActiveProject == activeProject )
     return;
 
-  app->ABISYM( mActiveProject ) = activeProject;
+  if ( app->mApplicationMembers->mActiveProject && app->mApplicationMembers->mActiveProject->parent() == this )
+    delete app->mApplicationMembers->mActiveProject;
+
+  app->mApplicationMembers->mActiveProject = activeProject;
   emit app->activeProjectChanged();
 }
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -134,8 +134,8 @@ QgsApplication::QgsApplication( int &argc, char **argv, bool GUIenabled, const Q
 
 void QgsApplication::init( QString profileFolder )
 {
-  mApplicationMembers->mActiveProject = new QgsProject();
-  mApplicationMembers->mActiveProject->setParent( this );
+  instance()->mApplicationMembers->mActiveProject = new QgsProject();
+  instance()->mApplicationMembers->mActiveProject->setParent( instance() );
 
   if ( profileFolder.isEmpty() )
   {
@@ -1431,7 +1431,7 @@ void QgsApplication::setActiveProject( QgsProject *activeProject )
   if ( app->mApplicationMembers->mActiveProject == activeProject )
     return;
 
-  if ( app->mApplicationMembers->mActiveProject && app->mApplicationMembers->mActiveProject->parent() == this )
+  if ( app->mApplicationMembers->mActiveProject && app->mApplicationMembers->mActiveProject->parent() == instance() )
     delete app->mApplicationMembers->mActiveProject;
 
   app->mApplicationMembers->mActiveProject = activeProject;

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1040,7 +1040,7 @@ void QgsApplication::initQgis()
   ( void )QgsApplication::dataItemProviderRegistry();
 
   // create project instance if doesn't exist
-  QgsProject::instance();
+  QgsApplication::activeProject();
 
   // Initialize authentication manager and connect to database
   authManager()->init( pluginPath(), qgisAuthDatabaseFilePath() );
@@ -1087,7 +1087,7 @@ void QgsApplication::exitQgis()
   //delete all registered functions from expression engine (see above comment)
   QgsExpression::cleanRegisteredFunctions();
 
-  delete QgsProject::instance();
+  delete QgsApplication::activeProject();
 
   delete QgsProviderRegistry::instance();
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -47,6 +47,7 @@ class QgsPageSizeRegistry;
 class QgsLayoutItemRegistry;
 class QgsAuthManager;
 class QgsNetworkContentFetcherRegistry;
+class QgsProject;
 
 /**
  * \ingroup core
@@ -739,6 +740,20 @@ class CORE_EXPORT QgsApplication : public QApplication
     SIP_END
 #endif
 
+    /**
+     * Returns the active QGIS project.
+     *
+     *  \since QGIS 3.2
+     */
+    static QgsProject *activeProject();
+
+    /**
+     * Change the active QGIS project.
+     *
+     * \since QGIS 3.2
+     */
+    static void setActiveProject( QgsProject *activeProject );
+
   signals:
     //! \note not available in Python bindings
     void preNotify( QObject *receiver, QEvent *event, bool *done ) SIP_SKIP;
@@ -754,6 +769,13 @@ class CORE_EXPORT QgsApplication : public QApplication
      * \copydoc nullRepresentation()
      */
     void nullRepresentationChanged();
+
+    /**
+     * Signal emitted whenever the active project changes.
+     *
+     * \since QGIS 3.2
+     */
+    void activeProjectChanged();
 
   private:
 
@@ -772,6 +794,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QString ABISYM( mThemeName );
     static QStringList ABISYM( mDefaultSvgPaths );
     static QMap<QString, QString> ABISYM( mSystemEnvVars );
+    static QgsProject *ABISYM( mActiveProject ) ;
 
     static QString ABISYM( mConfigPath );
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -794,7 +794,6 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QString ABISYM( mThemeName );
     static QStringList ABISYM( mDefaultSvgPaths );
     static QMap<QString, QString> ABISYM( mSystemEnvVars );
-    static QgsProject *ABISYM( mActiveProject ) ;
 
     static QString ABISYM( mConfigPath );
 
@@ -858,6 +857,7 @@ class CORE_EXPORT QgsApplication : public QApplication
       QgsLayoutItemRegistry *mLayoutItemRegistry = nullptr;
       QgsUserProfileManager *mUserConfigManager = nullptr;
       QString mNullRepresentation;
+      QgsProject *mActiveProject = nullptr;
 
       ApplicationMembers();
       ~ApplicationMembers();

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -55,7 +55,7 @@ QgsBrowserModel::~QgsBrowserModel()
 
 void QgsBrowserModel::updateProjectHome()
 {
-  QString home = QgsProject::instance()->homePath();
+  QString home = QgsApplication::activeProject()->homePath();
   if ( mProjectHome && mProjectHome->path() == home )
     return;
 
@@ -176,9 +176,9 @@ void QgsBrowserModel::initialize()
 {
   if ( ! mInitialized )
   {
-    connect( QgsProject::instance(), &QgsProject::readProject, this, &QgsBrowserModel::updateProjectHome );
-    connect( QgsProject::instance(), &QgsProject::projectSaved, this, &QgsBrowserModel::updateProjectHome );
-    connect( QgsProject::instance(), &QgsProject::homePathChanged, this, &QgsBrowserModel::updateProjectHome );
+    connect( QgsApplication::activeProject(), &QgsProject::readProject, this, &QgsBrowserModel::updateProjectHome );
+    connect( QgsApplication::activeProject(), &QgsProject::projectSaved, this, &QgsBrowserModel::updateProjectHome );
+    connect( QgsApplication::activeProject(), &QgsProject::homePathChanged, this, &QgsBrowserModel::updateProjectHome );
     addRootItems();
     mInitialized = true;
   }

--- a/src/core/qgscolorscheme.cpp
+++ b/src/core/qgscolorscheme.cpp
@@ -195,8 +195,8 @@ QgsNamedColorList QgsProjectColorScheme::fetchColors( const QString &context, co
 
   QgsNamedColorList colorList;
 
-  QStringList colorStrings = QgsProject::instance()->readListEntry( QStringLiteral( "Palette" ), QStringLiteral( "/Colors" ) );
-  QStringList colorLabels = QgsProject::instance()->readListEntry( QStringLiteral( "Palette" ), QStringLiteral( "/Labels" ) );
+  QStringList colorStrings = QgsApplication::activeProject()->readListEntry( QStringLiteral( "Palette" ), QStringLiteral( "/Colors" ) );
+  QStringList colorLabels = QgsApplication::activeProject()->readListEntry( QStringLiteral( "Palette" ), QStringLiteral( "/Labels" ) );
 
   //generate list from custom colors
   int colorIndex = 0;
@@ -234,8 +234,8 @@ bool QgsProjectColorScheme::setColors( const QgsNamedColorList &colors, const QS
     customColors.append( color );
     customColorLabels.append( label );
   }
-  QgsProject::instance()->writeEntry( QStringLiteral( "Palette" ), QStringLiteral( "/Colors" ), customColors );
-  QgsProject::instance()->writeEntry( QStringLiteral( "Palette" ), QStringLiteral( "/Labels" ), customColorLabels );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "Palette" ), QStringLiteral( "/Colors" ), customColors );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "Palette" ), QStringLiteral( "/Labels" ), customColorLabels );
   return true;
 }
 

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -27,12 +27,12 @@
 int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs )
 {
   // Get the display precision from the project settings
-  bool automatic = QgsProject::instance()->readBoolEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ) );
+  bool automatic = QgsApplication::activeProject()->readBoolEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ) );
   int dp = 0;
 
   if ( automatic )
   {
-    QString format = QgsProject::instance()->readEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DegreeFormat" ), QStringLiteral( "MU" ) );
+    QString format = QgsApplication::activeProject()->readEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DegreeFormat" ), QStringLiteral( "MU" ) );
     bool formatGeographic = ( format == QLatin1String( "DM" ) || format == QLatin1String( "DMS" ) || format == QLatin1String( "D" ) );
 
     // we can only calculate an automatic precision if one of these is true:
@@ -53,7 +53,7 @@ int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, c
     }
   }
   else
-    dp = QgsProject::instance()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ) );
+    dp = QgsApplication::activeProject()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ) );
 
   // Keep dp sensible
   if ( dp < 0 )

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -1582,11 +1582,11 @@ QList<QAction *> QgsProjectHomeItem::actions( QWidget *parent )
   QAction *setHome = new QAction( tr( "Set Project Home…" ), parent );
   connect( setHome, &QAction::triggered, this, [ = ]
   {
-    QString oldHome = QgsProject::instance()->homePath();
+    QString oldHome = QgsApplication::activeProject()->homePath();
     QString newPath = QFileDialog::getExistingDirectory( parent, tr( "Select Project Home Directory" ), oldHome );
     if ( !newPath.isEmpty() )
     {
-      QgsProject::instance()->setPresetHomePath( newPath );
+      QgsApplication::activeProject()->setPresetHomePath( newPath );
     }
   } );
   lst << setHome;

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -69,7 +69,7 @@ void QgsEditFormConfig::onRelationsLoaded()
     if ( !rel )
       continue;
 
-    rel->init( QgsProject::instance()->relationManager() );
+    rel->init( QgsApplication::activeProject()->relationManager() );
   }
 }
 

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -928,7 +928,7 @@ QList<QgsExpressionContextScope *> QgsExpressionContextUtils::globalProjectLayer
   QList<QgsExpressionContextScope *> scopes;
   scopes << globalScope();
 
-  QgsProject *project = QgsProject::instance();  // TODO: use project associated with layer
+  QgsProject *project = QgsApplication::activeProject();  // TODO: use project associated with layer
   if ( project )
     scopes << projectScope( project );
 

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -160,7 +160,7 @@ QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVarian
     // related attributes
     if ( mLayer && mIncludeRelatedAttributes )
     {
-      QList< QgsRelation > relations = QgsProject::instance()->relationManager()->referencedRelations( mLayer.data() );
+      QList< QgsRelation > relations = QgsApplication::activeProject()->relationManager()->referencedRelations( mLayer.data() );
       Q_FOREACH ( const QgsRelation &relation, relations )
       {
         if ( attributeCounter > 0 )

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -921,7 +921,7 @@ QString QgsMapLayer::loadNamedProperty( const QString &uri, QgsMapLayer::Propert
   }
   else
   {
-    QFileInfo project( QgsProject::instance()->fileName() );
+    QFileInfo project( QgsApplication::activeProject()->fileName() );
     QgsDebugMsgLevel( QString( "project fileName: %1" ).arg( project.absoluteFilePath() ), 4 );
 
     QString xml;
@@ -1711,7 +1711,7 @@ static QList<const QgsMapLayer *> _depOutEdges( const QgsMapLayer *vl, const Qgs
   {
     Q_FOREACH ( const QgsMapLayerDependency &dep, layers )
     {
-      if ( const QgsMapLayer *l = QgsProject::instance()->mapLayer( dep.layerId() ) )
+      if ( const QgsMapLayer *l = QgsApplication::activeProject()->mapLayer( dep.layerId() ) )
         lst << l;
     }
   }
@@ -1719,7 +1719,7 @@ static QList<const QgsMapLayer *> _depOutEdges( const QgsMapLayer *vl, const Qgs
   {
     Q_FOREACH ( const QgsMapLayerDependency &dep, vl->dependencies() )
     {
-      if ( const QgsMapLayer *l = QgsProject::instance()->mapLayer( dep.layerId() ) )
+      if ( const QgsMapLayer *l = QgsApplication::activeProject()->mapLayer( dep.layerId() ) )
         lst << l;
     }
   }

--- a/src/core/qgsmaplayermodel.cpp
+++ b/src/core/qgsmaplayermodel.cpp
@@ -25,16 +25,16 @@
 QgsMapLayerModel::QgsMapLayerModel( const QList<QgsMapLayer *> &layers, QObject *parent )
   : QAbstractItemModel( parent )
 {
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+  connect( QgsApplication::activeProject(), static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
   addLayers( layers );
 }
 
 QgsMapLayerModel::QgsMapLayerModel( QObject *parent )
   : QAbstractItemModel( parent )
 {
-  connect( QgsProject::instance(), &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
-  addLayers( QgsProject::instance()->mapLayers().values() );
+  connect( QgsApplication::activeProject(), &QgsProject::layersAdded, this, &QgsMapLayerModel::addLayers );
+  connect( QgsApplication::activeProject(), static_cast < void ( QgsProject::* )( const QStringList & ) >( &QgsProject::layersWillBeRemoved ), this, &QgsMapLayerModel::removeLayers );
+  addLayers( QgsApplication::activeProject()->mapLayers().values() );
 }
 
 void QgsMapLayerModel::setItemsCheckable( bool checkable )

--- a/src/core/qgsmaplayerproxymodel.cpp
+++ b/src/core/qgsmaplayerproxymodel.cpp
@@ -57,7 +57,7 @@ void QgsMapLayerProxyModel::setExceptedLayerIds( const QStringList &ids )
 
   Q_FOREACH ( const QString &id, ids )
   {
-    QgsMapLayer *l = QgsProject::instance()->mapLayer( id );
+    QgsMapLayer *l = QgsApplication::activeProject()->mapLayer( id );
     if ( l )
       mExceptList << l;
   }

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -85,7 +85,7 @@ QgsVectorLayer *QgsMimeDataUtils::Uri::vectorLayer( bool &owner, QString &error 
       return nullptr;
     }
     QString layerId = url.queryItemValue( QStringLiteral( "layerid" ) );
-    QgsVectorLayer *vectorLayer = qobject_cast< QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+    QgsVectorLayer *vectorLayer = qobject_cast< QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( layerId ) );
     if ( !vectorLayer )
     {
       error = QObject::tr( "Cannot get memory layer." );

--- a/src/core/qgspluginlayerregistry.cpp
+++ b/src/core/qgspluginlayerregistry.cpp
@@ -89,7 +89,7 @@ bool QgsPluginLayerRegistry::removePluginLayerType( const QString &typeName )
     return false;
 
   // remove all remaining layers of this type - to avoid invalid behavior
-  QList<QgsMapLayer *> layers = QgsProject::instance()->mapLayers().values();
+  QList<QgsMapLayer *> layers = QgsApplication::activeProject()->mapLayers().values();
   Q_FOREACH ( QgsMapLayer *layer, layers )
   {
     if ( layer->type() == QgsMapLayer::PluginLayer )
@@ -97,7 +97,7 @@ bool QgsPluginLayerRegistry::removePluginLayerType( const QString &typeName )
       QgsPluginLayer *pl = qobject_cast<QgsPluginLayer *>( layer );
       if ( pl->pluginLayerType() == typeName )
       {
-        QgsProject::instance()->removeMapLayers(
+        QgsApplication::activeProject()->removeMapLayers(
           QStringList() << layer->id() );
       }
     }

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -385,11 +385,7 @@ QgsProject::~QgsProject()
 
 QgsProject *QgsProject::instance()
 {
-  if ( !sProject )
-  {
-    sProject = new QgsProject;
-  }
-  return sProject;
+  return QgsApplication::activeProject();
 }
 
 void QgsProject::setTitle( const QString &title )

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     /**
      * Create a new QgsProject.
      *
-     * Most of the time you want to use QgsProject::instance() instead as many components of QGIS work with the singleton.
+     * Most of the time you want to use QgsApplication::activeProject() instead as many components of QGIS work with the singleton.
      */
     explicit QgsProject( QObject *parent SIP_TRANSFERTHIS = nullptr );
 
@@ -718,7 +718,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      *
      * Example:
      *
-     *     QVector<QgsVectorLayer*> vectorLayers = QgsProject::instance()->layers<QgsVectorLayer*>();
+     *     QVector<QgsVectorLayer*> vectorLayers = QgsApplication::activeProject()->layers<QgsVectorLayer*>();
      *
      * \note not available in Python bindings
      * \see mapLayers()

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -97,7 +97,13 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     Q_PROPERTY( QgsProjectMetadata metadata READ metadata WRITE setMetadata NOTIFY metadataChanged )
 
   public:
-    //! Returns the QgsProject singleton instance
+
+    /**
+     * Returns the active QGIS project.
+     * Alias for ``QgsApplication.activeProject()``
+     *
+     * \deprecated since QGIS 3.2 use QgsApplication::activeProject() instead.
+     */
     static QgsProject *instance();
 
     /**

--- a/src/core/qgsprojectfiletransform.cpp
+++ b/src/core/qgsprojectfiletransform.cpp
@@ -477,7 +477,7 @@ void QgsProjectFileTransform::transform1800to1900()
   }
 
   QgsReadWriteContext context;
-  context.setPathResolver( QgsProject::instance()->pathResolver() );
+  context.setPathResolver( QgsApplication::activeProject()->pathResolver() );
 
   QDomNodeList layerItemList = mDom.elementsByTagName( QStringLiteral( "rasterproperties" ) );
   for ( int i = 0; i < layerItemList.size(); ++i )

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -244,7 +244,7 @@ typedef void cleanupProviderFunction_t();
 
 void QgsProviderRegistry::clean()
 {
-  QgsProject::instance()->removeAllMapLayers();
+  QgsApplication::activeProject()->removeAllMapLayers();
 
   Providers::const_iterator it = mProviders.begin();
 

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -38,7 +38,7 @@ QgsRelation QgsRelation::createFromXml( const QDomNode &node )
   QString name = elem.attribute( QStringLiteral( "name" ) );
   QString strength = elem.attribute( QStringLiteral( "strength" ) );
 
-  const QMap<QString, QgsMapLayer *> &mapLayers = QgsProject::instance()->mapLayers();
+  const QMap<QString, QgsMapLayer *> &mapLayers = QgsApplication::activeProject()->mapLayers();
 
   QgsMapLayer *referencingLayer = mapLayers[referencingLayerId];
   QgsMapLayer *referencedLayer = mapLayers[referencedLayerId];
@@ -329,7 +329,7 @@ QString QgsRelation::resolveReferencingField( const QString &referencedField ) c
 
 void QgsRelation::updateRelationStatus()
 {
-  const QMap<QString, QgsMapLayer *> &mapLayers = QgsProject::instance()->mapLayers();
+  const QMap<QString, QgsMapLayer *> &mapLayers = QgsApplication::activeProject()->mapLayers();
 
   mReferencingLayer = qobject_cast<QgsVectorLayer *>( mapLayers[mReferencingLayerId] );
   mReferencedLayer = qobject_cast<QgsVectorLayer *>( mapLayers[mReferencedLayerId] );

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -23,7 +23,7 @@
 
 QgsSnappingUtils::QgsSnappingUtils( QObject *parent, bool enableSnappingForInvisibleFeature )
   : QObject( parent )
-  , mSnappingConfig( QgsProject::instance() )
+  , mSnappingConfig( QgsApplication::activeProject() )
   , mEnableSnappingForInvisibleFeature( enableSnappingForInvisibleFeature )
 {
 }

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -351,8 +351,13 @@ QgsTaskManager::QgsTaskManager( QObject *parent )
   : QObject( parent )
   , mTaskMutex( new QMutex( QMutex::Recursive ) )
 {
-  connect( QgsApplication::activeProject(), static_cast < void ( QgsProject::* )( const QList< QgsMapLayer * >& ) > ( &QgsProject::layersWillBeRemoved ),
-           this, &QgsTaskManager::layersWillBeRemoved );
+  connect( QgsApplication::instance(), &QgsApplication::activeProjectChanged, this, [this]()
+  {
+    QgsProject *activeProject = QgsApplication::activeProject();
+    if ( activeProject )
+      connect( activeProject, static_cast < void ( QgsProject::* )( const QList< QgsMapLayer * >& ) > ( &QgsProject::layersWillBeRemoved ),
+               this, &QgsTaskManager::layersWillBeRemoved, Qt::UniqueConnection );
+  } );
 }
 
 QgsTaskManager::~QgsTaskManager()

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -351,7 +351,7 @@ QgsTaskManager::QgsTaskManager( QObject *parent )
   : QObject( parent )
   , mTaskMutex( new QMutex( QMutex::Recursive ) )
 {
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QList< QgsMapLayer * >& ) > ( &QgsProject::layersWillBeRemoved ),
+  connect( QgsApplication::activeProject(), static_cast < void ( QgsProject::* )( const QList< QgsMapLayer * >& ) > ( &QgsProject::layersWillBeRemoved ),
            this, &QgsTaskManager::layersWillBeRemoved );
 }
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -162,7 +162,7 @@ QgsVectorLayer::QgsVectorLayer( const QString &vectorLayerPath,
   }
 
   connect( this, &QgsVectorLayer::selectionChanged, this, [ = ] { emit repaintRequested(); } );
-  connect( QgsProject::instance()->relationManager(), &QgsRelationManager::relationsLoaded, this, &QgsVectorLayer::onRelationsLoaded );
+  connect( QgsApplication::activeProject()->relationManager(), &QgsRelationManager::relationsLoaded, this, &QgsVectorLayer::onRelationsLoaded );
 
   connect( this, &QgsVectorLayer::subsetStringChanged, this, &QgsMapLayer::configChanged );
 
@@ -1603,7 +1603,7 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
       QStringList stuff = reg.capturedTexts();
       QString lName = stuff[1];
 
-      const QMap<QString, QgsMapLayer *> &layers = QgsProject::instance()->mapLayers();
+      const QMap<QString, QgsMapLayer *> &layers = QgsApplication::activeProject()->mapLayers();
 
       QMap<QString, QgsMapLayer *>::const_iterator it;
       for ( it = layers.constBegin(); it != layers.constEnd() && ( *it )->name() != lName; ++it )
@@ -4285,7 +4285,7 @@ void QgsVectorLayer::onSymbolsCounted()
 
 QList<QgsRelation> QgsVectorLayer::referencingRelations( int idx ) const
 {
-  return QgsProject::instance()->relationManager()->referencingRelations( this, idx );
+  return QgsApplication::activeProject()->relationManager()->referencingRelations( this, idx );
 }
 
 int QgsVectorLayer::listStylesInDatabase( QStringList &ids, QStringList &names, QStringList &descriptions, QString &msgError )
@@ -4501,7 +4501,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
   // disconnect layers that are not present in the list of dependencies anymore
   Q_FOREACH ( const QgsMapLayerDependency &dep, mDependencies )
   {
-    QgsVectorLayer *lyr = static_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( dep.layerId() ) );
+    QgsVectorLayer *lyr = static_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( dep.layerId() ) );
     if ( !lyr )
       continue;
     disconnect( lyr, &QgsVectorLayer::featureAdded, this, &QgsVectorLayer::dataChanged );
@@ -4521,7 +4521,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency> &oDeps )
   // connect to new layers
   Q_FOREACH ( const QgsMapLayerDependency &dep, mDependencies )
   {
-    QgsVectorLayer *lyr = static_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( dep.layerId() ) );
+    QgsVectorLayer *lyr = static_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( dep.layerId() ) );
     if ( !lyr )
       continue;
     connect( lyr, &QgsVectorLayer::featureAdded, this, &QgsVectorLayer::dataChanged );

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -615,11 +615,11 @@ void QgsVectorLayerFeatureIterator::prepareExpression( int fieldIdx )
   QgsExpression *exp = new QgsExpression( exps[oi].cachedExpression );
 
   QgsDistanceArea da;
-  da.setSourceCrs( mSource->mCrs, QgsProject::instance()->transformContext() );
-  da.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  da.setSourceCrs( mSource->mCrs, QgsApplication::activeProject()->transformContext() );
+  da.setEllipsoid( QgsApplication::activeProject()->ellipsoid() );
   exp->setGeomCalculator( &da );
-  exp->setDistanceUnits( QgsProject::instance()->distanceUnits() );
-  exp->setAreaUnits( QgsProject::instance()->areaUnits() );
+  exp->setDistanceUnits( QgsApplication::activeProject()->distanceUnits() );
+  exp->setAreaUnits( QgsApplication::activeProject()->areaUnits() );
 
   exp->prepare( mExpressionContext.get() );
   Q_FOREACH ( const QString &col, exp->referencedColumns() )
@@ -660,7 +660,7 @@ void QgsVectorLayerFeatureIterator::prepareFields()
 
   mExpressionContext.reset( new QgsExpressionContext() );
   mExpressionContext->appendScope( QgsExpressionContextUtils::globalScope() );
-  mExpressionContext->appendScope( QgsExpressionContextUtils::projectScope( QgsProject::instance() ) );
+  mExpressionContext->appendScope( QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() ) );
   mExpressionContext->appendScope( new QgsExpressionContextScope( mSource->mLayerScope ) );
 
   mFieldsToPrepare = ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes ) ? mRequest.subsetOfAttributes() : mSource->mFields.allAttributesList();

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -273,13 +273,13 @@ QgsSymbol *QgsSymbol::defaultSymbol( QgsWkbTypes::GeometryType geomType )
   switch ( geomType )
   {
     case QgsWkbTypes::PointGeometry :
-      defaultSymbol = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Marker" ), QLatin1String( "" ) );
+      defaultSymbol = QgsApplication::activeProject()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Marker" ), QLatin1String( "" ) );
       break;
     case QgsWkbTypes::LineGeometry :
-      defaultSymbol = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Line" ), QLatin1String( "" ) );
+      defaultSymbol = QgsApplication::activeProject()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Line" ), QLatin1String( "" ) );
       break;
     case QgsWkbTypes::PolygonGeometry :
-      defaultSymbol = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Fill" ), QLatin1String( "" ) );
+      defaultSymbol = QgsApplication::activeProject()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Fill" ), QLatin1String( "" ) );
       break;
     default:
       break;
@@ -311,17 +311,17 @@ QgsSymbol *QgsSymbol::defaultSymbol( QgsWkbTypes::GeometryType geomType )
   double opacity = 1.0;
   bool ok = false;
   // upgrade old setting
-  double alpha = QgsProject::instance()->readDoubleEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/AlphaInt" ), 255, &ok );
+  double alpha = QgsApplication::activeProject()->readDoubleEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/AlphaInt" ), 255, &ok );
   if ( ok )
     opacity = alpha / 255.0;
-  double newOpacity = QgsProject::instance()->readDoubleEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Opacity" ), 1.0, &ok );
+  double newOpacity = QgsApplication::activeProject()->readDoubleEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/Opacity" ), 1.0, &ok );
   if ( ok )
     opacity = newOpacity;
   s->setOpacity( opacity );
 
   // set random color, it project prefs allow
   if ( defaultSymbol.isEmpty() ||
-       QgsProject::instance()->readBoolEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/RandomColors" ), true ) )
+       QgsApplication::activeProject()->readBoolEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/RandomColors" ), true ) )
   {
     s->setColor( QgsApplication::colorSchemeRegistry()->fetchRandomStyleColor() );
   }

--- a/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourceconfigdlg.cpp
@@ -36,7 +36,7 @@ QgsExternalResourceConfigDlg::QgsExternalResourceConfigDlg( QgsVectorLayer *vl, 
   mUseLink->setChecked( false );
   mFullUrl->setChecked( false );
 
-  QString defpath = QgsProject::instance()->fileName().isEmpty() ? QDir::homePath() : QFileInfo( QgsProject::instance()->absoluteFilePath() ).path();
+  QString defpath = QgsApplication::activeProject()->fileName().isEmpty() ? QDir::homePath() : QFileInfo( QgsApplication::activeProject()->absoluteFilePath() ).path();
 
   mRootPath->setPlaceholderText( QgsSettings().value( QStringLiteral( "/UI/lastExternalResourceWidgetDefaultPath" ), QDir::toNativeSeparators( QDir::cleanPath( defpath ) ) ).toString() );
 
@@ -97,7 +97,7 @@ void QgsExternalResourceConfigDlg::chooseDefaultPath()
   }
   else
   {
-    QString path = QFileInfo( QgsProject::instance()->absoluteFilePath() ).path();
+    QString path = QFileInfo( QgsApplication::activeProject()->absoluteFilePath() ).path();
     dir = QgsSettings().value( QStringLiteral( "/UI/lastExternalResourceWidgetDefaultPath" ), QDir::toNativeSeparators( QDir::cleanPath( path ) ) ).toString();
   }
 

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -92,7 +92,7 @@ void QgsRelationReferenceConfigDlg::setConfig( const QVariantMap &config )
 void QgsRelationReferenceConfigDlg::relationChanged( int idx )
 {
   QString relName = mComboRelation->itemData( idx ).toString();
-  QgsRelation rel = QgsProject::instance()->relationManager()->relation( relName );
+  QgsRelation rel = QgsApplication::activeProject()->relationManager()->relation( relName );
 
   mReferencedLayer = rel.referencedLayer();
   mExpressionWidget->setLayer( mReferencedLayer ); // set even if 0

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -188,7 +188,7 @@ void QgsRelationReferenceSearchWidgetWrapper::initWidget( QWidget *editor )
     mWidget->setChainFilters( config( QStringLiteral( "ChainFilters" ) ).toBool() );
   }
 
-  QgsRelation relation = QgsProject::instance()->relationManager()->relation( config( QStringLiteral( "Relation" ) ).toString() );
+  QgsRelation relation = QgsApplication::activeProject()->relationManager()->relation( config( QStringLiteral( "Relation" ) ).toString() );
   mWidget->setRelation( relation, false );
 
   mWidget->showIndeterminateState();

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -69,7 +69,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget *editor )
 
   QgsRelation relation; // invalid relation by default
   if ( relationName.isValid() )
-    relation = QgsProject::instance()->relationManager()->relation( relationName.toString() );
+    relation = QgsApplication::activeProject()->relationManager()->relation( relationName.toString() );
   else if ( ! layer()->referencingRelations( fieldIdx() ).isEmpty() )
     relation = layer()->referencingRelations( fieldIdx() )[0];
 

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -96,7 +96,7 @@ void QgsRelationWidgetWrapper::initWidget( QWidget *editor )
 
   w->setEditorContext( myContext );
 
-  QgsRelation nmrel = QgsProject::instance()->relationManager()->relation( config( QStringLiteral( "nm-rel" ) ).toString() );
+  QgsRelation nmrel = QgsApplication::activeProject()->relationManager()->relation( config( QStringLiteral( "nm-rel" ) ).toString() );
 
   // If this widget is already embedded by the same relation, reduce functionality
   const QgsAttributeEditorContext *ctx = &context();

--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -68,7 +68,7 @@ QVariantMap QgsValueRelationConfigDlg::config()
 
 void QgsValueRelationConfigDlg::setConfig( const QVariantMap &config )
 {
-  QgsVectorLayer *lyr = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( config.value( QStringLiteral( "Layer" ) ).toString() ) );
+  QgsVectorLayer *lyr = qobject_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( config.value( QStringLiteral( "Layer" ) ).toString() ) );
   mLayerName->setLayer( lyr );
   mKeyColumn->setField( config.value( QStringLiteral( "Key" ) ).toString() );
   mValueColumn->setField( config.value( QStringLiteral( "Value" ) ).toString() );

--- a/src/gui/layertree/qgscustomlayerorderwidget.cpp
+++ b/src/gui/layertree/qgscustomlayerorderwidget.cpp
@@ -108,14 +108,14 @@ QVariant CustomLayerOrderModel::data( const QModelIndex &index, int role ) const
 
   if ( role == Qt::DisplayRole )
   {
-    QgsMapLayer *layer = QgsProject::instance()->mapLayer( id );
+    QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( id );
     if ( layer )
       return layer->name();
   }
 
   if ( role == Qt::UserRole + 1 )
   {
-    QgsMapLayer *layer = QgsProject::instance()->mapLayer( id );
+    QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( id );
     if ( layer )
       return layer->id();
   }

--- a/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
+++ b/src/gui/layertree/qgslayertreemapcanvasbridge.cpp
@@ -92,7 +92,7 @@ void QgsLayerTreeMapCanvasBridge::setCanvasLayers()
 
   if ( mFirstCRS.isValid() && firstLayers )
   {
-    QgsProject::instance()->setCrs( mFirstCRS );
+    QgsApplication::activeProject()->setCrs( mFirstCRS );
   }
 
   mLastLayerCount = currentLayerCount;

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -294,7 +294,7 @@ void QgsLayerTreeViewDefaultActions::zoomToGroup( QgsMapCanvas *canvas )
 
   QList<QgsMapLayer *> layers;
   Q_FOREACH ( const QString &layerId, groupNode->findLayerIds() )
-    layers << QgsProject::instance()->mapLayer( layerId );
+    layers << QgsApplication::activeProject()->mapLayer( layerId );
 
   zoomToLayers( canvas, layers );
 }

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -150,7 +150,7 @@ QgsAdvancedDigitizingDockWidget::QgsAdvancedDigitizingDockWidget( QgsMapCanvas *
 
 
   updateCapacity( true );
-  connect( QgsProject::instance(), &QgsProject::snappingConfigChanged, this, [ = ] { updateCapacity( true ); } );
+  connect( QgsApplication::activeProject(), &QgsProject::snappingConfigChanged, this, [ = ] { updateCapacity( true ); } );
 
   disable();
 }
@@ -442,7 +442,7 @@ void QgsAdvancedDigitizingDockWidget::updateCapacity( bool updateUIwithoutChange
     return;
   }
 
-  bool snappingEnabled = QgsProject::instance()->snappingConfig().enabled();
+  bool snappingEnabled = QgsApplication::activeProject()->snappingConfig().enabled();
 
   // update the UI according to new capacities
   // still keep the old to compare

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -91,7 +91,7 @@ class GUI_EXPORT QgsAttributeEditorContext
       if ( mLayer )
       {
         mDistanceArea = distanceArea;
-        mDistanceArea.setSourceCrs( mLayer->crs(), QgsProject::instance()->transformContext() );
+        mDistanceArea.setSourceCrs( mLayer->crs(), QgsApplication::activeProject()->transformContext() );
       }
     }
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1334,7 +1334,7 @@ void QgsAttributeForm::init()
       }
     }
 
-    Q_FOREACH ( const QgsRelation &rel, QgsProject::instance()->relationManager()->referencedRelations( mLayer ) )
+    Q_FOREACH ( const QgsRelation &rel, QgsApplication::activeProject()->relationManager()->referencedRelations( mLayer ) )
     {
       QgsRelationWidgetWrapper *rww = new QgsRelationWidgetWrapper( mLayer, rel, nullptr, this );
       const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( mLayer, rel.id() );
@@ -1349,7 +1349,7 @@ void QgsAttributeForm::init()
       mFormWidgets.append( formWidget );
     }
 
-    if ( QgsProject::instance()->relationManager()->referencedRelations( mLayer ).isEmpty() )
+    if ( QgsApplication::activeProject()->relationManager()->referencedRelations( mLayer ).isEmpty() )
     {
       QSpacerItem *spacerItem = new QSpacerItem( 20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding );
       gridLayout->addItem( spacerItem, row, 0 );
@@ -1794,7 +1794,7 @@ void QgsAttributeForm::createWrappers()
     QVariant vRel = myWidget->property( "qgisRelation" );
     if ( vRel.isValid() )
     {
-      QgsRelationManager *relMgr = QgsProject::instance()->relationManager();
+      QgsRelationManager *relMgr = QgsApplication::activeProject()->relationManager();
       QgsRelation relation = relMgr->relation( vRel.toString() );
       if ( relation.isValid() )
       {

--- a/src/gui/qgsattributetypeloaddialog.cpp
+++ b/src/gui/qgsattributetypeloaddialog.cpp
@@ -65,7 +65,7 @@ void QgsAttributeTypeLoadDialog::fillLayerList()
 {
   layerComboBox->blockSignals( true );
   layerComboBox->clear();
-  Q_FOREACH ( QgsMapLayer *l, QgsProject::instance()->mapLayers() )
+  Q_FOREACH ( QgsMapLayer *l, QgsApplication::activeProject()->mapLayers() )
   {
     QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( l );
     if ( vl )
@@ -84,7 +84,7 @@ void QgsAttributeTypeLoadDialog::fillComboBoxes( int layerIndex )
   keyComboBox->clear();
   valueComboBox->clear();
 
-  QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( layerIndex < 0 ? nullptr : QgsProject::instance()->mapLayer( layerComboBox->itemData( layerIndex ).toString() ) );
+  QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( layerIndex < 0 ? nullptr : QgsApplication::activeProject()->mapLayer( layerComboBox->itemData( layerIndex ).toString() ) );
   if ( vLayer )
   {
     QMap<QString, int> fieldMap = vLayer->dataProvider()->fieldNameMap();
@@ -121,7 +121,7 @@ void QgsAttributeTypeLoadDialog::createPreview( int fieldIndex, bool full )
   }
   int idx = keyComboBox->currentData().toInt();
   int idx2 = valueComboBox->currentData().toInt();
-  QgsMapLayer *dataLayer = QgsProject::instance()->mapLayer( layerComboBox->currentData().toString() );
+  QgsMapLayer *dataLayer = QgsApplication::activeProject()->mapLayer( layerComboBox->currentData().toString() );
   QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( dataLayer );
   if ( !vLayer )
     return;
@@ -170,7 +170,7 @@ void QgsAttributeTypeLoadDialog::loadDataToValueMap()
   mValueMap.clear();
   int idx = keyComboBox->currentData().toInt();
   int idx2 = valueComboBox->currentData().toInt();
-  QgsMapLayer *dataLayer = QgsProject::instance()->mapLayer( layerComboBox->currentData().toString() );
+  QgsMapLayer *dataLayer = QgsApplication::activeProject()->mapLayer( layerComboBox->currentData().toString() );
   QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( dataLayer );
   if ( !vLayer )
     return;

--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -204,7 +204,7 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
   if ( defaultProjectionOption == QLatin1String( "prompt" ) )
   {
     QgsCoordinateReferenceSystem defaultCrs =
-      QgsProject::instance()->crs();
+      QgsApplication::activeProject()->crs();
     if ( layerCrs == defaultCrs )
       mNoticeLabel->setText( "NOTICE: Layer srs set from project (" + defaultCrs.authid() + ')' );
   }

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -42,7 +42,7 @@
 
 QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   : QWidget( parent )
-  , mProject( QgsProject::instance() )
+  , mProject( QgsApplication::activeProject() )
 {
   setupUi( this );
   connect( btnRun, &QToolButton::pressed, this, &QgsExpressionBuilderWidget::btnRun_pressed );

--- a/src/gui/qgsexpressionlineedit.cpp
+++ b/src/gui/qgsexpressionlineedit.cpp
@@ -41,7 +41,7 @@ QgsExpressionLineEdit::QgsExpressionLineEdit( QWidget *parent )
 
   mExpressionContext = QgsExpressionContext();
   mExpressionContext << QgsExpressionContextUtils::globalScope()
-                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+                     << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
 }
 
 void QgsExpressionLineEdit::setExpressionDialogTitle( const QString &title )

--- a/src/gui/qgsextentgroupbox.cpp
+++ b/src/gui/qgsextentgroupbox.cpp
@@ -104,7 +104,7 @@ void QgsExtentGroupBox::setOutputCrs( const QgsCoordinateReferenceSystem &output
       case UserExtent:
         try
         {
-          QgsCoordinateTransform ct( mOutputCrs, outputCrs, QgsProject::instance() );
+          QgsCoordinateTransform ct( mOutputCrs, outputCrs, QgsApplication::activeProject() );
           QgsRectangle extent = ct.transformBoundingBox( outputExtent() );
           mOutputCrs = outputCrs;
           setOutputExtentFromUser( extent, outputCrs );
@@ -134,7 +134,7 @@ void QgsExtentGroupBox::setOutputExtent( const QgsRectangle &r, const QgsCoordin
   {
     try
     {
-      QgsCoordinateTransform ct( srcCrs, mOutputCrs, QgsProject::instance() );
+      QgsCoordinateTransform ct( srcCrs, mOutputCrs, QgsApplication::activeProject() );
       extent = ct.transformBoundingBox( r );
     }
     catch ( QgsCsException & )
@@ -245,7 +245,7 @@ void QgsExtentGroupBox::layerMenuAboutToShow()
 
 void QgsExtentGroupBox::setExtentToLayerExtent( const QString &layerId )
 {
-  QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId );
+  QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( layerId );
   if ( !layer )
     return;
 

--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -174,7 +174,7 @@ QString QgsExternalResourceWidget::resolvePath( const QString &path )
       return path;
       break;
     case QgsFileWidget::RelativeProject:
-      return QFileInfo( QgsProject::instance()->absoluteFilePath() ).dir().filePath( path );
+      return QFileInfo( QgsApplication::activeProject()->absoluteFilePath() ).dir().filePath( path );
       break;
     case QgsFileWidget::RelativeDefaultPath:
       return QDir( mDefaultRoot ).filePath( path );

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -67,7 +67,7 @@ QgsFieldExpressionWidget::QgsFieldExpressionWidget( QWidget *parent )
 
   mExpressionContext = QgsExpressionContext();
   mExpressionContext << QgsExpressionContextUtils::globalScope()
-                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+                     << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
 }
 
 void QgsFieldExpressionWidget::setExpressionDialogTitle( const QString &title )
@@ -162,7 +162,7 @@ void QgsFieldExpressionWidget::setLayer( QgsMapLayer *layer )
   if ( vl )
     mExpressionContext = vl->createExpressionContext();
   else
-    mExpressionContext = QgsProject::instance()->createExpressionContext();
+    mExpressionContext = QgsApplication::activeProject()->createExpressionContext();
 
   mFieldProxyModel->sourceFieldModel()->setLayer( vl );
 

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -236,7 +236,7 @@ void QgsFileWidget::openFileDialog()
   QUrl url = QUrl::fromUserInput( oldPath );
   if ( !url.isValid() )
   {
-    QString defPath = QDir::cleanPath( QFileInfo( QgsProject::instance()->absoluteFilePath() ).path() );
+    QString defPath = QDir::cleanPath( QFileInfo( QgsApplication::activeProject()->absoluteFilePath() ).path() );
     if ( defPath.isEmpty() )
     {
       defPath = QDir::homePath();
@@ -341,7 +341,7 @@ QString QgsFileWidget::relativePath( const QString &filePath, bool removeRelativ
   QString RelativePath;
   if ( mRelativeStorage == RelativeProject )
   {
-    RelativePath = QDir::toNativeSeparators( QDir::cleanPath( QFileInfo( QgsProject::instance()->absoluteFilePath() ).path() ) );
+    RelativePath = QDir::toNativeSeparators( QDir::cleanPath( QFileInfo( QgsApplication::activeProject()->absoluteFilePath() ).path() ) );
   }
   else if ( mRelativeStorage == RelativeDefaultPath && !mDefaultRoot.isEmpty() )
   {

--- a/src/gui/qgsformannotation.cpp
+++ b/src/gui/qgsformannotation.cpp
@@ -163,7 +163,7 @@ void QgsFormAnnotation::readXml( const QDomElement &itemElem, const QgsReadWrite
   // upgrade old layer
   if ( !mapLayer() && itemElem.hasAttribute( QStringLiteral( "vectorLayer" ) ) )
   {
-    setMapLayer( QgsProject::instance()->mapLayer( itemElem.attribute( QStringLiteral( "vectorLayer" ) ) ) );
+    setMapLayer( QgsApplication::activeProject()->mapLayer( itemElem.attribute( QStringLiteral( "vectorLayer" ) ) ) );
   }
 
   mDesignerWidget.reset( createDesignerWidget( mDesignerForm ) );

--- a/src/gui/qgsmapcanvasannotationitem.cpp
+++ b/src/gui/qgsmapcanvasannotationitem.cpp
@@ -60,7 +60,7 @@ void QgsMapCanvasAnnotationItem::updatePosition()
 
   if ( mAnnotation->hasFixedMapPosition() )
   {
-    QgsCoordinateTransform t( mAnnotation->mapPositionCrs(), mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+    QgsCoordinateTransform t( mAnnotation->mapPositionCrs(), mMapCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
     QgsPointXY coord = mAnnotation->mapPosition();
     try
     {
@@ -144,7 +144,7 @@ void QgsMapCanvasAnnotationItem::setFeatureForMapPosition()
 
   try
   {
-    QgsCoordinateTransform ct( mAnnotation->mapPositionCrs(), mMapCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+    QgsCoordinateTransform ct( mAnnotation->mapPositionCrs(), mMapCanvas->mapSettings().destinationCrs(), QgsApplication::activeProject() );
     if ( ct.isValid() )
       mapPosition = ct.transform( mapPosition );
   }

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -141,7 +141,7 @@ QList<QgsMapToolIdentify::IdentifyResult> QgsMapToolIdentify::identify( const Qg
   {
     QApplication::setOverrideCursor( Qt::WaitCursor );
 
-    QStringList noIdentifyLayerIdList = QgsProject::instance()->readListEntry( QStringLiteral( "Identify" ), QStringLiteral( "/disabledLayers" ) );
+    QStringList noIdentifyLayerIdList = QgsApplication::activeProject()->readListEntry( QStringLiteral( "Identify" ), QStringLiteral( "/disabledLayers" ) );
 
     int layerCount;
     if ( layerList.isEmpty() )
@@ -376,7 +376,7 @@ void QgsMapToolIdentify::closestVertexAttributes( const QgsAbstractGeometry &geo
 
 QString QgsMapToolIdentify::formatCoordinate( const QgsPointXY &canvasPoint ) const
 {
-  return QgsCoordinateUtils::formatCoordinateForProject( QgsProject::instance(), canvasPoint, mCanvas->mapSettings().destinationCrs(),
+  return QgsCoordinateUtils::formatCoordinateForProject( QgsApplication::activeProject(), canvasPoint, mCanvas->mapSettings().destinationCrs(),
          mCoordinatePrecision );
 }
 
@@ -399,10 +399,10 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
   QMap< QString, QString > derivedAttributes;
 
   // init distance/area calculator
-  QString ellipsoid = QgsProject::instance()->ellipsoid();
+  QString ellipsoid = QgsApplication::activeProject()->ellipsoid();
   QgsDistanceArea calc;
   calc.setEllipsoid( ellipsoid );
-  calc.setSourceCrs( layer->crs(), QgsProject::instance()->transformContext() );
+  calc.setSourceCrs( layer->crs(), QgsApplication::activeProject()->transformContext() );
 
   QgsWkbTypes::Type wkbType = QgsWkbTypes::NoGeometry;
   QgsWkbTypes::GeometryType geometryType = QgsWkbTypes::NullGeometry;

--- a/src/gui/qgsmetadatawidget.cpp
+++ b/src/gui/qgsmetadatawidget.cpp
@@ -207,7 +207,7 @@ void QgsMetadataWidget::fillSourceFromLayer()
       break;
 
     case ProjectMetadata:
-      lineEditIdentifier->setText( QgsProject::instance()->fileName() );
+      lineEditIdentifier->setText( QgsApplication::activeProject()->fileName() );
       break;
   }
 
@@ -983,7 +983,7 @@ void QgsMetadataWidget::acceptMetadata()
       break;
 
     case ProjectMetadata:
-      QgsProject::instance()->setMetadata( *static_cast< QgsProjectMetadata * >( mMetadata.get() ) );
+      QgsApplication::activeProject()->setMetadata( *static_cast< QgsProjectMetadata * >( mMetadata.get() ) );
       break;
   }
 }

--- a/src/gui/qgsnewauxiliarylayerdialog.cpp
+++ b/src/gui/qgsnewauxiliarylayerdialog.cpp
@@ -38,7 +38,7 @@ void QgsNewAuxiliaryLayerDialog::accept()
   if ( idx >= 0 )
   {
     const QgsField field = mLayer->fields().field( idx );
-    QgsAuxiliaryLayer *alayer = QgsProject::instance()->auxiliaryStorage()->createAuxiliaryLayer( field, mLayer );
+    QgsAuxiliaryLayer *alayer = QgsApplication::activeProject()->auxiliaryStorage()->createAuxiliaryLayer( field, mLayer );
 
     if ( alayer )
     {

--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -484,7 +484,7 @@ bool QgsNewGeoPackageLayerDialog::apply()
     myList << layer;
     //addMapLayers returns a list of all successfully added layers
     //so we compare that to our original list.
-    if ( myList == QgsProject::instance()->addMapLayers( myList ) )
+    if ( myList == QgsApplication::activeProject()->addMapLayers( myList ) )
       return true;
   }
   else

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -96,7 +96,7 @@ QgsOWSSourceSelect::QgsOWSSourceSelect( const QString &service, QWidget *parent,
   if ( widgetMode() != QgsProviderRegistry::WidgetMode::Manager )
   {
     //set the current project CRS if available
-    QgsCoordinateReferenceSystem currentRefSys = QgsProject::instance()->crs();
+    QgsCoordinateReferenceSystem currentRefSys = QgsApplication::activeProject()->crs();
     //convert CRS id to epsg
     if ( currentRefSys.isValid() )
     {
@@ -397,7 +397,7 @@ void QgsOWSSourceSelect::mChangeCRSButton_clicked()
   mySelector->setMessage( QString() );
   mySelector->setOgcWmsCrsFilter( mSelectedLayersCRSs );
 
-  QgsCoordinateReferenceSystem defaultCRS = QgsProject::instance()->crs();
+  QgsCoordinateReferenceSystem defaultCRS = QgsApplication::activeProject()->crs();
   if ( defaultCRS.isValid() )
   {
     mySelector->setCrs( defaultCRS );

--- a/src/gui/qgsprojectionselectionwidget.cpp
+++ b/src/gui/qgsprojectionselectionwidget.cpp
@@ -35,7 +35,7 @@ QgsProjectionSelectionWidget::QgsProjectionSelectionWidget( QWidget *parent )
   mCrsComboBox->addItem( tr( "invalid projection" ), QgsProjectionSelectionWidget::CurrentCrs );
   mCrsComboBox->setSizePolicy( QSizePolicy::Ignored, QSizePolicy::Preferred );
 
-  mProjectCrs = QgsProject::instance()->crs();
+  mProjectCrs = QgsApplication::activeProject()->crs();
   addProjectCrsOption();
 
   QgsSettings settings;

--- a/src/gui/qgspropertyassistantwidget.cpp
+++ b/src/gui/qgspropertyassistantwidget.cpp
@@ -260,7 +260,7 @@ bool QgsPropertyAssistantWidget::computeValuesFromExpression( const QString &exp
   else
   {
     context << QgsExpressionContextUtils::globalScope()
-            << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+            << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
             << QgsExpressionContextUtils::layerScope( mLayer );
   }
 
@@ -473,7 +473,7 @@ QgsPropertyColorAssistantWidget::QgsPropertyColorAssistantWidget( QWidget *paren
   if ( !mColorRampButton->colorRamp() )
   {
     // set a default ramp
-    QString defaultRampName = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/ColorRamp" ), QString() );
+    QString defaultRampName = QgsApplication::activeProject()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/ColorRamp" ), QString() );
     std::unique_ptr< QgsColorRamp > defaultRamp( QgsStyle::defaultStyle()->colorRamp( !defaultRampName.isEmpty() ? defaultRampName : QStringLiteral( "Blues" ) ) );
     if ( defaultRamp )
       mColorRampButton->setColorRamp( defaultRamp.get() );

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -449,7 +449,7 @@ void QgsRasterLayerSaveAsDialog::setResolution( double xRes, double yRes, const 
     // TODO: consider more precise resolution calculation
 
     QgsPointXY center = outputRectangle().center();
-    QgsCoordinateTransform ct( srcCrs, outputCrs(), QgsProject::instance() );
+    QgsCoordinateTransform ct( srcCrs, outputCrs(), QgsApplication::activeProject() );
     QgsPointXY srsCenter = ct.transform( center, QgsCoordinateTransform::ReverseTransform );
 
     QgsRectangle srcExtent( srsCenter.x() - xRes / 2, srsCenter.y() - yRes / 2, srsCenter.x() + xRes / 2, srsCenter.y() + yRes / 2 );

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -223,7 +223,7 @@ void QgsRelationEditorWidget::setRelations( const QgsRelation &relation, const Q
 
   mToggleEditingButton->setVisible( true );
 
-  const auto transactionGroups = QgsProject::instance()->transactionGroups();
+  const auto transactionGroups = QgsApplication::activeProject()->transactionGroups();
   for ( auto it = transactionGroups.constBegin(); it != transactionGroups.constEnd(); ++it )
   {
     if ( it.value()->layers().contains( mRelation.referencingLayer() ) )
@@ -471,7 +471,7 @@ void QgsRelationEditorWidget::duplicateFeature()
   while ( fit.nextFeature( f ) )
   {
     QgsVectorLayerUtils::QgsDuplicateFeatureContext duplicatedFeatureContext;
-    QgsVectorLayerUtils::duplicateFeature( layer, f, QgsProject::instance(), 0, duplicatedFeatureContext );
+    QgsVectorLayerUtils::duplicateFeature( layer, f, QgsApplication::activeProject(), 0, duplicatedFeatureContext );
   }
 }
 

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -265,7 +265,7 @@ void QgsRubberBand::addGeometry( const QgsGeometry &geometry, const QgsCoordinat
   QgsGeometry geom = geometry;
   if ( crs.isValid() )
   {
-    QgsCoordinateTransform ct( crs, ms.destinationCrs(), QgsProject::instance() );
+    QgsCoordinateTransform ct( crs, ms.destinationCrs(), QgsApplication::activeProject() );
     geom.transform( ct );
   }
 

--- a/src/gui/qgsscalerangewidget.cpp
+++ b/src/gui/qgsscalerangewidget.cpp
@@ -69,10 +69,10 @@ QgsScaleRangeWidget::QgsScaleRangeWidget( QWidget *parent )
 
 void QgsScaleRangeWidget::reloadProjectScales()
 {
-  bool projectScales = QgsProject::instance()->readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) );
+  bool projectScales = QgsApplication::activeProject()->readBoolEntry( QStringLiteral( "Scales" ), QStringLiteral( "/useProjectScales" ) );
   if ( projectScales )
   {
-    QStringList scalesList = QgsProject::instance()->readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) );
+    QStringList scalesList = QgsApplication::activeProject()->readListEntry( QStringLiteral( "Scales" ), QStringLiteral( "/ScalesList" ) );
     mMinimumScaleWidget->updateScales( scalesList );
     mMaximumScaleWidget->updateScales( scalesList );
   }

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -1256,7 +1256,7 @@ void QgsTextFormatWidget::updateSvgWidgets( const QString &svgPath )
     mShapeSVGPathLineEdit->setText( svgPath );
   }
 
-  QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( svgPath, QgsProject::instance()->pathResolver() );
+  QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( svgPath, QgsApplication::activeProject()->pathResolver() );
   bool validSVG = QFileInfo::exists( resolvedPath );
 
   // draw red text for path field if invalid (path can't be resolved)

--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -112,7 +112,7 @@ QgsPalettedRendererWidget::QgsPalettedRendererWidget( QgsRasterLayer *layer, con
     mLoadFromLayerAction->setEnabled( false );
   }
 
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) >( &QgsProject::layerWillBeRemoved ), this, &QgsPalettedRendererWidget::layerWillBeRemoved );
+  connect( QgsApplication::activeProject(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) >( &QgsProject::layerWillBeRemoved ), this, &QgsPalettedRendererWidget::layerWillBeRemoved );
   connect( mBandComboBox, &QgsRasterBandComboBox::bandChanged, this, &QgsPalettedRendererWidget::bandChanged );
 }
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -419,7 +419,7 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
   btnColorRamp->setShowRandomColorRamp( true );
 
   // set project default color ramp
-  QString defaultColorRamp = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/ColorRamp" ), QLatin1String( "" ) );
+  QString defaultColorRamp = QgsApplication::activeProject()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/ColorRamp" ), QLatin1String( "" ) );
   if ( !defaultColorRamp.isEmpty() )
   {
     btnColorRamp->setColorRampFromName( defaultColorRamp );
@@ -667,7 +667,7 @@ void QgsCategorizedSymbolRendererWidget::addCategories()
     QgsExpression *expression = new QgsExpression( attrName );
     QgsExpressionContext context;
     context << QgsExpressionContextUtils::globalScope()
-            << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+            << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
             << QgsExpressionContextUtils::atlasScope( nullptr )
             << QgsExpressionContextUtils::layerScope( mLayer );
 
@@ -1049,7 +1049,7 @@ QgsExpressionContext QgsCategorizedSymbolRendererWidget::createExpressionContext
 {
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
              << QgsExpressionContextUtils::atlasScope( nullptr );
 
   if ( mContext.mapCanvas() )

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.cpp
@@ -177,7 +177,7 @@ void QgsDataDefinedSizeLegendWidget::changeSymbol()
 
   QgsExpressionContext ec;
   ec << QgsExpressionContextUtils::globalScope()
-     << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+     << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
      << QgsExpressionContextUtils::atlasScope( nullptr );
   if ( mMapCanvas )
     ec << QgsExpressionContextUtils::mapSettingsScope( mMapCanvas->mapSettings() );

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -408,7 +408,7 @@ QgsExpressionContext QgsGraduatedSymbolRendererWidget::createExpressionContext()
 {
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
              << QgsExpressionContextUtils::atlasScope( nullptr );
 
   if ( mContext.mapCanvas() )
@@ -469,7 +469,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   btnColorRamp->setShowRandomColorRamp( true );
 
   // set project default color ramp
-  QString defaultColorRamp = QgsProject::instance()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/ColorRamp" ), QLatin1String( "" ) );
+  QString defaultColorRamp = QgsApplication::activeProject()->readEntry( QStringLiteral( "DefaultStyles" ), QStringLiteral( "/ColorRamp" ), QLatin1String( "" ) );
   if ( !defaultColorRamp.isEmpty() )
   {
     btnColorRamp->setColorRampFromName( defaultColorRamp );

--- a/src/gui/symbology/qgsheatmaprendererwidget.cpp
+++ b/src/gui/symbology/qgsheatmaprendererwidget.cpp
@@ -37,7 +37,7 @@ QgsExpressionContext QgsHeatmapRendererWidget::createExpressionContext() const
 {
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
              << QgsExpressionContextUtils::atlasScope( nullptr );
 
   if ( mContext.mapCanvas() )

--- a/src/gui/symbology/qgslayerpropertieswidget.cpp
+++ b/src/gui/symbology/qgslayerpropertieswidget.cpp
@@ -216,7 +216,7 @@ QgsExpressionContext QgsLayerPropertiesWidget::createExpressionContext() const
 
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
              << QgsExpressionContextUtils::atlasScope( nullptr );
 
   if ( mContext.mapCanvas() )

--- a/src/gui/symbology/qgsrendererwidget.cpp
+++ b/src/gui/symbology/qgsrendererwidget.cpp
@@ -326,7 +326,7 @@ QgsExpressionContext QgsDataDefinedValueDialog::createExpressionContext() const
 {
   QgsExpressionContext expContext;
   expContext << QgsExpressionContextUtils::globalScope()
-             << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+             << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
              << QgsExpressionContextUtils::atlasScope( nullptr );
   if ( mContext.mapCanvas() )
   {

--- a/src/gui/symbology/qgssvgselectorwidget.cpp
+++ b/src/gui/symbology/qgssvgselectorwidget.cpp
@@ -488,7 +488,7 @@ void QgsSvgSelectorWidget::updateLineEditFeedback( bool ok, const QString &tip )
 
 void QgsSvgSelectorWidget::mFileLineEdit_textChanged( const QString &text )
 {
-  QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( text, QgsProject::instance()->pathResolver() );
+  QString resolvedPath = QgsSymbolLayerUtils::svgSymbolNameToPath( text, QgsApplication::activeProject()->pathResolver() );
   bool validSVG = !resolvedPath.isNull();
 
   updateLineEditFeedback( validSVG, resolvedPath );

--- a/src/gui/symbology/qgssymbolwidgetcontext.cpp
+++ b/src/gui/symbology/qgssymbolwidgetcontext.cpp
@@ -78,7 +78,7 @@ QList<QgsExpressionContextScope *> QgsSymbolWidgetContext::globalProjectAtlasMap
 {
   QList<QgsExpressionContextScope *> scopes;
   scopes << QgsExpressionContextUtils::globalScope()
-         << QgsExpressionContextUtils::projectScope( QgsProject::instance() )
+         << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() )
          << QgsExpressionContextUtils::atlasScope( nullptr );
   if ( mMapCanvas )
   {

--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -79,7 +79,7 @@ QgsGeometryCheckerResultTab::QgsGeometryCheckerResultTab( QgisInterface *iface, 
   connect( ui.pushButtonFixWithPrompt, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::fixErrorsWithPrompt );
   connect( ui.pushButtonErrorResolutionSettings, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::setDefaultResolutionMethods );
   connect( ui.checkBoxHighlight, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::highlightErrors );
-  connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsGeometryCheckerResultTab::checkRemovedLayer );
+  connect( QgsApplication::activeProject(), static_cast<void ( QgsProject::* )( const QStringList & )>( &QgsProject::layersWillBeRemoved ), this, &QgsGeometryCheckerResultTab::checkRemovedLayer );
   connect( ui.pushButtonExport, &QAbstractButton::clicked, this, &QgsGeometryCheckerResultTab::exportErrors );
 
   bool allLayersEditable = true;
@@ -263,7 +263,7 @@ bool QgsGeometryCheckerResultTab::exportErrorsDo( const QString &file )
   {
     return false;
   }
-  if ( !createEmptyDataSource( file, driver, "UTF-8", QgsWkbTypes::Point, attributes, QgsProject::instance()->crs() ) )
+  if ( !createEmptyDataSource( file, driver, "UTF-8", QgsWkbTypes::Point, attributes, QgsApplication::activeProject()->crs() ) )
   {
     return false;
   }
@@ -292,7 +292,7 @@ bool QgsGeometryCheckerResultTab::exportErrorsDo( const QString &file )
 
   // Remove existing layer with same uri
   QStringList toRemove;
-  for ( QgsMapLayer *maplayer : QgsProject::instance()->mapLayers() )
+  for ( QgsMapLayer *maplayer : QgsApplication::activeProject()->mapLayers() )
   {
     if ( dynamic_cast<QgsVectorLayer *>( maplayer ) &&
          static_cast<QgsVectorLayer *>( maplayer )->dataProvider()->dataSourceUri() == layer->dataProvider()->dataSourceUri() )
@@ -302,10 +302,10 @@ bool QgsGeometryCheckerResultTab::exportErrorsDo( const QString &file )
   }
   if ( !toRemove.isEmpty() )
   {
-    QgsProject::instance()->removeMapLayers( toRemove );
+    QgsApplication::activeProject()->removeMapLayers( toRemove );
   }
 
-  QgsProject::instance()->addMapLayers( QList<QgsMapLayer *>() << layer );
+  QgsApplication::activeProject()->addMapLayers( QList<QgsMapLayer *>() << layer );
   return true;
 }
 

--- a/src/plugins/geometry_checker/qgsgeometrycheckfactory.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckfactory.cpp
@@ -264,7 +264,7 @@ template<> QgsGeometryCheck *QgsGeometryCheckFactoryT<QgsGeometryFollowBoundarie
   QgsSettings().setValue( sSettingsGroup + "checkFollowBoundaries", ui.checkBoxFollowBoundaries->isChecked() );
   if ( ui.checkBoxFollowBoundaries->isEnabled() && ui.checkBoxFollowBoundaries->isChecked() )
   {
-    QgsVectorLayer *checkLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( ui.comboBoxFollowBoundaries->currentData().toString() ) );
+    QgsVectorLayer *checkLayer = qobject_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( ui.comboBoxFollowBoundaries->currentData().toString() ) );
     return new QgsGeometryFollowBoundariesCheck( context, checkLayer );
   }
   else

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -791,7 +791,7 @@ void QgsGeorefPluginGui::updateMouseCoordinatePrecision()
   // function needs to be called every time one of the above happens.
 
   // Get the display precision from the project s
-  bool automatic = QgsProject::instance()->readBoolEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ) );
+  bool automatic = QgsApplication::activeProject()->readBoolEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ) );
   int dp = 0;
 
   if ( automatic )
@@ -804,7 +804,7 @@ void QgsGeorefPluginGui::updateMouseCoordinatePrecision()
       dp = static_cast<int>( std::ceil( -1.0 * std::log10( mCanvas->mapUnitsPerPixel() ) ) );
   }
   else
-    dp = QgsProject::instance()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ) );
+    dp = QgsApplication::activeProject()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ) );
 
   // Keep dp sensible
   if ( dp < 0 )
@@ -1101,7 +1101,7 @@ void QgsGeorefPluginGui::setupConnections()
   connect( mCanvas, &QgsMapCanvas::zoomLastStatusChanged, mActionZoomLast, &QAction::setEnabled );
   connect( mCanvas, &QgsMapCanvas::zoomNextStatusChanged, mActionZoomNext, &QAction::setEnabled );
   // Connect when one Layer is removed - Case where change the Projetct in QGIS
-  connect( QgsProject::instance(), static_cast<void ( QgsProject::* )( const QString & )>( &QgsProject::layerWillBeRemoved ), this, &QgsGeorefPluginGui::layerWillBeRemoved );
+  connect( QgsApplication::activeProject(), static_cast<void ( QgsProject::* )( const QString & )>( &QgsProject::layerWillBeRemoved ), this, &QgsGeorefPluginGui::layerWillBeRemoved );
 
   // Connect extents changed - Use for need add again Raster
   connect( mCanvas, &QgsMapCanvas::extentsChanged, this, &QgsGeorefPluginGui::extentsChanged );
@@ -1112,7 +1112,7 @@ void QgsGeorefPluginGui::removeOldLayer()
   // delete layer (and don't signal it as it's our private layer)
   if ( mLayer )
   {
-    QgsProject::instance()->removeMapLayers(
+    QgsApplication::activeProject()->removeMapLayers(
       ( QStringList() << mLayer->id() ) );
     mLayer = nullptr;
   }
@@ -1158,7 +1158,7 @@ void QgsGeorefPluginGui::addRaster( const QString &file )
   mLayer = new QgsRasterLayer( file, QStringLiteral( "Raster" ) );
 
   // so layer is not added to legend
-  QgsProject::instance()->addMapLayers(
+  QgsApplication::activeProject()->addMapLayers(
     QList<QgsMapLayer *>() << mLayer, false, false );
 
   // add layer to map canvas
@@ -1512,7 +1512,7 @@ bool QgsGeorefPluginGui::writePDFMapFile( const QString &fileName, const QgsGeor
   double paperHeight = s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/HeightPDFMap" ), "420" ).toDouble();
 
   //create layout
-  QgsLayout layout( QgsProject::instance() );
+  QgsLayout layout( QgsApplication::activeProject() );
   std::unique_ptr< QgsLayoutItemPage > page = qgis::make_unique< QgsLayoutItemPage >( &layout );
 
   double leftMargin = 8;
@@ -1578,7 +1578,7 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString &fileName, const QgsG
   }
 
   //create layout A4 with 300 dpi
-  QgsLayout layout( QgsProject::instance() );
+  QgsLayout layout( QgsApplication::activeProject() );
 
   std::unique_ptr< QgsLayoutItemPage > page = qgis::make_unique< QgsLayoutItemPage >( &layout );
   page->setPageSize( QgsLayoutSize( 210, 297 ) ); //A4

--- a/src/plugins/globe/globe_plugin.cpp
+++ b/src/plugins/globe/globe_plugin.cpp
@@ -636,7 +636,7 @@ QgsRectangle GlobePlugin::getQGISLayerExtent() const
 void GlobePlugin::showCurrentCoordinates( const osgEarth::GeoPoint &geoPoint )
 {
   osg::Vec3d pos = geoPoint.vec3d();
-  emit xyCoordinates( QgsCoordinateTransform( QgsCoordinateReferenceSystem( GEO_EPSG_CRS_AUTHID ), mQGisIface->mapCanvas()->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() ).transform( QgsPointXY( pos.x(), pos.y() ) ) );
+  emit xyCoordinates( QgsCoordinateTransform( QgsCoordinateReferenceSystem( GEO_EPSG_CRS_AUTHID ), mQGisIface->mapCanvas()->mapSettings().destinationCrs(), QgsApplication::activeProject()->transformContext() ).transform( QgsPointXY( pos.x(), pos.y() ) ) );
 }
 
 void GlobePlugin::setSelectedCoordinates( const osg::Vec3d &coords )
@@ -665,11 +665,11 @@ void GlobePlugin::syncExtent()
   if ( mapSettings.destinationCrs().authid().compare( QString( "EPSG:%1" ).arg( epsgGlobe ), Qt::CaseInsensitive ) != 0 )
   {
     QgsCoordinateReferenceSystem srcCRS( mapSettings.destinationCrs() );
-    extent = QgsCoordinateTransform( srcCRS, globeCrs, QgsProject::instance()->transformContext() ).transformBoundingBox( extent );
+    extent = QgsCoordinateTransform( srcCRS, globeCrs, QgsApplication::activeProject()->transformContext() ).transformBoundingBox( extent );
   }
 
   QgsDistanceArea dist;
-  dist.setSourceCrs( globeCrs, QgsProject::instance()->transformContext() );
+  dist.setSourceCrs( globeCrs, QgsApplication::activeProject()->transformContext() );
   dist.setEllipsoid( "WGS84" );
 
   QgsPointXY ll = QgsPointXY( extent.xMinimum(), extent.yMinimum() );
@@ -924,7 +924,7 @@ void GlobePlugin::updateLayers()
 #endif
     for ( const osg::ref_ptr<osgEarth::ModelLayer> &modelLayer : modelLayers )
     {
-      QgsMapLayer *mapLayer = QgsProject::instance()->mapLayer( QString::fromStdString( modelLayer->getName() ) );
+      QgsMapLayer *mapLayer = QgsApplication::activeProject()->mapLayer( QString::fromStdString( modelLayer->getName() ) );
       if ( mapLayer )
         disconnect( mapLayer, SIGNAL( repaintRequested() ), this, SLOT( layerChanged() ) );
       if ( dynamic_cast<QgsVectorLayer *>( mapLayer ) )
@@ -935,7 +935,7 @@ void GlobePlugin::updateLayers()
 
     for ( const QString &layerId : selectedLayerIds )
     {
-      QgsMapLayer *mapLayer = QgsProject::instance()->mapLayer( layerId );
+      QgsMapLayer *mapLayer = QgsApplication::activeProject()->mapLayer( layerId );
       connect( mapLayer, SIGNAL( repaintRequested() ), this, SLOT( layerChanged() ) );
 
       QgsGlobeVectorLayerConfig *layerConfig = 0;
@@ -957,7 +957,7 @@ void GlobePlugin::updateLayers()
       else
       {
         drapedLayers.append( mapLayer );
-        QgsRectangle extent = QgsCoordinateTransform( mapLayer->crs(), QgsCoordinateReferenceSystem( GEO_EPSG_CRS_AUTHID ), QgsProject::instance()->transformContext() ).transform( mapLayer->extent() );
+        QgsRectangle extent = QgsCoordinateTransform( mapLayer->crs(), QgsCoordinateReferenceSystem( GEO_EPSG_CRS_AUTHID ), QgsApplication::activeProject()->transformContext() ).transform( mapLayer->extent() );
         mLayerExtents.insert( mapLayer->id(), extent );
       }
     }
@@ -1023,7 +1023,7 @@ void GlobePlugin::layerChanged( QgsMapLayer *mapLayer )
           if ( ! mMapNode->getMap()->getModelLayerByName( layerId.toStdString() ) )
 #endif
           {
-            QgsMapLayer *layer = QgsProject::instance()->mapLayer( layerId );
+            QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( layerId );
             if ( layer )
             {
               layers.append( layer );
@@ -1031,7 +1031,7 @@ void GlobePlugin::layerChanged( QgsMapLayer *mapLayer )
           }
         }
         mTileSource->setLayers( layers );
-        QgsRectangle extent = QgsCoordinateTransform( mapLayer->crs(), QgsCoordinateReferenceSystem( GEO_EPSG_CRS_AUTHID ), QgsProject::instance()->transformContext() ).transform( mapLayer->extent() );
+        QgsRectangle extent = QgsCoordinateTransform( mapLayer->crs(), QgsCoordinateReferenceSystem( GEO_EPSG_CRS_AUTHID ), QgsApplication::activeProject()->transformContext() ).transform( mapLayer->extent() );
         mLayerExtents.insert( mapLayer->id(), extent );
       }
       // Remove any model layer of that layer, in case one existed
@@ -1040,7 +1040,7 @@ void GlobePlugin::layerChanged( QgsMapLayer *mapLayer )
 #else
       mMapNode->getMap()->removeModelLayer( mMapNode->getMap()->getModelLayerByName( mapLayer->id().toStdString() ) );
 #endif
-      QgsRectangle layerExtent = QgsCoordinateTransform( mapLayer->crs(), QgsCoordinateReferenceSystem( GEO_EPSG_CRS_AUTHID ), QgsProject::instance()->transformContext() ).transform( mapLayer->extent() );
+      QgsRectangle layerExtent = QgsCoordinateTransform( mapLayer->crs(), QgsCoordinateReferenceSystem( GEO_EPSG_CRS_AUTHID ), QgsApplication::activeProject()->transformContext() ).transform( mapLayer->extent() );
       QgsRectangle dirtyExtent = layerExtent;
       if ( mLayerExtents.contains( mapLayer->id() ) )
       {

--- a/src/plugins/globe/qgsglobefeatureidentify.cpp
+++ b/src/plugins/globe/qgsglobefeatureidentify.cpp
@@ -57,7 +57,7 @@ void QgsGlobeFeatureIdentifyCallback::onHit( osgEarth::ObjectID id )
   std::string layerId;
   if ( feature->getUserValue( "qgisLayerId", layerId ) )
   {
-    QgsVectorLayer *lyr = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( QString::fromStdString( layerId ) ) );
+    QgsVectorLayer *lyr = qobject_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( QString::fromStdString( layerId ) ) );
 #endif
     if ( lyr )
     {

--- a/src/plugins/globe/qgsglobeplugindialog.cpp
+++ b/src/plugins/globe/qgsglobeplugindialog.cpp
@@ -229,49 +229,49 @@ void QgsGlobePluginDialog::readProjectSettings()
   mElevationTreeView->resizeColumnToContents( 0 );
 
 #if OSGEARTH_VERSION_GREATER_OR_EQUAL( 2, 5, 0 )
-  mSpinBoxVerticalScale->setValue( QgsProject::instance()->readDoubleEntry( "Globe-Plugin", "/verticalScale", 1 ) );
+  mSpinBoxVerticalScale->setValue( QgsApplication::activeProject()->readDoubleEntry( "Globe-Plugin", "/verticalScale", 1 ) );
 #endif
 
   // Map settings
-  groupBoxSky->setChecked( QgsProject::instance()->readBoolEntry( "Globe-Plugin", "/skyEnabled", true ) );
-  checkBoxDateTime->setChecked( QgsProject::instance()->readBoolEntry( "Globe-Plugin", "/overrideDateTime", false ) );
-  dateTimeEditSky->setDateTime( QDateTime::fromString( QgsProject::instance()->readEntry( "Globe-Plugin", "/skyDateTime", QDateTime::currentDateTime().toString() ) ) );
-  checkBoxSkyAutoAmbient->setChecked( QgsProject::instance()->readBoolEntry( "Globe-Plugin", "/skyAutoAmbient", false ) );
-  horizontalSliderMinAmbient->setValue( QgsProject::instance()->readDoubleEntry( "Globe-Plugin", "/skyMinAmbient", 30. ) );
+  groupBoxSky->setChecked( QgsApplication::activeProject()->readBoolEntry( "Globe-Plugin", "/skyEnabled", true ) );
+  checkBoxDateTime->setChecked( QgsApplication::activeProject()->readBoolEntry( "Globe-Plugin", "/overrideDateTime", false ) );
+  dateTimeEditSky->setDateTime( QDateTime::fromString( QgsApplication::activeProject()->readEntry( "Globe-Plugin", "/skyDateTime", QDateTime::currentDateTime().toString() ) ) );
+  checkBoxSkyAutoAmbient->setChecked( QgsApplication::activeProject()->readBoolEntry( "Globe-Plugin", "/skyAutoAmbient", false ) );
+  horizontalSliderMinAmbient->setValue( QgsApplication::activeProject()->readDoubleEntry( "Globe-Plugin", "/skyMinAmbient", 30. ) );
 }
 
 void QgsGlobePluginDialog::writeProjectSettings()
 {
   // Imagery settings
-  QgsProject::instance()->removeEntry( "Globe-Plugin", "/imageryDatasources/" );
+  QgsApplication::activeProject()->removeEntry( "Globe-Plugin", "/imageryDatasources/" );
   for ( int row = 0, nRows = mImageryTreeView->topLevelItemCount(); row < nRows; ++row )
   {
     QTreeWidgetItem *item = mImageryTreeView->topLevelItem( row );
     QString key = QString( "/imageryDatasources/L%1" ).arg( row );
-    QgsProject::instance()->writeEntry( "Globe-Plugin", key + "/type", item->text( 0 ) );
-    QgsProject::instance()->writeEntry( "Globe-Plugin", key + "/uri", item->text( 1 ) );
+    QgsApplication::activeProject()->writeEntry( "Globe-Plugin", key + "/type", item->text( 0 ) );
+    QgsApplication::activeProject()->writeEntry( "Globe-Plugin", key + "/uri", item->text( 1 ) );
   }
 
   // Elevation settings
-  QgsProject::instance()->removeEntry( "Globe-Plugin", "/elevationDatasources/" );
+  QgsApplication::activeProject()->removeEntry( "Globe-Plugin", "/elevationDatasources/" );
   for ( int row = 0, nRows = mElevationTreeView->topLevelItemCount(); row < nRows; ++row )
   {
     QTreeWidgetItem *item = mElevationTreeView->topLevelItem( row );
     QString key = QString( "/elevationDatasources/L%1" ).arg( row );
-    QgsProject::instance()->writeEntry( "Globe-Plugin", key + "/type", item->text( 0 ) );
-    QgsProject::instance()->writeEntry( "Globe-Plugin", key + "/uri", item->text( 1 ) );
+    QgsApplication::activeProject()->writeEntry( "Globe-Plugin", key + "/type", item->text( 0 ) );
+    QgsApplication::activeProject()->writeEntry( "Globe-Plugin", key + "/uri", item->text( 1 ) );
   }
 
 #if OSGEARTH_VERSION_GREATER_OR_EQUAL( 2, 5, 0 )
-  QgsProject::instance()->writeEntry( "Globe-Plugin", "/verticalScale", mSpinBoxVerticalScale->value() );
+  QgsApplication::activeProject()->writeEntry( "Globe-Plugin", "/verticalScale", mSpinBoxVerticalScale->value() );
 #endif
 
   // Map settings
-  QgsProject::instance()->writeEntry( "Globe-Plugin", "/skyEnabled/", groupBoxSky->isChecked() );
-  QgsProject::instance()->writeEntry( "Globe-Plugin", "/overrideDateTime/", checkBoxDateTime->isChecked() );
-  QgsProject::instance()->writeEntry( "Globe-Plugin", "/skyDateTime/", dateTimeEditSky->dateTime().toString() );
-  QgsProject::instance()->writeEntry( "Globe-Plugin", "/skyAutoAmbient/", checkBoxSkyAutoAmbient->isChecked() );
-  QgsProject::instance()->writeEntry( "Globe-Plugin", "/skyMinAmbient/", horizontalSliderMinAmbient->value() );
+  QgsApplication::activeProject()->writeEntry( "Globe-Plugin", "/skyEnabled/", groupBoxSky->isChecked() );
+  QgsApplication::activeProject()->writeEntry( "Globe-Plugin", "/overrideDateTime/", checkBoxDateTime->isChecked() );
+  QgsApplication::activeProject()->writeEntry( "Globe-Plugin", "/skyDateTime/", dateTimeEditSky->dateTime().toString() );
+  QgsApplication::activeProject()->writeEntry( "Globe-Plugin", "/skyAutoAmbient/", checkBoxSkyAutoAmbient->isChecked() );
+  QgsApplication::activeProject()->writeEntry( "Globe-Plugin", "/skyMinAmbient/", horizontalSliderMinAmbient->value() );
 }
 
 bool QgsGlobePluginDialog::validateRemoteUri( const QString &uri, QString &errMsg ) const
@@ -432,14 +432,14 @@ void QgsGlobePluginDialog::on_mRemoveElevationButton_clicked()
 
 QList<QgsGlobePluginDialog::LayerDataSource> QgsGlobePluginDialog::getImageryDataSources() const
 {
-  int keysCount = QgsProject::instance()->subkeyList( "Globe-Plugin", "/imageryDatasources/" ).count();
+  int keysCount = QgsApplication::activeProject()->subkeyList( "Globe-Plugin", "/imageryDatasources/" ).count();
   QList<LayerDataSource> datasources;
   for ( int i = 0; i < keysCount; ++i )
   {
     QString key = QString( "/imageryDatasources/L%1" ).arg( i );
     LayerDataSource datasource;
-    datasource.type  = QgsProject::instance()->readEntry( "Globe-Plugin", key + "/type" );
-    datasource.uri   = QgsProject::instance()->readEntry( "Globe-Plugin", key + "/uri" );
+    datasource.type  = QgsApplication::activeProject()->readEntry( "Globe-Plugin", key + "/type" );
+    datasource.uri   = QgsApplication::activeProject()->readEntry( "Globe-Plugin", key + "/uri" );
     datasources.append( datasource );
   }
   return datasources;
@@ -447,14 +447,14 @@ QList<QgsGlobePluginDialog::LayerDataSource> QgsGlobePluginDialog::getImageryDat
 
 QList<QgsGlobePluginDialog::LayerDataSource> QgsGlobePluginDialog::getElevationDataSources() const
 {
-  int keysCount = QgsProject::instance()->subkeyList( "Globe-Plugin", "/elevationDatasources/" ).count();
+  int keysCount = QgsApplication::activeProject()->subkeyList( "Globe-Plugin", "/elevationDatasources/" ).count();
   QList<LayerDataSource> datasources;
   for ( int i = 0; i < keysCount; ++i )
   {
     QString key = QString( "/elevationDatasources/L%1" ).arg( i );
     LayerDataSource datasource;
-    datasource.type  = QgsProject::instance()->readEntry( "Globe-Plugin", key + "/type" );
-    datasource.uri   = QgsProject::instance()->readEntry( "Globe-Plugin", key + "/uri" );
+    datasource.type  = QgsApplication::activeProject()->readEntry( "Globe-Plugin", key + "/type" );
+    datasource.uri   = QgsApplication::activeProject()->readEntry( "Globe-Plugin", key + "/uri" );
     datasources.append( datasource );
   }
   return datasources;
@@ -467,15 +467,15 @@ double QgsGlobePluginDialog::getVerticalScale() const
 
 bool QgsGlobePluginDialog::getSkyEnabled() const
 {
-  return QgsProject::instance()->readBoolEntry( "Globe-Plugin", "/skyEnabled", true );
+  return QgsApplication::activeProject()->readBoolEntry( "Globe-Plugin", "/skyEnabled", true );
 }
 
 QDateTime QgsGlobePluginDialog::getSkyDateTime() const
 {
-  bool overrideDateTime = QgsProject::instance()->readBoolEntry( "Globe-Plugin", "/overrideDateTime", false );
+  bool overrideDateTime = QgsApplication::activeProject()->readBoolEntry( "Globe-Plugin", "/overrideDateTime", false );
   if ( overrideDateTime )
   {
-    return QDateTime::fromString( QgsProject::instance()->readEntry( "Globe-Plugin", "/skyDateTime", QDateTime::currentDateTime().toString() ) );
+    return QDateTime::fromString( QgsApplication::activeProject()->readEntry( "Globe-Plugin", "/skyDateTime", QDateTime::currentDateTime().toString() ) );
   }
   else
   {
@@ -485,12 +485,12 @@ QDateTime QgsGlobePluginDialog::getSkyDateTime() const
 
 bool QgsGlobePluginDialog::getSkyAutoAmbience() const
 {
-  return QgsProject::instance()->readBoolEntry( "Globe-Plugin", "/skyAutoAmbient", false );
+  return QgsApplication::activeProject()->readBoolEntry( "Globe-Plugin", "/skyAutoAmbient", false );
 }
 
 double QgsGlobePluginDialog::getSkyMinAmbient() const
 {
-  return QgsProject::instance()->readDoubleEntry( "Globe-Plugin", "/skyMinAmbient", 30. ) / 100.;
+  return QgsApplication::activeProject()->readDoubleEntry( "Globe-Plugin", "/skyMinAmbient", 30. ) / 100.;
 }
 
 /// ADVANCED //////////////////////////////////////////////////////////////////

--- a/src/plugins/globe/qgsglobevectorlayerproperties.cpp
+++ b/src/plugins/globe/qgsglobevectorlayerproperties.cpp
@@ -182,8 +182,8 @@ void QgsGlobeVectorLayerPropertiesPage::showRenderingModeWidget( int index )
 QgsGlobeLayerPropertiesFactory::QgsGlobeLayerPropertiesFactory( QObject *parent )
   : QObject( parent )
 {
-  connect( QgsProject::instance(), SIGNAL( readMapLayer( QgsMapLayer *, QDomElement ) ), this, SLOT( readGlobeVectorLayerConfig( QgsMapLayer *, QDomElement ) ) );
-  connect( QgsProject::instance(), SIGNAL( writeMapLayer( QgsMapLayer *, QDomElement &, QDomDocument & ) ), this, SLOT( writeGlobeVectorLayerConfig( QgsMapLayer *, QDomElement &, QDomDocument & ) ) );
+  connect( QgsApplication::activeProject(), SIGNAL( readMapLayer( QgsMapLayer *, QDomElement ) ), this, SLOT( readGlobeVectorLayerConfig( QgsMapLayer *, QDomElement ) ) );
+  connect( QgsApplication::activeProject(), SIGNAL( writeMapLayer( QgsMapLayer *, QDomElement &, QDomDocument & ) ), this, SLOT( writeGlobeVectorLayerConfig( QgsMapLayer *, QDomElement &, QDomDocument & ) ) );
 }
 
 QgsMapLayerConfigWidget *QgsGlobeLayerPropertiesFactory::createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool dockWidget, QWidget *parent ) const

--- a/src/plugins/globe/qgsglobewidget.cpp
+++ b/src/plugins/globe/qgsglobewidget.cpp
@@ -85,8 +85,8 @@ QgsGlobeWidget::QgsGlobeWidget( QgisInterface *iface, QWidget *parent )
   setAttribute( Qt::WA_DeleteOnClose );
 
   connect( mQgisIface->mapCanvas(), SIGNAL( layersChanged() ), this, SLOT( updateLayerSelectionMenu() ) );
-  connect( QgsProject::instance(), SIGNAL( layersAdded( QList<QgsMapLayer *> ) ), this, SLOT( updateLayerSelectionMenu() ) );
-  connect( QgsProject::instance(), SIGNAL( layerRemoved( QString ) ), this, SLOT( updateLayerSelectionMenu() ) );
+  connect( QgsApplication::activeProject(), SIGNAL( layersAdded( QList<QgsMapLayer *> ) ), this, SLOT( updateLayerSelectionMenu() ) );
+  connect( QgsApplication::activeProject(), SIGNAL( layerRemoved( QString ) ), this, SLOT( updateLayerSelectionMenu() ) );
 
   updateLayerSelectionMenu();
 }
@@ -110,9 +110,9 @@ void QgsGlobeWidget::updateLayerSelectionMenu()
   }
 
   mLayerSelectionMenu->clear();
-  QString heightmap = QgsProject::instance()->readEntry( "Heightmap", "layer" );
+  QString heightmap = QgsApplication::activeProject()->readEntry( "Heightmap", "layer" );
   // Use layerTreeRoot to get layers ordered as in the layer tree
-  for ( QgsLayerTreeLayer *layerTreeLayer : QgsProject::instance()->layerTreeRoot()->findLayers() )
+  for ( QgsLayerTreeLayer *layerTreeLayer : QgsApplication::activeProject()->layerTreeRoot()->findLayers() )
   {
     QgsMapLayer *layer = layerTreeLayer->layer();
     if ( !layer )

--- a/src/plugins/gps_importer/qgsgpsplugin.cpp
+++ b/src/plugins/gps_importer/qgsgpsplugin.cpp
@@ -114,7 +114,7 @@ void QgsGpsPlugin::run()
   // find all GPX layers
   std::vector<QgsVectorLayer *> gpxLayers;
   QMap<QString, QgsMapLayer *>::const_iterator iter;
-  QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();
+  QMap<QString, QgsMapLayer *> layers = QgsApplication::activeProject()->mapLayers();
   for ( iter = layers.constBegin();
         iter != layers.constEnd(); ++iter )
   {

--- a/src/plugins/grass/qgsgrassmoduleoptions.cpp
+++ b/src/plugins/grass/qgsgrassmoduleoptions.cpp
@@ -465,7 +465,7 @@ QStringList QgsGrassModuleStandardOptions::checkOutput()
 QList<QgsGrassProvider *> QgsGrassModuleStandardOptions::grassProviders()
 {
   QList<QgsGrassProvider *> providers;
-  Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->mapLayers().values() )
+  Q_FOREACH ( QgsMapLayer *layer, QgsApplication::activeProject()->mapLayers().values() )
   {
     if ( layer->type() == QgsMapLayer::VectorLayer )
     {
@@ -486,7 +486,7 @@ QList<QgsGrassProvider *> QgsGrassModuleStandardOptions::grassProviders()
 QList<QgsGrassRasterProvider *> QgsGrassModuleStandardOptions::grassRasterProviders()
 {
   QList<QgsGrassRasterProvider *> providers;
-  Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->mapLayers().values() )
+  Q_FOREACH ( QgsMapLayer *layer, QgsApplication::activeProject()->mapLayers().values() )
   {
     if ( layer->type() == QgsMapLayer::RasterLayer )
     {

--- a/src/plugins/grass/qgsgrassmoduleparam.cpp
+++ b/src/plugins/grass/qgsgrassmoduleparam.cpp
@@ -840,9 +840,9 @@ QgsGrassModuleGdalInput::QgsGrassModuleGdalInput(
 
   lbl->setBuddy( mLayerPassword );
 
-  connect( QgsProject::instance(), &QgsProject::layersAdded,
+  connect( QgsApplication::activeProject(), &QgsProject::layersAdded,
            this, &QgsGrassModuleGdalInput::updateQgisLayers );
-  connect( QgsProject::instance(), &QgsProject::layersRemoved,
+  connect( QgsApplication::activeProject(), &QgsProject::layersRemoved,
            this, &QgsGrassModuleGdalInput::updateQgisLayers );
 
   // Fill in QGIS layers
@@ -867,7 +867,7 @@ void QgsGrassModuleGdalInput::updateQgisLayers()
     mLayerComboBox->addItem( tr( "Select a layer" ), QVariant() );
   }
 
-  Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->mapLayers().values() )
+  Q_FOREACH ( QgsMapLayer *layer, QgsApplication::activeProject()->mapLayers().values() )
   {
     if ( !layer ) continue;
 
@@ -1195,8 +1195,8 @@ QgsGrassModuleSelection::QgsGrassModuleSelection(
   connect( mModeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsGrassModuleSelection::onModeChanged );
   l->addWidget( mModeComboBox );
 
-  connect( QgsProject::instance(), &QgsProject::layersAdded, this, &QgsGrassModuleSelection::onLayerChanged );
-  connect( QgsProject::instance(), &QgsProject::layersRemoved, this, &QgsGrassModuleSelection::onLayerChanged );
+  connect( QgsApplication::activeProject(), &QgsProject::layersAdded, this, &QgsGrassModuleSelection::onLayerChanged );
+  connect( QgsApplication::activeProject(), &QgsProject::layersRemoved, this, &QgsGrassModuleSelection::onLayerChanged );
 
   // Fill in layer current fields
   onLayerChanged();
@@ -1212,7 +1212,7 @@ void QgsGrassModuleSelection::onLayerChanged()
 
   QStringList layerIds;
   // add new layers matching selected input layer if not yet present
-  Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->mapLayers().values() )
+  Q_FOREACH ( QgsMapLayer *layer, QgsApplication::activeProject()->mapLayers().values() )
   {
     QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layer );
     if ( vectorLayer && vectorLayer->providerType() == QLatin1String( "grass" ) )
@@ -1295,7 +1295,7 @@ QgsVectorLayer *QgsGrassModuleSelection::currentSelectionLayer()
   {
     return nullptr;
   }
-  QgsMapLayer *layer = QgsProject::instance()->mapLayer( id );
+  QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( id );
   return qobject_cast<QgsVectorLayer *>( layer );
 }
 
@@ -1309,13 +1309,13 @@ void QgsGrassModuleSelection::onModeChanged()
     QgsDebugMsg( "uri = " + uri );
 
     QgsVectorLayer *layer = new QgsVectorLayer( uri, name, QStringLiteral( "grass" ) );
-    QgsProject::instance()->addMapLayer( layer );
+    QgsApplication::activeProject()->addMapLayer( layer );
     onLayerChanged(); // update with added layer
   }
   else if ( mModeComboBox->itemData( index ).toInt() == Layer )
   {
     QString id = mModeComboBox->itemData( index, Qt::UserRole + 1 ).toString();
-    QgsMapLayer *layer = QgsProject::instance()->mapLayer( id );
+    QgsMapLayer *layer = QgsApplication::activeProject()->mapLayer( id );
     QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( layer );
     if ( vectorLayer )
     {

--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -520,7 +520,7 @@ void QgsGrassNewMapset::setRegionPage()
   if ( mRegionModified && newCrs.isValid() && mCrs.isValid()
        && newCrs.srsid() != mCrs.srsid() )
   {
-    QgsCoordinateTransform trans( mCrs, newCrs, QgsProject::instance() );
+    QgsCoordinateTransform trans( mCrs, newCrs, QgsApplication::activeProject() );
 
     double n = mNorthLineEdit->text().toDouble();
     double s = mSouthLineEdit->text().toDouble();
@@ -856,7 +856,7 @@ void QgsGrassNewMapset::setSelectedRegion()
       return;
     }
 
-    QgsCoordinateTransform trans( source, dest, QgsProject::instance() );
+    QgsCoordinateTransform trans( source, dest, QgsApplication::activeProject() );
 
     bool ok = true;
     for ( int i = 0; i < 4; i++ )
@@ -946,7 +946,7 @@ void QgsGrassNewMapset::setCurrentRegion()
   if ( srs.isValid() && mCrs.isValid()
        && srs.srsid() != mCrs.srsid() )
   {
-    QgsCoordinateTransform trans( srs, mCrs, QgsProject::instance() );
+    QgsCoordinateTransform trans( srs, mCrs, QgsApplication::activeProject() );
 
     bool ok = true;
     for ( int i = 0; i < 2; i++ )
@@ -1064,7 +1064,7 @@ void QgsGrassNewMapset::drawRegion()
       return;
     }
 
-    QgsCoordinateTransform trans( source, dest, QgsProject::instance() );
+    QgsCoordinateTransform trans( source, dest, QgsApplication::activeProject() );
 
     for ( int i = points.size() - 1; i >= 0; i-- )
     {

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -252,7 +252,7 @@ void QgsGrassPlugin::initGui()
   connect( QgsGrass::instance(), &QgsGrass::newLayer, this, &QgsGrassPlugin::onNewLayer );
 
   // Connect start/stop editing
-  connect( QgsProject::instance(), &QgsProject::layerWasAdded, this, &QgsGrassPlugin::onLayerWasAdded );
+  connect( QgsApplication::activeProject(), &QgsProject::layerWasAdded, this, &QgsGrassPlugin::onLayerWasAdded );
 
   connect( qGisInterface->layerTreeView(), &QgsLayerTreeView::currentLayerChanged,
            this, &QgsGrassPlugin::onCurrentLayerChanged );
@@ -428,7 +428,7 @@ void QgsGrassPlugin::onFieldsChanged()
   QString uri = grassProvider->dataSourceUri();
   uri.remove( QRegExp( "[^_]*$" ) );
   QgsDebugMsg( "uri = " + uri );
-  Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->mapLayers().values() )
+  Q_FOREACH ( QgsMapLayer *layer, QgsApplication::activeProject()->mapLayers().values() )
   {
     if ( !layer || layer->type() != QgsMapLayer::VectorLayer )
     {
@@ -726,13 +726,13 @@ void QgsGrassPlugin::projectRead()
 {
 
   bool ok;
-  QString gisdbase = QgsProject::instance()->readPath(
-                       QgsProject::instance()->readEntry(
+  QString gisdbase = QgsApplication::activeProject()->readPath(
+                       QgsApplication::activeProject()->readEntry(
                          QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingGisdbase" ), QLatin1String( "" ), &ok ).trimmed()
                      );
-  QString location = QgsProject::instance()->readEntry(
+  QString location = QgsApplication::activeProject()->readEntry(
                        QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingLocation" ), QLatin1String( "" ), &ok ).trimmed();
-  QString mapset = QgsProject::instance()->readEntry(
+  QString mapset = QgsApplication::activeProject()->readEntry(
                      QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingMapset" ), QLatin1String( "" ), &ok ).trimmed();
 
   if ( gisdbase.isEmpty() || location.isEmpty() || mapset.isEmpty() )
@@ -792,12 +792,12 @@ void QgsGrassPlugin::unload()
   disconnect( QgsGrass::instance(), &QgsGrass::regionPenChanged, this, &QgsGrassPlugin::displayRegion );
   disconnect( QgsGrass::instance(), &QgsGrass::newLayer, this, &QgsGrassPlugin::onNewLayer );
 
-  disconnect( QgsProject::instance(), &QgsProject::layerWasAdded, this, &QgsGrassPlugin::onLayerWasAdded );
+  disconnect( QgsApplication::activeProject(), &QgsProject::layerWasAdded, this, &QgsGrassPlugin::onLayerWasAdded );
 
   disconnect( qGisInterface->layerTreeView(), &QgsLayerTreeView::currentLayerChanged,
               this, &QgsGrassPlugin::onCurrentLayerChanged );
 
-  Q_FOREACH ( QgsMapLayer *layer, QgsProject::instance()->mapLayers().values() )
+  Q_FOREACH ( QgsMapLayer *layer, QgsApplication::activeProject()->mapLayers().values() )
   {
     if ( !layer || layer->type() != QgsMapLayer::VectorLayer )
     {

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -82,9 +82,9 @@ void QgsOfflineEditingPlugin::initGui()
 
   connect( mQGisIface, &QgisInterface::projectRead, this, &QgsOfflineEditingPlugin::updateActions );
   connect( mQGisIface, &QgisInterface::newProjectCreated, this, &QgsOfflineEditingPlugin::updateActions );
-  connect( QgsProject::instance(), &QgsProject::writeProject, this, &QgsOfflineEditingPlugin::updateActions );
-  connect( QgsProject::instance(), &QgsProject::layerWasAdded, this, &QgsOfflineEditingPlugin::updateActions );
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QString & ) >( &QgsProject::layerWillBeRemoved ), this, &QgsOfflineEditingPlugin::updateActions );
+  connect( QgsApplication::activeProject(), &QgsProject::writeProject, this, &QgsOfflineEditingPlugin::updateActions );
+  connect( QgsApplication::activeProject(), &QgsProject::layerWasAdded, this, &QgsOfflineEditingPlugin::updateActions );
+  connect( QgsApplication::activeProject(), static_cast < void ( QgsProject::* )( const QString & ) >( &QgsProject::layerWillBeRemoved ), this, &QgsOfflineEditingPlugin::updateActions );
   updateActions();
 }
 
@@ -126,7 +126,7 @@ void QgsOfflineEditingPlugin::unload()
 {
   disconnect( mQGisIface, &QgisInterface::projectRead, this, &QgsOfflineEditingPlugin::updateActions );
   disconnect( mQGisIface, &QgisInterface::newProjectCreated, this, &QgsOfflineEditingPlugin::updateActions );
-  disconnect( QgsProject::instance(), &QgsProject::writeProject, this, &QgsOfflineEditingPlugin::updateActions );
+  disconnect( QgsApplication::activeProject(), &QgsProject::writeProject, this, &QgsOfflineEditingPlugin::updateActions );
 
   // remove the GUI
   mQGisIface->removePluginDatabaseMenu( tr( "&Offline Editing" ), mActionConvertProject );
@@ -144,7 +144,7 @@ void QgsOfflineEditingPlugin::help()
 
 void QgsOfflineEditingPlugin::updateActions()
 {
-  bool hasLayers = QgsProject::instance()->count() > 0;
+  bool hasLayers = QgsApplication::activeProject()->count() > 0;
   bool isOfflineProject = mOfflineEditing->isOfflineProject();
   mActionConvertProject->setEnabled( hasLayers && !isOfflineProject );
   mActionSynchronize->setEnabled( hasLayers && isOfflineProject );

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -109,7 +109,7 @@ QgsOfflineEditingPluginGui::QgsOfflineEditingPluginGui( QWidget *parent, Qt::Win
   mOfflineDbFile = QStringLiteral( "offline.sqlite" );
   mOfflineDataPathLineEdit->setText( QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ) );
 
-  QgsLayerTree *rootNode = QgsProject::instance()->layerTreeRoot()->clone();
+  QgsLayerTree *rootNode = QgsApplication::activeProject()->layerTreeRoot()->clone();
   QgsLayerTreeModel *treeModel = new QgsSelectLayerTreeModel( rootNode, this );
   mLayerTree->setModel( treeModel );
   mLayerTree->header()->setResizeMode( QHeaderView::ResizeToContents );

--- a/src/plugins/topology/checkDock.cpp
+++ b/src/plugins/topology/checkDock.cpp
@@ -89,7 +89,7 @@ checkDock::checkDock( QgisInterface *qIface, QWidget *parent )
   connect( mFixButton, &QAbstractButton::clicked, this, &checkDock::fix );
   connect( mErrorTableView, &QAbstractItemView::clicked, this, &checkDock::errorListClicked );
 
-  connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( const QString & ) >( &QgsProject::layerWillBeRemoved ), this, &checkDock::parseErrorListByLayer );
+  connect( QgsApplication::activeProject(), static_cast < void ( QgsProject::* )( const QString & ) >( &QgsProject::layerWillBeRemoved ), this, &checkDock::parseErrorListByLayer );
 
   connect( this, &QDockWidget::visibilityChanged, this, &checkDock::updateRubberBands );
   connect( qgsInterface, &QgisInterface::newProjectCreated, mConfigureDialog, &rulesDialog::clearRules );
@@ -151,7 +151,7 @@ void checkDock::deleteErrors()
 
 void checkDock::parseErrorListByLayer( const QString &layerId )
 {
-  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( layerId ) );
+  QgsVectorLayer *layer = qobject_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( layerId ) );
   QList<TopolError *>::Iterator it = mErrorList.begin();
 
   while ( it != mErrorList.end() )
@@ -328,17 +328,17 @@ void checkDock::runTests( ValidateType type )
     QString layer2Str = mTestTable->item( i, 4 )->text();
 
     // test if layer1 is in the registry
-    if ( !( ( QgsVectorLayer * )QgsProject::instance()->mapLayers().contains( layer1Str ) ) )
+    if ( !( ( QgsVectorLayer * )QgsApplication::activeProject()->mapLayers().contains( layer1Str ) ) )
     {
       QgsMessageLog::logMessage( tr( "Layer %1 not found in registry." ).arg( layer1Str ), tr( "Topology plugin" ) );
       return;
     }
 
-    QgsVectorLayer *layer1 = ( QgsVectorLayer * )QgsProject::instance()->mapLayer( layer1Str );
+    QgsVectorLayer *layer1 = ( QgsVectorLayer * )QgsApplication::activeProject()->mapLayer( layer1Str );
     QgsVectorLayer *layer2 = nullptr;
 
-    if ( ( QgsVectorLayer * )QgsProject::instance()->mapLayers().contains( layer2Str ) )
-      layer2 = ( QgsVectorLayer * )QgsProject::instance()->mapLayer( layer2Str );
+    if ( ( QgsVectorLayer * )QgsApplication::activeProject()->mapLayers().contains( layer2Str ) )
+      layer2 = ( QgsVectorLayer * )QgsApplication::activeProject()->mapLayer( layer2Str );
 
     QProgressDialog progress( testName, tr( "Abort" ), 0, layer1->featureCount(), this );
     progress.setWindowModality( Qt::WindowModal );

--- a/src/plugins/topology/rulesDialog.cpp
+++ b/src/plugins/topology/rulesDialog.cpp
@@ -135,8 +135,8 @@ void rulesDialog::readTest( int index, QgsProject *project )
 void rulesDialog::projectRead()
 {
   clearRules();
-  QgsProject *project = QgsProject::instance();
-  int testCount = QgsProject::instance()->readNumEntry( QStringLiteral( "Topol" ), QStringLiteral( "/testCount" ) );
+  QgsProject *project = QgsApplication::activeProject();
+  int testCount = QgsApplication::activeProject()->readNumEntry( QStringLiteral( "Topol" ), QStringLiteral( "/testCount" ) );
   mRulesTable->clearContents();
 
   for ( int i = 0; i < testCount; ++i )
@@ -153,14 +153,14 @@ void rulesDialog::showControls( const QString &testName )
   mLayer2Box->clear();
   mLayer2Box->addItem( tr( "No layer" ) );
   TopologyRule topologyRule = mTestConfMap[testName];
-  QList<QString> layerList = QgsProject::instance()->mapLayers().keys();
+  QList<QString> layerList = QgsApplication::activeProject()->mapLayers().keys();
 
   if ( topologyRule.useSecondLayer )
   {
     mLayer2Box->setVisible( true );
     for ( int i = 0; i < layerList.count(); ++i )
     {
-      QgsVectorLayer *v1 = ( QgsVectorLayer * )QgsProject::instance()->mapLayer( layerList[i] );
+      QgsVectorLayer *v1 = ( QgsVectorLayer * )QgsApplication::activeProject()->mapLayer( layerList[i] );
 
       if ( !v1 )
       {
@@ -245,7 +245,7 @@ void rulesDialog::addRule()
 
   // save state to the project file.....
   QString postfix = QStringLiteral( "%1" ).arg( row );
-  QgsProject *project = QgsProject::instance();
+  QgsProject *project = QgsApplication::activeProject();
 
   project->writeEntry( QStringLiteral( "Topol" ), QStringLiteral( "/testCount" ), row + 1 );
   project->writeEntry( QStringLiteral( "Topol" ), "/testname_" + postfix, test );
@@ -281,7 +281,7 @@ void rulesDialog::updateRuleItems( const QString &layerName )
 
   QString layerId = mLayer1Box->currentData().toString();
 
-  QgsVectorLayer *vlayer = ( QgsVectorLayer * )QgsProject::instance()->mapLayer( layerId );
+  QgsVectorLayer *vlayer = ( QgsVectorLayer * )QgsApplication::activeProject()->mapLayer( layerId );
 
   if ( !vlayer )
   {
@@ -302,7 +302,7 @@ void rulesDialog::updateRuleItems( const QString &layerName )
 
 void rulesDialog::initGui()
 {
-  QList<QString> layerList = QgsProject::instance()->mapLayers().keys();
+  QList<QString> layerList = QgsApplication::activeProject()->mapLayers().keys();
 
   mLayer1Box->clear();
   mLayer1Box->addItem( tr( "No layer" ) );
@@ -313,7 +313,7 @@ void rulesDialog::initGui()
   mLayer1Box->blockSignals( true );
   for ( int i = 0; i < layerList.size(); ++i )
   {
-    QgsVectorLayer *v1 = ( QgsVectorLayer * )QgsProject::instance()->mapLayer( layerList[i] );
+    QgsVectorLayer *v1 = ( QgsVectorLayer * )QgsApplication::activeProject()->mapLayer( layerList[i] );
     qDebug() << "layerid = " + layerList[i];
 
     // add layer name to the layer combo boxes

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
@@ -178,7 +178,7 @@ QString QgsArcGisServiceSourceSelect::getPreferredCrs( const QSet<QString> &crsS
   }
 
   //first: project CRS
-  QgsCoordinateReferenceSystem projectRefSys = QgsProject::instance()->crs();
+  QgsCoordinateReferenceSystem projectRefSys = QgsApplication::activeProject()->crs();
   //convert to EPSG
   QString ProjectCRS;
   if ( projectRefSys.isValid() )

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -530,7 +530,7 @@ QgsDelimitedTextFeatureSource::QgsDelimitedTextFeatureSource( const QgsDelimited
   mFile->setFromUrl( url );
 
   mExpressionContext << QgsExpressionContextUtils::globalScope()
-                     << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+                     << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
   mExpressionContext.setFields( mFields );
 }
 

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -2797,7 +2797,7 @@ void QgsGdalProvider::initBaseDataset()
   //set up the coordinat transform - in the case of raster this is mainly used to convert
   //the inverese projection of the map extents of the canvas when zooming in etc. so
   //that they match the coordinate system of this layer
-  //QgsDebugMsg( "Layer registry has " + QString::number( QgsProject::instance()->count() ) + "layers" );
+  //QgsDebugMsg( "Layer registry has " + QString::number( QgsApplication::activeProject()->count() ) + "layers" );
 
   //metadata();
 

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -1107,14 +1107,14 @@ void QgsGrass::saveMapset()
 {
 
   // Save working mapset in project file
-  QgsProject::instance()->writeEntry( QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingGisdbase" ),
-                                      QgsProject::instance()->writePath( getDefaultGisdbase() ) );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingGisdbase" ),
+      QgsApplication::activeProject()->writePath( getDefaultGisdbase() ) );
 
-  QgsProject::instance()->writeEntry( QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingLocation" ),
-                                      getDefaultLocation() );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingLocation" ),
+      getDefaultLocation() );
 
-  QgsProject::instance()->writeEntry( QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingMapset" ),
-                                      getDefaultMapset() );
+  QgsApplication::activeProject()->writeEntry( QStringLiteral( "GRASS" ), QStringLiteral( "/WorkingMapset" ),
+      getDefaultMapset() );
 }
 
 void QgsGrass::createMapset( const QString &gisdbase, const QString &location,

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -109,7 +109,7 @@ void QgsGeoPackageRootItem::newConnection()
 void QgsGeoPackageRootItem::createDatabase()
 {
   QgsNewGeoPackageLayerDialog dialog( nullptr );
-  dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
+  dialog.setCrs( QgsApplication::activeProject()->defaultCrsForNewLayers() );
   if ( dialog.exec() == QDialog::Accepted )
   {
     if ( QgsOgrDataCollectionItem::storeConnection( dialog.databasePath(), QStringLiteral( "GPKG" ) ) )
@@ -513,7 +513,7 @@ void QgsGeoPackageCollectionItem::addTable()
 {
   QgsNewGeoPackageLayerDialog dialog( nullptr );
   dialog.setDatabasePath( mPath );
-  dialog.setCrs( QgsProject::instance()->defaultCrsForNewLayers() );
+  dialog.setCrs( QgsApplication::activeProject()->defaultCrsForNewLayers() );
   dialog.setOverwriteBehavior( QgsNewGeoPackageLayerDialog::AddNewLayer );
   dialog.lockDatabasePath();
   if ( dialog.exec() == QDialog::Accepted )
@@ -546,7 +546,7 @@ void QgsGeoPackageAbstractLayerItem::deleteLayer()
 {
   // Check if the layer(s) are in the registry
   QList<QgsMapLayer *> layersList;
-  const auto mapLayers( QgsProject::instance()->mapLayers() );
+  const auto mapLayers( QgsApplication::activeProject()->mapLayers() );
   for ( QgsMapLayer *layer :  mapLayers )
   {
     if ( layer->publicSource() == mUri )
@@ -572,7 +572,7 @@ void QgsGeoPackageAbstractLayerItem::deleteLayer()
 
   if ( layersList.isEmpty() )
   {
-    QgsProject::instance()->removeMapLayers( layersList );
+    QgsApplication::activeProject()->removeMapLayers( layersList );
   }
 
   QString errCause;

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -325,7 +325,7 @@ void QgsOgrLayerItem::deleteLayer()
   QString title = mIsSubLayer ? QObject::tr( "Delete Layer" ) : QObject::tr( "Delete File" );
   // Check if the layer is in the registry
   const QgsMapLayer *projectLayer = nullptr;
-  Q_FOREACH ( const QgsMapLayer *layer, QgsProject::instance()->mapLayers() )
+  Q_FOREACH ( const QgsMapLayer *layer, QgsApplication::activeProject()->mapLayers() )
   {
     if ( layer->publicSource() == mUri )
     {

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -114,7 +114,7 @@ bool QgsVirtualLayerProvider::loadSourceLayers()
   {
     if ( layer.isReferenced() )
     {
-      QgsMapLayer *l = QgsProject::instance()->mapLayer( layer.reference() );
+      QgsMapLayer *l = QgsApplication::activeProject()->mapLayer( layer.reference() );
       if ( !l )
       {
         PROVIDER_ERROR( QString( "Cannot find layer %1" ).arg( layer.reference() ) );
@@ -242,7 +242,7 @@ bool QgsVirtualLayerProvider::createIt()
       }
       // is it in loaded layers ?
       bool found = false;
-      Q_FOREACH ( const QgsMapLayer *l, QgsProject::instance()->mapLayers() )
+      Q_FOREACH ( const QgsMapLayer *l, QgsApplication::activeProject()->mapLayers() )
       {
         if ( l->type() != QgsMapLayer::VectorLayer )
           continue;

--- a/src/providers/virtual/qgsvirtuallayersourceselect.cpp
+++ b/src/providers/virtual/qgsvirtuallayersourceselect.cpp
@@ -103,7 +103,7 @@ void QgsVirtualLayerSourceSelect::layerComboChanged( int idx )
     return;
 
   QString lid = mLayerNameCombo->itemData( idx ).toString();
-  QgsVectorLayer *l = static_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( lid ) );
+  QgsVectorLayer *l = static_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( lid ) );
   if ( !l )
     return;
   QgsVirtualLayerDefinition def = QgsVirtualLayerDefinition::fromUrl( QUrl::fromEncoded( l->source().toUtf8() ) );
@@ -294,7 +294,7 @@ void QgsVirtualLayerSourceSelect::updateLayersList()
   }
 
   // configure auto completion with table and column names
-  Q_FOREACH ( QgsMapLayer *l, QgsProject::instance()->mapLayers() )
+  Q_FOREACH ( QgsMapLayer *l, QgsApplication::activeProject()->mapLayers() )
   {
     if ( l->type() == QgsMapLayer::VectorLayer )
     {
@@ -342,7 +342,7 @@ void QgsVirtualLayerSourceSelect::importLayer()
     QStringList ids = mEmbeddedSelectionDialog->layers();
     Q_FOREACH ( const QString &id, ids )
     {
-      QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( id ) );
+      QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( QgsApplication::activeProject()->mapLayer( id ) );
       addEmbeddedLayer( vl->name(), vl->providerType(), vl->dataProvider()->encoding(), vl->source() );
     }
   }
@@ -365,7 +365,7 @@ void QgsVirtualLayerSourceSelect::addButtonClicked()
   if ( idx != -1 )
   {
     id = ( mLayerNameCombo->itemData( idx ).toString() );
-    if ( !id.isEmpty() && mLayerNameCombo->currentText() == QgsProject::instance()->mapLayer( id )->name() )
+    if ( !id.isEmpty() && mLayerNameCombo->currentText() == QgsApplication::activeProject()->mapLayer( id )->name() )
     {
       int r = QMessageBox::warning( nullptr, tr( "Warning" ), tr( "A virtual layer of this name already exists, would you like to overwrite it?" ), QMessageBox::Yes | QMessageBox::No );
       if ( r == QMessageBox::Yes )

--- a/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
+++ b/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
@@ -353,7 +353,7 @@ int vtableCreateConnect( sqlite3 *sql, void *aux, int argc, const char *const *a
     {
       layerid = layerid.mid( 1, layerid.size() - 2 );
     }
-    QgsMapLayer *l = QgsProject::instance()->mapLayer( layerid );
+    QgsMapLayer *l = QgsApplication::activeProject()->mapLayer( layerid );
     if ( !l || l->type() != QgsMapLayer::VectorLayer )
     {
       if ( outErr )
@@ -883,7 +883,7 @@ void registerQgisFunctions( sqlite3 *db )
 
   // initialize the expression context
   qgisFunctionExpressionContext << QgsExpressionContextUtils::globalScope();
-  qgisFunctionExpressionContext << QgsExpressionContextUtils::projectScope( QgsProject::instance() );
+  qgisFunctionExpressionContext << QgsExpressionContextUtils::projectScope( QgsApplication::activeProject() );
 }
 
 int qgsvlayerModuleInit( sqlite3 *db, char **pzErrMsg, void *unused /*const sqlite3_api_routines *pApi*/ )

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -174,7 +174,7 @@ QString QgsWFSSourceSelect::getPreferredCrs( const QSet<QString> &crsSet ) const
   }
 
   //first: project CRS
-  QgsCoordinateReferenceSystem projectRefSys = QgsProject::instance()->crs();
+  QgsCoordinateReferenceSystem projectRefSys = QgsApplication::activeProject()->crs();
   //convert to EPSG
   QString ProjectCRS;
   if ( projectRefSys.isValid() )

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -115,7 +115,7 @@ QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
     setTabOrder( lstLayers, mImageFormatGroup->button( 0 ) );
 
     //set the current project CRS if available
-    QgsCoordinateReferenceSystem currentRefSys = QgsProject::instance()->crs();
+    QgsCoordinateReferenceSystem currentRefSys = QgsApplication::activeProject()->crs();
     //convert CRS id to epsg
     if ( currentRefSys.isValid() )
     {
@@ -637,7 +637,7 @@ void QgsWMSSourceSelect::btnChangeSpatialRefSys_clicked()
   mySelector->setMessage( QString() );
   mySelector->setOgcWmsCrsFilter( mCRSs );
 
-  QgsCoordinateReferenceSystem defaultCRS = QgsProject::instance()->crs();
+  QgsCoordinateReferenceSystem defaultCRS = QgsApplication::activeProject()->crs();
   if ( defaultCRS.isValid() )
   {
     mySelector->setCrs( defaultCRS );


### PR DESCRIPTION
use QgsApplication::activeProject instead

## Description

QgsProject being a singleton has over time led to many workarounds that make the codebase hard to maintain in a sustainable way.

This pull request proposes to get rid of the problem by delegating the project management to a new method on application level.
`QgsApplication::activeProject()` right now pretty much does the same thing as `QgsProject::instance()` did before. There is one project created on startup and deleted on shutdown of the application.
By itself this offers no risks. But, once someone starts using `setActiveProject` from plugins or other code, there's a certain risk involved, that existing code is not prepared for projects "just disappearing". This scenario will need to be carefully tested before we introduce calls to `setActiveProject` somewhere in code we ship.

Other open questions (which can be addressed in the future as well):

 * Should we have a list of open projects, owned by the application, of which one is the active one? I.e. have a project registry.
 * Do we want to be able to run without an activeProject()