### PR TITLE
[postgres] Really disable dynamic queue size

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -28,13 +28,6 @@
 
 QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsPostgresFeatureSource>( source, ownSource, request )
-  , mFeatureQueueSize( 1 )
-  , mFetched( 0 )
-  , mFetchGeometry( false )
-  , mExpressionCompiled( false )
-  , mOrderByCompiled( false )
-  , mLastFetch( false )
-  , mFilterRequiresGeometry( false )
 {
   if ( request.filterType() == QgsFeatureRequest::FilterFids && request.filterFids().isEmpty() )
   {
@@ -260,8 +253,10 @@ bool QgsPostgresFeatureIterator::fetchFeature( QgsFeature &feature )
 
   if ( mFeatureQueue.empty() && !mLastFetch )
   {
+#if 0 //disabled dynamic queue size
     QElapsedTimer timer;
     timer.start();
+#endif
 
     QString fetch = QStringLiteral( "FETCH FORWARD %1 FROM %2" ).arg( mFeatureQueueSize ).arg( mCursorName );
     QgsDebugMsgLevel( QString( "fetching %1 features." ).arg( mFeatureQueueSize ), 4 );
@@ -299,6 +294,7 @@ bool QgsPostgresFeatureIterator::fetchFeature( QgsFeature &feature )
     }
     unlock();
 
+#if 0 //disabled dynamic queue size
     if ( timer.elapsed() > 500 && mFeatureQueueSize > 1 )
     {
       mFeatureQueueSize /= 2;
@@ -307,6 +303,7 @@ bool QgsPostgresFeatureIterator::fetchFeature( QgsFeature &feature )
     {
       mFeatureQueueSize *= 2;
     }
+#endif
   }
 
   if ( mFeatureQueue.empty() )

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -102,13 +102,13 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
     QQueue<QgsFeature> mFeatureQueue;
 
     //! Maximal size of the feature queue
-    int mFeatureQueueSize;
+    int mFeatureQueueSize = 2000;
 
     //! Number of retrieved features
-    int mFetched;
+    int mFetched = 0;
 
     //! Sets to true, if geometry is in the requested columns
-    bool mFetchGeometry;
+    bool mFetchGeometry = false;
 
     bool mIsTransactionConnection = false;
 
@@ -119,10 +119,10 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
     inline void lock();
     inline void unlock();
 
-    bool mExpressionCompiled;
-    bool mOrderByCompiled;
-    bool mLastFetch;
-    bool mFilterRequiresGeometry;
+    bool mExpressionCompiled = false;
+    bool mOrderByCompiled = false;
+    bool mLastFetch = false;
+    bool mFilterRequiresGeometry = false;
 
     QgsCoordinateTransform mTransform;
     QgsRectangle mFilterRect;


### PR DESCRIPTION
The original commit speed up some layers, but regressed performance for others. It was decided to revert the dynamic queue feature, but it seems this was never actually done.

Fixes #16239, #19203
