### PR TITLE
QgsRectangle::intersect should use a reference, not a pointer

### DIFF
--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -207,7 +207,7 @@ Gets rectangle enlarged by buffer.
 .. versionadded:: 3.0
 %End
 
-    QgsRectangle intersect( const QgsRectangle *rect ) const;
+    QgsRectangle intersect( const QgsRectangle &rect ) const;
 %Docstring
 Returns the intersection with the given rectangle.
 %End

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -199,7 +199,7 @@ int QgsDemHeightMapGenerator::render( int x, int y, int z )
   extent.grow( mapUnitsPerPixel / 2 );
   // but make sure not to go beyond the full extent (returns invalid values)
   QgsRectangle fullExtent = mTilingScheme.tileToExtent( 0, 0, 0 );
-  extent = extent.intersect( &fullExtent );
+  extent = extent.intersect( fullExtent );
 
   JobData jd;
   jd.jobId = ++mLastJobId;
@@ -225,7 +225,7 @@ QByteArray QgsDemHeightMapGenerator::renderSynchronously( int x, int y, int z )
   extent.grow( mapUnitsPerPixel / 2 );
   // but make sure not to go beyond the full extent (returns invalid values)
   QgsRectangle fullExtent = mTilingScheme.tileToExtent( 0, 0, 0 );
-  extent = extent.intersect( &fullExtent );
+  extent = extent.intersect( fullExtent );
 
   QgsRasterBlock *block = mDtm->dataProvider()->block( 1, extent, mResolution, mResolution );
 

--- a/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
@@ -129,7 +129,7 @@ QVariantMap QgsZonalHistogramAlgorithm::processAlgorithm( const QVariantMap &par
     }
 
     QgsGeometry featureGeometry = f.geometry();
-    QgsRectangle featureRect = featureGeometry.boundingBox().intersect( &mRasterExtent );
+    QgsRectangle featureRect = featureGeometry.boundingBox().intersect( mRasterExtent );
     if ( featureRect.isEmpty() )
     {
       current++;

--- a/src/analysis/processing/qgsrasteranalysisutils.cpp
+++ b/src/analysis/processing/qgsrasteranalysisutils.cpp
@@ -27,7 +27,7 @@ void QgsRasterAnalysisUtils::cellInfoForBBox( const QgsRectangle &rasterBBox, co
     int &nCellsX, int &nCellsY, int rasterWidth, int rasterHeight, QgsRectangle &rasterBlockExtent )
 {
   //get intersecting bbox
-  QgsRectangle intersectBox = rasterBBox.intersect( &featureBBox );
+  QgsRectangle intersectBox = rasterBBox.intersect( featureBBox );
   if ( intersectBox.isEmpty() )
   {
     nCellsX = 0;

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -243,7 +243,7 @@ int QgsZonalStatistics::calculateStatistics( QgsFeedback *feedback )
     }
     QgsGeometry featureGeometry = f.geometry();
 
-    QgsRectangle featureRect = featureGeometry.boundingBox().intersect( &rasterBBox );
+    QgsRectangle featureRect = featureGeometry.boundingBox().intersect( rasterBBox );
     if ( featureRect.isEmpty() )
     {
       ++featureCounter;

--- a/src/core/geometry/qgsbox3d.cpp
+++ b/src/core/geometry/qgsbox3d.cpp
@@ -77,7 +77,7 @@ void QgsBox3d::normalize()
 
 QgsBox3d QgsBox3d::intersect( const QgsBox3d &other ) const
 {
-  QgsRectangle intersect2d = mBounds2d.intersect( &( other.mBounds2d ) );
+  QgsRectangle intersect2d = mBounds2d.intersect( other.mBounds2d );
   double zMin = std::max( mZmin, other.mZmin );
   double zMax = std::min( mZmax, other.mZmax );
   return QgsBox3d( intersect2d.xMinimum(), intersect2d.yMinimum(), zMin,

--- a/src/core/geometry/qgsrectangle.cpp
+++ b/src/core/geometry/qgsrectangle.cpp
@@ -183,15 +183,15 @@ QgsRectangle QgsRectangle::buffered( double width ) const
   return QgsRectangle( mXmin - width, mYmin - width, mXmax + width, mYmax + width );
 }
 
-QgsRectangle QgsRectangle::intersect( const QgsRectangle *rect ) const
+QgsRectangle QgsRectangle::intersect( const QgsRectangle &rect ) const
 {
   QgsRectangle intersection = QgsRectangle();
-  if ( rect && intersects( *rect ) )
+  if ( intersects( rect ) )
   {
-    intersection.setXMinimum( mXmin > rect->xMinimum() ? mXmin : rect->xMinimum() );
-    intersection.setXMaximum( mXmax < rect->xMaximum() ? mXmax : rect->xMaximum() );
-    intersection.setYMinimum( mYmin > rect->yMinimum() ? mYmin : rect->yMinimum() );
-    intersection.setYMaximum( mYmax < rect->yMaximum() ? mYmax : rect->yMaximum() );
+    intersection.setXMinimum( mXmin > rect.xMinimum() ? mXmin : rect.xMinimum() );
+    intersection.setXMaximum( mXmax < rect.xMaximum() ? mXmax : rect.xMaximum() );
+    intersection.setYMinimum( mYmin > rect.yMinimum() ? mYmin : rect.yMinimum() );
+    intersection.setYMaximum( mYmax < rect.yMaximum() ? mYmax : rect.yMaximum() );
   }
   return intersection;
 }

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -201,7 +201,7 @@ class CORE_EXPORT QgsRectangle
     /**
      * Returns the intersection with the given rectangle.
      */
-    QgsRectangle intersect( const QgsRectangle *rect ) const;
+    QgsRectangle intersect( const QgsRectangle &rect ) const;
 
     /**
      * Returns true when rectangle intersects with other rectangle.

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -59,7 +59,7 @@ QgsRasterBlock *QgsRasterDataProvider::block( int bandNo, QgsRectangle  const &b
   }
 
   // Read necessary extent only
-  QgsRectangle tmpExtent = extent().intersect( &boundingBox );
+  QgsRectangle tmpExtent = extent().intersect( boundingBox );
 
   if ( tmpExtent.isEmpty() )
   {

--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -51,7 +51,7 @@ void QgsRasterInterface::initStatistics( QgsRasterBandStats &statistics,
   }
   else
   {
-    finalExtent = extent().intersect( &boundingBox );
+    finalExtent = extent().intersect( boundingBox );
   }
   statistics.extent = finalExtent;
 
@@ -295,7 +295,7 @@ void QgsRasterInterface::initHistogram( QgsRasterHistogram &histogram,
   }
   else
   {
-    finalExtent = extent().intersect( &boundingBox );
+    finalExtent = extent().intersect( boundingBox );
   }
   histogram.extent = finalExtent;
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -134,7 +134,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   }
 
   // clip raster extent to view extent
-  QgsRectangle myRasterExtent = myProjectedViewExtent.intersect( &myProjectedLayerExtent );
+  QgsRectangle myRasterExtent = myProjectedViewExtent.intersect( myProjectedLayerExtent );
   if ( myRasterExtent.isEmpty() )
   {
     QgsDebugMsg( "draw request outside view extent." );

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -233,7 +233,7 @@ void ProjectorData::calcSrcExtent()
   // Expand a bit to avoid possible approx coords falling out because of representation error?
 
   // Combine with maximum source  extent
-  mSrcExtent = mSrcExtent.intersect( &mExtent );
+  mSrcExtent = mSrcExtent.intersect( mExtent );
 
   // If mMaxSrcXRes, mMaxSrcYRes are defined (fixed src resolution)
   // align extent to src resolution to avoid jumping of reprojected pixels

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -447,7 +447,7 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
   QgsFeatureRequest r( masterModel()->request() );
   if ( !r.filterRect().isNull() )
   {
-    r.setFilterRect( r.filterRect().intersect( &rect ) );
+    r.setFilterRect( r.filterRect().intersect( rect ) );
   }
   else
   {

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -691,7 +691,7 @@ void QgsGdalProvider::readBlock( int bandNo, QgsRectangle  const &extent, int pi
   }
 #endif
 
-  QgsRectangle myRasterExtent = extent.intersect( &mExtent );
+  QgsRectangle myRasterExtent = extent.intersect( mExtent );
   if ( myRasterExtent.isEmpty() )
   {
     QgsDebugMsg( "draw request outside view extent." );

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -429,7 +429,7 @@ QString QgsPostgresFeatureIterator::whereClauseRect()
   QgsRectangle rect = mFilterRect;
   if ( mSource->mSpatialColType == SctGeography )
   {
-    rect = QgsRectangle( -180.0, -90.0, 180.0, 90.0 ).intersect( &rect );
+    rect = QgsRectangle( -180.0, -90.0, 180.0, 90.0 ).intersect( rect );
   }
 
   if ( !rect.isFinite() )

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1062,7 +1062,7 @@ namespace QgsWfs
           }
         }
         // EPSG:4326 max extent is -180, -90, 180, 90
-        rect = new QgsRectangle( rect->intersect( new QgsRectangle( -180.0, -90.0, 180.0, 90.0 ) ) );
+        rect = new QgsRectangle( rect->intersect( QgsRectangle( -180.0, -90.0, 180.0, 90.0 ) ) );
 
         fcString = QStringLiteral( "{\"type\": \"FeatureCollection\",\n" );
         fcString += " \"bbox\": [ " + qgsDoubleToString( rect->xMinimum(), prec ) + ", " + qgsDoubleToString( rect->yMinimum(), prec ) + ", " + qgsDoubleToString( rect->xMaximum(), prec ) + ", " + qgsDoubleToString( rect->yMaximum(), prec ) + "],\n";

--- a/src/server/services/wfs/qgswfsutils.cpp
+++ b/src/server/services/wfs/qgswfsutils.cpp
@@ -203,7 +203,7 @@ namespace QgsWfs
           }
           else
           {
-            request.setFilterRect( request.filterRect().intersect( &childRequest.filterRect() ) );
+            request.setFilterRect( request.filterRect().intersect( childRequest.filterRect() ) );
           }
         }
         else

--- a/tests/src/core/testqgsrectangle.cpp
+++ b/tests/src/core/testqgsrectangle.cpp
@@ -109,7 +109,7 @@ void TestQgsRectangle::manipulate()
   // Check intersection
   QVERIFY( rect2.intersects( rect1 ) );
   // Create intersection
-  rect3 = rect2.intersect( &rect1 );
+  rect3 = rect2.intersect( rect1 );
   // Check width and height (real numbers, careful)
   QCOMPARE( rect3.width(), 1.0 );
   QCOMPARE( rect3.height(), 1.0 );


### PR DESCRIPTION
We never call this method using nullptrs, so there's no need
for this to be a pointer argument in the first place. And
having it a pointer encourages leaky code, such as the
leak this commit fixes in server.
