### PR TITLE
[BUGFIX] Regression in Composer legend, layer's title was not the default legend's title

### DIFF
--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -751,6 +751,15 @@ QgsLegendModelV2::QgsLegendModelV2( QgsLayerTreeGroup* rootNode, QObject* parent
 {
   setFlag( QgsLayerTreeModel::AllowLegendChangeState, false );
   setFlag( QgsLayerTreeModel::AllowNodeReorder, true );
+
+  Q_FOREACH ( QgsLayerTreeLayer* nodeLayer, rootGroup()->findLayers() )
+  {
+    QString layerTitle = nodeLayer->layer()->title();
+    if ( !layerTitle.isNull() )
+    {
+      nodeLayer->setCustomProperty( "legend/title-label", layerTitle );
+    }
+  }
 }
 
 QVariant QgsLegendModelV2::data( const QModelIndex& index, int role ) const

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -116,11 +116,13 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /** Set the title of the layer
      *  used by QGIS Server in GetCapabilities request
+     *  and in composer legend as a default title
      * @return the layer title
      */
     void setTitle( const QString& title ) { mTitle = title; }
     /** Get the title of the layer
      *  used by QGIS Server in GetCapabilities request
+     *  and in composer legend as a default title
      * @return the layer title
      */
     QString title() const { return mTitle; }


### PR DESCRIPTION
## Description
In release-2_14, the layer's title was the default legend's title. This
capabilities has been lost with the use of the QgsLegendModelV2 in
QgsLegendRenderer.


## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
