### PR TITLE
Ensure qgis.db is writable when copied from RO source

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1532,6 +1532,19 @@ bool QgsApplication::createDatabase( QString *errorMessage )
       }
       return false;
     }
+
+    QFile::Permissions perms = QFile( qgisPrivateDbFile.fileName() ).permissions();
+    if ( !( perms & QFile::WriteOwner ) )
+    {
+      if ( !qgisPrivateDbFile.setPermissions( perms | QFile::WriteOwner ) )
+      {
+        if ( errorMessage )
+        {
+          *errorMessage = tr( "Can not make '%1' user writable" ).arg( qgisPrivateDbFile.fileName() );
+        }
+        return false;
+      }
+    }
   }
   else
   {


### PR DESCRIPTION
## Description

In some package managers (such as NIX[1], used in NixOS[2]), all the data is
installed into a read-only file system.

When QGis is first launched on those systems, it copies the template
`qgis.db` from the share directory into the user private .local
directory, but keeps its permissions unchanged: readonly. Any attempt
from QGIS to update this file fails.

This commit makes sure that the `qgis.db` file is user writable when it
is copied from the installation directory.

I have tested this patch on both the `master` and `release-2_8` branches (NixOS currently uses QGIS-2.8). I plan to add this patch to the current packaging of the 2.8 version in NixOS, but would prefer if it could be integrated upstream for later releases (3+).

[1] https://nixos.org/nix/
[2] https://nixos.org/


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
