### PR TITLE
Place labels next to their corresponding options in North Arrow decor…

### DIFF
--- a/src/ui/qgsdecorationnortharrowdialog.ui
+++ b/src/ui/qgsdecorationnortharrowdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>560</width>
-    <height>234</height>
+    <width>578</width>
+    <height>259</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,8 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>.</normaloff>.</iconset>
+    <normaloff/>
+   </iconset>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -74,16 +75,7 @@
       </item>
       <item row="2" column="2" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout_26">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
+        <property name="margin">
          <number>0</number>
         </property>
         <item>
@@ -237,7 +229,7 @@
        </layout>
       </item>
       <item row="3" column="1">
-       <widget class="QLabel" name="textLabel6">
+       <widget class="QLabel" name="angleLabel">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
           <horstretch>0</horstretch>
@@ -258,8 +250,8 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QLabel" name="textLabel8">
+      <item row="5" column="1">
+       <widget class="QLabel" name="placementLabel">
         <property name="text">
          <string>Placement</string>
         </property>
@@ -268,7 +260,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="4" column="1">
        <widget class="QLabel" name="lblMargin">
         <property name="minimumSize">
          <size>
@@ -429,16 +421,19 @@
  </customwidgets>
  <tabstops>
   <tabstop>grpEnable</tabstop>
+  <tabstop>pbnChangeColor</tabstop>
+  <tabstop>pbnChangeOutlineColor</tabstop>
+  <tabstop>spinSize</tabstop>
   <tabstop>mSvgPathLineEdit</tabstop>
   <tabstop>mSvgSelectorBtn</tabstop>
-  <tabstop>pbnChangeColor</tabstop>
   <tabstop>sliderRotation</tabstop>
   <tabstop>spinAngle</tabstop>
-  <tabstop>cboPlacement</tabstop>
-  <tabstop>spinVertical</tabstop>
-  <tabstop>spinHorizontal</tabstop>
-  <tabstop>wgtUnitSelection</tabstop>
   <tabstop>cboxAutomatic</tabstop>
+  <tabstop>spinHorizontal</tabstop>
+  <tabstop>spinVertical</tabstop>
+  <tabstop>wgtUnitSelection</tabstop>
+  <tabstop>cboPlacement</tabstop>
+  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsdecorationnortharrowdialog.ui
+++ b/src/ui/qgsdecorationnortharrowdialog.ui
@@ -134,7 +134,7 @@
         <item>
          <widget class="QLabel" name="outlineLabel">
           <property name="text">
-           <string>Outline</string>
+           <string>Stroke</string>
           </property>
          </widget>
         </item>
@@ -159,7 +159,7 @@
         </item>
        </layout>
       </item>
-      <item row="4" column="2" colspan="3">
+      <item row="5" column="2" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="labelHorizontal">
@@ -250,7 +250,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="4" column="1">
        <widget class="QLabel" name="placementLabel">
         <property name="text">
          <string>Placement</string>
@@ -260,7 +260,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QLabel" name="lblMargin">
         <property name="minimumSize">
          <size>
@@ -273,7 +273,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="2" colspan="3">
+      <item row="4" column="2" colspan="3">
        <widget class="QComboBox" name="cboPlacement">
         <property name="toolTip">
          <string>Placement on screen</string>
@@ -429,10 +429,10 @@
   <tabstop>sliderRotation</tabstop>
   <tabstop>spinAngle</tabstop>
   <tabstop>cboxAutomatic</tabstop>
+  <tabstop>cboPlacement</tabstop>
   <tabstop>spinHorizontal</tabstop>
   <tabstop>spinVertical</tabstop>
   <tabstop>wgtUnitSelection</tabstop>
-  <tabstop>cboPlacement</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
…ation

The "placement" and "Margin from edge" labels are currently inverted, hence 
![image](https://user-images.githubusercontent.com/7983394/41563709-be3192ca-7350-11e8-9843-393d2c25dfbd.png)
instead of
![image](https://user-images.githubusercontent.com/7983394/41563631-7d729a5e-7350-11e8-8fe8-4d0a2b809141.png)
Also fix tabstops