### PR TITLE
enable test for getfeatureinfo value relation widget values

### DIFF
--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -178,13 +178,11 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  '&CRS=EPSG:3857' +
                                  '&FEATURE_COUNT=10' +
                                  '&QUERY_LAYERS=layer0&I=487&J=308',
-                                 'wms_getfeatureinfo-values1-text-xml',
+                                 'wms_getfeatureinfo-values0-text-xml',
                                  'test_project_values.qgs')
 
-    # TODO fix regression in QGIS 3 as the widget values don't get solved and enable test
-    @unittest.expectedFailure
     def testGetFeatureInfoValueRelation(self):
-        """Test GetFeatureInfo resolves "value relation" widget values"""
+        """Test GetFeatureInfo resolves "value relation" widget values. regression 18518"""
         mypath = self.testdata_path + "test_project_values.qgs"
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=layer1&styles=&' +

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values0-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values0-text-xml.txt
@@ -1,0 +1,22 @@
+*****
+Content-Type: text/xml; charset=utf-8
+
+<GetFeatureInfoResponse>
+ <Layer name="layer0">
+  <Feature id="0">
+   <Attribute value="1" name="id"/>
+   <Attribute value="one" name="name"/>
+   <Attribute value="First Value" name="utf8nameè"/>
+  </Feature>
+  <Feature id="1">
+   <Attribute value="2" name="id"/>
+   <Attribute value="two" name="name"/>
+   <Attribute value="Second Value" name="utf8nameè"/>
+  </Feature>
+  <Feature id="2">
+   <Attribute value="3" name="id"/>
+   <Attribute value="three" name="name"/>
+   <Attribute value="Third èé↓" name="utf8nameè"/>
+  </Feature>
+ </Layer>
+</GetFeatureInfoResponse>

--- a/tests/testdata/qgis_server/wms_getfeatureinfo-values1-text-xml.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo-values1-text-xml.txt
@@ -2,21 +2,27 @@
 Content-Type: text/xml; charset=utf-8
 
 <GetFeatureInfoResponse>
- <Layer name="layer0">
+ <Layer name="layer1">
   <Feature id="0">
-   <Attribute value="1" name="id"/>
-   <Attribute value="one" name="name"/>
-   <Attribute value="First Value" name="utf8nameè"/>
+   <Attribute value="Id no. 1 value" name="id"/>
+   <Attribute value="one_value" name="name"/>
+   <Attribute value="one èé" name="utf8nameè"/>
+   <BoundingBox maxy="5606025.2373" maxx="913209.0358" miny="5606025.2373" CRS="EPSG:3857" minx="913209.0358"/>
+   <Attribute type="derived" value="Point (913209.0358 5606025.2373)" name="geometry"/>
   </Feature>
   <Feature id="1">
-   <Attribute value="2" name="id"/>
-   <Attribute value="two" name="name"/>
-   <Attribute value="Second Value" name="utf8nameè"/>
+   <Attribute value="Id no. 2 value" name="id"/>
+   <Attribute value="two_val" name="name"/>
+   <Attribute value="two àò" name="utf8nameè"/>
+   <BoundingBox maxy="5606017.8743" maxx="913214.6741" miny="5606017.8743" CRS="EPSG:3857" minx="913214.6741"/>
+   <Attribute type="derived" value="Point (913214.6741 5606017.8743)" name="geometry"/>
   </Feature>
   <Feature id="2">
-   <Attribute value="3" name="id"/>
-   <Attribute value="three" name="name"/>
-   <Attribute value="Third èé↓" name="utf8nameè"/>
+   <Attribute value="Id número 3 value" name="id"/>
+   <Attribute value="three_val" name="name"/>
+   <Attribute value="three èé↓" name="utf8nameè"/>
+   <BoundingBox maxy="5606011.4565" maxx="913204.9128" miny="5606011.4565" CRS="EPSG:3857" minx="913204.9128"/>
+   <Attribute type="derived" value="Point (913204.9128 5606011.4565)" name="geometry"/>
   </Feature>
  </Layer>
 </GetFeatureInfoResponse>


### PR DESCRIPTION
@elpaso Thank you for the fix in https://github.com/qgis/QGIS/pull/7244

There was already a disabled test for that case, which I'm enabling now. So.. we have two tests on the same thing. Should we remove one of them?

There are another two related tests that are disabled and that point to the same project:
```
    # TODO make GetFeatureInfo show the dictionary values and enable test
    @unittest.expectedFailure
    def testGetFeatureInfoValueRelationArray(self):
        """Test GetFeatureInfo on "value relation" widget with array field (multiple selections)"""
        mypath = self.testdata_path + "test_project_values.qgs"
        self.wms_request_compare('GetFeatureInfo',
                                 '&layers=layer3&styles=&' +
                                 'VERSION=1.3.0&' +
                                 'info_format=text%2Fxml&' +
                                 'width=926&height=787&srs=EPSG%3A4326' +
                                 '&bbox=912217,5605059,914099,5606652' +
                                 '&CRS=EPSG:3857' +
                                 '&FEATURE_COUNT=10' +
                                 '&WITH_GEOMETRY=True' +
                                 '&QUERY_LAYERS=layer3&I=487&J=308',
                                 'wms_getfeatureinfo-values3-text-xml',
                                 'test_project_values.qgs')

    # TODO make GetFeatureInfo show what's in the display expression and enable test
    @unittest.expectedFailure
    def testGetFeatureInfoRelationReference(self):
        """Test GetFeatureInfo solves "relation reference" widget "display expression" values"""
        mypath = self.testdata_path + "test_project_values.qgs"
        self.wms_request_compare('GetFeatureInfo',
                                 '&layers=layer2&styles=&' +
                                 'VERSION=1.3.0&' +
                                 'info_format=text%2Fxml&' +
                                 'width=926&height=787&srs=EPSG%3A4326' +
                                 '&bbox=912217,5605059,914099,5606652' +
                                 '&CRS=EPSG:3857' +
                                 '&FEATURE_COUNT=10' +
                                 '&WITH_GEOMETRY=True' +
                                 '&QUERY_LAYERS=layer2&I=487&J=308',
                                 'wms_getfeatureinfo-values2-text-xml',
                                 'test_project_values.qgs')
```


