### PR TITLE
Replace Style tab by Symbology in Raster Layer Properties dialog

### DIFF
--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -103,10 +103,10 @@
          </item>
          <item>
           <property name="text">
-           <string>Style</string>
+           <string>Symbology</string>
           </property>
           <property name="toolTip">
-           <string>Style</string>
+           <string>Symbology</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
to be coherent with vector layer properties dialog and reduce the 'style' misuse/confusion throughout QGIS dialogs