### PR TITLE
Do not crash on exit due to dangling layer pointer (fixes #18732)

### DIFF
--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -47,6 +47,7 @@ void QgsActionMenu::init()
   connect( mLayer, &QgsVectorLayer::editingStarted, this, &QgsActionMenu::reloadActions );
   connect( mLayer, &QgsVectorLayer::editingStopped, this, &QgsActionMenu::reloadActions );
   connect( mLayer, &QgsVectorLayer::readOnlyChanged, this, &QgsActionMenu::reloadActions );
+  connect( mLayer, &QgsMapLayer::willBeDeleted, this, &QgsActionMenu::layerWillBeDeleted );
 
   reloadActions();
 }
@@ -165,6 +166,15 @@ void QgsActionMenu::reloadActions()
   }
 
   emit reinit();
+}
+
+void QgsActionMenu::layerWillBeDeleted()
+{
+  // here we are just making sure that we are not going to have reloadActions() called again
+  // with a dangling pointer to a layer when actions get removed on QGIS exit
+  clear();
+  mLayer = nullptr;
+  disconnect( QgsGui::mapLayerActionRegistry(), &QgsMapLayerActionRegistry::changed, this, &QgsActionMenu::reloadActions );
 }
 
 

--- a/src/gui/qgsactionmenu.h
+++ b/src/gui/qgsactionmenu.h
@@ -119,6 +119,7 @@ class GUI_EXPORT QgsActionMenu : public QMenu
   private slots:
     void triggerAction();
     void reloadActions();
+    void layerWillBeDeleted();
 
   private:
     void init();


### PR DESCRIPTION
When using attribute dialog to edit attributes of multiple selected features,
the dialog may stay alive until QGIS exits (parented to QgisApp) and its internal
QgsActionMenu would try to reload actions when they get removed in ~QgisApp,
referring to a deleted map layer, so let's clean things up when the layer gets
deleted to avoid trouble later.