### PR TITLE
Some minor fixes to rpm/buildrpms.sh

### DIFF
--- a/rpm/buildrpms.sh
+++ b/rpm/buildrpms.sh
@@ -43,6 +43,7 @@ then
     mock_args="--old-chroot"
 fi
 
+relver=1
 compile_spec_only=0
 build_only=0
 srpm_only=0
@@ -82,13 +83,14 @@ then
   # Get next release version number and increment after
   if [ ! -f version.cfg ]
   then
-    echo "relver=1" > version.cfg
-  fi
-  source version.cfg
-  if [ "$build_only" -ne "1" ]
-  then
-    (( relver+=1 ))
     echo "relver=$relver" > version.cfg
+  else
+    source version.cfg
+    if [ "$build_only" -ne "1" ]
+    then
+      (( relver+=1 ))
+      echo "relver=$relver" > version.cfg
+    fi
   fi
   timestamp=0
 else
@@ -139,7 +141,7 @@ then
     --define "_relver $relver" \
     --define "_version $version" \
     --define "_timestamp $timestamp" \
-    --resultdir=$OUTDIR $mock_args -ne 0;
+    --resultdir=$OUTDIR $mock_args
   then
     print_error "Creating source package failed"
     exit 1
@@ -171,7 +173,7 @@ do :
     --define "_relver $relver" \
     --define "_version $version" \
     --define "_timestamp $timestamp" \
-    --resultdir=$OUTDIR/$arch $mock_args -eq 0;
+    --resultdir=$OUTDIR/$arch $mock_args
   then
     # Add to package list
     packages="$packages $(ls $OUTDIR/$arch/*-$version-$relver.*.rpm)"

--- a/rpm/default.cfg
+++ b/rpm/default.cfg
@@ -10,10 +10,10 @@ OUTDIR="result/"
 
 # Which arches to build for. Check /etc/mock for possible options
 ARCHS=(
-        "fedora-26-i386"
-        "fedora-26-x86_64"
         "fedora-27-i386"
         "fedora-27-x86_64"
+        "fedora-28-i386"
+        "fedora-28-x86_64"
       )
 
 # Which git branch to export. Normally take the current

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -18,11 +18,7 @@
 %define builddate %(date '+%a %b %d %Y')
 %endif
 
-%if 0%{?fedora} >= 27
 %define grass grass74
-%else
-%define grass grass72
-%endif
 
 Name:           qgis
 Version:        %{_version}


### PR DESCRIPTION
## Description

Resolves a couple of issues in the `rpm/buildrpms.sh` script
- Release number count was starting from 2 instead of 1
- Some `if`s were getting confused about command flags (see `mock` failing here: https://ci.services.vigano.me/#/builders/2/builds/38/steps/1/logs/stdio)

I also removed support for Fedora 26, to keep code clean, since it reached the EoL on May 29th.

CI: https://ci.services.vigano.me/#/builders/2/builds/44

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit

/cc @m-kuhn 