### PR TITLE
Take changes of embedded forms into account

### DIFF
--- a/python/gui/auto_generated/editorwidgets/core/qgswidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/core/qgswidgetwrapper.sip.in
@@ -155,6 +155,15 @@ Sets the editor widget's property collection, used for data defined overrides.
 .. versionadded:: 3.0
 %End
 
+    void notifyAboutToSave();
+%Docstring
+Notify this widget, that the containing form is about to save and
+that any pending changes should be pushed to the edit buffer or they
+might be lost.
+
+.. versionadded:: 3.2
+%End
+
   protected:
 
     virtual QWidget *createWidget( QWidget *parent ) = 0;

--- a/src/gui/editorwidgets/core/qgswidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgswidgetwrapper.cpp
@@ -97,6 +97,11 @@ QgsWidgetWrapper *QgsWidgetWrapper::fromWidget( QWidget *widget )
   return widget->property( "EWV2Wrapper" ).value<QgsWidgetWrapper *>();
 }
 
+void QgsWidgetWrapper::notifyAboutToSave()
+{
+  aboutToSave();
+}
+
 void QgsWidgetWrapper::initWidget( QWidget *editor )
 {
   Q_UNUSED( editor )
@@ -105,4 +110,9 @@ void QgsWidgetWrapper::initWidget( QWidget *editor )
 void QgsWidgetWrapper::setEnabled( bool enabled )
 {
   Q_UNUSED( enabled );
+}
+
+void QgsWidgetWrapper::aboutToSave()
+{
+
 }

--- a/src/gui/editorwidgets/core/qgswidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgswidgetwrapper.h
@@ -190,6 +190,15 @@ class GUI_EXPORT QgsWidgetWrapper : public QObject
      */
     void setDataDefinedProperties( const QgsPropertyCollection &collection ) { mPropertyCollection = collection; }
 
+    /**
+     * Notify this widget, that the containing form is about to save and
+     * that any pending changes should be pushed to the edit buffer or they
+     * might be lost.
+     *
+     * \since QGIS 3.2
+     */
+    void notifyAboutToSave();
+
   protected:
 
     /**
@@ -234,6 +243,15 @@ class GUI_EXPORT QgsWidgetWrapper : public QObject
     virtual void setEnabled( bool enabled );
 
   private:
+
+    /**
+     * Called when the containing attribute form is about to save.
+     * Use this to push any widget states to the edit buffer.
+     *
+     * \since QGIS 3.2
+     */
+    virtual void aboutToSave();
+
     QgsAttributeEditorContext mContext;
     QVariantMap mConfig;
     QWidget *mWidget = nullptr;

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -48,6 +48,9 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
 
 void QgsRelationWidgetWrapper::aboutToSave()
 {
+  // Calling isModified() will emit a beforeModifiedCheck()
+  // signal that will make the embedded form to send any
+  // outstanding widget changes to the edit buffer
   mRelation.referencingLayer()->isModified();
 
   if ( mNmRelation.isValid() )

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -46,6 +46,14 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
     mWidget->setVisible( visible );
 }
 
+void QgsRelationWidgetWrapper::aboutToSave()
+{
+  mRelation.referencingLayer()->isModified();
+
+  if ( mNmRelation.isValid() )
+    mNmRelation.referencedLayer()->isModified();
+}
+
 QgsRelation QgsRelationWidgetWrapper::relation() const
 {
   return mRelation;
@@ -96,14 +104,14 @@ void QgsRelationWidgetWrapper::initWidget( QWidget *editor )
 
   w->setEditorContext( myContext );
 
-  QgsRelation nmrel = QgsProject::instance()->relationManager()->relation( config( QStringLiteral( "nm-rel" ) ).toString() );
+  mNmRelation = QgsProject::instance()->relationManager()->relation( config( QStringLiteral( "nm-rel" ) ).toString() );
 
   // If this widget is already embedded by the same relation, reduce functionality
   const QgsAttributeEditorContext *ctx = &context();
   do
   {
     if ( ( ctx->relation().name() == mRelation.name() && ctx->formMode() == QgsAttributeEditorContext::Embed )
-         || ( nmrel.isValid() && ctx->relation().name() == nmrel.name() ) )
+         || ( mNmRelation.isValid() && ctx->relation().name() == mNmRelation.name() ) )
     {
       w->setVisible( false );
       break;
@@ -113,7 +121,7 @@ void QgsRelationWidgetWrapper::initWidget( QWidget *editor )
   while ( ctx );
 
 
-  w->setRelations( mRelation, nmrel );
+  w->setRelations( mRelation, mNmRelation );
 
   mWidget = w;
 }

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -103,7 +103,9 @@ class GUI_EXPORT QgsRelationWidgetWrapper : public QgsWidgetWrapper
     void setVisible( bool visible );
 
   private:
+    void aboutToSave() override;
     QgsRelation mRelation;
+    QgsRelation mNmRelation;
     QgsRelationEditorWidget *mWidget = nullptr;
 };
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -290,7 +290,7 @@ bool QgsAttributeForm::saveEdits()
     QgsAttributes src = mFeature.attributes();
     QgsAttributes dst = mFeature.attributes();
 
-    Q_FOREACH ( QgsWidgetWrapper *ww, mWidgets )
+    for ( QgsWidgetWrapper *ww : qgis::as_const( mWidgets ) )
     {
       QgsEditorWidgetWrapper *eww = qobject_cast<QgsEditorWidgetWrapper *>( ww );
       if ( eww )
@@ -587,6 +587,11 @@ bool QgsAttributeForm::save()
 {
   if ( mIsSaving )
     return true;
+
+  for ( QgsWidgetWrapper *wrapper : qgis::as_const( mWidgets ) )
+  {
+    wrapper->notifyAboutToSave();
+  }
 
   // only do the dirty checks when editing an existing feature - for new
   // features we need to add them even if the attributes are unchanged from the initial


### PR DESCRIPTION
when clicking on ok of an attribute form, tell all embedded widgets (all
widgets actually) that we are going to close the form and it's the last
call to push changes to the edit buffer or they will be lost.

Fix https://issues.qgis.org/issues/19137

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
