### PR TITLE
Fix crashes in geometry checker (fixes #18736)

### DIFF
--- a/src/plugins/geometry_checker/qgsgeometrycheckerdialog.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerdialog.cpp
@@ -89,6 +89,16 @@ void QgsGeometryCheckerDialog::done( int r )
 
 void QgsGeometryCheckerDialog::closeEvent( QCloseEvent *ev )
 {
+  if ( QgsGeometryCheckerSetupTab *setupTab = qobject_cast<QgsGeometryCheckerSetupTab *>( mTabWidget->widget( 0 ) ) )
+  {
+    // do not allow closing the dialog - this would delete the geometry checker and crash
+    if ( setupTab->isRunningInBackground() )
+    {
+      ev->ignore();
+      return;
+    }
+  }
+
   if ( qobject_cast<QgsGeometryCheckerResultTab *>( mTabWidget->widget( 1 ) ) &&
        !static_cast<QgsGeometryCheckerResultTab *>( mTabWidget->widget( 1 ) )->isCloseable() )
   {

--- a/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerresulttab.cpp
@@ -616,10 +616,11 @@ void QgsGeometryCheckerResultTab::checkRemovedLayer( const QStringList &ids )
   bool requiredLayersRemoved = false;
   for ( const QString &layerId : mChecker->getContext()->featurePools.keys() )
   {
-    if ( ids.contains( layerId ) && isEnabled() )
+    if ( ids.contains( layerId ) )
     {
       mChecker->getContext()->featurePools[layerId]->clearLayer();
-      requiredLayersRemoved = true;
+      if ( isEnabled() )
+        requiredLayersRemoved = true;
     }
   }
   if ( requiredLayersRemoved )

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -467,10 +467,14 @@ void QgsGeometryCheckerSetupTab::runChecks()
   connect( mAbortButton, &QAbstractButton::clicked, &futureWatcher, &QFutureWatcherBase::cancel );
   connect( mAbortButton, &QAbstractButton::clicked, this, &QgsGeometryCheckerSetupTab::showCancelFeedback );
 
+  mIsRunningInBackground = true;
+
   int maxSteps = 0;
   futureWatcher.setFuture( checker->execute( &maxSteps ) );
   ui.progressBar->setRange( 0, maxSteps );
   evLoop.exec();
+
+  mIsRunningInBackground = false;
 
   // Restore window
   unsetCursor();

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.h
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.h
@@ -34,6 +34,8 @@ class QgsGeometryCheckerSetupTab : public QWidget
     QgsGeometryCheckerSetupTab( QgisInterface *iface, QDialog *checkerDialog, QWidget *parent = nullptr );
     ~QgsGeometryCheckerSetupTab() override;
 
+    bool isRunningInBackground() const { return mIsRunningInBackground; }
+
   signals:
     void checkerStarted( QgsGeometryChecker *checker );
     void checkerFinished( bool );
@@ -45,6 +47,7 @@ class QgsGeometryCheckerSetupTab : public QWidget
     QPushButton *mRunButton = nullptr;
     QPushButton *mAbortButton = nullptr;
     QMutex m_errorListMutex;
+    bool mIsRunningInBackground = false;
 
     QList<QgsVectorLayer *> getSelectedLayers();
 

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.h
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.h
@@ -34,6 +34,10 @@ class QgsGeometryCheckerSetupTab : public QWidget
     QgsGeometryCheckerSetupTab( QgisInterface *iface, QDialog *checkerDialog, QWidget *parent = nullptr );
     ~QgsGeometryCheckerSetupTab() override;
 
+    /**
+     * Indicates whether the geometry checker is currently running its checks in the background.
+     * Useful to figure out whether it is safe to close the dialog and thus destroy the checker.
+     */
     bool isRunningInBackground() const { return mIsRunningInBackground; }
 
   signals:


### PR DESCRIPTION
This fixes two different crashes:
- when trying to close the checker dialog while checks are running in background
- when trying to run checks again after previously aborting a run
