### PR TITLE
Make non progress reporting tasks have undefined bars instead of 0%

### DIFF
--- a/src/gui/qgstaskmanagerwidget.cpp
+++ b/src/gui/qgstaskmanagerwidget.cpp
@@ -78,7 +78,7 @@ void QgsTaskManagerWidget::modelRowsInserted( const QModelIndex &, int start, in
 
     QProgressBar *progressBar = new QProgressBar();
     progressBar->setAutoFillBackground( true );
-    progressBar->setRange(0, 0);
+    progressBar->setRange( 0, 0 );
     connect( task, &QgsTask::progressChanged, progressBar, [progressBar]( double progress )
     {
       //until first progress report, we show a progress bar of interderminant length

--- a/src/gui/qgstaskmanagerwidget.cpp
+++ b/src/gui/qgstaskmanagerwidget.cpp
@@ -78,6 +78,7 @@ void QgsTaskManagerWidget::modelRowsInserted( const QModelIndex &, int start, in
 
     QProgressBar *progressBar = new QProgressBar();
     progressBar->setAutoFillBackground( true );
+    progressBar->setRange(0, 0);
     connect( task, &QgsTask::progressChanged, progressBar, [progressBar]( double progress )
     {
       //until first progress report, we show a progress bar of interderminant length


### PR DESCRIPTION
## Description
This changes the behavior for  non progress reporting tasks to have an undefined bars instead of 0%

Before:
![image 5](https://user-images.githubusercontent.com/233663/41731762-8206e008-757f-11e8-9c40-0f69dd791a4a.png)
![image 3](https://user-images.githubusercontent.com/233663/41731900-ec7a5d16-757f-11e8-82b8-4957f93448b8.png)


After:
![image](https://user-images.githubusercontent.com/233663/41732073-5ee0ee10-7580-11e8-9705-8fed2b7afe15.png)

![image](https://user-images.githubusercontent.com/233663/41732039-45a9b0c6-7580-11e8-845b-9614ab035bae.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
