### PR TITLE
[layouts] Save last used export folder in project

### DIFF
--- a/python/core/auto_generated/qgsfileutils.sip.in
+++ b/python/core/auto_generated/qgsfileutils.sip.in
@@ -76,6 +76,14 @@ for filenames with an '_' character.
 
    This method strips slashes from the filename, so it is safe to call with file names only, not complete paths.
 %End
+
+    static QString findClosestExistingPath( const QString &path );
+%Docstring
+Returns the top-most existing folder from ``path``. E.g. if ``path`` is "/home/user/projects/2018/P4343"
+and "/home/user/projects" exists but no "2018" subfolder exists, then the function will return "/home/user/projects".
+
+.. versionadded:: 3.2
+%End
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
@@ -57,7 +57,7 @@ Returns the layout view utilized by the designer.
 Returns the designer's message bar.
 %End
 
-    virtual void selectItems( QList< QgsLayoutItem * > items ) = 0;
+    virtual void selectItems( const QList< QgsLayoutItem * > &items ) = 0;
 %Docstring
 Selects the specified ``items``.
 %End

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -246,7 +246,7 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
 
   connect( mActionOptions, &QAction::triggered, this, [ = ]
   {
-    QgisApp::instance()->showOptionsDialog( this, QString( "mOptionsPageComposer" ) );
+    QgisApp::instance()->showOptionsDialog( this, QStringLiteral( "mOptionsPageComposer" ) );
   } );
 
   mView = new QgsLayoutView();
@@ -322,7 +322,7 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   mActionsToolbar->addWidget( resizeToolButton );
 
   QToolButton *atlasExportToolButton = new QToolButton( mAtlasToolbar );
-  atlasExportToolButton->setIcon( QgsApplication::getThemeIcon( "mActionExport.svg" ) );
+  atlasExportToolButton->setIcon( QgsApplication::getThemeIcon( QStringLiteral( "mActionExport.svg" ) ) );
   atlasExportToolButton->setPopupMode( QToolButton::InstantPopup );
   atlasExportToolButton->setAutoRaise( true );
   atlasExportToolButton->setToolButtonStyle( Qt::ToolButtonIconOnly );
@@ -1462,7 +1462,7 @@ void QgsLayoutDesignerDialog::updateStatusZoom()
     zoomLevel = mView->transform().m11() * 100 / scale100;
   }
   whileBlocking( mStatusZoomCombo )->lineEdit()->setText( tr( "%1%" ).arg( zoomLevel, 0, 'f', 1 ) );
-  whileBlocking( mStatusZoomSlider )->setValue( zoomLevel );
+  whileBlocking( mStatusZoomSlider )->setValue( static_cast< int >( zoomLevel ) );
 }
 
 void QgsLayoutDesignerDialog::updateStatusCursorPos( QPointF position )
@@ -1544,7 +1544,7 @@ void QgsLayoutDesignerDialog::dockVisibilityChanged( bool visible )
   }
 }
 
-void QgsLayoutDesignerDialog::undoRedoOccurredForItems( const QSet<QString> itemUuids )
+void QgsLayoutDesignerDialog::undoRedoOccurredForItems( const QSet<QString> &itemUuids )
 {
   mBlockItemOptions = true;
 
@@ -2327,7 +2327,7 @@ void QgsLayoutDesignerDialog::printAtlas()
   progressDialog->setWindowTitle( tr( "Printing Atlas" ) );
   connect( feedback.get(), &QgsFeedback::progressChanged, this, [ & ]( double progress )
   {
-    progressDialog->setValue( progress );
+    progressDialog->setValue( static_cast< int >( progress ) );
     progressDialog->setLabelText( feedback->property( "progress" ).toString() ) ;
 
 #ifdef Q_OS_LINUX
@@ -2498,7 +2498,7 @@ void QgsLayoutDesignerDialog::exportAtlasToRaster()
   progressDialog->setWindowTitle( tr( "Exporting Atlas" ) );
   connect( feedback.get(), &QgsFeedback::progressChanged, this, [ & ]( double progress )
   {
-    progressDialog->setValue( progress );
+    progressDialog->setValue( static_cast< int >( progress ) );
     progressDialog->setLabelText( feedback->property( "progress" ).toString() ) ;
 
 #ifdef Q_OS_LINUX
@@ -2649,7 +2649,7 @@ void QgsLayoutDesignerDialog::exportAtlasToSvg()
   progressDialog->setWindowTitle( tr( "Exporting Atlas" ) );
   connect( feedback.get(), &QgsFeedback::progressChanged, this, [ & ]( double progress )
   {
-    progressDialog->setValue( progress );
+    progressDialog->setValue( static_cast< int >( progress ) );
     progressDialog->setLabelText( feedback->property( "progress" ).toString() ) ;
 
 #ifdef Q_OS_LINUX
@@ -2856,7 +2856,7 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
   progressDialog->setWindowTitle( tr( "Exporting Atlas" ) );
   connect( feedback.get(), &QgsFeedback::progressChanged, this, [ & ]( double progress )
   {
-    progressDialog->setValue( progress );
+    progressDialog->setValue( static_cast< int >( progress ) );
     progressDialog->setLabelText( feedback->property( "progress" ).toString() ) ;
 
 #ifdef Q_OS_LINUX
@@ -3499,12 +3499,12 @@ void QgsLayoutDesignerDialog::restoreWindowState()
 
   if ( !restoreState( settings.value( QStringLiteral( "LayoutDesigner/state" ), QByteArray::fromRawData( reinterpret_cast< const char * >( defaultLayerDesignerUIstate ), sizeof defaultLayerDesignerUIstate ), QgsSettings::App ).toByteArray() ) )
   {
-    QgsDebugMsg( "restore of layout UI state failed" );
+    QgsDebugMsg( QStringLiteral( "restore of layout UI state failed" ) );
   }
   // restore window geometry
   if ( !restoreGeometry( settings.value( QStringLiteral( "LayoutDesigner/geometry" ), QgsSettings::App ).toByteArray() ) )
   {
-    QgsDebugMsg( "restore of layout UI geometry failed" );
+    QgsDebugMsg( QStringLiteral( "restore of layout UI geometry failed" ) );
     // default to 80% of screen size, at 10% from top left corner
     resize( QDesktopWidget().availableGeometry( this ).size() * 0.8 );
     QSize pos = QDesktopWidget().availableGeometry( this ).size() * 0.1;
@@ -3727,11 +3727,11 @@ bool QgsLayoutDesignerDialog::showFileSizeWarning()
   // Image size
   double oneInchInLayoutUnits = mLayout->convertToLayoutUnits( QgsLayoutMeasurement( 1, QgsUnitTypes::LayoutInches ) );
   QSizeF maxPageSize = mLayout->pageCollection()->maximumPageSize();
-  int width = ( int )( mLayout->renderContext().dpi() * maxPageSize.width() / oneInchInLayoutUnits );
-  int height = ( int )( mLayout->renderContext().dpi() * maxPageSize.height() / oneInchInLayoutUnits );
+  int width = static_cast< int >( mLayout->renderContext().dpi() * maxPageSize.width() / oneInchInLayoutUnits );
+  int height = static_cast< int >( mLayout->renderContext().dpi() * maxPageSize.height() / oneInchInLayoutUnits );
   int memuse = width * height * 3 / 1000000;  // pixmap + image
-  QgsDebugMsg( QString( "Image %1x%2" ).arg( width ).arg( height ) );
-  QgsDebugMsg( QString( "memuse = %1" ).arg( memuse ) );
+  QgsDebugMsg( QStringLiteral( "Image %1x%2" ).arg( width ).arg( height ) );
+  QgsDebugMsg( QStringLiteral( "memuse = %1" ).arg( memuse ) );
 
   if ( memuse > 400 )   // about 4500x4500
   {
@@ -4165,7 +4165,7 @@ void QgsLayoutDesignerDialog::updateWindowTitle()
   setWindowTitle( title );
 }
 
-void QgsLayoutDesignerDialog::selectItems( const QList<QgsLayoutItem *> items )
+void QgsLayoutDesignerDialog::selectItems( const QList<QgsLayoutItem *> &items )
 {
   for ( QGraphicsItem *item : items )
   {

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -120,7 +120,7 @@ QgsMessageBar *QgsAppLayoutDesignerInterface::messageBar()
   return mDesigner->messageBar();
 }
 
-void QgsAppLayoutDesignerInterface::selectItems( const QList<QgsLayoutItem *> items )
+void QgsAppLayoutDesignerInterface::selectItems( const QList<QgsLayoutItem *> &items )
 {
   mDesigner->selectItems( items );
 }

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -502,6 +502,9 @@ class QgsLayoutDesignerDialog: public QMainWindow, private Ui::QgsLayoutDesigner
     QString reportTypeString();
     void updateActionNames( QgsMasterLayoutInterface::Type type );
 
+    QString defaultExportPath() const;
+    void setLastExportPath( const QString &path ) const;
+
 };
 
 #endif // QGSLAYOUTDESIGNERDIALOG_H

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -59,7 +59,7 @@ class QgsAppLayoutDesignerInterface : public QgsLayoutDesignerInterface
     QgsMasterLayoutInterface *masterLayout() override;
     QgsLayoutView *view() override;
     QgsMessageBar *messageBar() override;
-    void selectItems( QList< QgsLayoutItem * > items ) override;
+    void selectItems( const QList< QgsLayoutItem * > &items ) override;
 
   public slots:
 

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -132,7 +132,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, private Ui::QgsLayoutDesigner
     /**
      * Selects the specified \a items.
      */
-    void selectItems( QList< QgsLayoutItem * > items );
+    void selectItems( const QList<QgsLayoutItem *> &items );
 
     /**
      * Returns the designer's message bar.
@@ -309,7 +309,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, private Ui::QgsLayoutDesigner
     void addPages();
     void statusMessageReceived( const QString &message );
     void dockVisibilityChanged( bool visible );
-    void undoRedoOccurredForItems( QSet< QString > itemUuids );
+    void undoRedoOccurredForItems( const QSet< QString > &itemUuids );
     void saveAsTemplate();
     void addItemsFromTemplate();
     void duplicate();

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -17,6 +17,7 @@
 #include <QRegularExpression>
 #include <QFileInfo>
 #include <QDir>
+#include <QSet>
 
 QString QgsFileUtils::representFileSize( qint64 bytes )
 {
@@ -106,12 +107,17 @@ QString QgsFileUtils::findClosestExistingPath( const QString &path )
   else
     currentPath = QDir( path );
 
+  QSet< QString > visited;
   while ( !currentPath.exists() )
   {
     const QString parentPath = QDir::cleanPath( currentPath.path() + QStringLiteral( "/.." ) );
+    if ( visited.contains( parentPath ) )
+      return QString(); // break circular links
+
     if ( parentPath.isEmpty() || parentPath == '.' )
       return QString();
     currentPath = QDir( parentPath );
+    visited << parentPath;
   }
 
   const QString res = QDir::cleanPath( currentPath.path() );

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -110,7 +110,7 @@ QString QgsFileUtils::findClosestExistingPath( const QString &path )
   QSet< QString > visited;
   while ( !currentPath.exists() )
   {
-    const QString parentPath = QDir::cleanPath( currentPath.path() + QStringLiteral( "/.." ) );
+    const QString parentPath = QDir::cleanPath( currentPath.absolutePath() + QStringLiteral( "/.." ) );
     if ( visited.contains( parentPath ) )
       return QString(); // break circular links
 
@@ -120,6 +120,10 @@ QString QgsFileUtils::findClosestExistingPath( const QString &path )
     visited << parentPath;
   }
 
-  const QString res = QDir::cleanPath( currentPath.path() );
+  const QString res = QDir::cleanPath( currentPath.absolutePath() );
+
+  if ( res == QDir::currentPath() )
+      return QString(); // avoid default to binary folder if a filename alone is specified
+
   return res == '.' ? QString() : res;
 }

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -96,6 +96,9 @@ QString QgsFileUtils::stringToSafeFilename( const QString &string )
 
 QString QgsFileUtils::findClosestExistingPath( const QString &path )
 {
+  if ( path.isEmpty() )
+    return QString();
+
   QDir currentPath;
   QFileInfo fi( path );
   if ( fi.isFile() )

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -123,7 +123,7 @@ QString QgsFileUtils::findClosestExistingPath( const QString &path )
   const QString res = QDir::cleanPath( currentPath.absolutePath() );
 
   if ( res == QDir::currentPath() )
-      return QString(); // avoid default to binary folder if a filename alone is specified
+    return QString(); // avoid default to binary folder if a filename alone is specified
 
   return res == '.' ? QString() : res;
 }

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -78,6 +78,14 @@ class CORE_EXPORT QgsFileUtils
      * \warning This method strips slashes from the filename, so it is safe to call with file names only, not complete paths.
      */
     static QString stringToSafeFilename( const QString &string );
+
+    /**
+     * Returns the top-most existing folder from \a path. E.g. if \a path is "/home/user/projects/2018/P4343"
+     * and "/home/user/projects" exists but no "2018" subfolder exists, then the function will return "/home/user/projects".
+     *
+     * \since QGIS 3.2
+     */
+    static QString findClosestExistingPath( const QString &path );
 };
 
 #endif // QGSFILEUTILS_H

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -612,7 +612,7 @@ void QgsProject::clear()
 // basically a debugging tool to dump property list values
 void dump_( const QgsProjectPropertyKey &topQgsPropertyKey )
 {
-  QgsDebugMsg( "current properties:" );
+  QgsDebugMsg( QStringLiteral( "current properties:" ) );
   topQgsPropertyKey.dump();
 }
 
@@ -660,13 +660,13 @@ void _getProperties( const QDomDocument &doc, QgsProjectPropertyKey &project_pro
 
   if ( scopes.count() < 1 )
   {
-    QgsDebugMsg( "empty ``properties'' XML tag ... bailing" );
+    QgsDebugMsg( QStringLiteral( "empty ``properties'' XML tag ... bailing" ) );
     return;
   }
 
   if ( ! project_properties.readXml( propertiesElem ) )
   {
-    QgsDebugMsg( "Project_properties.readXml() failed" );
+    QgsDebugMsg( QStringLiteral( "Project_properties.readXml() failed" ) );
   }
 }
 
@@ -683,7 +683,7 @@ static void _getTitle( const QDomDocument &doc, QString &title )
 
   if ( !nl.count() )
   {
-    QgsDebugMsg( "unable to find title element" );
+    QgsDebugMsg( QStringLiteral( "unable to find title element" ) );
     return;
   }
 
@@ -691,7 +691,7 @@ static void _getTitle( const QDomDocument &doc, QString &title )
 
   if ( !titleNode.hasChildNodes() ) // if not, then there's no actual text
   {
-    QgsDebugMsg( "unable to find title element" );
+    QgsDebugMsg( QStringLiteral( "unable to find title element" ) );
     return;
   }
 
@@ -699,7 +699,7 @@ static void _getTitle( const QDomDocument &doc, QString &title )
 
   if ( !titleTextNode.isText() )
   {
-    QgsDebugMsg( "unable to find title element" );
+    QgsDebugMsg( QStringLiteral( "unable to find title element" ) );
     return;
   }
 
@@ -715,7 +715,7 @@ QgsProjectVersion getVersion( const QDomDocument &doc )
 
   if ( !nl.count() )
   {
-    QgsDebugMsg( " unable to find qgis element in project file" );
+    QgsDebugMsg( QStringLiteral( " unable to find qgis element in project file" ) );
     return QgsProjectVersion( 0, 0, 0, QString() );
   }
 
@@ -839,7 +839,7 @@ bool QgsProject::addLayer( const QDomElement &layerElem, QList<QDomNode> &broken
 
   if ( !mapLayer )
   {
-    QgsDebugMsg( "Unable to create layer" );
+    QgsDebugMsg( QStringLiteral( "Unable to create layer" ) );
 
     return false;
   }
@@ -976,7 +976,7 @@ bool QgsProject::readProjectFile( const QString &filename )
 
     // Shows a warning when an old project file is read.
     emit oldProjectVersionWarning( fileVersion.text() );
-    QgsDebugMsg( "Emitting oldProjectVersionWarning(oldVersion)." );
+    QgsDebugMsg( QStringLiteral( "Emitting oldProjectVersionWarning(oldVersion)." ) );
 
     projectFile.updateRevision( thisVersion );
   }
@@ -1124,7 +1124,7 @@ bool QgsProject::readProjectFile( const QString &filename )
   // review the integrity of the retrieved map layers
   if ( !clean )
   {
-    QgsDebugMsg( "Unable to get map layers from project file." );
+    QgsDebugMsg( QStringLiteral( "Unable to get map layers from project file." ) );
 
     if ( !brokenNodes.isEmpty() )
     {
@@ -1551,15 +1551,15 @@ bool QgsProject::writeProjectFile( const QString &filename )
   qgisNode.appendChild( titleNode );
 
   QDomElement transactionNode = doc->createElement( QStringLiteral( "autotransaction" ) );
-  transactionNode.setAttribute( QStringLiteral( "active" ), mAutoTransaction ? "1" : "0" );
+  transactionNode.setAttribute( QStringLiteral( "active" ), mAutoTransaction ? '1' : '0' );
   qgisNode.appendChild( transactionNode );
 
   QDomElement evaluateDefaultValuesNode = doc->createElement( QStringLiteral( "evaluateDefaultValues" ) );
-  evaluateDefaultValuesNode.setAttribute( QStringLiteral( "active" ), mEvaluateDefaultValues ? "1" : "0" );
+  evaluateDefaultValuesNode.setAttribute( QStringLiteral( "active" ), mEvaluateDefaultValues ? '1' : '0' );
   qgisNode.appendChild( evaluateDefaultValuesNode );
 
   QDomElement trustNode = doc->createElement( QStringLiteral( "trust" ) );
-  trustNode.setAttribute( QStringLiteral( "active" ), mTrustLayerMetadata ? "1" : "0" );
+  trustNode.setAttribute( QStringLiteral( "active" ), mTrustLayerMetadata ? '1' : '0' );
   qgisNode.appendChild( trustNode );
 
   QDomText titleText = doc->createTextNode( title() );  // XXX why have title TWICE?
@@ -1643,7 +1643,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
 
   dump_( mProperties );
 
-  QgsDebugMsg( QString( "there are %1 property scopes" ).arg( static_cast<int>( mProperties.count() ) ) );
+  QgsDebugMsg( QStringLiteral( "there are %1 property scopes" ).arg( static_cast<int>( mProperties.count() ) ) );
 
   if ( !mProperties.isEmpty() ) // only worry about properties if we
     // actually have any properties
@@ -2691,6 +2691,7 @@ QSet<QgsMapLayer *> QgsProject::requiredLayers() const
 void QgsProject::setRequiredLayers( const QSet<QgsMapLayer *> &layers )
 {
   QStringList layerIds;
+  layerIds.reserve( layers.count() );
   for ( QgsMapLayer *layer : layers )
   {
     layerIds << layer->id();

--- a/src/gui/layout/qgslayoutdesignerinterface.h
+++ b/src/gui/layout/qgslayoutdesignerinterface.h
@@ -76,7 +76,7 @@ class GUI_EXPORT QgsLayoutDesignerInterface: public QObject
     /**
      * Selects the specified \a items.
      */
-    virtual void selectItems( QList< QgsLayoutItem * > items ) = 0;
+    virtual void selectItems( const QList< QgsLayoutItem * > &items ) = 0;
 
   public slots:
 

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -66,6 +66,8 @@ class TestQgsFileUtils(unittest.TestCase):
     def testFindClosestExistingPath(self):
         self.assertEqual(QgsFileUtils.findClosestExistingPath(''), '')
         self.assertEqual(QgsFileUtils.findClosestExistingPath('.'), '')
+        self.assertEqual(QgsFileUtils.findClosestExistingPath('just_a_filename'), '')
+        self.assertEqual(QgsFileUtils.findClosestExistingPath('just_a_filename.txt'), '')
         self.assertEqual(QgsFileUtils.findClosestExistingPath('a_very_unlikely_path_to_really_exist/because/no_one_would_have_a_folder_called/MapInfo is the bestest/'), '')
         # sorry anyone not on linux!
         self.assertEqual(QgsFileUtils.findClosestExistingPath('/usr/youve_been_hacked/by_the_l77t_krew'), '/usr')
@@ -75,9 +77,9 @@ class TestQgsFileUtils(unittest.TestCase):
         with open(file, 'wt') as f:
             f.write('\n')
 
-        self.assertEqual(QgsFileUtils.findClosestExistingPath(os.path.join(base_path, 'a file name.bmp')), base_path) # non-existant file
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(os.path.join(base_path, 'a file name.bmp')), base_path) # non-existent file
         self.assertEqual(QgsFileUtils.findClosestExistingPath(file), base_path) # real file!
-        self.assertEqual(QgsFileUtils.findClosestExistingPath(os.path.join(base_path, 'non/existant/subfolder')), base_path)
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(os.path.join(base_path, 'non/existent/subfolder')), base_path)
 
         sub_folder1 = os.path.join(base_path, 'subfolder1')
         os.mkdir(sub_folder1)

--- a/tests/src/python/test_qgsfileutils.py
+++ b/tests/src/python/test_qgsfileutils.py
@@ -14,6 +14,8 @@ __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
 
+import tempfile
+import os
 from qgis.core import QgsFileUtils
 from qgis.testing import unittest
 
@@ -60,6 +62,35 @@ class TestQgsFileUtils(unittest.TestCase):
         self.assertEqual(
             QgsFileUtils.stringToSafeFilename('rendered map_final? rev (12-03-1017)_real/\\?%*:|"<>.tif'),
             'rendered map_final_ rev (12-03-1017)_real__________.tif')
+
+    def testFindClosestExistingPath(self):
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(''), '')
+        self.assertEqual(QgsFileUtils.findClosestExistingPath('.'), '')
+        self.assertEqual(QgsFileUtils.findClosestExistingPath('a_very_unlikely_path_to_really_exist/because/no_one_would_have_a_folder_called/MapInfo is the bestest/'), '')
+        # sorry anyone not on linux!
+        self.assertEqual(QgsFileUtils.findClosestExistingPath('/usr/youve_been_hacked/by_the_l77t_krew'), '/usr')
+
+        base_path = tempfile.mkdtemp()
+        file = os.path.join(base_path, 'test.csv')
+        with open(file, 'wt') as f:
+            f.write('\n')
+
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(os.path.join(base_path, 'a file name.bmp')), base_path) # non-existant file
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(file), base_path) # real file!
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(os.path.join(base_path, 'non/existant/subfolder')), base_path)
+
+        sub_folder1 = os.path.join(base_path, 'subfolder1')
+        os.mkdir(sub_folder1)
+        sub_folder2 = os.path.join(sub_folder1, 'subfolder2')
+        os.mkdir(sub_folder2)
+        bad_sub_folder = os.path.join(sub_folder2, 'nooo')
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(bad_sub_folder), sub_folder2)
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(sub_folder2), sub_folder2)
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(sub_folder2 + '/.'), sub_folder2)
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(sub_folder2 + '/..'), sub_folder1)
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(sub_folder2 + '/../ddddddd'), sub_folder1)
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(sub_folder2 + '/../subfolder2'), sub_folder2)
+        self.assertEqual(QgsFileUtils.findClosestExistingPath(sub_folder2 + '/../subfolder2/zxcv/asfdasd'), sub_folder2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
And use it in preference to the global last used export folder.

Because GIS use is typically specific project based, and it makes little sense to default to an output folder related to a different project. In fact, it's REALLY REALLY annoying to keep resetting the default export folder to some other project's export folder.