### PR TITLE
String length constraints-postgis

### DIFF
--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -334,7 +334,8 @@ class DlgImportVector(QDialog, Ui_Dialog):
                     options['layerName'] = table
                 else:
                     uri = self.outUri.uri(False)
-
+                # defaulting dropStringConstraints option to 'True' till this option is not added to UI
+                options['dropStringConstraints'] = True
                 if self.chkDropTable.isChecked():
                     options['overwrite'] = True
 


### PR DESCRIPTION
Bug fixes #19213
PostGIS error while adding features: ERROR: value too long for type character varying(50)

## Description
Since in the DB Manager Plugin there is no GUI option to set this option , I have updated the option dict to remove string length constraint.
Bug fixes #[19213](https://issues.qgis.org/issues/19213)
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
