### PR TITLE
Fix a Python error in Processing GUI

### DIFF
--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -97,7 +97,7 @@ class AlgorithmDialog(QgsProcessingAlgorithmDialogBase):
             if not param.isDestination():
                 wrapper = self.mainWidget().wrappers[param.name()]
                 value = None
-                if wrapper.widget:
+                if wrapper.widget is not None:
                     value = wrapper.value()
                     parameters[param.name()] = value
 


### PR DESCRIPTION
Original error - while updating an algorithm's parameters (gdal:importvectorintopostgisdatabaseavailableconnections)

```
Traceback (most recent call last):
  File "/home/martin/qgis/git-master/build-debug/output/python/plugins/processing/algs/gdal/GdalAlgorithmDialog.py", line 121, in parametersHaveChanged
    or (not p.checkValueIsAcceptable(parameters[p.name()])):
KeyError: 'TABLE'
```

It turns out that an empty QComboBox evaluates to False:

```
>>> t=QLineEdit()
>>> bool(t)
True
>>> c=QComboBox()
>>> bool(c)
False
```

Due to that, the 'TABLE' parameter was missing if its (editable) combo box was empty.

