### PR TITLE
Make sure that bool(obj) is True for QGIS API objects

### DIFF
--- a/python/core/auto_generated/qgsfeaturesource.sip.in
+++ b/python/core/auto_generated/qgsfeaturesource.sip.in
@@ -62,6 +62,12 @@ if the feature count is unknown.
     sipRes = sipCpp->featureCount();
 %End
 
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+%MethodCode
+    sipRes = true;
+%End
+
     virtual long featureCount() const = 0;
 %Docstring
 Returns the number of features contained in the source, or -1

--- a/python/core/auto_generated/qgsfeaturestore.sip.in
+++ b/python/core/auto_generated/qgsfeaturestore.sip.in
@@ -74,6 +74,12 @@ Returns the number of features contained in the store.
     sipRes = sipCpp->count();
 %End
 
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+%MethodCode
+    sipRes = true;
+%End
+
     QgsFeatureList features() const;
 %Docstring
 Returns the list of features contained in the store.

--- a/python/core/auto_generated/qgsfields.sip.in
+++ b/python/core/auto_generated/qgsfields.sip.in
@@ -103,6 +103,12 @@ Returns number of items
     sipRes = sipCpp->count();
 %End
 
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+%MethodCode
+    sipRes = true;
+%End
+
     int size() const;
 %Docstring
 Returns number of items

--- a/python/core/auto_generated/qgsmaplayerstore.sip.in
+++ b/python/core/auto_generated/qgsmaplayerstore.sip.in
@@ -46,6 +46,12 @@ Returns the number of layers contained in the store.
     sipRes = sipCpp->count();
 %End
 
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+%MethodCode
+    sipRes = true;
+%End
+
     QgsMapLayer *mapLayer( const QString &id ) const;
 %Docstring
 Retrieve a pointer to a layer by layer ``id``.

--- a/python/core/auto_generated/qgsvectorlayercache.sip.in
+++ b/python/core/auto_generated/qgsvectorlayercache.sip.in
@@ -221,6 +221,12 @@ if the feature count is unknown.
     sipRes = sipCpp->featureCount();
 %End
 
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+%MethodCode
+    sipRes = true;
+%End
+
     long featureCount() const;
 %Docstring
 Returns the number of features contained in the source, or -1

--- a/src/core/qgsfeaturesource.h
+++ b/src/core/qgsfeaturesource.h
@@ -77,6 +77,12 @@ class CORE_EXPORT QgsFeatureSource
     % MethodCode
     sipRes = sipCpp->featureCount();
     % End
+
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+    % MethodCode
+    sipRes = true;
+    % End
 #endif
 
     /**

--- a/src/core/qgsfeaturestore.h
+++ b/src/core/qgsfeaturestore.h
@@ -79,6 +79,12 @@ class CORE_EXPORT QgsFeatureStore : public QgsFeatureSink
     % MethodCode
     sipRes = sipCpp->count();
     % End
+
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+    % MethodCode
+    sipRes = true;
+    % End
 #endif
 
     /**

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -133,6 +133,12 @@ class CORE_EXPORT QgsFields
     % MethodCode
     sipRes = sipCpp->count();
     % End
+
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+    % MethodCode
+    sipRes = true;
+    % End
 #endif
 
     //! Returns number of items

--- a/src/core/qgsmaplayerstore.h
+++ b/src/core/qgsmaplayerstore.h
@@ -59,6 +59,12 @@ class CORE_EXPORT QgsMapLayerStore : public QObject
     % MethodCode
     sipRes = sipCpp->count();
     % End
+
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+    % MethodCode
+    sipRes = true;
+    % End
 #endif
 
     /**

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -276,6 +276,12 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
     % MethodCode
     sipRes = sipCpp->featureCount();
     % End
+
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+    % MethodCode
+    sipRes = true;
+    % End
 #endif
 
     /**


### PR DESCRIPTION
bool(obj) in Python has the following semantics:
1. if the object has `__bool__()` method, return its value
2. if the object has `__len__()` method, return its value
3. return True

So for objects in QGIS API that implement `__len__()` method, we were getting
unexpected behavior - for example, "if layer: ..." would evaluate as False
in case the layer was empty, while the usual expectation is that any reference
to an object that is not None should evaluate to True.