### PR TITLE
Fix a couple of regressions in rpm/buildrpms.sh

### DIFF
--- a/rpm/buildrpms.sh
+++ b/rpm/buildrpms.sh
@@ -175,11 +175,11 @@ do :
        --define "_timestamp $timestamp" \
        --resultdir=$OUTDIR/$arch $mock_args
   then
-    # Add to package list
-    packages="$packages $(ls $OUTDIR/$arch/*-$version-$relver.*.rpm)"
-  else
     print_error "Package creation for $arch failed. Abort"
     exit 1
+  else
+    # Add to package list
+    packages="$packages $(ls $OUTDIR/$arch/*-$version-$relver.*.rpm)"
   fi
 done
 

--- a/rpm/buildrpms.sh
+++ b/rpm/buildrpms.sh
@@ -137,11 +137,11 @@ then
 
   print_info "Creating source package"
   # Build source package
-  if mock --buildsrpm --spec qgis.spec --sources ./sources \
-    --define "_relver $relver" \
-    --define "_version $version" \
-    --define "_timestamp $timestamp" \
-    --resultdir=$OUTDIR $mock_args
+  if ! mock --buildsrpm --spec qgis.spec --sources ./sources \
+       --define "_relver $relver" \
+       --define "_version $version" \
+       --define "_timestamp $timestamp" \
+       --resultdir=$OUTDIR $mock_args
   then
     print_error "Creating source package failed"
     exit 1
@@ -169,11 +169,11 @@ do :
   fi
   mkdir $OUTDIR/$arch
 
-  if mock -r $arch --rebuild $OUTDIR/$srpm \
-    --define "_relver $relver" \
-    --define "_version $version" \
-    --define "_timestamp $timestamp" \
-    --resultdir=$OUTDIR/$arch $mock_args
+  if ! mock -r $arch --rebuild $OUTDIR/$srpm \
+       --define "_relver $relver" \
+       --define "_version $version" \
+       --define "_timestamp $timestamp" \
+       --resultdir=$OUTDIR/$arch $mock_args
   then
     # Add to package list
     packages="$packages $(ls $OUTDIR/$arch/*-$version-$relver.*.rpm)"

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -327,6 +327,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %{_mandir}/man1/%{name}.1*
 %dir %{_datadir}/%{name}/
 %{_datadir}/mime/packages/qgis.xml
+%{_datadir}/metainfo/org.qgis.qgis.appdata.xml
 %{_datadir}/pixmaps/
 %{_datadir}/icons/hicolor/*/apps/*
 %{_datadir}/icons/hicolor/*/mimetypes/*


### PR DESCRIPTION
## Description
I've introduced a regression in  #7287 regarding `buildrpms.sh` and another regression has been introduced by https://github.com/qgis/QGIS/pull/7283 in the `spec` file:

```bash
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/qgis-3.1.0-gitad00020.fc26.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/share/metainfo/org.qgis.qgis.appdata.xml


RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/share/metainfo/org.qgis.qgis.appdata.xml
```

See https://ci.services.vigano.me/#/builders/2/builds/45 and https://copr-be.cloud.fedoraproject.org/results/dani/qgis-testing/fedora-26-x86_64/00769779-qgis/builder-live.log

@m-kuhn this PR has been opened against master, how can these fixes be backported/cherry-pick to the `release-3.2` branch? Should I open a new PR against it? Thanks

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
