### PR TITLE
[Bugfix][Processing] R script: ParameterString has to be encoding

### DIFF
--- a/python/plugins/processing/algs/r/RAlgorithm.py
+++ b/python/plugins/processing/algs/r/RAlgorithm.py
@@ -27,6 +27,7 @@ __revision__ = '$Format:%H$'
 
 import os
 import json
+import types
 
 from qgis.PyQt.QtGui import QIcon
 
@@ -499,12 +500,20 @@ class RAlgorithm(GeoAlgorithm):
                     commands.append(param.name + '= NULL')
                 else:
                     commands.append(param.name + ' = "' + param.value + '"')
-            elif isinstance(param, (ParameterTableField, ParameterTableMultipleField, ParameterString,
+            elif isinstance(param, (ParameterTableField, ParameterTableMultipleField,
                                     ParameterFile)):
                 if param.value is None:
                     commands.append(param.name + '= NULL')
                 else:
                     commands.append(param.name + '="' + param.value + '"')
+            elif isinstance(param, ParameterString):
+                if param.value is None:
+                    commands.append(param.name + '= NULL')
+                elif type(param.value) == types.StringType:
+                    commands.append(param.name + '="' + param.value + '"')
+                else:
+                    c = unicode(param.name) + u'="' + unicode(param.value) + u'"'
+                    commands.append(c.encode('utf8'))
             elif isinstance(param, (ParameterNumber, ParameterSelection)):
                 if param.value is None:
                     commands.append(param.name + '= NULL')


### PR DESCRIPTION
## Description
In Processing R script, each parameter is inserted in the script by rewriting
the file. So it's necessary to encode ParameterString to correctly write the
processing r script.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
