### PR TITLE
Remove white background from qgis_icon.svg

### DIFF
--- a/images/icons/qgis_icon.svg
+++ b/images/icons/qgis_icon.svg
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="256" height="256" viewBox="0, 0, 256, 256">
-  <g id="Background">
-    <rect x="0" y="0" width="256" height="256" fill="#FFFFFF"/>
-  </g>
   <defs>
     <linearGradient id="Gradient_1" gradientUnits="userSpaceOnUse" x1="200.788" y1="249.007" x2="197.17" y2="11.232">
       <stop offset="0" stop-color="#589632"/>
@@ -14,7 +11,6 @@
       <stop offset="1" stop-color="#93B023"/>
     </linearGradient>
   </defs>
-  <g id="Background"/>
   <g id="Layer_1">
     <path d="M137.607,136.899 L172.044,136.899 L142.898,108.083 L107.19,108.083 L107.19,142.392 L137.607,172.708 z" fill="#EE7913" id="polygon3"/>
     <path d="M248.061,212.048 L186.618,151.306 L152.01,151.306 L152.01,187.067 L210.891,245.749 L248.061,245.749 z" fill="url(#Gradient_1)" id="polygon10"/>


### PR DESCRIPTION
## Description

Remove the white background from `./images/icons/qgis_icon.svg` making it suitable to be used as the app icon. Not sure if this breaks something else [1]. See https://github.com/qgis/QGIS/pull/7291#issuecomment-399852427 for further explanations.

Preview: https://github.com/daniviga/QGIS/blob/b232c42ef5ca117139428240ef5838e7dd5d553e/images/icons/qgis_icon.svg

[1] BTW it was already transparent in QGIS 2: https://github.com/daniviga/QGIS/blob/e3148219fe6f6561704634d34954d59efd11306f/images/icons/qgis_icon.svg

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
