### PR TITLE
Confirm delete when feature is still linked

### DIFF
--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -98,6 +98,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
 
     def tearDown(self):
         self.rollbackTransaction()
+        del self.transaction
 
     def test_delete_feature(self):
         """

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -34,7 +34,13 @@ from qgis.gui import (
 )
 
 from qgis.PyQt.QtCore import QTimer
-from qgis.PyQt.QtWidgets import QToolButton, QTableView, QApplication
+from qgis.PyQt.QtWidgets import (
+    QToolButton,
+    QMessageBox,
+    QDialogButtonBox,
+    QTableView,
+    QApplication
+)
 from qgis.testing import start_app, unittest
 
 start_app()
@@ -108,6 +114,16 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         self.widget.featureSelectionManager().select([fid])
 
         btn = self.widget.findChild(QToolButton, 'mDeleteFeatureButton')
+
+        def clickOk():
+            # Click the "Delete features" button on the confirmation message
+            # box
+            widget = self.widget.findChild(QMessageBox)
+            buttonBox = widget.findChild(QDialogButtonBox)
+            deleteButton = next((b for b in buttonBox.buttons() if buttonBox.buttonRole(b) == QDialogButtonBox.AcceptRole))
+            deleteButton.click()
+
+        QTimer.singleShot(1, clickOk)
         btn.click()
 
         # This is the important check that the feature is deleted


### PR DESCRIPTION
when deleting a feature on an N:M relation and the feature in question is still linked to more than a single feature ask for confirmation. The user might not have been aware of that.
Fix #18755 https://issues.qgis.org/issues/18755

![screenshot from 2018-06-26 12-15-13](https://user-images.githubusercontent.com/588407/41912029-a719554c-794e-11e8-8b6e-c95d8b954a69.png)

![screenshot from 2018-06-26 12-15-27](https://user-images.githubusercontent.com/588407/41912028-a6fcc7d8-794e-11e8-9436-eea882c12705.png)

