### PR TITLE
Hide zoom to feature button for nonspatial embedded forms

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -257,6 +257,11 @@ void QgsRelationEditorWidget::setRelations( const QgsRelation &relation, const Q
     mToggleEditingButton->setEnabled( false );
   }
 
+  if ( mNmRelation.isValid() )
+    mZoomToFeatureButton->setVisible( mNmRelation.referencedLayer()->isSpatial() );
+  else
+    mZoomToFeatureButton->setVisible( mRelation.referencingLayer()->isSpatial() );
+
   setObjectName( QStringLiteral( "referenced/" ) + mRelation.name() );
 
   updateUi();


### PR DESCRIPTION
A "zoom to" button only makes sense if there is a geometry to zoom to.

Fix #19261 https://issues.qgis.org/issues/19261
