### PR TITLE
Make the Keyboard shortcuts list sortable.

### DIFF
--- a/src/ui/qgsconfigureshortcutsdialog.ui
+++ b/src/ui/qgsconfigureshortcutsdialog.ui
@@ -26,6 +26,9 @@
      <property name="rootIsDecorated">
       <bool>false</bool>
      </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <property name="columnCount">
       <number>2</number>
      </property>


### PR DESCRIPTION
## Description
Make the keyboard shortcut sortable. I am not sure if people will use it, but I use it to see what's the duplicate keyboard shortcut (since there is no search for keyboard shortcut with a special key) and just to see all the shortcut easier.

<img width="662" alt="screen shot 2018-06-27 at 14 03 58" src="https://user-images.githubusercontent.com/1421861/41958153-61ce4824-7a13-11e8-92a4-412092bb5421.png">

Funded by @kartoza

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
