### PR TITLE
[3d] Handle tilting and rotation of camera better

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(QGIS_3D_SRCS
   qgs3dutils.cpp
   qgscameracontroller.cpp
   qgsphongmaterialsettings.cpp
+  qgsraycastingutils_p.cpp
   qgstessellatedpolygongeometry.cpp
   qgstilingscheme.cpp
   qgsvectorlayer3drenderer.cpp
@@ -74,6 +75,7 @@ SET(QGIS_3D_HDRS
   qgs3dutils.h
   qgscameracontroller.h
   qgsphongmaterialsettings.h
+  qgsraycastingutils_p.h
   qgstessellatedpolygongeometry.h
   qgstilingscheme.h
   qgsvectorlayer3drenderer.h

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -83,6 +83,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
   private:
     void addLayerEntity( QgsMapLayer *layer );
     void removeLayerEntity( QgsMapLayer *layer );
+    void addCameraViewCenterEntity( Qt3DRender::QCamera *camera );
 
   private:
     const Qgs3DMapSettings &mMap;
@@ -93,6 +94,8 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Forward renderer provided by 3D window
     Qt3DExtras::QForwardRenderer *mForwardRenderer = nullptr;
     QList<QgsChunkedEntity *> mChunkEntities;
+    //! Entity that shows view center - useful for debugging camera issues
+    Qt3DCore::QEntity *mEntityCameraViewCenter = nullptr;
     //! Keeps track of entities that belong to a particular layer
     QMap<QgsMapLayer *, Qt3DCore::QEntity *> mLayerEntities;
     bool mTerrainUpdateScheduled = false;

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -38,6 +38,7 @@ Qgs3DMapSettings::Qgs3DMapSettings( const Qgs3DMapSettings &other )
   , mMaxTerrainGroundError( other.mMaxTerrainGroundError )
   , mShowTerrainBoundingBoxes( other.mShowTerrainBoundingBoxes )
   , mShowTerrainTileInfo( other.mShowTerrainTileInfo )
+  , mShowCameraViewCenter( other.mShowCameraViewCenter )
   , mLayers( other.mLayers )
   , mSkyboxEnabled( other.mSkyboxEnabled )
   , mSkyboxFileBase( other.mSkyboxFileBase )
@@ -133,6 +134,7 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
   QDomElement elemDebug = elem.firstChildElement( "debug" );
   mShowTerrainBoundingBoxes = elemDebug.attribute( "bounding-boxes", "0" ).toInt();
   mShowTerrainTileInfo = elemDebug.attribute( "terrain-tile-info", "0" ).toInt();
+  mShowCameraViewCenter = elemDebug.attribute( "camera-view-center", "0" ).toInt();
 }
 
 QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteContext &context ) const
@@ -189,6 +191,7 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   QDomElement elemDebug = doc.createElement( "debug" );
   elemDebug.setAttribute( "bounding-boxes", mShowTerrainBoundingBoxes ? 1 : 0 );
   elemDebug.setAttribute( "terrain-tile-info", mShowTerrainTileInfo ? 1 : 0 );
+  elemDebug.setAttribute( "camera-view-center", mShowCameraViewCenter ? 1 : 0 );
   elem.appendChild( elemDebug );
 
   return elem;
@@ -375,6 +378,15 @@ void Qgs3DMapSettings::setShowTerrainTilesInfo( bool enabled )
 
   mShowTerrainTileInfo = enabled;
   emit showTerrainTilesInfoChanged();
+}
+
+void Qgs3DMapSettings::setShowCameraViewCenter( bool enabled )
+{
+  if ( mShowCameraViewCenter == enabled )
+    return;
+
+  mShowCameraViewCenter = enabled;
+  emit showCameraViewCenterChanged();
 }
 
 void Qgs3DMapSettings::setShowLabels( bool enabled )

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -227,6 +227,18 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
     void setShowTerrainTilesInfo( bool enabled );
     //! Returns whether to display extra tile info on top of terrain tiles (for debugging)
     bool showTerrainTilesInfo() const { return mShowTerrainTileInfo; }
+
+    /**
+     * Sets whether to show camera's view center as a sphere (for debugging)
+     * \since QGIS 3.4
+     */
+    void setShowCameraViewCenter( bool enabled );
+
+    /**
+     * Returns whether to show camera's view center as a sphere (for debugging)
+     * \since QGIS 3.4
+     */
+    bool showCameraViewCenter() const { return mShowCameraViewCenter; }
     //! Sets whether to display labels on terrain tiles
     void setShowLabels( bool enabled );
     //! Returns whether to display labels on terrain tiles
@@ -253,6 +265,12 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
     void showTerrainBoundingBoxesChanged();
     //! Emitted when the flag whether terrain's tile info is shown has changed
     void showTerrainTilesInfoChanged();
+
+    /**
+     * Emitted when the flag whether camera's view center is shown has changed
+     * \since QGIS 3.4
+     */
+    void showCameraViewCenterChanged();
     //! Emitted when the flag whether labels are displayed on terrain tiles has changed
     void showLabelsChanged();
 
@@ -269,6 +287,7 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject
     float mMaxTerrainGroundError = 1.f;  //!< Maximum allowed horizontal map error in map units (determines how many zoom levels will be used)
     bool mShowTerrainBoundingBoxes = false;  //!< Whether to show bounding boxes of entities - useful for debugging
     bool mShowTerrainTileInfo = false;  //!< Whether to draw extra information about terrain tiles to the textures - useful for debugging
+    bool mShowCameraViewCenter = false;  //!< Whether to show camera view center as a sphere - useful for debugging
     bool mShowLabels = false; //!< Whether to display labels on terrain tiles
     QList<QgsMapLayerRef> mLayers;   //!< Layers to be rendered
     QList<QgsAbstract3DRenderer *> mRenderers;  //!< Extra stuff to render as 3D object

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -67,7 +67,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     //! Returns the point in the world coordinates towards which the camera is looking
     QgsVector3D lookingAtPoint() const;
     //! Sets the point toward which the camera is looking - this is used when world origin changes (e.g. after terrain generator changes)
-    void setLookingAtPoint( const QgsVector3D &point );
+    void setLookingAtPoint( const QgsVector3D &point, float distance = -1 );
 
     //! Writes camera configuration to the given DOM element
     QDomElement writeXml( QDomDocument &doc ) const;
@@ -75,7 +75,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     void readXml( const QDomElement &elem );
 
   private:
-    void setCameraData( float x, float y, float dist, float pitch = 0, float yaw = 0 );
+    void setCameraData( float x, float y, float elev, float dist, float pitch = 0, float yaw = 0 );
 
   signals:
     //! Emitted when camera has been updated
@@ -97,14 +97,14 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
     struct CameraData
     {
-      float x = 0, y = 0;  // ground point towards which the camera is looking
+      float x = 0, y = 0, elev = 0;  // ground point towards which the camera is looking
       float dist = 40;  // distance of camera from the point it is looking at
       float pitch = 0; // aircraft nose up/down (0 = looking straight down to the plane). angle in degrees
       float yaw = 0;   // aircraft nose left/right. angle in degrees
 
       bool operator==( const CameraData &other ) const
       {
-        return x == other.x && y == other.y && dist == other.dist && pitch == other.pitch && yaw == other.yaw;
+        return x == other.x && y == other.y && elev == other.elev && dist == other.dist && pitch == other.pitch && yaw == other.yaw;
       }
       bool operator!=( const CameraData &other ) const
       {
@@ -119,8 +119,8 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
         // - y grows towards camera
         // so a point on the plane (x',y') is transformed to (x,-z) in our 3D world
         camera->setUpVector( QVector3D( 0, 0, -1 ) );
-        camera->setPosition( QVector3D( x, dist, y ) );
-        camera->setViewCenter( QVector3D( x, 0, y ) );
+        camera->setPosition( QVector3D( x, dist + elev, y ) );
+        camera->setViewCenter( QVector3D( x, elev, y ) );
         camera->rotateAboutViewCenter( QQuaternion::fromEulerAngles( pitch, yaw, 0 ) );
       }
 

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -25,6 +25,7 @@
 class QDomDocument;
 class QDomElement;
 
+class QgsTerrainEntity;
 class QgsVector3D;
 
 /**
@@ -48,9 +49,11 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
     /**
      * Connects to object picker attached to terrain entity. Called internally from 3D scene.
-     * This allows camera controller understand how far from the camera is the terrain under mouse cursor
+     * This allows camera controller understand how far from the camera is the terrain under mouse cursor.
+     * Also it allows adjustment of camera's view center to a point on terrain.
      */
-    void addTerrainPicker( Qt3DRender::QObjectPicker *picker );
+    void setTerrainEntity( QgsTerrainEntity *te );
+
     //! Assigns camera that should be controlled by this class. Called internally from 3D scene.
     void setCamera( Qt3DRender::QCamera *camera );
     //! Sets viewport rectangle. Called internally from 3D canvas. Allows conversion of mouse coordinates.
@@ -94,6 +97,8 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     QRect mViewport;
     //! height of terrain when mouse button was last pressed - for camera control
     float mLastPressedHeight = 0;
+
+    QPointer<QgsTerrainEntity> mTerrainEntity;
 
     struct CameraData
     {

--- a/src/3d/qgsraycastingutils_p.cpp
+++ b/src/3d/qgsraycastingutils_p.cpp
@@ -1,0 +1,340 @@
+/***************************************************************************
+  qgsraycastingutils_h.cpp
+  --------------------------------------
+  Date                 : June 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsraycastingutils_p.h"
+
+#include "qgsaabb.h"
+
+#include <Qt3DRender/QCamera>
+
+///@cond PRIVATE
+
+
+namespace QgsRayCastingUtils
+{
+
+// copied from qt3d/src/render/raycasting/qray3d_p.h + qray3d.cpp
+// by KDAB, licensed under the terms of LGPL
+
+
+  Ray3D::Ray3D()
+    : m_direction( 0.0f, 0.0f, 1.0f )
+    , m_distance( 1.0f )
+  {
+  }
+
+  Ray3D::Ray3D( const QVector3D &origin, const QVector3D &direction, float distance )
+    : m_origin( origin )
+    , m_direction( direction )
+    , m_distance( distance )
+  {}
+
+  Ray3D::~Ray3D()
+  {
+  }
+
+  QVector3D Ray3D::origin() const
+  {
+    return m_origin;
+  }
+
+  void Ray3D::setOrigin( const QVector3D &value )
+  {
+    m_origin = value;
+  }
+
+  QVector3D Ray3D::direction() const
+  {
+    return m_direction;
+  }
+
+  void Ray3D::setDirection( const QVector3D &value )
+  {
+    if ( value.isNull() )
+      return;
+
+    m_direction = value;
+  }
+
+  float Ray3D::distance() const
+  {
+    return m_distance;
+  }
+
+  void Ray3D::setDistance( float distance )
+  {
+    m_distance = distance;
+  }
+
+  QVector3D Ray3D::point( float t ) const
+  {
+    return m_origin + t * m_direction;
+  }
+
+  Ray3D &Ray3D::transform( const QMatrix4x4 &matrix )
+  {
+    m_origin = matrix * m_origin;
+    m_direction = matrix.mapVector( m_direction );
+
+    return *this;
+  }
+
+  Ray3D Ray3D::transformed( const QMatrix4x4 &matrix ) const
+  {
+    return Ray3D( matrix * m_origin, matrix.mapVector( m_direction ) );
+  }
+
+  bool Ray3D::operator==( const Ray3D &other ) const
+  {
+    return m_origin == other.origin() && m_direction == other.direction();
+  }
+
+  bool Ray3D::operator!=( const Ray3D &other ) const
+  {
+    return !( *this == other );
+  }
+
+  bool Ray3D::contains( const QVector3D &point ) const
+  {
+    QVector3D ppVec( point - m_origin );
+    if ( ppVec.isNull() ) // point coincides with origin
+      return true;
+    const float dot = QVector3D::dotProduct( ppVec, m_direction );
+    if ( qFuzzyIsNull( dot ) )
+      return false;
+    return qFuzzyCompare( dot * dot, ppVec.lengthSquared() * m_direction.lengthSquared() );
+  }
+
+  bool Ray3D::contains( const Ray3D &ray ) const
+  {
+    const float dot = QVector3D::dotProduct( m_direction, ray.direction() );
+    if ( !qFuzzyCompare( dot * dot, m_direction.lengthSquared() * ray.direction().lengthSquared() ) )
+      return false;
+    return contains( ray.origin() );
+  }
+
+  float Ray3D::projectedDistance( const QVector3D &point ) const
+  {
+    Q_ASSERT( !m_direction.isNull() );
+
+    return QVector3D::dotProduct( point - m_origin, m_direction ) /
+           m_direction.lengthSquared();
+  }
+
+  QVector3D Ray3D::project( const QVector3D &vector ) const
+  {
+    QVector3D norm = m_direction.normalized();
+    return QVector3D::dotProduct( vector, norm ) * norm;
+  }
+
+
+  float Ray3D::distance( const QVector3D &point ) const
+  {
+    float t = projectedDistance( point );
+    return ( point - ( m_origin + t * m_direction ) ).length();
+  }
+
+  QDebug operator<<( QDebug dbg, const Ray3D &ray )
+  {
+    QDebugStateSaver saver( dbg );
+    dbg.nospace() << "QRay3D(origin("
+                  << ray.origin().x() << ", " << ray.origin().y() << ", "
+                  << ray.origin().z() << ") - direction("
+                  << ray.direction().x() << ", " << ray.direction().y() << ", "
+                  << ray.direction().z() << "))";
+    return dbg;
+  }
+
+}
+
+
+////////////////////////////////////////////////////////////////////////////
+
+
+struct box
+{
+  box( const QgsAABB &b )
+  {
+    min[0] = b.xMin; min[1] = b.yMin; min[2] = b.zMin;
+    max[0] = b.xMax; max[1] = b.yMax; max[2] = b.zMax;
+  }
+  double min[3];
+  double max[3];
+};
+
+struct ray
+{
+  ray( double xO, double yO, double zO, double xD, double yD, double zD )
+  {
+    origin[0] = xO; origin[1] = yO; origin[2] = zO;
+    dir[0] = xD; dir[1] = yD; dir[2] = zD;
+    dir_inv[0] = 1 / dir[0]; dir_inv[1] = 1 / dir[1]; dir_inv[2] = 1 / dir[2];
+  }
+  ray( const QgsRayCastingUtils::Ray3D &r )
+  {
+    // ignoring length...
+    origin[0] = r.origin().x(); origin[1] = r.origin().y(); origin[2] = r.origin().z();
+    dir[0] = r.direction().x(); dir[1] = r.direction().y(); dir[2] = r.direction().z();
+    dir_inv[0] = 1 / dir[0]; dir_inv[1] = 1 / dir[1]; dir_inv[2] = 1 / dir[2];
+  }
+  double origin[3];
+  double dir[3];
+  double dir_inv[3];
+};
+
+// https://tavianator.com/fast-branchless-raybounding-box-intersections/
+// https://tavianator.com/fast-branchless-raybounding-box-intersections-part-2-nans/
+
+bool intersection( box b, ray r )
+{
+  double t1 = ( b.min[0] - r.origin[0] ) * r.dir_inv[0];
+  double t2 = ( b.max[0] - r.origin[0] ) * r.dir_inv[0];
+
+  double tmin = std::min( t1, t2 );
+  double tmax = std::max( t1, t2 );
+
+  for ( int i = 1; i < 3; ++i )
+  {
+    t1 = ( b.min[i] - r.origin[i] ) * r.dir_inv[i];
+    t2 = ( b.max[i] - r.origin[i] ) * r.dir_inv[i];
+
+    tmin = std::max( tmin, std::min( std::min( t1, t2 ), tmax ) );
+    tmax = std::min( tmax, std::max( std::max( t1, t2 ), tmin ) );
+  }
+
+  return tmax > std::max( tmin, 0.0 );
+}
+
+
+namespace QgsRayCastingUtils
+{
+
+  bool rayBoxIntersection( const Ray3D &r, const QgsAABB &aabb )
+  {
+    box b( aabb );
+
+    // intersection() does not like yMin==yMax (excludes borders)
+    if ( b.min[0] == b.max[0] ) b.max[0] += 0.1;
+    if ( b.min[1] == b.max[1] ) b.max[1] += 0.1;
+    if ( b.min[2] == b.max[2] ) b.max[2] += 0.1;
+
+    return intersection( b, ray( r ) );
+  }
+
+// copied from intersectsSegmentTriangle() from qt3d/src/render/backend/triangleboundingvolume.cpp
+// by KDAB, licensed under the terms of LGPL
+  bool rayTriangleIntersection( const Ray3D &ray,
+                                const QVector3D &a,
+                                const QVector3D &b,
+                                const QVector3D &c,
+                                QVector3D &uvw,
+                                float &t )
+  {
+    // Note: a, b, c in clockwise order
+    // RealTime Collision Detection page 192
+
+    const QVector3D ab = b - a;
+    const QVector3D ac = c - a;
+    const QVector3D qp = ( ray.origin() - ray.point( ray.distance() ) );
+
+    const QVector3D n = QVector3D::crossProduct( ab, ac );
+    const float d = QVector3D::dotProduct( qp, n );
+
+    if ( d <= 0.0f )
+      return false;
+
+    const QVector3D ap = ray.origin() - a;
+    t = QVector3D::dotProduct( ap, n );
+
+    if ( t < 0.0f || t > d )
+      return false;
+
+    const QVector3D e = QVector3D::crossProduct( qp, ap );
+    uvw.setY( QVector3D::dotProduct( ac, e ) );
+
+    if ( uvw.y() < 0.0f || uvw.y() > d )
+      return false;
+
+    uvw.setZ( -QVector3D::dotProduct( ab, e ) );
+
+    if ( uvw.z() < 0.0f || uvw.y() + uvw.z() > d )
+      return false;
+
+    const float ood = 1.0f / d;
+    t *= ood;
+    uvw.setY( uvw.y() * ood );
+    uvw.setZ( uvw.z() * ood );
+    uvw.setX( 1.0f - uvw.y() - uvw.z() );
+
+    return true;
+  }
+
+}
+
+
+////////////////////////////////////////////////////////////////////////////
+
+
+
+static QRect windowViewport( const QSize &area, const QRectF &relativeViewport )
+{
+  if ( area.isValid() )
+  {
+    const int areaWidth = area.width();
+    const int areaHeight = area.height();
+    return QRect( relativeViewport.x() * areaWidth,
+                  ( 1.0 - relativeViewport.y() - relativeViewport.height() ) * areaHeight,
+                  relativeViewport.width() * areaWidth,
+                  relativeViewport.height() * areaHeight );
+  }
+  return relativeViewport.toRect();
+}
+
+static QgsRayCastingUtils::Ray3D intersectionRay( const QPoint &pos, const QMatrix4x4 &viewMatrix,
+    const QMatrix4x4 &projectionMatrix, const QRect &viewport )
+{
+  QVector3D nearPos = QVector3D( pos.x(), pos.y(), 0.0f );
+  nearPos = nearPos.unproject( viewMatrix, projectionMatrix, viewport );
+  QVector3D farPos = QVector3D( pos.x(), pos.y(), 1.0f );
+  farPos = farPos.unproject( viewMatrix, projectionMatrix, viewport );
+
+  return QgsRayCastingUtils::Ray3D( nearPos,
+                                    ( farPos - nearPos ).normalized(),
+                                    ( farPos - nearPos ).length() );
+}
+
+
+namespace QgsRayCastingUtils
+{
+
+  Ray3D rayForViewportAndCamera( const QSize &area,
+                                 const QPoint &pos,
+                                 const QRectF &relativeViewport,
+                                 const Qt3DRender::QCamera *camera )
+  {
+    QMatrix4x4 viewMatrix = camera->viewMatrix();
+    QMatrix4x4 projectionMatrix = camera->projectionMatrix();
+    //viewMatrixForCamera(cameraId, viewMatrix, projectionMatrix);
+    const QRect viewport = windowViewport( area, relativeViewport );
+
+    // In GL the y is inverted compared to Qt
+    const QPoint glCorrectPos = QPoint( pos.x(), area.isValid() ? area.height() - pos.y() : pos.y() );
+    const auto ray = intersectionRay( glCorrectPos, viewMatrix, projectionMatrix, viewport );
+    return ray;
+  }
+
+}
+
+/// @endcond

--- a/src/3d/qgsraycastingutils_p.cpp
+++ b/src/3d/qgsraycastingutils_p.cpp
@@ -302,7 +302,7 @@ static QRect windowViewport( const QSize &area, const QRectF &relativeViewport )
   return relativeViewport.toRect();
 }
 
-static QgsRayCastingUtils::Ray3D intersectionRay( const QPoint &pos, const QMatrix4x4 &viewMatrix,
+static QgsRayCastingUtils::Ray3D intersectionRay( const QPointF &pos, const QMatrix4x4 &viewMatrix,
     const QMatrix4x4 &projectionMatrix, const QRect &viewport )
 {
   QVector3D nearPos = QVector3D( pos.x(), pos.y(), 0.0f );
@@ -320,7 +320,7 @@ namespace QgsRayCastingUtils
 {
 
   Ray3D rayForViewportAndCamera( const QSize &area,
-                                 const QPoint &pos,
+                                 const QPointF &pos,
                                  const QRectF &relativeViewport,
                                  const Qt3DRender::QCamera *camera )
   {
@@ -330,7 +330,7 @@ namespace QgsRayCastingUtils
     const QRect viewport = windowViewport( area, relativeViewport );
 
     // In GL the y is inverted compared to Qt
-    const QPoint glCorrectPos = QPoint( pos.x(), area.isValid() ? area.height() - pos.y() : pos.y() );
+    const QPointF glCorrectPos = QPointF( pos.x(), area.isValid() ? area.height() - pos.y() : pos.y() );
     const auto ray = intersectionRay( glCorrectPos, viewMatrix, projectionMatrix, viewport );
     return ray;
   }

--- a/src/3d/qgsraycastingutils_p.h
+++ b/src/3d/qgsraycastingutils_p.h
@@ -109,7 +109,7 @@ namespace QgsRayCastingUtils
    * \since QGIS 3.4
    */
   Ray3D rayForViewportAndCamera( const QSize &area,
-                                 const QPoint &pos,
+                                 const QPointF &pos,
                                  const QRectF &relativeViewport,
                                  const Qt3DRender::QCamera *camera );
 }

--- a/src/3d/qgsraycastingutils_p.h
+++ b/src/3d/qgsraycastingutils_p.h
@@ -1,0 +1,119 @@
+/***************************************************************************
+  qgsraycastingutils_p.h
+  --------------------------------------
+  Date                 : June 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRAYCASTINGUTILS_P_H
+#define QGSRAYCASTINGUTILS_P_H
+
+///@cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
+#include <QVector3D>
+
+class QgsAABB;
+
+namespace Qt3DRender
+{
+  class QCamera;
+}
+
+
+namespace QgsRayCastingUtils
+{
+
+  /**
+   * Utility class to handle 3D rays. A ray has an origin, a direction and distance.
+   * \note With switch to Qt 5.11 we may remove it and use QRayCaster/QScreenRayCaster instead.
+   * \since QGIS 3.4
+   */
+  class Ray3D
+  {
+    public:
+      Ray3D();
+      explicit Ray3D( const QVector3D &origin, const QVector3D &direction = QVector3D( 0.0f, 0.0f, 1.0f ), float distance = 1.0f );
+      ~Ray3D();
+
+      QVector3D origin() const;
+      void setOrigin( const QVector3D &value );
+
+      QVector3D direction() const;
+      void setDirection( const QVector3D &value );
+
+      float distance() const;
+      void setDistance( float distance );
+
+      bool contains( const QVector3D &point ) const;
+      bool contains( const Ray3D &ray ) const;
+
+      QVector3D point( float t ) const;
+      float projectedDistance( const QVector3D &point ) const;
+
+      QVector3D project( const QVector3D &vector ) const;
+
+      float distance( const QVector3D &point ) const;
+
+      Ray3D &transform( const QMatrix4x4 &matrix );
+      Ray3D transformed( const QMatrix4x4 &matrix ) const;
+
+      bool operator==( const Ray3D &other ) const;
+      bool operator!=( const Ray3D &other ) const;
+
+    private:
+      QVector3D m_origin;
+      QVector3D m_direction;
+      float m_distance;
+  };
+
+  /**
+   * Tests whether axis-aligned bounding box is intersected by a ray.
+   * \note ray's distance is ignored (considered infinite)
+   * \note With switch to Qt 5.11 we may remove it and use QRayCaster/QScreenRayCaster instead.
+   * \since QGIS 3.4
+   */
+  bool rayBoxIntersection( const Ray3D &r, const QgsAABB &aabb );
+
+  /**
+   * Tests whether a triangle is intersected by a ray.
+   * \note With switch to Qt 5.11 we may remove it and use QRayCaster/QScreenRayCaster instead.
+   * \since QGIS 3.4
+   */
+  bool rayTriangleIntersection( const Ray3D &ray,
+                                const QVector3D &a,
+                                const QVector3D &b,
+                                const QVector3D &c,
+                                QVector3D &uvw,
+                                float &t );
+
+  /**
+   * Returns a ray coming out of camera
+   * \note With switch to Qt 5.11 we may remove it and use QRayCaster/QScreenRayCaster instead.
+   * \since QGIS 3.4
+   */
+  Ray3D rayForViewportAndCamera( const QSize &area,
+                                 const QPoint &pos,
+                                 const QRectF &relativeViewport,
+                                 const Qt3DRender::QCamera *camera );
+}
+
+/// @endcond
+
+#endif // QGSRAYCASTINGUTILS_P_H

--- a/src/3d/terrain/qgsdemterraintilegeometry_p.h
+++ b/src/3d/terrain/qgsdemterraintilegeometry_p.h
@@ -41,6 +41,10 @@ namespace Qt3DRender
 
 } // Qt3DRender
 
+namespace QgsRayCastingUtils
+{
+  class Ray3D;
+}
 
 /**
  * \ingroup 3d
@@ -56,6 +60,8 @@ class DemTerrainTileGeometry : public Qt3DRender::QGeometry
      * heightMap is array of float values with one height value for each vertex
      */
     explicit DemTerrainTileGeometry( int resolution, float skirtHeight, const QByteArray &heightMap, QNode *parent = nullptr );
+
+    bool rayIntersection( const QgsRayCastingUtils::Ray3D &ray, const QMatrix4x4 &worldTransform, QVector3D &intersectionPoint );
 
   private:
     void init();

--- a/src/3d/terrain/qgsterrainentity_p.cpp
+++ b/src/3d/terrain/qgsterrainentity_p.cpp
@@ -18,6 +18,8 @@
 #include "qgsaabb.h"
 #include "qgs3dmapsettings.h"
 #include "qgschunknode_p.h"
+#include "qgsdemterraintilegeometry_p.h"
+#include "qgsraycastingutils_p.h"
 #include "qgsterraingenerator.h"
 #include "qgsterraintexturegenerator_p.h"
 #include "qgsterraintextureimage_p.h"
@@ -25,6 +27,8 @@
 
 #include "qgscoordinatetransform.h"
 
+#include <Qt3DCore/QTransform>
+#include <Qt3DRender/QGeometryRenderer>
 #include <Qt3DRender/QObjectPicker>
 
 
@@ -88,6 +92,31 @@ QgsTerrainEntity::~QgsTerrainEntity()
 
   delete mTextureGenerator;
   delete mTerrainToMapTransform;
+}
+
+bool QgsTerrainEntity::rayIntersection( const QgsRayCastingUtils::Ray3D &ray, QVector3D &intersectionPoint )
+{
+  if ( !rootNode() )
+    return false;
+
+  if ( mMap.terrainGenerator()->type() != QgsTerrainGenerator::Dem )
+    return false;  // currently only working with DEM terrain
+
+  QList<QgsChunkNode *> lst = activeNodes();
+  for ( QgsChunkNode *n : lst )
+  {
+    if ( n->entity() && QgsRayCastingUtils::rayBoxIntersection( ray, n->bbox() ) )
+    {
+      Qt3DRender::QGeometryRenderer *rend = n->entity()->findChild<Qt3DRender::QGeometryRenderer *>();
+      Qt3DRender::QGeometry *geom = rend->geometry();
+      DemTerrainTileGeometry *demGeom = static_cast<DemTerrainTileGeometry *>( geom );
+      Qt3DCore::QTransform *tr = n->entity()->findChild<Qt3DCore::QTransform *>();
+      if ( demGeom->rayIntersection( ray, tr->matrix(), intersectionPoint ) )
+        return true;
+    }
+  }
+
+  return false;
 }
 
 void QgsTerrainEntity::onShowBoundingBoxesChanged()

--- a/src/3d/terrain/qgsterrainentity_p.h
+++ b/src/3d/terrain/qgsterrainentity_p.h
@@ -37,6 +37,11 @@ namespace Qt3DRender
   class QObjectPicker;
 }
 
+namespace QgsRayCastingUtils
+{
+  class Ray3D;
+}
+
 class Qgs3DMapSettings;
 class QgsTerrainTextureGenerator;
 class QgsCoordinateTransform;
@@ -68,6 +73,9 @@ class QgsTerrainEntity : public QgsChunkedEntity
 
     //! Returns object picker attached to the terrain entity - used by camera controller
     Qt3DRender::QObjectPicker *terrainPicker() const { return mTerrainPicker; }
+
+    //! Tests whether the ray intersects the terrain - if it does, it sets the intersection point (in world coordinates)
+    bool rayIntersection( const QgsRayCastingUtils::Ray3D &ray, QVector3D &intersectionPoint );
 
   private slots:
     void onShowBoundingBoxesChanged();

--- a/src/app/3d/qgs3dmapconfigwidget.cpp
+++ b/src/app/3d/qgs3dmapconfigwidget.cpp
@@ -60,6 +60,7 @@ Qgs3DMapConfigWidget::Qgs3DMapConfigWidget( Qgs3DMapSettings *map, QgsMapCanvas 
   chkShowLabels->setChecked( mMap->showLabels() );
   chkShowTileInfo->setChecked( mMap->showTerrainTilesInfo() );
   chkShowBoundingBoxes->setChecked( mMap->showTerrainBoundingBoxes() );
+  chkShowCameraViewCenter->setChecked( mMap->showCameraViewCenter() );
 
   connect( cboTerrainLayer, static_cast<void ( QComboBox::* )( int )>( &QgsMapLayerComboBox::currentIndexChanged ), this, &Qgs3DMapConfigWidget::onTerrainLayerChanged );
   connect( spinMapResolution, static_cast<void ( QSpinBox::* )( int )>( &QSpinBox::valueChanged ), this, &Qgs3DMapConfigWidget::updateMaxZoomLevel );
@@ -125,6 +126,7 @@ void Qgs3DMapConfigWidget::apply()
   mMap->setShowLabels( chkShowLabels->isChecked() );
   mMap->setShowTerrainTilesInfo( chkShowTileInfo->isChecked() );
   mMap->setShowTerrainBoundingBoxes( chkShowBoundingBoxes->isChecked() );
+  mMap->setShowCameraViewCenter( chkShowCameraViewCenter->isChecked() );
 }
 
 void Qgs3DMapConfigWidget::onTerrainLayerChanged()

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>691</width>
-    <height>775</height>
+    <height>830</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -183,6 +183,13 @@
     <widget class="QCheckBox" name="chkShowBoundingBoxes">
      <property name="text">
       <string>Show bounding boxes</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="chkShowCameraViewCenter">
+     <property name="text">
+      <string>Show camera's view center</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This will update camera's view center as the camera moves around.
Before the view center would be always at the zero elevation, which
means that with terrain further away from zero elevation tilting
and rotation of camera would feel weird due to the center point being
far away.

In order to update camera's view center we need to calculate intersection
of terrain with a 3D ray coming from the camera's position towards the center
of the viewport. This is done by going through the active terrain tiles
and checking whether their bounding box intersects the ray - if it does,
then we do an exact test of terrain tile's triangle mesh against the ray
to find the closest intersection point. When we have the intersection,
we update the view center to be at the terrain's surface.

Unfortunately raycasting in Qt3D is only available from 5.11 which has been
released only very recently. I have therefore ported some code from Qt3D
internals and added ray vs axis-aligned box from a different source
(Qt3D uses bounding spheres but they are not available in public API either)
