### PR TITLE
Add missing QGIS 3.x Python 3 bindings for Qt5's WebKit module on Debian -- fixes #19275

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -26,7 +26,7 @@ Build-Depends:
  libqwt-qt5-dev, libqca-qt5-2-dev, libqca-qt5-2-plugins,
  python3-dev, python3-all-dev, python3-sip, python3-sip-dev,
  pyqt5-dev-tools, pyqt5-dev, pyqt5.qsci-dev,
- python3-pyqt5, python3-pyqt5.qsci, python3-pyqt5.qtsql, python3-pyqt5.qtsvg,
+ python3-pyqt5, python3-pyqt5.qsci, python3-pyqt5.qtsql, python3-pyqt5.qtsvg, python3-pyqt5.qtwebkit,
  python3-gdal,
  python3-nose2, python3-yaml, python3-mock, python3-psycopg2, python3-future, python3-termcolor,
  pkg-config,


### PR DESCRIPTION
`WebKit` is missing from the list of dependencies in QGIS 3.x on Debian. This fixes issue [#19275](https://issues.qgis.org/issues/19275).