### PR TITLE
[python] Block imports of PyQt4 modules

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -667,8 +667,8 @@ def _import(name, globals={}, locals={}, fromlist=[], level=None):
         level = 0
 
     if 'PyQt4' in name:
-        msg = 'Importing PyQt4 classes would cause a crash, ' \
-              'please use PyQt5 in "{}"'.format(name)
+        msg = 'PyQt4 classes cannot be imported in QGIS 3.x.\n' \
+              'Use {} or the version independent {} import instead.'.format(name.replace('PyQt4', 'PyQt5'), name.replace('PyQt4', 'qgis.PyQt'))
         raise ImportError(msg)
 
     mod = _builtin_import(name, globals, locals, fromlist, level)

--- a/python/utils.py
+++ b/python/utils.py
@@ -667,7 +667,9 @@ def _import(name, globals={}, locals={}, fromlist=[], level=None):
         level = 0
 
     if 'PyQt4' in name:
-        raise ImportError('Cannot import PyQt4 classes - this would cause a crash!')
+        msg = 'Importing PyQt4 classes would cause a crash, ' \
+              'please use PyQt5 in "{}"'.format(name)
+        raise ImportError(msg)
 
     mod = _builtin_import(name, globals, locals, fromlist, level)
 

--- a/python/utils.py
+++ b/python/utils.py
@@ -659,9 +659,16 @@ _plugin_modules = {}
 
 
 def _import(name, globals={}, locals={}, fromlist=[], level=None):
-    """ wrapper around builtin import that keeps track of loaded plugin modules """
+    """
+    Wrapper around builtin import that keeps track of loaded plugin modules and blocks
+    certain unsafe imports
+    """
     if level is None:
         level = 0
+
+    if 'PyQt4' in name:
+        raise ImportError('Cannot import PyQt4 classes - this would cause a crash!')
+
     mod = _builtin_import(name, globals, locals, fromlist, level)
 
     if mod and '__file__' in mod.__dict__:


### PR DESCRIPTION
Prevents crashes when PyQt4 modules are imported in QGIS 3.x. This instantly segfaults QGIS. Throwing an exception makes it easier to identify the cause as a faulty plugin, and shows exactly where the bad import is located.

