### PR TITLE
Fix parameter type for the BUFFER parameter of the Voronoi polygons algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -73,7 +73,7 @@ class VoronoiPolygons(QgisAlgorithm):
 
     def initAlgorithm(self, config=None):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'), [QgsProcessing.TypeVectorPoint]))
-        self.addParameter(QgsProcessingParameterDistance(self.BUFFER, self.tr('Buffer region'), parentParameterName=self.INPUT,
+        self.addParameter(QgsProcessingParameterNumber(self.BUFFER, self.tr('Buffer region'), parentParameterName=self.INPUT,
                                                          minValue=0.0, maxValue=9999999999, defaultValue=0.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Voronoi polygons'), type=QgsProcessing.TypeVectorPolygon))


### PR DESCRIPTION
## Description
Simple fix of the type of a parameter for an algorithm in Processing

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [-] Commits which fix bugs include `fixes #11111` in the commit message next to the description

  Not included, because when filing the bug, I thought I had to provide the link to the pull request.
  The bug/issue is: #19294

- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [-] New unit tests have been added for core changes
- [-] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
