### PR TITLE
Remove last traces of qextserial from rpm and fix build

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -96,7 +96,7 @@ BuildRequires: qt5-qttools-static
 BuildRequires: qt5-qtwebkit-devel
 BuildRequires: qt5-qtxmlpatterns-devel
 BuildRequires: qtkeychain-qt5-devel
-BuildRequires: qextserialport-devel
+BuildRequires: qt5-qtserialport-devel
 BuildRequires: qt5-qt3d-devel
 
 # Qwt stuff


### PR DESCRIPTION
## Description

Following https://github.com/qgis/QGIS/commit/212cffcab1c93f899b1acd81bda71f7d0fcd8ef8 I'm fully removing qextserial from rpm spec file and I'm adding an explicit dependency on `qt5-qtserialport-devel` otherwise the RPM build fails:

```
CMake Error at CMakeLists.txt:303 (FIND_PACKAGE):
  By not providing "FindQt5SerialPort.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "Qt5SerialPort", but CMake did not find one.

  Could not find a package configuration file provided by "Qt5SerialPort"
  with any of the following names:

    Qt5SerialPortConfig.cmake
    qt5serialport-config.cmake

  Add the installation prefix of "Qt5SerialPort" to CMAKE_PREFIX_PATH or set
  "Qt5SerialPort_DIR" to a directory containing one of the above files.  If
  "Qt5SerialPort" provides a separate development package or SDK, be sure it
  has been installed.
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
