### PR TITLE
[3d] More camera controls

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -49,6 +49,9 @@ QgsCameraController::QgsCameraController( Qt3DCore::QNode *parent )
   , mKeyboardTyPosInput( new Qt3DInput::QButtonAxisInput() )
   , mKeyboardTxNegInput( new Qt3DInput::QButtonAxisInput() )
   , mKeyboardTyNegInput( new Qt3DInput::QButtonAxisInput() )
+  , mTelevAxis( new Qt3DInput::QAxis() )
+  , mKeyboardTelevPosInput( new Qt3DInput::QButtonAxisInput() )
+  , mKeyboardTelevNegInput( new Qt3DInput::QButtonAxisInput() )
 {
 
   // not using QAxis + QAnalogAxisInput for mouse X,Y because
@@ -115,6 +118,18 @@ QgsCameraController::QgsCameraController( Qt3DCore::QNode *parent )
   mKeyboardTyNegInput->setSourceDevice( mKeyboardDevice );
   mTyAxis->addInput( mKeyboardTyNegInput );
 
+  // Keyboard Neg Telev
+  mKeyboardTelevNegInput->setButtons( QVector<int>() << Qt::Key_PageDown );
+  mKeyboardTelevNegInput->setScale( -1.0f );
+  mKeyboardTelevNegInput->setSourceDevice( mKeyboardDevice );
+  mTelevAxis->addInput( mKeyboardTelevNegInput );
+
+  // Keyboard Pos Telev
+  mKeyboardTelevPosInput->setButtons( QVector<int>() << Qt::Key_PageUp );
+  mKeyboardTelevPosInput->setScale( 1.0f );
+  mKeyboardTelevPosInput->setSourceDevice( mKeyboardDevice );
+  mTelevAxis->addInput( mKeyboardTelevPosInput );
+
   mLogicalDevice->addAction( mLeftMouseButtonAction );
   mLogicalDevice->addAction( mMiddleMouseButtonAction );
   mLogicalDevice->addAction( mRightMouseButtonAction );
@@ -123,6 +138,7 @@ QgsCameraController::QgsCameraController( Qt3DCore::QNode *parent )
   mLogicalDevice->addAxis( mWheelAxis );
   mLogicalDevice->addAxis( mTxAxis );
   mLogicalDevice->addAxis( mTyAxis );
+  mLogicalDevice->addAxis( mTelevAxis );
 
   // Disable the logical device when the entity is disabled
   connect( this, &Qt3DCore::QEntity::enabledChanged,
@@ -244,6 +260,7 @@ void QgsCameraController::frameTriggered( float dt )
 
   float tx = mTxAxis->value() * dt * mCameraData.dist * 1.5;
   float ty = -mTyAxis->value() * dt * mCameraData.dist * 1.5;
+  float telev = mTelevAxis->value() * dt * 300;
 
   if ( !mShiftAction->isActive() && ( tx || ty ) )
   {
@@ -281,6 +298,9 @@ void QgsCameraController::frameTriggered( float dt )
     mCameraData.x -= p2.x() - p1.x();
     mCameraData.y -= p2.y() - p1.y();
   }
+
+  if ( telev != 0 )
+    mCameraData.elev += telev;
 
   if ( std::isnan( mCameraData.x ) || std::isnan( mCameraData.y ) )
   {

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -175,6 +175,10 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     Qt3DInput::QButtonAxisInput *mKeyboardTyPosInput = nullptr;
     Qt3DInput::QButtonAxisInput *mKeyboardTxNegInput = nullptr;
     Qt3DInput::QButtonAxisInput *mKeyboardTyNegInput = nullptr;
+
+    Qt3DInput::QAxis *mTelevAxis = nullptr;
+    Qt3DInput::QButtonAxisInput *mKeyboardTelevPosInput = nullptr;
+    Qt3DInput::QButtonAxisInput *mKeyboardTelevNegInput = nullptr;
 };
 
 #endif // QGSCAMERACONTROLLER_H

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -79,6 +79,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
   private:
     void setCameraData( float x, float y, float elev, float dist, float pitch = 0, float yaw = 0 );
+    void rotateCamera( float diffPitch, float diffYaw );
 
   signals:
     //! Emitted when camera has been updated


### PR DESCRIPTION
New controls for more freedom!
- use page up / page down keys to move camera up/down vertically
- use ctrl + arrow keys to rotate camera, keeping the camera in one position (as opposed to shift + arrow keys when camera rotates around a point it is looking at)
- use ctrl + mouse (with left button pressed) to rotate camera like with ctrl + arrow keys