### PR TITLE
Fix build with QT 5.5

### DIFF
--- a/src/app/mesh/qgsmeshrenderermeshsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrenderermeshsettingswidget.cpp
@@ -34,7 +34,7 @@ QgsMeshRendererMeshSettingsWidget::QgsMeshRendererMeshSettingsWidget( QWidget *p
   setupUi( this );
 
   connect( mColorWidget, &QgsColorButton::colorChanged, this, &QgsMeshRendererMeshSettingsWidget::widgetChanged );
-  connect( mLineWidthSpinBox, QOverload<double>::of( &QgsDoubleSpinBox::valueChanged ),
+  connect( mLineWidthSpinBox, qgis::overload<double>::of( &QgsDoubleSpinBox::valueChanged ),
            this, &QgsMeshRendererMeshSettingsWidget::widgetChanged );
 }
 

--- a/src/app/mesh/qgsmeshrenderervectorsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrenderervectorsettingswidget.cpp
@@ -27,15 +27,14 @@ QgsMeshRendererVectorSettingsWidget::QgsMeshRendererVectorSettingsWidget( QWidge
   setupUi( this );
 
   connect( mColorWidget, &QgsColorButton::colorChanged, this, &QgsMeshRendererVectorSettingsWidget::widgetChanged );
-  connect( mLineWidthSpinBox, QOverload<double>::of( &QgsDoubleSpinBox::valueChanged ),
+  connect( mLineWidthSpinBox, qgis::overload<double>::of( &QgsDoubleSpinBox::valueChanged ),
            this, &QgsMeshRendererVectorSettingsWidget::widgetChanged );
 
-  connect( mShaftLengthComboBox, QOverload<int>::of( &QComboBox::currentIndexChanged ),
+  connect( mShaftLengthComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ),
            this, &QgsMeshRendererVectorSettingsWidget::widgetChanged );
 
-  connect( mShaftLengthComboBox, QOverload<int>::of( &QComboBox::currentIndexChanged ),
+  connect( mShaftLengthComboBox, qgis::overload<int>::of( &QComboBox::currentIndexChanged ),
            mShaftOptionsStackedWidget, &QStackedWidget::setCurrentIndex );
-
   QVector<QLineEdit *> widgets;
   widgets << mMinMagLineEdit << mMaxMagLineEdit
           << mHeadWidthLineEdit << mHeadLengthLineEdit

--- a/tests/code_layout/test_banned_keywords.sh
+++ b/tests/code_layout/test_banned_keywords.sh
@@ -104,6 +104,9 @@ HINTS[26]="Use std::unique_ptr instead"
 KEYWORDS[27]="QSharedPointer"
 HINTS[27]="Use std::shared_ptr instead"
 
+KEYWORDS[28]="QOverload"
+HINTS[28]="Use qgis::overload instead"
+
 RES=
 DIR=$(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
QOverload is new in QT 5.7

I'm not sure if the #if QT_VERSION >= approach is the best, or if we should just revert to the pre QT 5.7 way ?