### PR TITLE
[3d] Fixes camera movement when it is looking from further away

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -370,7 +370,7 @@ void QgsCameraController::frameTriggered( float dt )
       // figure out our distance from terrain and update the camera's view center
       // so that camera tilting and rotation is around a point on terrain, not an point at fixed elevation
       QVector3D intersectionPoint;
-      QgsRayCastingUtils::Ray3D ray = QgsRayCastingUtils::rayForViewportAndCamera( mViewport.size(), QPointF( mViewport.width() / 2., mViewport.height() / 2. ), QRectF( 0.0, 0.0, 1.0, 1.0 ), mCamera );
+      QgsRayCastingUtils::Ray3D ray = QgsRayCastingUtils::rayForCameraCenter( mCamera );
       if ( mTerrainEntity->rayIntersection( ray, intersectionPoint ) )
       {
         float dist = ( intersectionPoint - mCamera->position() ).length();

--- a/src/3d/qgsraycastingutils_p.h
+++ b/src/3d/qgsraycastingutils_p.h
@@ -91,6 +91,20 @@ namespace QgsRayCastingUtils
    */
   bool rayBoxIntersection( const Ray3D &r, const QgsAABB &aabb );
 
+  //! Represents a plane in 3D space
+  struct Plane3D
+  {
+    QVector3D center;  //!< A point that lies on the plane
+    QVector3D normal;  //!< Normal vector of the plane
+  };
+
+  /**
+   * Tests whether a plane is intersected by a ray.
+   * \note With switch to Qt 5.11 we may remove it and use QRayCaster/QScreenRayCaster instead.
+   * \since QGIS 3.4
+   */
+  bool rayPlaneIntersection( const Ray3D &r, const Plane3D &plane, QVector3D &pt );
+
   /**
    * Tests whether a triangle is intersected by a ray.
    * \note With switch to Qt 5.11 we may remove it and use QRayCaster/QScreenRayCaster instead.
@@ -112,6 +126,13 @@ namespace QgsRayCastingUtils
                                  const QPointF &pos,
                                  const QRectF &relativeViewport,
                                  const Qt3DRender::QCamera *camera );
+
+  /**
+   * Returns a ray coming out of center of camera
+   * \note With switch to Qt 5.11 we may remove it and use QRayCaster/QScreenRayCaster instead.
+   * \since QGIS 3.4
+   */
+  Ray3D rayForCameraCenter( const Qt3DRender::QCamera *camera );
 }
 
 /// @endcond


### PR DESCRIPTION
At around ~70km distance of camera from terrain the updates of camera
view centers didn't work correctly and the whole view got locked,
unable to pan camera around until zoomed closer. The reason is that
QVector3D::unproject() has "is fuzzy zero" tolerance too high (1e-5)
and was returning incorrect vectors.

Introduced a new function with simplified ray creation and lower tolerance.

This commit also adds a routine for ray-plane intersection which
isn't used in the end, but may be useful at some point later for
simplified ray vs terrain tile tests.

cc @saberraz 