### PR TITLE
A couple more DB Manager improvements

### DIFF
--- a/python/plugins/db_manager/db_model.py
+++ b/python/plugins/db_manager/db_model.py
@@ -156,6 +156,9 @@ class ConnectionItem(TreeItem):
             return self.getItemData().connectionName()
         return None
 
+    def icon(self):
+        return self.getItemData().connectionIcon()
+
     def populate(self):
         if self.populated:
             return True

--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -27,7 +27,7 @@ from qgis.PyQt.QtWidgets import QApplication, QAction, QMenu, QInputDialog, QMes
 from qgis.PyQt.QtGui import QKeySequence, QIcon
 
 from qgis.gui import QgsMessageBar
-from qgis.core import Qgis, QgsSettings
+from qgis.core import Qgis, QgsApplication, QgsSettings
 from ..db_plugins import createDbPlugin
 
 
@@ -90,6 +90,9 @@ class DBPlugin(QObject):
 
     def __del__(self):
         pass  # print "DBPlugin.__del__", self.connName
+
+    def connectionIcon(self):
+        return QgsApplication.getThemeIcon("/mIconDbSchema.svg")
 
     def connectionName(self):
         return self.connName

--- a/python/plugins/db_manager/db_plugins/spatialite/connector.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/connector.py
@@ -172,8 +172,8 @@ class SpatiaLiteDBConnector(DBConnector):
         items = []
 
         sys_tables = ["SpatialIndex", "geom_cols_ref_sys", "geometry_columns", "geometry_columns_auth",
-                      "views_geometry_columns", "virts_geometry_columns", "spatial_ref_sys",
-                      "sqlite_sequence",  # "tableprefix_metadata", "tableprefix_rasters",
+                      "views_geometry_columns", "virts_geometry_columns", "spatial_ref_sys", "spatial_ref_sys_all", "spatial_ref_sys_aux",
+                      "sqlite_sequence", "tableprefix_metadata", "tableprefix_rasters",
                       "layer_params", "layer_statistics", "layer_sub_classes", "layer_table_layout",
                       "pattern_bitmaps", "symbol_bitmaps", "project_defs", "raster_pyramids",
                       "sqlite_stat1", "sqlite_stat2", "spatialite_history",
@@ -181,7 +181,8 @@ class SpatiaLiteDBConnector(DBConnector):
                       "geometry_columns_statistics", "geometry_columns_time",
                       "sql_statements_log", "vector_layers", "vector_layers_auth", "vector_layers_field_infos", "vector_layers_statistics",
                       "views_geometry_columns_auth", "views_geometry_columns_field_infos", "views_geometry_columns_statistics",
-                      "virts_geometry_columns_auth", "virts_geometry_columns_field_infos", "virts_geometry_columns_statistics"
+                      "virts_geometry_columns_auth", "virts_geometry_columns_field_infos", "virts_geometry_columns_statistics",
+                      "ElementaryGeometries"
                       ]
 
         try:

--- a/python/plugins/db_manager/db_plugins/spatialite/connector.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/connector.py
@@ -182,7 +182,7 @@ class SpatiaLiteDBConnector(DBConnector):
                       "sql_statements_log", "vector_layers", "vector_layers_auth", "vector_layers_field_infos", "vector_layers_statistics",
                       "views_geometry_columns_auth", "views_geometry_columns_field_infos", "views_geometry_columns_statistics",
                       "virts_geometry_columns_auth", "virts_geometry_columns_field_infos", "virts_geometry_columns_statistics",
-                      "ElementaryGeometries"
+                      "virts_layer_statistics", "views_layer_statistics", "ElementaryGeometries"
                       ]
 
         try:

--- a/python/plugins/db_manager/db_plugins/vlayers/plugin.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/plugin.py
@@ -60,7 +60,7 @@ class VLayerDBPlugin(DBPlugin):
 
     @classmethod
     def connections(self):
-        return [VLayerDBPlugin(QCoreApplication.translate('db_manager', 'QGIS layers'))]
+        return [VLayerDBPlugin(QCoreApplication.translate('db_manager', 'Project layers'))]
 
     def databasesFactory(self, connection, uri):
         return FakeDatabase(connection, uri)

--- a/python/plugins/db_manager/db_plugins/vlayers/plugin.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/plugin.py
@@ -39,6 +39,9 @@ class VLayerDBPlugin(DBPlugin):
     def icon(self):
         return QgsApplication.getThemeIcon("/mIconVirtualLayer.svg")
 
+    def connectionIcon(self):
+        return QgsApplication.getThemeIcon("/providerQgis.svg")
+
     @classmethod
     def typeName(self):
         return 'vlayers'

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -253,6 +253,7 @@ bool QgsSpatiaLiteConnection::getTableInfoAbstractInterface( sqlite3 *handle, bo
                    << QStringLiteral( "views_geometry_columns_auth" ) << QStringLiteral( "views_geometry_columns_field_infos" )
                    << QStringLiteral( "views_geometry_columns_statistics" ) << QStringLiteral( "virts_geometry_columns_auth" )
                    << QStringLiteral( "virts_geometry_columns_field_infos" ) << QStringLiteral( "virts_geometry_columns_statistics" )
+                   << QStringLiteral( "virts_layer_statistics" ) << QStringLiteral( "views_layer_statistics" )
                    << QStringLiteral( "ElementaryGeometries" );
   // attempting to load the VectorLayersList
   list = gaiaGetVectorLayersList( handle, nullptr, nullptr, GAIA_VECTORS_LIST_FAST );


### PR DESCRIPTION
## Description
PR improves DB Manager by:
- Adding an icon for providers' connections (to harmonize behavior with our browser panels)
- Rename "QGIS layers" to "Project layers", it is IMHO a better label here
- For the spatialite provider, hide a few more tables (again, to harmonize behavior with our browser panels)

Before vs. PR:
![screenshot from 2018-06-30 12-21-40](https://user-images.githubusercontent.com/1728657/42121914-c6b22db8-7c62-11e8-8d50-ddadd65f6b0f.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
