### PR TITLE
[3d] Increase the range of camera tilt from [0-80] degrees to [0-180]

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -241,8 +241,8 @@ QPointF screen_point_to_point_on_plane( const QPointF &pt, const QRect &viewport
 
 void QgsCameraController::rotateCamera( float diffPitch, float diffYaw )
 {
-  if ( mCameraData.pitch + diffPitch > 80 )
-    diffPitch = 80 - mCameraData.pitch;  // prevent going under the plane
+  if ( mCameraData.pitch + diffPitch > 180 )
+    diffPitch = 180 - mCameraData.pitch;  // prevent going over the head
   if ( mCameraData.pitch + diffPitch < 0 )
     diffPitch = 0 - mCameraData.pitch;   // prevent going over the head
 
@@ -353,8 +353,8 @@ void QgsCameraController::frameTriggered( float dt )
     mCameraData.x = mCameraData.y = 0;
   }
 
-  if ( mCameraData.pitch > 80 )
-    mCameraData.pitch = 80;  // prevent going under the plane
+  if ( mCameraData.pitch > 180 )
+    mCameraData.pitch = 180;  // prevent going over the head
   if ( mCameraData.pitch < 0 )
     mCameraData.pitch = 0;   // prevent going over the head
   if ( mCameraData.dist < 10 )


### PR DESCRIPTION
Previously the changing camera's pitch (tilting the view) would stop
when the camera view is nearly parallel with the horizon. Now it will
be also possible to look up.

Let's see how this will work - we can always switch back in case of problems.
