### PR TITLE
Add handlesnull parameter to @qgsfunction

### DIFF
--- a/doc/index.dox
+++ b/doc/index.dox
@@ -23,8 +23,8 @@ You can also <a href="https://qgis.org/downloads/qgis-api-doc.zip">download</a>
 this documentation or a <a href="qgis.qch">Qt help file</a>
 for offline use.
 
-A Python version of the documentation is available
-<a href="https://qgis.org/pyqgis/master">here</a>.
+There is also a <a href="https://qgis.org/pyqgis/master">Python version of
+the documentation</a> available.
 
 \section index_APIStability Earlier versions of the API
 

--- a/python/core/additions/qgsfunction.py
+++ b/python/core/additions/qgsfunction.py
@@ -22,7 +22,7 @@ import inspect
 import string
 from builtins import str
 from qgis.PyQt.QtCore import QCoreApplication
-from qgis._core import QgsExpressionFunction, QgsExpression, QgsMessageLog, QgsFeatureRequest
+from qgis._core import QgsExpressionFunction, QgsExpression, QgsMessageLog, QgsFeatureRequest, Qgis
 
 
 def register_function(function, arg_count, group, usesgeometry=False,

--- a/python/core/additions/qgsfunction.py
+++ b/python/core/additions/qgsfunction.py
@@ -51,7 +51,7 @@ def register_function(function, arg_count, group, usesgeometry=False,
     :param arg_count:
     :param group:
     :param usesgeometry: 
-    :param handlesnull: Needs to be set to True if this function has does not always return NULL if any parameter is NULL. Default False.
+    :param handlesnull: Needs to be set to True if this function does not always return NULL if any parameter is NULL. Default False.
     :return:
     """
 

--- a/python/core/additions/qgsfunction.py
+++ b/python/core/additions/qgsfunction.py
@@ -50,8 +50,8 @@ def register_function(function, arg_count, group, usesgeometry=False,
     :param function:
     :param arg_count:
     :param group:
-    :param usesgeometry:
-    :param handlesnull:
+    :param usesgeometry: 
+    :param handlesnull: Needs to be set to True if this function has does not always return NULL if any parameter is NULL. Default False.
     :return:
     """
 
@@ -136,6 +136,19 @@ def register_function(function, arg_count, group, usesgeometry=False,
 def qgsfunction(args='auto', group='custom', **kwargs):
     """
     Decorator function used to define a user expression function.
+
+    :param args: Number of parameters, set to 'auto' to accept a variable length of parameters.
+    :param group: The expression group to which this expression should be added.
+    :param \**kwargs:
+        See below
+
+    :Keyword Arguments:
+        * *referenced_columns* (``list``) --
+          An array of field names on which this expression works. Can be set to ``[QgsFeatureRequest.ALL_ATTRIBUTES]``. By default empty.
+        * *usesgeometry* (``bool``) --
+          Defines if this expression requires the geometry. By default False.
+        * *handlesnull* (``bool``) --
+          Defines if this expression has custom handling for NULL values. If False, the result will always be NULL as soon as any parameter is NULL. False by default.
 
     Example:
       @qgsfunction(2, 'test'):

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -17,7 +17,7 @@ import qgis  # NOQA
 from qgis.PyQt.QtCore import QVariant
 from qgis.testing import unittest
 from qgis.utils import qgsfunction
-from qgis.core import QgsExpression, QgsFeatureRequest
+from qgis.core import QgsExpression, QgsFeatureRequest, QgsExpressionContext, NULL
 
 
 class TestQgsExpressionCustomFunctions(unittest.TestCase):
@@ -167,9 +167,12 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         self.assertEqual(set(exp.referencedColumns()), set(['a', 'b']))
 
     def testHandlesNull(self):
+        context = QgsExpressionContext()
         QgsExpression.registerFunction(self.null_mean)
         exp = QgsExpression('null_mean(1, 2, NULL, 3)')
-        self.assertEqual(set(exp.evaluate()), 2)
+        result = exp.evaluate(context)
+        self.assertFalse(exp.hasEvalError())
+        self.assertEqual(result, 2)
 
     def testCantOverrideBuiltinsWithUnregister(self):
         success = QgsExpression.unregisterFunction("sqrt")

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -67,6 +67,11 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
     def referenced_columns_set(values, feature, parent):
         return 2
 
+    @qgsfunction(args=-1, group='testing', register=False, handlesnull=True)
+    def null_mean(values, feature, parent):
+        vals = [val for val in values if val != NULL]
+        return sum(vals) / len(vals)
+
     def tearDown(self):
         QgsExpression.unregisterFunction('testfun')
 
@@ -160,6 +165,11 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         QgsExpression.registerFunction(self.referenced_columns_set)
         exp = QgsExpression('referenced_columns_set()')
         self.assertEqual(set(exp.referencedColumns()), set(['a', 'b']))
+
+    def testHandlesNull(self):
+        QgsExpression.registerFunction(self.handles_null)
+        exp = QgsExpression('null_mean(1, 2, NULL, 3)')
+        self.assertEqual(set(exp.evaluate()), 2)
 
     def testCantOverrideBuiltinsWithUnregister(self):
         success = QgsExpression.unregisterFunction("sqrt")

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -167,7 +167,7 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
         self.assertEqual(set(exp.referencedColumns()), set(['a', 'b']))
 
     def testHandlesNull(self):
-        QgsExpression.registerFunction(self.handles_null)
+        QgsExpression.registerFunction(self.null_mean)
         exp = QgsExpression('null_mean(1, 2, NULL, 3)')
         self.assertEqual(set(exp.evaluate()), 2)
 


### PR DESCRIPTION
Up to date it was not possible to create a function that handles NULL values with the
@qgsfunction decorator. As soon as any parameter was NULL, the return value would also
be NULL.

Example of a function that returns a value now with a NULL paramter and would have returned NULL before

```
@qgsfunction(args=-1, group='Custom', handlesnull=True)
def mean_value(vals, feature, parent):
    valid_vals = [val for val in vals if val != NULL]
    return sum(valid_vals)/len(valid_vals)
```

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
