### PR TITLE
Two raster's save as... fixes

### DIFF
--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -358,19 +358,23 @@ bool QgsRasterLayerSaveAsDialog::addToCanvas() const
 
 QString QgsRasterLayerSaveAsDialog::outputFileName() const
 {
-  QStringList extensions = QgsRasterFileWriter::extensionsForFormat( outputFormat() );
-  QString defaultExt;
-  if ( !extensions.empty() )
-  {
-    defaultExt = extensions.at( 0 );
-  }
-
-  // ensure the user never omits the extension from the file name
   QString fileName = mFilename->filePath();
-  QFileInfo fi( fileName );
-  if ( !fileName.isEmpty() && fi.suffix().isEmpty() )
+
+  if ( mFilename->storageMode() != QgsFileWidget::GetDirectory )
   {
-    fileName += '.' + defaultExt;
+    QStringList extensions = QgsRasterFileWriter::extensionsForFormat( outputFormat() );
+    QString defaultExt;
+    if ( !extensions.empty() )
+    {
+      defaultExt = extensions.at( 0 );
+    }
+
+    // ensure the user never omits the extension from the file name
+    QFileInfo fi( fileName );
+    if ( !fileName.isEmpty() && fi.suffix().isEmpty() )
+    {
+      fileName += '.' + defaultExt;
+    }
   }
 
   return fileName;

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -133,8 +133,6 @@ QgsRasterLayerSaveAsDialog::QgsRasterLayerSaveAsDialog( QgsRasterLayer *rasterLa
   // don't restore nodata, it needs user input
   // pyramids are not necessarily built every time
 
-  mTilesGroupBox->hide();
-
   mCrsSelector->setLayerCrs( mLayerCrs );
   //default to layer CRS - see https://issues.qgis.org/issues/14209 for discussion
   mCrsSelector->setCrs( mLayerCrs );
@@ -163,14 +161,17 @@ QgsRasterLayerSaveAsDialog::QgsRasterLayerSaveAsDialog( QgsRasterLayer *rasterLa
 
   if ( mTileModeCheckBox->isChecked() )
   {
+    mTilesGroupBox->show();
     mFilename->setStorageMode( QgsFileWidget::GetDirectory );
-    mFilename->setDialogTitle( tr( "Select output directory" ) );
+    mFilename->setDialogTitle( tr( "Select Output Directory" ) );
   }
   else
   {
+    mTilesGroupBox->hide();
     mFilename->setStorageMode( QgsFileWidget::SaveFile );
     mFilename->setDialogTitle( tr( "Save Layer As" ) );
   }
+
   mFilename->setDefaultRoot( settings.value( QStringLiteral( "UI/lastRasterFileDir" ), QDir::homePath() ).toString() );
   connect( mFilename, &QgsFileWidget::fileChanged, this, [ = ]( const QString & filePath )
   {
@@ -711,7 +712,7 @@ void QgsRasterLayerSaveAsDialog::mTileModeCheckBox_toggled( bool toggled )
     // Show / hide tile options
     mTilesGroupBox->show();
     mFilename->setStorageMode( QgsFileWidget::GetDirectory );
-    mFilename->setDialogTitle( tr( "Select output directory" ) );
+    mFilename->setDialogTitle( tr( "Select Output Directory" ) );
   }
   else
   {


### PR DESCRIPTION
## Description
Simple fixes:
- The VRT tiles groupbox was hidden() upon dialog opening, irrespective of whether the [x] create vrt checkbox was toggled on by default (for e.g. WMS layers)
- When the user selected output is a directory, we shouldn't add an extension to its path

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
