### PR TITLE
Fix warning, unused signal in qgis quick coordinate transformer

### DIFF
--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -156,7 +156,19 @@ Sets the destination coordinate reference system.
 Sets the ``context`` in which the coordinate transform should be
 calculated.
 
+.. seealso:: :py:func:`context`
+
 .. versionadded:: 3.0
+%End
+
+    QgsCoordinateTransformContext context() const;
+%Docstring
+Returns the context in which the coordinate transform will be
+calculated.
+
+.. seealso:: :py:func:`setContext`
+
+.. versionadded:: 3.4
 %End
 
     QgsCoordinateReferenceSystem sourceCrs() const;

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -185,6 +185,11 @@ void QgsCoordinateTransform::setContext( const QgsCoordinateTransformContext &co
   }
 }
 
+QgsCoordinateTransformContext QgsCoordinateTransform::context() const
+{
+  return mContext;
+}
+
 QgsCoordinateReferenceSystem QgsCoordinateTransform::sourceCrs() const
 {
   return d->mSourceCRS;

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -175,9 +175,18 @@ class CORE_EXPORT QgsCoordinateTransform
     /**
      * Sets the \a context in which the coordinate transform should be
      * calculated.
+     * \see context()
      * \since QGIS 3.0
      */
     void setContext( const QgsCoordinateTransformContext &context );
+
+    /**
+     * Returns the context in which the coordinate transform will be
+     * calculated.
+     * \see setContext()
+     * \since QGIS 3.4
+     */
+    QgsCoordinateTransformContext context() const;
 
     /**
      * Returns the source coordinate reference system, which the transform will

--- a/src/quickgui/qgsquickcoordinatetransformer.cpp
+++ b/src/quickgui/qgsquickcoordinatetransformer.cpp
@@ -76,14 +76,13 @@ void QgsQuickCoordinateTransformer::setSourceCrs( const QgsCoordinateReferenceSy
 
 void QgsQuickCoordinateTransformer::setTransformContext( const QgsCoordinateTransformContext &context )
 {
-  mTransformContext = context;
-  mCoordinateTransform.setContext( mTransformContext );
+  mCoordinateTransform.setContext( context );
   emit transformContextChanged();
 }
 
 QgsCoordinateTransformContext QgsQuickCoordinateTransformer::transformContext() const
 {
-  return mTransformContext;
+  return mCoordinateTransform.context();
 }
 
 void QgsQuickCoordinateTransformer::updatePosition()

--- a/src/quickgui/qgsquickcoordinatetransformer.cpp
+++ b/src/quickgui/qgsquickcoordinatetransformer.cpp
@@ -76,7 +76,14 @@ void QgsQuickCoordinateTransformer::setSourceCrs( const QgsCoordinateReferenceSy
 
 void QgsQuickCoordinateTransformer::setTransformContext( const QgsCoordinateTransformContext &context )
 {
-  mCoordinateTransform.setContext( context );
+  mTransformContext = context;
+  mCoordinateTransform.setContext( mTransformContext );
+  emit transformContextChanged();
+}
+
+QgsCoordinateTransformContext QgsQuickCoordinateTransformer::transformContext() const
+{
+  return mTransformContext;
 }
 
 void QgsQuickCoordinateTransformer::updatePosition()

--- a/src/quickgui/qgsquickcoordinatetransformer.h
+++ b/src/quickgui/qgsquickcoordinatetransformer.h
@@ -108,7 +108,6 @@ class QUICK_EXPORT QgsQuickCoordinateTransformer : public QObject
     QgsPoint mProjectedPosition;
     QgsPoint mSourcePosition;
     QgsCoordinateTransform mCoordinateTransform;
-    QgsCoordinateTransformContext mTransformContext;
 };
 
 #endif // QGSQUICKCOORDINATETRANSFORMER_H

--- a/src/quickgui/qgsquickcoordinatetransformer.h
+++ b/src/quickgui/qgsquickcoordinatetransformer.h
@@ -53,7 +53,7 @@ class QUICK_EXPORT QgsQuickCoordinateTransformer : public QObject
     Q_PROPERTY( QgsCoordinateReferenceSystem sourceCrs READ sourceCrs WRITE setSourceCrs NOTIFY sourceCrsChanged )
 
     //! Transformation context, can be set from QgsQuickMapSettings::transformContext()
-    Q_PROPERTY( QgsCoordinateTransformContext transformContext WRITE setTransformContext )
+    Q_PROPERTY( QgsCoordinateTransformContext transformContext READ transformContext WRITE setTransformContext NOTIFY transformContextChanged )
 
   public:
     //! Creates new coordinate transformer
@@ -83,6 +83,9 @@ class QUICK_EXPORT QgsQuickCoordinateTransformer : public QObject
     //!\copydoc QgsQuickCoordinateTransformer::transformContext
     void setTransformContext( const QgsCoordinateTransformContext &context );
 
+    //!\copydoc QgsQuickCoordinateTransformer::transformContext
+    QgsCoordinateTransformContext transformContext() const;
+
   signals:
     //!\copydoc QgsQuickCoordinateTransformer::projectedPosition
     void projectedPositionChanged();
@@ -105,6 +108,7 @@ class QUICK_EXPORT QgsQuickCoordinateTransformer : public QObject
     QgsPoint mProjectedPosition;
     QgsPoint mSourcePosition;
     QgsCoordinateTransform mCoordinateTransform;
+    QgsCoordinateTransformContext mTransformContext;
 };
 
 #endif // QGSQUICKCOORDINATETRANSFORMER_H

--- a/tests/src/python/test_qgscoordinatetransform.py
+++ b/tests/src/python/test_qgscoordinatetransform.py
@@ -145,6 +145,7 @@ class TestQgsCoordinateTransform(unittest.TestCase):
                                                    3, 4)
 
         transform = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:28354'), QgsCoordinateReferenceSystem('EPSG:28353'), context)
+        self.assertEqual(list(transform.context().sourceDestinationDatumTransforms().keys()), [('EPSG:28356', 'EPSG:4283')])
         # should be no datum transforms
         self.assertEqual(transform.sourceDatumTransformId(), -1)
         self.assertEqual(transform.destinationDatumTransformId(), -1)
@@ -193,6 +194,7 @@ class TestQgsCoordinateTransform(unittest.TestCase):
         transform.setContext(context)
         self.assertEqual(transform.sourceDatumTransformId(), 3)
         self.assertEqual(transform.destinationDatumTransformId(), 4)
+        self.assertEqual(list(transform.context().sourceDestinationDatumTransforms().keys()), [('EPSG:28356', 'EPSG:4283')])
 
     def testProjectContext(self):
         """


### PR DESCRIPTION
Fixes `Warning: Property declaration transformContext has no READ accessor function or associated MEMBER variable. The property will be invalid.` 