### PR TITLE
Handle invalid step size

### DIFF
--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -138,7 +138,7 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
     int minval = min.toInt();
     if ( allowNull )
     {
-      int stepval = step.toInt();
+      int stepval = step.isValid() ? step.toInt() : 1;
       minval -= stepval;
       mIntSpinBox->setValue( minval );
       mIntSpinBox->setSpecialValueText( QgsApplication::nullRepresentation() );

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -479,7 +479,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
 
         # check new values
         self.assertTrue(vl.getFeatures('id=1').nextFeature(f))
-        self.assertEqual(f.attributes(), [1, 1, NULL])
+        self.assertEqual(f.attributes(), [1, 1, 0])
 
     def testTransactionTuple(self):
         # create a vector layer based on postgres


### PR DESCRIPTION
in range widgets in combination with NULL values.

Up to date if no Step value is configured (in the .qgs file) and Min Value is 1 and Null allowed, the widget would start at 2, making 1 unavailable.