### PR TITLE
[symbol] fix crasher when rendering a symbol layer subsequent to rendering a geometry generator layer (fixes #19121)

### DIFF
--- a/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology/qgsgeometrygeneratorsymbollayer.cpp
@@ -191,7 +191,8 @@ void QgsGeometryGeneratorSymbolLayer::render( QgsSymbolRenderContext &context )
 {
   if ( context.feature() )
   {
-    QgsExpressionContext &expressionContext = context.renderContext().expressionContext();
+    QgsRenderContext renderContext = context.renderContext();
+    QgsExpressionContext &expressionContext = renderContext.expressionContext();
 
     QgsFeature f = expressionContext.feature();
     QgsGeometry geom = mExpression->evaluate( &expressionContext ).value<QgsGeometry>();
@@ -201,7 +202,7 @@ void QgsGeometryGeneratorSymbolLayer::render( QgsSymbolRenderContext &context )
 
     subSymbolExpressionContextScope->setFeature( f );
 
-    mSymbol->renderFeature( f, context.renderContext(), -1, context.selected() );
+    mSymbol->renderFeature( f, renderContext, -1, context.selected() );
   }
 }
 


### PR DESCRIPTION
## Description
@m-kuhn , this PR fixes reported issue 19121 (https://issues.qgis.org/issues/19121). 

Long story short, the geometry generator's render function was passing on a referenced QgsRenderContext, which modified its geometry(), replacing it with another QgsGeometry that'd scope out, and led to crash when a parent symbol rendered a subsequent symbol layer.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
