### PR TITLE
Fix gdal_calc for use in modeler

### DIFF
--- a/python/plugins/processing/algs/gdal/gdalcalc.py
+++ b/python/plugins/processing/algs/gdal/gdalcalc.py
@@ -222,7 +222,7 @@ class gdalcalc(GdalAlgorithm):
         if self.parameterAsString(parameters, self.BAND_A, context):
             arguments.append('--A_band ' + self.parameterAsString(parameters, self.BAND_A, context))
 
-        if self.INPUT_B in parameters and parameters[self.INPUT_B] is not None:
+        if self.INPUT_B in parameters and parameters[self.INPUT_B] is not (None or ''):
             layer = self.parameterAsRasterLayer(parameters, self.INPUT_B, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_B))
@@ -231,7 +231,7 @@ class gdalcalc(GdalAlgorithm):
             if self.parameterAsString(parameters, self.BAND_B, context):
                 arguments.append('--B_band ' + self.parameterAsString(parameters, self.BAND_B, context))
 
-        if self.INPUT_C in parameters and parameters[self.INPUT_C] is not None:
+        if self.INPUT_C in parameters and parameters[self.INPUT_C] is not (None or ''):
             layer = self.parameterAsRasterLayer(parameters, self.INPUT_C, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_C))
@@ -240,7 +240,7 @@ class gdalcalc(GdalAlgorithm):
             if self.parameterAsString(parameters, self.BAND_C, context):
                 arguments.append('--C_band ' + self.parameterAsString(parameters, self.BAND_C, context))
 
-        if self.INPUT_D in parameters and parameters[self.INPUT_D] is not None:
+        if self.INPUT_D in parameters and parameters[self.INPUT_D] is not (None or ''):
             layer = self.parameterAsRasterLayer(parameters, self.INPUT_D, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_D))
@@ -249,7 +249,7 @@ class gdalcalc(GdalAlgorithm):
             if self.parameterAsString(parameters, self.BAND_D, context):
                 arguments.append('--D_band ' + self.parameterAsString(parameters, self.BAND_D, context))
 
-        if self.INPUT_E in parameters and parameters[self.INPUT_E] is not None:
+        if self.INPUT_E in parameters and parameters[self.INPUT_E] is not (None or ''):
             layer = self.parameterAsRasterLayer(parameters, self.INPUT_E, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_E))
@@ -258,7 +258,7 @@ class gdalcalc(GdalAlgorithm):
             if self.parameterAsString(parameters, self.BAND_E, context):
                 arguments.append('--E_band ' + self.parameterAsString(parameters, self.BAND_E, context))
 
-        if self.INPUT_F in parameters and parameters[self.INPUT_F] is not None:
+        if self.INPUT_F in parameters and parameters[self.INPUT_F] is not (None or ''):
             layer = self.parameterAsRasterLayer(parameters, self.INPUT_F, context)
             if layer is None:
                 raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT_F))


### PR DESCRIPTION
Do not process optional parameters that are empty strings. Fixes #19329
(https://issues.qgis.org/issues/19329)