### PR TITLE
[processing][needs-docs] Add 'not selected' option for optional layer parameters in processing models

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -864,10 +864,10 @@ class MapLayerWidgetWrapper(WidgetWrapper):
             self.combo = QComboBox()
             layers = self.getAvailableLayers()
             self.combo.setEditable(True)
+            if self.param.flags() & QgsProcessingParameterDefinition.FlagOptional:
+                self.combo.addItem(self.NOT_SELECTED, self.NOT_SET_OPTION)
             for layer in layers:
                 self.combo.addItem(self.dialog.resolveValueDescription(layer), layer)
-            if self.param.flags() & QgsProcessingParameterDefinition.FlagOptional:
-                self.combo.setEditText("")
 
             widget = QWidget()
             layout = QHBoxLayout()


### PR DESCRIPTION
Fixes #19329 (https://issues.qgis.org/issues/19329)

## Description
At least the gdalcalc ("gdal:rastercalculator") algorithm is unusable in models because the optional layer parameters are set as empty strings by default, raising an exception because the algorithm only tests for `None`. This could affect other algorithms which have optional map layer parameters.

https://github.com/qgis/QGIS/blob/2695e000422b48b3772a39c7a4040f29d43d0d61/python/plugins/processing/algs/gdal/gdalcalc.py#L225-L228

This is a regression, as the algorithm does not display this behaviour in QGIS 2.18. Rather than patching [gdalcalc.py](https://github.com/qgis/QGIS/blob/master/python/plugins/processing/algs/gdal/gdalcalc.py) to add checks for empty strings (as proposed in https://github.com/qgis/QGIS/pull/7360) this PR updates the behaviour of `MapLayerWidgetWrapper` to add a default 'Not selected' option to layer selection comboboxes for optional parameters in modeler view. This is in keeping with how other combobox widgets behave and would also resolve the problem for other algorithms that have optional layer parameters.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
