### PR TITLE
[processing] fix Random extract/select within subset algorithms

### DIFF
--- a/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
@@ -125,9 +125,12 @@ class RandomExtractWithinSubsets(QgisAlgorithm):
             classes[attrs[index]].append(feature)
             feedback.setProgress(int(i * total))
 
-        for subset in classes.values():
+        for k, subset in classes.items():
             selValue = value if method != 1 else int(round(value * len(subset), 0))
-            selran.extend(random.sample(subset, min(selValue, len(subset))))
+            if selValue > len(subset):
+                selValue = len(subset)
+                feedback.reportError(self.tr('Subset "{}" is smaller than requested number of features.'.format(k)))
+            selran.extend(random.sample(subset, selValue))
 
         total = 100.0 / featureCount if featureCount else 1
         for (i, feat) in enumerate(selran):

--- a/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
@@ -127,7 +127,7 @@ class RandomExtractWithinSubsets(QgisAlgorithm):
 
         for subset in classes.values():
             selValue = value if method != 1 else int(round(value * len(subset), 0))
-            selran.extend(random.sample(subset, selValue))
+            selran.extend(random.sample(subset, min(selValue, len(subset))))
 
         total = 100.0 / featureCount if featureCount else 1
         for (i, feat) in enumerate(selran):

--- a/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
@@ -133,12 +133,15 @@ class RandomSelectionWithinSubsets(QgisAlgorithm):
                 feedback.setProgress(int(i * total))
 
             selran = []
-            for subset in classes.values():
+            for k, subset in classes.items():
                 if feedback.isCanceled():
                     break
 
                 selValue = value if method != 1 else int(round(value * len(subset), 0))
-                selran.extend(random.sample(subset, min(selValue, len(subset))))
+                if selValue > len(subset):
+                    selValue = len(subset)
+                    feedback.reportError(self.tr('Subset "{}" is smaller than requested number of features.'.format(k)))
+                selran.extend(random.sample(subset, selValue))
 
             layer.selectByIds(selran)
         else:

--- a/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
@@ -138,7 +138,7 @@ class RandomSelectionWithinSubsets(QgisAlgorithm):
                     break
 
                 selValue = value if method != 1 else int(round(value * len(subset), 0))
-                selran.extend(random.sample(subset, selValue))
+                selran.extend(random.sample(subset, min(selValue, len(subset))))
 
             layer.selectByIds(selran)
         else:

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -3923,6 +3923,21 @@ tests:
         name: points_weighted.gml
         compare: false
 
+  - algorithm: qgis:randomextractwithinsubsets
+    name: Random extract within subset (subset smaller than number)
+    params:
+      FIELD: id2
+      INPUT:
+        name: points.gml
+        type: vector
+      METHOD: 0
+      NUMBER: 3
+    results:
+      OUTPUT:
+        type: vector
+        name: points.gml
+        compare: false
+
   - algorithm: qgis:heatmapkerneldensityestimation
     name: Heatmap (Kernel density estimation)
     params:
@@ -5355,6 +5370,7 @@ tests:
         compare:
           fields:
             fid: skip
+
   - algorithm: native:difference
     name: Test Difference B - A (basic)
     params:


### PR DESCRIPTION
Fixes Random select/extract within subsets algorithms, when number of features within subset is smaller than number of requested features. In such case we select/extract all features from the subset instead of throwing Python exception (fix [#19322](https://issues.qgis.org/issues/19322))

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
