### PR TITLE
FindSIP: Update regex to also save new sip_module_dir

### DIFF
--- a/cmake/FindSIP.cmake
+++ b/cmake/FindSIP.cmake
@@ -42,6 +42,7 @@ ELSE(SIP_VERSION)
     STRING(REGEX REPLACE ".*\ndefault_sip_dir:([^\n]+).*$" "\\1" SIP_DEFAULT_SIP_DIR ${sip_config})
     STRING(REGEX REPLACE ".*\nsip_inc_dir:([^\n]+).*$" "\\1" SIP_INCLUDE_DIR ${sip_config})
     STRING(REGEX REPLACE ".*\nsip_mod_dir:([^\n]+).*$" "\\1" SIP_MOD_DIR ${sip_config})
+    STRING(REGEX REPLACE ".*\nsip_module_dir:([^\n]+).*$" "\\1" SIP_MODULE_DIR ${sip_config})
     SET(SIP_FOUND TRUE)
   ENDIF(sip_config)
 


### PR DESCRIPTION
sip4 has changed sip_mod_dir to sip_module_dir. Store the variable for later usage

This is useful together with #7365 to make the package build again and detect new sip4 correctly
