### PR TITLE
[Processing] Add missing functionality to set R parameters as advanced.

### DIFF
--- a/python/plugins/processing/algs/r/RAlgorithm.py
+++ b/python/plugins/processing/algs/r/RAlgorithm.py
@@ -158,24 +158,15 @@ class RAlgorithm(GeoAlgorithm):
             self.passFileNames = True
             return
         tokens = line.split('=')
-        desc = self.createDescriptiveName(tokens[0])
         if tokens[1].lower().strip() == 'group':
             self.group = self.i18n_group = tokens[0]
             return
         if tokens[1].lower().strip() == 'name':
             self.name = self.i18n_name = tokens[0]
             return
-
         if tokens[1].lower().strip().startswith('output'):
             outToken = tokens[1].strip()[len('output') + 1:]
             out = self.processOutputParameterToken(outToken)
-
-        elif tokens[1].lower().strip().startswith('optional'):
-            optToken = tokens[1].strip()[len('optional') + 1:]
-            param = self.processInputParameterToken(optToken, tokens[0])
-            if param:
-                param.optional = True
-
         else:
             param = self.processInputParameterToken(tokens[1], tokens[0])
 
@@ -191,8 +182,18 @@ class RAlgorithm(GeoAlgorithm):
 
     def processInputParameterToken(self, token, name):
         param = None
+        optional = False
+        isAdvanced = False
 
         desc = self.createDescriptiveName(name)
+
+        tokens = token.lower().strip().split(' ')
+        if "optional" in tokens[0]:
+            optional = True
+        if "advanced" in tokens[0]:
+            isAdvanced = True
+        if optional or isAdvanced:
+            token = (' ').join(tokens[1:])
 
         if token.lower().strip().startswith('raster'):
             param = ParameterRaster(name, desc, False)
@@ -280,6 +281,10 @@ class RAlgorithm(GeoAlgorithm):
                 param = ParameterCrs(name, desc, default)
             else:
                 param = ParameterCrs(name, desc)
+
+        if param is not None:
+            param.optional = optional
+            param.isAdvanced = isAdvanced
 
         return param
 


### PR DESCRIPTION
## Description
To set a parameter as advanced you have to use “advanced” keyword in the input parameter description at the top of the R script. It can be used in combination with “optional” key word by separating them with comma and no spaces, i.e. “advanced,optional”.

So the following are correct:
##param_name=optional string
##param_name=optional,advanced string
##param_name=advanced,optional string
##param_name=advanced string
##param_name=string

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
