### PR TITLE
Offline Editing GeoPackage File Export

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -424,6 +424,7 @@ bool QgsOfflineEditing::createOfflineDb( const QString &offlineDbPath, Container
         showWarning( tr( "Creation of database failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
         return false;
       }
+      break;
     }
     case SpatiaLite:
     {
@@ -624,6 +625,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
                                        tableName, layer->isSpatial() ? "(Geometry)" : "" );
       newLayer = new QgsVectorLayer( connectionString,
                                      layer->name() + " (offline)", QStringLiteral( "spatialite" ) );
+      break;
     }
     case GPKG:
     {
@@ -642,6 +644,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
 
       QString uri = QStringLiteral( "%1|layername=%2" ).arg( offlineDbPath,  tableName );
       newLayer = new QgsVectorLayer( uri, layer->name() + " (offline)", QStringLiteral( "ogr" ) );
+      break;
     }
   }
 

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -83,7 +83,7 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
     return false;
   }
   QString dbPath = QDir( offlineDataPath ).absoluteFilePath( offlineDbFile );
-  if ( createSpatialiteDB( dbPath, gpkg ) )
+  if ( createOfflineDb( dbPath, gpkg ) )
   {
     spatialite_database_unique_ptr database;
     int rc = database.open( dbPath );
@@ -385,7 +385,7 @@ void QgsOfflineEditing::initializeSpatialMetadata( sqlite3 *sqlite_handle )
   spatial_ref_sys_init( sqlite_handle, 0 );
 }
 
-bool QgsOfflineEditing::createSpatialiteDB( const QString &offlineDbPath, bool gpkg )
+bool QgsOfflineEditing::createOfflineDb( const QString &offlineDbPath, bool gpkg )
 {
   int ret;
   char *errMsg = nullptr;

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -76,14 +76,14 @@ QgsOfflineEditing::QgsOfflineEditing()
  *  - remove remote layers
  *  - mark as offline project
  */
-bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected, ContainerType dbContainerType )
+bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected, ContainerType containerType )
 {
   if ( layerIds.isEmpty() )
   {
     return false;
   }
   QString dbPath = QDir( offlineDataPath ).absoluteFilePath( offlineDbFile );
-  if ( createOfflineDb( dbPath, dbContainerType ) )
+  if ( createOfflineDb( dbPath, containerType ) )
   {
     spatialite_database_unique_ptr database;
     int rc = database.open( dbPath );
@@ -138,7 +138,7 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
         if ( vl )
         {
           QString origLayerId = vl->id();
-          QgsVectorLayer *newLayer = copyVectorLayer( vl, database.get(), dbPath, onlySelected, dbContainerType );
+          QgsVectorLayer *newLayer = copyVectorLayer( vl, database.get(), dbPath, onlySelected, containerType );
           if ( newLayer )
           {
             layerIdMapping.insert( origLayerId, newLayer );
@@ -385,7 +385,7 @@ void QgsOfflineEditing::initializeSpatialMetadata( sqlite3 *sqlite_handle )
   spatial_ref_sys_init( sqlite_handle, 0 );
 }
 
-bool QgsOfflineEditing::createOfflineDb( const QString &offlineDbPath, ContainerType dbContainerType )
+bool QgsOfflineEditing::createOfflineDb( const QString &offlineDbPath, ContainerType containerType )
 {
   int ret;
   char *errMsg = nullptr;
@@ -407,7 +407,7 @@ bool QgsOfflineEditing::createOfflineDb( const QString &offlineDbPath, Container
   QString dbPath = newDb.fileName();
 
   // creating geopackage
-  if ( dbContainerType == GPKG )
+  if ( containerType == GPKG )
   {
     OGRSFDriverH hGpkgDriver = OGRGetDriverByName( "GPKG" );
     if ( !hGpkgDriver )
@@ -492,7 +492,7 @@ void QgsOfflineEditing::createLoggingTables( sqlite3 *db )
   */
 }
 
-QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType dbContainerType )
+QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType containerType )
 {
   if ( !layer )
     return nullptr;
@@ -503,7 +503,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
   // new layer
   QgsVectorLayer *newLayer = nullptr;
 
-  if ( dbContainerType != GPKG )
+  if ( containerType != GPKG )
   {
     // create table
     QString sql = QStringLiteral( "CREATE TABLE '%1' (" ).arg( tableName );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -76,14 +76,14 @@ QgsOfflineEditing::QgsOfflineEditing()
  *  - remove remote layers
  *  - mark as offline project
  */
-bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected, bool gpkg )
+bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected, ContainerType dbContainerType )
 {
   if ( layerIds.isEmpty() )
   {
     return false;
   }
   QString dbPath = QDir( offlineDataPath ).absoluteFilePath( offlineDbFile );
-  if ( createOfflineDb( dbPath, gpkg ) )
+  if ( createOfflineDb( dbPath, dbContainerType ) )
   {
     spatialite_database_unique_ptr database;
     int rc = database.open( dbPath );
@@ -138,7 +138,7 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString &offlineDataPath,
         if ( vl )
         {
           QString origLayerId = vl->id();
-          QgsVectorLayer *newLayer = copyVectorLayer( vl, database.get(), dbPath, onlySelected, gpkg );
+          QgsVectorLayer *newLayer = copyVectorLayer( vl, database.get(), dbPath, onlySelected, dbContainerType );
           if ( newLayer )
           {
             layerIdMapping.insert( origLayerId, newLayer );
@@ -385,7 +385,7 @@ void QgsOfflineEditing::initializeSpatialMetadata( sqlite3 *sqlite_handle )
   spatial_ref_sys_init( sqlite_handle, 0 );
 }
 
-bool QgsOfflineEditing::createOfflineDb( const QString &offlineDbPath, bool gpkg )
+bool QgsOfflineEditing::createOfflineDb( const QString &offlineDbPath, ContainerType dbContainerType )
 {
   int ret;
   char *errMsg = nullptr;
@@ -407,7 +407,7 @@ bool QgsOfflineEditing::createOfflineDb( const QString &offlineDbPath, bool gpkg
   QString dbPath = newDb.fileName();
 
   // creating geopackage
-  if ( gpkg )
+  if ( dbContainerType == GPKG )
   {
     OGRSFDriverH hGpkgDriver = OGRGetDriverByName( "GPKG" );
     if ( !hGpkgDriver )
@@ -492,7 +492,7 @@ void QgsOfflineEditing::createLoggingTables( sqlite3 *db )
   */
 }
 
-QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, bool gpkg )
+QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType dbContainerType )
 {
   if ( !layer )
     return nullptr;
@@ -503,7 +503,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
   // new layer
   QgsVectorLayer *newLayer = nullptr;
 
-  if ( !gpkg )
+  if ( dbContainerType != GPKG )
   {
     // create table
     QString sql = QStringLiteral( "CREATE TABLE '%1' (" ).arg( tableName );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -111,7 +111,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void createLoggingTables( sqlite3 *db );
 
     QgsVectorLayer *copyVectorLayerGpkg( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath );
-    QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected );
+    QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, bool gpkg );
 
     void applyAttributesAdded( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId, int commitNo );
     void applyFeaturesAdded( QgsVectorLayer *offlineLayer, QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -49,6 +49,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
       UpdateGeometries
     };
 
+    //! Type of offline database container file
     enum ContainerType
     {
       SpatiaLite,

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
      * \param layerIds List of layer names to convert
      * \param onlySelected Only copy selected features from layers where a selection is present
      */
-    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType dbContainerType = SpatiaLite );
+    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType containerType = SpatiaLite );
 
     //! Returns true if current project is offline
     bool isOfflineProject() const;
@@ -113,10 +113,10 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
 
   private:
     void initializeSpatialMetadata( sqlite3 *sqlite_handle );
-    bool createOfflineDb( const QString &offlineDbPath, ContainerType dbContainerType = SpatiaLite );
+    bool createOfflineDb( const QString &offlineDbPath, ContainerType containerType = SpatiaLite );
     void createLoggingTables( sqlite3 *db );
 
-    QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType dbContainerType = SpatiaLite );
+    QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType containerType = SpatiaLite );
 
     void applyAttributesAdded( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId, int commitNo );
     void applyFeaturesAdded( QgsVectorLayer *offlineLayer, QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -107,10 +107,9 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
 
   private:
     void initializeSpatialMetadata( sqlite3 *sqlite_handle );
-    bool createSpatialiteDB( const QString &offlineDbPath, bool gpkg );
+    bool createSpatialiteDB( const QString &offlineDbPath, bool gpkg = false );
     void createLoggingTables( sqlite3 *db );
 
-    QgsVectorLayer *copyVectorLayerGpkg( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath );
     QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, bool gpkg );
 
     void applyAttributesAdded( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId, int commitNo );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -49,6 +49,12 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
       UpdateGeometries
     };
 
+    enum ContainerType
+    {
+      SpatiaLite,
+      GPKG
+    };
+
     QgsOfflineEditing();
 
     /**
@@ -58,7 +64,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
      * \param layerIds List of layer names to convert
      * \param onlySelected Only copy selected features from layers where a selection is present
      */
-    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, bool gpkg = false );
+    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType dbContainerType = SpatiaLite );
 
     //! Returns true if current project is offline
     bool isOfflineProject() const;
@@ -107,10 +113,10 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
 
   private:
     void initializeSpatialMetadata( sqlite3 *sqlite_handle );
-    bool createOfflineDb( const QString &offlineDbPath, bool gpkg = false );
+    bool createOfflineDb( const QString &offlineDbPath, ContainerType dbContainerType = SpatiaLite );
     void createLoggingTables( sqlite3 *db );
 
-    QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, bool gpkg );
+    QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, ContainerType dbContainerType = SpatiaLite );
 
     void applyAttributesAdded( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId, int commitNo );
     void applyFeaturesAdded( QgsVectorLayer *offlineLayer, QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -58,7 +58,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
      * \param layerIds List of layer names to convert
      * \param onlySelected Only copy selected features from layers where a selection is present
      */
-    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false );
+    bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, bool gpkg = false );
 
     //! Returns true if current project is offline
     bool isOfflineProject() const;
@@ -107,8 +107,10 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
 
   private:
     void initializeSpatialMetadata( sqlite3 *sqlite_handle );
-    bool createSpatialiteDB( const QString &offlineDbPath );
+    bool createSpatialiteDB( const QString &offlineDbPath, bool gpkg );
     void createLoggingTables( sqlite3 *db );
+
+    QgsVectorLayer *copyVectorLayerGpkg( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath );
     QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected );
 
     void applyAttributesAdded( QgsVectorLayer *remoteLayer, sqlite3 *db, int layerId, int commitNo );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
      * \param offlineDbFile Offline db file name
      * \param layerIds List of layer names to convert
      * \param onlySelected Only copy selected features from layers where a selection is present
+     * \param containerType defines the SQLite file container type like SpatiaLite or GPKG
      */
     bool convertToOfflineProject( const QString &offlineDataPath, const QString &offlineDbFile, const QStringList &layerIds, bool onlySelected = false, ContainerType containerType = SpatiaLite );
 

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -107,7 +107,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
 
   private:
     void initializeSpatialMetadata( sqlite3 *sqlite_handle );
-    bool createSpatialiteDB( const QString &offlineDbPath, bool gpkg = false );
+    bool createOfflineDb( const QString &offlineDbPath, bool gpkg = false );
     void createLoggingTables( sqlite3 *db );
 
     QgsVectorLayer *copyVectorLayer( QgsVectorLayer *layer, sqlite3 *db, const QString &offlineDbPath, bool onlySelected, bool gpkg );

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -104,7 +104,7 @@ void QgsOfflineEditingPlugin::convertProject()
     }
 
     mProgressDialog->setTitle( tr( "Converting to Offline Project" ) );
-    if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected() ) )
+    if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected(), myPluginGui->isGeopackage() ) )
     {
       updateActions();
       // Redraw, to make the offline layer visible

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -104,7 +104,7 @@ void QgsOfflineEditingPlugin::convertProject()
     }
 
     mProgressDialog->setTitle( tr( "Converting to Offline Project" ) );
-    if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected(), myPluginGui->isGeopackage() ) )
+    if ( mOfflineEditing->convertToOfflineProject( myPluginGui->offlineDataPath(), myPluginGui->offlineDbFile(), selectedLayerIds, myPluginGui->onlySelected(), myPluginGui->dbContainerType() ) )
     {
       updateActions();
       // Redraw, to make the offline layer visible

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -146,14 +146,17 @@ bool QgsOfflineEditingPluginGui::onlySelected() const
   return mOnlySelectedCheckBox->checkState() == Qt::Checked;
 }
 
-bool QgsOfflineEditingPluginGui::isGeopackage() const
+QgsOfflineEditing::ContainerType QgsOfflineEditingPluginGui::dbContainerType() const
 {
-  return mSelectDatatypeCombo->currentIndex() == 0;
+  if ( mSelectDatatypeCombo->currentIndex() == 0 )
+    return QgsOfflineEditing::GPKG;
+  else
+    return QgsOfflineEditing::SpatiaLite;
 }
 
 void QgsOfflineEditingPluginGui::mBrowseButton_clicked()
 {
-  if ( isGeopackage() )
+  if ( dbContainerType() == QgsOfflineEditing::GPKG )
   {
     //GeoPackage
     QString fileName = QFileDialog::getSaveFileName( this,

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -180,7 +180,7 @@ void QgsOfflineEditingPluginGui::mBrowseButton_clicked()
     }
     case QgsOfflineEditing::SpatiaLite:
     {
-      //Spacialite
+      //SpaciaLite
       QString fileName = QFileDialog::getSaveFileName( this,
                          tr( "Select target database for offline data" ),
                          QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ),

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -267,7 +267,7 @@ void QgsOfflineEditingPluginGui::datatypeChanged( int index )
   }
   else
   {
-    //Spatialite
+    //SpatiaLite
     mOfflineDbFile = QStringLiteral( "offline.sqlite" );
   }
   mOfflineDataPathLineEdit->setText( QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ) );

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -106,7 +106,7 @@ QgsOfflineEditingPluginGui::QgsOfflineEditingPluginGui( QWidget *parent, Qt::Win
 
   restoreState();
 
-  mOnlySelectedCheckBox->setDisabled(true);
+  mOnlySelectedCheckBox->setDisabled( true );
   mOfflineDbFile = QStringLiteral( "offline.gpkg" );
   mOfflineDataPathLineEdit->setText( QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ) );
 
@@ -154,7 +154,7 @@ bool QgsOfflineEditingPluginGui::isGeopackage() const
 
 void QgsOfflineEditingPluginGui::mBrowseButton_clicked()
 {
-  if( isGeopackage() )
+  if ( isGeopackage() )
   {
     //GeoPackage
     QString fileName = QFileDialog::getSaveFileName( this,
@@ -255,16 +255,14 @@ void QgsOfflineEditingPluginGui::deSelectAll()
 
 void QgsOfflineEditingPluginGui::datatypeChanged( int index )
 {
-  if( index==0 )
+  if ( index == 0 )
   {
     //GeoPackage
-    mOnlySelectedCheckBox->setDisabled(true);
     mOfflineDbFile = QStringLiteral( "offline.gpkg" );
   }
   else
   {
     //Spatialite
-    mOnlySelectedCheckBox->setEnabled(true);
     mOfflineDbFile = QStringLiteral( "offline.sqlite" );
   }
   mOfflineDataPathLineEdit->setText( QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ) );

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -106,7 +106,6 @@ QgsOfflineEditingPluginGui::QgsOfflineEditingPluginGui( QWidget *parent, Qt::Win
 
   restoreState();
 
-  mOnlySelectedCheckBox->setDisabled( true );
   mOfflineDbFile = QStringLiteral( "offline.gpkg" );
   mOfflineDataPathLineEdit->setText( QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ) );
 

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -156,44 +156,47 @@ QgsOfflineEditing::ContainerType QgsOfflineEditingPluginGui::dbContainerType() c
 
 void QgsOfflineEditingPluginGui::mBrowseButton_clicked()
 {
-  if ( dbContainerType() == QgsOfflineEditing::GPKG )
+  switch ( dbContainerType() )
   {
-    //GeoPackage
-    QString fileName = QFileDialog::getSaveFileName( this,
-                       tr( "Select target database for offline data" ),
-                       QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ),
-                       tr( "GeoPackage" ) + " (*.gpkg);;"
-                       + tr( "All files" ) + " (*.*)" );
-
-    if ( !fileName.isEmpty() )
+    case QgsOfflineEditing::GPKG:
     {
-      if ( !fileName.endsWith( QLatin1String( ".gpkg" ), Qt::CaseInsensitive ) )
+      //GeoPackage
+      QString fileName = QFileDialog::getSaveFileName( this,
+                         tr( "Select target database for offline data" ),
+                         QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ),
+                         tr( "GeoPackage" ) + " (*.gpkg);;"
+                         + tr( "All files" ) + " (*.*)" );
+
+      if ( !fileName.isEmpty() )
       {
-        fileName += QLatin1String( ".gpkg" );
+        if ( !fileName.endsWith( QLatin1String( ".gpkg" ), Qt::CaseInsensitive ) )
+        {
+          fileName += QLatin1String( ".gpkg" );
+        }
+        mOfflineDbFile = QFileInfo( fileName ).fileName();
+        mOfflineDataPath = QFileInfo( fileName ).absolutePath();
+        mOfflineDataPathLineEdit->setText( fileName );
       }
-      mOfflineDbFile = QFileInfo( fileName ).fileName();
-      mOfflineDataPath = QFileInfo( fileName ).absolutePath();
-      mOfflineDataPathLineEdit->setText( fileName );
     }
-  }
-  else
-  {
-    //Spacialite
-    QString fileName = QFileDialog::getSaveFileName( this,
-                       tr( "Select target database for offline data" ),
-                       QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ),
-                       tr( "SpatiaLite DB" ) + " (*.sqlite);;"
-                       + tr( "All files" ) + " (*.*)" );
-
-    if ( !fileName.isEmpty() )
+    case QgsOfflineEditing::SpatiaLite:
     {
-      if ( !fileName.endsWith( QLatin1String( ".sqlite" ), Qt::CaseInsensitive ) )
+      //Spacialite
+      QString fileName = QFileDialog::getSaveFileName( this,
+                         tr( "Select target database for offline data" ),
+                         QDir( mOfflineDataPath ).absoluteFilePath( mOfflineDbFile ),
+                         tr( "SpatiaLite DB" ) + " (*.sqlite);;"
+                         + tr( "All files" ) + " (*.*)" );
+
+      if ( !fileName.isEmpty() )
       {
-        fileName += QLatin1String( ".sqlite" );
+        if ( !fileName.endsWith( QLatin1String( ".sqlite" ), Qt::CaseInsensitive ) )
+        {
+          fileName += QLatin1String( ".sqlite" );
+        }
+        mOfflineDbFile = QFileInfo( fileName ).fileName();
+        mOfflineDataPath = QFileInfo( fileName ).absolutePath();
+        mOfflineDataPathLineEdit->setText( fileName );
       }
-      mOfflineDbFile = QFileInfo( fileName ).fileName();
-      mOfflineDataPath = QFileInfo( fileName ).absolutePath();
-      mOfflineDataPathLineEdit->setText( fileName );
     }
   }
 }

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.h
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.h
@@ -46,11 +46,13 @@ class QgsOfflineEditingPluginGui : public QDialog, private Ui::QgsOfflineEditing
     QString offlineDbFile();
     QStringList selectedLayerIds();
     bool onlySelected() const;
+    bool isGeopackage() const;
 
   public slots:
     //! Change the selection of layers in the list
     void selectAll();
     void deSelectAll();
+    void datatypeChanged( int index );
 
   private:
     void saveState();

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.h
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.h
@@ -23,6 +23,7 @@
 
 #include "ui_offline_editing_plugin_guibase.h"
 
+#include "qgsofflineediting.h"
 #include "qgslayertreemodel.h"
 
 class QgsSelectLayerTreeModel : public QgsLayerTreeModel
@@ -46,7 +47,7 @@ class QgsOfflineEditingPluginGui : public QDialog, private Ui::QgsOfflineEditing
     QString offlineDbFile();
     QStringList selectedLayerIds();
     bool onlySelected() const;
-    bool isGeopackage() const;
+    QgsOfflineEditing::ContainerType dbContainerType() const;
 
   public slots:
     //! Change the selection of layers in the list

--- a/src/plugins/offline_editing/offline_editing_plugin_guibase.ui
+++ b/src/plugins/offline_editing/offline_editing_plugin_guibase.ui
@@ -19,6 +19,43 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="selectDatatypeComboLabel">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Storage Type</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="mSelectDatatypeCombo">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>GeoPackage</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Spatialite</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="label_2">

--- a/src/plugins/offline_editing/offline_editing_plugin_guibase.ui
+++ b/src/plugins/offline_editing/offline_editing_plugin_guibase.ui
@@ -29,7 +29,7 @@
         </size>
        </property>
        <property name="text">
-        <string>Storage Type</string>
+        <string>Storage type</string>
        </property>
       </widget>
      </item>
@@ -48,7 +48,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Spatialite</string>
+         <string>SpatiaLite</string>
         </property>
        </item>
       </widget>

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -195,6 +195,7 @@ SET(TESTS
  testqgslayerdefinition.cpp
  testqgssqliteutils.cpp
  testqgsmimedatautils.cpp
+ testqgsofflineediting.cpp
    )
 
 IF(WITH_QTWEBKIT)

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -1,0 +1,147 @@
+/***************************************************************************
+  testqgsofflineediting.cpp
+
+ ---------------------
+ begin                : 3.7.2018
+ copyright            : (C) 2018 by david signer
+ email                : david at opengis dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include <QObject>
+
+#include <QString>
+#include <QStringList>
+#include <QApplication>
+#include <QFileInfo>
+#include <QDir>
+
+#include "qgsunittypes.h"
+#include "qgsofflineediting.h"
+#include "qgstest.h"
+#include "qgsvectorlayerref.h"
+
+/**
+ * \ingroup UnitTests
+ */
+class TestQgsOfflineEditing : public QObject
+{
+    Q_OBJECT
+
+  private:
+    QgsOfflineEditing *mOfflineEditing = nullptr;
+    QgsVectorLayer *mpLayer = nullptr;
+    QString offlineDataPath;
+    QString offlineDbFile;
+    QStringList layerIds;
+    long numberOfFeatures;
+    int numberOfFields;
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void createSpatialiteAndSynchronizeBack();
+    void createGeopackageAndSynchronizeBack();
+};
+
+void TestQgsOfflineEditing::initTestCase()
+{
+  //
+  // Runs once before any tests are run
+  //
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsApplication::showSettings();
+
+  //OfflineEditing
+  mOfflineEditing = new QgsOfflineEditing();
+  offlineDataPath = ".";
+}
+
+void TestQgsOfflineEditing::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsOfflineEditing::init()
+{
+  QString myFileName( TEST_DATA_DIR ); //defined in CmakeLists.txt
+  myFileName = myFileName + "/points.shp";
+  QFileInfo myMapFileInfo( myFileName );
+  mpLayer = new QgsVectorLayer( myMapFileInfo.filePath(),
+                                myMapFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
+  QgsProject::instance()->addMapLayer( mpLayer );
+
+  numberOfFeatures = mpLayer->featureCount();
+  numberOfFields = mpLayer->fields().size();
+
+  layerIds.append( mpLayer->id() );
+}
+
+void TestQgsOfflineEditing::cleanup()
+{
+  QgsProject::instance()->removeAllMapLayers();
+  layerIds.clear();
+  QDir dir( offlineDataPath );
+  dir.remove( offlineDbFile );
+}
+
+void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
+{
+  offlineDbFile = "TestQgsOfflineEditing.sqlite";
+  QCOMPARE( mpLayer->name(), QStringLiteral( "points" ) );
+  QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
+  QCOMPARE( mpLayer->fields().size(), numberOfFields );
+
+  //convert
+  mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, false );
+
+  mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayers().first() );
+  QCOMPARE( mpLayer->name(), QStringLiteral( "points (offline)" ) );
+  QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
+
+  //synchronize back
+  mOfflineEditing->synchronize();
+
+  mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayers().first() );
+  QCOMPARE( mpLayer->name(), QStringLiteral( "points" ) );
+  QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
+  QCOMPARE( mpLayer->fields().size(), numberOfFields );
+}
+
+void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
+{
+  offlineDbFile = "TestQgsOfflineEditing.gpkg";
+  QCOMPARE( mpLayer->name(), QStringLiteral( "points" ) );
+  QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
+  QCOMPARE( mpLayer->fields().size(), numberOfFields );
+
+  //convert
+  mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, true );
+
+  mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayers().first() );
+  QCOMPARE( mpLayer->name(), QStringLiteral( "points (offline)" ) );
+  QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
+  //comparing with the number +1 because GPKG created an fid
+  QCOMPARE( mpLayer->fields().size(), numberOfFields + 1 );
+
+  //synchronize back
+  mOfflineEditing->synchronize();
+
+  mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayers().first() );
+  QCOMPARE( mpLayer->name(), QStringLiteral( "points" ) );
+  QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
+  QCOMPARE( mpLayer->fields().size(), numberOfFields );
+}
+
+QGSTEST_MAIN( TestQgsOfflineEditing )
+#include "testqgsofflineediting.moc"

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -103,7 +103,7 @@ void TestQgsOfflineEditing::createSpatialiteAndSynchronizeBack()
   QCOMPARE( mpLayer->fields().size(), numberOfFields );
 
   //convert
-  mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, false );
+  mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::SpatiaLite );
 
   mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayers().first() );
   QCOMPARE( mpLayer->name(), QStringLiteral( "points (offline)" ) );
@@ -126,7 +126,7 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   QCOMPARE( mpLayer->fields().size(), numberOfFields );
 
   //convert
-  mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, true );
+  mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG );
 
   mpLayer = qobject_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayers().first() );
   QCOMPARE( mpLayer->name(), QStringLiteral( "points (offline)" ) );


### PR DESCRIPTION
With the core plugin Offline Editing it's possible to select, whether the export should create a SpatiaLite or a GeoPackage file. It's selectable in a combobox. The default is GeoPackage.

The implementations (beside the GUI) are the creation of the file, the layer and some individual handling of the log-tables. The functionality beside that is mostly the same like before with SpatiaLite-export.

[FEATURE]