### PR TITLE
[WIP][server] Clean parameters management

### DIFF
--- a/python/server/auto_additions/qgsserverparameters.py
+++ b/python/server/auto_additions/qgsserverparameters.py
@@ -1,2 +1,2 @@
 # The following has been generated automatically from src/server/qgsserverparameters.h
-QgsServerParameters.ParameterName.baseClass = QgsServerParameters
+QgsServerParameter.Name.baseClass = QgsServerParameter

--- a/python/server/auto_additions/qgsserverparameters.py
+++ b/python/server/auto_additions/qgsserverparameters.py
@@ -1,0 +1,2 @@
+# The following has been generated automatically from src/server/qgsserverparameters.h
+QgsServerParameters.ParameterName.baseClass = QgsServerParameters

--- a/python/server/auto_generated/qgsserverexception.sip.in
+++ b/python/server/auto_generated/qgsserverexception.sip.in
@@ -94,7 +94,6 @@ Returns the exception version
 };
 
 
-
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/server/auto_generated/qgsserverexception.sip.in
+++ b/python/server/auto_generated/qgsserverexception.sip.in
@@ -94,6 +94,7 @@ Returns the exception version
 };
 
 
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -128,9 +128,6 @@ Converts the parameter into a double.
 %Docstring
 Converts the parameter into a boolean.
 
-:param ok: True if there's no error during the conversion, false otherwise
-:param delimiter: The character used for delimiting
-
 :return: A boolean
 %End
 
@@ -139,7 +136,6 @@ Converts the parameter into a boolean.
 Converts the parameter into a color.
 
 :param ok: True if there's no error during the conversion, false otherwise
-:param delimiter: The character used for delimiting
 
 :return: A color
 %End

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -197,6 +197,7 @@ defined.
   protected:
     virtual bool loadParameter( const QPair<QString, QString> &item );
 
+
 };
 
 /************************************************************************

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -29,6 +29,8 @@ the Free Software Foundation; either version 2 of the License, or     *
     QgsServerParameterDefinition( const QVariant::Type type = QVariant::String,
                                   const QVariant defaultValue = QVariant( "" ) );
 
+    virtual ~QgsServerParameterDefinition();
+
     QString typeName() const;
     virtual bool isValid() const;
 
@@ -109,6 +111,8 @@ Constructor.
 %Docstring
 Constructor.
 %End
+
+    virtual ~QgsServerParameters();
 
     void load( const QUrlQuery &query );
 %Docstring

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -9,6 +9,80 @@
 
 
 
+class QgsServerParameterDefinition
+{
+%Docstring
+*************************************************************************
+
+This program is free software; you can redistribute it and/or modify  *
+it under the terms of the GNU General Public License as published by  *
+the Free Software Foundation; either version 2 of the License, or     *
+(at your option) any later version.                                   *
+
+**************************************************************************
+%End
+
+%TypeHeaderCode
+#include "qgsserverparameters.h"
+%End
+  public:
+    QgsServerParameterDefinition( const QVariant::Type type = QVariant::String,
+                                  const QVariant defaultValue = QVariant( "" ) );
+
+    QString typeName() const;
+    virtual bool isValid() const;
+
+    QString toString() const;
+    QStringList toStringList( char delimiter = ',' ) const;
+    QList<int> toIntList( bool &ok, char delimiter = ',' ) const;
+    QList<double> toDoubleList( bool &ok, char delimiter = ',' ) const;
+    QList<QColor> toColorList( bool &ok, char delimiter = ',' ) const;
+    QList<QgsGeometry> toGeomList( bool &ok, char delimiter = ',' ) const;
+    QgsRectangle toRectangle( bool &ok ) const;
+    int toInt( bool &ok ) const;
+    double toDouble( bool &ok ) const;
+    bool toBool() const;
+    QColor toColor( bool &ok ) const;
+
+    static void raiseError( const QString &msg );
+
+    QVariant::Type mType;
+    QVariant mValue;
+    QVariant mDefaultValue;
+};
+
+class QgsServerParameter : QgsServerParameterDefinition
+{
+
+%TypeHeaderCode
+#include "qgsserverparameters.h"
+%End
+  public:
+    static const QMetaObject staticMetaObject;
+
+  public:
+    enum Name
+    {
+      UNKNOWN,
+      SERVICE,
+      VERSION_SERVICE,
+      REQUEST,
+      MAP,
+      FILE_NAME
+    };
+
+    QgsServerParameter( const QgsServerParameter::Name name = QgsServerParameter::UNKNOWN,
+                        const QVariant::Type type = QVariant::String,
+                        const QVariant defaultValue = QVariant( "" ) );
+
+    void raiseError() const;
+
+    static QString name( const QgsServerParameter::Name name );
+    static QgsServerParameter::Name name( const QString &name );
+
+    QgsServerParameter::Name mName;
+};
+
 class QgsServerParameters
 {
 %Docstring
@@ -25,23 +99,6 @@ global parameters received from the client.
     static const QMetaObject staticMetaObject;
 
   public:
-    enum ParameterName
-    {
-      SERVICE,
-      VERSION_SERVICE,
-      REQUEST,
-      MAP,
-      FILE_NAME
-    };
-
-    struct Parameter
-    {
-      ParameterName mName;
-      QVariant::Type mType;
-      QVariant mDefaultValue;
-      QVariant mValue;
-      bool mDefined;
-    };
 
     QgsServerParameters();
 %Docstring
@@ -136,6 +193,9 @@ defined.
 
 :return: version
 %End
+
+  protected:
+    virtual bool loadParameter( const QPair<QString, QString> &item );
 
 };
 

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -55,6 +55,11 @@ the Free Software Foundation; either version 2 of the License, or     *
 
 class QgsServerParameter : QgsServerParameterDefinition
 {
+%Docstring
+Parameter common to all services (WMS, WFS, ...)
+
+.. versionadded:: 3.4
+%End
 
 %TypeHeaderCode
 #include "qgsserverparameters.h"
@@ -76,11 +81,30 @@ class QgsServerParameter : QgsServerParameterDefinition
     QgsServerParameter( const QgsServerParameter::Name name = QgsServerParameter::UNKNOWN,
                         const QVariant::Type type = QVariant::String,
                         const QVariant defaultValue = QVariant( "" ) );
+%Docstring
+Constructor for QgsServerParameter.
+
+:param name: The name of the parameter
+:param type: The type of the parameter
+:param defaultValue: The default value to use if not defined
+%End
 
     void raiseError() const;
+%Docstring
+Raises an error in case of an invalid conversion.
+\throws QgsBadRequestException Invalid parameter exception
+%End
 
     static QString name( const QgsServerParameter::Name name );
+%Docstring
+Converts a parameter's name into its string representation.
+%End
+
     static QgsServerParameter::Name name( const QString &name );
+%Docstring
+Converts a string into a parameter's name (UNKNOWN in case of an
+invalid string).
+%End
 
     QgsServerParameter::Name mName;
 };
@@ -88,8 +112,7 @@ class QgsServerParameter : QgsServerParameterDefinition
 class QgsServerParameters
 {
 %Docstring
-QgsServerParameters provides an interface to retrieve and manipulate
-global parameters received from the client.
+QgsServerParameters provides an interface to retrieve and manipulate global parameters received from the client.
 
 .. versionadded:: 3.4
 %End

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -12,41 +12,145 @@
 class QgsServerParameterDefinition
 {
 %Docstring
-*************************************************************************
+Definition of a parameter with basic conversion methods
 
-This program is free software; you can redistribute it and/or modify  *
-it under the terms of the GNU General Public License as published by  *
-the Free Software Foundation; either version 2 of the License, or     *
-(at your option) any later version.                                   *
-
-**************************************************************************
+.. versionadded:: 3.4
 %End
 
 %TypeHeaderCode
 #include "qgsserverparameters.h"
 %End
   public:
+
     QgsServerParameterDefinition( const QVariant::Type type = QVariant::String,
                                   const QVariant defaultValue = QVariant( "" ) );
+%Docstring
+Constructor for QgsServerParameterDefinition.
+
+:param type: The type of the parameter
+:param defaultValue: The default value of the parameter
+%End
 
     virtual ~QgsServerParameterDefinition();
 
     QString typeName() const;
+%Docstring
+Returns the type of the parameter as a string.
+%End
+
     virtual bool isValid() const;
+%Docstring
+Returns true if the parameter is valid, false otherwise.
+%End
 
     QString toString() const;
+%Docstring
+Converts the parameter into a string.
+%End
+
     QStringList toStringList( char delimiter = ',' ) const;
+%Docstring
+Converts the parameter into a list of strings.
+
+:param delimiter: The character used for delimiting
+
+:return: A list of strings
+%End
+
     QList<int> toIntList( bool &ok, char delimiter = ',' ) const;
+%Docstring
+Converts the parameter into a list of integers.
+
+:param ok: True if there's no error during the conversion, false otherwise
+:param delimiter: The character used for delimiting
+
+:return: A list of integers
+%End
+
     QList<double> toDoubleList( bool &ok, char delimiter = ',' ) const;
+%Docstring
+Converts the parameter into a list of doubles.
+
+:param ok: True if there's no error during the conversion, false otherwise
+:param delimiter: The character used for delimiting
+
+:return: A list of doubles
+%End
+
     QList<QColor> toColorList( bool &ok, char delimiter = ',' ) const;
+%Docstring
+Converts the parameter into a list of colors.
+
+:param ok: True if there's no error during the conversion, false otherwise
+:param delimiter: The character used for delimiting
+
+:return: A list of colors
+%End
+
     QList<QgsGeometry> toGeomList( bool &ok, char delimiter = ',' ) const;
+%Docstring
+Converts the parameter into a list of geometries.
+
+:param ok: True if there's no error during the conversion, false otherwise
+:param delimiter: The character used for delimiting
+
+:return: A list of geometries
+%End
+
     QgsRectangle toRectangle( bool &ok ) const;
+%Docstring
+Converts the parameter into a rectangle.
+
+:param ok: True if there's no error during the conversion, false otherwise
+
+:return: A rectangle
+%End
+
     int toInt( bool &ok ) const;
+%Docstring
+Converts the parameter into an integer.
+
+:param ok: True if there's no error during the conversion, false otherwise
+
+:return: An integer
+%End
+
     double toDouble( bool &ok ) const;
+%Docstring
+Converts the parameter into a double.
+
+:param ok: True if there's no error during the conversion, false otherwise
+
+:return: A double
+%End
+
     bool toBool() const;
+%Docstring
+Converts the parameter into a boolean.
+
+:param ok: True if there's no error during the conversion, false otherwise
+:param delimiter: The character used for delimiting
+
+:return: A boolean
+%End
+
     QColor toColor( bool &ok ) const;
+%Docstring
+Converts the parameter into a color.
+
+:param ok: True if there's no error during the conversion, false otherwise
+:param delimiter: The character used for delimiting
+
+:return: A color
+%End
 
     static void raiseError( const QString &msg );
+%Docstring
+Raises an exception in case of an invalid parameters.
+
+:param msg: The message describing the exception
+            \throws QgsBadRequestException Invalid parameter exception
+%End
 
     QVariant::Type mType;
     QVariant mValue;

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -142,6 +142,13 @@ Removes a parameter.
 %End
 
     void remove( QgsServerParameter::Name name );
+%Docstring
+Removes a parameter.
+
+:param name: The name of the parameter
+
+.. versionadded:: 3.4
+%End
 
     QString value( const QString &key ) const;
 %Docstring
@@ -201,7 +208,12 @@ defined.
 %End
 
   protected:
+
     virtual bool loadParameter( const QString &name, const QString &value );
+%Docstring
+Loads a parameter with a specific value. This method should be
+implemented in subclasses.
+%End
 
 
 };

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -1,0 +1,148 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/server/qgsserverparameters.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsServerParameters
+{
+%Docstring
+QgsServerParameters provides an interface to retrieve and manipulate
+global parameters received from the client.
+
+.. versionadded:: 3.4
+%End
+
+%TypeHeaderCode
+#include "qgsserverparameters.h"
+%End
+  public:
+    static const QMetaObject staticMetaObject;
+
+  public:
+    enum ParameterName
+    {
+      SERVICE,
+      VERSION_SERVICE,
+      REQUEST,
+      MAP,
+      FILE_NAME
+    };
+
+    struct Parameter
+    {
+      ParameterName mName;
+      QVariant::Type mType;
+      QVariant mDefaultValue;
+      QVariant mValue;
+      bool mDefined;
+    };
+
+    QgsServerParameters();
+%Docstring
+Constructor.
+%End
+
+    QgsServerParameters( const QUrlQuery &query );
+%Docstring
+Constructor.
+%End
+
+    void load( const QUrlQuery &query );
+%Docstring
+Loads new parameters.
+
+:param query: url query
+%End
+
+    void clear();
+%Docstring
+Removes all parameters.
+%End
+
+    void add( const QString &key, const QString &value );
+%Docstring
+Adds a parameter.
+
+:param key: the name of the parameter
+:param value: the value of the parameter
+%End
+
+    void remove( const QString &key );
+%Docstring
+Removes a parameter.
+
+:param key: the name of the parameter
+%End
+
+    QString value( const QString &key ) const;
+%Docstring
+Returns the value of a parameter.
+
+:param key: the name of the parameter
+%End
+
+    QUrlQuery urlQuery() const;
+%Docstring
+Returns a url query with underlying parameters.
+%End
+
+    QMap<QString, QString> toMap() const;
+%Docstring
+Returns all parameters in a map.
+%End
+
+    QString service() const;
+%Docstring
+Returns SERVICE parameter as a string or an empty string if not
+defined.
+
+:return: service
+%End
+
+    QString request() const;
+%Docstring
+Returns REQUEST parameter as a string or an empty string if not
+defined.
+
+:return: request
+%End
+
+    QString map() const;
+%Docstring
+Returns MAP parameter as a string or an empty string if not
+defined.
+
+:return: map
+%End
+
+    QString fileName() const;
+%Docstring
+Returns  FILE_NAME parameter as a string or an empty string if not
+defined.
+
+:return: filename
+%End
+
+    QString version() const;
+%Docstring
+Returns VERSION parameter as a string or an empty string if not
+defined.
+
+:return: version
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/server/qgsserverparameters.h                                     *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -195,7 +195,7 @@ defined.
 %End
 
   protected:
-    virtual bool loadParameter( const QPair<QString, QString> &item );
+    virtual bool loadParameter( const QString &name, const QString &value );
 
 
 };

--- a/python/server/auto_generated/qgsserverparameters.sip.in
+++ b/python/server/auto_generated/qgsserverparameters.sip.in
@@ -137,6 +137,8 @@ Removes a parameter.
 :param key: the name of the parameter
 %End
 
+    void remove( QgsServerParameter::Name name );
+
     QString value( const QString &key ) const;
 %Docstring
 Returns the value of a parameter.

--- a/python/server/auto_generated/qgsserverrequest.sip.in
+++ b/python/server/auto_generated/qgsserverrequest.sip.in
@@ -74,6 +74,11 @@ Returns a map of query parameters with keys converted
 to uppercase
 %End
 
+    QgsServerParameters serverParameters() const;
+%Docstring
+Returns parameters
+%End
+
     void setParameter( const QString &key, const QString &value );
 %Docstring
 Set a parameter

--- a/python/server/server_auto.sip
+++ b/python/server/server_auto.sip
@@ -4,6 +4,7 @@
 %Include auto_generated/qgscapabilitiescache.sip
 %Include auto_generated/qgsconfigcache.sip
 %Include auto_generated/qgsserversettings.sip
+%Include auto_generated/qgsserverparameters.sip
 %Include auto_generated/qgsbufferserverrequest.sip
 %Include auto_generated/qgsbufferserverresponse.sip
 %Include auto_generated/qgsrequesthandler.sip

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(QGIS_SERVER_SRCS
   qgsfilterrestorer.cpp
   qgsrequesthandler.cpp
   qgsserver.cpp
+  qgsserverparameters.cpp
   qgsserverexception.cpp
   qgsserverinterface.cpp
   qgsserverinterfaceimpl.cpp
@@ -56,6 +57,7 @@ SET (QGIS_SERVER_MOC_HDRS
   qgsconfigcache.h
   qgsserverlogger.h
   qgsserversettings.h
+  qgsserverparameters.h
 )
 
 

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -303,8 +303,8 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
   {
     try
     {
-      const QgsServerParameters params( request.parameters() );
-      printRequestParameters( request.parameters(), logLevel );
+      const QgsServerParameters params = request.serverParameters();
+      printRequestParameters( params.toMap(), logLevel );
 
       //Config file path
       if ( ! project )

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -38,6 +38,7 @@
 #include "qgsfilterresponsedecorator.h"
 #include "qgsservice.h"
 #include "qgsserverprojectutils.h"
+#include "qgsserverparameters.h"
 
 #include <QDomDocument>
 #include <QNetworkDiskCache>
@@ -135,7 +136,7 @@ void QgsServer::printRequestParameters( const QMap< QString, QString> &parameter
   }
 }
 
-QString QgsServer::configPath( const QString &defaultConfigPath, const QMap<QString, QString> &parameters )
+QString QgsServer::configPath( const QString &defaultConfigPath, const QString &configPath )
 {
   QString cfPath( defaultConfigPath );
   QString projectFile = sSettings.projectFile();
@@ -146,14 +147,13 @@ QString QgsServer::configPath( const QString &defaultConfigPath, const QMap<QStr
   }
   else
   {
-    QMap<QString, QString>::const_iterator paramIt = parameters.find( QStringLiteral( "MAP" ) );
-    if ( paramIt == parameters.constEnd() )
+    if ( configPath.isEmpty() )
     {
       QgsMessageLog::logMessage( QStringLiteral( "Using default configuration file path: %1" ).arg( defaultConfigPath ), QStringLiteral( "Server" ), Qgis::Info );
     }
     else
     {
-      cfPath = paramIt.value();
+      cfPath = configPath;
       QgsDebugMsg( QString( "MAP:%1" ).arg( cfPath ) );
     }
   }
@@ -303,13 +303,13 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
   {
     try
     {
-      QMap<QString, QString> parameterMap = request.parameters();
-      printRequestParameters( parameterMap, logLevel );
+      const QgsServerParameters params( request.parameters() );
+      printRequestParameters( request.parameters(), logLevel );
 
       //Config file path
       if ( ! project )
       {
-        QString configFilePath = configPath( *sConfigFilePath, parameterMap );
+        QString configFilePath = configPath( *sConfigFilePath, params.map() );
 
         // load the project if needed and not empty
         project = mConfigCache->project( configFilePath );
@@ -325,30 +325,14 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
         sServerInterface->setConfigFilePath( project->fileName() );
       }
 
-      //Service parameter
-      QString serviceString = parameterMap.value( QStringLiteral( "SERVICE" ) );
-
-      if ( serviceString.isEmpty() )
+      if ( ! params.fileName().isEmpty() )
       {
-        // SERVICE not mandatory for WMS 1.3.0 GetMap & GetFeatureInfo
-        QString requestString = parameterMap.value( QStringLiteral( "REQUEST" ) );
-        if ( requestString == QLatin1String( "GetMap" ) || requestString == QLatin1String( "GetFeatureInfo" ) )
-        {
-          serviceString = QStringLiteral( "WMS" );
-        }
-      }
-
-      QString versionString = parameterMap.value( QStringLiteral( "VERSION" ) );
-
-      //possibility for client to suggest a download filename
-      QString outputFileName = parameterMap.value( QStringLiteral( "FILE_NAME" ) );
-      if ( !outputFileName.isEmpty() )
-      {
-        requestHandler.setResponseHeader( QStringLiteral( "Content-Disposition" ), "attachment; filename=\"" + outputFileName + "\"" );
+        const QString value = QString( "attachment; filename=\"%1\"" ).arg( params.fileName() );
+        requestHandler.setResponseHeader( QStringLiteral( "Content-Disposition" ), value );
       }
 
       // Lookup for service
-      QgsService *service = sServiceRegistry->getService( serviceString, versionString );
+      QgsService *service = sServiceRegistry->getService( params.service(), params.version() );
       if ( service )
       {
         service->executeRequest( request, responseDecorator, project );

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -106,7 +106,7 @@ class SERVER_EXPORT QgsServer
      * Returns the configuration file path.
      */
     static QString configPath( const QString &defaultConfigPath,
-                               const QMap<QString, QString> &parameters );
+                               const QString &configPath );
 
     /**
      * \brief QgsServer::printRequestParameters prints the request parameters

--- a/src/server/qgsserverexception.h
+++ b/src/server/qgsserverexception.h
@@ -114,6 +114,13 @@ class SERVER_EXPORT QgsOgcServiceException
 class SERVER_EXPORT QgsBadRequestException: public QgsOgcServiceException
 {
   public:
+
+    /**
+     * Constructor for QgsBadRequestException (HTTP error code 400).
+     * \param code Error code name
+     * \param message Exception message to return to the client
+     * \param locator Locator attribute according to OGC specifications
+     */
     QgsBadRequestException( const QString &code, const QString &message, const QString &locator = QString() )
       : QgsOgcServiceException( code, message, locator, 400 )
     {}
@@ -121,4 +128,3 @@ class SERVER_EXPORT QgsBadRequestException: public QgsOgcServiceException
 #endif
 
 #endif
-

--- a/src/server/qgsserverexception.h
+++ b/src/server/qgsserverexception.h
@@ -109,6 +109,7 @@ class SERVER_EXPORT QgsOgcServiceException
  * \ingroup server
  * \class  QgsBadRequestException
  * \brief Exception thrown in case of malformed request
+ * \since QGIS 3.4
  */
 #ifndef SIP_RUN
 class SERVER_EXPORT QgsBadRequestException: public QgsOgcServiceException

--- a/src/server/qgsserverexception.h
+++ b/src/server/qgsserverexception.h
@@ -105,5 +105,20 @@ class SERVER_EXPORT QgsOgcServiceException
     QString mVersion;
 };
 
+/**
+ * \ingroup server
+ * \class  QgsBadRequestException
+ * \brief Exception thrown in case of malformed request
+ */
+#ifndef SIP_RUN
+class SERVER_EXPORT QgsBadRequestException: public QgsOgcServiceException
+{
+  public:
+    QgsBadRequestException( const QString &code, const QString &message, const QString &locator = QString() )
+      : QgsOgcServiceException( code, message, locator, 400 )
+    {}
+};
+#endif
+
 #endif
 

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -260,14 +260,28 @@ QgsServerParameter::QgsServerParameter( const QgsServerParameter::Name name,
 
 QString QgsServerParameter::name( const QgsServerParameter::Name name )
 {
-  const QMetaEnum metaEnum( QMetaEnum::fromType<QgsServerParameter::Name>() );
-  return metaEnum.valueToKey( name );
+  if ( name == QgsServerParameter::VERSION_SERVICE )
+  {
+    return QStringLiteral( "VERSION" );
+  }
+  else
+  {
+    const QMetaEnum metaEnum( QMetaEnum::fromType<QgsServerParameter::Name>() );
+    return metaEnum.valueToKey( name );
+  }
 }
 
 QgsServerParameter::Name QgsServerParameter::name( const QString &name )
 {
-  const QMetaEnum metaEnum( QMetaEnum::fromType<QgsServerParameter::Name>() );
-  return ( QgsServerParameter::Name ) metaEnum.keyToValue( name.toUpper().toStdString().c_str() );
+  if ( name.compare( QStringLiteral( "VERSION" ) ) == 0 )
+  {
+    return QgsServerParameter::VERSION_SERVICE;
+  }
+  else
+  {
+    const QMetaEnum metaEnum( QMetaEnum::fromType<QgsServerParameter::Name>() );
+    return ( QgsServerParameter::Name ) metaEnum.keyToValue( name.toUpper().toStdString().c_str() );
+  }
 }
 
 void QgsServerParameter::raiseError() const
@@ -316,6 +330,11 @@ QUrlQuery QgsServerParameters::urlQuery() const
   }
 
   return query;
+}
+
+void QgsServerParameters::remove( QgsServerParameter::Name name )
+{
+  remove( QgsServerParameter::name( name ) );
 }
 
 void QgsServerParameters::remove( const QString &key )

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -139,24 +139,24 @@ QList<int> QgsServerParameterDefinition::toIntList( bool &ok, const char delimit
   return ints;
 }
 
-QList<float> QgsServerParameterDefinition::toFloatList( bool &ok, const char delimiter ) const
+QList<double> QgsServerParameterDefinition::toDoubleList( bool &ok, const char delimiter ) const
 {
   ok = true;
-  QList<float> floats;
+  QList<double> vals;
 
   for ( const auto &part : toStringList( delimiter ) )
   {
-    const float val = part.toFloat( &ok );
+    const double val = part.toDouble( &ok );
 
     if ( !ok )
     {
-      return QList<float>();
+      return QList<double>();
     }
 
-    floats.append( val );
+    vals.append( val );
   }
 
-  return floats;
+  return vals;
 }
 
 QgsRectangle QgsServerParameterDefinition::toRectangle( bool &ok ) const

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -167,7 +167,7 @@ QMap<QString, QString> QgsServerParameters::toMap() const
 
   for ( auto parameter : mParameters.toStdMap() )
   {
-    if ( ! parameter.second.mDefined )
+    if ( parameter.second.mValue.isNull() )
       continue;
 
     const QString paramName = QgsServerParameter::name( parameter.first );
@@ -205,7 +205,6 @@ void QgsServerParameters::load( const QUrlQuery &query )
     if ( name >= 0 )
     {
       mParameters[name].mValue = item.second;
-      mParameters[name].mDefined = true;
       if ( ! mParameters[name].isValid() )
       {
         mParameters[name].raiseError();

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -1,0 +1,154 @@
+/***************************************************************************
+                              qgsserverparameters.cpp
+                              --------------------
+  begin                : Jun 27, 2018
+  copyright            : (C) 2018 by Paul Blottiere
+  email                : paul dot blottiere at oslandia dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsserverparameters.h"
+#include "qgsserverexception.h"
+
+QgsServerParameters::QgsServerParameters()
+{
+  const Parameter pService = { ParameterName::SERVICE,
+                               QVariant::String,
+                               QVariant( "" ),
+                               QVariant()
+                             };
+  save( pService );
+
+  const Parameter pRequest = { ParameterName::REQUEST,
+                               QVariant::String,
+                               QVariant( "" ),
+                               QVariant()
+                             };
+  save( pRequest );
+
+  const Parameter pVersion = { ParameterName::VERSION_SERVICE,
+                               QVariant::String,
+                               QVariant( "" ),
+                               QVariant()
+                             };
+  save( pService );
+
+  const Parameter pMap = { ParameterName::MAP,
+                           QVariant::String,
+                           QVariant( "" ),
+                           QVariant()
+                         };
+  save( pMap );
+
+  const Parameter pFile = { ParameterName::FILE_NAME,
+                            QVariant::String,
+                            QVariant( "" ),
+                            QVariant()
+                          };
+  save( pFile );
+}
+
+QgsServerParameters::QgsServerParameters( const QgsServerRequest::Parameters &parameters )
+  : QgsServerParameters()
+{
+  load( parameters );
+}
+
+void QgsServerParameters::save( const Parameter &parameter )
+{
+  mParameters[ parameter.mName ] = parameter;
+}
+
+QString QgsServerParameters::map() const
+{
+  return value( ParameterName::MAP ).toString();
+}
+
+QString QgsServerParameters::version() const
+{
+  return value( ParameterName::VERSION_SERVICE ).toString();
+}
+
+QString QgsServerParameters::fileName() const
+{
+  return value( ParameterName::FILE_NAME ).toString();
+}
+
+QString QgsServerParameters::service() const
+{
+  QString serviceValue = value( ParameterName::SERVICE ).toString();
+
+  if ( serviceValue.isEmpty() )
+  {
+    // SERVICE not mandatory for WMS 1.3.0 GetMap & GetFeatureInfo
+    if ( request() == QLatin1String( "GetMap" ) \
+         || request() == QLatin1String( "GetFeatureInfo" ) )
+    {
+      serviceValue = "WMS";
+    }
+  }
+
+  return serviceValue;
+}
+
+QString QgsServerParameters::request() const
+{
+  return value( ParameterName::REQUEST ).toString();
+}
+
+QVariant QgsServerParameters::value( ParameterName name ) const
+{
+  return mParameters[name].mValue;
+}
+
+void QgsServerParameters::load( const QgsServerRequest::Parameters &parameters )
+{
+  const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
+
+  for ( const QString &key : parameters.keys() )
+  {
+    const ParameterName name = ( ParameterName ) metaEnum.keyToValue( key.toStdString().c_str() );
+    if ( name >= 0 )
+    {
+      const QVariant value( parameters[key] );
+      mParameters[name].mValue = value;
+
+      if ( !value.canConvert( mParameters[name].mType ) )
+      {
+        raiseError( name );
+      }
+    }
+    else
+    {
+      mUnmanagedParameters[key] = parameters[key];
+    }
+  }
+}
+
+QString QgsServerParameters::name( ParameterName name ) const
+{
+  const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
+  return metaEnum.valueToKey( name );
+}
+
+void QgsServerParameters::raiseError( ParameterName paramName ) const
+{
+  const QString value = mParameters[paramName].mValue.toString();
+  const QString param = name( paramName );
+  const QString type = QVariant::typeToName( mParameters[paramName].mType );
+  const QString msg = QString( "%1 ('%2') cannot be converted into %3" ).arg( param, value, type );
+  raiseError( msg );
+}
+
+void QgsServerParameters::raiseError( const QString &msg ) const
+{
+  throw QgsBadRequestException( QStringLiteral( "Invalid WMS Parameter" ), msg );
+}

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -431,14 +431,14 @@ void QgsServerParameters::load( const QUrlQuery &query )
         mParameters[name].raiseError();
       }
     }
-    else if ( ! loadParameter( item ) )
+    else if ( ! loadParameter( item.first, item.second ) )
     {
       mUnmanagedParameters[item.first.toUpper()] = item.second;
     }
   }
 }
 
-bool QgsServerParameters::loadParameter( const QPair<QString, QString> & )
+bool QgsServerParameters::loadParameter( const QString &, const QString & )
 {
   return false;
 }

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -438,7 +438,7 @@ void QgsServerParameters::load( const QUrlQuery &query )
   }
 }
 
-bool QgsServerParameters::loadParameter( const QPair<QString, QString> &item )
+bool QgsServerParameters::loadParameter( const QPair<QString, QString> & )
 {
   return false;
 }

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -23,35 +23,40 @@ QgsServerParameters::QgsServerParameters()
   const Parameter pService = { ParameterName::SERVICE,
                                QVariant::String,
                                QVariant( "" ),
-                               QVariant()
+                               QVariant(),
+                               false
                              };
   save( pService );
 
   const Parameter pRequest = { ParameterName::REQUEST,
                                QVariant::String,
                                QVariant( "" ),
-                               QVariant()
+                               QVariant(),
+                               false
                              };
   save( pRequest );
 
   const Parameter pVersion = { ParameterName::VERSION_SERVICE,
                                QVariant::String,
                                QVariant( "" ),
-                               QVariant()
+                               QVariant(),
+                               false
                              };
-  save( pService );
+  save( pVersion );
 
   const Parameter pMap = { ParameterName::MAP,
                            QVariant::String,
                            QVariant( "" ),
-                           QVariant()
+                           QVariant(),
+                           false
                          };
   save( pMap );
 
   const Parameter pFile = { ParameterName::FILE_NAME,
                             QVariant::String,
                             QVariant( "" ),
-                            QVariant()
+                            QVariant(),
+                            false
                           };
   save( pFile );
 }
@@ -142,8 +147,11 @@ QMap<QString, QString> QgsServerParameters::toMap() const
 
   for ( auto parameter : mParameters.toStdMap() )
   {
-    const QString name = metaEnum.valueToKey( parameter.first );
-    params[name] = parameter.second.mValue.toString();
+    if ( ! parameter.second.mDefined )
+      continue;
+
+    const QString paramName = name( parameter.first );
+    params[paramName] = parameter.second.mValue.toString();
   }
 
   return params;
@@ -180,7 +188,7 @@ void QgsServerParameters::load( const QUrlQuery &query )
     {
       const QVariant value( item.second );
       mParameters[paramName].mValue = value;
-
+      mParameters[paramName].mDefined = true;
       if ( !value.canConvert( mParameters[paramName].mType ) )
       {
         raiseError( paramName );

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -166,9 +166,14 @@ QVariant QgsServerParameters::value( ParameterName name ) const
 
 void QgsServerParameters::load( const QUrlQuery &query )
 {
+  // clean query string first
+  QUrlQuery cleanQuery( query );
+  cleanQuery.setQuery( query.query().replace( '+', QStringLiteral( "%20" ) ) );
+
+  // load parameters
   const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
 
-  for ( const auto &item : query.queryItems() )
+  for ( const auto &item : cleanQuery.queryItems( QUrl::FullyDecoded ) )
   {
     const ParameterName paramName = name( item.first );
     if ( paramName >= 0 )

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -126,8 +126,6 @@ class SERVER_EXPORT QgsServerParameterDefinition
 
     /**
      * Converts the parameter into a boolean.
-     * \param ok True if there's no error during the conversion, false otherwise
-     * \param delimiter The character used for delimiting
      * \returns A boolean
      */
     bool toBool() const;
@@ -135,7 +133,6 @@ class SERVER_EXPORT QgsServerParameterDefinition
     /**
      * Converts the parameter into a color.
      * \param ok True if there's no error during the conversion, false otherwise
-     * \param delimiter The character used for delimiting
      * \returns A color
      */
     QColor toColor( bool &ok ) const;

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -127,6 +127,8 @@ class SERVER_EXPORT QgsServerParameters
      */
     void remove( const QString &key );
 
+    void remove( QgsServerParameter::Name name );
+
     /**
      * Returns the value of a parameter.
      * \param key the name of the parameter

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -32,6 +32,8 @@ class SERVER_EXPORT QgsServerParameterDefinition
     QgsServerParameterDefinition( const QVariant::Type type = QVariant::String,
                                   const QVariant defaultValue = QVariant( "" ) );
 
+    virtual ~QgsServerParameterDefinition() = default;
+
     QString typeName() const;
     virtual bool isValid() const;
 
@@ -102,6 +104,8 @@ class SERVER_EXPORT QgsServerParameters
      * Constructor.
      */
     QgsServerParameters( const QUrlQuery &query );
+
+    virtual ~QgsServerParameters() = default;
 
     /**
      * Loads new parameters.

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -22,6 +22,8 @@
 #include <QObject>
 #include <QMetaEnum>
 #include <QUrlQuery>
+#include <QColor>
+#include "qgsgeometry.h"
 #include "qgis_server.h"
 
 class SERVER_EXPORT QgsServerParameterDefinition
@@ -31,8 +33,19 @@ class SERVER_EXPORT QgsServerParameterDefinition
                                   const QVariant defaultValue = QVariant( "" ) );
 
     QString typeName() const;
+    virtual bool isValid() const;
 
-    bool isValid() const;
+    QString toString() const;
+    QStringList toStringList( char delimiter = ',' ) const;
+    QList<int> toIntList( bool &ok, char delimiter = ',' ) const;
+    QList<float> toFloatList( bool &ok, char delimiter = ',' ) const;
+    QList<QColor> toColorList( bool &ok, char delimiter = ',' ) const;
+    QList<QgsGeometry> toGeomList( bool &ok, char delimiter = ',' ) const;
+    QgsRectangle toRectangle( bool &ok ) const;
+    int toInt( bool &ok ) const;
+    double toDouble( bool &ok ) const;
+    bool toBool() const;
+    QColor toColor( bool &ok ) const;
 
     static void raiseError( const QString &msg );
 
@@ -63,7 +76,7 @@ class SERVER_EXPORT QgsServerParameter : public QgsServerParameterDefinition
 
     void raiseError() const;
 
-    static QString name( QgsServerParameter::Name );
+    static QString name( const QgsServerParameter::Name name );
     static QgsServerParameter::Name name( const QString &name );
 
     QgsServerParameter::Name mName;
@@ -164,6 +177,9 @@ class SERVER_EXPORT QgsServerParameters
      * \returns version
      */
     QString version() const;
+
+  protected:
+    virtual bool loadParameter( const QPair<QString, QString> &item );
 
   private:
     void save( const QgsServerParameter &parameter );

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -26,29 +26,125 @@
 #include "qgsgeometry.h"
 #include "qgis_server.h"
 
+/**
+ * \ingroup server
+ * \class QgsServerParameterDefinition
+ * \brief Definition of a parameter with basic conversion methods
+ * \since QGIS 3.4
+ */
 class SERVER_EXPORT QgsServerParameterDefinition
 {
   public:
+
+    /**
+     * Constructor for QgsServerParameterDefinition.
+     * \param type The type of the parameter
+     * \param defaultValue The default value of the parameter
+     */
     QgsServerParameterDefinition( const QVariant::Type type = QVariant::String,
                                   const QVariant defaultValue = QVariant( "" ) );
 
+    /**
+     * Default destructor for QgsServerParameterDefinition.
+     */
     virtual ~QgsServerParameterDefinition() = default;
 
+    /**
+     * Returns the type of the parameter as a string.
+     */
     QString typeName() const;
+
+    /**
+     * Returns true if the parameter is valid, false otherwise.
+     */
     virtual bool isValid() const;
 
+    /**
+     * Converts the parameter into a string.
+     */
     QString toString() const;
+
+    /**
+     * Converts the parameter into a list of strings.
+     * \param delimiter The character used for delimiting
+     * \returns A list of strings
+     */
     QStringList toStringList( char delimiter = ',' ) const;
+
+    /**
+     * Converts the parameter into a list of integers.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \param delimiter The character used for delimiting
+     * \returns A list of integers
+     */
     QList<int> toIntList( bool &ok, char delimiter = ',' ) const;
+
+    /**
+     * Converts the parameter into a list of doubles.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \param delimiter The character used for delimiting
+     * \returns A list of doubles
+     */
     QList<double> toDoubleList( bool &ok, char delimiter = ',' ) const;
+
+    /**
+     * Converts the parameter into a list of colors.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \param delimiter The character used for delimiting
+     * \returns A list of colors
+     */
     QList<QColor> toColorList( bool &ok, char delimiter = ',' ) const;
+
+    /**
+     * Converts the parameter into a list of geometries.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \param delimiter The character used for delimiting
+     * \returns A list of geometries
+     */
     QList<QgsGeometry> toGeomList( bool &ok, char delimiter = ',' ) const;
+
+    /**
+     * Converts the parameter into a rectangle.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \returns A rectangle
+     */
     QgsRectangle toRectangle( bool &ok ) const;
+
+    /**
+     * Converts the parameter into an integer.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \returns An integer
+     */
     int toInt( bool &ok ) const;
+
+    /**
+     * Converts the parameter into a double.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \returns A double
+     */
     double toDouble( bool &ok ) const;
+
+    /**
+     * Converts the parameter into a boolean.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \param delimiter The character used for delimiting
+     * \returns A boolean
+     */
     bool toBool() const;
+
+    /**
+     * Converts the parameter into a color.
+     * \param ok True if there's no error during the conversion, false otherwise
+     * \param delimiter The character used for delimiting
+     * \returns A color
+     */
     QColor toColor( bool &ok ) const;
 
+    /**
+     * Raises an exception in case of an invalid parameters.
+     * \param msg The message describing the exception
+     * \throws QgsBadRequestException Invalid parameter exception
+     */
     static void raiseError( const QString &msg );
 
     QVariant::Type mType;

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -50,6 +50,7 @@ class SERVER_EXPORT QgsServerParameters
       QVariant::Type mType;
       QVariant mDefaultValue;
       QVariant mValue;
+      bool mDefined;
     };
 
     /**

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -181,12 +181,13 @@ class SERVER_EXPORT QgsServerParameters
   protected:
     virtual bool loadParameter( const QPair<QString, QString> &item );
 
+    QMap<QString, QString> mUnmanagedParameters;
+
   private:
     void save( const QgsServerParameter &parameter );
     QVariant value( QgsServerParameter::Name name ) const;
 
     QMap<QgsServerParameter::Name, QgsServerParameter> mParameters;
-    QMap<QString, QString> mUnmanagedParameters;
 };
 
 #endif

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -39,7 +39,6 @@ class SERVER_EXPORT QgsServerParameterDefinition
     QVariant::Type mType;
     QVariant mValue;
     QVariant mDefaultValue;
-    bool mDefined = false;
 };
 
 class SERVER_EXPORT QgsServerParameter : public QgsServerParameterDefinition
@@ -58,7 +57,7 @@ class SERVER_EXPORT QgsServerParameter : public QgsServerParameterDefinition
     };
     Q_ENUM( Name )
 
-    QgsServerParameter( const QgsServerParameter::Name name = Name::UNKNOWN,
+    QgsServerParameter( const QgsServerParameter::Name name = QgsServerParameter::UNKNOWN,
                         const QVariant::Type type = QVariant::String,
                         const QVariant defaultValue = QVariant( "" ) );
 

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -38,7 +38,7 @@ class SERVER_EXPORT QgsServerParameterDefinition
     QString toString() const;
     QStringList toStringList( char delimiter = ',' ) const;
     QList<int> toIntList( bool &ok, char delimiter = ',' ) const;
-    QList<float> toFloatList( bool &ok, char delimiter = ',' ) const;
+    QList<double> toDoubleList( bool &ok, char delimiter = ',' ) const;
     QList<QColor> toColorList( bool &ok, char delimiter = ',' ) const;
     QList<QgsGeometry> toGeomList( bool &ok, char delimiter = ',' ) const;
     QgsRectangle toRectangle( bool &ok ) const;

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -179,7 +179,7 @@ class SERVER_EXPORT QgsServerParameters
     QString version() const;
 
   protected:
-    virtual bool loadParameter( const QPair<QString, QString> &item );
+    virtual bool loadParameter( const QString &name, const QString &value );
 
     QMap<QString, QString> mUnmanagedParameters;
 

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -21,15 +21,15 @@
 #include <QMap>
 #include <QObject>
 #include <QMetaEnum>
-
-#include "qgsserverrequest.h"
+#include <QUrlQuery>
+#include "qgis_server.h"
 
 /**
  * QgsServerParameters provides an interface to retrieve and manipulate
  * global parameters received from the client.
  * \since QGIS 3.4
  */
-class QgsServerParameters
+class SERVER_EXPORT QgsServerParameters
 {
     Q_GADGET
 
@@ -59,15 +59,48 @@ class QgsServerParameters
 
     /**
      * Constructor.
-     * \param map of parameters where keys are parameters' names.
      */
-    QgsServerParameters( const QgsServerRequest::Parameters &parameters );
+    QgsServerParameters( const QUrlQuery &query );
 
     /**
      * Loads new parameters.
-     * \param map of parameters
+     * \param query url query
      */
-    void load( const QgsServerRequest::Parameters &parameters );
+    void load( const QUrlQuery &query );
+
+    /**
+     * Removes all parameters.
+     */
+    void clear();
+
+    /**
+     * Adds a parameter.
+     * \param key the name of the parameter
+     * \param value the value of the parameter
+     */
+    void add( const QString &key, const QString &value );
+
+    /**
+     * Removes a parameter.
+     * \param key the name of the parameter
+     */
+    void remove( const QString &key );
+
+    /**
+     * Returns the value of a parameter.
+     * \param key the name of the parameter
+     */
+    QString value( const QString &key ) const;
+
+    /**
+     * Returns a url query with underlying parameters.
+     */
+    QUrlQuery urlQuery() const;
+
+    /**
+     * Returns all parameters in a map.
+     */
+    QMap<QString, QString> toMap() const;
 
     /**
      * Returns SERVICE parameter as a string or an empty string if not
@@ -107,6 +140,8 @@ class QgsServerParameters
   private:
     void save( const Parameter &parameter );
     QVariant value( ParameterName name ) const;
+
+    ParameterName name( const QString &name ) const;
     QString name( ParameterName name ) const;
 
     void raiseError( ParameterName name ) const;

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -56,11 +56,18 @@ class SERVER_EXPORT QgsServerParameterDefinition
     QVariant mDefaultValue;
 };
 
+/**
+ * \ingroup server
+ * \class QgsServerParameter
+ * \brief Parameter common to all services (WMS, WFS, ...)
+ * \since QGIS 3.4
+ */
 class SERVER_EXPORT QgsServerParameter : public QgsServerParameterDefinition
 {
     Q_GADGET
 
   public:
+    //! Parameter's name common to all services
     enum Name
     {
       UNKNOWN,
@@ -72,21 +79,40 @@ class SERVER_EXPORT QgsServerParameter : public QgsServerParameterDefinition
     };
     Q_ENUM( Name )
 
+    /**
+     * Constructor for QgsServerParameter.
+     * \param name The name of the parameter
+     * \param type The type of the parameter
+     * \param defaultValue The default value to use if not defined
+     */
     QgsServerParameter( const QgsServerParameter::Name name = QgsServerParameter::UNKNOWN,
                         const QVariant::Type type = QVariant::String,
                         const QVariant defaultValue = QVariant( "" ) );
 
+    /**
+     * Raises an error in case of an invalid conversion.
+     * \throws QgsBadRequestException Invalid parameter exception
+     */
     void raiseError() const;
 
+    /**
+     * Converts a parameter's name into its string representation.
+     */
     static QString name( const QgsServerParameter::Name name );
+
+    /**
+     * Converts a string into a parameter's name (UNKNOWN in case of an
+     * invalid string).
+     */
     static QgsServerParameter::Name name( const QString &name );
 
     QgsServerParameter::Name mName;
 };
 
 /**
- * QgsServerParameters provides an interface to retrieve and manipulate
- * global parameters received from the client.
+ * \ingroup server
+ * \class QgsServerParameters
+ * \brief QgsServerParameters provides an interface to retrieve and manipulate global parameters received from the client.
  * \since QGIS 3.4
  */
 class SERVER_EXPORT QgsServerParameters

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -24,6 +24,52 @@
 #include <QUrlQuery>
 #include "qgis_server.h"
 
+class SERVER_EXPORT QgsServerParameterDefinition
+{
+  public:
+    QgsServerParameterDefinition( const QVariant::Type type = QVariant::String,
+                                  const QVariant defaultValue = QVariant( "" ) );
+
+    QString typeName() const;
+
+    bool isValid() const;
+
+    static void raiseError( const QString &msg );
+
+    QVariant::Type mType;
+    QVariant mValue;
+    QVariant mDefaultValue;
+    bool mDefined = false;
+};
+
+class SERVER_EXPORT QgsServerParameter : public QgsServerParameterDefinition
+{
+    Q_GADGET
+
+  public:
+    enum Name
+    {
+      UNKNOWN,
+      SERVICE,
+      VERSION_SERVICE, // conflict with #define VERSION
+      REQUEST,
+      MAP,
+      FILE_NAME
+    };
+    Q_ENUM( Name )
+
+    QgsServerParameter( const QgsServerParameter::Name name = Name::UNKNOWN,
+                        const QVariant::Type type = QVariant::String,
+                        const QVariant defaultValue = QVariant( "" ) );
+
+    void raiseError() const;
+
+    static QString name( QgsServerParameter::Name );
+    static QgsServerParameter::Name name( const QString &name );
+
+    QgsServerParameter::Name mName;
+};
+
 /**
  * QgsServerParameters provides an interface to retrieve and manipulate
  * global parameters received from the client.
@@ -34,24 +80,6 @@ class SERVER_EXPORT QgsServerParameters
     Q_GADGET
 
   public:
-    enum ParameterName
-    {
-      SERVICE,
-      VERSION_SERVICE, // should be VERSION, but there's a conflict with #define VERSION
-      REQUEST,
-      MAP,
-      FILE_NAME
-    };
-    Q_ENUM( ParameterName )
-
-    struct Parameter
-    {
-      ParameterName mName;
-      QVariant::Type mType;
-      QVariant mDefaultValue;
-      QVariant mValue;
-      bool mDefined;
-    };
 
     /**
      * Constructor.
@@ -139,16 +167,10 @@ class SERVER_EXPORT QgsServerParameters
     QString version() const;
 
   private:
-    void save( const Parameter &parameter );
-    QVariant value( ParameterName name ) const;
+    void save( const QgsServerParameter &parameter );
+    QVariant value( QgsServerParameter::Name name ) const;
 
-    ParameterName name( const QString &name ) const;
-    QString name( ParameterName name ) const;
-
-    void raiseError( ParameterName name ) const;
-    void raiseError( const QString &msg ) const;
-
-    QMap<ParameterName, Parameter> mParameters;
+    QMap<QgsServerParameter::Name, QgsServerParameter> mParameters;
     QMap<QString, QString> mUnmanagedParameters;
 };
 

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -131,6 +131,11 @@ class SERVER_EXPORT QgsServerParameters
      */
     void remove( const QString &key );
 
+    /**
+     * Removes a parameter.
+     * \param name The name of the parameter
+     * \since QGIS 3.4
+     */
     void remove( QgsServerParameter::Name name );
 
     /**
@@ -185,6 +190,11 @@ class SERVER_EXPORT QgsServerParameters
     QString version() const;
 
   protected:
+
+    /**
+     * Loads a parameter with a specific value. This method should be
+     * implemented in subclasses.
+     */
     virtual bool loadParameter( const QString &name, const QString &value );
 
     QMap<QString, QString> mUnmanagedParameters;

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -1,0 +1,119 @@
+/***************************************************************************
+                              qgsserverparameters.h
+                              ------------------
+  begin                : Jun 27, 2018
+  copyright            : (C) 2018 by Paul Blottiere
+  email                : paul dot blottiere at oslandia dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSERVERPARAMETERS_H
+#define QGSSERVERPARAMETERS_H
+
+#include <QMap>
+#include <QObject>
+#include <QMetaEnum>
+
+#include "qgsserverrequest.h"
+
+/**
+ * QgsServerParameters provides an interface to retrieve and manipulate
+ * global parameters received from the client.
+ * \since QGIS 3.4
+ */
+class QgsServerParameters
+{
+    Q_GADGET
+
+  public:
+    enum ParameterName
+    {
+      SERVICE,
+      VERSION_SERVICE, // should be VERSION, but there's a conflict with #define VERSION
+      REQUEST,
+      MAP,
+      FILE_NAME
+    };
+    Q_ENUM( ParameterName )
+
+    struct Parameter
+    {
+      ParameterName mName;
+      QVariant::Type mType;
+      QVariant mDefaultValue;
+      QVariant mValue;
+    };
+
+    /**
+     * Constructor.
+     */
+    QgsServerParameters();
+
+    /**
+     * Constructor.
+     * \param map of parameters where keys are parameters' names.
+     */
+    QgsServerParameters( const QgsServerRequest::Parameters &parameters );
+
+    /**
+     * Loads new parameters.
+     * \param map of parameters
+     */
+    void load( const QgsServerRequest::Parameters &parameters );
+
+    /**
+     * Returns SERVICE parameter as a string or an empty string if not
+     * defined.
+     * \returns service
+     */
+    QString service() const;
+
+    /**
+     * Returns REQUEST parameter as a string or an empty string if not
+     * defined.
+     * \returns request
+     */
+    QString request() const;
+
+    /**
+     * Returns MAP parameter as a string or an empty string if not
+     * defined.
+     * \returns map
+     */
+    QString map() const;
+
+    /**
+     * Returns  FILE_NAME parameter as a string or an empty string if not
+     * defined.
+     * \returns filename
+     */
+    QString fileName() const;
+
+    /**
+     * Returns VERSION parameter as a string or an empty string if not
+     * defined.
+     * \returns version
+     */
+    QString version() const;
+
+  private:
+    void save( const Parameter &parameter );
+    QVariant value( ParameterName name ) const;
+    QString name( ParameterName name ) const;
+
+    void raiseError( ParameterName name ) const;
+    void raiseError( const QString &msg ) const;
+
+    QMap<ParameterName, Parameter> mParameters;
+    QMap<QString, QString> mUnmanagedParameters;
+};
+
+#endif

--- a/src/server/qgsserverrequest.h
+++ b/src/server/qgsserverrequest.h
@@ -22,6 +22,7 @@
 #include <QUrl>
 #include <QMap>
 #include "qgis_server.h"
+#include "qgsserverparameters.h"
 
 /**
  * \ingroup server
@@ -97,6 +98,11 @@ class SERVER_EXPORT QgsServerRequest
     QgsServerRequest::Parameters parameters() const;
 
     /**
+     * Returns parameters
+     */
+    QgsServerParameters serverParameters() const;
+
+    /**
      * Set a parameter
      */
     void setParameter( const QString &key, const QString &value );
@@ -159,11 +165,8 @@ class SERVER_EXPORT QgsServerRequest
     Method     mMethod = GetMethod;
     // We mark as mutable in order
     // to support lazy initialization
-    // Use QMap here because it will be faster for small
-    // number of elements
-    mutable bool mDecoded = false;
-    mutable Parameters mParams;
     mutable Headers mHeaders;
+    QgsServerParameters mParams;
 };
 
 #endif

--- a/src/server/services/wfs/qgswfs.cpp
+++ b/src/server/services/wfs/qgswfs.cpp
@@ -64,17 +64,17 @@ namespace QgsWfs
       void executeRequest( const QgsServerRequest &request, QgsServerResponse &response,
                            const QgsProject *project ) override
       {
-        QgsServerRequest::Parameters params = request.parameters();
-        QString versionString = params.value( "VERSION" );
+        const QgsWfsParameters params( QUrlQuery( request.url() ) );
 
         // Set the default version
+        QString versionString = params.version();
         if ( versionString.isEmpty() )
         {
           versionString = version(); // defined in qgswfsutils.h
         }
 
         // Get the request
-        QString req = params.value( QStringLiteral( "REQUEST" ) );
+        const QString req = params.request();
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -54,7 +54,7 @@ namespace QgsWfs
     QDomDocument doc;
 
     QgsServerRequest::Parameters parameters = request.parameters();
-    QgsWfsParameters wfsParameters( parameters );
+    QgsWfsParameters wfsParameters( QUrlQuery( request.url() ) );
     QgsWfsParameters::Format oFormat = wfsParameters.outputFormat();
 
     // test oFormat

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -91,7 +91,7 @@ namespace QgsWfs
     Q_UNUSED( version );
 
     mRequestParameters = request.parameters();
-    mWfsParameters = QgsWfsParameters( mRequestParameters );
+    mWfsParameters = QgsWfsParameters( QUrlQuery( request.url() ) );
     mWfsParameters.dump();
     getFeatureRequest aRequest;
 

--- a/src/server/services/wfs/qgswfsparameters.cpp
+++ b/src/server/services/wfs/qgswfsparameters.cpp
@@ -21,170 +21,204 @@
 
 namespace QgsWfs
 {
+  //
+  // QgsWfsParameter
+  //
+  QgsWfsParameter::QgsWfsParameter( const QgsWfsParameter::Name name,
+                                    const QVariant::Type type,
+                                    const QVariant defaultValue )
+    : QgsServerParameterDefinition( type, defaultValue )
+    , mName( name )
+  {
+  }
+
+  int QgsWfsParameter::toInt() const
+  {
+    bool ok = false;
+    const int val = QgsServerParameterDefinition::toInt( ok );
+
+    if ( !ok )
+    {
+      raiseError();
+    }
+
+    return val;
+  }
+
+  QgsRectangle QgsWfsParameter::toRectangle() const
+  {
+    QString value = toString();
+    const QStringList corners = mValue.toString().split( ',' );
+    if ( corners.size() == 5 )
+    {
+      value = value.chopped( corners[4].size() + 1 );
+    }
+
+    QgsServerParameterDefinition param;
+    param.mValue = QVariant( value );
+
+    bool ok = false;
+    const QgsRectangle rectangle = param.toRectangle( ok );
+
+    if ( !ok )
+    {
+      const QString msg = QString( "%1 ('%2') cannot be converted into rectangle" ).arg( name( mName ), toString() );
+      QgsServerParameterDefinition::raiseError( msg );
+    }
+
+    return rectangle;
+  }
+
+  QStringList QgsWfsParameter::toStringListWithExp( const QString &exp ) const
+  {
+    QStringList theList;
+
+    QString val = mValue.toString();
+    if ( val.isEmpty() )
+      return theList;
+
+    QRegExp rx( exp );
+    if ( rx.indexIn( val, 0 ) == -1 )
+    {
+      theList << val;
+    }
+    else
+    {
+      int pos = 0;
+      while ( ( pos = rx.indexIn( val, pos ) ) != -1 )
+      {
+        theList << rx.cap( 1 );
+        pos += rx.matchedLength();
+      }
+    }
+
+    return theList;
+  }
+
+  void QgsWfsParameter::raiseError() const
+  {
+    const QString msg = QString( "%1 ('%2') cannot be converted into %3" ).arg( name( mName ), toString(), typeName() );
+    QgsServerParameterDefinition::raiseError( msg );
+  }
+
+  QString QgsWfsParameter::name( const QgsWfsParameter::Name name )
+  {
+    const QMetaEnum metaEnum( QMetaEnum::fromType<QgsWfsParameter::Name>() );
+    return metaEnum.valueToKey( name );
+  }
+
+  QgsWfsParameter::Name QgsWfsParameter::name( const QString &name )
+  {
+    const QMetaEnum metaEnum( QMetaEnum::fromType<QgsWfsParameter::Name>() );
+    return ( QgsWfsParameter::Name ) metaEnum.keyToValue( name.toUpper().toStdString().c_str() );
+  }
+
+  //
+  // QgsWfsParameters
+  //
   QgsWfsParameters::QgsWfsParameters()
+    : QgsServerParameters()
   {
     // Available version number
     mVersions.append( QgsProjectVersion( 1, 0, 0 ) );
     mVersions.append( QgsProjectVersion( 1, 1, 0 ) );
 
-    const Parameter pOutputFormat = { ParameterName::OUTPUTFORMAT,
-                                      QVariant::String,
-                                      QVariant( "" ),
-                                      QVariant()
-                                    };
+    const QgsWfsParameter pOutputFormat = QgsWfsParameter( QgsWfsParameter::OUTPUTFORMAT );
     save( pOutputFormat );
 
-    const Parameter pResultType = { ParameterName::RESULTTYPE,
-                                    QVariant::String,
-                                    QVariant( "" ),
-                                    QVariant()
-                                  };
+    const QgsWfsParameter pResultType = QgsWfsParameter( QgsWfsParameter::RESULTTYPE );
     save( pResultType );
 
-    const Parameter pPropertyName = { ParameterName::PROPERTYNAME,
-                                      QVariant::String,
-                                      QVariant( "" ),
-                                      QVariant()
-                                    };
+    const QgsWfsParameter pPropertyName = QgsWfsParameter( QgsWfsParameter::PROPERTYNAME );
     save( pPropertyName );
 
-    const Parameter pMaxFeatures = { ParameterName::MAXFEATURES,
-                                     QVariant::Int,
-                                     QVariant( -1 ),
-                                     QVariant()
-                                   };
+    const QgsWfsParameter pMaxFeatures = QgsWfsParameter( QgsWfsParameter::MAXFEATURES,
+                                         QVariant::Int,
+                                         QVariant( -1 ) );
     save( pMaxFeatures );
 
-    const Parameter pStartIndex = { ParameterName::STARTINDEX,
-                                    QVariant::Int,
-                                    QVariant( 0 ),
-                                    QVariant()
-                                  };
+    const QgsWfsParameter pStartIndex = QgsWfsParameter( QgsWfsParameter::STARTINDEX,
+                                        QVariant::Int,
+                                        QVariant( 0 ) );
     save( pStartIndex );
 
-    const Parameter pSrsName = { ParameterName::SRSNAME,
-                                 QVariant::String,
-                                 QVariant( "" ),
-                                 QVariant()
-                               };
+    const QgsWfsParameter pSrsName = QgsWfsParameter( QgsWfsParameter::SRSNAME );
     save( pSrsName );
 
-    const Parameter pTypeName = { ParameterName::TYPENAME,
-                                  QVariant::String,
-                                  QVariant( "" ),
-                                  QVariant()
-                                };
+    const QgsWfsParameter pTypeName = QgsWfsParameter( QgsWfsParameter::TYPENAME );
     save( pTypeName );
 
-    const Parameter pFeatureId = { ParameterName::FEATUREID,
-                                   QVariant::String,
-                                   QVariant( "" ),
-                                   QVariant()
-                                 };
+    const QgsWfsParameter pFeatureId = QgsWfsParameter( QgsWfsParameter::FEATUREID );
     save( pFeatureId );
 
-    const Parameter pFilter = { ParameterName::FILTER,
-                                QVariant::String,
-                                QVariant( "" ),
-                                QVariant()
-                              };
+    const QgsWfsParameter pFilter = QgsWfsParameter( QgsWfsParameter::FILTER );
     save( pFilter );
 
-    const Parameter pBbox = { ParameterName::BBOX,
-                              QVariant::String,
-                              QVariant( "" ),
-                              QVariant()
-                            };
+    const QgsWfsParameter pBbox = QgsWfsParameter( QgsWfsParameter::BBOX );
     save( pBbox );
 
-    const Parameter pSortBy = { ParameterName::SORTBY,
-                                QVariant::String,
-                                QVariant( "" ),
-                                QVariant()
-                              };
+    const QgsWfsParameter pSortBy = QgsWfsParameter( QgsWfsParameter::SORTBY );
     save( pSortBy );
 
-    const Parameter pExpFilter = { ParameterName::EXP_FILTER,
-                                   QVariant::String,
-                                   QVariant( "" ),
-                                   QVariant()
-                                 };
+    const QgsWfsParameter pExpFilter = QgsWfsParameter( QgsWfsParameter::EXP_FILTER );
     save( pExpFilter );
 
-    const Parameter pGeometryName = { ParameterName::GEOMETRYNAME,
-                                      QVariant::String,
-                                      QVariant( "" ),
-                                      QVariant()
-                                    };
+    const QgsWfsParameter pGeometryName = QgsWfsParameter( QgsWfsParameter::GEOMETRYNAME );
     save( pGeometryName );
   }
 
-  QgsWfsParameters::QgsWfsParameters( const QgsServerRequest::Parameters &parameters ) : QgsWfsParameters()
+  QgsWfsParameters::QgsWfsParameters( const QgsServerParameters &parameters )
+    : QgsWfsParameters()
   {
-    load( parameters );
+    load( parameters.urlQuery() );
   }
 
-  void QgsWfsParameters::load( const QgsServerRequest::Parameters &parameters )
+  bool QgsWfsParameters::loadParameter( const QPair<QString, QString> &parameter )
   {
-    mRequestParameters = parameters;
+    bool loaded = false;
 
-    const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
-    foreach ( QString key, parameters.keys() )
+    const QString key = parameter.first;
+    const QgsWfsParameter::Name name = QgsWfsParameter::name( key );
+    if ( name >= 0 )
     {
-      const ParameterName name = ( ParameterName ) metaEnum.keyToValue( key.toStdString().c_str() );
-      if ( name >= 0 )
+      mWfsParameters[name].mValue = parameter.second;
+      if ( ! mWfsParameters[name].isValid() )
       {
-        QVariant value( parameters[key] );
-        if ( value.canConvert( mParameters[name].mType ) )
-        {
-          mParameters[name].mValue = value;
-        }
-        else
-        {
-          raiseError( name );
-        }
+        mWfsParameters[name].raiseError();
       }
+
+      loaded = true;
     }
+
+    return loaded;
+  }
+
+  void QgsWfsParameters::save( const QgsWfsParameter &parameter )
+  {
+    mWfsParameters[ parameter.mName ] = parameter;
   }
 
   void QgsWfsParameters::dump() const
   {
-    const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
-
     log( "WFS Request parameters:" );
-    for ( auto parameter : mParameters.toStdMap() )
+    for ( auto parameter : mWfsParameters.toStdMap() )
     {
-      const QString value = parameter.second.mValue.toString();
+      const QString value = parameter.second.toString();
 
       if ( ! value.isEmpty() )
       {
-        const QString name = metaEnum.valueToKey( parameter.first );
-        log( " - " + name + " : " + value );
+        const QString name = QgsWfsParameter::name( parameter.first );
+        log( QStringLiteral( " - %1 : %2" ).arg( name, value ) );
       }
     }
 
     if ( !version().isEmpty() )
-      log( " - VERSION : " + version() );
-  }
-
-  void QgsWfsParameters::save( const Parameter &parameter )
-  {
-    mParameters[ parameter.mName ] = parameter;
-  }
-
-  QVariant QgsWfsParameters::value( ParameterName name ) const
-  {
-    return mParameters[name].mValue;
-  }
-
-  QVariant QgsWfsParameters::defaultValue( ParameterName name ) const
-  {
-    return mParameters[name].mDefaultValue;
+      log( QStringLiteral( " - VERSION : %1" ).arg( version() ) );
   }
 
   QString QgsWfsParameters::outputFormatAsString() const
   {
-    return value( ParameterName::OUTPUTFORMAT ).toString();
+    return mWfsParameters[ QgsWfsParameter::OUTPUTFORMAT ].toString();
   }
 
   QgsWfsParameters::Format QgsWfsParameters::outputFormat() const
@@ -223,7 +257,7 @@ namespace QgsWfs
 
   QString QgsWfsParameters::resultTypeAsString() const
   {
-    return value( ParameterName::RESULTTYPE ).toString();
+    return mWfsParameters[ QgsWfsParameter::RESULTTYPE ].toString();
   }
 
   QgsWfsParameters::ResultType QgsWfsParameters::resultType() const
@@ -240,90 +274,72 @@ namespace QgsWfs
 
   QStringList QgsWfsParameters::propertyNames() const
   {
-    return toStringListWithExp( ParameterName::PROPERTYNAME );
+    return mWfsParameters[ QgsWfsParameter::PROPERTYNAME ].toStringListWithExp();
   }
 
   QString QgsWfsParameters::maxFeatures() const
   {
-    return value( ParameterName::MAXFEATURES ).toString();
+    return mWfsParameters[ QgsWfsParameter::MAXFEATURES ].toString();
   }
 
   int QgsWfsParameters::maxFeaturesAsInt() const
   {
-    return toInt( ParameterName::MAXFEATURES );
+    return mWfsParameters[ QgsWfsParameter::MAXFEATURES ].toInt();
   }
 
   QString QgsWfsParameters::startIndex() const
   {
-    return value( ParameterName::STARTINDEX ).toString();
+    return mWfsParameters[ QgsWfsParameter::STARTINDEX ].toString();
   }
 
   int QgsWfsParameters::startIndexAsInt() const
   {
-    return toInt( ParameterName::STARTINDEX );
+    return mWfsParameters[ QgsWfsParameter::STARTINDEX ].toInt();
   }
 
   QString QgsWfsParameters::srsName() const
   {
-    return value( ParameterName::SRSNAME ).toString();
+    return mWfsParameters[ QgsWfsParameter::SRSNAME ].toString();
   }
 
   QStringList QgsWfsParameters::typeNames() const
   {
-    return toStringList( ParameterName::TYPENAME );
+    return mWfsParameters[ QgsWfsParameter::TYPENAME ].toStringList();
   }
 
   QStringList QgsWfsParameters::featureIds() const
   {
-    return toStringList( ParameterName::FEATUREID );
+    return mWfsParameters[ QgsWfsParameter::FEATUREID ].toStringList();
   }
 
   QStringList QgsWfsParameters::filters() const
   {
-    return toStringListWithExp( ParameterName::FILTER );
+    return mWfsParameters[ QgsWfsParameter::FILTER ].toStringListWithExp();
   }
 
   QString QgsWfsParameters::bbox() const
   {
-    return value( ParameterName::BBOX ).toString();
+    return mWfsParameters[ QgsWfsParameter::BBOX ].toString();
   }
 
   QgsRectangle QgsWfsParameters::bboxAsRectangle() const
   {
-    return toRectangle( ParameterName::BBOX );
+    return mWfsParameters[ QgsWfsParameter::BBOX ].toRectangle();
   }
 
   QStringList QgsWfsParameters::sortBy() const
   {
-    return toStringListWithExp( ParameterName::SORTBY );
+    return mWfsParameters[ QgsWfsParameter::SORTBY ].toStringListWithExp();
   }
 
   QStringList QgsWfsParameters::expFilters() const
   {
-    return toStringListWithExp( ParameterName::EXP_FILTER );
+    return mWfsParameters[ QgsWfsParameter::EXP_FILTER ].toStringListWithExp();
   }
 
   QString QgsWfsParameters::geometryNameAsString() const
   {
-    return value( ParameterName::GEOMETRYNAME ).toString();
-  }
-
-  QString QgsWfsParameters::request() const
-  {
-    if ( mRequestParameters.contains( "REQUEST" ) )
-      return mRequestParameters["REQUEST"];
-    else
-      return QString();
-  }
-
-  QString QgsWfsParameters::version() const
-  {
-    // VERSION parameter is not managed with other parameters because
-    // there's a conflict with qgis VERSION defined in qgsconfig.h
-    if ( mRequestParameters.contains( "VERSION" ) )
-      return mRequestParameters["VERSION"];
-    else
-      return QString();
+    return mWfsParameters[ QgsWfsParameter::GEOMETRYNAME ].toString();
   }
 
   QgsProjectVersion QgsWfsParameters::versionAsNumber() const
@@ -339,141 +355,8 @@ namespace QgsWfs
     return version;
   }
 
-  QString QgsWfsParameters::name( ParameterName name ) const
-  {
-    const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
-    return metaEnum.valueToKey( name );
-  }
-
-  int QgsWfsParameters::toInt( const QVariant &value, const QVariant &defaultValue, bool *error ) const
-  {
-    int val = defaultValue.toInt();
-    QString valStr = value.toString();
-    bool ok = true;
-
-    if ( !valStr.isEmpty() )
-    {
-      val = value.toInt( &ok );
-    }
-    *error = !ok;
-
-    return val;
-  }
-
-  int QgsWfsParameters::toInt( ParameterName p ) const
-  {
-    bool error;
-    int val = toInt( value( p ), defaultValue( p ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + " ('" + valStr + "') cannot be converted into int";
-      raiseError( msg );
-    }
-
-    return val;
-  }
-
-  QgsRectangle QgsWfsParameters::toRectangle( const QVariant &value, bool *error ) const
-  {
-    *error = false;
-    QString bbox = value.toString();
-    QgsRectangle extent;
-
-    if ( !bbox.isEmpty() )
-    {
-      QStringList corners = bbox.split( ',' );
-      // We need at least 4 elements, an optional fifth could be the CRS in WFS 1.1.0 BBOX
-      if ( corners.size() >= 4 )
-      {
-        double d[4];
-        bool ok;
-
-        for ( int i = 0; i < 4; i++ )
-        {
-          corners[i].replace( QLatin1String( " " ), QLatin1String( "+" ) );
-          d[i] = corners[i].toDouble( &ok );
-          if ( !ok )
-          {
-            *error = !ok;
-            return extent;
-          }
-        }
-
-        extent = QgsRectangle( d[0], d[1], d[2], d[3] );
-
-      }
-      else
-      {
-        *error = true;
-        return extent;
-      }
-    }
-
-    return extent;
-  }
-
-  QgsRectangle QgsWfsParameters::toRectangle( ParameterName p ) const
-  {
-    bool error;
-    QgsRectangle extent = toRectangle( value( p ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + " ('" + valStr + "') cannot be converted into a rectangle";
-      raiseError( msg );
-    }
-
-    return extent;
-  }
-
-  QStringList QgsWfsParameters::toStringList( ParameterName p, char delimiter ) const
-  {
-    return value( p ).toString().split( delimiter, QString::SkipEmptyParts );
-  }
-
-  QStringList QgsWfsParameters::toStringListWithExp( ParameterName p, const QString &exp ) const
-  {
-    QStringList theList;
-
-    QString val = value( p ).toString();
-    if ( val.isEmpty() )
-      return theList;
-
-    QRegExp rx( exp );
-    if ( rx.indexIn( val, 0 ) == -1 )
-    {
-      theList << val;
-    }
-    else
-    {
-      int pos = 0;
-      while ( ( pos = rx.indexIn( val, pos ) ) != -1 )
-      {
-        theList << rx.cap( 1 );
-        pos += rx.matchedLength();
-      }
-    }
-    return theList;
-  }
-
   void QgsWfsParameters::log( const QString &msg ) const
   {
     QgsMessageLog::logMessage( msg, "Server", Qgis::Info );
-  }
-
-  void QgsWfsParameters::raiseError( ParameterName paramName ) const
-  {
-    const QString value = mParameters[paramName].mValue.toString();
-    const QString param = name( paramName );
-    const QString type = QVariant::typeToName( mParameters[paramName].mType );
-    raiseError( param + " ('" + value + "') cannot be converted into " + type );
-  }
-
-  void QgsWfsParameters::raiseError( const QString &msg ) const
-  {
-    throw QgsBadRequestException( QStringLiteral( "Invalid WFS Parameter" ), msg );
   }
 }

--- a/src/server/services/wfs/qgswfsparameters.cpp
+++ b/src/server/services/wfs/qgswfsparameters.cpp
@@ -173,15 +173,14 @@ namespace QgsWfs
     load( parameters.urlQuery() );
   }
 
-  bool QgsWfsParameters::loadParameter( const QPair<QString, QString> &parameter )
+  bool QgsWfsParameters::loadParameter( const QString &key, const QString &value )
   {
     bool loaded = false;
 
-    const QString key = parameter.first;
     const QgsWfsParameter::Name name = QgsWfsParameter::name( key );
     if ( name >= 0 )
     {
-      mWfsParameters[name].mValue = parameter.second;
+      mWfsParameters[name].mValue = value;
       if ( ! mWfsParameters[name].isValid() )
       {
         mWfsParameters[name].raiseError();

--- a/src/server/services/wfs/qgswfsparameters.cpp
+++ b/src/server/services/wfs/qgswfsparameters.cpp
@@ -51,7 +51,7 @@ namespace QgsWfs
     const QStringList corners = mValue.toString().split( ',' );
     if ( corners.size() == 5 )
     {
-      value = value.chopped( corners[4].size() + 1 );
+      value.resize( value.size() - corners[4].size() - 1 );
     }
 
     QgsServerParameterDefinition param;

--- a/src/server/services/wfs/qgswfsparameters.h
+++ b/src/server/services/wfs/qgswfsparameters.h
@@ -152,21 +152,17 @@ namespace QgsWfs
        * Constructor for WFS parameters with specific values.
        * \param parameters Map of parameters where keys are parameters' names.
        */
-      // QgsWfsParameters( const QgsServerRequest::Parameters &parameters );
       QgsWfsParameters( const QgsServerParameters &parameters );
 
       /**
        * Constructor for WFS parameters with default values only.
-        */
+       */
       QgsWfsParameters();
 
-      virtual ~QgsWfsParameters() = default;
-
       /**
-       * Loads new parameters.
-       * \param parameters Map of parameters
+       * Default destructor for QgsWfsParameters.
        */
-      // void load( const QgsServerRequest::Parameters &parameters );
+      virtual ~QgsWfsParameters() = default;
 
       /**
        * Dumps parameters.

--- a/src/server/services/wfs/qgswfsparameters.h
+++ b/src/server/services/wfs/qgswfsparameters.h
@@ -263,7 +263,7 @@ namespace QgsWfs
       QString geometryNameAsString() const;
 
     private:
-      bool loadParameter( const QPair<QString, QString> &parameter ) override;
+      bool loadParameter( const QString &name, const QString &key ) override;
       void save( const QgsWfsParameter &parameter );
 
       void log( const QString &msg ) const;

--- a/src/server/services/wfs/qgswfsparameters.h
+++ b/src/server/services/wfs/qgswfsparameters.h
@@ -33,9 +33,9 @@ namespace QgsWfs
 
   /**
    * \ingroup server
-   * \class QgsWfs::QgsWfsParameters
-   * \brief Provides an interface to retrieve and manipulate WFS parameters received from the client.
-   * \since QGIS 3.0
+   * \class QgsWfs::QgsWfsParameter
+   * \brief WFS parameter received from the client.
+   * \since QGIS 3.4
    */
   class QgsWfsParameter : public QgsServerParameterDefinition
   {
@@ -62,24 +62,69 @@ namespace QgsWfs
       };
       Q_ENUM( Name )
 
+      /**
+       * Constructor for QgsWfsParameter.
+      * \param name Name of the WMS parameter
+      * \param type Type of the parameter
+      * \param defaultValue Default value of the parameter
+       */
       QgsWfsParameter( const QgsWfsParameter::Name name = QgsWfsParameter::UNKNOWN,
                        const QVariant::Type type = QVariant::String,
                        const QVariant defaultValue = QVariant( "" ) );
 
+      /**
+       * Default destructor for QgsWfsParameter.
+       */
       virtual ~QgsWfsParameter() = default;
 
+      /**
+       * Converts the parameter into an integer.
+       * \returns An integer
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       int toInt() const;
+
+      /**
+       * Converts the parameter into a list of string.
+       * \param exp The expression to use for splitting
+       * \returns A list of strings
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       QStringList toStringListWithExp( const QString &exp = "\\(([^()]+)\\)" ) const;
+
+      /**
+       * Converts the parameter into a rectangle.
+       * \returns A rectangle
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       QgsRectangle toRectangle() const;
 
+      /**
+       * Raises an error in case of an invalid conversion.
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       void raiseError() const;
 
+      /**
+       * Converts a parameter's name into its string representation.
+       */
       static QString name( const QgsWfsParameter::Name );
+
+      /**
+       * Converts a string into a parameter's name (UNKNOWN in case of an
+       * invalid string).
+       */
       static QgsWfsParameter::Name name( const QString &name );
 
       QgsWfsParameter::Name mName;
   };
 
+  /**
+   * \ingroup server
+   * \class QgsWfs::QgsWfsParameters
+   * \brief Provides an interface to retrieve and manipulate WFS parameters received from the client.
+   * \since QGIS 3.0
+   */
   class QgsWfsParameters : public QgsServerParameters
   {
       Q_GADGET

--- a/src/server/services/wfs/qgswfsparameters.h
+++ b/src/server/services/wfs/qgswfsparameters.h
@@ -121,26 +121,12 @@ namespace QgsWfs
        * Loads new parameters.
        * \param parameters Map of parameters
        */
-      void load( const QgsServerRequest::Parameters &parameters );
+      // void load( const QgsServerRequest::Parameters &parameters );
 
       /**
        * Dumps parameters.
        */
       void dump() const;
-
-      /**
-       * Returns REQUEST parameter as a string or an empty string if not
-       * defined.
-       * \returns request
-       */
-      QString request() const;
-
-      /**
-       * Returns VERSION parameter as a string or an empty string if not
-       * defined.
-       * \returns version
-       */
-      QString version() const;
 
       /**
        * Returns VERSION parameter if defined or its default value.

--- a/src/server/services/wfs/qgswfsparameters.h
+++ b/src/server/services/wfs/qgswfsparameters.h
@@ -66,6 +66,8 @@ namespace QgsWfs
                        const QVariant::Type type = QVariant::String,
                        const QVariant defaultValue = QVariant( "" ) );
 
+      virtual ~QgsWfsParameter() = default;
+
       int toInt() const;
       QStringList toStringListWithExp( const QString &exp = "\\(([^()]+)\\)" ) const;
       QgsRectangle toRectangle() const;
@@ -112,6 +114,8 @@ namespace QgsWfs
        * Constructor for WFS parameters with default values only.
         */
       QgsWfsParameters();
+
+      virtual ~QgsWfsParameters() = default;
 
       /**
        * Loads new parameters.

--- a/src/server/services/wfs/qgswfsutils.cpp
+++ b/src/server/services/wfs/qgswfsutils.cpp
@@ -24,6 +24,7 @@
 #include "qgsogcutils.h"
 #include "qgsconfigcache.h"
 #include "qgsserverprojectutils.h"
+#include "qgswfsparameters.h"
 
 namespace QgsWfs
 {
@@ -44,14 +45,14 @@ namespace QgsWfs
     if ( href.isEmpty() )
     {
       QUrl url = request.url();
-      QUrlQuery q( url );
 
-      q.removeAllQueryItems( QStringLiteral( "REQUEST" ) );
-      q.removeAllQueryItems( QStringLiteral( "VERSION" ) );
-      q.removeAllQueryItems( QStringLiteral( "SERVICE" ) );
-      q.removeAllQueryItems( QStringLiteral( "_DC" ) );
+      QgsWfsParameters params;
+      params.load( QUrlQuery( url ) );
+      params.remove( QgsServerParameter::REQUEST );
+      params.remove( QgsServerParameter::VERSION_SERVICE );
+      params.remove( QgsServerParameter::SERVICE );
 
-      url.setQuery( q );
+      url.setQuery( params.urlQuery() );
       href = url.toString( QUrl::FullyDecoded );
     }
 

--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -54,7 +54,9 @@ namespace QgsWms
     Q_UNUSED( version );
 
     QgsServerRequest::Parameters params = request.parameters();
-    QgsRenderer renderer( serverIface, project, params );
+
+    QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
+    QgsRenderer renderer( serverIface, project, wmsParameters );
 
     QMap<QString, QString> formatOptionsMap = parseFormatOptions( params.value( QStringLiteral( "FORMAT_OPTIONS" ) ) );
 

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -31,6 +31,7 @@
 #include "qgswmsgetfeatureinfo.h"
 #include "qgswmsdescribelayer.h"
 #include "qgswmsgetlegendgraphics.h"
+#include "qgswmsparameters.h"
 
 #define QSTR_COMPARE( str, lit )\
   (str.compare( QStringLiteral( lit ), Qt::CaseInsensitive ) == 0)
@@ -69,83 +70,85 @@ namespace QgsWms
       void executeRequest( const QgsServerRequest &request, QgsServerResponse &response,
                            const QgsProject *project ) override
       {
-        QgsServerRequest::Parameters params = request.parameters();
-        QString versionString = params.value( "VERSION" );
-        if ( versionString.isEmpty() )
+        const QgsWmsParameters parameters( QUrlQuery( request.url() ) );
+
+        QString version = parameters.version();
+        if ( version.isEmpty() )
         {
-          //WMTVER needs to be supported by WMS 1.1.1 for backwards compatibility with WMS 1.0.0
-          versionString = params.value( "WMTVER" );
+          // WMTVER needs to be supported by WMS 1.1.1 for backwards
+          // compatibility with WMS 1.0.0
+          version = parameters.wmtver();
         }
 
         // Set the default version
-        const bool valid = versionString.compare( "1.1.1" ) == 0 || versionString.compare( "1.3.0" ) == 0;
-        if ( versionString.isEmpty() || !valid )
+        if ( version.isEmpty() || !parameters.versionIsValid( version ) )
         {
-          versionString = mVersion;
+          version = mVersion;
         }
 
         // Get the request
-        QString req = params.value( QStringLiteral( "REQUEST" ) );
+        const QString req = parameters.request();
         if ( req.isEmpty() )
         {
           throw QgsServiceException( QStringLiteral( "OperationNotSupported" ),
                                      QStringLiteral( "Please check the value of the REQUEST parameter" ) );
         }
 
-        if ( ( QSTR_COMPARE( mVersion, "1.1.1" ) && QSTR_COMPARE( req, "capabilities" ) )
-             || QSTR_COMPARE( req, "GetCapabilities" ) )
+        if ( ( mVersion.compare( QStringLiteral( "1.1.1" ) ) == 0 \
+               && req.compare( QStringLiteral( "capabilities" ) ) == 0 )
+             || req.compare( QStringLiteral( "GetCapabilities" ) ) == 0 )
         {
-          writeGetCapabilities( mServerIface, project, versionString, request, response, false );
+          writeGetCapabilities( mServerIface, project, version, request, response, false );
         }
         else if ( QSTR_COMPARE( req, "GetProjectSettings" ) )
         {
           //getProjectSettings extends WMS 1.3.0 capabilities
-          versionString = QStringLiteral( "1.3.0" );
-          writeGetCapabilities( mServerIface, project, versionString, request, response, true );
+          version = QStringLiteral( "1.3.0" );
+          writeGetCapabilities( mServerIface, project, version, request, response, true );
         }
         else if ( QSTR_COMPARE( req, "GetMap" ) )
         {
-          QString format = params.value( QStringLiteral( "FORMAT" ) );
+          QString format = parameters.formatAsString();
           if QSTR_COMPARE( format, "application/dxf" )
           {
-            writeAsDxf( mServerIface, project, versionString, request, response );
+            writeAsDxf( mServerIface, project, version, request, response );
           }
           else
           {
-            writeGetMap( mServerIface, project, versionString, request, response );
+            writeGetMap( mServerIface, project, version, request, response );
           }
         }
         else if ( QSTR_COMPARE( req, "GetFeatureInfo" ) )
         {
-          writeGetFeatureInfo( mServerIface, project, versionString, request, response );
+          writeGetFeatureInfo( mServerIface, project, version, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetContext" ) )
         {
-          writeGetContext( mServerIface, project, versionString, request, response );
+          writeGetContext( mServerIface, project, version, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetSchemaExtension" ) )
         {
-          writeGetSchemaExtension( mServerIface, versionString, request, response );
+          writeGetSchemaExtension( mServerIface, version, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetStyle" ) )
         {
-          writeGetStyle( mServerIface, project, versionString, request, response );
+          writeGetStyle( mServerIface, project, version, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetStyles" ) )
         {
-          writeGetStyles( mServerIface, project, versionString, request, response );
+          writeGetStyles( mServerIface, project, version, request, response );
         }
         else if ( QSTR_COMPARE( req, "DescribeLayer" ) )
         {
-          writeDescribeLayer( mServerIface, project, versionString, request, response );
+          writeDescribeLayer( mServerIface, project, version, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetLegendGraphic" ) || QSTR_COMPARE( req, "GetLegendGraphics" ) )
         {
-          writeGetLegendGraphics( mServerIface, project, versionString, request, response );
+          writeGetLegendGraphics( mServerIface, project, version, request, response );
         }
         else if ( QSTR_COMPARE( req, "GetPrint" ) )
         {
-          writeGetPrint( mServerIface, project, versionString, request, response );
+          writeGetPrint( mServerIface, project, version, request, response );
         }
         else
         {

--- a/src/server/services/wms/qgswmsgetfeatureinfo.cpp
+++ b/src/server/services/wms/qgswmsgetfeatureinfo.cpp
@@ -31,7 +31,9 @@ namespace QgsWms
   {
     Q_UNUSED( version );
     QgsServerRequest::Parameters params = request.parameters();
-    QgsRenderer renderer( serverIface, project, params );
+
+    QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
+    QgsRenderer renderer( serverIface, project, wmsParameters );
 
     QString infoFormat = params.value( QStringLiteral( "INFO_FORMAT" ), QStringLiteral( "text/plain" ) );
 

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -34,7 +34,9 @@ namespace QgsWms
     Q_UNUSED( version );
 
     QgsServerRequest::Parameters params = request.parameters();
-    QgsRenderer renderer( serverIface, project, params );
+
+    QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
+    QgsRenderer renderer( serverIface, project, wmsParameters );
 
     std::unique_ptr<QImage> result( renderer.getLegendGraphics() );
 

--- a/src/server/services/wms/qgswmsgetmap.cpp
+++ b/src/server/services/wms/qgswmsgetmap.cpp
@@ -34,7 +34,9 @@ namespace QgsWms
     Q_UNUSED( version );
 
     QgsServerRequest::Parameters params = request.parameters();
-    QgsRenderer renderer( serverIface, project, params );
+
+    QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
+    QgsRenderer renderer( serverIface, project, wmsParameters );
 
     std::unique_ptr<QImage> result( renderer.getMap() );
     if ( result )

--- a/src/server/services/wms/qgswmsgetprint.cpp
+++ b/src/server/services/wms/qgswmsgetprint.cpp
@@ -32,7 +32,8 @@ namespace QgsWms
 
     Q_UNUSED( version );
 
-    QgsRenderer renderer( serverIface, project, params );
+    QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
+    QgsRenderer renderer( serverIface, project, wmsParameters );
 
     QString format = params.value( "FORMAT" );
     QString contentType;

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -472,11 +472,10 @@ namespace QgsWms
     load( parameters.urlQuery() );
   }
 
-  bool QgsWmsParameters::loadParameter( const QPair<QString, QString> &parameter )
+  bool QgsWmsParameters::loadParameter( const QString &key, const QString &value )
   {
     bool loaded = false;
 
-    const QString key = parameter.first;
     const QRegExp composerParamRegExp( QStringLiteral( "^MAP\\d+:" ) );
     if ( key.contains( composerParamRegExp ) )
     {
@@ -487,7 +486,7 @@ namespace QgsWms
       if ( name >= 0 )
       {
         QgsWmsParameter param = mWmsParameters[name];
-        param.mValue = parameter.second;
+        param.mValue = value;
         param.mId = mapId;
 
         if ( ! param.isValid() )
@@ -504,7 +503,7 @@ namespace QgsWms
       const QgsWmsParameter::Name name = QgsWmsParameter::name( key );
       if ( name >= 0 )
       {
-        mWmsParameters[name].mValue = parameter.second;
+        mWmsParameters[name].mValue = value;
         if ( ! mWmsParameters[name].isValid() )
         {
           mWmsParameters[name].raiseError();
@@ -519,7 +518,7 @@ namespace QgsWms
         {
           QString id = key.left( separator );
           QString param = key.right( key.length() - separator - 1 );
-          mExternalWMSParameters[id].insert( param, parameter.second );
+          mExternalWMSParameters[id].insert( param, value );
 
           loaded = true;
         }

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -126,10 +126,10 @@ namespace QgsWms
     return vals;
   }
 
-  QList<float> QgsWmsParameter::toFloatList( const char delimiter ) const
+  QList<double> QgsWmsParameter::toDoubleList( const char delimiter ) const
   {
     bool ok = false;
-    const QList<float> vals = QgsServerParameterDefinition::toFloatList( ok, delimiter );
+    const QList<double> vals = QgsServerParameterDefinition::toDoubleList( ok, delimiter );
 
     if ( !ok )
     {
@@ -216,9 +216,7 @@ namespace QgsWms
                                          QVariant( 2.0 ) );
     save( pIcLabelSpace );
 
-    const QgsWmsParameter pItFontFamily( QgsWmsParameter::ITEMFONTFAMILY,
-                                         QVariant::String,
-                                         QVariant( "" ) );
+    const QgsWmsParameter pItFontFamily( QgsWmsParameter::ITEMFONTFAMILY );
     save( pItFontFamily );
 
     const QgsWmsParameter pItFontBold( QgsWmsParameter::ITEMFONTBOLD,
@@ -241,9 +239,7 @@ namespace QgsWms
                                         QVariant( "black" ) );
     save( pItFontColor );
 
-    const QgsWmsParameter pHighlightGeom( QgsWmsParameter::HIGHLIGHT_GEOM,
-                                          QVariant::String,
-                                          QVariant( "" ) );
+    const QgsWmsParameter pHighlightGeom( QgsWmsParameter::HIGHLIGHT_GEOM );
     save( pHighlightGeom );
 
     const QgsWmsParameter pShowFeatureCount( QgsWmsParameter::SHOWFEATURECOUNT,
@@ -251,14 +247,10 @@ namespace QgsWms
         QVariant( false ) );
     save( pShowFeatureCount );
 
-    const QgsWmsParameter pHighlightSymbol( QgsWmsParameter::HIGHLIGHT_SYMBOL,
-                                            QVariant::String,
-                                            QVariant( "" ) );
+    const QgsWmsParameter pHighlightSymbol( QgsWmsParameter::HIGHLIGHT_SYMBOL );
     save( pHighlightSymbol );
 
-    const QgsWmsParameter pHighlightLabel( QgsWmsParameter::HIGHLIGHT_LABELSTRING,
-                                           QVariant::String,
-                                           QVariant( "" ) );
+    const QgsWmsParameter pHighlightLabel( QgsWmsParameter::HIGHLIGHT_LABELSTRING );
     save( pHighlightLabel );
 
     const QgsWmsParameter pHighlightColor( QgsWmsParameter::HIGHLIGHT_LABELCOLOR,
@@ -266,19 +258,13 @@ namespace QgsWms
                                            QVariant( "black" ) );
     save( pHighlightColor );
 
-    const QgsWmsParameter pHighlightFontSize( QgsWmsParameter::HIGHLIGHT_LABELSIZE,
-        QVariant::String,
-        QVariant( "" ) );
+    const QgsWmsParameter pHighlightFontSize( QgsWmsParameter::HIGHLIGHT_LABELSIZE );
     save( pHighlightFontSize );
 
-    const QgsWmsParameter pHighlightFontWeight( QgsWmsParameter::HIGHLIGHT_LABELWEIGHT,
-        QVariant::String,
-        QVariant( "" ) );
+    const QgsWmsParameter pHighlightFontWeight( QgsWmsParameter::HIGHLIGHT_LABELWEIGHT );
     save( pHighlightFontWeight );
 
-    const QgsWmsParameter pHighlightFont( QgsWmsParameter::HIGHLIGHT_LABELFONT,
-                                          QVariant::String,
-                                          QVariant( "" ) );
+    const QgsWmsParameter pHighlightFont( QgsWmsParameter::HIGHLIGHT_LABELFONT );
     save( pHighlightFont );
 
     const QgsWmsParameter pHighlightBufferColor( QgsWmsParameter::HIGHLIGHT_LABELBUFFERCOLOR,
@@ -286,29 +272,19 @@ namespace QgsWms
         QVariant( "black" ) );
     save( pHighlightBufferColor );
 
-    const QgsWmsParameter pHighlightBufferSize( QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE,
-        QVariant::String,
-        QVariant( "" ) );
+    const QgsWmsParameter pHighlightBufferSize( QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE );
     save( pHighlightBufferSize );
 
-    const QgsWmsParameter pCRS( QgsWmsParameter::CRS,
-                                QVariant::String,
-                                QVariant( "" ) );
+    const QgsWmsParameter pCRS( QgsWmsParameter::CRS );
     save( pCRS );
 
-    const QgsWmsParameter pSRS( QgsWmsParameter::SRS,
-                                QVariant::String,
-                                QVariant( "" ) );
+    const QgsWmsParameter pSRS( QgsWmsParameter::SRS );
     save( pSRS );
 
-    const QgsWmsParameter pFormat( QgsWmsParameter::FORMAT,
-                                   QVariant::String,
-                                   QVariant( "" ) );
+    const QgsWmsParameter pFormat( QgsWmsParameter::FORMAT );
     save( pFormat );
 
-    const QgsWmsParameter pInfoFormat( QgsWmsParameter::INFO_FORMAT,
-                                       QVariant::String,
-                                       QVariant( "" ) );
+    const QgsWmsParameter pInfoFormat( QgsWmsParameter::INFO_FORMAT );
     save( pInfoFormat );
 
     const QgsWmsParameter pI( QgsWmsParameter::I,
@@ -331,9 +307,7 @@ namespace QgsWms
                               QVariant( -1 ) );
     save( pY );
 
-    const QgsWmsParameter pRule( QgsWmsParameter::RULE,
-                                 QVariant::String,
-                                 QVariant( "" ) );
+    const QgsWmsParameter pRule( QgsWmsParameter::RULE );
     save( pRule );
 
     const QgsWmsParameter pRuleLabel( QgsWmsParameter::RULELABEL,
@@ -356,29 +330,19 @@ namespace QgsWms
                                   QVariant( 0 ) );
     save( pWidth );
 
-    const QgsWmsParameter pBbox( QgsWmsParameter::BBOX,
-                                 QVariant::String,
-                                 QVariant( "" ) );
+    const QgsWmsParameter pBbox( QgsWmsParameter::BBOX );
     save( pBbox );
 
-    const QgsWmsParameter pSld( QgsWmsParameter::SLD,
-                                QVariant::String,
-                                QVariant( "" ) );
+    const QgsWmsParameter pSld( QgsWmsParameter::SLD );
     save( pSld );
 
-    const QgsWmsParameter pLayer( QgsWmsParameter::LAYER,
-                                  QVariant::String,
-                                  QVariant( "" ) );
+    const QgsWmsParameter pLayer( QgsWmsParameter::LAYER );
     save( pLayer );
 
-    const QgsWmsParameter pLayers( QgsWmsParameter::LAYERS,
-                                   QVariant::String,
-                                   QVariant( "" ) );
+    const QgsWmsParameter pLayers( QgsWmsParameter::LAYERS );
     save( pLayers );
 
-    const QgsWmsParameter pQueryLayers( QgsWmsParameter::QUERY_LAYERS,
-                                        QVariant::String,
-                                        QVariant( "" ) );
+    const QgsWmsParameter pQueryLayers( QgsWmsParameter::QUERY_LAYERS );
     save( pQueryLayers );
 
     const QgsWmsParameter pFeatureCount( QgsWmsParameter::FEATURE_COUNT,
@@ -391,9 +355,7 @@ namespace QgsWms
                                        QVariant( true ) );
     save( pLayerTitle );
 
-    const QgsWmsParameter pLayerFtFamily( QgsWmsParameter::LAYERFONTFAMILY,
-                                          QVariant::String,
-                                          QVariant( "" ) );
+    const QgsWmsParameter pLayerFtFamily( QgsWmsParameter::LAYERFONTFAMILY );
     save( pLayerFtFamily );
 
     const QgsWmsParameter pLayerFtBold( QgsWmsParameter::LAYERFONTBOLD,
@@ -416,34 +378,22 @@ namespace QgsWms
                                          QVariant( "black" ) );
     save( pLayerFtColor );
 
-    const QgsWmsParameter pStyle( QgsWmsParameter::STYLE,
-                                  QVariant::String,
-                                  QVariant( "" ) );
+    const QgsWmsParameter pStyle( QgsWmsParameter::STYLE );
     save( pStyle );
 
-    const QgsWmsParameter pStyles( QgsWmsParameter::STYLES,
-                                   QVariant::String,
-                                   QVariant( "" ) );
+    const QgsWmsParameter pStyles( QgsWmsParameter::STYLES );
     save( pStyles );
 
-    const QgsWmsParameter pOpacities( QgsWmsParameter::OPACITIES,
-                                      QVariant::String,
-                                      QVariant( "" ) );
+    const QgsWmsParameter pOpacities( QgsWmsParameter::OPACITIES );
     save( pOpacities );
 
-    const QgsWmsParameter pFilter( QgsWmsParameter::FILTER,
-                                   QVariant::String,
-                                   QVariant( "" ) );
+    const QgsWmsParameter pFilter( QgsWmsParameter::FILTER );
     save( pFilter );
 
-    const QgsWmsParameter pFilterGeom( QgsWmsParameter::FILTER_GEOM,
-                                       QVariant::String,
-                                       QVariant( "" ) );
+    const QgsWmsParameter pFilterGeom( QgsWmsParameter::FILTER_GEOM );
     save( pFilterGeom );
 
-    const QgsWmsParameter pSelection( QgsWmsParameter::SELECTION,
-                                      QVariant::String,
-                                      QVariant( "" ) );
+    const QgsWmsParameter pSelection( QgsWmsParameter::SELECTION );
     save( pSelection );
 
     const QgsWmsParameter pWmsPrecision( QgsWmsParameter::WMS_PRECISION,
@@ -466,14 +416,10 @@ namespace QgsWms
                                 QVariant( -1 ) );
     save( pDpi );
 
-    const QgsWmsParameter pTemplate( QgsWmsParameter::TEMPLATE,
-                                     QVariant::String,
-                                     QVariant( "" ) );
+    const QgsWmsParameter pTemplate( QgsWmsParameter::TEMPLATE );
     save( pTemplate );
 
-    const QgsWmsParameter pExtent( QgsWmsParameter::EXTENT,
-                                   QVariant::String,
-                                   QVariant( "" ) );
+    const QgsWmsParameter pExtent( QgsWmsParameter::EXTENT );
     save( pExtent );
 
     const QgsWmsParameter pRotation( QgsWmsParameter::ROTATION,
@@ -500,6 +446,9 @@ namespace QgsWms
                                        QVariant::Bool,
                                        QVariant( false ) );
     save( pWithMapTip );
+
+    const QgsWmsParameter pWmtver( QgsWmsParameter::WMTVER );
+    save( pWmtver );
   }
 
   QgsWmsParameters::QgsWmsParameters( const QgsServerParameters &parameters )
@@ -695,6 +644,11 @@ namespace QgsWms
     }
 
     return version;
+  }
+
+  bool QgsWmsParameters::versionIsValid( const QString version ) const
+  {
+    return mVersions.contains( QgsProjectVersion( version ) );
   }
 
   QString QgsWmsParameters::formatAsString() const
@@ -1132,9 +1086,9 @@ namespace QgsWms
     return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE ].toStringList( ';' );
   }
 
-  QList<float> QgsWmsParameters::highlightLabelBufferSizeAsFloat() const
+  QList<double> QgsWmsParameters::highlightLabelBufferSizeAsFloat() const
   {
-    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE ].toFloatList( ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE ].toDoubleList( ';' );
   }
 
   QString QgsWmsParameters::wmsPrecision() const
@@ -1326,7 +1280,7 @@ namespace QgsWms
     QList<int> weights = highlightLabelWeightAsInt();
     QStringList fonts = highlightLabelFont();
     QList<QColor> bufferColors = highlightLabelBufferColorAsColor();
-    QList<float> bufferSizes = highlightLabelBufferSizeAsFloat();
+    QList<double> bufferSizes = highlightLabelBufferSizeAsFloat();
 
     int nLayers = std::min( geoms.size(), slds.size() );
     for ( int i = 0; i < nLayers; i++ )
@@ -1535,11 +1489,11 @@ namespace QgsWms
       bufferColors = wmsParam.toColorList( ';' );
     }
 
-    QList<float> bufferSizes;
+    QList<double> bufferSizes;
     wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE, mapId );
     if ( wmsParam.isValid() )
     {
-      bufferSizes = wmsParam.toFloatList( ';' );
+      bufferSizes = wmsParam.toDoubleList( ';' );
     }
 
     int nHLayers = std::min( geoms.size(), slds.size() );
@@ -1603,6 +1557,11 @@ namespace QgsWms
   bool QgsWmsParameters::withMapTip() const
   {
     return mWmsParameters[ QgsWmsParameter::WITH_MAPTIP ].toBool();
+  }
+
+  QString QgsWmsParameters::wmtver() const
+  {
+    return mWmsParameters[ QgsWmsParameter::WMTVER ].toString();
   }
 
   void QgsWmsParameters::log( const QString &msg ) const

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1031,6 +1031,20 @@ namespace QgsWms
     return settings;
   }
 
+  QString QgsWmsParameters::layoutParameter( const QString &id, bool &ok ) const
+  {
+    QString label;
+    ok = false;
+
+    if ( mUnmanagedParameters.contains( id.toUpper() ) )
+    {
+      label = mUnmanagedParameters[id.toUpper()];
+      ok = true;
+    }
+
+    return label;
+  }
+
   QStringList QgsWmsParameters::highlightLabelString() const
   {
     return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELSTRING ].toStringList( ';' );

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -22,616 +22,605 @@
 
 namespace QgsWms
 {
+  //
+  // QgsWmsParameter
+  //
+  QgsWmsParameter::QgsWmsParameter( const QgsWmsParameter::Name name,
+                                    const QVariant::Type type,
+                                    const QVariant defaultValue )
+    : QgsServerParameterDefinition( type, defaultValue )
+    , mName( name )
+  {
+  }
+
+  bool QgsWmsParameter::isValid() const
+  {
+    return ( mName != QgsWmsParameter::UNKNOWN ) && QgsServerParameterDefinition::isValid();
+  }
+
+  void QgsWmsParameter::raiseError() const
+  {
+    const QString msg = QString( "%1 ('%2') cannot be converted into %3" ).arg( name( mName ), toString(), typeName() );
+    QgsServerParameterDefinition::raiseError( msg );
+  }
+
+  QList<QgsGeometry> QgsWmsParameter::toGeomList( const char delimiter ) const
+  {
+    bool ok = true;
+    const QList<QgsGeometry> geoms = QgsServerParameterDefinition::toGeomList( ok, delimiter );
+
+    if ( !ok )
+    {
+      const QString msg = QString( "%1 ('%2') cannot be converted into a list of geometries" ).arg( name( mName ), toString(), typeName() );
+      QgsServerParameterDefinition::raiseError( msg );
+    }
+
+    return geoms;
+  }
+
+  QgsRectangle QgsWmsParameter::toRectangle() const
+  {
+    bool ok = true;
+    const QgsRectangle rect = QgsServerParameterDefinition::toRectangle( ok );
+
+    if ( !ok )
+    {
+      const QString msg = QString( "%1 ('%2') cannot be converted into a rectangle" ).arg( name( mName ), toString(), typeName() );
+      QgsServerParameterDefinition::raiseError( msg );
+    }
+
+    return rect;
+  }
+
+  int QgsWmsParameter::toInt() const
+  {
+    bool ok = false;
+    const int val = QgsServerParameterDefinition::toInt( ok );
+
+    if ( !ok )
+    {
+      raiseError();
+    }
+
+    return val;
+  }
+
+  QColor QgsWmsParameter::toColor() const
+  {
+    bool ok = false;
+    const QColor col = QgsServerParameterDefinition::toColor( ok );
+
+    if ( !ok )
+    {
+      raiseError();
+    }
+
+    return col;
+  }
+
+  QList<QColor> QgsWmsParameter::toColorList( const char delimiter ) const
+  {
+    bool ok = false;
+    const QList<QColor> vals = QgsServerParameterDefinition::toColorList( ok, delimiter );
+
+    if ( !ok )
+    {
+      const QString msg = QString( "%1 ('%2') cannot be converted into a list of colors" ).arg( name( mName ), toString(), typeName() );
+      QgsServerParameterDefinition::raiseError( msg );
+    }
+
+    return vals;
+  }
+
+  QList<int> QgsWmsParameter::toIntList( const char delimiter ) const
+  {
+    bool ok = false;
+    const QList<int> vals = QgsServerParameterDefinition::toIntList( ok, delimiter );
+
+    if ( !ok )
+    {
+      const QString msg = QString( "%1 ('%2') cannot be converted into a list of int" ).arg( name( mName ), toString(), typeName() );
+      QgsServerParameterDefinition::raiseError( msg );
+    }
+
+    return vals;
+  }
+
+  QList<float> QgsWmsParameter::toFloatList( const char delimiter ) const
+  {
+    bool ok = false;
+    const QList<float> vals = QgsServerParameterDefinition::toFloatList( ok, delimiter );
+
+    if ( !ok )
+    {
+      const QString msg = QString( "%1 ('%2') cannot be converted into a list of float" ).arg( name( mName ), toString(), typeName() );
+      QgsServerParameterDefinition::raiseError( msg );
+    }
+
+    return vals;
+  }
+
+  double QgsWmsParameter::toDouble() const
+  {
+    bool ok = false;
+    const double val = QgsServerParameterDefinition::toDouble( ok );
+
+    if ( !ok )
+    {
+      raiseError();
+    }
+
+    return val;
+  }
+
+  QString QgsWmsParameter::name( const QgsWmsParameter::Name name )
+  {
+    const QMetaEnum metaEnum( QMetaEnum::fromType<QgsWmsParameter::Name>() );
+    return metaEnum.valueToKey( name );
+  }
+
+  QgsWmsParameter::Name QgsWmsParameter::name( const QString &name )
+  {
+    const QMetaEnum metaEnum( QMetaEnum::fromType<QgsWmsParameter::Name>() );
+    return ( QgsWmsParameter::Name ) metaEnum.keyToValue( name.toUpper().toStdString().c_str() );
+  }
+
+  //
+  // QgsWmsParameters
+  //
   QgsWmsParameters::QgsWmsParameters()
+    : QgsServerParameters()
   {
     // Available version number
     mVersions.append( QgsProjectVersion( 1, 1, 1 ) );
     mVersions.append( QgsProjectVersion( 1, 3, 0 ) );
 
     // WMS parameters definition
-    const Parameter pBoxSpace = { ParameterName::BOXSPACE,
-                                  QVariant::Double,
-                                  QVariant( 2.0 ),
-                                  QVariant()
-                                };
+    const QgsWmsParameter pQuality( QgsWmsParameter::IMAGE_QUALITY,
+                                    QVariant::Int,
+                                    QVariant( 0 ) );
+    save( pQuality );
+
+    const QgsWmsParameter pBoxSpace( QgsWmsParameter::BOXSPACE,
+                                     QVariant::Double,
+                                     QVariant( 2.0 ) );
     save( pBoxSpace );
 
-    const Parameter pSymbSpace = { ParameterName::SYMBOLSPACE,
-                                   QVariant::Double,
-                                   QVariant( 2.0 ),
-                                   QVariant()
-                                 };
+    const QgsWmsParameter pSymbSpace( QgsWmsParameter::SYMBOLSPACE,
+                                      QVariant::Double,
+                                      QVariant( 2.0 ) );
     save( pSymbSpace );
 
-    const Parameter pLayerSpace = { ParameterName::LAYERSPACE,
-                                    QVariant::Double,
-                                    QVariant( 3.0 ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pLayerSpace( QgsWmsParameter::LAYERSPACE,
+                                       QVariant::Double,
+                                       QVariant( 3.0 ) );
     save( pLayerSpace );
 
-    const Parameter pTitleSpace = { ParameterName::LAYERTITLESPACE,
-                                    QVariant::Double,
-                                    QVariant( 3.0 ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pTitleSpace( QgsWmsParameter::LAYERTITLESPACE,
+                                       QVariant::Double,
+                                       QVariant( 3.0 ) );
     save( pTitleSpace );
 
-    const Parameter pSymbHeight = { ParameterName::SYMBOLHEIGHT,
-                                    QVariant::Double,
-                                    QVariant( 4.0 ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pSymbHeight( QgsWmsParameter::SYMBOLHEIGHT,
+                                       QVariant::Double,
+                                       QVariant( 4.0 ) );
     save( pSymbHeight );
 
-    const Parameter pSymbWidth = { ParameterName::SYMBOLWIDTH,
-                                   QVariant::Double,
-                                   QVariant( 7.0 ),
-                                   QVariant()
-                                 };
+    const QgsWmsParameter pSymbWidth( QgsWmsParameter::SYMBOLWIDTH,
+                                      QVariant::Double,
+                                      QVariant( 7.0 ) );
     save( pSymbWidth );
 
-    const Parameter pIcLabelSpace = { ParameterName::ICONLABELSPACE,
-                                      QVariant::Double,
-                                      QVariant( 2.0 ),
-                                      QVariant()
-                                    };
+    const QgsWmsParameter pIcLabelSpace( QgsWmsParameter::ICONLABELSPACE,
+                                         QVariant::Double,
+                                         QVariant( 2.0 ) );
     save( pIcLabelSpace );
 
-    const Parameter pItFontFamily = { ParameterName::ITEMFONTFAMILY,
-                                      QVariant::String,
-                                      QVariant( "" ),
-                                      QVariant()
-                                    };
+    const QgsWmsParameter pItFontFamily( QgsWmsParameter::ITEMFONTFAMILY,
+                                         QVariant::String,
+                                         QVariant( "" ) );
     save( pItFontFamily );
 
-    const Parameter pItFontBold = { ParameterName::ITEMFONTBOLD,
-                                    QVariant::Bool,
-                                    QVariant( false ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pItFontBold( QgsWmsParameter::ITEMFONTBOLD,
+                                       QVariant::Bool,
+                                       QVariant( false ) );
     save( pItFontBold );
 
-    const Parameter pItFontItalic = { ParameterName::ITEMFONTITALIC,
-                                      QVariant::Bool,
-                                      QVariant( false ),
-                                      QVariant()
-                                    };
+    const QgsWmsParameter pItFontItalic( QgsWmsParameter::ITEMFONTITALIC,
+                                         QVariant::Bool,
+                                         QVariant( false ) );
     save( pItFontItalic );
 
-    const Parameter pItFontSize = { ParameterName::ITEMFONTSIZE,
-                                    QVariant::Double,
-                                    QVariant( -1 ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pItFontSize( QgsWmsParameter::ITEMFONTSIZE,
+                                       QVariant::Double,
+                                       QVariant( -1 ) );
     save( pItFontSize );
 
-    const Parameter pItFontColor = { ParameterName::ITEMFONTCOLOR,
-                                     QVariant::String,
-                                     QVariant( "black" ),
-                                     QVariant()
-                                   };
+    const QgsWmsParameter pItFontColor( QgsWmsParameter::ITEMFONTCOLOR,
+                                        QVariant::String,
+                                        QVariant( "black" ) );
     save( pItFontColor );
 
-    const Parameter pHighlightGeom = { ParameterName::HIGHLIGHT_GEOM,
-                                       QVariant::String,
-                                       QVariant( "" ),
-                                       QVariant()
-                                     };
+    const QgsWmsParameter pHighlightGeom( QgsWmsParameter::HIGHLIGHT_GEOM,
+                                          QVariant::String,
+                                          QVariant( "" ) );
     save( pHighlightGeom );
 
-    const Parameter pShowFeatureCount = { ParameterName::SHOWFEATURECOUNT,
-                                          QVariant::Bool,
-                                          QVariant( false ),
-                                          QVariant()
-                                        };
+    const QgsWmsParameter pShowFeatureCount( QgsWmsParameter::SHOWFEATURECOUNT,
+        QVariant::Bool,
+        QVariant( false ) );
     save( pShowFeatureCount );
 
-    const Parameter pHighlightSymbol = { ParameterName::HIGHLIGHT_SYMBOL,
-                                         QVariant::String,
-                                         QVariant( "" ),
-                                         QVariant()
-                                       };
+    const QgsWmsParameter pHighlightSymbol( QgsWmsParameter::HIGHLIGHT_SYMBOL,
+                                            QVariant::String,
+                                            QVariant( "" ) );
     save( pHighlightSymbol );
 
-    const Parameter pHighlightLabel = { ParameterName::HIGHLIGHT_LABELSTRING,
-                                        QVariant::String,
-                                        QVariant( "" ),
-                                        QVariant()
-                                      };
+    const QgsWmsParameter pHighlightLabel( QgsWmsParameter::HIGHLIGHT_LABELSTRING,
+                                           QVariant::String,
+                                           QVariant( "" ) );
     save( pHighlightLabel );
 
-    const Parameter pHighlightColor = { ParameterName::HIGHLIGHT_LABELCOLOR,
-                                        QVariant::String,
-                                        QVariant( "black" ),
-                                        QVariant()
-                                      };
+    const QgsWmsParameter pHighlightColor( QgsWmsParameter::HIGHLIGHT_LABELCOLOR,
+                                           QVariant::String,
+                                           QVariant( "black" ) );
     save( pHighlightColor );
 
-    const Parameter pHighlightFontSize = { ParameterName::HIGHLIGHT_LABELSIZE,
-                                           QVariant::String,
-                                           QVariant( "" ),
-                                           QVariant()
-                                         };
+    const QgsWmsParameter pHighlightFontSize( QgsWmsParameter::HIGHLIGHT_LABELSIZE,
+        QVariant::String,
+        QVariant( "" ) );
     save( pHighlightFontSize );
 
-    const Parameter pHighlightFontWeight = { ParameterName::HIGHLIGHT_LABELWEIGHT,
-                                             QVariant::String,
-                                             QVariant( "" ),
-                                             QVariant()
-                                           };
+    const QgsWmsParameter pHighlightFontWeight( QgsWmsParameter::HIGHLIGHT_LABELWEIGHT,
+        QVariant::String,
+        QVariant( "" ) );
     save( pHighlightFontWeight );
 
-    const Parameter pHighlightFont = { ParameterName::HIGHLIGHT_LABELFONT,
-                                       QVariant::String,
-                                       QVariant( "" ),
-                                       QVariant()
-                                     };
+    const QgsWmsParameter pHighlightFont( QgsWmsParameter::HIGHLIGHT_LABELFONT,
+                                          QVariant::String,
+                                          QVariant( "" ) );
     save( pHighlightFont );
 
-    const Parameter pHighlightBufferColor = { ParameterName::HIGHLIGHT_LABELBUFFERCOLOR,
-                                              QVariant::String,
-                                              QVariant( "black" ),
-                                              QVariant()
-                                            };
+    const QgsWmsParameter pHighlightBufferColor( QgsWmsParameter::HIGHLIGHT_LABELBUFFERCOLOR,
+        QVariant::String,
+        QVariant( "black" ) );
     save( pHighlightBufferColor );
 
-    const Parameter pHighlightBufferSize = { ParameterName::HIGHLIGHT_LABELBUFFERSIZE,
-                                             QVariant::String,
-                                             QVariant( "" ),
-                                             QVariant()
-                                           };
+    const QgsWmsParameter pHighlightBufferSize( QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE,
+        QVariant::String,
+        QVariant( "" ) );
     save( pHighlightBufferSize );
 
-    const Parameter pCRS = { ParameterName::CRS,
-                             QVariant::String,
-                             QVariant( "" ),
-                             QVariant()
-                           };
+    const QgsWmsParameter pCRS( QgsWmsParameter::CRS,
+                                QVariant::String,
+                                QVariant( "" ) );
     save( pCRS );
 
-    const Parameter pSRS = { ParameterName::SRS,
-                             QVariant::String,
-                             QVariant( "" ),
-                             QVariant()
-                           };
+    const QgsWmsParameter pSRS( QgsWmsParameter::SRS,
+                                QVariant::String,
+                                QVariant( "" ) );
     save( pSRS );
 
-    const Parameter pFormat = { ParameterName::FORMAT,
-                                QVariant::String,
-                                QVariant( "" ),
-                                QVariant()
-                              };
+    const QgsWmsParameter pFormat( QgsWmsParameter::FORMAT,
+                                   QVariant::String,
+                                   QVariant( "" ) );
     save( pFormat );
 
-    const Parameter pInfoFormat = { ParameterName::INFO_FORMAT,
-                                    QVariant::String,
-                                    QVariant( "" ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pInfoFormat( QgsWmsParameter::INFO_FORMAT,
+                                       QVariant::String,
+                                       QVariant( "" ) );
     save( pInfoFormat );
 
-    const Parameter pI = { ParameterName::I,
-                           QVariant::Int,
-                           QVariant( -1 ),
-                           QVariant()
-                         };
+    const QgsWmsParameter pI( QgsWmsParameter::I,
+                              QVariant::Int,
+                              QVariant( -1 ) );
     save( pI );
 
-    const Parameter pJ = { ParameterName::J,
-                           QVariant::Int,
-                           QVariant( -1 ),
-                           QVariant()
-                         };
+    const QgsWmsParameter pJ( QgsWmsParameter::J,
+                              QVariant::Int,
+                              QVariant( -1 ) );
     save( pJ );
 
-    const Parameter pX = { ParameterName::X,
-                           QVariant::Int,
-                           QVariant( -1 ),
-                           QVariant()
-                         };
+    const QgsWmsParameter pX( QgsWmsParameter::X,
+                              QVariant::Int,
+                              QVariant( -1 ) );
     save( pX );
 
-    const Parameter pY = { ParameterName::Y,
-                           QVariant::Int,
-                           QVariant( -1 ),
-                           QVariant()
-                         };
+    const QgsWmsParameter pY( QgsWmsParameter::Y,
+                              QVariant::Int,
+                              QVariant( -1 ) );
     save( pY );
 
-    const Parameter pRule = { ParameterName::RULE,
-                              QVariant::String,
-                              QVariant( "" ),
-                              QVariant()
-                            };
+    const QgsWmsParameter pRule( QgsWmsParameter::RULE,
+                                 QVariant::String,
+                                 QVariant( "" ) );
     save( pRule );
 
-    const Parameter pRuleLabel = { ParameterName::RULELABEL,
-                                   QVariant::Bool,
-                                   QVariant( true ),
-                                   QVariant()
-                                 };
+    const QgsWmsParameter pRuleLabel( QgsWmsParameter::RULELABEL,
+                                      QVariant::Bool,
+                                      QVariant( true ) );
     save( pRuleLabel );
 
-    const Parameter pScale = { ParameterName::SCALE,
-                               QVariant::Double,
-                               QVariant( -1 ),
-                               QVariant()
-                             };
+    const QgsWmsParameter pScale( QgsWmsParameter::SCALE,
+                                  QVariant::Double,
+                                  QVariant( -1 ) );
     save( pScale );
 
-    const Parameter pHeight = { ParameterName::HEIGHT,
-                                QVariant::Int,
-                                QVariant( 0 ),
-                                QVariant()
-                              };
+    const QgsWmsParameter pHeight( QgsWmsParameter::HEIGHT,
+                                   QVariant::Int,
+                                   QVariant( 0 ) );
     save( pHeight );
 
-    const Parameter pWidth = { ParameterName::WIDTH,
-                               QVariant::Int,
-                               QVariant( 0 ),
-                               QVariant()
-                             };
+    const QgsWmsParameter pWidth( QgsWmsParameter::WIDTH,
+                                  QVariant::Int,
+                                  QVariant( 0 ) );
     save( pWidth );
 
-    const Parameter pBbox = { ParameterName::BBOX,
-                              QVariant::String,
-                              QVariant( "" ),
-                              QVariant()
-                            };
+    const QgsWmsParameter pBbox( QgsWmsParameter::BBOX,
+                                 QVariant::String,
+                                 QVariant( "" ) );
     save( pBbox );
 
-    const Parameter pSld = { ParameterName::SLD,
-                             QVariant::String,
-                             QVariant( "" ),
-                             QVariant()
-                           };
+    const QgsWmsParameter pSld( QgsWmsParameter::SLD,
+                                QVariant::String,
+                                QVariant( "" ) );
     save( pSld );
 
-    const Parameter pLayer = { ParameterName::LAYER,
-                               QVariant::String,
-                               QVariant( "" ),
-                               QVariant()
-                             };
+    const QgsWmsParameter pLayer( QgsWmsParameter::LAYER,
+                                  QVariant::String,
+                                  QVariant( "" ) );
     save( pLayer );
 
-    const Parameter pLayers = { ParameterName::LAYERS,
-                                QVariant::String,
-                                QVariant( "" ),
-                                QVariant()
-                              };
+    const QgsWmsParameter pLayers( QgsWmsParameter::LAYERS,
+                                   QVariant::String,
+                                   QVariant( "" ) );
     save( pLayers );
 
-    const Parameter pQueryLayers = { ParameterName::QUERY_LAYERS,
-                                     QVariant::String,
-                                     QVariant( "" ),
-                                     QVariant()
-                                   };
+    const QgsWmsParameter pQueryLayers( QgsWmsParameter::QUERY_LAYERS,
+                                        QVariant::String,
+                                        QVariant( "" ) );
     save( pQueryLayers );
 
-    const Parameter pFeatureCount = { ParameterName::FEATURE_COUNT,
-                                      QVariant::Int,
-                                      QVariant( 1 ),
-                                      QVariant()
-                                    };
+    const QgsWmsParameter pFeatureCount( QgsWmsParameter::FEATURE_COUNT,
+                                         QVariant::Int,
+                                         QVariant( 1 ) );
     save( pFeatureCount );
 
-    const Parameter pLayerTitle = { ParameterName::LAYERTITLE,
-                                    QVariant::Bool,
-                                    QVariant( true ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pLayerTitle( QgsWmsParameter::LAYERTITLE,
+                                       QVariant::Bool,
+                                       QVariant( true ) );
     save( pLayerTitle );
 
-    const Parameter pLayerFtFamily = { ParameterName::LAYERFONTFAMILY,
-                                       QVariant::String,
-                                       QVariant( "" ),
-                                       QVariant()
-                                     };
+    const QgsWmsParameter pLayerFtFamily( QgsWmsParameter::LAYERFONTFAMILY,
+                                          QVariant::String,
+                                          QVariant( "" ) );
     save( pLayerFtFamily );
 
-    const Parameter pLayerFtBold = { ParameterName::LAYERFONTBOLD,
-                                     QVariant::Bool,
-                                     QVariant( false ),
-                                     QVariant()
-                                   };
+    const QgsWmsParameter pLayerFtBold( QgsWmsParameter::LAYERFONTBOLD,
+                                        QVariant::Bool,
+                                        QVariant( false ) );
     save( pLayerFtBold );
 
-    const Parameter pLayerFtItalic = { ParameterName::LAYERFONTITALIC,
-                                       QVariant::Bool,
-                                       QVariant( false ),
-                                       QVariant()
-                                     };
+    const QgsWmsParameter pLayerFtItalic( QgsWmsParameter::LAYERFONTITALIC,
+                                          QVariant::Bool,
+                                          QVariant( false ) );
     save( pLayerFtItalic );
 
-    const Parameter pLayerFtSize = { ParameterName::LAYERFONTSIZE,
-                                     QVariant::Double,
-                                     QVariant( -1 ),
-                                     QVariant()
-                                   };
+    const QgsWmsParameter pLayerFtSize( QgsWmsParameter::LAYERFONTSIZE,
+                                        QVariant::Double,
+                                        QVariant( -1 ) );
     save( pLayerFtSize );
 
-    const Parameter pLayerFtColor = { ParameterName::LAYERFONTCOLOR,
-                                      QVariant::String,
-                                      QVariant( "black" ),
-                                      QVariant()
-                                    };
+    const QgsWmsParameter pLayerFtColor( QgsWmsParameter::LAYERFONTCOLOR,
+                                         QVariant::String,
+                                         QVariant( "black" ) );
     save( pLayerFtColor );
 
-    const Parameter pStyle = { ParameterName::STYLE,
-                               QVariant::String,
-                               QVariant( "" ),
-                               QVariant()
-                             };
+    const QgsWmsParameter pStyle( QgsWmsParameter::STYLE,
+                                  QVariant::String,
+                                  QVariant( "" ) );
     save( pStyle );
 
-    const Parameter pStyles = { ParameterName::STYLES,
-                                QVariant::String,
-                                QVariant( "" ),
-                                QVariant()
-                              };
+    const QgsWmsParameter pStyles( QgsWmsParameter::STYLES,
+                                   QVariant::String,
+                                   QVariant( "" ) );
     save( pStyles );
 
-    const Parameter pOpacities = { ParameterName::OPACITIES,
-                                   QVariant::String,
-                                   QVariant( "" ),
-                                   QVariant()
-                                 };
+    const QgsWmsParameter pOpacities( QgsWmsParameter::OPACITIES,
+                                      QVariant::String,
+                                      QVariant( "" ) );
     save( pOpacities );
 
-    const Parameter pFilter = { ParameterName::FILTER,
-                                QVariant::String,
-                                QVariant( "" ),
-                                QVariant()
-                              };
+    const QgsWmsParameter pFilter( QgsWmsParameter::FILTER,
+                                   QVariant::String,
+                                   QVariant( "" ) );
     save( pFilter );
 
-    const Parameter pFilterGeom = { ParameterName::FILTER_GEOM,
-                                    QVariant::String,
-                                    QVariant( "" ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pFilterGeom( QgsWmsParameter::FILTER_GEOM,
+                                       QVariant::String,
+                                       QVariant( "" ) );
     save( pFilterGeom );
 
-    const Parameter pSelection = { ParameterName::SELECTION,
-                                   QVariant::String,
-                                   QVariant( "" ),
-                                   QVariant()
-                                 };
+    const QgsWmsParameter pSelection( QgsWmsParameter::SELECTION,
+                                      QVariant::String,
+                                      QVariant( "" ) );
     save( pSelection );
 
-    const Parameter pWmsPrecision = { ParameterName::WMS_PRECISION,
-                                      QVariant::Int,
-                                      QVariant( -1 ),
-                                      QVariant()
-                                    };
+    const QgsWmsParameter pWmsPrecision( QgsWmsParameter::WMS_PRECISION,
+                                         QVariant::Int,
+                                         QVariant( -1 ) );
     save( pWmsPrecision );
 
-    const Parameter pTransparent = { ParameterName::TRANSPARENT,
-                                     QVariant::Bool,
-                                     QVariant( false ),
-                                     QVariant()
-                                   };
+    const QgsWmsParameter pTransparent( QgsWmsParameter::TRANSPARENT,
+                                        QVariant::Bool,
+                                        QVariant( false ) );
     save( pTransparent );
 
-    const Parameter pBgColor = { ParameterName::BGCOLOR,
-                                 QVariant::String,
-                                 QVariant( "white" ),
-                                 QVariant()
-                               };
+    const QgsWmsParameter pBgColor( QgsWmsParameter::BGCOLOR,
+                                    QVariant::String,
+                                    QVariant( "white" ) );
     save( pBgColor );
 
-    const Parameter pDpi = { ParameterName::DPI,
-                             QVariant::Int,
-                             QVariant( -1 ),
-                             QVariant()
-                           };
+    const QgsWmsParameter pDpi( QgsWmsParameter::DPI,
+                                QVariant::Int,
+                                QVariant( -1 ) );
     save( pDpi );
 
-    const Parameter pTemplate = { ParameterName::TEMPLATE,
-                                  QVariant::String,
-                                  QVariant(),
-                                  QVariant()
-                                };
+    const QgsWmsParameter pTemplate( QgsWmsParameter::TEMPLATE,
+                                     QVariant::String,
+                                     QVariant( "" ) );
     save( pTemplate );
 
-    const Parameter pExtent = { ParameterName::EXTENT,
-                                QVariant::String,
-                                QVariant( "" ),
-                                QVariant()
-                              };
+    const QgsWmsParameter pExtent( QgsWmsParameter::EXTENT,
+                                   QVariant::String,
+                                   QVariant( "" ) );
     save( pExtent );
 
-    const Parameter pRotation = { ParameterName::ROTATION,
-                                  QVariant::Double,
-                                  QVariant( 0.0 ),
-                                  QVariant()
-                                };
+    const QgsWmsParameter pRotation( QgsWmsParameter::ROTATION,
+                                     QVariant::Double,
+                                     QVariant( 0.0 ) );
     save( pRotation );
 
-    const Parameter pGridX = { ParameterName::GRID_INTERVAL_X,
-                               QVariant::Double,
-                               QVariant( 0.0 ),
-                               QVariant()
-                             };
+    const QgsWmsParameter pGridX( QgsWmsParameter::GRID_INTERVAL_X,
+                                  QVariant::Double,
+                                  QVariant( 0.0 ) );
     save( pGridX );
 
-    const Parameter pGridY = { ParameterName::GRID_INTERVAL_Y,
-                               QVariant::Double,
-                               QVariant( 0.0 ),
-                               QVariant()
-                             };
+    const QgsWmsParameter pGridY( QgsWmsParameter::GRID_INTERVAL_Y,
+                                  QVariant::Double,
+                                  QVariant( 0.0 ) );
     save( pGridY );
 
-    const Parameter pWithGeometry = { ParameterName::WITH_GEOMETRY,
-                                      QVariant::Bool,
-                                      QVariant( false ),
-                                      QVariant()
-                                    };
+    const QgsWmsParameter pWithGeometry( QgsWmsParameter::WITH_GEOMETRY,
+                                         QVariant::Bool,
+                                         QVariant( false ) );
     save( pWithGeometry );
 
-    const Parameter pWithMapTip = { ParameterName::WITH_MAPTIP,
-                                    QVariant::Bool,
-                                    QVariant( false ),
-                                    QVariant()
-                                  };
+    const QgsWmsParameter pWithMapTip( QgsWmsParameter::WITH_MAPTIP,
+                                       QVariant::Bool,
+                                       QVariant( false ) );
     save( pWithMapTip );
   }
 
-  QgsWmsParameters::QgsWmsParameters( const QgsServerRequest::Parameters &parameters )
+  QgsWmsParameters::QgsWmsParameters( const QgsServerParameters &parameters )
+    : QgsWmsParameters()
   {
-    load( parameters );
+    load( parameters.urlQuery() );
   }
 
-  void QgsWmsParameters::load( const QgsServerRequest::Parameters &parameters )
+  bool QgsWmsParameters::loadParameter( const QPair<QString, QString> &parameter )
   {
-    mRequestParameters = parameters;
+    bool loaded = false;
 
-    const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
-    static QRegExp composerParamRegExp( QStringLiteral( "^MAP\\d+:" ) );
-
-    foreach ( QString key, parameters.keys() )
+    const QString key = parameter.first;
+    const QRegExp composerParamRegExp( QStringLiteral( "^MAP\\d+:" ) );
+    if ( key.contains( composerParamRegExp ) )
     {
-      if ( key.contains( composerParamRegExp ) )
+      const int mapId = key.mid( 3, key.indexOf( ':' ) - 3 ).toInt();
+      const QString theKey = key.mid( key.indexOf( ':' ) + 1 );
+      const QgsWmsParameter::Name name = QgsWmsParameter::name( theKey );
+
+      if ( name >= 0 )
       {
-        const int mapId = key.mid( 3, key.indexOf( ':' ) - 3 ).toInt();
-        const QString theKey = key.mid( key.indexOf( ':' ) + 1 );
-        const ParameterName name = ( ParameterName ) metaEnum.keyToValue( theKey.toStdString().c_str() );
-        if ( name >= 0 )
+        QgsWmsParameter param = mWmsParameters[name];
+        param.mValue = parameter.second;
+        param.mId = mapId;
+
+        if ( ! param.isValid() )
         {
-          QVariant value( parameters[key] );
-          Parameter param = mParameters[name];
-          Parameter nParam =
-          {
-            param.mName,
-            param.mType,
-            param.mDefaultValue,
-            value
-          };
-          save( nParam, mapId );
-          if ( !value.canConvert( nParam.mType ) )
-          {
-            raiseError( name, mapId );
-          }
+          param.raiseError();
         }
+
+        save( param, true ); // multi MAP parameters for composer
+        loaded = true;
       }
-      else
+    }
+    else
+    {
+      const QgsWmsParameter::Name name = QgsWmsParameter::name( key );
+      if ( name >= 0 )
       {
-        const ParameterName name = ( ParameterName ) metaEnum.keyToValue( key.toStdString().c_str() );
-        if ( name >= 0 )
+        mWmsParameters[name].mValue = parameter.second;
+        if ( ! mWmsParameters[name].isValid() )
         {
-          QVariant value( parameters[key] );
-          mParameters[name].mValue = value;
-          if ( !value.canConvert( mParameters[name].mType ) )
-          {
-            raiseError( name );
-          }
+          mWmsParameters[name].raiseError();
         }
-        else //maybe an external wms parameter?
+
+        loaded = true;
+      }
+      else //maybe an external wms parameter?
+      {
+        int separator = key.indexOf( QStringLiteral( ":" ) );
+        if ( separator >= 1 )
         {
-          int separator = key.indexOf( QStringLiteral( ":" ) );
-          if ( separator >= 1 )
-          {
-            QString id = key.left( separator );
-            QString param = key.right( key.length() - separator - 1 );
-            mExternalWMSParameters[id].insert( param, parameters[key] );
-          }
+          QString id = key.left( separator );
+          QString param = key.right( key.length() - separator - 1 );
+          mExternalWMSParameters[id].insert( param, parameter.second );
+
+          loaded = true;
         }
       }
     }
+
+    return loaded;
   }
 
   void QgsWmsParameters::dump() const
   {
-    const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
-
     log( QStringLiteral( "WMS Request parameters:" ) );
-    for ( auto parameter : mParameters.toStdMap() )
+    for ( auto parameter : mWmsParameters.toStdMap() )
     {
-      const QString value = parameter.second.mValue.toString();
+      const QString value = parameter.second.toString();
 
       if ( ! value.isEmpty() )
       {
-        const QString name = metaEnum.valueToKey( parameter.first );
-        log( QStringLiteral( " - " ) + name + QStringLiteral( " : " ) + value );
-      }
-    }
-    for ( auto map : mComposerParameters.toStdMap() )
-    {
-      const int mapId = map.first;
-      log( QStringLiteral( " - MAP" ) + QString::number( mapId ) );
-      for ( auto param : mComposerParameters[map.first].toStdMap() )
-      {
-        const QString value = param.second.mValue.toString();
+        QString name = QgsWmsParameter::name( parameter.first );
 
-        if ( ! value.isEmpty() )
+        if ( parameter.second.mId >= 0 )
         {
-          const QString name = metaEnum.valueToKey( param.first );
-          log( QStringLiteral( " - MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + name + QStringLiteral( " : " ) + value );
+          name = QStringLiteral( "%1:%2" ).arg( QString::number( parameter.second.mId ), name );
         }
+
+        log( QStringLiteral( " - %1 : %2" ).arg( name, value ) );
       }
     }
 
     if ( !version().isEmpty() )
-      log( QStringLiteral( " - VERSION : " ) + version() );
+      log( QStringLiteral( " - VERSION : %1" ).arg( version() ) );
   }
 
-  void QgsWmsParameters::save( const Parameter &parameter )
+  void QgsWmsParameters::save( const QgsWmsParameter &parameter, bool multi )
   {
-    mParameters[ parameter.mName ] = parameter;
-  }
-
-  QVariant QgsWmsParameters::value( ParameterName name ) const
-  {
-    return mParameters[name].mValue;
-  }
-
-  QVariant QgsWmsParameters::defaultValue( ParameterName name ) const
-  {
-    return mParameters[name].mDefaultValue;
-  }
-
-  void QgsWmsParameters::save( const Parameter &parameter, int mapId )
-  {
-    mComposerParameters[ mapId ][ parameter.mName ] = parameter;
-  }
-
-  QVariant QgsWmsParameters::value( ParameterName name, int mapId ) const
-  {
-    if ( mComposerParameters.contains( mapId ) && mComposerParameters[ mapId ].contains( name ) )
-      return mComposerParameters[ mapId ][ name ].mValue;
+    if ( multi )
+    {
+      mWmsParameters.insertMulti( parameter.mName, parameter );
+    }
     else
-      return value( name );
-  }
-
-  QVariant QgsWmsParameters::defaultValue( ParameterName name, int mapId ) const
-  {
-    if ( mComposerParameters.contains( mapId ) && mComposerParameters[ mapId ].contains( name ) )
-      return mComposerParameters[ mapId ][ name ].mDefaultValue;
-    else
-      return defaultValue( name );
+    {
+      mWmsParameters[ parameter.mName ] = parameter;
+    }
   }
 
   QStringList QgsWmsParameters::highlightGeom() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_GEOM, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_GEOM ].toStringList( ';' );
   }
 
   QList<QgsGeometry> QgsWmsParameters::highlightGeomAsGeom() const
   {
-    return toGeomList( highlightGeom(), ParameterName::HIGHLIGHT_GEOM );
+    return mWmsParameters[QgsWmsParameter::HIGHLIGHT_GEOM].toGeomList( ';' );
   }
 
   QStringList QgsWmsParameters::highlightSymbol() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_SYMBOL, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_SYMBOL ].toStringList( ';' );
   }
 
   QString QgsWmsParameters::crs() const
   {
     QString rs;
-    QString srs = value( ParameterName::SRS ).toString();
-    QString crs = value( ParameterName::CRS ).toString();
+    const QString srs = mWmsParameters[ QgsWmsParameter::SRS ].toString();
+    const QString crs = mWmsParameters[ QgsWmsParameter::CRS ].toString();
 
     // both SRS/CRS are supported but there's a priority according to the
     // specified version when both are defined in the request
@@ -652,540 +641,65 @@ namespace QgsWms
 
   QString QgsWmsParameters::bbox() const
   {
-    return value( ParameterName::BBOX ).toString();
+    return mWmsParameters[ QgsWmsParameter::BBOX ].toString();
   }
 
   QgsRectangle QgsWmsParameters::bboxAsRectangle() const
   {
-    return toRectangle( ParameterName::BBOX );
+    return mWmsParameters[ QgsWmsParameter::BBOX ].toRectangle();
   }
 
   QString QgsWmsParameters::height() const
   {
-    return value( ParameterName::HEIGHT ).toString();
+    return mWmsParameters[ QgsWmsParameter::HEIGHT ].toString();
   }
 
   QString QgsWmsParameters::width() const
   {
-    return value( ParameterName::WIDTH ).toString();
+    return mWmsParameters[ QgsWmsParameter::WIDTH ].toString();
   }
 
   int QgsWmsParameters::heightAsInt() const
   {
-    return toInt( ParameterName::HEIGHT );
+    return mWmsParameters[ QgsWmsParameter::HEIGHT ].toInt();
   }
 
   int QgsWmsParameters::widthAsInt() const
   {
-    return toInt( ParameterName::WIDTH );
+    return mWmsParameters[ QgsWmsParameter::WIDTH ].toInt();
   }
 
   QString QgsWmsParameters::dpi() const
   {
-    return value( ParameterName::DPI ).toString();
+    return mWmsParameters[ QgsWmsParameter::DPI ].toString();
   }
 
   double QgsWmsParameters::dpiAsDouble() const
   {
-    return toDouble( ParameterName::DPI );
-  }
-
-  QString QgsWmsParameters::version() const
-  {
-    // VERSION parameter is not managed with other parameters because
-    // there's a conflict with qgis VERSION defined in qgsconfig.h
-    if ( mRequestParameters.contains( QStringLiteral( "VERSION" ) ) )
-      return mRequestParameters[QStringLiteral( "VERSION" )];
-    else
-      return QString();
+    return mWmsParameters[ QgsWmsParameter::DPI ].toDouble();
   }
 
   QgsProjectVersion QgsWmsParameters::versionAsNumber() const
   {
-    QString vStr = version();
+    const QString vStr = version();
+
     QgsProjectVersion version;
 
     if ( vStr.isEmpty() )
+    {
       version = QgsProjectVersion( 1, 3, 0 ); // default value
+    }
     else if ( mVersions.contains( QgsProjectVersion( vStr ) ) )
+    {
       version = QgsProjectVersion( vStr );
+    }
 
     return version;
   }
 
-  double QgsWmsParameters::toDouble( const QVariant &value, const QVariant &defaultValue, bool *error ) const
-  {
-    double val = defaultValue.toDouble();
-    QString valStr = value.toString();
-    bool ok = true;
-
-    if ( !valStr.isEmpty() )
-    {
-      val = value.toDouble( &ok );
-    }
-    *error = !ok;
-
-    return val;
-  }
-
-  double QgsWmsParameters::toDouble( ParameterName p ) const
-  {
-    bool error;
-    double val = toDouble( value( p ), defaultValue( p ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a double" );
-      raiseError( msg );
-    }
-
-    return val;
-  }
-
-  double QgsWmsParameters::toDouble( ParameterName p, int mapId ) const
-  {
-    bool error;
-    double val = toDouble( value( p, mapId ), defaultValue( p, mapId ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p, mapId ).toString();
-      QString msg = QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + n +
-                    QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a double" );
-      raiseError( msg );
-    }
-
-    return val;
-  }
-
-  bool QgsWmsParameters::toBool( const QVariant &value, const QVariant &defaultValue ) const
-  {
-    bool val = defaultValue.toBool();
-    QString valStr = value.toString();
-
-    if ( ! valStr.isEmpty() )
-      val = value.toBool();
-
-    return val;
-  }
-
-  bool QgsWmsParameters::toBool( ParameterName p ) const
-  {
-    return toBool( value( p ), defaultValue( p ) );
-  }
-
-  bool QgsWmsParameters::toBool( ParameterName p, int mapId ) const
-  {
-    return toBool( value( p, mapId ), defaultValue( p, mapId ) );
-  }
-
-  int QgsWmsParameters::toInt( const QVariant &value, const QVariant &defaultValue, bool *error ) const
-  {
-    int val = defaultValue.toInt();
-    QString valStr = value.toString();
-    bool ok = true;
-
-    if ( !valStr.isEmpty() )
-    {
-      val = value.toInt( &ok );
-    }
-    *error = !ok;
-
-    return val;
-  }
-
-  int QgsWmsParameters::toInt( ParameterName p ) const
-  {
-    bool error;
-    int val = toInt( value( p ), defaultValue( p ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into int" );
-      raiseError( msg );
-    }
-
-    return val;
-  }
-
-  int QgsWmsParameters::toInt( ParameterName p, int mapId ) const
-  {
-    bool error;
-    int val = toInt( value( p, mapId ), defaultValue( p, mapId ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p, mapId ).toString();
-      QString msg = QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + n +
-                    QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into int" );
-      raiseError( msg );
-    }
-
-    return val;
-  }
-
-  QColor QgsWmsParameters::toColor( const QVariant &value, const QVariant &defaultValue, bool *error ) const
-  {
-    *error = false;
-    QColor c = defaultValue.value<QColor>();
-    QString cStr = value.toString();
-
-    if ( !cStr.isEmpty() )
-    {
-      // support hexadecimal notation to define colors
-      if ( cStr.startsWith( QStringLiteral( "0x" ), Qt::CaseInsensitive ) )
-        cStr.replace( 0, 2, QStringLiteral( "#" ) );
-
-      c = QColor( cStr );
-
-      *error = !c.isValid();
-    }
-
-    return c;
-  }
-
-  QColor QgsWmsParameters::toColor( ParameterName p ) const
-  {
-    bool error;
-    QColor c = toColor( value( p ), defaultValue( p ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a color" );
-      raiseError( msg );
-    }
-
-    return c;
-  }
-
-  QColor QgsWmsParameters::toColor( ParameterName p, int mapId ) const
-  {
-    bool error;
-    QColor c = toColor( value( p, mapId ), defaultValue( p, mapId ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p, mapId ).toString();
-      QString msg = QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + n +
-                    QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a color" );
-      raiseError( msg );
-    }
-
-    return c;
-  }
-
-  QgsRectangle QgsWmsParameters::toRectangle( const QVariant &value, bool *error ) const
-  {
-    *error = false;
-    QString bbox = value.toString();
-    QgsRectangle extent;
-
-    if ( !bbox.isEmpty() )
-    {
-      QStringList corners = bbox.split( ',' );
-
-      if ( corners.size() == 4 )
-      {
-        double d[4];
-        bool ok;
-
-        for ( int i = 0; i < 4; i++ )
-        {
-          corners[i].replace( QLatin1String( " " ), QLatin1String( "+" ) );
-          d[i] = corners[i].toDouble( &ok );
-          if ( !ok )
-          {
-            *error = !ok;
-            return extent;
-          }
-        }
-
-        if ( d[0] > d[2] || d[1] > d[3] )
-        {
-          *error = true;
-          return extent;
-        }
-
-        extent = QgsRectangle( d[0], d[1], d[2], d[3] );
-      }
-      else
-      {
-        *error = true;
-        return extent;
-      }
-    }
-
-    return extent;
-  }
-
-  QgsRectangle QgsWmsParameters::toRectangle( ParameterName p ) const
-  {
-    bool error;
-    QgsRectangle extent = toRectangle( value( p ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a rectangle" );
-      raiseError( msg );
-    }
-
-    return extent;
-  }
-
-  QgsRectangle QgsWmsParameters::toRectangle( ParameterName p, int mapId ) const
-  {
-    bool error;
-    QgsRectangle extent = toRectangle( value( p, mapId ), &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p, mapId ).toString();
-      QString msg = QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + n +
-                    QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a rectangle" );
-      raiseError( msg );
-    }
-
-    return extent;
-  }
-
-  QStringList QgsWmsParameters::toStringList( ParameterName name, char delimiter ) const
-  {
-    return value( name ).toString().split( delimiter, QString::SkipEmptyParts );
-  }
-
-  QStringList QgsWmsParameters::toStringList( ParameterName name, int mapId, char delimiter ) const
-  {
-    return value( name, mapId ).toString().split( delimiter, QString::SkipEmptyParts );
-  }
-
-  QList<int> QgsWmsParameters::toIntList( const QStringList &l, bool *error ) const
-  {
-    *error = false;
-    QList<int> elements;
-
-    for ( const QString &element : l )
-    {
-      bool ok;
-      int e = element.toInt( &ok );
-
-      if ( ok )
-      {
-        elements.append( e );
-      }
-      else
-      {
-        *error = !ok;
-        return elements;
-      }
-    }
-
-    return elements;
-  }
-
-  QList<int> QgsWmsParameters::toIntList( const QStringList &l, ParameterName p ) const
-  {
-    bool error;
-    QList<int> elements = toIntList( l, &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a list of int" );
-      raiseError( msg );
-    }
-
-    return elements;
-  }
-
-  QList<int> QgsWmsParameters::toIntList( const QStringList &l, ParameterName p, int mapId ) const
-  {
-    bool error;
-    QList<int> elements = toIntList( l, &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p, mapId ).toString();
-      QString msg = QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + n +
-                    QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a list of int" );
-      raiseError( msg );
-    }
-
-    return elements;
-  }
-
-  QList<float> QgsWmsParameters::toFloatList( const QStringList &l, bool *error ) const
-  {
-    *error = false;
-    QList<float> elements;
-
-    for ( const QString &element : l )
-    {
-      bool ok;
-      float e = element.toFloat( &ok );
-
-      if ( ok )
-      {
-        elements.append( e );
-      }
-      else
-      {
-        *error = !ok;
-        return elements;
-      }
-    }
-
-    return elements;
-  }
-
-  QList<float> QgsWmsParameters::toFloatList( const QStringList &l, ParameterName p ) const
-  {
-    bool error;
-    QList<float> elements = toFloatList( l, &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + QStringLiteral( " ('" ) + valStr +
-                    QStringLiteral( "') cannot be converted into a list of float" );
-      raiseError( msg );
-    }
-
-    return elements;
-  }
-
-  QList<float> QgsWmsParameters::toFloatList( const QStringList &l, ParameterName p, int mapId ) const
-  {
-    bool error;
-    QList<float> elements = toFloatList( l, &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + n +
-                    QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a list of float" );
-      raiseError( msg );
-    }
-
-    return elements;
-  }
-
-  QList<QColor> QgsWmsParameters::toColorList( const QStringList &l, bool *error ) const
-  {
-    *error = false;
-    QList<QColor> elements;
-
-    for ( const QString &element : l )
-    {
-      QColor c = QColor( element );
-
-      if ( c.isValid() )
-      {
-        elements.append( c );
-      }
-      else
-      {
-        *error = !c.isValid();
-        return elements;
-      }
-    }
-
-    return elements;
-  }
-
-  QList<QColor> QgsWmsParameters::toColorList( const QStringList &l, ParameterName p ) const
-  {
-    bool error;
-    QList<QColor> elements = toColorList( l, &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + QStringLiteral( " ('" ) + valStr +
-                    QStringLiteral( "') cannot be converted into a list of colors" );
-      raiseError( msg );
-    }
-
-    return elements;
-  }
-
-  QList<QColor> QgsWmsParameters::toColorList( const QStringList &l, ParameterName p, int mapId ) const
-  {
-    bool error;
-    QList<QColor> elements = toColorList( l, &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + n +
-                    QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a list of colors" );
-      raiseError( msg );
-    }
-
-    return elements;
-  }
-
-  QList<QgsGeometry> QgsWmsParameters::toGeomList( const QStringList &l, bool *error ) const
-  {
-    *error = false;
-    QList<QgsGeometry> geometries;
-
-    for ( const QString &wkt : l )
-    {
-      QgsGeometry g( QgsGeometry::fromWkt( wkt ) );
-
-      if ( g.isGeosValid() )
-      {
-        geometries.append( g );
-      }
-      else
-      {
-        *error = true;
-        return geometries;
-      }
-    }
-
-    return geometries;
-  }
-
-  QList<QgsGeometry> QgsWmsParameters::toGeomList( const QStringList &l, ParameterName p ) const
-  {
-    bool error;
-    QList<QgsGeometry> elements = toGeomList( l, &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p ).toString();
-      QString msg = n + QStringLiteral( " ('" ) + valStr +
-                    QStringLiteral( "') cannot be converted into a list of geometries" );
-      raiseError( msg );
-    }
-
-    return elements;
-  }
-
-  QList<QgsGeometry> QgsWmsParameters::toGeomList( const QStringList &l, ParameterName p, int mapId ) const
-  {
-    bool error;
-    QList<QgsGeometry> elements = toGeomList( l, &error );
-    if ( error )
-    {
-      QString n = name( p );
-      QString valStr = value( p, mapId ).toString();
-      QString msg = QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) + n +
-                    QStringLiteral( " ('" ) + valStr + QStringLiteral( "') cannot be converted into a list of geometries" );
-      raiseError( msg );
-    }
-
-    return elements;
-  }
-
   QString QgsWmsParameters::formatAsString() const
   {
-    return value( ParameterName::FORMAT ).toString();
+    return mWmsParameters[ QgsWmsParameter::FORMAT ].toString();
   }
 
   QgsWmsParameters::Format QgsWmsParameters::format() const
@@ -1206,7 +720,7 @@ namespace QgsWms
 
   QString QgsWmsParameters::infoFormatAsString() const
   {
-    return value( ParameterName::INFO_FORMAT ).toString();
+    return mWmsParameters[ QgsWmsParameter::INFO_FORMAT ].toString();
   }
 
   bool QgsWmsParameters::infoFormatIsImage() const
@@ -1250,247 +764,257 @@ namespace QgsWms
 
   QString QgsWmsParameters::i() const
   {
-    return value( ParameterName::I ).toString();
+    return mWmsParameters[ QgsWmsParameter::I ].toString();
   }
 
   QString QgsWmsParameters::j() const
   {
-    return value( ParameterName::J ).toString();
+    return mWmsParameters[ QgsWmsParameter::J ].toString();
   }
 
   int QgsWmsParameters::iAsInt() const
   {
-    return toInt( ParameterName::I );
+    return mWmsParameters[ QgsWmsParameter::I ].toInt();
   }
 
   int QgsWmsParameters::jAsInt() const
   {
-    return toInt( ParameterName::J );
+    return mWmsParameters[ QgsWmsParameter::J ].toInt();
   }
 
   QString QgsWmsParameters::x() const
   {
-    return value( ParameterName::X ).toString();
+    return mWmsParameters[ QgsWmsParameter::X ].toString();
   }
 
   QString QgsWmsParameters::y() const
   {
-    return value( ParameterName::Y ).toString();
+    return mWmsParameters[ QgsWmsParameter::Y ].toString();
   }
 
   int QgsWmsParameters::xAsInt() const
   {
-    return toInt( ParameterName::X );
+    return mWmsParameters[ QgsWmsParameter::X ].toInt();
   }
 
   int QgsWmsParameters::yAsInt() const
   {
-    return toInt( ParameterName::Y );
+    return mWmsParameters[ QgsWmsParameter::Y ].toInt();
   }
 
   QString QgsWmsParameters::rule() const
   {
-    return value( ParameterName::RULE ).toString();
+    return mWmsParameters[ QgsWmsParameter::RULE ].toString();
   }
 
   QString QgsWmsParameters::ruleLabel() const
   {
-    return value( ParameterName::RULELABEL ).toString();
+    return mWmsParameters[ QgsWmsParameter::RULELABEL ].toString();
   }
 
   bool QgsWmsParameters::ruleLabelAsBool() const
   {
-    return toBool( ParameterName::RULELABEL );
+    return mWmsParameters[ QgsWmsParameter::RULELABEL ].toBool();
   }
 
   QString QgsWmsParameters::transparent() const
   {
-    return value( ParameterName::TRANSPARENT ).toString();
+    return mWmsParameters[ QgsWmsParameter::TRANSPARENT ].toString();
   }
 
   bool QgsWmsParameters::transparentAsBool() const
   {
-    return toBool( ParameterName::TRANSPARENT );
+    return mWmsParameters[ QgsWmsParameter::TRANSPARENT ].toBool();
   }
 
   QString QgsWmsParameters::scale() const
   {
-    return value( ParameterName::SCALE ).toString();
+    return mWmsParameters[ QgsWmsParameter::SCALE ].toString();
   }
 
   double QgsWmsParameters::scaleAsDouble() const
   {
-    return toDouble( ParameterName::SCALE );
+    return mWmsParameters[ QgsWmsParameter::SCALE ].toDouble();
+  }
+
+  QString QgsWmsParameters::imageQuality() const
+  {
+    return mWmsParameters[ QgsWmsParameter::IMAGE_QUALITY ].toString();
+  }
+
+  int QgsWmsParameters::imageQualityAsInt() const
+  {
+    return mWmsParameters[ QgsWmsParameter::IMAGE_QUALITY ].toInt();
   }
 
   QString QgsWmsParameters::showFeatureCount() const
   {
-    return value( ParameterName::SHOWFEATURECOUNT ).toString();
+    return mWmsParameters[ QgsWmsParameter::SHOWFEATURECOUNT ].toString();
   }
 
   bool QgsWmsParameters::showFeatureCountAsBool() const
   {
-    return toBool( ParameterName::SHOWFEATURECOUNT );
+    return mWmsParameters[ QgsWmsParameter::SHOWFEATURECOUNT ].toBool();
   }
 
   QString QgsWmsParameters::featureCount() const
   {
-    return value( ParameterName::FEATURE_COUNT ).toString();
+    return mWmsParameters[ QgsWmsParameter::FEATURE_COUNT ].toString();
   }
 
   int QgsWmsParameters::featureCountAsInt() const
   {
-    return toInt( ParameterName::FEATURE_COUNT );
+    return mWmsParameters[ QgsWmsParameter::FEATURE_COUNT ].toInt();
   }
 
   QString QgsWmsParameters::boxSpace() const
   {
-    return value( ParameterName::BOXSPACE ).toString();
+    return mWmsParameters[ QgsWmsParameter::BOXSPACE ].toString();
   }
 
   double QgsWmsParameters::boxSpaceAsDouble() const
   {
-    return toDouble( ParameterName::BOXSPACE );
+    return mWmsParameters[ QgsWmsParameter::BOXSPACE ].toDouble();
   }
 
   QString QgsWmsParameters::layerSpace() const
   {
-    return value( ParameterName::LAYERSPACE ).toString();
+    return mWmsParameters[ QgsWmsParameter::LAYERSPACE ].toString();
   }
 
   double QgsWmsParameters::layerSpaceAsDouble() const
   {
-    return toDouble( ParameterName::LAYERSPACE );
+    return mWmsParameters[ QgsWmsParameter::LAYERSPACE ].toDouble();
   }
 
   QString QgsWmsParameters::layerTitleSpace() const
   {
-    return value( ParameterName::LAYERTITLESPACE ).toString();
+    return mWmsParameters[ QgsWmsParameter::LAYERTITLESPACE ].toString();
   }
 
   double QgsWmsParameters::layerTitleSpaceAsDouble() const
   {
-    return toDouble( ParameterName::LAYERTITLESPACE );
+    return mWmsParameters[ QgsWmsParameter::LAYERTITLESPACE ].toDouble();
   }
 
   QString QgsWmsParameters::symbolSpace() const
   {
-    return value( ParameterName::SYMBOLSPACE ).toString();
+    return mWmsParameters[ QgsWmsParameter::SYMBOLSPACE ].toString();
   }
 
   double QgsWmsParameters::symbolSpaceAsDouble() const
   {
-    return toDouble( ParameterName::SYMBOLSPACE );
+    return mWmsParameters[ QgsWmsParameter::SYMBOLSPACE ].toDouble();
   }
 
   QString QgsWmsParameters::symbolHeight() const
   {
-    return value( ParameterName::SYMBOLHEIGHT ).toString();
+    return mWmsParameters[ QgsWmsParameter::SYMBOLHEIGHT ].toString();
   }
 
   double QgsWmsParameters::symbolHeightAsDouble() const
   {
-    return toDouble( SYMBOLHEIGHT );
+    return mWmsParameters[ QgsWmsParameter::SYMBOLHEIGHT ].toDouble();
   }
 
   QString QgsWmsParameters::symbolWidth() const
   {
-    return value( ParameterName::SYMBOLWIDTH ).toString();
+    return mWmsParameters[ QgsWmsParameter::SYMBOLWIDTH ].toString();
   }
 
   double QgsWmsParameters::symbolWidthAsDouble() const
   {
-    return toDouble( SYMBOLWIDTH );
+    return mWmsParameters[ QgsWmsParameter::SYMBOLWIDTH ].toDouble();
   }
 
   QString QgsWmsParameters::iconLabelSpace() const
   {
-    return value( ParameterName::ICONLABELSPACE ).toString();
+    return mWmsParameters[ QgsWmsParameter::ICONLABELSPACE ].toString();
   }
 
   double QgsWmsParameters::iconLabelSpaceAsDouble() const
   {
-    return toDouble( ICONLABELSPACE );
+    return mWmsParameters[ QgsWmsParameter::ICONLABELSPACE ].toDouble();
   }
 
   QString QgsWmsParameters::layerFontFamily() const
   {
-    return value( ParameterName::LAYERFONTFAMILY ).toString();
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTFAMILY ].toString();
   }
 
   QString QgsWmsParameters::itemFontFamily() const
   {
-    return value( ParameterName::ITEMFONTFAMILY ).toString();
+    return mWmsParameters[ QgsWmsParameter::ITEMFONTFAMILY ].toString();
   }
 
   QString QgsWmsParameters::layerFontBold() const
   {
-    return value( ParameterName::LAYERFONTBOLD ).toString();
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTBOLD ].toString();
   }
 
   bool QgsWmsParameters::layerFontBoldAsBool() const
   {
-    return toBool( ParameterName::LAYERFONTBOLD );
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTBOLD ].toBool();
   }
 
   QString QgsWmsParameters::itemFontBold() const
   {
-    return value( ParameterName::ITEMFONTBOLD ).toString();
+    return mWmsParameters[ QgsWmsParameter::ITEMFONTBOLD ].toString();
   }
 
   bool QgsWmsParameters::itemFontBoldAsBool() const
   {
-    return toBool( ParameterName::ITEMFONTBOLD );
+    return mWmsParameters[ QgsWmsParameter::ITEMFONTBOLD ].toBool();
   }
 
   QString QgsWmsParameters::layerFontItalic() const
   {
-    return value( ParameterName::LAYERFONTITALIC ).toString();
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTITALIC ].toString();
   }
 
   bool QgsWmsParameters::layerFontItalicAsBool() const
   {
-    return toBool( ParameterName::LAYERFONTITALIC );
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTITALIC ].toBool();
   }
 
   QString QgsWmsParameters::itemFontItalic() const
   {
-    return value( ParameterName::ITEMFONTITALIC ).toString();
+    return mWmsParameters[ QgsWmsParameter::ITEMFONTITALIC ].toString();
   }
 
   bool QgsWmsParameters::itemFontItalicAsBool() const
   {
-    return toBool( ParameterName::ITEMFONTITALIC );
+    return mWmsParameters[ QgsWmsParameter::ITEMFONTITALIC ].toBool();
   }
 
   QString QgsWmsParameters::layerFontSize() const
   {
-    return value( ParameterName::LAYERFONTSIZE ).toString();
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTSIZE ].toString();
   }
 
   double QgsWmsParameters::layerFontSizeAsDouble() const
   {
-    return toDouble( LAYERFONTSIZE );
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTSIZE ].toDouble();
   }
 
   QString QgsWmsParameters::layerFontColor() const
   {
-    return value( ParameterName::LAYERFONTCOLOR ).toString();
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTCOLOR ].toString();
   }
 
   QColor QgsWmsParameters::layerFontColorAsColor() const
   {
-    return toColor( ParameterName::LAYERFONTCOLOR );
+    return mWmsParameters[ QgsWmsParameter::LAYERFONTCOLOR ].toColor();
   }
 
   QString QgsWmsParameters::itemFontSize() const
   {
-    return value( ParameterName::ITEMFONTSIZE ).toString();
+    return mWmsParameters[ QgsWmsParameter::ITEMFONTSIZE ].toString();
   }
 
   double QgsWmsParameters::itemFontSizeAsDouble() const
   {
-    return toDouble( ITEMFONTSIZE );
+    return mWmsParameters[ QgsWmsParameter::ITEMFONTSIZE ].toDouble();
   }
 
   QFont QgsWmsParameters::layerFont() const
@@ -1528,12 +1052,12 @@ namespace QgsWms
 
   QString QgsWmsParameters::layerTitle() const
   {
-    return value( ParameterName::LAYERTITLE ).toString();
+    return mWmsParameters[ QgsWmsParameter::LAYERTITLE ].toString();
   }
 
   bool QgsWmsParameters::layerTitleAsBool() const
   {
-    return toBool( ParameterName::LAYERTITLE );
+    return mWmsParameters[ QgsWmsParameter::LAYERTITLE ].toBool();
   }
 
   QgsLegendSettings QgsWmsParameters::legendSettings() const
@@ -1555,82 +1079,82 @@ namespace QgsWms
 
   QStringList QgsWmsParameters::highlightLabelString() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_LABELSTRING, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELSTRING ].toStringList( ';' );
   }
 
   QStringList QgsWmsParameters::highlightLabelSize() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_LABELSIZE, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELSIZE ].toStringList( ';' );
   }
 
   QList<int> QgsWmsParameters::highlightLabelSizeAsInt() const
   {
-    return toIntList( highlightLabelSize(), ParameterName::HIGHLIGHT_LABELSIZE );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELSIZE ].toIntList( ';' );
   }
 
   QStringList QgsWmsParameters::highlightLabelColor() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_LABELCOLOR, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELCOLOR ].toStringList( ';' );
   }
 
   QList<QColor> QgsWmsParameters::highlightLabelColorAsColor() const
   {
-    return toColorList( highlightLabelColor(), ParameterName::HIGHLIGHT_LABELCOLOR );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELCOLOR ].toColorList( ';' );
   }
 
   QStringList QgsWmsParameters::highlightLabelWeight() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_LABELWEIGHT, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELWEIGHT ].toStringList( ';' );
   }
 
   QList<int> QgsWmsParameters::highlightLabelWeightAsInt() const
   {
-    return toIntList( highlightLabelWeight(), ParameterName::HIGHLIGHT_LABELWEIGHT );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELWEIGHT ].toIntList( ';' );
   }
 
   QStringList QgsWmsParameters::highlightLabelFont() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_LABELFONT, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELFONT ].toStringList( ';' );
   }
 
   QStringList QgsWmsParameters::highlightLabelBufferColor() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_LABELBUFFERCOLOR, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELBUFFERCOLOR ].toStringList( ';' );
   }
 
   QList<QColor> QgsWmsParameters::highlightLabelBufferColorAsColor() const
   {
-    return toColorList( highlightLabelBufferColor(), ParameterName::HIGHLIGHT_LABELBUFFERCOLOR );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELBUFFERCOLOR ].toColorList( ';' );
   }
 
   QStringList QgsWmsParameters::highlightLabelBufferSize() const
   {
-    return toStringList( ParameterName::HIGHLIGHT_LABELBUFFERSIZE, ';' );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE ].toStringList( ';' );
   }
 
   QList<float> QgsWmsParameters::highlightLabelBufferSizeAsFloat() const
   {
-    return toFloatList( highlightLabelBufferSize(), ParameterName::HIGHLIGHT_LABELBUFFERSIZE );
+    return mWmsParameters[ QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE ].toFloatList( ';' );
   }
 
   QString QgsWmsParameters::wmsPrecision() const
   {
-    return value( ParameterName::WMS_PRECISION ).toString();
+    return mWmsParameters[ QgsWmsParameter::WMS_PRECISION ].toString();
   }
 
   int QgsWmsParameters::wmsPrecisionAsInt() const
   {
-    return toInt( ParameterName::WMS_PRECISION );
+    return mWmsParameters[ QgsWmsParameter::WMS_PRECISION ].toInt();
   }
 
   QString QgsWmsParameters::sld() const
   {
-    return value( ParameterName::SLD ).toString();
+    return mWmsParameters[ QgsWmsParameter::SLD ].toString();
   }
 
   QStringList QgsWmsParameters::filters() const
   {
-    const QString filter = value( ParameterName::FILTER ).toString();
+    const QString filter = mWmsParameters[ QgsWmsParameter::FILTER ].toString();
     if ( filter.startsWith( QStringLiteral( "(<" ) ) && filter.endsWith( QStringLiteral( "Filter>)" ) ) )
     {
       // OGC filter on multiple layers
@@ -1658,40 +1182,40 @@ namespace QgsWms
 
   QString QgsWmsParameters::filterGeom() const
   {
-    return value( ParameterName::FILTER_GEOM ).toString();
+    return mWmsParameters[ QgsWmsParameter::FILTER_GEOM ].toString();
   }
 
   QStringList QgsWmsParameters::selections() const
   {
-    return toStringList( ParameterName::SELECTION, ';' );
+    return mWmsParameters[ QgsWmsParameter::SELECTION ].toStringList( ';' );
   }
 
   QStringList QgsWmsParameters::opacities() const
   {
-    return toStringList( ParameterName::OPACITIES );
+    return mWmsParameters[ QgsWmsParameter::OPACITIES ].toStringList();
   }
 
   QList<int> QgsWmsParameters::opacitiesAsInt() const
   {
-    return toIntList( opacities(), ParameterName::OPACITIES );
+    return mWmsParameters[ QgsWmsParameter::OPACITIES ].toIntList();
   }
 
   QStringList QgsWmsParameters::allLayersNickname() const
   {
-    QStringList layer = toStringList( ParameterName::LAYER );
-    QStringList layers = toStringList( ParameterName::LAYERS );
+    QStringList layer = mWmsParameters[ QgsWmsParameter::LAYER ].toStringList();
+    const QStringList layers = mWmsParameters[ QgsWmsParameter::LAYERS ].toStringList();
     return layer << layers;
   }
 
   QStringList QgsWmsParameters::queryLayersNickname() const
   {
-    return toStringList( ParameterName::QUERY_LAYERS );
+    return mWmsParameters[ QgsWmsParameter::QUERY_LAYERS ].toStringList();
   }
 
   QStringList QgsWmsParameters::allStyles() const
   {
-    QStringList style = toStringList( ParameterName::STYLE );
-    QStringList styles = toStringList( ParameterName::STYLES );
+    QStringList style = mWmsParameters[ QgsWmsParameter::STYLE ].toStringList();
+    const QStringList styles = mWmsParameters[ QgsWmsParameter::STYLES ].toStringList();
     return style << styles;
   }
 
@@ -1717,7 +1241,7 @@ namespace QgsWms
         }
         else
         {
-          QString filterStr = value( ParameterName::FILTER ).toString();
+          QString filterStr = mWmsParameters[ QgsWmsParameter::FILTER ].toString();
           raiseError( QStringLiteral( "FILTER ('" ) + filterStr + QStringLiteral( "') is not properly formatted" ) );
         }
       }
@@ -1745,7 +1269,7 @@ namespace QgsWms
       }
       else
       {
-        QString selStr = value( ParameterName::SELECTION ).toString();
+        QString selStr = mWmsParameters[ QgsWmsParameter::SELECTION ].toString();
         raiseError( QStringLiteral( "SELECTION ('" ) + selStr + QStringLiteral( "') is not properly formatted" ) );
       }
     }
@@ -1841,32 +1365,47 @@ namespace QgsWms
 
   QString QgsWmsParameters::backgroundColor() const
   {
-    return value( ParameterName::BGCOLOR ).toString();
+    return mWmsParameters[ QgsWmsParameter::BGCOLOR ].toString();
   }
 
   QColor QgsWmsParameters::backgroundColorAsColor() const
   {
-    return toColor( ParameterName::BGCOLOR );
+    return mWmsParameters[ QgsWmsParameter::BGCOLOR ].toColor();
   }
 
   QString QgsWmsParameters::composerTemplate() const
   {
-    return value( ParameterName::TEMPLATE ).toString();
+    return mWmsParameters[ QgsWmsParameter::TEMPLATE ].toString();
   }
 
-  QgsWmsParametersComposerMap QgsWmsParameters::composerMapParameters( int mapId ) const
+  QgsWmsParametersComposerMap QgsWmsParameters::composerMapParameters( const int mapId ) const
   {
+    QgsWmsParameter wmsParam;
     QgsWmsParametersComposerMap param;
     param.mId = mapId;
 
     //map extent is mandatory
-    QString extentStr = value( ParameterName::EXTENT, mapId ).toString();
+    QString extentStr;
+    wmsParam = idParameter( QgsWmsParameter::EXTENT, mapId );
+    if ( wmsParam.isValid() )
+    {
+      extentStr = wmsParam.toString();
+    }
+
     if ( extentStr.isEmpty() )
+    {
       return param;
+    }
 
     QString pMapId = QStringLiteral( "MAP" ) + QString::number( mapId );
 
-    QgsRectangle extent = toRectangle( ParameterName::EXTENT, mapId );
+    wmsParam = idParameter( QgsWmsParameter::EXTENT, mapId );
+    QgsRectangle extent;
+    if ( wmsParam.isValid() )
+    {
+      extent = wmsParam.toRectangle();
+    }
+
     if ( extent.isEmpty() )
       return param;
 
@@ -1874,28 +1413,56 @@ namespace QgsWms
     param.mExtent = extent;
 
     // scale
-    if ( !value( ParameterName::SCALE, mapId ).toString().isEmpty() )
+    wmsParam = idParameter( QgsWmsParameter::SCALE, mapId );
+    if ( wmsParam.isValid() && !wmsParam.toString().isEmpty() )
     {
-      param.mScale = toDouble( ParameterName::SCALE, mapId );
+      param.mScale = wmsParam.toDouble();
     }
 
     // rotation
-    if ( !value( ParameterName::ROTATION, mapId ).toString().isEmpty() )
+    wmsParam = idParameter( QgsWmsParameter::ROTATION, mapId );
+    if ( wmsParam.isValid() && !wmsParam.toString().isEmpty() )
     {
-      param.mRotation = toDouble( ParameterName::ROTATION, mapId );
+      param.mRotation = wmsParam.toDouble();
     }
 
     //grid space x / y
-    if ( !value( ParameterName::GRID_INTERVAL_X, mapId ).toString().isEmpty() && !value( ParameterName::GRID_INTERVAL_Y, mapId ).toString().isEmpty() )
+    double gridx( -1 ), gridy( -1 );
+
+    wmsParam = idParameter( QgsWmsParameter::GRID_INTERVAL_X, mapId );
+    if ( wmsParam.isValid() && !wmsParam.toString().isEmpty() )
     {
-      param.mGridX = toDouble( ParameterName::GRID_INTERVAL_X, mapId );
-      param.mGridY = toDouble( ParameterName::GRID_INTERVAL_Y, mapId );
+      gridx = wmsParam.toDouble();
+    }
+
+    wmsParam = idParameter( QgsWmsParameter::GRID_INTERVAL_Y, mapId );
+    if ( wmsParam.isValid() && !wmsParam.toString().isEmpty() )
+    {
+      gridy = wmsParam.toDouble();
+    }
+
+    if ( gridx != -1 && gridy != -1 )
+    {
+      param.mGridX = gridx;
+      param.mGridY = gridy;
     }
 
     //layers
+    QStringList layers;
+    wmsParam = idParameter( QgsWmsParameter::LAYERS, mapId );
+    if ( wmsParam.isValid() )
+    {
+      layers = wmsParam.toStringList();
+    }
+
+    QStringList styles;
+    wmsParam = idParameter( QgsWmsParameter::STYLES, mapId );
+    if ( wmsParam.isValid() )
+    {
+      styles = wmsParam.toStringList();
+    }
+
     QList<QgsWmsParametersLayer> lParams;
-    QStringList layers = toStringList( ParameterName::LAYERS, mapId, ',' );
-    QStringList styles = toStringList( ParameterName::STYLES, mapId, ',' );
     for ( int i = 0; i < layers.size(); i++ )
     {
       QString layer = layers[i];
@@ -1911,15 +1478,69 @@ namespace QgsWms
 
     //highlight layers
     QList<QgsWmsParametersHighlightLayer> hParams;
-    QList<QgsGeometry> geoms = toGeomList( toStringList( ParameterName::HIGHLIGHT_GEOM, mapId, ';' ), ParameterName::HIGHLIGHT_GEOM, mapId );
-    QStringList slds = toStringList( ParameterName::HIGHLIGHT_SYMBOL, mapId, ';' );
-    QStringList labels = toStringList( ParameterName::HIGHLIGHT_LABELSTRING, mapId, ';' );
-    QList<QColor> colors = toColorList( toStringList( ParameterName::HIGHLIGHT_LABELCOLOR, mapId, ';' ), ParameterName::HIGHLIGHT_LABELCOLOR, mapId );
-    QList<int> sizes = toIntList( toStringList( ParameterName::HIGHLIGHT_LABELSIZE, mapId, ';' ), ParameterName::HIGHLIGHT_LABELSIZE, mapId );
-    QList<int> weights = toIntList( toStringList( ParameterName::HIGHLIGHT_LABELWEIGHT, mapId, ';' ), ParameterName::HIGHLIGHT_LABELWEIGHT, mapId );
-    QStringList fonts = toStringList( ParameterName::HIGHLIGHT_LABELFONT, mapId, ';' );
-    QList<QColor> bufferColors = toColorList( toStringList( ParameterName::HIGHLIGHT_LABELBUFFERCOLOR, mapId, ';' ), ParameterName::HIGHLIGHT_LABELBUFFERCOLOR, mapId );
-    QList<float> bufferSizes = toFloatList( toStringList( ParameterName::HIGHLIGHT_LABELBUFFERSIZE, mapId, ';' ), ParameterName::HIGHLIGHT_LABELBUFFERSIZE, mapId );
+
+    QList<QgsGeometry> geoms;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_GEOM, mapId );
+    if ( wmsParam.isValid() )
+    {
+      geoms = wmsParam.toGeomList( ';' );
+    }
+
+    QStringList slds;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_SYMBOL, mapId );
+    if ( wmsParam.isValid() )
+    {
+      slds = wmsParam.toStringList( ';' );
+    }
+
+    QStringList labels;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_LABELSTRING, mapId );
+    if ( wmsParam.isValid() )
+    {
+      labels = wmsParam.toStringList( ';' );
+    }
+
+    QStringList fonts;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_LABELFONT, mapId );
+    if ( wmsParam.isValid() )
+    {
+      fonts = wmsParam.toStringList( ';' );
+    }
+
+    QList<QColor> colors;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_LABELCOLOR, mapId );
+    if ( wmsParam.isValid() )
+    {
+      colors = wmsParam.toColorList( ';' );
+    }
+
+    QList<int> sizes;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_LABELSIZE, mapId );
+    if ( wmsParam.isValid() )
+    {
+      sizes = wmsParam.toIntList( ';' );
+    }
+
+    QList<int> weights;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_LABELWEIGHT, mapId );
+    if ( wmsParam.isValid() )
+    {
+      weights = wmsParam.toIntList( ';' );
+    }
+
+    QList<QColor> bufferColors;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_LABELBUFFERCOLOR, mapId );
+    if ( wmsParam.isValid() )
+    {
+      bufferColors = wmsParam.toColorList( ';' );
+    }
+
+    QList<float> bufferSizes;
+    wmsParam = idParameter( QgsWmsParameter::HIGHLIGHT_LABELBUFFERSIZE, mapId );
+    if ( wmsParam.isValid() )
+    {
+      bufferSizes = wmsParam.toFloatList( ';' );
+    }
 
     int nHLayers = std::min( geoms.size(), slds.size() );
     for ( int i = 0; i < nHLayers; i++ )
@@ -1976,18 +1597,12 @@ namespace QgsWms
 
   bool QgsWmsParameters::withGeometry() const
   {
-    return toBool( ParameterName::WITH_GEOMETRY );
+    return mWmsParameters[ QgsWmsParameter::WITH_GEOMETRY ].toBool();
   }
 
   bool QgsWmsParameters::withMapTip() const
   {
-    return toBool( ParameterName::WITH_MAPTIP );
-  }
-
-  QString QgsWmsParameters::name( ParameterName name ) const
-  {
-    const QMetaEnum metaEnum( QMetaEnum::fromType<ParameterName>() );
-    return metaEnum.valueToKey( name );
+    return mWmsParameters[ QgsWmsParameter::WITH_MAPTIP ].toBool();
   }
 
   void QgsWmsParameters::log( const QString &msg ) const
@@ -1995,26 +1610,23 @@ namespace QgsWms
     QgsMessageLog::logMessage( msg, QStringLiteral( "Server" ), Qgis::Info );
   }
 
-  void QgsWmsParameters::raiseError( ParameterName paramName ) const
-  {
-    const QString value = mParameters[paramName].mValue.toString();
-    const QString param = name( paramName );
-    const QString type = QVariant::typeToName( mParameters[paramName].mType );
-    raiseError( param + QStringLiteral( " ('" ) + value + QStringLiteral( "') cannot be converted into " ) + type );
-  }
-
-  void QgsWmsParameters::raiseError( ParameterName paramName, int mapId ) const
-  {
-    const QString value = mComposerParameters[mapId][paramName].mValue.toString();
-    const QString param = name( paramName );
-    const QString type = QVariant::typeToName( mComposerParameters[mapId][paramName].mType );
-    raiseError( QStringLiteral( "MAP" ) + QString::number( mapId ) + QStringLiteral( ":" ) +
-                param + QStringLiteral( " ('" ) + value +
-                QStringLiteral( "') cannot be converted into " ) + type );
-  }
-
   void QgsWmsParameters::raiseError( const QString &msg ) const
   {
     throw QgsBadRequestException( QStringLiteral( "Invalid WMS Parameter" ), msg );
+  }
+
+  QgsWmsParameter QgsWmsParameters::idParameter( const QgsWmsParameter::Name name, const int id ) const
+  {
+    QgsWmsParameter p;
+
+    for ( const auto &param : mWmsParameters.values( name ) )
+    {
+      if ( param.mId == id )
+      {
+        p = param;
+      }
+    }
+
+    return p;
   }
 }

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -393,6 +393,21 @@ namespace QgsWms
     const QgsWmsParameter pFilterGeom( QgsWmsParameter::FILTER_GEOM );
     save( pFilterGeom );
 
+    const QgsWmsParameter pPolygTol( QgsWmsParameter::FI_POLYGON_TOLERANCE,
+                                     QVariant::Double,
+                                     QVariant( 0.0 ) );
+    save( pPolygTol );
+
+    const QgsWmsParameter pLineTol( QgsWmsParameter::FI_LINE_TOLERANCE,
+                                    QVariant::Double,
+                                    QVariant( 0.0 ) );
+    save( pLineTol );
+
+    const QgsWmsParameter pPointTol( QgsWmsParameter::FI_POINT_TOLERANCE,
+                                     QVariant::Double,
+                                     QVariant( 0.0 ) );
+    save( pPointTol );
+
     const QgsWmsParameter pSelection( QgsWmsParameter::SELECTION );
     save( pSelection );
 
@@ -914,6 +929,36 @@ namespace QgsWms
   QString QgsWmsParameters::itemFontBold() const
   {
     return mWmsParameters[ QgsWmsParameter::ITEMFONTBOLD ].toString();
+  }
+
+  QString QgsWmsParameters::polygonTolerance() const
+  {
+    return mWmsParameters[ QgsWmsParameter::FI_POLYGON_TOLERANCE ].toString();
+  }
+
+  QString QgsWmsParameters::lineTolerance() const
+  {
+    return mWmsParameters[ QgsWmsParameter::FI_LINE_TOLERANCE ].toString();
+  }
+
+  QString QgsWmsParameters::pointTolerance() const
+  {
+    return mWmsParameters[ QgsWmsParameter::FI_POINT_TOLERANCE ].toString();
+  }
+
+  int QgsWmsParameters::polygonToleranceAsInt() const
+  {
+    return mWmsParameters[ QgsWmsParameter::FI_POLYGON_TOLERANCE ].toInt();
+  }
+
+  int QgsWmsParameters::lineToleranceAsInt() const
+  {
+    return mWmsParameters[ QgsWmsParameter::FI_LINE_TOLERANCE ].toInt();
+  }
+
+  int QgsWmsParameters::pointToleranceAsInt() const
+  {
+    return mWmsParameters[ QgsWmsParameter::FI_POINT_TOLERANCE ].toInt();
   }
 
   bool QgsWmsParameters::itemFontBoldAsBool() const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -116,6 +116,9 @@ namespace QgsWms
         SYMBOLWIDTH,
         OPACITIES,
         SLD,
+        FI_POLYGON_TOLERANCE,
+        FI_LINE_TOLERANCE,
+        FI_POINT_TOLERANCE,
         FILTER,
         FILTER_GEOM,
         FORMAT,
@@ -345,6 +348,18 @@ namespace QgsWms
        * \returns layer parameters
        */
       QList<QgsWmsParametersLayer> layersParameters() const;
+
+      QString polygonTolerance() const;
+
+      QString lineTolerance() const;
+
+      QString pointTolerance() const;
+
+      int polygonToleranceAsInt() const;
+
+      int lineToleranceAsInt() const;
+
+      int pointToleranceAsInt() const;
 
       /**
        * Returns FORMAT parameter as a string.

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -70,9 +70,9 @@ namespace QgsWms
 
   /**
    * \ingroup server
-   * \class QgsWmsParameters
-   * \brief Interface to retrieve and manipulate WMS parameters received from the client.
-   * \since QGIS 3.0
+   * \class QgsWmsParameter
+   * \brief WMS parameter received from the client.
+   * \since QGIS 3.4
    */
   class QgsWmsParameter : public QgsServerParameterDefinition
   {
@@ -155,26 +155,97 @@ namespace QgsWms
       };
       Q_ENUM( Name )
 
+      /**
+       * Constructor for QgsWmsParameter.
+       * \param name Name of the WMS parameter
+       * \param type Type of the parameter
+       * \param defaultValue Default value of the parameter
+       */
       QgsWmsParameter( const QgsWmsParameter::Name name = QgsWmsParameter::UNKNOWN,
                        const QVariant::Type type = QVariant::String,
                        const QVariant defaultValue = QVariant( "" ) );
 
+      /**
+       * Default destructor for QgsWmsParameter.
+       */
       virtual ~QgsWmsParameter() = default;
 
+      /**
+       * Returns true if the parameter is valid, false otherwise.
+       */
       bool isValid() const override;
 
+      /**
+       * Converts the parameter into a list of geometries.
+       * \param delimiter The character delimiting string geometries
+       * \returns A list of geometries
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       QList<QgsGeometry> toGeomList( const char delimiter = ',' ) const;
+
+      /**
+       * Converts the parameter into a list of integers.
+       * \param delimiter The character delimiting string integers
+       * \returns A list of integers
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       QList<int> toIntList( const char delimiter = ',' ) const;
+
+      /**
+       * Converts the parameter into a list of doubles.
+       * \param delimiter The character delimiting string doubles
+       * \returns A list of doubles
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       QList<double> toDoubleList( const char delimiter = ',' ) const;
+
+      /**
+       * Converts the parameter into a list of colors.
+       * \param delimiter The character delimiting string colors
+       * \returns A list of colors
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       QList<QColor> toColorList( const char delimiter = ',' ) const;
+
+      /**
+       * Converts the parameter into a rectangle.
+       * \returns A rectangle
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       QgsRectangle toRectangle() const;
+
+      /**
+       * Converts the parameter into an integer.
+       * \returns An integer
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       int toInt() const;
+
+      /**
+       * Converts the parameter into a double.
+       * \returns A double
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       double toDouble() const;
+
+      /**
+       * Converts the parameter into a color.
+       * \returns A color
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       QColor toColor() const;
 
       void raiseError() const;
 
+      /**
+       * Converts a parameter's name into its string representation.
+       */
       static QString name( const QgsWmsParameter::Name );
+
+      /**
+       * Converts a string into a parameter's name (UNKNOWN in case of an
+       * invalid string).
+       */
       static QgsWmsParameter::Name name( const QString &name );
 
       QgsWmsParameter::Name mName;

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -338,6 +338,10 @@ namespace QgsWms
        */
       QgsProjectVersion versionAsNumber() const;
 
+      /**
+       * Returns true if \a version is valid, false otherwise.
+       * \since QGIS 3.4
+       */
       bool versionIsValid( const QString version ) const;
 
       /**
@@ -417,16 +421,46 @@ namespace QgsWms
        */
       QList<QgsWmsParametersLayer> layersParameters() const;
 
+      /**
+       * Returns FI_POLYGON_TOLERANCE parameter or an empty string if not
+       * defined.
+       * \since QGIS 3.4
+       */
       QString polygonTolerance() const;
 
+      /**
+       * Returns FI_LINE_TOLERANCE parameter or an empty string if not
+       * defined.
+       * \since QGIS 3.4
+       */
       QString lineTolerance() const;
 
+      /**
+       * Returns FI_POINT_TOLERANCE parameter or an empty string if not
+       * defined.
+       * \since QGIS 3.4
+       */
       QString pointTolerance() const;
 
+      /**
+       * Returns FI_POLYGON_TOLERANCE parameter as an integer.
+       * \throws QgsBadRequestException
+       * \since QGIS 3.4
+       */
       int polygonToleranceAsInt() const;
 
+      /**
+       * Returns FI_LINE_TOLERANCE parameter as an integer.
+       * \throws QgsBadRequestException
+       * \since QGIS 3.4
+       */
       int lineToleranceAsInt() const;
 
+      /**
+       * Returns FI_POINT_TOLERANCE parameter as an integer.
+       * \throws QgsBadRequestException
+       * \since QGIS 3.4
+       */
       int pointToleranceAsInt() const;
 
       /**
@@ -454,8 +488,18 @@ namespace QgsWms
        */
       bool infoFormatIsImage() const;
 
+      /**
+       * Returns IMAGE_QUALITY parameter or an empty string if not
+       * defined.
+       * \since QGIS 3.4
+       */
       QString imageQuality() const;
 
+      /**
+       * Returns IMAGE_QUALITY parameter as an integer.
+       * \throws QgsBadRequestException
+       * \since QGIS 3.4
+       */
       int imageQualityAsInt() const;
 
       /**
@@ -1054,8 +1098,19 @@ namespace QgsWms
        */
       bool withMapTip() const;
 
+      /**
+       * Returns WMTVER parameter or an empty string if not defined.
+       * \since QGIS 3.4
+       */
       QString wmtver() const;
 
+      /**
+       * Returns a layout parameter thanks to its \a id.
+       * \param id Parameter id
+       * \param ok True if the parameter is valid, false otherwise
+       * \returns The layout parameter
+       * \since QGIS 3.4
+       */
       QString layoutParameter( const QString &id, bool &ok ) const;
 
     private:

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -159,6 +159,8 @@ namespace QgsWms
                        const QVariant::Type type = QVariant::String,
                        const QVariant defaultValue = QVariant( "" ) );
 
+      virtual ~QgsWmsParameter() = default;
+
       bool isValid() const override;
 
       QList<QgsGeometry> toGeomList( const char delimiter = ',' ) const;
@@ -209,6 +211,8 @@ namespace QgsWms
        * Constructor for WMS parameters with default values only.
         */
       QgsWmsParameters();
+
+      virtual ~QgsWmsParameters() = default;
 
       /**
        * Loads new parameters.

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -991,7 +991,7 @@ namespace QgsWms
       QString layoutParameter( const QString &id, bool &ok ) const;
 
     private:
-      bool loadParameter( const QPair<QString, QString> &parameter ) override;
+      bool loadParameter( const QString &name, const QString &value ) override;
 
       void save( const QgsWmsParameter &parameter, bool multi = false );
 

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -973,6 +973,8 @@ namespace QgsWms
 
       QString wmtver() const;
 
+      QString layoutParameter( const QString &id, bool &ok ) const;
+
     private:
       bool loadParameter( const QPair<QString, QString> &parameter ) override;
 

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -147,7 +147,8 @@ namespace QgsWms
         GRID_INTERVAL_X,
         GRID_INTERVAL_Y,
         WITH_GEOMETRY,
-        WITH_MAPTIP
+        WITH_MAPTIP,
+        WMTVER
       };
       Q_ENUM( Name )
 
@@ -159,7 +160,7 @@ namespace QgsWms
 
       QList<QgsGeometry> toGeomList( const char delimiter = ',' ) const;
       QList<int> toIntList( const char delimiter = ',' ) const;
-      QList<float> toFloatList( const char delimiter = ',' ) const;
+      QList<double> toDoubleList( const char delimiter = ',' ) const;
       QList<QColor> toColorList( const char delimiter = ',' ) const;
       QgsRectangle toRectangle() const;
       int toInt() const;
@@ -265,6 +266,8 @@ namespace QgsWms
        * \returns version
        */
       QgsProjectVersion versionAsNumber() const;
+
+      bool versionIsValid( const QString version ) const;
 
       /**
        * Returns BBOX if defined or an empty string.
@@ -856,7 +859,7 @@ namespace QgsWms
        * \returns highlight label buffer size
        * \throws QgsBadRequestException
        */
-      QList<float> highlightLabelBufferSizeAsFloat() const;
+      QList<double> highlightLabelBufferSizeAsFloat() const;
 
       /**
        * Returns HIGHLIGHT_LABELBUFFERCOLOR as a list of string.
@@ -967,6 +970,8 @@ namespace QgsWms
        * \returns true if maptip information is requested for feature info response
        */
       bool withMapTip() const;
+
+      QString wmtver() const;
 
     private:
       bool loadParameter( const QPair<QString, QString> &parameter ) override;

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -235,6 +235,10 @@ namespace QgsWms
        */
       QColor toColor() const;
 
+      /**
+       * Raises an error in case of an invalid conversion.
+       * \throws QgsBadRequestException Invalid parameter exception
+       */
       void raiseError() const;
 
       /**
@@ -252,6 +256,12 @@ namespace QgsWms
       int mId = -1;
   };
 
+  /**
+   * \ingroup server
+   * \class QgsWms::QgsWmsParameters
+   * \brief Provides an interface to retrieve and manipulate WMS parameters received from the client.
+   * \since QGIS 3.0
+   */
   class QgsWmsParameters : public QgsServerParameters
   {
       Q_GADGET
@@ -274,8 +284,6 @@ namespace QgsWms
        * Constructor for WMS parameters with specific values.
        * \param parameters Map of parameters where keys are parameters' names.
        */
-      // QgsWmsParameters( const QgsServerRequest::Parameters &parameters );
-
       QgsWmsParameters( const QgsServerParameters &parameters );
 
       /**
@@ -284,12 +292,6 @@ namespace QgsWms
       QgsWmsParameters();
 
       virtual ~QgsWmsParameters() = default;
-
-      /**
-       * Loads new parameters.
-       * \param parameters Map of parameters
-       */
-      // void load( const QgsServerRequest::Parameters &parameters );
 
       /**
        * Dumps parameters.

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -262,13 +262,6 @@ namespace QgsWms
       int heightAsInt() const;
 
       /**
-       * Returns VERSION parameter as a string or an empty string if not
-       * defined.
-       * \returns version
-       */
-      QString version() const;
-
-      /**
        * Returns VERSION parameter if defined or its default value.
        * \returns version
        */

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2307,10 +2307,9 @@ namespace QgsWms
     double mapUnitTolerance = 0.0;
     if ( ml->geometryType() == QgsWkbTypes::PolygonGeometry )
     {
-      QMap<QString, QString>::const_iterator tolIt = mParameters.find( QStringLiteral( "FI_POLYGON_TOLERANCE" ) );
-      if ( tolIt != mParameters.constEnd() )
+      if ( ! mWmsParameters.polygonTolerance().isEmpty() )
       {
-        mapUnitTolerance = tolIt.value().toInt() * rct.mapToPixel().mapUnitsPerPixel();
+        mapUnitTolerance = mWmsParameters.polygonToleranceAsInt() * rct.mapToPixel().mapUnitsPerPixel();
       }
       else
       {
@@ -2319,10 +2318,9 @@ namespace QgsWms
     }
     else if ( ml->geometryType() == QgsWkbTypes::LineGeometry )
     {
-      QMap<QString, QString>::const_iterator tolIt = mParameters.find( QStringLiteral( "FI_LINE_TOLERANCE" ) );
-      if ( tolIt != mParameters.constEnd() )
+      if ( ! mWmsParameters.lineTolerance().isEmpty() )
       {
-        mapUnitTolerance = tolIt.value().toInt() * rct.mapToPixel().mapUnitsPerPixel();
+        mapUnitTolerance = mWmsParameters.lineToleranceAsInt() * rct.mapToPixel().mapUnitsPerPixel();
       }
       else
       {
@@ -2331,10 +2329,9 @@ namespace QgsWms
     }
     else //points
     {
-      QMap<QString, QString>::const_iterator tolIt = mParameters.find( QStringLiteral( "FI_POINT_TOLERANCE" ) );
-      if ( tolIt != mParameters.constEnd() )
+      if ( ! mWmsParameters.pointTolerance().isEmpty() )
       {
-        mapUnitTolerance = tolIt.value().toInt() * rct.mapToPixel().mapUnitsPerPixel();
+        mapUnitTolerance = mWmsParameters.pointToleranceAsInt() * rct.mapToPixel().mapUnitsPerPixel();
       }
       else
       {

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -525,11 +525,13 @@ namespace QgsWms
     c->layoutItems<QgsLayoutItemLabel>( labels );
     for ( const auto &label : qgis::as_const( labels ) )
     {
-      QString labelId = label->id().toUpper();
-      if ( !mParameters.contains( labelId ) )
+      bool ok = false;
+      const QString labelId = label->id();
+      const QString labelParam = mWmsParameters.layoutParameter( labelId, ok );
+
+      if ( !ok )
         continue;
 
-      QString labelParam = mParameters[ labelId ];
       if ( labelParam.isEmpty() )
       {
         //remove exported labels referenced in the request
@@ -549,15 +551,18 @@ namespace QgsWms
     {
       if ( html->frameCount() == 0 )
         continue;
+
       QgsLayoutFrame *htmlFrame = html->frame( 0 );
-      QString htmlId = htmlFrame->id().toUpper();
-      if ( !mParameters.contains( htmlId ) )
+      bool ok = false;
+      const QString htmlId = htmlFrame->id();
+      const QString url = mWmsParameters.layoutParameter( htmlId, ok );
+
+      if ( !ok )
       {
         html->update();
         continue;
       }
 
-      QString url = mParameters[ htmlId ];
       //remove exported Htmls referenced in the request
       //but with empty string
       if ( url.isEmpty() )

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -127,15 +127,14 @@ namespace QgsWms
 
   QgsRenderer::QgsRenderer( QgsServerInterface *serverIface,
                             const QgsProject *project,
-                            const QgsServerRequest::Parameters &parameters )
-    : mParameters( parameters )
+                            const QgsWmsParameters &parameters )
+    : mWmsParameters( parameters )
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     , mAccessControl( serverIface->accessControls() )
 #endif
     , mSettings( *serverIface->serverSettings() )
     , mProject( project )
   {
-    mWmsParameters.load( parameters );
     mWmsParameters.dump();
 
     initRestrictedLayers();
@@ -1402,7 +1401,7 @@ namespace QgsWms
     {
       searchRect = layerFilterGeom->boundingBox();
     }
-    else if ( mParameters.contains( QStringLiteral( "BBOX" ) ) )
+    else if ( !mWmsParameters.bbox().isEmpty() )
     {
       searchRect = layerRect;
     }
@@ -2267,21 +2266,15 @@ namespace QgsWms
 
   int QgsRenderer::getImageQuality() const
   {
-
     // First taken from QGIS project
     int imageQuality = QgsServerProjectUtils::wmsImageQuality( *mProject );
 
     // Then checks if a parameter is given, if so use it instead
-    if ( mParameters.contains( QStringLiteral( "IMAGE_QUALITY" ) ) )
+    if ( !mWmsParameters.imageQuality().isEmpty() )
     {
-      bool conversionSuccess;
-      int imageQualityParameter;
-      imageQualityParameter = mParameters[ QStringLiteral( "IMAGE_QUALITY" )].toInt( &conversionSuccess );
-      if ( conversionSuccess )
-      {
-        imageQuality = imageQualityParameter;
-      }
+      imageQuality = mWmsParameters.imageQualityAsInt();
     }
+
     return imageQuality;
   }
 

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -77,7 +77,7 @@ namespace QgsWms
           QgsConfigParser and QgsCapabilitiesCache*/
       QgsRenderer( QgsServerInterface *serverIface,
                    const QgsProject *project,
-                   const QgsServerRequest::Parameters &parameters );
+                   const QgsWmsParameters &parameters );
 
       ~QgsRenderer();
 
@@ -292,7 +292,8 @@ namespace QgsWms
 
     private:
 
-      const QgsServerRequest::Parameters &mParameters;
+      QgsServerRequest::Parameters mParameters;
+      const QgsWmsParameters &mWmsParameters;
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
       //! The access control helper
@@ -302,7 +303,6 @@ namespace QgsWms
 
       const QgsServerSettings &mSettings;
       const QgsProject *mProject = nullptr;
-      QgsWmsParameters mWmsParameters;
       QStringList mRestrictedLayers;
       QMap<QString, QgsMapLayer *> mNicknameLayers;
       QMap<QString, QList<QgsMapLayer *> > mLayerGroups;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -292,7 +292,6 @@ namespace QgsWms
 
     private:
 
-      QgsServerRequest::Parameters mParameters;
       const QgsWmsParameters &mWmsParameters;
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/tests/src/python/test_qgsserver_wms.py
+++ b/tests/src/python/test_qgsserver_wms.py
@@ -107,7 +107,7 @@ class TestQgsServerWMS(TestQgsServerWMSTestBase):
         project = QgsProject()
         project.read(projectPath)
 
-        query_string = 'https://www.qgis.org/?SERVICE=WMS&VERSION=1.3&REQUEST=%s' % (request)
+        query_string = 'https://www.qgis.org/?SERVICE=WMS&VERSION=1.3.0&REQUEST=%s' % (request)
         if extra is not None:
             query_string += extra
         header, body = self._execute_request_project(query_string, project)


### PR DESCRIPTION
## Description

This PR improves parameters management in WMS and WFS in order to remove duplicated code.

Moreover, considering that a parameter is now (almost) everywhere a Q_ENUM, several errors due to string comparison are fixed. This way, the WFS `GetCapabilities` document is much more `OGC` compliant.

Documentation has to be updated for several classes (WIP).

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
