### PR TITLE
Delimited text detectTypes flag - fixes #18601

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -120,7 +120,7 @@ QgsDelimitedTextProvider::QgsDelimitedTextProvider( const QString &uri, const Pr
     }
   }
 
-  mDetectTypes=true;
+  mDetectTypes = true;
   if ( url.hasQueryItem( QStringLiteral( "detectTypes" ) ) )
     mDetectTypes = ! url.queryItemValue( QStringLiteral( "detectTypes" ) ).toLower().startsWith( 'n' );
 
@@ -557,9 +557,9 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
         couldBeDouble[i] = true;
       }
 
-      if( ! mDetectTypes )
+      if ( ! mDetectTypes )
       {
-          continue;
+        continue;
       }
 
       // Now test for still valid possible types for the field
@@ -626,7 +626,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
         typeName = QStringLiteral( "double" );
       }
     }
-    if( typeName == QStringLiteral( "integer" ) )
+    if ( typeName == QStringLiteral( "integer" ) )
     {
       fieldType = QVariant::Int;
     }
@@ -634,7 +634,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
     {
       fieldType = QVariant::LongLong;
     }
-    else if(  typeName == QStringLiteral( "real" ) || typeName == QStringLiteral( "double" ) )
+    else if ( typeName == QStringLiteral( "real" ) || typeName == QStringLiteral( "double" ) )
     {
       typeName = QStringLiteral( "double" );
       fieldType = QVariant::Double;

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -227,6 +227,7 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
     QString mWktFieldName;
     QString mXFieldName;
     QString mYFieldName;
+    bool mDetectTypes;
 
     mutable int mXFieldIndex = -1;
     mutable int mYFieldIndex = -1;

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -227,7 +227,7 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
     QString mWktFieldName;
     QString mXFieldName;
     QString mYFieldName;
-    bool mDetectTypes;
+    bool mDetectTypes = true;
 
     mutable int mXFieldIndex = -1;
     mutable int mYFieldIndex = -1;

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -145,7 +145,7 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
   QUrl url = mFile->url();
 
-  url.addQueryItem( QStringLiteral( "detectTypes" ), cbxDetectTypes->isChecked() ? QStringLiteral("yes") : QStringLiteral("no") );
+  url.addQueryItem( QStringLiteral( "detectTypes" ), cbxDetectTypes->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
 
   if ( cbxPointIsComma->isChecked() )
   {
@@ -194,9 +194,9 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
   }
 
-  if ( ! geomTypeNone->isChecked() ) url.addQueryItem( QStringLiteral( "spatialIndex" ), cbxSpatialIndex->isChecked() ? QStringLiteral("yes") : QStringLiteral("no") );
-  url.addQueryItem( QStringLiteral( "subsetIndex" ), cbxSubsetIndex->isChecked() ? QStringLiteral("yes") : QStringLiteral("no") );
-  url.addQueryItem( QStringLiteral( "watchFile" ), cbxWatchFile->isChecked() ? QStringLiteral("yes") : QStringLiteral("no") );
+  if ( ! geomTypeNone->isChecked() ) url.addQueryItem( QStringLiteral( "spatialIndex" ), cbxSpatialIndex->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
+  url.addQueryItem( QStringLiteral( "subsetIndex" ), cbxSubsetIndex->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
+  url.addQueryItem( QStringLiteral( "watchFile" ), cbxWatchFile->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
 
   // store the settings
   saveSettings();

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -194,7 +194,7 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
   }
 
-  if ( ! geomTypeNone->isChecked() ) 
+  if ( ! geomTypeNone->isChecked() )
   {
     url.addQueryItem( QStringLiteral( "spatialIndex" ), cbxSpatialIndex->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
   }

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -145,6 +145,8 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
   QUrl url = mFile->url();
 
+  url.addQueryItem( QStringLiteral( "detectTypes" ), cbxDetectTypes->isChecked() ? QStringLiteral("yes") : QStringLiteral("no") );
+
   if ( cbxPointIsComma->isChecked() )
   {
     url.addQueryItem( QStringLiteral( "decimalPoint" ), QStringLiteral( "," ) );
@@ -192,9 +194,9 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
   }
 
-  if ( ! geomTypeNone->isChecked() ) url.addQueryItem( QStringLiteral( "spatialIndex" ), cbxSpatialIndex->isChecked() ? "yes" : "no" );
-  url.addQueryItem( QStringLiteral( "subsetIndex" ), cbxSubsetIndex->isChecked() ? "yes" : "no" );
-  url.addQueryItem( QStringLiteral( "watchFile" ), cbxWatchFile->isChecked() ? "yes" : "no" );
+  if ( ! geomTypeNone->isChecked() ) url.addQueryItem( QStringLiteral( "spatialIndex" ), cbxSpatialIndex->isChecked() ? QStringLiteral("yes") : QStringLiteral("no") );
+  url.addQueryItem( QStringLiteral( "subsetIndex" ), cbxSubsetIndex->isChecked() ? QStringLiteral("yes") : QStringLiteral("no") );
+  url.addQueryItem( QStringLiteral( "watchFile" ), cbxWatchFile->isChecked() ? QStringLiteral("yes") : QStringLiteral("no") );
 
   // store the settings
   saveSettings();
@@ -284,6 +286,7 @@ void QgsDelimitedTextSourceSelect::loadSettings( const QString &subkey, bool loa
 
   rowCounter->setValue( settings.value( key + "/startFrom", 0 ).toInt() );
   cbxUseHeader->setChecked( settings.value( key + "/useHeader", "true" ) != "false" );
+  cbxDetectTypes->setChecked( settings.value( key + "/detectTypes", "true" ) != "false" );
   cbxTrimFields->setChecked( settings.value( key + "/trimFields", "false" ) == "true" );
   cbxSkipEmptyFields->setChecked( settings.value( key + "/skipEmptyFields", "false" ) == "true" );
   cbxPointIsComma->setChecked( settings.value( key + "/decimalPoint", "." ).toString().contains( ',' ) );
@@ -329,6 +332,7 @@ void QgsDelimitedTextSourceSelect::saveSettings( const QString &subkey, bool sav
   settings.setValue( key + "/delimiterRegexp", txtDelimiterRegexp->text() );
   settings.setValue( key + "/startFrom", rowCounter->value() );
   settings.setValue( key + "/useHeader", cbxUseHeader->isChecked() ? "true" : "false" );
+  settings.setValue( key + "/detectTypes", cbxDetectTypes->isChecked() ? "true" : "false" );
   settings.setValue( key + "/trimFields", cbxTrimFields->isChecked() ? "true" : "false" );
   settings.setValue( key + "/skipEmptyFields", cbxSkipEmptyFields->isChecked() ? "true" : "false" );
   settings.setValue( key + "/decimalPoint", cbxPointIsComma->isChecked() ? "," : "." );

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -194,7 +194,11 @@ void QgsDelimitedTextSourceSelect::addButtonClicked()
 
   }
 
-  if ( ! geomTypeNone->isChecked() ) url.addQueryItem( QStringLiteral( "spatialIndex" ), cbxSpatialIndex->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
+  if ( ! geomTypeNone->isChecked() ) 
+  {
+    url.addQueryItem( QStringLiteral( "spatialIndex" ), cbxSpatialIndex->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
+  }
+
   url.addQueryItem( QStringLiteral( "subsetIndex" ), cbxSubsetIndex->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
   url.addQueryItem( QStringLiteral( "watchFile" ), cbxWatchFile->isChecked() ? QStringLiteral( "yes" ) : QStringLiteral( "no" ) );
 

--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -45,16 +45,7 @@
       <bool>true</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>0</number>
       </property>
       <item>
@@ -295,16 +286,7 @@
             </widget>
             <widget class="QWidget" name="swpDelimOptions">
              <layout class="QVBoxLayout" name="verticalLayout_11">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
+              <property name="margin">
                <number>0</number>
               </property>
               <item>
@@ -325,16 +307,7 @@
                  <property name="spacing">
                   <number>0</number>
                  </property>
-                 <property name="leftMargin">
-                  <number>2</number>
-                 </property>
-                 <property name="topMargin">
-                  <number>2</number>
-                 </property>
-                 <property name="rightMargin">
-                  <number>2</number>
-                 </property>
-                 <property name="bottomMargin">
+                 <property name="margin">
                   <number>2</number>
                  </property>
                  <item>
@@ -593,16 +566,7 @@
             </widget>
             <widget class="QWidget" name="swpRegexpOptions">
              <layout class="QVBoxLayout" name="verticalLayout_12">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
+              <property name="margin">
                <number>0</number>
               </property>
               <item>
@@ -811,6 +775,16 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0">
+           <widget class="QCheckBox" name="cbxDetectTypes">
+            <property name="text">
+             <string>Detect field types</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -900,16 +874,7 @@
             </property>
             <widget class="QWidget" name="swpGeomXY">
              <layout class="QVBoxLayout" name="verticalLayout_8">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
+              <property name="margin">
                <number>0</number>
               </property>
               <item>
@@ -1033,16 +998,7 @@
             </widget>
             <widget class="QWidget" name="swpGeomWKT">
              <layout class="QVBoxLayout" name="verticalLayout_6">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
+              <property name="margin">
                <number>0</number>
               </property>
               <item>
@@ -1332,6 +1288,7 @@
   <tabstop>recordOptionsGroupBox</tabstop>
   <tabstop>rowCounter</tabstop>
   <tabstop>cbxUseHeader</tabstop>
+  <tabstop>cbxDetectTypes</tabstop>
   <tabstop>cbxPointIsComma</tabstop>
   <tabstop>cbxTrimFields</tabstop>
   <tabstop>cbxSkipEmptyFields</tabstop>

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -337,7 +337,7 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
             print((prefix + '    ' + repr(msg) + ','))
         print((prefix + '    ]'))
         print('    return wanted')
-        print('',flush=True)
+        print('', flush=True)
 
     def recordDifference(self, record1, record2):
         # Compare a record defined as a dictionary
@@ -804,7 +804,7 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
         params = {'yField': 'y', 'xField': 'x', 'type': 'csv', 'delimiter': '\\t'}
         requests = None
         self.runTest(filename, requests, **params)
-     
+
     def test_041_no_detect_type(self):
         # CSV file parsing
         # Skip lines
@@ -816,7 +816,7 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
     def test_042_no_detect_types_csvt(self):
         # CSVT field types
         filename = 'testcsvt.csv'
-        params = {'geomType': 'none', 'type': 'csv', 'detectTypes': 'no' }
+        params = {'geomType': 'none', 'type': 'csv', 'detectTypes': 'no'}
         requests = None
         self.runTest(filename, requests, **params)
 

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -337,7 +337,7 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
             print((prefix + '    ' + repr(msg) + ','))
         print((prefix + '    ]'))
         print('    return wanted')
-        print()
+        print('',flush=True)
 
     def recordDifference(self, record1, record2):
         # Compare a record defined as a dictionary
@@ -802,6 +802,21 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
         # x/y containing some null geometries
         filename = 'test14666.csv'
         params = {'yField': 'y', 'xField': 'x', 'type': 'csv', 'delimiter': '\\t'}
+        requests = None
+        self.runTest(filename, requests, **params)
+     
+    def test_041_no_detect_type(self):
+        # CSV file parsing
+        # Skip lines
+        filename = 'testtypes.csv'
+        params = {'yField': 'lat', 'xField': 'lon', 'type': 'csv', 'detectTypes': 'no'}
+        requests = None
+        self.runTest(filename, requests, **params)
+
+    def test_042_no_detect_types_csvt(self):
+        # CSVT field types
+        filename = 'testcsvt.csv'
+        params = {'geomType': 'none', 'type': 'csv', 'detectTypes': 'no' }
         requests = None
         self.runTest(filename, requests, **params)
 

--- a/tests/src/python/test_qgsdelimitedtextprovider_wanted.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider_wanted.py
@@ -2449,3 +2449,142 @@ def test_040_issue_14666():
         '2 records have missing geometry definitions',
     ]
     return wanted
+
+def test_041_no_detect_type():
+    wanted={}
+    wanted['uri']='file://testtypes.csv?yField=lat&xField=lon&type=csv&detectTypes=no'
+    wanted['fieldTypes']=['text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text']
+    wanted['geometryType']=0
+    wanted['data']={
+        2: {
+            'id': 'line1',
+            'description': '1.0',
+            'lon': '1.0',
+            'lat': '1.0',
+            'empty': 'NULL',
+            'text': 'NULL',
+            'int': '0',
+            'longlong': '0',
+            'real': 'NULL',
+            'text2': '1',
+            '#fid': 2,
+            '#geometry': 'Point (1 1)',
+            },
+        3: {
+            'id': 'line2',
+            'description': '1.0',
+            'lon': '1.0',
+            'lat': '5.0',
+            'empty': 'NULL',
+            'text': '1',
+            'int': 'NULL',
+            'longlong': '9189304972279762602',
+            'real': '1.3',
+            'text2': '-4',
+            '#fid': 3,
+            '#geometry': 'Point (1 5)',
+            },
+        4: {
+            'id': 'line3',
+            'description': '5.0',
+            'lon': '5.0',
+            'lat': '5.0',
+            'empty': 'NULL',
+            'text': '1xx',
+            'int': '2',
+            'longlong': '345',
+            'real': '2',
+            'text2': '1x',
+            '#fid': 4,
+            '#geometry': 'Point (5 5)',
+            },
+        5: {
+            'id': 'line4',
+            'description': '5.0',
+            'lon': '5.0',
+            'lat': '1.0',
+            'empty': 'NULL',
+            'text': 'A string',
+            'int': '-3456',
+            'longlong': '-3123724580211819352',
+            'real': '-123.56',
+            'text2': 'NULL',
+            '#fid': 5,
+            '#geometry': 'Point (5 1)',
+            },
+        6: {
+            'id': 'line5',
+            'description': '3.0',
+            'lon': '3.0',
+            'lat': '1.0',
+            'empty': 'NULL',
+            'text': 'NULL',
+            'int': 'NULL',
+            'longlong': 'NULL',
+            'real': '23e-5',
+            'text2': '23',
+            '#fid': 6,
+            '#geometry': 'Point (3 1)',
+            },
+        7: {
+            'id': 'line6',
+            'description': '1.0',
+            'lon': '1.0',
+            'lat': '3.0',
+            'empty': 'NULL',
+            'text': '1.5',
+            'int': '9',
+            'longlong': '42',
+            'real': '99',
+            'text2': '0',
+            '#fid': 7,
+            '#geometry': 'Point (1 3)',
+            },
+        }
+    wanted['log']=[
+        ]
+    return wanted
+
+def test_042_no_detect_types_csvt():
+    wanted={}
+    wanted['uri']='file://testcsvt.csv?geomType=none&type=csv&detectTypes=no'
+    wanted['fieldTypes']=['integer', 'text', 'integer', 'double', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text']
+    wanted['geometryType']=4
+    wanted['data']={
+        2: {
+            'id': '1',
+            'description': 'Test csvt 1',
+            'fint': '1',
+            'freal': '1.2',
+            'fstr': '1',
+            'fstr_1': 'text',
+            'fdatetime': '2015-03-02T12:30:00',
+            'fdate': '2014-12-30',
+            'ftime': '23:55',
+            'flong': '-456',
+            'flonglong': '-678',
+            'field_12': 'NULL',
+            '#fid': 2,
+            '#geometry': 'None',
+            },
+        3: {
+            'id': '2',
+            'description': 'Test csvt 2',
+            'fint': '3',
+            'freal': '1.5',
+            'fstr': '99',
+            'fstr_1': '23.5',
+            'fdatetime': '80',
+            'fdate': '2015-03-28',
+            'ftime': '2014-12-30',
+            'flong': '01:55',
+            'flonglong': '9189304972279762602',
+            'field_12': '-3123724580211819352',
+            '#fid': 3,
+            '#geometry': 'None',
+            },
+        }
+    wanted['log']=[
+        ]
+    return wanted
+

--- a/tests/src/python/test_qgsdelimitedtextprovider_wanted.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider_wanted.py
@@ -2450,12 +2450,13 @@ def test_040_issue_14666():
     ]
     return wanted
 
+
 def test_041_no_detect_type():
-    wanted={}
-    wanted['uri']='file://testtypes.csv?yField=lat&xField=lon&type=csv&detectTypes=no'
-    wanted['fieldTypes']=['text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text']
-    wanted['geometryType']=0
-    wanted['data']={
+    wanted = {}
+    wanted['uri'] = 'file://testtypes.csv?yField=lat&xField=lon&type=csv&detectTypes=no'
+    wanted['fieldTypes'] = ['text', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text']
+    wanted['geometryType'] = 0
+    wanted['data'] = {
         2: {
             'id': 'line1',
             'description': '1.0',
@@ -2469,7 +2470,7 @@ def test_041_no_detect_type():
             'text2': '1',
             '#fid': 2,
             '#geometry': 'Point (1 1)',
-            },
+        },
         3: {
             'id': 'line2',
             'description': '1.0',
@@ -2483,7 +2484,7 @@ def test_041_no_detect_type():
             'text2': '-4',
             '#fid': 3,
             '#geometry': 'Point (1 5)',
-            },
+        },
         4: {
             'id': 'line3',
             'description': '5.0',
@@ -2497,7 +2498,7 @@ def test_041_no_detect_type():
             'text2': '1x',
             '#fid': 4,
             '#geometry': 'Point (5 5)',
-            },
+        },
         5: {
             'id': 'line4',
             'description': '5.0',
@@ -2511,7 +2512,7 @@ def test_041_no_detect_type():
             'text2': 'NULL',
             '#fid': 5,
             '#geometry': 'Point (5 1)',
-            },
+        },
         6: {
             'id': 'line5',
             'description': '3.0',
@@ -2525,7 +2526,7 @@ def test_041_no_detect_type():
             'text2': '23',
             '#fid': 6,
             '#geometry': 'Point (3 1)',
-            },
+        },
         7: {
             'id': 'line6',
             'description': '1.0',
@@ -2539,18 +2540,19 @@ def test_041_no_detect_type():
             'text2': '0',
             '#fid': 7,
             '#geometry': 'Point (1 3)',
-            },
-        }
-    wanted['log']=[
-        ]
+        },
+    }
+    wanted['log'] = [
+    ]
     return wanted
 
+
 def test_042_no_detect_types_csvt():
-    wanted={}
-    wanted['uri']='file://testcsvt.csv?geomType=none&type=csv&detectTypes=no'
-    wanted['fieldTypes']=['integer', 'text', 'integer', 'double', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text']
-    wanted['geometryType']=4
-    wanted['data']={
+    wanted = {}
+    wanted['uri'] = 'file://testcsvt.csv?geomType=none&type=csv&detectTypes=no'
+    wanted['fieldTypes'] = ['integer', 'text', 'integer', 'double', 'text', 'text', 'text', 'text', 'text', 'text', 'text', 'text']
+    wanted['geometryType'] = 4
+    wanted['data'] = {
         2: {
             'id': '1',
             'description': 'Test csvt 1',
@@ -2566,7 +2568,7 @@ def test_042_no_detect_types_csvt():
             'field_12': 'NULL',
             '#fid': 2,
             '#geometry': 'None',
-            },
+        },
         3: {
             'id': '2',
             'description': 'Test csvt 2',
@@ -2582,9 +2584,8 @@ def test_042_no_detect_types_csvt():
             'field_12': '-3123724580211819352',
             '#fid': 3,
             '#geometry': 'None',
-            },
-        }
-    wanted['log']=[
-        ]
+        },
+    }
+    wanted['log'] = [
+    ]
     return wanted
-


### PR DESCRIPTION
[FEATURE] Adds a detectTypes flag to the delimited text provider url. If
set to "no" then type detection is not done and all attributes are
treated as text fields.  Otherwise the original behaviour of
detecting field types is preserved.

[needs-docs] Adds a "Detect field types" checkbox to the delimited text provider user interface to allow turning type detection on or off.

![delimited_text_detect_types](https://user-images.githubusercontent.com/631058/42347721-d971061c-80fa-11e8-8740-438e86434252.png)


This addresses (at least partially) issue #18601.  A more complete
solution would be to allow users to set field types.

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
