### PR TITLE
[2.18LTR] Fix  field calculator in not able to add a new field

### DIFF
--- a/src/app/qgsfieldcalculator.h
+++ b/src/app/qgsfieldcalculator.h
@@ -66,7 +66,7 @@ class APP_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
                        static_cast< QVariant::Type >( mOutputFieldTypeComboBox->itemData( mOutputFieldTypeComboBox->currentIndex(), Qt::UserRole ).toInt() ),
                        mOutputFieldTypeComboBox->itemData( mOutputFieldTypeComboBox->currentIndex(), Qt::UserRole + 1 ).toString(),
                        mOutputFieldWidthSpinBox->value(),
-                       mOutputFieldPrecisionSpinBox->value() );
+                       mOutputFieldPrecisionSpinBox->isEnabled() ? mOutputFieldPrecisionSpinBox->value() : 0 );
     }
 
     /** Idx of changed attribute*/

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -291,7 +291,6 @@ const QList< QgsVectorDataProvider::NativeType > &QgsVectorDataProvider::nativeT
 
 bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
 {
-  int i;
   QgsDebugMsgLevel( QString( "field name = %1 type = %2 length = %3 precision = %4" )
                     .arg( field.name(),
                           QVariant::typeToName( field.type() ) )

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -311,8 +311,8 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     if ( field.length() > 0 )
     {
       // source length limited
-      if ( ( nativeType.mMinLen > 0 && field.length() < nativeType.mMinLen ) ||
-           ( nativeType.mMaxLen > 0 && field.length() > nativeType.mMaxLen ) )
+      if (( nativeType.mMinLen > 0 && field.length() < nativeType.mMinLen ) ||
+          ( nativeType.mMaxLen > 0 && field.length() > nativeType.mMaxLen ) )
       {
         // source length exceeds destination limits
         continue;
@@ -322,8 +322,8 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     if ( field.precision() > 0 )
     {
       // source precision limited
-      if ( ( nativeType.mMinPrec > 0 && field.precision() < nativeType.mMinPrec ) ||
-           ( nativeType.mMaxPrec > 0 && field.precision() > nativeType.mMaxPrec ) )
+      if (( nativeType.mMinPrec > 0 && field.precision() < nativeType.mMinPrec ) ||
+          ( nativeType.mMaxPrec > 0 && field.precision() > nativeType.mMaxPrec ) )
       {
         // source precision exceeds destination limits
         continue;

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -309,10 +309,10 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     if ( field.type() != nativeType.mType )
       continue;
 
-    if ( field.length() == -1 )
+    if ( field.length() <= 0 )
     {
       // source length unlimited
-      if ( nativeType.mMinLen > -1 || nativeType.mMaxLen > -1 )
+      if ( nativeType.mMinLen > 0 || nativeType.mMaxLen > 0 )
       {
         // destination limited
         continue;
@@ -321,18 +321,18 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     else
     {
       // source length limited
-      if ( nativeType.mMinLen > -1 && nativeType.mMaxLen > -1 &&
-           ( field.length() < nativeType.mMinLen || field.length() > nativeType.mMaxLen ) )
+      if ( ( nativeType.mMinLen > 0 && field.length() < nativeType.mMinLen ) ||
+           ( nativeType.mMaxLen > 0 && field.length() > nativeType.mMaxLen ) )
       {
         // source length exceeds destination limits
         continue;
       }
     }
 
-    if ( field.precision() == -1 )
+    if ( field.precision() <= 0 )
     {
       // source precision unlimited / n/a
-      if ( nativeType.mMinPrec > -1 || nativeType.mMaxPrec > -1 )
+      if ( nativeType.mMinPrec > 0 || nativeType.mMaxPrec > 0 )
       {
         // destination limited
         continue;
@@ -341,8 +341,8 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     else
     {
       // source precision unlimited / n/a
-      if ( nativeType.mMinPrec > -1 && nativeType.mMaxPrec > -1 &&
-           ( field.precision() < nativeType.mMinPrec || field.precision() > nativeType.mMaxPrec ) )
+      if ( ( nativeType.mMinPrec > 0 && field.precision() < nativeType.mMinPrec ) ||
+           ( nativeType.mMaxPrec > 0 && field.precision() > nativeType.mMaxPrec ) )
       {
         // source precision exceeds destination limits
         continue;

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -309,16 +309,7 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     if ( field.type() != nativeType.mType )
       continue;
 
-    if ( field.length() <= 0 )
-    {
-      // source length unlimited
-      if ( nativeType.mMinLen > 0 || nativeType.mMaxLen > 0 )
-      {
-        // destination limited
-        continue;
-      }
-    }
-    else
+    if ( field.length() > 0 )
     {
       // source length limited
       if ( ( nativeType.mMinLen > 0 && field.length() < nativeType.mMinLen ) ||
@@ -329,18 +320,9 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
       }
     }
 
-    if ( field.precision() <= 0 )
+    if ( field.precision() > 0 )
     {
-      // source precision unlimited / n/a
-      if ( nativeType.mMinPrec > 0 || nativeType.mMaxPrec > 0 )
-      {
-        // destination limited
-        continue;
-      }
-    }
-    else
-    {
-      // source precision unlimited / n/a
+      // source precision limited
       if ( ( nativeType.mMinPrec > 0 && field.precision() < nativeType.mMinPrec ) ||
            ( nativeType.mMaxPrec > 0 && field.precision() > nativeType.mMaxPrec ) )
       {

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -297,22 +297,22 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
                           QVariant::typeToName( field.type() ) )
                     .arg( field.length() )
                     .arg( field.precision() ), 2 );
-  for ( i = 0; i < mNativeTypes.size(); i++ )
+  Q_FOREACH ( const NativeType &nativeType, mNativeTypes )
   {
     QgsDebugMsgLevel( QString( "native field type = %1 min length = %2 max length = %3 min precision = %4 max precision = %5" )
-                      .arg( QVariant::typeToName( mNativeTypes[i].mType ) )
-                      .arg( mNativeTypes[i].mMinLen )
-                      .arg( mNativeTypes[i].mMaxLen )
-                      .arg( mNativeTypes[i].mMinPrec )
-                      .arg( mNativeTypes[i].mMaxPrec ), 2 );
+                      .arg( QVariant::typeToName( nativeType.mType ) )
+                      .arg( nativeType.mMinLen )
+                      .arg( nativeType.mMaxLen )
+                      .arg( nativeType.mMinPrec )
+                      .arg( nativeType.mMaxPrec ), 2 );
 
-    if ( field.type() != mNativeTypes[i].mType )
+    if ( field.type() != nativeType.mType )
       continue;
 
     if ( field.length() == -1 )
     {
       // source length unlimited
-      if ( mNativeTypes[i].mMinLen > -1 || mNativeTypes[i].mMaxLen > -1 )
+      if ( nativeType.mMinLen > -1 || nativeType.mMaxLen > -1 )
       {
         // destination limited
         continue;
@@ -321,8 +321,8 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     else
     {
       // source length limited
-      if ( mNativeTypes[i].mMinLen > -1 && mNativeTypes[i].mMaxLen > -1 &&
-           ( field.length() < mNativeTypes[i].mMinLen || field.length() > mNativeTypes[i].mMaxLen ) )
+      if ( nativeType.mMinLen > -1 && nativeType.mMaxLen > -1 &&
+           ( field.length() < nativeType.mMinLen || field.length() > nativeType.mMaxLen ) )
       {
         // source length exceeds destination limits
         continue;
@@ -332,7 +332,7 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     if ( field.precision() == -1 )
     {
       // source precision unlimited / n/a
-      if ( mNativeTypes[i].mMinPrec > -1 || mNativeTypes[i].mMaxPrec > -1 )
+      if ( nativeType.mMinPrec > -1 || nativeType.mMaxPrec > -1 )
       {
         // destination limited
         continue;
@@ -341,8 +341,8 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
     else
     {
       // source precision unlimited / n/a
-      if ( mNativeTypes[i].mMinPrec > -1 && mNativeTypes[i].mMaxPrec > -1 &&
-           ( field.precision() < mNativeTypes[i].mMinPrec || field.precision() > mNativeTypes[i].mMaxPrec ) )
+      if ( nativeType.mMinPrec > -1 && nativeType.mMaxPrec > -1 &&
+           ( field.precision() < nativeType.mMinPrec || field.precision() > nativeType.mMaxPrec ) )
       {
         // source precision exceeds destination limits
         continue;


### PR DESCRIPTION
## Description
This should to fix the regression issue [#19283](https://issues.qgis.org/issues/19283) raised since 033071a (which must not be reverted). The PR is basically a backport of 00c301e and e715b91.
Also, set 0 as default precision on field definition if not defined from the user in order to avoid to define precision for string or datetime type.
Commit 6e45069 can be applied to master branch too.

_Sorry I cannot build a 2.18 branch on my machine right now so please test before merging (if it looks good to you)._

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
