### PR TITLE
[3d] Allow configuration of interpolation method for animations

### DIFF
--- a/src/app/3d/qgs3danimationsettings.cpp
+++ b/src/app/3d/qgs3danimationsettings.cpp
@@ -46,17 +46,14 @@ Qgs3DAnimationSettings::Keyframe Qgs3DAnimationSettings::interpolate( float time
     // QEasingCurve is probably not flexible enough, we may need more granular
     // control with Bezier curves to allow smooth transition at keyframes
 
-    float totalTime = duration();
-    float interpTime = mEasingCurve.valueForProgress( time / totalTime );
-    float time2 = interpTime * totalTime;
-
     for ( int i = 0; i < mKeyframes.size() - 1; i++ )
     {
       const Keyframe &k0 = mKeyframes.at( i );
       const Keyframe &k1 = mKeyframes.at( i + 1 );
-      if ( time2 >= k0.time && time2 <= k1.time )
+      if ( time >= k0.time && time <= k1.time )
       {
-        float eIp = ( time2 - k0.time ) / ( k1.time - k0.time );
+        float ip = ( time - k0.time ) / ( k1.time - k0.time );
+        float eIp = mEasingCurve.valueForProgress( ip );
         float eIip = 1.0f - eIp;
 
         Keyframe kf;

--- a/src/app/3d/qgs3danimationsettings.h
+++ b/src/app/3d/qgs3danimationsettings.h
@@ -18,6 +18,7 @@
 
 #include "qgsvector3d.h"
 
+#include <QEasingCurve>
 #include <QVector>
 
 class QDomDocument;
@@ -50,6 +51,11 @@ class Qgs3DAnimationSettings
     //! Returns keyframes of the animation
     Keyframes keyFrames() const { return mKeyframes; }
 
+    //! Sets the interpolation method for transitions of the camera
+    void setEasingCurve( const QEasingCurve &curve ) { mEasingCurve = curve; }
+    //! Returns the interpolation method for transitions of the camera
+    QEasingCurve easingCurve() const { return mEasingCurve; }
+
     //! Returns duration of the whole animation in seconds
     float duration() const;
 
@@ -63,6 +69,7 @@ class Qgs3DAnimationSettings
 
   private:
     Keyframes mKeyframes;
+    QEasingCurve mEasingCurve;
 };
 
 Q_DECLARE_METATYPE( Qgs3DAnimationSettings::Keyframe )

--- a/src/app/3d/qgs3danimationwidget.cpp
+++ b/src/app/3d/qgs3danimationwidget.cpp
@@ -45,6 +45,7 @@ Qgs3DAnimationWidget::Qgs3DAnimationWidget( QWidget *parent )
   connect( btnRemoveKeyframe, &QToolButton::clicked, this, &Qgs3DAnimationWidget::onRemoveKeyframe );
   connect( btnEditKeyframe, &QToolButton::clicked, this, &Qgs3DAnimationWidget::onEditKeyframe );
   connect( btnDuplicateKeyframe, &QToolButton::clicked, this, &Qgs3DAnimationWidget::onDuplicateKeyframe );
+  connect( cboInterpolation, qgis::overload<int>::of( &QComboBox::currentIndexChanged ), this, &Qgs3DAnimationWidget::onInterpolationChanged );
 
   btnPlayPause->setCheckable( true );
   connect( btnPlayPause, &QToolButton::clicked, this, &Qgs3DAnimationWidget::onPlayPause );
@@ -68,6 +69,8 @@ void Qgs3DAnimationWidget::setCameraController( QgsCameraController *cameraContr
 
 void Qgs3DAnimationWidget::setAnimation( const Qgs3DAnimationSettings &animSettings )
 {
+  cboInterpolation->setCurrentIndex( animSettings.easingCurve().type() );
+
   // initialize GUI from the given animation
   cboKeyframe->clear();
   cboKeyframe->addItem( tr( "<none>" ) );
@@ -91,6 +94,7 @@ void Qgs3DAnimationWidget::initializeController( const Qgs3DAnimationSettings &a
 Qgs3DAnimationSettings Qgs3DAnimationWidget::animation() const
 {
   Qgs3DAnimationSettings animSettings;
+  animSettings.setEasingCurve( QEasingCurve( ( QEasingCurve::Type ) cboInterpolation->currentIndex() ) );
   Qgs3DAnimationSettings::Keyframes keyframes;
   for ( int i = 1; i < cboKeyframe->count(); ++i )
   {
@@ -328,4 +332,12 @@ void Qgs3DAnimationWidget::onDuplicateKeyframe()
   initializeController( animation() );
 
   cboKeyframe->setCurrentIndex( newIndex + 1 );
+}
+
+void Qgs3DAnimationWidget::onInterpolationChanged()
+{
+  initializeController( animation() );
+
+  if ( cboKeyframe->currentIndex() <= 0 )
+    onSliderValueChanged();
 }

--- a/src/app/3d/qgs3danimationwidget.h
+++ b/src/app/3d/qgs3danimationwidget.h
@@ -51,6 +51,7 @@ class Qgs3DAnimationWidget : public QWidget, private Ui::Animation3DWidget
     void onRemoveKeyframe();
     void onEditKeyframe();
     void onDuplicateKeyframe();
+    void onInterpolationChanged();
 
   private:
     void initializeController( const Qgs3DAnimationSettings &animSettings );

--- a/src/ui/3d/animation3dwidget.ui
+++ b/src/ui/3d/animation3dwidget.ui
@@ -79,6 +79,162 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Interpolation</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="cboInterpolation">
+       <item>
+        <property name="text">
+         <string>Linear</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InQuad</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutQuad</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InOutQuad</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutInQuad</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InCubic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutCubic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InOutCubic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutInCubic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InQuart</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutQuart</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InOutQuart</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutInQuart</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InQuint</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutQuint</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InOutQuint</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutInQuint</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InSine</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutSine</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InOutSine</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutInSine</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InExpo</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutExpo</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InOutExpo</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutInExpo</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InCirc</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutCirc</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>InOutCirc</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>OutInCirc</string>
+        </property>
+       </item>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -126,8 +282,10 @@
   <tabstop>btnRemoveKeyframe</tabstop>
   <tabstop>btnEditKeyframe</tabstop>
   <tabstop>btnDuplicateKeyframe</tabstop>
+  <tabstop>cboInterpolation</tabstop>
   <tabstop>btnPlayPause</tabstop>
   <tabstop>sliderTime</tabstop>
+  <tabstop>btnRepeat</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Adds a combo box that sets interpolation method for the whole animation.

One thing that's not very intuitive is that this makes the time non-linear: the timing of keyframes has to be interpolated, so e.g. keyframe at time 3 seconds out of 9 seconds will have time adjusted according to the easing curve - for OutQuint the keyframe will show up much earlier than at 3 seconds.

I am not yet convinced this is the right way forward (due to the un-intuitiveness of time shifts of keyframes), but here we go, I am looking forward for some feedback (ping @nirvn) :-)