### PR TITLE
[BACKPORT] Fixes #18485 - do not truncate project title if filename contains period

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -508,7 +508,7 @@ QString QgsProject::baseName() const
   }
   else
   {
-    return QFileInfo( mFile.fileName() ).baseName();
+    return QFileInfo( mFile.fileName() ).completeBaseName();
   }
 }
 

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -1091,6 +1091,20 @@ class TestQgsProject(unittest.TestCase):
         self.assertTrue(l.setSubsetString('class=\'a\''))
         self.assertTrue(p.isDirty())
 
+    def testProjectTitleWithPeriod(self):
+        tmpDir = QTemporaryDir()
+        tmpFile = "{}/2.18.21.qgs".format(tmpDir.path())
+        tmpFile2 = "{}/qgis-3.2.0.qgs".format(tmpDir.path())
+
+        p0 = QgsProject()
+        p0.setFileName(tmpFile)
+
+        p1 = QgsProject()
+        p1.setFileName(tmpFile2)
+
+        self.assertEqual(p0.baseName(), '2.18.21')
+        self.assertEqual(p1.baseName(), 'qgis-3.2.0')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is the backport of PR #7380

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
