### PR TITLE
Speed up rendering of RGB images

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterblock.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterblock.sip.in
@@ -166,6 +166,7 @@ returned value is undefined.
 :return: value *
 %End
 
+
     QRgb color( int row, int column ) const;
 %Docstring
 Read a single color
@@ -245,6 +246,7 @@ Set color on index (indexed line by line)
 
 :return: true on success *
 %End
+
 
     bool setIsNoData( int row, int column );
 %Docstring

--- a/src/core/raster/qgsrasterblock.h
+++ b/src/core/raster/qgsrasterblock.h
@@ -197,6 +197,20 @@ class CORE_EXPORT QgsRasterBlock
     double value( qgssize index ) const;
 
     /**
+     * Gives direct access to the raster block data.
+     * The data type of the block must be Qgis::Byte otherwise it returns null pointer.
+     * Useful for most efficient read access.
+     * \note not available in Python bindings
+     * \since QGIS 3.4
+     */
+    const quint8 *byteData() const SIP_SKIP
+    {
+      if ( mDataType != Qgis::Byte )
+        return nullptr;
+      return static_cast< const quint8 * >( mData );
+    }
+
+    /**
      * \brief Read a single color
      *  \param row row index
      *  \param column column index
@@ -330,6 +344,20 @@ class CORE_EXPORT QgsRasterBlock
       QRgb *bits = reinterpret_cast< QRgb * >( mImage->bits() );
       bits[index] = color;
       return true;
+    }
+
+    /**
+     * Gives direct read/write access to the raster RGB data.
+     * The data type of the block must be Qgis::ARGB32 or Qgis::ARGB32_Premultiplied otherwise it returns null pointer.
+     * Useful for most efficient read/write access to RGB blocks.
+     * \note not available in Python bindings
+     * \since QGIS 3.4
+     */
+    QRgb *colorData() SIP_SKIP
+    {
+      if ( !mImage )
+        return nullptr;
+      return reinterpret_cast< QRgb * >( mImage->bits() );
     }
 
     /**


### PR DESCRIPTION
In my simple test case this made map rendering of RGB satellite image tiles
go down by ~50% from ~40ms per tile to ~20ms per tile (in debug version, ahem)
