### PR TITLE
Remove '\n' character at the end of env variables

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -59,7 +59,7 @@ def setupenv():
         for line in f:
             linedata = line.split("=")
             name = linedata[0]
-            data = linedata[1]
+            data = linedata[1].rstrip()
             os.environ[name] = data
 
 


### PR DESCRIPTION
Causing issues when running on windows, in a standalone script, as paths are not recognized by the system

## Description
Environment variables read from the 'qgis-bin.env' file contain return carriage. This prevents code to run in a standalone application.

In QGIS, using the python console, everything is fine : 

```
>>> repr(os.environ['QGIS_PREFIX_PATH'])
"'C:/OSGEO4~1/apps/qgis'"
```

In a standalone script there is the extra '\n' character : 

```
>>> import os
>>> from qgis.core import QgsApplication
>>> repr(os.environ['QGIS_PREFIX_PATH'])
"'C:/OSGEO4~1/apps/qgis\\n'"
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ok] Commit messages are descriptive and explain the rationale for changes
- [na] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [na] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [na] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ok] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [na] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [na] New unit tests have been added for core changes
- [na] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
