### PR TITLE
Fix input parameters of SAGA processing algorithms

### DIFF
--- a/python/plugins/processing/algs/saga/description/SnapPointstoLines.txt
+++ b/python/plugins/processing/algs/saga/description/SnapPointstoLines.txt
@@ -1,7 +1,7 @@
 Snap Points to Lines
 shapes_points
-QgsProcessingParameterFeatureSource|INPUT|Points|1|None|False
-QgsProcessingParameterFeatureSource|SNAP|Snap Features|-1|None|False
+QgsProcessingParameterFeatureSource|INPUT|Points|0|None|False
+QgsProcessingParameterFeatureSource|SNAP|Snap Features|1|None|False
 QgsProcessingParameterVectorDestination|OUTPUT|Result
 QgsProcessingParameterVectorDestination|MOVES|Moves
 QgsProcessingParameterNumber|DISTANCE|Search Distance|QgsProcessingParameterNumber.Double|0.000000|False|0.000000|None

--- a/python/plugins/processing/algs/saga/description/SnapPointstoPoints.txt
+++ b/python/plugins/processing/algs/saga/description/SnapPointstoPoints.txt
@@ -1,7 +1,7 @@
 Snap Points to Points
 shapes_points
-QgsProcessingParameterFeatureSource|INPUT|Points|-1|None|False
-QgsProcessingParameterFeatureSource|SNAP|Snap Features|-1|None|False
+QgsProcessingParameterFeatureSource|INPUT|Points|0|None|False
+QgsProcessingParameterFeatureSource|SNAP|Snap Features|0|None|False
 QgsProcessingParameterVectorDestination|OUTPUT|Result
 QgsProcessingParameterVectorDestination|MOVES|Moves
 QgsProcessingParameterNumber|DISTANCE|Search Distance|QgsProcessingParameterNumber.Double|0.000000|False|0.000000|None


### PR DESCRIPTION
## Description
Update SAGA SnapPointstoLines and SnapPointstoPoints to have the correct input parameter types. Currently 'snap points to lines' only has lines in the points input dropdown and has both points and lines in the lines snap dropdown. This PR changes the parameter type of the points input to only list point layers, and the lines input to only list line vector layers.

The 'snap points to points' algorithm allows both lines and points in both dropdowns. This PR sets the parameter type for both dropdowns to be point vector layers only.

Fixes #19382 (https://issues.qgis.org/issues/19382)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
