### PR TITLE
Get proper mFeature in relation reference widget

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -556,8 +556,6 @@ void QgsRelationReferenceWidget::init()
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRelationReferenceWidget::comboReferenceChanged );
 
-    mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );
-    highlightFeature( mFeature );
     updateAttributeEditorFrame( mFeature );
     QApplication::restoreOverrideCursor();
   }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -556,7 +556,12 @@ void QgsRelationReferenceWidget::init()
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRelationReferenceWidget::comboReferenceChanged );
 
-    updateAttributeEditorFrame( mFeature );
+    if ( !mFeatureInitialized )
+    {
+      //call it for the first intialization
+      emit mComboBox->currentIndexChanged( mComboBox->currentIndex() );
+      mFeatureInitialized = true;
+    }
     QApplication::restoreOverrideCursor();
   }
 }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -555,7 +555,9 @@ void QgsRelationReferenceWidget::init()
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRelationReferenceWidget::comboReferenceChanged );
+
     mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );
+    highlightFeature( mFeature );
     updateAttributeEditorFrame( mFeature );
     QApplication::restoreOverrideCursor();
   }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -555,6 +555,7 @@ void QgsRelationReferenceWidget::init()
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRelationReferenceWidget::comboReferenceChanged );
+    mReferencedLayer->getFeatures( mComboBox->currentFeatureRequest() ).nextFeature( mFeature );
     updateAttributeEditorFrame( mFeature );
     QApplication::restoreOverrideCursor();
   }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -558,7 +558,7 @@ void QgsRelationReferenceWidget::init()
 
     if ( !mFeatureInitialized )
     {
-      //call it for the first intialization
+      //call it for the first initialization
       emit mComboBox->currentIndexChanged( mComboBox->currentIndex() );
       mFeatureInitialized = true;
     }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -460,8 +460,8 @@ void QgsRelationReferenceWidget::showEvent( QShowEvent *e )
   Q_UNUSED( e )
 
   mShown = true;
-
-  init();
+  if ( !mInitialized )
+    init();
 }
 
 void QgsRelationReferenceWidget::init()
@@ -555,14 +555,12 @@ void QgsRelationReferenceWidget::init()
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsRelationReferenceWidget::comboReferenceChanged );
+    //call it for the first time
+    emit mComboBox->currentIndexChanged( mComboBox->currentIndex() );
 
-    if ( !mFeatureInitialized )
-    {
-      //call it for the first initialization
-      emit mComboBox->currentIndexChanged( mComboBox->currentIndex() );
-      mFeatureInitialized = true;
-    }
     QApplication::restoreOverrideCursor();
+
+    mInitialized = true;
   }
 }
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -222,6 +222,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool mIsEditable = true;
     QStringList mFilterFields;
     QMap<QString, QMap<QString, QSet<QString> > > mFilterCache;
+    bool mFeatureInitialized = false;
 
     // Q_PROPERTY
     bool mEmbedForm = false;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -222,7 +222,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool mIsEditable = true;
     QStringList mFilterFields;
     QMap<QString, QMap<QString, QSet<QString> > > mFilterCache;
-    bool mFeatureInitialized = false;
+    bool mInitialized = false;
 
     // Q_PROPERTY
     bool mEmbedForm = false;

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -160,6 +160,7 @@ void QgsFeatureListComboBox::onDataChanged( const QModelIndex &topLeft, const QM
       QModelIndex modelIndex = mModel->index( currentIndex, 0, QModelIndex() );
       mLineEdit->setText( mModel->data( modelIndex, QgsFeatureFilterModel::ValueRole ).toString() );
     }
+    emit currentIndexChanged( currentIndex );
   }
 }
 

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -160,7 +160,6 @@ void QgsFeatureListComboBox::onDataChanged( const QModelIndex &topLeft, const QM
       QModelIndex modelIndex = mModel->index( currentIndex, 0, QModelIndex() );
       mLineEdit->setText( mModel->data( modelIndex, QgsFeatureFilterModel::ValueRole ).toString() );
     }
-    emit currentIndexChanged( currentIndex );
   }
 }
 


### PR DESCRIPTION
The issue was, that the embedded attribute form of the relation reference didn't got updated in case there was the first entry in the combo box selected (because feature was not valid).
With this fix we update the embedded form after the initialization.

IMHO this should have been needed before and not only for the first entry in the combo box. But because the combo box gets an update in case it's not the first entry, the signal is fired to update the combo box and so the embedded form. In the older version it seems the combo box got rearranged even when it's the first entry, and so it worked back then.

Anyway the embedded form is updated (and the related feature highlighted) now in any case after the initialization.

Fix #19342
