### PR TITLE
[FEATURE] API for efficient raster sampling

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -288,6 +288,8 @@ is supported by provider.
 
 A null QVariant will be returned if the point is outside data source extent.
 
+.. seealso:: :py:func:`identify`
+
 .. versionadded:: 3.4
 %End
 

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -277,17 +277,19 @@ if point is outside data source extent.
 .. seealso:: :py:func:`sample`
 %End
 
-    virtual QVariant sample( const QgsPointXY &point, int band, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
+    virtual double sample( const QgsPointXY &point, int band,
+                           bool *ok /Out/ = 0,
+                           const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
 %Docstring
 Samples a raster value from the specified ``band`` found at the ``point`` position. The context
 parameters ``boundingBox``, ``width`` and ``height`` are important to identify
 on the same zoom level as a displayed map and to do effective
 caching (WCS). If context params are not specified the highest
-resolution is used. capabilities() may be used to test if format
-is supported by provider.
+resolution is used.
 
-A null QVariant will be returned if the point is outside data source extent, or an invalid
-band number was specified.
+If ``ok`` is specified and the point is outside data source extent, or an invalid
+band number was specified, then ``ok`` will be set to false. In this case the function will return
+a NaN value.
 
 .. seealso:: :py:func:`identify`
 

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -246,6 +246,50 @@ into a subset of the GUI raster properties "Metadata" tab.
 %End
 
     virtual QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
+%Docstring
+Identify raster value(s) found on the point position. The context
+parameters extent, width and height are important to identify
+on the same zoom level as a displayed map and to do effective
+caching (WCS). If context params are not specified the highest
+resolution is used. capabilities() may be used to test if format
+is supported by provider. Values are set to 'no data' or empty string
+if point is outside data source extent.
+
+:param point: coordinates in data source CRS
+:param format: result format
+:param boundingBox: context bounding box
+:param width: context width
+:param height: context height
+:param dpi: context dpi
+
+:return: QgsRaster.IdentifyFormatValue: map of values for each band, keys are band numbers
+         (from 1).
+         QgsRaster.IdentifyFormatFeature: map of QgsRasterFeatureList for each sublayer
+         (WMS) - TODO: it is not consistent with QgsRaster.IdentifyFormatValue.
+         QgsRaster.IdentifyFormatHtml: map of HTML strings for each sublayer (WMS).
+         Empty if failed or there are no results (TODO: better error reporting).
+
+.. note::
+
+   The arbitraryness of the returned document is enforced by WMS standards
+   up to at least v1.3.0
+
+.. seealso:: :py:func:`sample`
+%End
+
+    virtual QVariant sample( const QgsPointXY &point, int band, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
+%Docstring
+Samples a raster value from the specified ``band`` found at the ``point`` position. The context
+parameters ``boundingBox``, ``width`` and ``height`` are important to identify
+on the same zoom level as a displayed map and to do effective
+caching (WCS). If context params are not specified the highest
+resolution is used. capabilities() may be used to test if format
+is supported by provider.
+
+A null QVariant will be returned if the point is outside data source extent.
+
+.. versionadded:: 3.4
+%End
 
     virtual QString lastErrorTitle() = 0;
 %Docstring

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -286,7 +286,8 @@ caching (WCS). If context params are not specified the highest
 resolution is used. capabilities() may be used to test if format
 is supported by provider.
 
-A null QVariant will be returned if the point is outside data source extent.
+A null QVariant will be returned if the point is outside data source extent, or an invalid
+band number was specified.
 
 .. seealso:: :py:func:`identify`
 

--- a/python/plugins/processing/algs/qgis/RasterSampling.py
+++ b/python/plugins/processing/algs/qgis/RasterSampling.py
@@ -31,7 +31,8 @@ import os
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtCore import QVariant
 
-from qgis.core import (QgsApplication,
+from qgis.core import (NULL,
+                       QgsApplication,
                        QgsField,
                        QgsFeatureSink,
                        QgsRaster,
@@ -179,20 +180,12 @@ class RasterSampling(QgisAlgorithm):
                 feedback.reportError(self.tr('Could not reproject feature {} to raster CRS').format(i.id()))
                 continue
 
-            if sampled_raster.bandCount() > 1:
-
-                for b in range(sampled_raster.bandCount()):
-                    attrs.append(
-                        sampled_raster.dataProvider().identify(
-                            point,
-                            QgsRaster.IdentifyFormatValue).results()[b + 1]
-                    )
-
-            attrs.append(
-                sampled_raster.dataProvider().identify(
-                    point,
-                    QgsRaster.IdentifyFormatValue).results()[1]
-            )
+            for b in range(sampled_raster.bandCount()):
+                value, ok = sampled_raster.dataProvider().sample(point, b + 1)
+                if ok:
+                    attrs.append(value)
+                else:
+                    attrs.append(NULL)
 
             i.setAttributes(attrs)
 

--- a/python/plugins/processing/algs/qgis/RasterSampling.py
+++ b/python/plugins/processing/algs/qgis/RasterSampling.py
@@ -61,7 +61,7 @@ class RasterSampling(QgisAlgorithm):
         return 'rastersampling'
 
     def displayName(self):
-        return self.tr('Sample Raster Values')
+        return self.tr('Sample raster values')
 
     def group(self):
         return self.tr('Raster analysis')

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -300,12 +300,16 @@ QgsRasterIdentifyResult QgsRasterDataProvider::identify( const QgsPointXY &point
   return QgsRasterIdentifyResult( QgsRaster::IdentifyFormatValue, results );
 }
 
-QVariant QgsRasterDataProvider::sample( const QgsPointXY &point, int band, const QgsRectangle &boundingBox, int width, int height, int )
+double QgsRasterDataProvider::sample( const QgsPointXY &point, int band,
+                                      bool *ok, const QgsRectangle &boundingBox, int width, int height, int )
 {
+  if ( ok )
+    *ok = false;
+
   if ( !extent().contains( point ) )
   {
     // Outside the raster
-    return QVariant();
+    return std::numeric_limits<double>::quiet_NaN();
   }
 
   QgsRectangle finalExtent = boundingBox;
@@ -335,8 +339,10 @@ QVariant QgsRasterDataProvider::sample( const QgsPointXY &point, int band, const
   QgsRectangle pixelExtent( xMin, yMin, xMax, yMax );
 
   std::unique_ptr< QgsRasterBlock > bandBlock( block( band, pixelExtent, 1, 1 ) );
+  if ( bandBlock && ok )
+    *ok = true;
 
-  return bandBlock ? bandBlock->value( 0 ) : QVariant();
+  return bandBlock ? bandBlock->value( 0 ) : std::numeric_limits<double>::quiet_NaN();
 }
 
 QString QgsRasterDataProvider::lastErrorFormat()

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -284,14 +284,13 @@ QgsRasterIdentifyResult QgsRasterDataProvider::identify( const QgsPointXY &point
 
   for ( int i = 1; i <= bandCount(); i++ )
   {
-    QgsRasterBlock *myBlock = block( i, pixelExtent, 1, 1 );
+    std::unique_ptr< QgsRasterBlock > bandBlock( block( i, pixelExtent, 1, 1 ) );
 
-    if ( myBlock )
+    if ( bandBlock )
     {
-      double value = myBlock->value( 0 );
+      double value = bandBlock->value( 0 );
 
       results.insert( i, value );
-      delete myBlock;
     }
     else
     {

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -237,12 +237,12 @@ QString QgsRasterDataProvider::htmlMetadata()
 // Default implementation for values
 QgsRasterIdentifyResult QgsRasterDataProvider::identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox, int width, int height, int /*dpi*/ )
 {
-  QgsDebugMsgLevel( "Entered", 4 );
+  QgsDebugMsgLevel( QStringLiteral( "Entered" ), 4 );
   QMap<int, QVariant> results;
 
   if ( format != QgsRaster::IdentifyFormatValue || !( capabilities() & IdentifyValue ) )
   {
-    QgsDebugMsg( "Format not supported" );
+    QgsDebugMsg( QStringLiteral( "Format not supported" ) );
     return QgsRasterIdentifyResult( ERR( tr( "Format not supported" ) ) );
   }
 

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -367,7 +367,8 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      * resolution is used. capabilities() may be used to test if format
      * is supported by provider.
      *
-     * A null QVariant will be returned if the point is outside data source extent.
+     * A null QVariant will be returned if the point is outside data source extent, or an invalid
+     * band number was specified.
      *
      * \see identify(), which is much more flexible but considerably less efficient.
      * \since QGIS 3.4

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -355,9 +355,23 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      *         Empty if failed or there are no results (TODO: better error reporting).
      * \note The arbitraryness of the returned document is enforced by WMS standards
      *       up to at least v1.3.0
+     * \see sample()
      */
-    //virtual QMap<int, QVariant> identify( const QgsPointXY & point, QgsRaster::IdentifyFormat format, const QgsRectangle &extent = QgsRectangle(), int width = 0, int height = 0 );
     virtual QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
+
+    /**
+     * Samples a raster value from the specified \a band found at the \a point position. The context
+     * parameters \a boundingBox, \a width and \a height are important to identify
+     * on the same zoom level as a displayed map and to do effective
+     * caching (WCS). If context params are not specified the highest
+     * resolution is used. capabilities() may be used to test if format
+     * is supported by provider.
+     *
+     * A null QVariant will be returned if the point is outside data source extent.
+     *
+     * \since QGIS 3.4
+     */
+    virtual QVariant sample( const QgsPointXY &point, int band, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
 
     /**
      * \brief Returns the caption error text for the last error in this provider

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -355,7 +355,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      *         Empty if failed or there are no results (TODO: better error reporting).
      * \note The arbitraryness of the returned document is enforced by WMS standards
      *       up to at least v1.3.0
-     * \see sample()
+     * \see sample(), which is much more efficient for simple "value at point" queries.
      */
     virtual QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
 
@@ -369,6 +369,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      *
      * A null QVariant will be returned if the point is outside data source extent.
      *
+     * \see identify(), which is much more flexible but considerably less efficient.
      * \since QGIS 3.4
      */
     virtual QVariant sample( const QgsPointXY &point, int band, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -364,16 +364,18 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      * parameters \a boundingBox, \a width and \a height are important to identify
      * on the same zoom level as a displayed map and to do effective
      * caching (WCS). If context params are not specified the highest
-     * resolution is used. capabilities() may be used to test if format
-     * is supported by provider.
+     * resolution is used.
      *
-     * A null QVariant will be returned if the point is outside data source extent, or an invalid
-     * band number was specified.
+     * If \a ok is specified and the point is outside data source extent, or an invalid
+     * band number was specified, then \a ok will be set to false. In this case the function will return
+     * a NaN value.
      *
      * \see identify(), which is much more flexible but considerably less efficient.
      * \since QGIS 3.4
      */
-    virtual QVariant sample( const QgsPointXY &point, int band, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
+    virtual double sample( const QgsPointXY &point, int band,
+                           bool *ok SIP_OUT = nullptr,
+                           const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
 
     /**
      * \brief Returns the caption error text for the last error in this provider

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -395,13 +395,13 @@ QgsRasterIdentifyResult QgsAmsProvider::identify( const QgsPointXY &point, QgsRa
   queryUrl.addQueryItem( QStringLiteral( "imageDisplay" ), QStringLiteral( "%1,%2,%3" ).arg( width ).arg( height ).arg( dpi ) );
   queryUrl.addQueryItem( QStringLiteral( "mapExtent" ), QStringLiteral( "%1,%2,%3,%4" ).arg( extent.xMinimum(), 0, 'f' ).arg( extent.yMinimum(), 0, 'f' ).arg( extent.xMaximum(), 0, 'f' ).arg( extent.yMaximum(), 0, 'f' ) );
   queryUrl.addQueryItem( QStringLiteral( "tolerance" ), QStringLiteral( "10" ) );
-  QVariantList queryResults = QgsArcGisRestUtils::queryServiceJSON( queryUrl, mErrorTitle, mError ).value( QStringLiteral( "results" ) ).toList();
+  const QVariantList queryResults = QgsArcGisRestUtils::queryServiceJSON( queryUrl, mErrorTitle, mError ).value( QStringLiteral( "results" ) ).toList();
 
   QMap<int, QVariant> entries;
 
   if ( format == QgsRaster::IdentifyFormatText )
   {
-    foreach ( const QVariant &result, queryResults )
+    for ( const QVariant &result : queryResults )
     {
       const QVariantMap resultMap = result.toMap();
       QVariantMap attributesMap = resultMap[QStringLiteral( "attributes" )].toMap();
@@ -415,7 +415,7 @@ QgsRasterIdentifyResult QgsAmsProvider::identify( const QgsPointXY &point, QgsRa
   }
   else if ( format == QgsRaster::IdentifyFormatFeature )
   {
-    foreach ( const QVariant &result, queryResults )
+    for ( const QVariant &result : queryResults )
     {
       const QVariantMap resultMap = result.toMap();
 

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -1022,12 +1022,15 @@ QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, QgsR
   }
 
   QgsRectangle finalExtent = boundingBox;
-  if ( finalExtent.isEmpty() )  finalExtent = extent();
+  if ( finalExtent.isEmpty() )
+    finalExtent = extent();
 
   QgsDebugMsgLevel( QStringLiteral( "myExtent = %1 " ).arg( finalExtent.toString() ), 3 );
 
-  if ( width == 0 ) width = xSize();
-  if ( height == 0 ) height = ySize();
+  if ( width == 0 )
+    width = xSize();
+  if ( height == 0 )
+    height = ySize();
 
   QgsDebugMsgLevel( QStringLiteral( "theWidth = %1 height = %2" ).arg( width ).arg( height ), 3 );
 
@@ -1036,8 +1039,8 @@ QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, QgsR
   double yres = ( finalExtent.height() ) / height;
 
   // Offset, not the cell index -> std::floor
-  int col = ( int ) std::floor( ( point.x() - finalExtent.xMinimum() ) / xres );
-  int row = ( int ) std::floor( ( finalExtent.yMaximum() - point.y() ) / yres );
+  int col = static_cast< int >( std::floor( ( point.x() - finalExtent.xMinimum() ) / xres ) );
+  int row = static_cast< int >( std::floor( ( finalExtent.yMaximum() - point.y() ) / yres ) );
 
   QgsDebugMsgLevel( QStringLiteral( "row = %1 col = %2" ).arg( row ).arg( col ), 3 );
 
@@ -1056,14 +1059,14 @@ QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, QgsR
 
   for ( int i = 1; i <= bandCount(); i++ )
   {
-    QgsRasterBlock *myBlock = block( i, pixelExtent, w, h );
+    std::unique_ptr< QgsRasterBlock > bandBlock( block( i, pixelExtent, w, h ) );
 
-    if ( !myBlock )
+    if ( !bandBlock )
     {
       return QgsRasterIdentifyResult( ERR( tr( "Cannot read data" ) ) );
     }
 
-    double value = myBlock->value( r, c );
+    double value = bandBlock->value( r, c );
 
     if ( ( sourceHasNoDataValue( i ) && useSourceNoDataValue( i ) &&
            ( std::isnan( value ) || qgsDoubleNear( value, sourceNoDataValue( i ) ) ) ) ||
@@ -1082,7 +1085,6 @@ QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, QgsR
       else
         results.insert( i, value );
     }
-    delete myBlock;
   }
   return QgsRasterIdentifyResult( QgsRaster::IdentifyFormatValue, results );
 }

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -1091,11 +1091,18 @@ QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, QgsR
 
 bool QgsGdalProvider::worldToPixel( double x, double y, int &col, int &row ) const
 {
+  /*
+   * This set of equations solves
+   * Xgeo = GT(0) + XpixelGT(1) + YlineGT(2)
+   * Ygeo = GT(3) + XpixelGT(4) + YlineGT(5)
+   * when Xgeo, Ygeo are given
+   */
   double div = ( mGeoTransform[2] * mGeoTransform[4] - mGeoTransform[1] * mGeoTransform[5] );
   if ( div < 2 * std::numeric_limits<double>::epsilon() )
     return false;
-  double doubleCol = -( mGeoTransform[2] * ( mGeoTransform[3] - y ) + mGeoTransform[5] * x - mGeoTransform[0] * mGeoTransform[5] ) / div;
-  double doubleRow = ( mGeoTransform[1] * ( mGeoTransform[3] - y ) + mGeoTransform[4] * x - mGeoTransform[0] * mGeoTransform[4] ) / div;
+  double doubleCol = -( mGeoTransform[2] * ( mGeoTransform[3] - y ) + mGeoTransform[5] * ( x - mGeoTransform[0] ) ) / div;
+  double doubleRow = ( mGeoTransform[1] * ( mGeoTransform[3] - y ) + mGeoTransform[4] * ( x - mGeoTransform[0] ) ) / div;
+  // note: we truncate here, not round, otherwise values will be 0.5 pixels off
   col = static_cast< int >( doubleCol );
   row = static_cast< int >( doubleRow );
   return true;

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -1002,7 +1002,7 @@ QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, QgsR
   if ( !initIfNeeded() )
     return QgsRasterIdentifyResult( ERR( tr( "Cannot read data" ) ) );
 
-  QgsDebugMsg( QString( "thePoint = %1 %2" ).arg( point.x(), 0, 'g', 10 ).arg( point.y(), 0, 'g', 10 ) );
+  QgsDebugMsgLevel( QStringLiteral( "thePoint = %1 %2" ).arg( point.x(), 0, 'g', 10 ).arg( point.y(), 0, 'g', 10 ), 3 );
 
   QMap<int, QVariant> results;
 
@@ -1024,12 +1024,12 @@ QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, QgsR
   QgsRectangle finalExtent = boundingBox;
   if ( finalExtent.isEmpty() )  finalExtent = extent();
 
-  QgsDebugMsg( "myExtent = " + finalExtent.toString() );
+  QgsDebugMsgLevel( QStringLiteral( "myExtent = %1 " ).arg( finalExtent.toString() ), 3 );
 
   if ( width == 0 ) width = xSize();
   if ( height == 0 ) height = ySize();
 
-  QgsDebugMsg( QString( "theWidth = %1 height = %2" ).arg( width ).arg( height ) );
+  QgsDebugMsgLevel( QStringLiteral( "theWidth = %1 height = %2" ).arg( width ).arg( height ), 3 );
 
   // Calculate the row / column where the point falls
   double xres = ( finalExtent.width() ) / width;
@@ -1039,7 +1039,7 @@ QgsRasterIdentifyResult QgsGdalProvider::identify( const QgsPointXY &point, QgsR
   int col = ( int ) std::floor( ( point.x() - finalExtent.xMinimum() ) / xres );
   int row = ( int ) std::floor( ( finalExtent.yMaximum() - point.y() ) / yres );
 
-  QgsDebugMsg( QString( "row = %1 col = %2" ).arg( row ).arg( col ) );
+  QgsDebugMsgLevel( QStringLiteral( "row = %1 col = %2" ).arg( row ).arg( col ), 3 );
 
   // QgsDebugMsg( "row = " + QString::number( row ) + " col = " + QString::number( col ) );
 

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -103,7 +103,7 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QgsRectangle extent() const override;
     bool isValid() const override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
-    QVariant sample( const QgsPointXY &point, int band, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
+    double sample( const QgsPointXY &point, int band, bool *ok = nullptr, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
     QString lastErrorTitle() override;
     QString lastError() override;
     int capabilities() const override;

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -292,6 +292,7 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     //! Close all cached dataset for the specified provider.
     static void closeCachedGdalHandlesFor( QgsGdalProvider *provider );
 
+    bool worldToPixel( double x, double y, int &col, int &row ) const;
 };
 
 #endif

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -292,6 +292,9 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     //! Close all cached dataset for the specified provider.
     static void closeCachedGdalHandlesFor( QgsGdalProvider *provider );
 
+    /**
+     * Converts a world (\a x, \a y) coordinate to a pixel \a row and \a col.
+     */
     bool worldToPixel( double x, double y, int &col, int &row ) const;
 };
 

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -103,7 +103,7 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QgsRectangle extent() const override;
     bool isValid() const override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
-    double sample( const QgsPointXY &point, int band, bool *ok = nullptr, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
+    double sample( const QgsPointXY &point, int band, bool *ok = nullptr, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
     QString lastErrorTitle() override;
     QString lastError() override;
     int capabilities() const override;

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -103,6 +103,7 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QgsRectangle extent() const override;
     bool isValid() const override;
     QgsRasterIdentifyResult identify( const QgsPointXY &point, QgsRaster::IdentifyFormat format, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 ) override;
+    QVariant sample( const QgsPointXY &point, int band, const QgsRectangle &boundingBox = QgsRectangle(), int width = 0, int height = 0, int dpi = 96 );
     QString lastErrorTitle() override;
     QString lastError() override;
     int capabilities() const override;

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -731,6 +731,9 @@ void TestQgsRasterLayer::sample()
   QVERIFY( rl->isValid() );
   QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1 ).isValid() );
   QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 1 ).toInt(), 125 );
+  // bad bands
+  QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 0 ).isValid() );
+  QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 10 ).isValid() );
 
   fileName = mTestDataDir + "landsat_4326.tif";
   rasterFileInfo = QFileInfo( fileName );

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -85,6 +85,7 @@ class TestQgsRasterLayer : public QObject
     void setRenderer();
     void regression992(); //test for issue #992 - GeoJP2 images improperly displayed as all black
     void testRefreshRendererIfNeeded();
+    void sample();
 
 
   private:
@@ -718,6 +719,28 @@ void TestQgsRasterLayer::testRefreshRendererIfNeeded()
   mpLandsatRasterLayer->refreshRendererIfNeeded( mpLandsatRasterLayer->renderer(), newExtent );
   double newMinVal = static_cast<QgsMultiBandColorRenderer *>( mpLandsatRasterLayer->renderer() )->redContrastEnhancement()->minimumValue();
   QGSCOMPARENOTNEAR( initMinVal, newMinVal, 1e-5 );
+}
+
+void TestQgsRasterLayer::sample()
+{
+  QString fileName = mTestDataDir + "landsat-f32-b1.tif";
+
+  QFileInfo rasterFileInfo( fileName );
+  std::unique_ptr< QgsRasterLayer > rl = qgis::make_unique< QgsRasterLayer> ( rasterFileInfo.filePath(),
+                                         rasterFileInfo.completeBaseName() );
+  QVERIFY( rl->isValid() );
+  QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1 ).isValid() );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 1 ).toInt(), 125 );
+
+  fileName = mTestDataDir + "landsat_4326.tif";
+  rasterFileInfo = QFileInfo( fileName );
+  rl = qgis::make_unique< QgsRasterLayer> ( rasterFileInfo.filePath(),
+       rasterFileInfo.completeBaseName() );
+  QVERIFY( rl->isValid() );
+  QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1 ).isValid() );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 1 ).toInt(), 125 );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 2 ).toInt(), 139 );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 3 ).toInt(), 111 );
 }
 
 QGSTEST_MAIN( TestQgsRasterLayer )

--- a/tests/src/core/testqgsrasterlayer.cpp
+++ b/tests/src/core/testqgsrasterlayer.cpp
@@ -729,21 +729,32 @@ void TestQgsRasterLayer::sample()
   std::unique_ptr< QgsRasterLayer > rl = qgis::make_unique< QgsRasterLayer> ( rasterFileInfo.filePath(),
                                          rasterFileInfo.completeBaseName() );
   QVERIFY( rl->isValid() );
-  QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1 ).isValid() );
-  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 1 ).toInt(), 125 );
+  QVERIFY( std::isnan( rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1 ) ) );
+  bool ok = false;
+  QVERIFY( std::isnan( rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1, &ok ) ) );
+  QVERIFY( !ok );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 1 ), 125.0 );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 1, &ok ), 125.0 );
+  QVERIFY( ok );
   // bad bands
-  QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 0 ).isValid() );
-  QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 10 ).isValid() );
+  QVERIFY( std::isnan( rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 0 ) ) );
+  QVERIFY( std::isnan( rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 0, &ok ) ) );
+  QVERIFY( !ok );
+  QVERIFY( std::isnan( rl->dataProvider()->sample( QgsPointXY( 788461, 3344957 ), 10, &ok ) ) );
+  QVERIFY( !ok );
 
   fileName = mTestDataDir + "landsat_4326.tif";
   rasterFileInfo = QFileInfo( fileName );
   rl = qgis::make_unique< QgsRasterLayer> ( rasterFileInfo.filePath(),
        rasterFileInfo.completeBaseName() );
   QVERIFY( rl->isValid() );
-  QVERIFY( !rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1 ).isValid() );
-  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 1 ).toInt(), 125 );
-  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 2 ).toInt(), 139 );
-  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 3 ).toInt(), 111 );
+  QVERIFY( std::isnan( rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1 ) ) );
+  QVERIFY( std::isnan( rl->dataProvider()->sample( QgsPointXY( 0, 0 ), 1, &ok ) ) );
+  QVERIFY( !ok );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 1, &ok ), 125.0 );
+  QVERIFY( ok );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 2 ), 139.0 );
+  QCOMPARE( rl->dataProvider()->sample( QgsPointXY( 17.943731, 30.230791 ), 3 ), 111.0 );
 }
 
 QGSTEST_MAIN( TestQgsRasterLayer )


### PR DESCRIPTION
Add QgsRasterDataProvider::sample method for efficient sampling of rasters at a given point. This is an alternative to the ::identify method, which is less efficient but more powerful.