### PR TITLE
Update v.buffer.txt to fix GRASS v.buffer error

### DIFF
--- a/python/plugins/processing/algs/grass7/description/v.buffer.txt
+++ b/python/plugins/processing/algs/grass7/description/v.buffer.txt
@@ -8,7 +8,6 @@ QgsProcessingParameterEnum|type|Input feature type|point;line;boundary;centroid;
 QgsProcessingParameterNumber|distance|Buffer distance in map units|QgsProcessingParameterNumber.Double|None|True|None|None
 QgsProcessingParameterNumber|minordistance|Buffer distance along minor axis in map units|QgsProcessingParameterNumber.Double|None|True|None|None
 QgsProcessingParameterNumber|angle|Angle of major axis in degrees|QgsProcessingParameterNumber.Double|0.0|True|0.0|360.0
-QgsProcessingParameterField|column|Name of column to use for buffer distances|None|input|-1|False|True
 QgsProcessingParameterNumber|scale|Scaling factor for attribute column values|QgsProcessingParameterNumber.Double|1.0|True|None|None
 QgsProcessingParameterNumber|tolerance|Maximum distance between theoretical arc and polygon segments as multiple of buffer|QgsProcessingParameterNumber.Double|0.01|True|None|None
 *QgsProcessingParameterBoolean|-s|Make outside corners straight|False


### PR DESCRIPTION
Removed 'buffer distance from field' option as it is not supported by GRASS fix #19377 

## Description
It fixes #19377 issue. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
