### PR TITLE
[processing] Fix wrongly set mask in gdal:fillnodata Fixes #19409

### DIFF
--- a/python/plugins/processing/algs/gdal/fillnodata.py
+++ b/python/plugins/processing/algs/gdal/fillnodata.py
@@ -113,7 +113,7 @@ class fillnodata(GdalAlgorithm):
         if self.parameterAsBool(parameters, self.NO_MASK, context):
             arguments.append('-nomask')
 
-        mask = self.parameterAsRasterLayer(parameters, self.INPUT, context)
+        mask = self.parameterAsRasterLayer(parameters, self.MASK_LAYER, context)
         if mask:
             arguments.append('-mask {}'.format(mask.source()))
 

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -49,6 +49,7 @@ from processing.algs.gdal.rasterize import rasterize
 from processing.algs.gdal.retile import retile
 from processing.algs.gdal.translate import translate
 from processing.algs.gdal.warp import warp
+from processing.algs.gdal.fillnodata import fillnodata
 
 from qgis.core import (QgsProcessingContext,
                        QgsProcessingFeedback,
@@ -1339,6 +1340,59 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
              '-s_srs EPSG:3111 -t_srs EPSG:3111 -r near -ot Float32 -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
+
+    def testFillnodata(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'dem.tif')
+        mask = os.path.join(testDataPath, 'raster.tif')
+        outsource = 'd:/temp/check.tif'
+        alg = fillnodata()
+        alg.initAlgorithm()
+
+        # with mask value
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'BAND': 1,
+                                    'DISTANCE': 10,
+                                    'ITERATIONS': 0,
+                                    'MASK_LAYER': mask,
+                                    'NO_MASK': False,
+                                    'OUTPUT': outsource}, context, feedback),
+            ['gdal_fillnodata.py',
+             '-md 10 -b 1 -mask ' +
+             mask +
+             ' -of GTiff ' +
+             source + ' ' +
+             outsource])
+
+        # without mask value
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'BAND': 1,
+                                    'DISTANCE': 10,
+                                    'ITERATIONS': 0,
+                                    'NO_MASK': False,
+                                    'OUTPUT': outsource}, context, feedback),
+            ['gdal_fillnodata.py',
+             '-md 10 -b 1 ' +
+             '-of GTiff ' +
+             source + ' ' +
+             outsource])
+
+        # nomask true
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'BAND': 1,
+                                    'DISTANCE': 10,
+                                    'ITERATIONS': 0,
+                                    'NO_MASK': True,
+                                    'OUTPUT': outsource}, context, feedback),
+            ['gdal_fillnodata.py',
+             '-md 10 -b 1 -nomask ' +
+             '-of GTiff ' +
+             source + ' ' +
+             outsource])
 
 
 class TestGdalOgrToPostGis(unittest.TestCase):


### PR DESCRIPTION
## Description
The mask parameter was wrongly set as the input raster
Tests added

fixes https://issues.qgis.org/issues/19409

as feature would be fine to add advanced parameters to select out format

little fix done inside GeoMove [1] project for CartoLab [2]

[1] http://cartolab.udc.es/geomove/
[2] http://cartolab.udc.es

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
