### PR TITLE
Processing gdal's warp algorithm improvements

### DIFF
--- a/python/plugins/processing/algs/gdal/translate.py
+++ b/python/plugins/processing/algs/gdal/translate.py
@@ -69,7 +69,7 @@ class translate(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.NODATA,
                                                        self.tr('Assign a specified nodata value to output bands'),
                                                        type=QgsProcessingParameterNumber.Double,
-                                                       defaultValue=0.0,
+                                                       defaultValue=None,
                                                        optional=True))
         self.addParameter(QgsProcessingParameterBoolean(self.COPY_SUBDATASETS,
                                                         self.tr('Copy all subdatasets of this file to individual output files'),

--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -87,6 +87,10 @@ class warp(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterCrs(self.TARGET_CRS,
                                                     self.tr('Target CRS'),
                                                     'EPSG:4326'))
+        self.addParameter(QgsProcessingParameterEnum(self.RESAMPLING,
+                                                     self.tr('Resampling method to use'),
+                                                     options=[i[0] for i in self.methods],
+                                                     defaultValue=0))
         self.addParameter(QgsProcessingParameterNumber(self.NODATA,
                                                        self.tr('Nodata value for output bands'),
                                                        type=QgsProcessingParameterNumber.Double,
@@ -108,11 +112,6 @@ class warp(GdalAlgorithm):
             'widget_wrapper': {
                 'class': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}})
         self.addParameter(options_param)
-
-        self.addParameter(QgsProcessingParameterEnum(self.RESAMPLING,
-                                                     self.tr('Resampling method to use'),
-                                                     options=[i[0] for i in self.methods],
-                                                     defaultValue=0))
 
         dataType_param = QgsProcessingParameterEnum(self.DATA_TYPE,
                                                     self.tr('Output data type'),

--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -90,7 +90,8 @@ class warp(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.NODATA,
                                                        self.tr('Nodata value for output bands'),
                                                        type=QgsProcessingParameterNumber.Double,
-                                                       defaultValue=0.0))
+                                                       defaultValue=None,
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.TARGET_RESOLUTION,
                                                        self.tr('Output file resolution in target georeferenced units'),
                                                        type=QgsProcessingParameterNumber.Double,

--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -96,7 +96,8 @@ class warp(GdalAlgorithm):
                                                        self.tr('Output file resolution in target georeferenced units'),
                                                        type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0,
-                                                       defaultValue=None))
+                                                       defaultValue=None,
+                                                       optional=True))
 
         options_param = QgsProcessingParameterString(self.OPTIONS,
                                                      self.tr('Additional creation parameters'),

--- a/python/plugins/processing/gui/NumberInputPanel.py
+++ b/python/plugins/processing/gui/NumberInputPanel.py
@@ -184,7 +184,7 @@ class NumberInputPanel(NUMBER_BASE, NUMBER_WIDGET):
                     self.spnValue.setClearValue(float(param.defaultValue()))
                 except:
                     pass
-        elif self.param.minimum() is not None:
+        elif self.param.minimum() is not None and not self.allowing_null:
             try:
                 self.setValue(float(self.param.minimum()))
                 if not self.allowing_null:

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -313,6 +313,15 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
              '-ot Float32 -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
+        # with None NODATA value
+        self.assertEqual(
+            translate_alg.getConsoleCommands({'INPUT': source,
+                                              'NODATA': None,
+                                              'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdal_translate',
+             '-ot Float32 -of JPEG ' +
+             source + ' ' +
+             'd:/temp/check.jpg'])
         # with NODATA value
         self.assertEqual(
             translate_alg.getConsoleCommands({'INPUT': source,
@@ -1285,6 +1294,16 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
              '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
+        # with None NODATA value
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'NODATA': None,
+                                    'SOURCE_CRS': 'EPSG:3111',
+                                    'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdalwarp',
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
+             source + ' ' +
+             'd:/temp/check.jpg'])
         # with NODATA value
         self.assertEqual(
             alg.getConsoleCommands({'INPUT': source,
@@ -1338,6 +1357,39 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
              '-s_srs EPSG:3111 -t_srs EPSG:3111 -r near -ot Float32 -of JPEG ' +
+             source + ' ' +
+             'd:/temp/check.jpg'])
+
+        # with target resolution with None value
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'SOURCE_CRS': 'EPSG:3111',
+                                    'TARGET_RESOLUTION': None,
+                                    'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdalwarp',
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
+             source + ' ' +
+             'd:/temp/check.jpg'])
+
+        # test target resolution with a valid value
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'SOURCE_CRS': 'EPSG:3111',
+                                    'TARGET_RESOLUTION': 10.0,
+                                    'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdalwarp',
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -tr 10.0 10.0 -r near -ot Float32 -of JPEG ' +
+             source + ' ' +
+             'd:/temp/check.jpg'])
+
+        # test target resolution with a value of zero, to be ignored
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'SOURCE_CRS': 'EPSG:3111',
+                                    'TARGET_RESOLUTION': 0.0,
+                                    'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdalwarp',
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 


### PR DESCRIPTION
## Description
The main improvement: make the destination NODATA parameter optional, instead of forcing the user to enter a non-obstructive value. 

I've also taken the time to make the destination resolution parameter optional, which revealed an issue with the way we provide a default value for the number input panel widget (it'd enforce the minimum value for default-less optional parameter). 

@nyalldawson , I'd like your rubberstamp for the number input panel change :)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
