### PR TITLE
Some valgrind spatialite provider fixes

### DIFF
--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -756,7 +756,7 @@ void QgsSqliteHandle::closeDb( QgsSqliteHandle *&handle )
     if ( --i.value()->ref == 0 )
     {
       delete i.value();
-      sHandles.remove( i.key() );
+      i = sHandles.erase( i );
     }
   }
 

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -666,6 +666,7 @@ error:
 
 
 QMap < QString, QgsSqliteHandle * > QgsSqliteHandle::sHandles;
+QMutex QgsSqliteHandle::sHandleMutex;
 
 
 bool QgsSqliteHandle::checkMetadata( sqlite3 *handle )
@@ -696,6 +697,7 @@ skip:
 QgsSqliteHandle *QgsSqliteHandle::openDb( const QString &dbPath, bool shared )
 {
   //QMap < QString, QgsSqliteHandle* >&handles = QgsSqliteHandle::handles;
+  QMutexLocker locker( &sHandleMutex );
 
   if ( shared && sHandles.contains( dbPath ) )
   {
@@ -743,6 +745,7 @@ void QgsSqliteHandle::closeDb( QgsSqliteHandle *&handle )
   }
   else
   {
+    QMutexLocker locker( &sHandleMutex );
     QMap < QString, QgsSqliteHandle * >::iterator i;
     for ( i = sHandles.begin(); i != sHandles.end() && i.value() != handle; ++i )
       ;
@@ -762,6 +765,7 @@ void QgsSqliteHandle::closeDb( QgsSqliteHandle *&handle )
 
 void QgsSqliteHandle::closeAll()
 {
+  QMutexLocker locker( &sHandleMutex );
   qDeleteAll( sHandles );
   sHandles.clear();
 }

--- a/src/providers/spatialite/qgsspatialiteconnection.h
+++ b/src/providers/spatialite/qgsspatialiteconnection.h
@@ -17,6 +17,7 @@
 
 #include <QStringList>
 #include <QObject>
+#include <QMutex>
 
 #include "qgsspatialiteutils.h"
 
@@ -178,6 +179,7 @@ class QgsSqliteHandle
     bool mIsValid;
 
     static QMap < QString, QgsSqliteHandle * > sHandles;
+    static QMutex sHandleMutex;
 };
 
 


### PR DESCRIPTION
Fixes some issues identified by valgrind within the spatialite provider, while attempting to diagnose why the WFS provider test is so flaky at the moment.

Without these changes valgrind reports a freed memory access warning on `sHandles.remove( i.key() );`. (not sure exactly why this doesn't work -- but changing to QMap::erase fixes the error, and maybe, just maybe, it'll fix the wfs provider test issue). 