### PR TITLE
Avoid double db close in offline editing plugin

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -1316,7 +1316,7 @@ QgsOfflineEditing::GeometryChanges QgsOfflineEditing::sqlQueryGeometryChanges( s
 void QgsOfflineEditing::committedAttributesAdded( const QString &qgisLayerId, const QList<QgsField> &addedAttributes )
 {
   sqlite3_database_unique_ptr database = openLoggingDb();
-  if ( !database.get() )
+  if ( !database )
     return;
 
   // insert log
@@ -1343,7 +1343,7 @@ void QgsOfflineEditing::committedAttributesAdded( const QString &qgisLayerId, co
 void QgsOfflineEditing::committedFeaturesAdded( const QString &qgisLayerId, const QgsFeatureList &addedFeatures )
 {
   sqlite3_database_unique_ptr database = openLoggingDb();
-  if ( !database.get() )
+  if ( !database )
     return;
 
   // insert log
@@ -1380,7 +1380,7 @@ void QgsOfflineEditing::committedFeaturesAdded( const QString &qgisLayerId, cons
 void QgsOfflineEditing::committedFeaturesRemoved( const QString &qgisLayerId, const QgsFeatureIds &deletedFeatureIds )
 {
   sqlite3_database_unique_ptr database = openLoggingDb();
-  if ( !database.get() )
+  if ( !database )
     return;
 
   // insert log
@@ -1407,7 +1407,7 @@ void QgsOfflineEditing::committedFeaturesRemoved( const QString &qgisLayerId, co
 void QgsOfflineEditing::committedAttributeValuesChanges( const QString &qgisLayerId, const QgsChangedAttributesMap &changedAttrsMap )
 {
   sqlite3_database_unique_ptr database = openLoggingDb();
-  if ( !database.get() )
+  if ( !database )
     return;
 
   // insert log
@@ -1441,7 +1441,7 @@ void QgsOfflineEditing::committedAttributeValuesChanges( const QString &qgisLaye
 void QgsOfflineEditing::committedGeometriesChanges( const QString &qgisLayerId, const QgsGeometryMap &changedGeometries )
 {
   sqlite3_database_unique_ptr database = openLoggingDb();
-  if ( !database.get() )
+  if ( !database )
     return;
 
   // insert log

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -1338,7 +1338,6 @@ void QgsOfflineEditing::committedAttributesAdded( const QString &qgisLayerId, co
   }
 
   increaseCommitNo( database.get() );
-  sqlite3_close( database.get() );
 }
 
 void QgsOfflineEditing::committedFeaturesAdded( const QString &qgisLayerId, const QgsFeatureList &addedFeatures )
@@ -1376,8 +1375,6 @@ void QgsOfflineEditing::committedFeaturesAdded( const QString &qgisLayerId, cons
                   .arg( newFeatureIds.at( i ) );
     sqlExec( database.get(), sql );
   }
-
-  sqlite3_close( database.get() );
 }
 
 void QgsOfflineEditing::committedFeaturesRemoved( const QString &qgisLayerId, const QgsFeatureIds &deletedFeatureIds )
@@ -1405,8 +1402,6 @@ void QgsOfflineEditing::committedFeaturesRemoved( const QString &qgisLayerId, co
       sqlExec( database.get(), sql );
     }
   }
-
-  sqlite3_close( database.get() );
 }
 
 void QgsOfflineEditing::committedAttributeValuesChanges( const QString &qgisLayerId, const QgsChangedAttributesMap &changedAttrsMap )
@@ -1441,7 +1436,6 @@ void QgsOfflineEditing::committedAttributeValuesChanges( const QString &qgisLaye
   }
 
   increaseCommitNo( database.get() );
-  sqlite3_close( database.get() );
 }
 
 void QgsOfflineEditing::committedGeometriesChanges( const QString &qgisLayerId, const QgsGeometryMap &changedGeometries )
@@ -1474,7 +1468,6 @@ void QgsOfflineEditing::committedGeometriesChanges( const QString &qgisLayerId, 
   }
 
   increaseCommitNo( database.get() );
-  sqlite3_close( database.get() );
 }
 
 void QgsOfflineEditing::startListenFeatureChanges()


### PR DESCRIPTION
Might fix the flaky unit test seen in 3.2 and later