### PR TITLE
Various map tips fixes

### DIFF
--- a/python/gui/auto_generated/qgsmaptip.sip.in
+++ b/python/gui/auto_generated/qgsmaptip.sip.in
@@ -62,6 +62,7 @@ Clear the current maptip if it exists
 
 :param mpMapCanvas: the canvas from which the tip should be cleared.
 %End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9336,7 +9336,6 @@ void QgisApp::saveLastMousePosition( const QgsPointXY &p )
       mpMaptip->clear( mMapCanvas );
       // don't start the timer if the mouse is not over the map canvas
       mpMapTipsTimer->start();
-      //QgsDebugMsg("Started maptips timer");
     }
   }
 }

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -67,6 +67,7 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   mWebView->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks );//Handle link clicks by yourself
   mWebView->setContextMenuPolicy( Qt::NoContextMenu ); //No context menu is allowed if you don't need it
   connect( mWebView, &QWebView::linkClicked, this, &QgsMapTip::onLinkClicked );
+  connect( mWebView, &QWebView::loadFinished, this, [ = ]( bool ) { resizeContent(); } );
 #endif
 
   mWebView->page()->settings()->setAttribute(
@@ -135,6 +136,17 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   mWidget->show();
 
 #if WITH_QTWEBKIT
+  resizeContent();
+#endif
+}
+
+void QgsMapTip::resizeContent()
+{
+  // Get the content size
+  QWebElement container = mWebView->page()->mainFrame()->findFirstElement(
+                            QStringLiteral( "#QgsWebViewContainer" ) );
+  int width = container.geometry().width();
+  int height = container.geometry().height();
   int scrollbarWidth = mWebView->page()->mainFrame()->scrollBarGeometry(
                          Qt::Vertical ).width();
   int scrollbarHeight = mWebView->page()->mainFrame()->scrollBarGeometry(
@@ -142,15 +154,11 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   if ( scrollbarWidth > 0 || scrollbarHeight > 0 )
   {
-    // Get the content size
-    QWebElement container = mWebView->page()->mainFrame()->findFirstElement(
-                              QStringLiteral( "#QgsWebViewContainer" ) );
-    int width = container.geometry().width() + 5 + scrollbarWidth;
-    int height = container.geometry().height() + 5 + scrollbarHeight;
-
-    mWidget->resize( width, height );
+    width += 5 + scrollbarWidth;
+    height += 5 + scrollbarHeight;
   }
-#endif
+
+  mWidget->resize( width, height );
 }
 
 void QgsMapTip::clear( QgsMapCanvas * )

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -78,6 +78,11 @@ class GUI_EXPORT QgsMapTip : public QWidget
      * \param mpMapCanvas the canvas from which the tip should be cleared.
      */
     void clear( QgsMapCanvas *mpMapCanvas = nullptr );
+
+  private slots:
+    void onLinkClicked( const QUrl &url );
+    void resizeContent();
+
   private:
     // Fetch the feature to use for the maptip text.
     // Only the first feature in the search radius is used
@@ -94,8 +99,6 @@ class GUI_EXPORT QgsMapTip : public QWidget
     QWidget *mWidget = nullptr;
     QgsWebView *mWebView = nullptr;
 
-  private slots:
-    void onLinkClicked( const QUrl &url );
-    void resizeContent();
+    const int MARGIN_VALUE = 5;
 };
 #endif // QGSMAPTIP_H

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -96,5 +96,6 @@ class GUI_EXPORT QgsMapTip : public QWidget
 
   private slots:
     void onLinkClicked( const QUrl &url );
+    void resizeContent();
 };
 #endif // QGSMAPTIP_H


### PR DESCRIPTION
...and return first not empty string

It's a small improvement to maptips whereas if the first matching feature within radius doesn't have a maptip (empty field, expression returns an empty string, etc.), we should attempt to match other feature(s) within the radius and return the first maptip string we hit.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
