### PR TITLE
osgeo4w: support newer cmake versions

### DIFF
--- a/ms-windows/osgeo4w/package-nightly.cmd
+++ b/ms-windows/osgeo4w/package-nightly.cmd
@@ -101,7 +101,9 @@ set GRASS7_VERSION=%GRASS7_VERSION:grass-=%
 set GRASS_VERSIONS=%GRASS6_VERSION% %GRASS7_VERSION%
 
 set PYTHONPATH=
-path %PF86%\CMake\bin;%PATH%;c:\cygwin\bin
+if exist "%PROGRAMFILES%\CMake\bin" path %PATH%;%PROGRAMFILES%\CMake\bin
+if exist "%PF86%\CMake\bin" path %PATH%;%PF86%\CMake\bin
+path %PATH%;c:\cygwin\bin
 
 PROMPT qgis%VERSION%$g 
 

--- a/ms-windows/osgeo4w/package.cmd
+++ b/ms-windows/osgeo4w/package.cmd
@@ -97,7 +97,9 @@ set GRASS7_VERSION=%GRASS7_VERSION:grass-=%
 set GRASS_VERSIONS=%GRASS6_VERSION% %GRASS7_VERSION%
 
 set PYTHONPATH=
-path %PF86%\CMake\bin;%PATH%;c:\cygwin\bin
+if exist "%PROGRAMFILES%\CMake\bin" path %PATH%;%PROGRAMFILES%\CMake\bin
+if exist "%PF86%\CMake\bin" path %PATH%;%PF86%\CMake\bin
+path %PATH%;c:\cygwin\bin
 
 PROMPT qgis%VERSION%$g 
 


### PR DESCRIPTION
cmake upgrade required for master needs adaptions in osgeo4w build scripts.  Please quickly review - 2.18 build will start once the 3.2 build is finished…