### PR TITLE
When there's no features to draw for a level based renderer, shortcut out of rendering

### DIFF
--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -398,6 +398,13 @@ void QgsVectorLayerRenderer::drawRendererLevels( QgsFeatureIterator &fit )
 
   delete mContext.expressionContext().popScope();
 
+  if ( features.empty() )
+  {
+    // nothing to draw
+    stopRenderer( selRenderer );
+    return;
+  }
+
   // find out the order
   QgsSymbolLevelOrder levels;
   QgsSymbolList symbols = mRenderer->symbols( mContext );


### PR DESCRIPTION
Avoids a misleading warning and saves some cycles