### PR TITLE
[3d] Off-screen rendering

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -3,15 +3,18 @@
 
 SET(QGIS_3D_SRCS
   qgsaabb.cpp
+  qgsabstract3dengine.cpp
   qgs3dmapscene.cpp
   qgs3dmapsettings.cpp
   qgs3dutils.cpp
   qgscameracontroller.cpp
+  qgsoffscreen3dengine.cpp
   qgsphongmaterialsettings.cpp
   qgsraycastingutils_p.cpp
   qgstessellatedpolygongeometry.cpp
   qgstilingscheme.cpp
   qgsvectorlayer3drenderer.cpp
+  qgswindow3dengine.cpp
 
   chunks/qgschunkboundsentity_p.cpp
   chunks/qgschunkedentity_p.cpp
@@ -47,7 +50,10 @@ SET(QGIS_3D_MOC_HDRS
 
   qgs3dmapscene.h
   qgs3dmapsettings.h
+  qgsabstract3dengine.h
   qgscameracontroller.h
+  qgsoffscreen3dengine.h
+  qgswindow3dengine.h
 
   chunks/qgschunkedentity_p.h
   chunks/qgschunkloader_p.h
@@ -70,15 +76,18 @@ QT5_ADD_RESOURCES(QGIS_3D_RCC_SRCS shaders.qrc)
 
 SET(QGIS_3D_HDRS
   qgsaabb.h
+  qgsabstract3dengine.h
   qgs3dmapscene.h
   qgs3dmapsettings.h
   qgs3dutils.h
   qgscameracontroller.h
+  qgsoffscreen3dengine.h
   qgsphongmaterialsettings.h
   qgsraycastingutils_p.h
   qgstessellatedpolygongeometry.h
   qgstilingscheme.h
   qgsvectorlayer3drenderer.h
+  qgswindow3dengine.h
 
   chunks/qgschunkboundsentity_p.h
   chunks/qgschunkedentity_p.h

--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -192,7 +192,7 @@ QgsChunkedEntity::SceneState _sceneState( QgsCameraController *cameraController 
 
 void Qgs3DMapScene::onCameraChanged()
 {
-  Q_FOREACH ( QgsChunkedEntity *entity, mChunkEntities )
+  for ( QgsChunkedEntity *entity : qgis::as_const( mChunkEntities ) )
   {
     if ( entity->isEnabled() )
       entity->update( _sceneState( mCameraController ) );
@@ -273,7 +273,7 @@ void Qgs3DMapScene::onFrameTriggered( float dt )
 {
   mCameraController->frameTriggered( dt );
 
-  Q_FOREACH ( QgsChunkedEntity *entity, mChunkEntities )
+  for ( QgsChunkedEntity *entity : qgis::as_const( mChunkEntities ) )
   {
     if ( entity->isEnabled() && entity->needsUpdate() )
     {
@@ -475,7 +475,7 @@ void Qgs3DMapScene::updateSceneState()
     return;
   }
 
-  Q_FOREACH ( QgsChunkedEntity *entity, mChunkEntities )
+  for ( QgsChunkedEntity *entity : qgis::as_const( mChunkEntities ) )
   {
     if ( entity->isEnabled() && entity->pendingJobsCount() > 0 )
     {

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -66,11 +66,22 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Returns number of pending jobs of the terrain entity
     int terrainPendingJobsCount() const;
 
+    enum SceneState
+    {
+      Ready,     //!< The scene is fully loaded/updated
+      Updating,  //!< The scene is still being loaded/updated
+    };
+
+    //! Returns the current state of the scene
+    SceneState sceneState() const { return mSceneState; }
+
   signals:
     //! Emitted when the current terrain entity is replaced by a new one
     void terrainEntityChanged();
     //! Emitted when the number of terrain's pending jobs changes
     void terrainPendingJobsCountChanged();
+    //! Emitted when the scene's state has changed
+    void sceneStateChanged();
 
   private slots:
     void onCameraChanged();
@@ -85,6 +96,8 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void addLayerEntity( QgsMapLayer *layer );
     void removeLayerEntity( QgsMapLayer *layer );
     void addCameraViewCenterEntity( Qt3DRender::QCamera *camera );
+    void setSceneState( SceneState state );
+    void updateSceneState();
 
   private:
     const Qgs3DMapSettings &mMap;
@@ -99,6 +112,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Keeps track of entities that belong to a particular layer
     QMap<QgsMapLayer *, Qt3DCore::QEntity *> mLayerEntities;
     bool mTerrainUpdateScheduled = false;
+    SceneState mSceneState = Ready;
 };
 
 #endif // QGS3DMAPSCENE_H

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -36,6 +36,7 @@ namespace Qt3DExtras
   class QForwardRenderer;
 }
 
+class QgsAbstract3DEngine;
 class QgsMapLayer;
 class QgsCameraController;
 class Qgs3DMapSettings;
@@ -52,7 +53,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     Q_OBJECT
   public:
     //! Constructs a 3D scene based on map settings and Qt 3D renderer configuration
-    Qgs3DMapScene( const Qgs3DMapSettings &map, Qt3DExtras::QForwardRenderer *defaultFrameGraph, Qt3DRender::QRenderSettings *renderSettings, Qt3DRender::QCamera *camera, const QRect &viewportRect, Qt3DCore::QNode *parent = nullptr );
+    Qgs3DMapScene( const Qgs3DMapSettings &map, QgsAbstract3DEngine *engine );
 
     //! Returns camera controller
     QgsCameraController *cameraController() { return mCameraController; }
@@ -87,12 +88,11 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
 
   private:
     const Qgs3DMapSettings &mMap;
+    QgsAbstract3DEngine *mEngine = nullptr;
     //! Provides a way to have a synchronous function executed each frame
     Qt3DLogic::QFrameAction *mFrameAction = nullptr;
     QgsCameraController *mCameraController = nullptr;
     QgsTerrainEntity *mTerrain = nullptr;
-    //! Forward renderer provided by 3D window
-    Qt3DExtras::QForwardRenderer *mForwardRenderer = nullptr;
     QList<QgsChunkedEntity *> mChunkEntities;
     //! Entity that shows view center - useful for debugging camera issues
     Qt3DCore::QEntity *mEntityCameraViewCenter = nullptr;

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -66,6 +66,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Returns number of pending jobs of the terrain entity
     int terrainPendingJobsCount() const;
 
+    //! Enumeration of possible states of the 3D scene
     enum SceneState
     {
       Ready,     //!< The scene is fully loaded/updated

--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -37,12 +37,11 @@ QImage Qgs3DUtils::captureSceneImage( QgsAbstract3DEngine &engine, Qgs3DMapScene
   {
     if ( scene->sceneState() == Qgs3DMapScene::Ready )
     {
-      qDebug() << "loaded - requesting image";
       engine.requestCaptureImage();
     }
   };
 
-  auto saveImageFcn = [&engine, &evLoop, &resImage]( const QImage & img )
+  auto saveImageFcn = [&evLoop, &resImage]( const QImage & img )
   {
     resImage = img;
     evLoop.quit();

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -19,6 +19,9 @@
 class QgsLineString;
 class QgsPolygon;
 
+class QgsAbstract3DEngine;
+class Qgs3DMapScene;
+
 #include "qgs3dmapsettings.h"
 #include "qgsaabb.h"
 
@@ -49,6 +52,13 @@ enum AltitudeBinding
 class _3D_EXPORT Qgs3DUtils
 {
   public:
+
+    /**
+     * Captures image of the current 3D scene of a 3D engine. The function waits
+     * until the scene is not fully loaded/updated before capturing the image.
+     * \since QGIS 3.4
+     */
+    static QImage captureSceneImage( QgsAbstract3DEngine &engine, Qgs3DMapScene *scene );
 
     /**
      * Calculates the highest needed zoom level for tiles in quad-tree given width of the base tile (zoom level 0)

--- a/src/3d/qgsabstract3dengine.cpp
+++ b/src/3d/qgsabstract3dengine.cpp
@@ -1,0 +1,16 @@
+/***************************************************************************
+  qgsabstract3dengine.cpp
+  --------------------------------------
+  Date                 : July 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsabstract3dengine.h"

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -69,7 +69,7 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
     /**
      * Starts a request for an image rendered by the engine.
      * The function does not block - when the rendered image is captured, it is returned in imageCaptured() signal.
-     * Only one image reqeust can be active at a time.
+     * Only one image request can be active at a time.
      */
     virtual void requestCaptureImage() = 0;
 

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -1,0 +1,52 @@
+#ifndef QGSABSTRACT3DENGINE_H
+#define QGSABSTRACT3DENGINE_H
+
+#include "qgis_3d.h"
+
+#include <QObject>
+
+class QColor;
+class QRect;
+
+namespace Qt3DCore
+{
+  class QEntity;
+}
+
+namespace Qt3DRender
+{
+  class QRenderSettings;
+  class QCamera;
+}
+
+/**
+ * Base class for 3D engine implementation. A 3D engine is responsible for setting up
+ * rendering with Qt3D. This means mainly:
+ * - creating Qt3D aspect engine and registering rendering aspect
+ * - setting up a camera, render settings and frame graph
+ *
+ * We have two implementations:
+ * - QgsWindow3DEngine - used for rendering on display (has a QWindow that can be embedded into QWidget)
+ * - QgsOffscreen3DEngine - renders scene to images
+ *
+ * \since QGIS 3.4
+ */
+class _3D_EXPORT QgsAbstract3DEngine : public QObject
+{
+    Q_OBJECT
+  public:
+
+    virtual void setClearColor( const QColor &color ) = 0;
+    virtual void setFrustumCullingEnabled( bool enabled ) = 0;
+    virtual void setRootEntity( Qt3DCore::QEntity *root ) = 0;
+
+    virtual Qt3DRender::QRenderSettings *renderSettings() = 0;
+    virtual Qt3DRender::QCamera *camera() = 0;
+    virtual QSize size() const = 0;
+
+  signals:
+    void imageCaptured( const QImage &image );
+};
+
+
+#endif // QGSABSTRACT3DENGINE_H

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -1,3 +1,18 @@
+/***************************************************************************
+  qgsabstract3dengine.h
+  --------------------------------------
+  Date                 : July 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #ifndef QGSABSTRACT3DENGINE_H
 #define QGSABSTRACT3DENGINE_H
 
@@ -20,6 +35,7 @@ namespace Qt3DRender
 }
 
 /**
+ * \ingroup 3d
  * Base class for 3D engine implementation. A 3D engine is responsible for setting up
  * rendering with Qt3D. This means mainly:
  * - creating Qt3D aspect engine and registering rendering aspect
@@ -36,17 +52,29 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
     Q_OBJECT
   public:
 
+    //! Sets background color of the scene
     virtual void setClearColor( const QColor &color ) = 0;
+    //! Sets whether frustum culling is enabled (this should make rendering faster by not rendering entities outside of camera's view)
     virtual void setFrustumCullingEnabled( bool enabled ) = 0;
+    //! Sets root entity of the 3D scene
     virtual void setRootEntity( Qt3DCore::QEntity *root ) = 0;
 
+    //! Returns access to the engine's render settings (the frame graph can be accessed from here)
     virtual Qt3DRender::QRenderSettings *renderSettings() = 0;
+    //! Returns pointer to the engine's camera entity
     virtual Qt3DRender::QCamera *camera() = 0;
+    //! Returns size of the engine's rendering area in pixels
     virtual QSize size() const = 0;
 
+    /**
+     * Starts a request for an image rendered by the engine.
+     * The function does not block - when the rendered image is captured, it is returned in imageCaptured() signal.
+     * Only one image reqeust can be active at a time.
+     */
     virtual void requestCaptureImage() = 0;
 
   signals:
+    //! Emitted after a call to requestCaptureImage() to return the captured image.
     void imageCaptured( const QImage &image );
 };
 

--- a/src/3d/qgsabstract3dengine.h
+++ b/src/3d/qgsabstract3dengine.h
@@ -44,6 +44,8 @@ class _3D_EXPORT QgsAbstract3DEngine : public QObject
     virtual Qt3DRender::QCamera *camera() = 0;
     virtual QSize size() const = 0;
 
+    virtual void requestCaptureImage() = 0;
+
   signals:
     void imageCaptured( const QImage &image );
 };

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -1,0 +1,217 @@
+/***************************************************************************
+  qgsoffscreen3dengine.cpp
+  --------------------------------------
+  Date                 : July 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsoffscreen3dengine.h"
+
+#include <QOffscreenSurface>
+#include <QSurfaceFormat>
+
+#include <Qt3DCore/QAspectEngine>
+#include <Qt3DLogic/QLogicAspect>
+#include <Qt3DRender/QCamera>
+#include <Qt3DRender/QCameraSelector>
+#include <Qt3DRender/QClearBuffers>
+#include <Qt3DRender/QRenderAspect>
+#include <Qt3DRender/QRenderCapture>
+#include <Qt3DRender/QRenderSettings>
+#include <Qt3DRender/QRenderTarget>
+#include <Qt3DRender/QRenderTargetOutput>
+#include <Qt3DRender/QRenderTargetSelector>
+#include <Qt3DRender/QRenderSurfaceSelector>
+#include <Qt3DRender/QTexture>
+#include <Qt3DRender/QViewport>
+
+// TODO: set size
+// TODO: destructor
+
+QgsOffscreen3DEngine::QgsOffscreen3DEngine()
+{
+  mSize = QSize( 640, 480 );
+
+  // Set up the default OpenGL surface format.
+  QSurfaceFormat format;
+  format.setDepthBufferSize( 32 ); // TODO: or 24?  (used by QWindow3D)
+  format.setSamples( 8 );
+  QSurfaceFormat::setDefaultFormat( format );
+
+  // Set up a camera to point at the shapes.
+  mCamera = new Qt3DRender::QCamera;
+  mCamera->lens()->setPerspectiveProjection( 45.0f, 1200.0f / 800.0f, 0.1f, 1000.0f );
+  mCamera->setPosition( QVector3D( 0, 0, 20.0f ) );
+  mCamera->setUpVector( QVector3D( 0, 1, 0 ) );
+  mCamera->setViewCenter( QVector3D( 0, 0, 0 ) );
+
+  // Set up the engine and the aspects that we want to use.
+  mAspectEngine = new Qt3DCore::QAspectEngine();
+  mRenderAspect = new Qt3DRender::QRenderAspect( Qt3DRender::QRenderAspect::Threaded ); // Only threaded mode seems to work right now.
+  mLogicAspect = new Qt3DLogic::QLogicAspect();
+
+  mAspectEngine->registerAspect( mRenderAspect );
+  mAspectEngine->registerAspect( mLogicAspect );
+
+  // Create the root entity of the engine.
+  // This is not the same as the 3D scene root: the QRenderSettings
+  // component must be held by the root of the QEntity tree,
+  // so it is added to this one. The 3D scene is added as a subtree later,
+  // in setRootEntity().
+  mRoot = new Qt3DCore::QEntity();
+  mRenderSettings = new Qt3DRender::QRenderSettings( mRoot );
+  mRoot->addComponent( mRenderSettings );
+
+  mCamera->setParent( mRoot );
+
+  // Create the offscreen frame graph, which will manage all of the resources required
+  // for rendering without a QWindow.
+  createFrameGraph();
+
+  // Set this frame graph to be in use.
+  mRenderSettings->setActiveFrameGraph( mSurfaceSelector );
+
+  // Set the root entity of the engine. This causes the engine to begin running.
+  mAspectEngine->setRootEntity( Qt3DCore::QEntityPtr( mRoot ) );
+
+
+  // start requesting renders
+  requestRenderCapture();
+}
+
+void QgsOffscreen3DEngine::setClearColor( const QColor &color )
+{
+  mClearBuffers->setClearColor( color );
+}
+
+void QgsOffscreen3DEngine::createRenderTarget()
+{
+  mTextureTarget = new Qt3DRender::QRenderTarget;
+
+  // The lifetime of the objects created here is managed
+  // automatically, as they become children of this object.
+
+  // Create a render target output for rendering colour.
+  mTextureOutput = new Qt3DRender::QRenderTargetOutput( mTextureTarget );
+  mTextureOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
+
+  // Create a texture to render into.
+  mTexture = new Qt3DRender::QTexture2D( mTextureOutput );
+  mTexture->setSize( mSize.width(), mSize.height() );
+  mTexture->setFormat( Qt3DRender::QAbstractTexture::RGB8_UNorm );
+  mTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  mTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
+
+  // Hook the texture up to our output, and the output up to this object.
+  mTextureOutput->setTexture( mTexture );
+  mTextureTarget->addOutput( mTextureOutput );
+
+  mDepthTextureOutput = new Qt3DRender::QRenderTargetOutput( mTextureTarget );
+  mDepthTextureOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Depth );
+  mDepthTexture = new Qt3DRender::QTexture2D( mDepthTextureOutput );
+  mDepthTexture->setSize( mSize.width(), mSize.height() );
+  mDepthTexture->setFormat( Qt3DRender::QAbstractTexture::DepthFormat );
+  mDepthTexture->setMinificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  mDepthTexture->setMagnificationFilter( Qt3DRender::QAbstractTexture::Linear );
+  mDepthTexture->setComparisonFunction( Qt3DRender::QAbstractTexture::CompareLessEqual );
+  mDepthTexture->setComparisonMode( Qt3DRender::QAbstractTexture::CompareRefToTexture );
+  // Hook up the depth texture
+  mDepthTextureOutput->setTexture( mDepthTexture );
+  mTextureTarget->addOutput( mDepthTextureOutput );
+}
+
+void QgsOffscreen3DEngine::createFrameGraph()
+{
+  // Firstly, create the offscreen surface. This will take the place
+  // of a QWindow, allowing us to render our scene without one.
+  mOffscreenSurface = new QOffscreenSurface();
+  mOffscreenSurface->setFormat( QSurfaceFormat::defaultFormat() );
+  mOffscreenSurface->create();
+
+  // Hook it up to the frame graph.
+  mSurfaceSelector = new Qt3DRender::QRenderSurfaceSelector( mRenderSettings );
+  mSurfaceSelector->setSurface( mOffscreenSurface );
+  mSurfaceSelector->setExternalRenderTargetSize( mSize );
+
+  // Create a texture to render into. This acts as the buffer that
+  // holds the rendered image.
+  mRenderTargetSelector = new Qt3DRender::QRenderTargetSelector( mSurfaceSelector );
+  createRenderTarget();  // new TextureRenderTarget(renderTargetSelector, size);
+  mRenderTargetSelector->setTarget( mTextureTarget );
+
+  // Create a node used for clearing the required buffers.
+  mClearBuffers = new Qt3DRender::QClearBuffers( mRenderTargetSelector );
+  mClearBuffers->setClearColor( QColor( 100, 100, 100, 255 ) );
+  mClearBuffers->setBuffers( Qt3DRender::QClearBuffers::ColorDepthBuffer );
+
+  // Create a viewport node. The viewport here just covers the entire render area.
+  mViewport = new Qt3DRender::QViewport( mRenderTargetSelector );
+  mViewport->setNormalizedRect( QRectF( 0.0, 0.0, 1.0, 1.0 ) );
+
+  // Create a camera selector node, and tell it to use the camera we've ben given.
+  mCameraSelector = new Qt3DRender::QCameraSelector( mViewport );
+  mCameraSelector->setCamera( mCamera );
+
+  // Add a render capture node to the frame graph.
+  // This is set as the next child of the render target selector node,
+  // so that the capture will be taken from the specified render target
+  // once all other rendering operations have taken place.
+  mRenderCapture = new Qt3DRender::QRenderCapture( mRenderTargetSelector );
+}
+
+void QgsOffscreen3DEngine::setRootEntity( Qt3DCore::QEntity *root )
+{
+  // Make sure any existing scene root is unparented.
+  if ( mSceneRoot )
+  {
+    mSceneRoot->setParent( static_cast<Qt3DCore::QNode *>( nullptr ) );
+  }
+
+  // Parent the incoming scene root to our current root entity.
+  mSceneRoot = root;
+  mSceneRoot->setParent( mAspectEngine->rootEntity().data() );
+}
+
+Qt3DRender::QRenderSettings *QgsOffscreen3DEngine::renderSettings()
+{
+  return mRenderSettings;
+}
+
+Qt3DRender::QCamera *QgsOffscreen3DEngine::camera()
+{
+  return mCamera;
+}
+
+QSize QgsOffscreen3DEngine::size() const
+{
+  return mSize;
+}
+
+//static int iii = 0;
+
+void QgsOffscreen3DEngine::requestRenderCapture()
+{
+  delete mReply;
+  mReply = mRenderCapture->requestCapture();
+  connect( mReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
+  {
+    QImage image = mReply->image();
+    /*
+    iii++;
+    qDebug() << "got image!" << iii;
+    image.save( QString( "/tmp/3d_%1.jpg" ).arg( iii ), "jpg" );
+    */
+    emit imageCaptured( image );
+
+    //if (!end)
+    requestRenderCapture();
+  } );
+}

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -82,14 +82,17 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   // Set the root entity of the engine. This causes the engine to begin running.
   mAspectEngine->setRootEntity( Qt3DCore::QEntityPtr( mRoot ) );
 
-
-  // start requesting renders
-  requestRenderCapture();
 }
 
 void QgsOffscreen3DEngine::setClearColor( const QColor &color )
 {
   mClearBuffers->setClearColor( color );
+}
+
+void QgsOffscreen3DEngine::setFrustumCullingEnabled( bool enabled )
+{
+  // TODO
+  Q_UNUSED( enabled );
 }
 
 void QgsOffscreen3DEngine::createRenderTarget()
@@ -195,23 +198,19 @@ QSize QgsOffscreen3DEngine::size() const
   return mSize;
 }
 
-//static int iii = 0;
-
-void QgsOffscreen3DEngine::requestRenderCapture()
+void QgsOffscreen3DEngine::requestCaptureImage()
 {
-  delete mReply;
+  if ( mReply )
+  {
+    qDebug() << "already having a pending capture, skipping";
+    return;
+  }
   mReply = mRenderCapture->requestCapture();
   connect( mReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
   {
     QImage image = mReply->image();
-    /*
-    iii++;
-    qDebug() << "got image!" << iii;
-    image.save( QString( "/tmp/3d_%1.jpg" ).arg( iii ), "jpg" );
-    */
+    mReply->deleteLater();
+    mReply = nullptr;
     emit imageCaptured( image );
-
-    //if (!end)
-    requestRenderCapture();
   } );
 }

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -33,8 +33,6 @@
 #include <Qt3DRender/QTexture>
 #include <Qt3DRender/QViewport>
 
-// TODO: set size
-// TODO: destructor
 
 QgsOffscreen3DEngine::QgsOffscreen3DEngine()
 {
@@ -48,7 +46,7 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
 
   // Set up a camera to point at the shapes.
   mCamera = new Qt3DRender::QCamera;
-  mCamera->lens()->setPerspectiveProjection( 45.0f, 1200.0f / 800.0f, 0.1f, 1000.0f );
+  mCamera->lens()->setPerspectiveProjection( 45.0f, float( mSize.width() ) / float( mSize.height() ), 0.1f, 1000.0f );
   mCamera->setPosition( QVector3D( 0, 0, 20.0f ) );
   mCamera->setUpVector( QVector3D( 0, 1, 0 ) );
   mCamera->setViewCenter( QVector3D( 0, 0, 0 ) );
@@ -82,6 +80,22 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   // Set the root entity of the engine. This causes the engine to begin running.
   mAspectEngine->setRootEntity( Qt3DCore::QEntityPtr( mRoot ) );
 
+}
+
+QgsOffscreen3DEngine::~QgsOffscreen3DEngine()
+{
+  delete mAspectEngine;
+}
+
+void QgsOffscreen3DEngine::setSize( const QSize &s )
+{
+  mSize = s;
+
+  mTexture->setSize( mSize.width(), mSize.height() );
+  mDepthTexture->setSize( mSize.width(), mSize.height() );
+  mSurfaceSelector->setExternalRenderTargetSize( mSize );
+
+  mCamera->setAspectRatio( float( mSize.width() ) / float( mSize.height() ) );
 }
 
 void QgsOffscreen3DEngine::setClearColor( const QColor &color )

--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -36,8 +36,6 @@
 
 QgsOffscreen3DEngine::QgsOffscreen3DEngine()
 {
-  mSize = QSize( 640, 480 );
-
   // Set up the default OpenGL surface format.
   QSurfaceFormat format;
   format.setDepthBufferSize( 32 ); // TODO: or 24?  (used by QWindow3D)
@@ -75,6 +73,7 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
   createFrameGraph();
 
   // Set this frame graph to be in use.
+  // the render settings also sets itself as the parent of mSurfaceSelector
   mRenderSettings->setActiveFrameGraph( mSurfaceSelector );
 
   // Set the root entity of the engine. This causes the engine to begin running.
@@ -85,6 +84,7 @@ QgsOffscreen3DEngine::QgsOffscreen3DEngine()
 QgsOffscreen3DEngine::~QgsOffscreen3DEngine()
 {
   delete mAspectEngine;
+  delete mOffscreenSurface;
 }
 
 void QgsOffscreen3DEngine::setSize( const QSize &s )
@@ -116,7 +116,7 @@ void QgsOffscreen3DEngine::createRenderTarget()
   // The lifetime of the objects created here is managed
   // automatically, as they become children of this object.
 
-  // Create a render target output for rendering colour.
+  // Create a render target output for rendering color.
   mTextureOutput = new Qt3DRender::QRenderTargetOutput( mTextureTarget );
   mTextureOutput->setAttachmentPoint( Qt3DRender::QRenderTargetOutput::Color0 );
 
@@ -161,7 +161,8 @@ void QgsOffscreen3DEngine::createFrameGraph()
   // Create a texture to render into. This acts as the buffer that
   // holds the rendered image.
   mRenderTargetSelector = new Qt3DRender::QRenderTargetSelector( mSurfaceSelector );
-  createRenderTarget();  // new TextureRenderTarget(renderTargetSelector, size);
+  createRenderTarget();
+  // the target selector also sets itself as the parent of mTextureTarget
   mRenderTargetSelector->setTarget( mTextureTarget );
 
   // Create a node used for clearing the required buffers.

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -1,0 +1,89 @@
+#ifndef QGSOFFSCREEN3DENGINE_H
+#define QGSOFFSCREEN3DENGINE_H
+
+#include "qgsabstract3dengine.h"
+
+#include <QSize>
+
+class QOffscreenSurface;
+
+namespace Qt3DCore
+{
+  class QAspectEngine;
+  class QNode;
+}
+
+namespace Qt3DRender
+{
+  class QCameraSelector;
+  class QClearBuffers;
+  class QRenderAspect;
+  class QRenderCapture;
+  class QRenderCaptureReply;
+  class QRenderTarget;
+  class QRenderTargetSelector;
+  class QRenderTargetOutput;
+  class QRenderSurfaceSelector;
+  class QTexture2D;
+  class QViewport;
+}
+
+namespace Qt3DLogic
+{
+  class QLogicAspect;
+}
+
+
+class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
+{
+    Q_OBJECT
+  public:
+    QgsOffscreen3DEngine();
+
+    void setClearColor( const QColor &color ) override;
+    //void setFrustumCullingEnabled( bool enabled ) override;
+    void setRootEntity( Qt3DCore::QEntity *root ) override;
+
+    Qt3DRender::QRenderSettings *renderSettings() override;
+    Qt3DRender::QCamera *camera() override;
+    QSize size() const override;
+
+  private:
+    void createRenderTarget();
+    void createFrameGraph();
+
+    void requestRenderCapture();
+
+  private:
+
+    QSize mSize;
+    Qt3DRender::QCamera *mCamera = nullptr;
+    QOffscreenSurface *mOffscreenSurface = nullptr;
+    Qt3DRender::QRenderCaptureReply *mReply = nullptr;
+
+    // basic Qt3D stuff
+    Qt3DCore::QAspectEngine *mAspectEngine = nullptr;              // The aspect engine, which holds the scene and related aspects.
+    Qt3DRender::QRenderAspect *mRenderAspect = nullptr;            // The render aspect, which deals with rendering the scene.
+    Qt3DLogic::QLogicAspect *mLogicAspect = nullptr;               // The logic aspect, which runs jobs to do with synchronising frames.
+    Qt3DRender::QRenderSettings *mRenderSettings = nullptr;        // The render settings, which control the general rendering behaviour.
+    Qt3DCore::QNode *mSceneRoot = nullptr;                         // The scene root, which becomes a child of the engine's root entity.
+    Qt3DCore::QEntity *mRoot = nullptr;
+
+    // render target stuff
+    Qt3DRender::QRenderTarget *mTextureTarget = nullptr;
+    Qt3DRender::QRenderTargetOutput *mTextureOutput = nullptr;
+    Qt3DRender::QTexture2D *mTexture = nullptr;
+    Qt3DRender::QRenderTargetOutput *mDepthTextureOutput = nullptr;
+    Qt3DRender::QTexture2D *mDepthTexture = nullptr;
+
+    // frame graph stuff
+    Qt3DRender::QRenderSurfaceSelector *mSurfaceSelector = nullptr;
+    Qt3DRender::QRenderTargetSelector *mRenderTargetSelector = nullptr;
+    Qt3DRender::QViewport *mViewport = nullptr;
+    Qt3DRender::QClearBuffers *mClearBuffers = nullptr;
+    Qt3DRender::QCameraSelector *mCameraSelector = nullptr;
+    Qt3DRender::QRenderCapture *mRenderCapture = nullptr;          // The render capture node, which is appended to the frame graph.
+
+};
+
+#endif // QGSOFFSCREEN3DENGINE_H

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -39,6 +39,9 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     Q_OBJECT
   public:
     QgsOffscreen3DEngine();
+    ~QgsOffscreen3DEngine();
+
+    void setSize( const QSize &s );
 
     void setClearColor( const QColor &color ) override;
     void setFrustumCullingEnabled( bool enabled ) override;

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -41,18 +41,18 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     QgsOffscreen3DEngine();
 
     void setClearColor( const QColor &color ) override;
-    //void setFrustumCullingEnabled( bool enabled ) override;
+    void setFrustumCullingEnabled( bool enabled ) override;
     void setRootEntity( Qt3DCore::QEntity *root ) override;
 
     Qt3DRender::QRenderSettings *renderSettings() override;
     Qt3DRender::QCamera *camera() override;
     QSize size() const override;
 
+    void requestCaptureImage() override;
+
   private:
     void createRenderTarget();
     void createFrameGraph();
-
-    void requestRenderCapture();
 
   private:
 

--- a/src/3d/qgsoffscreen3dengine.h
+++ b/src/3d/qgsoffscreen3dengine.h
@@ -1,3 +1,18 @@
+/***************************************************************************
+  qgsoffscreen3dengine.h
+  --------------------------------------
+  Date                 : July 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #ifndef QGSOFFSCREEN3DENGINE_H
 #define QGSOFFSCREEN3DENGINE_H
 
@@ -34,6 +49,15 @@ namespace Qt3DLogic
 }
 
 
+/**
+ * \ingroup 3d
+ * Off-screen 3D engine implementation. It is useful for recording rendered 3D scenes of arbitrary size.
+ *
+ * \note While the on-screen 3D engine also allows capturing of images, its limitation is that
+ * the captured images are of the size of the on-screen window.
+ *
+ * \since QGIS 3.4
+ */
 class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
 {
     Q_OBJECT
@@ -41,6 +65,7 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     QgsOffscreen3DEngine();
     ~QgsOffscreen3DEngine();
 
+    //! Sets the size of the rendering area (in pixels)
     void setSize( const QSize &s );
 
     void setClearColor( const QColor &color ) override;
@@ -59,7 +84,7 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
 
   private:
 
-    QSize mSize;
+    QSize mSize = QSize( 640, 480 );
     Qt3DRender::QCamera *mCamera = nullptr;
     QOffscreenSurface *mOffscreenSurface = nullptr;
     Qt3DRender::QRenderCaptureReply *mReply = nullptr;
@@ -68,7 +93,7 @@ class _3D_EXPORT QgsOffscreen3DEngine : public QgsAbstract3DEngine
     Qt3DCore::QAspectEngine *mAspectEngine = nullptr;              // The aspect engine, which holds the scene and related aspects.
     Qt3DRender::QRenderAspect *mRenderAspect = nullptr;            // The render aspect, which deals with rendering the scene.
     Qt3DLogic::QLogicAspect *mLogicAspect = nullptr;               // The logic aspect, which runs jobs to do with synchronising frames.
-    Qt3DRender::QRenderSettings *mRenderSettings = nullptr;        // The render settings, which control the general rendering behaviour.
+    Qt3DRender::QRenderSettings *mRenderSettings = nullptr;        // The render settings, which control the general rendering behavior.
     Qt3DCore::QNode *mSceneRoot = nullptr;                         // The scene root, which becomes a child of the engine's root entity.
     Qt3DCore::QEntity *mRoot = nullptr;
 

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -1,0 +1,61 @@
+#include "qgswindow3dengine.h"
+
+#include <Qt3DRender/QRenderCapture>
+#include <Qt3DExtras/Qt3DWindow>
+#include <Qt3DExtras/QForwardRenderer>
+
+
+QgsWindow3DEngine::QgsWindow3DEngine()
+{
+  mWindow3D = new Qt3DExtras::Qt3DWindow;
+
+  mCapture = new Qt3DRender::QRenderCapture;
+  mWindow3D->activeFrameGraph()->setParent( mCapture );
+  mWindow3D->setActiveFrameGraph( mCapture );
+}
+
+QWindow *QgsWindow3DEngine::window()
+{
+  return mWindow3D;
+}
+
+void QgsWindow3DEngine::requestCaptureImage()
+{
+  Qt3DRender::QRenderCaptureReply *captureReply;
+  captureReply = mCapture->requestCapture();
+  connect( captureReply, &Qt3DRender::QRenderCaptureReply::completed, this, [ = ]
+  {
+    emit imageCaptured( captureReply->image() );
+    captureReply->deleteLater();
+  } );
+}
+
+void QgsWindow3DEngine::setClearColor( const QColor &color )
+{
+  mWindow3D->defaultFrameGraph()->setClearColor( color );
+}
+
+void QgsWindow3DEngine::setFrustumCullingEnabled( bool enabled )
+{
+  mWindow3D->defaultFrameGraph()->setFrustumCullingEnabled( enabled );
+}
+
+void QgsWindow3DEngine::setRootEntity( Qt3DCore::QEntity *root )
+{
+  mWindow3D->setRootEntity( root );
+}
+
+Qt3DRender::QRenderSettings *QgsWindow3DEngine::renderSettings()
+{
+  return mWindow3D->renderSettings();
+}
+
+Qt3DRender::QCamera *QgsWindow3DEngine::camera()
+{
+  return mWindow3D->camera();
+}
+
+QSize QgsWindow3DEngine::size() const
+{
+  return mWindow3D->size();
+}

--- a/src/3d/qgswindow3dengine.cpp
+++ b/src/3d/qgswindow3dengine.cpp
@@ -1,3 +1,18 @@
+/***************************************************************************
+  qgswindow3dengine.cpp
+  --------------------------------------
+  Date                 : July 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "qgswindow3dengine.h"
 
 #include <Qt3DRender/QRenderCapture>

--- a/src/3d/qgswindow3dengine.h
+++ b/src/3d/qgswindow3dengine.h
@@ -32,12 +32,20 @@ namespace Qt3DExtras
 class QWindow;
 
 
+/**
+ * \ingroup 3d
+ * On-screen 3D engine: it creates OpenGL window (QWindow) and displays rendered 3D scene there.
+ * The window can be embedded into a QWidget-based application with QWidget::createWindowContainer().
+ *
+ * \since QGIS 3.4
+ */
 class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
 {
     Q_OBJECT
   public:
     QgsWindow3DEngine();
 
+    //! Returns the internal 3D window where all the rendered output is displayed
     QWindow *window();
 
     void requestCaptureImage() override;

--- a/src/3d/qgswindow3dengine.h
+++ b/src/3d/qgswindow3dengine.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+  qgswindow3dengine.h
+  --------------------------------------
+  Date                 : July 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSWINDOW3DENGINE_H
+#define QGSWINDOW3DENGINE_H
+
+#include "qgsabstract3dengine.h"
+
+
+namespace Qt3DRender
+{
+  class QRenderCapture;
+}
+
+namespace Qt3DExtras
+{
+  class Qt3DWindow;
+}
+
+class QWindow;
+
+
+class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
+{
+    Q_OBJECT
+  public:
+    QgsWindow3DEngine();
+
+    QWindow *window();
+
+    void requestCaptureImage();
+
+    void setClearColor( const QColor &color ) override;
+    void setFrustumCullingEnabled( bool enabled ) override;
+    void setRootEntity( Qt3DCore::QEntity *root ) override;
+
+    Qt3DRender::QRenderSettings *renderSettings() override;
+    Qt3DRender::QCamera *camera() override;
+    QSize size() const override;
+
+  private:
+    //! 3D window with all the 3D magic inside
+    Qt3DExtras::Qt3DWindow *mWindow3D = nullptr;
+    //! Frame graph node for render capture
+    Qt3DRender::QRenderCapture *mCapture = nullptr;
+};
+
+
+#endif // QGSWINDOW3DENGINE_H

--- a/src/3d/qgswindow3dengine.h
+++ b/src/3d/qgswindow3dengine.h
@@ -40,7 +40,7 @@ class _3D_EXPORT QgsWindow3DEngine : public QgsAbstract3DEngine
 
     QWindow *window();
 
-    void requestCaptureImage();
+    void requestCaptureImage() override;
 
     void setClearColor( const QColor &color ) override;
     void setFrustumCullingEnabled( bool enabled ) override;

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -26,6 +26,7 @@ namespace Qt3DExtras
 
 class Qgs3DMapSettings;
 class Qgs3DMapScene;
+class QgsWindow3DEngine;
 class QgsCameraController;
 class QgsPointXY;
 
@@ -66,10 +67,10 @@ class Qgs3DMapCanvas : public QWidget
     void resizeEvent( QResizeEvent *ev ) override;
 
   private:
-    //! 3D window with all the 3D magic inside
-    Qt3DExtras::Qt3DWindow *mWindow3D = nullptr;
-    //! Frame graph node for render capture
-    Qt3DRender::QRenderCapture *mCapture = nullptr;
+    QgsWindow3DEngine *mEngine = nullptr;
+
+    QString mCaptureFileName;
+    QString mCaptureFileFormat;
 
     //! Container QWidget that encapsulates mWindow3D so we can use it embedded in ordinary widgets app
     QWidget *mContainer = nullptr;


### PR DESCRIPTION
This PR introduces code that allows rendering of QGIS 3D scenes either to on-screen window or to off-screen buffers. Off-screen rendering is a pre-requisite for stuff like print layouts support or test suite that compares expected and rendered 3D views.

This PR does not add any features visible to the user.

Off-screen rendering works only with Qt >= 5.9.2

A good amount of code for off-screen rendering comes originally from:
https://github.com/Sonnentierchen/Qt3D-OffscreenRenderer
That saved me a lot of frustration compared to having to start from scratch - kudos to @Sonnentierchen for providing the code!