### PR TITLE
Fix map tips not respecting user settings for font family and size

### DIFF
--- a/python/gui/auto_generated/qgsmaptip.sip.in
+++ b/python/gui/auto_generated/qgsmaptip.sip.in
@@ -63,6 +63,11 @@ Clear the current maptip if it exists
 :param mpMapCanvas: the canvas from which the tip should be cleared.
 %End
 
+    void applyFontSettings();
+%Docstring
+Apply font family and size to match user settings
+%End
+
 };
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2339,6 +2339,11 @@ void QgisApp::setAppStyleSheet( const QString &stylesheet )
   {
     d->setStyleSheet( stylesheet );
   }
+
+  if ( mpMaptip )
+  {
+    mpMaptip->applyFontSettings();
+  }
 }
 
 int QgisApp::messageTimeout()

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1634,6 +1634,8 @@ void QgsOptions::saveOptions()
   if ( mStyleSheetNewOpts != mStyleSheetOldOpts )
   {
     mStyleSheetBuilder->saveToSettings( mStyleSheetNewOpts );
+    // trigger an extra  style sheet build to propagate saved settings
+    mStyleSheetBuilder->buildStyleSheet( mStyleSheetNewOpts );
   }
 
   mDefaultDatumTransformTableWidget->transformContext().writeSettings();

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -57,6 +57,12 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   // we only want the first qualifying feature and we will only display the
   // field defined as the label field in the layer configuration file/database
 
+  // Do not render map tips if the layer is not visible
+  if ( !pMapCanvas->layers().contains( pLayer ) )
+  {
+    return;
+  }
+
   // Show the maptip on the canvas
   QString tipText, lastTipText, tipHtml, bodyStyle, containerStyle,
           backgroundColor, strokeColor;

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -19,6 +19,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsexpression.h"
 #include "qgslogger.h"
+#include "qgssettings.h"
 #include "qgswebview.h"
 #include "qgswebframe.h"
 
@@ -40,6 +41,9 @@ QgsMapTip::QgsMapTip()
 {
   // Init the visible flag
   mMapTipVisible = false;
+
+  // Init font-related values
+  applyFontSettings();
 }
 
 void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
@@ -118,7 +122,8 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   bodyStyle = QString(
                 "background-color: %1;"
                 "margin: 0;"
-                "white-space: nowrap;" ).arg( backgroundColor );
+                "white-space: nowrap;"
+                "font: %2pt \"%3\";" ).arg( backgroundColor ).arg( mFontSize ).arg( mFontFamily );
 
   containerStyle = QString(
                      "display: inline-block;"
@@ -130,6 +135,8 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
               "<div id='QgsWebViewContainer' style='%2'>%3</div>"
               "</body>"
               "</html>" ).arg( bodyStyle, containerStyle, tipText );
+
+  QgsDebugMsg( tipHtml );
 
   mWidget->move( pixelPosition.x(),
                  pixelPosition.y() );
@@ -214,6 +221,14 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPointXY &mapPosition, Qg
   }
 
   return tipString;
+}
+
+void QgsMapTip::applyFontSettings()
+{
+  QgsSettings settings;
+  QFont defaultFont = qApp->font();
+  mFontSize = settings.value( QStringLiteral( "/qgis/stylesheet/fontPointSize" ), defaultFont.pointSize() ).toInt();
+  mFontFamily = settings.value( QStringLiteral( "/qgis/stylesheet/fontFamily" ), defaultFont.family() ).toString();
 }
 
 // This slot handles all clicks

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -79,6 +79,11 @@ class GUI_EXPORT QgsMapTip : public QWidget
      */
     void clear( QgsMapCanvas *mpMapCanvas = nullptr );
 
+    /**
+     * Apply font family and size to match user settings
+     */
+    void applyFontSettings();
+
   private slots:
     void onLinkClicked( const QUrl &url );
     void resizeContent();
@@ -98,6 +103,9 @@ class GUI_EXPORT QgsMapTip : public QWidget
 
     QWidget *mWidget = nullptr;
     QgsWebView *mWebView = nullptr;
+
+    QString mFontFamily;
+    int mFontSize = 8;
 
     const int MARGIN_VALUE = 5;
 };


### PR DESCRIPTION
## Description
This PR fixes map tips not respecting user settings for font family and size. It's important for non-Latin user who might need to explicitly set a given font for their characters to render properly.

Another tiny fix is attached to this PR here, whereas map tips aren't rendered if the selected layer isn't visible (i.e. unchecked in the layers panel).

@nyalldawson , your review appreciated, as always.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
