### PR TITLE
[oauth] Automatic management of state parameter

### DIFF
--- a/src/auth/oauth2/qgsauthoauth2config.cpp
+++ b/src/auth/oauth2/qgsauthoauth2config.cpp
@@ -44,7 +44,6 @@ QgsAuthOAuth2Config::QgsAuthOAuth2Config( QObject *parent )
   connect( this, &QgsAuthOAuth2Config::usernameChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::passwordChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::scopeChanged, this, &QgsAuthOAuth2Config::configChanged );
-  connect( this, &QgsAuthOAuth2Config::stateChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::apiKeyChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::persistTokenChanged, this, &QgsAuthOAuth2Config::configChanged );
   connect( this, &QgsAuthOAuth2Config::accessMethodChanged, this, &QgsAuthOAuth2Config::configChanged );
@@ -187,14 +186,6 @@ void QgsAuthOAuth2Config::setScope( const QString &value )
     emit scopeChanged( mScope );
 }
 
-void QgsAuthOAuth2Config::setState( const QString &value )
-{
-  QString preval( mState );
-  mState = value;
-  if ( preval != value )
-    emit stateChanged( mState );
-}
-
 void QgsAuthOAuth2Config::setApiKey( const QString &value )
 {
   QString preval( mApiKey );
@@ -253,7 +244,6 @@ void QgsAuthOAuth2Config::setToDefaults()
   setUsername( QString() );
   setPassword( QString() );
   setScope( QString() );
-  setState( QString() );
   setApiKey( QString() );
   setPersistToken( false );
   setAccessMethod( QgsAuthOAuth2Config::Header );
@@ -278,7 +268,6 @@ bool QgsAuthOAuth2Config::operator==( const QgsAuthOAuth2Config &other ) const
            && other.username() == this->username()
            && other.password() == this->password()
            && other.scope() == this->scope()
-           && other.state() == this->state()
            && other.apiKey() == this->apiKey()
            && other.persistToken() == this->persistToken()
            && other.accessMethod() == this->accessMethod()
@@ -410,7 +399,6 @@ QVariantMap QgsAuthOAuth2Config::mappedProperties() const
   vmap.insert( QStringLiteral( "requestTimeout" ), this->requestTimeout() );
   vmap.insert( QStringLiteral( "requestUrl" ), this->requestUrl() );
   vmap.insert( QStringLiteral( "scope" ), this->scope() );
-  vmap.insert( QStringLiteral( "state" ), this->state() );
   vmap.insert( QStringLiteral( "tokenUrl" ), this->tokenUrl() );
   vmap.insert( QStringLiteral( "username" ), this->username() );
   vmap.insert( QStringLiteral( "version" ), this->version() );

--- a/src/auth/oauth2/qgsauthoauth2config.h
+++ b/src/auth/oauth2/qgsauthoauth2config.h
@@ -50,7 +50,6 @@ class QgsAuthOAuth2Config : public QObject
     Q_PROPERTY( QString username READ username WRITE setUsername NOTIFY usernameChanged )
     Q_PROPERTY( QString password READ password WRITE setPassword NOTIFY passwordChanged )
     Q_PROPERTY( QString scope READ scope WRITE setScope NOTIFY scopeChanged )
-    Q_PROPERTY( QString state READ state WRITE setState NOTIFY stateChanged )
     Q_PROPERTY( QString apiKey READ apiKey WRITE setApiKey NOTIFY apiKeyChanged )
     Q_PROPERTY( bool persistToken READ persistToken WRITE setPersistToken NOTIFY persistTokenChanged )
     Q_PROPERTY( AccessMethod accessMethod READ accessMethod WRITE setAccessMethod NOTIFY accessMethodChanged )
@@ -138,9 +137,6 @@ class QgsAuthOAuth2Config : public QObject
 
     //! Scope of authentication
     QString scope() const { return mScope; }
-
-    //! State passed with request
-    QString state() const { return mState; }
 
     //! API key
     QString apiKey() const { return mApiKey; }
@@ -282,8 +278,6 @@ class QgsAuthOAuth2Config : public QObject
     void setPassword( const QString &value );
     //! Set scope to \a value
     void setScope( const QString &value );
-    //! Set state to \a value
-    void setState( const QString &value );
     //! Set api key to \a value
     void setApiKey( const QString &value );
     // advanced
@@ -335,8 +329,6 @@ class QgsAuthOAuth2Config : public QObject
     void passwordChanged( const QString & );
     //! Emitted when configuration scope has changed
     void scopeChanged( const QString & );
-    //! Emitted when configuration state has changed
-    void stateChanged( const QString & );
     //! Emitted when configuration API key has changed
     void apiKeyChanged( const QString & );
 
@@ -369,7 +361,6 @@ class QgsAuthOAuth2Config : public QObject
     QString mUsername;
     QString mPassword;
     QString mScope;
-    QString mState;
     QString mApiKey;
     bool mPersistToken = false;
     AccessMethod mAccessMethod = AccessMethod::Header;

--- a/src/auth/oauth2/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/qgsauthoauth2edit.cpp
@@ -161,7 +161,6 @@ void QgsAuthOAuth2Edit::setupConnections()
   connect( leUsername, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setUsername );
   connect( lePassword, &QgsPasswordLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setPassword );
   connect( leScope, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setScope );
-  connect( leState, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setState );
   connect( leApiKey, &QLineEdit::textChanged, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setApiKey );
   connect( chkbxTokenPersist, &QCheckBox::toggled, mOAuthConfigCustom.get(), &QgsAuthOAuth2Config::setPersistToken );
   connect( cmbbxAccessMethod, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ),
@@ -380,7 +379,6 @@ void QgsAuthOAuth2Edit::loadFromOAuthConfig( const QgsAuthOAuth2Config *config )
     leUsername->setText( config->username() );
     lePassword->setText( config->password() );
     leScope->setText( config->scope() );
-    leState->setText( config->state() );
     leApiKey->setText( config->apiKey() );
 
     // advanced

--- a/src/auth/oauth2/qgsauthoauth2edit.ui
+++ b/src/auth/oauth2/qgsauthoauth2edit.ui
@@ -202,9 +202,9 @@
            <property name="geometry">
             <rect>
              <x>0</x>
-             <y>0</y>
-             <width>398</width>
-             <height>469</height>
+             <y>-241</y>
+             <width>401</width>
+             <height>516</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout">
@@ -230,14 +230,91 @@
               </property>
              </widget>
             </item>
-            <item row="12" column="1" colspan="4">
-             <widget class="QLineEdit" name="leState">
-              <property name="placeholderText">
-               <string>Recommended</string>
+            <item row="7" column="0">
+             <widget class="QLabel" name="lblClientId">
+              <property name="text">
+               <string>Client ID</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
               </property>
              </widget>
             </item>
-            <item row="18" column="0">
+            <item row="14" column="0" colspan="4">
+             <widget class="QLabel" name="label">
+              <property name="font">
+               <font>
+                <pointsize>12</pointsize>
+                <italic>true</italic>
+               </font>
+              </property>
+              <property name="text">
+               <string>Advanced</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="1" colspan="3">
+             <widget class="QgsPasswordLineEdit" name="leClientSecret">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="lblRedirectUrl">
+              <property name="text">
+               <string>Redirect URL</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1" colspan="3">
+             <widget class="QPlainTextEdit" name="pteDescription">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>40</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblDescription">
+              <property name="text">
+               <string>Description</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1" colspan="3">
+             <widget class="QLineEdit" name="leRequestUrl">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="12" column="1" colspan="3">
+             <widget class="QLineEdit" name="leApiKey">
+              <property name="placeholderText">
+               <string>Optional</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="0">
+             <widget class="QLabel" name="lblUsername">
+              <property name="text">
+               <string>Username</string>
+              </property>
+             </widget>
+            </item>
+            <item row="17" column="0">
              <widget class="QLabel" name="lblRequestTimeout">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -253,17 +330,7 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="lblRedirectUrl">
-              <property name="text">
-               <string>Redirect URL</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="18" column="1">
+            <item row="17" column="1">
              <widget class="QSpinBox" name="spnbxRequestTimeout">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -291,71 +358,7 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblDescription">
-              <property name="text">
-               <string>Description</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1" colspan="4">
-             <widget class="QLineEdit" name="leRefreshTokenUrl">
-              <property name="placeholderText">
-               <string>Optional</string>
-              </property>
-             </widget>
-            </item>
-            <item row="13" column="0">
-             <widget class="QLabel" name="lblApiKey">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>API Key</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1" colspan="4">
-             <widget class="QLineEdit" name="leRequestUrl">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="14" column="0" colspan="5">
-             <widget class="Line" name="line">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="lblRequestUrl">
-              <property name="text">
-               <string>Request URL</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="11" column="1" colspan="4">
-             <widget class="QLineEdit" name="leScope">
-              <property name="placeholderText">
-               <string>Optional (space delimiter)</string>
-              </property>
-             </widget>
-            </item>
-            <item row="17" column="0">
+            <item row="16" column="0">
              <widget class="QLabel" name="lblAccessMethod">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -371,155 +374,16 @@
               </property>
              </widget>
             </item>
-            <item row="9" column="0">
-             <widget class="QLabel" name="lblUsername">
-              <property name="text">
-               <string>Username</string>
-              </property>
-             </widget>
-            </item>
-            <item row="13" column="1" colspan="4">
-             <widget class="QLineEdit" name="leApiKey">
-              <property name="placeholderText">
-               <string>Optional</string>
-              </property>
-             </widget>
-            </item>
-            <item row="15" column="0" colspan="5">
-             <widget class="QLabel" name="label">
-              <property name="font">
-               <font>
-                <pointsize>12</pointsize>
-                <italic>true</italic>
-               </font>
-              </property>
-              <property name="text">
-               <string>Advanced</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="10" column="0">
-             <widget class="QLabel" name="lblPassword">
-              <property name="text">
-               <string>Password</string>
-              </property>
-             </widget>
-            </item>
-            <item row="17" column="1" colspan="4">
-             <widget class="QComboBox" name="cmbbxAccessMethod">
+            <item row="12" column="0">
+             <widget class="QLabel" name="lblApiKey">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="toolTip">
-               <string>Resource access token method</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1" colspan="4">
-             <widget class="QPlainTextEdit" name="pteDescription">
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>40</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1" colspan="4">
-             <widget class="QLineEdit" name="leTokenUrl">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="1" colspan="4">
-             <widget class="QgsPasswordLineEdit" name="leClientSecret">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="16" column="1" colspan="3">
-             <widget class="QCheckBox" name="chkbxTokenPersist">
               <property name="text">
-               <string>Persist between launches</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="lblTokenUrl">
-              <property name="text">
-               <string>Token URL</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="0">
-             <widget class="QLabel" name="lblClientSecret">
-              <property name="text">
-               <string>Client Secret</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="10" column="1" colspan="4">
-             <widget class="QgsPasswordLineEdit" name="lePassword">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="19" column="1">
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="7" column="0">
-             <widget class="QLabel" name="lblClientId">
-              <property name="text">
-               <string>Client ID</string>
-              </property>
-              <property name="wordWrap">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="7" column="1" colspan="4">
-             <widget class="QLineEdit" name="leClientId">
-              <property name="placeholderText">
-               <string>Required</string>
-              </property>
-             </widget>
-            </item>
-            <item row="12" column="0">
-             <widget class="QLabel" name="lblState">
-              <property name="text">
-               <string>State</string>
-              </property>
-             </widget>
-            </item>
-            <item row="16" column="0">
-             <widget class="QLabel" name="lblTokenPersist">
-              <property name="text">
-               <string>Token Session</string>
+               <string>API Key</string>
               </property>
               <property name="wordWrap">
                <bool>true</bool>
@@ -536,14 +400,136 @@
               </property>
              </widget>
             </item>
-            <item row="9" column="1" colspan="4">
+            <item row="3" column="1" colspan="3">
+             <widget class="QLineEdit" name="leRefreshTokenUrl">
+              <property name="placeholderText">
+               <string>Optional</string>
+              </property>
+             </widget>
+            </item>
+            <item row="15" column="0">
+             <widget class="QLabel" name="lblTokenPersist">
+              <property name="text">
+               <string>Token Session</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="1" colspan="3">
+             <widget class="QgsPasswordLineEdit" name="lePassword">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="1" colspan="3">
+             <widget class="QLineEdit" name="leClientId">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="1" colspan="3">
              <widget class="QLineEdit" name="leUsername">
               <property name="placeholderText">
                <string>Required</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="1" colspan="4">
+            <item row="1" column="0">
+             <widget class="QLabel" name="lblRequestUrl">
+              <property name="text">
+               <string>Request URL</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="0" colspan="4">
+             <widget class="Line" name="line">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lblTokenUrl">
+              <property name="text">
+               <string>Token URL</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="16" column="1" colspan="3">
+             <widget class="QComboBox" name="cmbbxAccessMethod">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Resource access token method</string>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="0">
+             <widget class="QLabel" name="lblClientSecret">
+              <property name="text">
+               <string>Client Secret</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="15" column="1" colspan="2">
+             <widget class="QCheckBox" name="chkbxTokenPersist">
+              <property name="text">
+               <string>Persist between launches</string>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="0">
+             <widget class="QLabel" name="lblPassword">
+              <property name="text">
+               <string>Password</string>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="1" colspan="3">
+             <widget class="QLineEdit" name="leScope">
+              <property name="placeholderText">
+               <string>Optional (space delimiter)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="18" column="1">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="2" column="1" colspan="3">
+             <widget class="QLineEdit" name="leTokenUrl">
+              <property name="placeholderText">
+               <string>Required</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1" colspan="3">
              <widget class="QFrame" name="frameRedirectUrl">
               <layout class="QHBoxLayout" name="horizontalLayout_4">
                <property name="spacing">
@@ -789,7 +775,7 @@
             <x>0</x>
             <y>0</y>
             <width>413</width>
-            <height>298</height>
+            <height>283</height>
            </rect>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
@@ -953,7 +939,6 @@
   <tabstop>leUsername</tabstop>
   <tabstop>lePassword</tabstop>
   <tabstop>leScope</tabstop>
-  <tabstop>leState</tabstop>
   <tabstop>leApiKey</tabstop>
   <tabstop>chkbxTokenPersist</tabstop>
   <tabstop>cmbbxAccessMethod</tabstop>
@@ -972,6 +957,7 @@
   <tabstop>pteDefinedDesc</tabstop>
  </tabstops>
  <resources>
+  <include location="oauth2_resources.qrc"/>
   <include location="oauth2_resources.qrc"/>
  </resources>
  <connections/>

--- a/src/auth/oauth2/qgso2.cpp
+++ b/src/auth/oauth2/qgso2.cpp
@@ -172,7 +172,7 @@ void QgsO2::link()
       // Save redirect URI, as we have to reuse it when requesting the access token
       redirectUri_ = localhostPolicy_.arg( replyServer_->serverPort() );
     }
-    // Assemble intial authentication URL
+    // Assemble initial authentication URL
     QList<QPair<QString, QString> > parameters;
     parameters.append( qMakePair( QString( O2_OAUTH2_RESPONSE_TYPE ), ( grantFlow_ == GrantFlowAuthorizationCode ) ?
                                   QString( O2_OAUTH2_GRANT_TYPE_CODE ) :

--- a/src/auth/oauth2/qgso2.cpp
+++ b/src/auth/oauth2/qgso2.cpp
@@ -16,6 +16,7 @@
 
 #include "o0globals.h"
 #include "o0settingsstore.h"
+#include "o2replyserver.h"
 #include "qgsapplication.h"
 #include "qgsauthoauth2config.h"
 #include "qgslogger.h"
@@ -24,6 +25,8 @@
 #include <QSettings>
 #include <QUrl>
 
+
+QString QgsO2::O2_OAUTH2_STATE = QStringLiteral( "state" );
 
 QgsO2::QgsO2( const QString &authcfg, QgsAuthOAuth2Config *oauth2config,
               QObject *parent, QNetworkAccessManager *manager )
@@ -125,8 +128,165 @@ void QgsO2::setVerificationResponseContent()
   }
 }
 
+bool QgsO2::isLocalHost( const QUrl redirectUrl ) const
+{
+  QString hostName = redirectUrl.host();
+  if ( hostName == QStringLiteral( "localhost" ) || hostName == QStringLiteral( "127.0.0.1" ) || hostName == QStringLiteral( "[::1]" ) )
+  {
+    return true;
+  }
+  return false;
+}
+
 // slot
 void QgsO2::clearProperties()
 {
   // TODO: clear object properties
+}
+
+void QgsO2::link()
+{
+  QgsDebugMsgLevel( QStringLiteral( "QgsO2::link" ), 4 );
+
+  if ( linked() )
+  {
+    QgsDebugMsgLevel( QStringLiteral( "QgsO2::link: Linked already" ), 4 );
+    emit linkingSucceeded();
+    return;
+  }
+
+  setLinked( false );
+  setToken( "" );
+  setTokenSecret( "" );
+  setExtraTokens( QVariantMap() );
+  setRefreshToken( QString() );
+  setExpires( 0 );
+
+  if ( grantFlow_ == GrantFlowAuthorizationCode )
+  {
+    if ( mIsLocalHost )
+    {
+      // Start listening to authentication replies
+      replyServer_->listen( QHostAddress::Any, localPort_ );
+
+      // Save redirect URI, as we have to reuse it when requesting the access token
+      redirectUri_ = localhostPolicy_.arg( replyServer_->serverPort() );
+    }
+    // Assemble intial authentication URL
+    QList<QPair<QString, QString> > parameters;
+    parameters.append( qMakePair( QString( O2_OAUTH2_RESPONSE_TYPE ), ( grantFlow_ == GrantFlowAuthorizationCode ) ?
+                                  QString( O2_OAUTH2_GRANT_TYPE_CODE ) :
+                                  QString( O2_OAUTH2_GRANT_TYPE_TOKEN ) ) );
+    parameters.append( qMakePair( QString( O2_OAUTH2_CLIENT_ID ), clientId_ ) );
+    parameters.append( qMakePair( QString( O2_OAUTH2_REDIRECT_URI ), redirectUri_ ) );
+    parameters.append( qMakePair( QString( O2_OAUTH2_SCOPE ), scope_ ) );
+    parameters.append( qMakePair( O2_OAUTH2_STATE, state_ ) );
+    parameters.append( qMakePair( QString( O2_OAUTH2_API_KEY ), apiKey_ ) );
+
+    for ( QVariantMap::const_iterator iter = extraReqParams_.begin(); iter != extraReqParams_.end(); ++iter )
+    {
+      parameters.append( qMakePair( iter.key(), iter.value().toString() ) );
+    }
+
+    // Show authentication URL with a web browser
+    QUrl url( requestUrl_ );
+    QUrlQuery query( url );
+    query.setQueryItems( parameters );
+    url.setQuery( query );
+    QgsDebugMsgLevel( QStringLiteral( "QgsO2::link: Emit openBrowser %1" ).arg( url.toString() ), 4 );
+    emit openBrowser( url );
+    if ( !mIsLocalHost )
+    {
+      emit getAuthCode();
+    }
+  }
+  else if ( grantFlow_ == GrantFlowResourceOwnerPasswordCredentials )
+  {
+    QList<O0RequestParameter> parameters;
+    parameters.append( O0RequestParameter( O2_OAUTH2_CLIENT_ID, clientId_.toUtf8() ) );
+    parameters.append( O0RequestParameter( O2_OAUTH2_CLIENT_SECRET, clientSecret_.toUtf8() ) );
+    parameters.append( O0RequestParameter( O2_OAUTH2_USERNAME, username_.toUtf8() ) );
+    parameters.append( O0RequestParameter( O2_OAUTH2_PASSWORD, password_.toUtf8() ) );
+    parameters.append( O0RequestParameter( O2_OAUTH2_GRANT_TYPE, O2_OAUTH2_GRANT_TYPE_PASSWORD ) );
+    parameters.append( O0RequestParameter( O2_OAUTH2_SCOPE, scope_.toUtf8() ) );
+    parameters.append( O0RequestParameter( O2_OAUTH2_API_KEY, apiKey_.toUtf8() ) );
+
+
+    for ( QVariantMap::const_iterator iter = extraReqParams_.begin(); iter != extraReqParams_.end(); ++iter )
+    {
+      parameters.append( O0RequestParameter( iter.key().toUtf8(), iter.value().toString().toUtf8() ) );
+    }
+
+
+    QByteArray payload = O0BaseAuth::createQueryParameters( parameters );
+
+    QUrl url( tokenUrl_ );
+    QNetworkRequest tokenRequest( url );
+    tokenRequest.setHeader( QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded" );
+    QNetworkReply *tokenReply = manager_->post( tokenRequest, payload );
+
+    connect( tokenReply, SIGNAL( finished() ), this, SLOT( onTokenReplyFinished() ), Qt::QueuedConnection );
+    connect( tokenReply, SIGNAL( error( QNetworkReply::NetworkError ) ), this, SLOT( onTokenReplyError( QNetworkReply::NetworkError ) ), Qt::QueuedConnection );
+  }
+}
+
+void QgsO2::onVerificationReceived( QMap<QString, QString> response )
+{
+  QgsDebugMsgLevel( QStringLiteral( "QgsO2::onVerificationReceived: Emitting closeBrowser()" ), 4 );
+  emit closeBrowser();
+
+  if ( mIsLocalHost )
+  {
+    if ( response.contains( QStringLiteral( "error" ) ) )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "QgsO2::onVerificationReceived: Verification failed: %1" ).arg( response["error"] ), 4 );
+      emit linkingFailed();
+      return;
+    }
+
+    if ( response.contains( QStringLiteral( "state" ) ) )
+    {
+      if ( response.value( QStringLiteral( "state" ), QStringLiteral( "ignore" ) ) != state_ )
+      {
+        QgsDebugMsgLevel( QStringLiteral( "QgsO2::onVerificationReceived: Verification failed: (Response returned wrong state)" ), 3 ) ;
+        emit linkingFailed();
+        return;
+      }
+    }
+    else
+    {
+      QgsDebugMsgLevel( QStringLiteral( "QgsO2::onVerificationReceived: Verification failed: (Response does not contain state)" ), 3 );
+      emit linkingFailed();
+      return;
+    }
+    // Save access code
+    setCode( response.value( QString( O2_OAUTH2_GRANT_TYPE_CODE ) ) );
+  }
+
+  if ( grantFlow_ == GrantFlowAuthorizationCode )
+  {
+
+    // Exchange access code for access/refresh tokens
+    QString query;
+    if ( !apiKey_.isEmpty() )
+      query = QStringLiteral( "?=%1" ).arg( QString( O2_OAUTH2_API_KEY ), apiKey_ );
+    QNetworkRequest tokenRequest( QUrl( tokenUrl_.toString() + query ) );
+    tokenRequest.setHeader( QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM );
+    QMap<QString, QString> parameters;
+    parameters.insert( O2_OAUTH2_GRANT_TYPE_CODE, code() );
+    parameters.insert( O2_OAUTH2_CLIENT_ID, clientId_ );
+    parameters.insert( O2_OAUTH2_CLIENT_SECRET, clientSecret_ );
+    parameters.insert( O2_OAUTH2_REDIRECT_URI, redirectUri_ );
+    parameters.insert( O2_OAUTH2_GRANT_TYPE, O2_AUTHORIZATION_CODE );
+    QByteArray data = buildRequestBody( parameters );
+    QNetworkReply *tokenReply = manager_->post( tokenRequest, data );
+    timedReplies_.add( tokenReply );
+    connect( tokenReply, &QNetworkReply::finished, this, &QgsO2::onTokenReplyFinished, Qt::QueuedConnection );
+    connect( tokenReply, qgis::overload<QNetworkReply::NetworkError>::of( &QNetworkReply::error ), this, &QgsO2::onTokenReplyError, Qt::QueuedConnection );
+  }
+  else
+  {
+    setToken( response.value( O2_OAUTH2_ACCESS_TOKEN ) );
+    setRefreshToken( response.value( O2_OAUTH2_REFRESH_TOKEN ) );
+  }
 }

--- a/src/auth/oauth2/qgso2.cpp
+++ b/src/auth/oauth2/qgso2.cpp
@@ -156,8 +156,8 @@ void QgsO2::link()
   }
 
   setLinked( false );
-  setToken( "" );
-  setTokenSecret( "" );
+  setToken( QString() );
+  setTokenSecret( QString() );
   setExtraTokens( QVariantMap() );
   setRefreshToken( QString() );
   setExpires( 0 );

--- a/src/auth/oauth2/qgso2.h
+++ b/src/auth/oauth2/qgso2.h
@@ -46,13 +46,38 @@ class QgsO2: public O2
 
     //! Authentication configuration id
     QString authcfg() const { return mAuthcfg; }
+
     //! OAuth2 configuration
     QgsAuthOAuth2Config *oauth2config() { return mOAuth2Config; }
+
+    Q_PROPERTY( QString state READ state WRITE setState NOTIFY stateChanged )
+
+    //! Retrieve oauth2 state
+    QString state() const  { return state_; }
+
+    //! Store oauth2 state to \a value
+    void setState( const QString &value ) { state_ = value; }
 
   public slots:
 
     //! Clear all properties
     void clearProperties();
+
+    //! Authenticate.
+    void link() override;
+
+  protected slots:
+
+    //! Handle verification response.
+    void onVerificationReceived( QMap<QString, QString> response ) override;
+
+  signals:
+
+    //! Emitted when the state has changed
+    void stateChanged();
+
+    //! Emitted when auth code needs to be retrieved (when not localhost)
+    void getAuthCode();
 
   private:
     void initOAuthConfig();
@@ -61,9 +86,15 @@ class QgsO2: public O2
 
     void setVerificationResponseContent();
 
+    bool isLocalHost( const QUrl redirectUrl ) const;
+
     QString mTokenCacheFile;
     QString mAuthcfg;
+    // Follow O2 style for this variable only:
+    QString state_;
     QgsAuthOAuth2Config *mOAuth2Config;
+    bool mIsLocalHost = false;
+    static QString O2_OAUTH2_STATE;
 };
 
 #endif // QGSO2_H

--- a/tests/src/auth/testqgsauthoauth2method.cpp
+++ b/tests/src/auth/testqgsauthoauth2method.cpp
@@ -108,7 +108,6 @@ QgsAuthOAuth2Config *TestQgsAuthOAuth2Method::baseConfig( bool loaded )
     config->setUsername( "myusername" );
     config->setPassword( "mypassword" );
     config->setScope( "scope_1 scope_2 scope_3" );
-    config->setState( "somestate" );
     config->setApiKey( "someapikey" );
     config->setPersistToken( false );
     config->setAccessMethod( QgsAuthOAuth2Config::Header );
@@ -150,7 +149,6 @@ QByteArray TestQgsAuthOAuth2Method::baseConfigTxt( bool pretty )
            "    \"requestTimeout\": 30,\n"
            "    \"requestUrl\": \"https://request.oauth2.test\",\n"
            "    \"scope\": \"scope_1 scope_2 scope_3\",\n"
-           "    \"state\": \"somestate\",\n"
            "    \"tokenUrl\": \"https://token.oauth2.test\",\n"
            "    \"username\": \"myusername\",\n"
            "    \"version\": 1\n"
@@ -177,7 +175,6 @@ QByteArray TestQgsAuthOAuth2Method::baseConfigTxt( bool pretty )
            "\"requestTimeout\":30,"
            "\"requestUrl\":\"https://request.oauth2.test\","
            "\"scope\":\"scope_1 scope_2 scope_3\","
-           "\"state\":\"somestate\","
            "\"tokenUrl\":\"https://token.oauth2.test\","
            "\"username\":\"myusername\","
            "\"version\":1}";
@@ -210,7 +207,6 @@ QVariantMap TestQgsAuthOAuth2Method::baseVariantMap()
   vmap.insert( "requestTimeout", 30 );
   vmap.insert( "requestUrl", "https://request.oauth2.test" );
   vmap.insert( "scope", "scope_1 scope_2 scope_3" );
-  vmap.insert( "state", "somestate" );
   vmap.insert( "tokenUrl", "https://token.oauth2.test" );
   vmap.insert( "username", "myusername" );
   vmap.insert( "version", 1 );


### PR DESCRIPTION
This is the first PR of a series, that ports a few security fixes and new features from the OGC work in
http://docs.opengeospatial.org/per/17-021.html

All credits should go to the original authors, I only tried to make the code style more QGIS "friendly".

Ported from https://github.com/securedimensions/QGIS-OAuth2-Plugin

> The Boundless Geo version of the plugin requests the state parameter to be provided by the user.
> We have changed that as we think that the user must not be responsible for providing that,
> as a duplication of a state parameter could lead to unintentional errors.
> The Testbed 13 version generates the state parameter automatically for each authorization
> request to the Authorization Server and checks the value from the redirect to ensure no CSRF attacks.
> 