### PR TITLE
[ui] improve confusing vector layer properties' display panel

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1310,7 +1310,7 @@
      <normaloff>:/images/themes/default/mActionMapTips.svg</normaloff>:/images/themes/default/mActionMapTips.svg</iconset>
    </property>
    <property name="text">
-    <string>Map Tips</string>
+    <string>Show Map Tips</string>
    </property>
    <property name="statusTip">
     <string>Show information about a feature when the mouse is hovered over it</string>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1173,20 +1173,38 @@ border-radius: 2px;</string>
                <number>0</number>
               </property>
               <item row="0" column="0">
-               <widget class="QLabel" name="label">
-                <property name="text">
-                 <string>Display expression</string>
+               <widget class="QGroupBox" name="groupBox_22">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
+                <property name="title">
+                 <string>Display Name</string>
+                </property>
+                <layout class="QGridLayout" name="gridLayout_50">
+                 <item row="0" column="0">
+                  <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget" native="true">
+                   <property name="focusPolicy">
+                    <enum>Qt::StrongFocus</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="labelDisplayNameInfo">
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                   <property name="text">
+                    <string>The feature display name is used in identify results and attribute table's dual view list.</string>
+                   </property>
+                  </widget>                  
+                 </item>
+                </layout>
                </widget>
               </item>
-              <item row="0" column="1">
-               <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget" native="true">
-                <property name="focusPolicy">
-                 <enum>Qt::StrongFocus</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0" colspan="2">
+              <item row="1" column="0">
                <widget class="QGroupBox" name="groupBox_2">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
@@ -1195,7 +1213,7 @@ border-radius: 2px;</string>
                  </sizepolicy>
                 </property>
                 <property name="title">
-                 <string>Map Tip</string>
+                 <string>HTML Map Tip</string>
                 </property>
                 <layout class="QGridLayout" name="gridLayout_8">
                  <item row="1" column="2">
@@ -1239,6 +1257,16 @@ border-radius: 2px;</string>
                     <string>The valid attribute names for this layer</string>
                    </property>
                   </widget>
+                 </item>
+                 <item row="3" column="0" colspan="3">
+                  <widget class="QLabel" name="labelMapTipInfo">
+                   <property name="wordWrap">
+                    <bool>true</bool>
+                   </property>
+                   <property name="text">
+                    <string>The HTML map tips are shown when moving mouse over features of the currently selected layer when the 'Show Map Tips' action is toggled on. If no HTML code is set, the feature display name is used.</string>
+                   </property>
+                  </widget>                  
                  </item>
                 </layout>
                </widget>


### PR DESCRIPTION
## Description
Mainly adding labels to clarify what a display name and map tips are, as well as clarifying the relationship between the two:
![screenshot from 2018-07-19 15-11-52](https://user-images.githubusercontent.com/1728657/42930152-6ef88a46-8b66-11e8-9eff-75a22a842713.png)



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
