### PR TITLE
Align the order of the options with other "select..." algorithms

### DIFF
--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -210,7 +210,7 @@ void QgsSelectByLocationAlgorithm::initAlgorithm( const QVariantMap & )
 {
   QStringList methods = QStringList() << QObject::tr( "creating new selection" )
                         << QObject::tr( "adding to current selection" )
-                        << QObject::tr( "select within current selection" )
+                        << QObject::tr( "selecting within current selection" )
                         << QObject::tr( "removing from current selection" );
 
   addParameter( new QgsProcessingParameterVectorLayer( QStringLiteral( "INPUT" ), QObject::tr( "Select features from" ),


### PR DESCRIPTION
namely "select by expression" and "select by attribute".
Also fix wording as it should be in present participle.

PS: Given that the algorithm seems to return expected result with the current order, I suspect this change issues some bug but I fail to find where the methods parameters are set for this alg... any pointer?