### PR TITLE
[atlas][backport 3.2] Increases number of pages

### DIFF
--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -3918,7 +3918,7 @@ void QgsLayoutDesignerDialog::updateAtlasPageComboBox( int pageCount )
   QgsLayoutAtlas *atlas = printLayout->atlas();
   mAtlasPageComboBox->blockSignals( true );
   mAtlasPageComboBox->clear();
-  for ( int i = 1; i <= pageCount && i < 500; ++i )
+  for ( int i = 1; i <= pageCount && i < 100000; ++i )
   {
     QString name = atlas->nameForPage( i - 1 );
     QString fullName = ( !name.isEmpty() ? QStringLiteral( "%1: %2" ).arg( i ).arg( name ) : QString::number( i ) );


### PR DESCRIPTION
## Description

This PR increases a hardcoded value limiting the maximum number of pages in the atlas.

Backport of #7399 for 3.2.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
