### PR TITLE
[ui][html code editor] use monospace font

### DIFF
--- a/src/gui/qgscodeeditorhtml.cpp
+++ b/src/gui/qgscodeeditorhtml.cpp
@@ -36,8 +36,14 @@ QgsCodeEditorHTML::QgsCodeEditorHTML( QWidget *parent )
 
 void QgsCodeEditorHTML::setSciLexerHTML()
 {
-  QsciLexerHTML *lexer = new QsciLexerHTML( this );
-  lexer->setDefaultFont( QFont( QStringLiteral( "Sans" ), 10 ) );
+  QFont font = getMonospaceFont();
+#ifdef Q_OS_MAC
+  // The font size gotten from getMonospaceFont() is too small on Mac
+  font.setPointSize( QLabel().font().pointSize() );
+#endif
 
+  QsciLexerHTML *lexer = new QsciLexerHTML( this );
+  lexer->setDefaultFont( font );
+  lexer->setFont( font, -1 );
   setLexer( lexer );
 }


### PR DESCRIPTION
## Description
This improves the HTML code editor by a/ using a monospace font, and b/ setting the font for _all_ types (i.e. setFont( ..., _-1_)).

@nyalldawson , this improves the layout HTML item's code editor widget.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
