### PR TITLE
[server] Fixes Post element in WFS GetCapabilities doc

### DIFF
--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -331,7 +331,6 @@ namespace QgsWfs
     QDomElement dcpElement = doc.createElement( QStringLiteral( "ows:DCP" ) );
     QDomElement httpElement = doc.createElement( QStringLiteral( "ows:HTTP" ) );
     QDomElement getElement = doc.createElement( QStringLiteral( "ows:Get" ) );
-    getElement.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "xlink:simple" ) );
     getElement.setAttribute( QStringLiteral( "xlink:href" ), hrefString );
     httpElement.appendChild( getElement );
 

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -333,9 +333,12 @@ namespace QgsWfs
     QDomElement getElement = doc.createElement( QStringLiteral( "ows:Get" ) );
     getElement.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "xlink:simple" ) );
     getElement.setAttribute( QStringLiteral( "xlink:href" ), hrefString );
-    QDomElement postElement = getElement.cloneNode().toElement();
     httpElement.appendChild( getElement );
+
+    QDomElement postElement = doc.createElement( QStringLiteral( "ows:Post" ) );
+    postElement.setAttribute( QStringLiteral( "xlink:href" ), hrefString );
     httpElement.appendChild( postElement );
+
     dcpElement.appendChild( httpElement );
     operationElement.appendChild( dcpElement );
 

--- a/tests/testdata/qgis_server/wfs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wfs_getcapabilities.txt
@@ -20,8 +20,8 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetCapabilities">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:type="xlink:simple" xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
-     <ows:Get xlink:type="xlink:simple" xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
+     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
+     <ows:Post xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
     </ows:HTTP>
    </ows:DCP>
    <ows:Parameter name="service">
@@ -38,8 +38,8 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="DescribeFeatureType">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:type="xlink:simple" xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
-     <ows:Get xlink:type="xlink:simple" xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
+     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
+     <ows:Post xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
     </ows:HTTP>
    </ows:DCP>
    <ows:Parameter name="outputFormat">
@@ -51,8 +51,8 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetFeature">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:type="xlink:simple" xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
-     <ows:Get xlink:type="xlink:simple" xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
+     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
+     <ows:Post xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
     </ows:HTTP>
    </ows:DCP>
    <ows:Parameter name="outputFormat">
@@ -68,8 +68,8 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="Transaction">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:type="xlink:simple" xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
-     <ows:Get xlink:type="xlink:simple" xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
+     <ows:Get xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
+     <ows:Post xlink:href="?MAP=/home/dhont/3liz_dev/QGIS/qgis_rldhont/tests/testdata/qgis_server/test_project_wfs.qgs"/>
     </ows:HTTP>
    </ows:DCP>
    <ows:Parameter name="inputFormat">


### PR DESCRIPTION
## Description

This PR fixes the `Post` element in the WFS `GetCapabilities` document.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
