### PR TITLE
do not truncate layer name in legend panel if filename contains period

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5594,7 +5594,7 @@ void QgisApp::showRasterCalculator()
       case QgsRasterCalculator::Success:
         if ( d.addLayerToProject() )
         {
-          addRasterLayer( d.outputFile(), QFileInfo( d.outputFile() ).baseName() );
+          addRasterLayer( d.outputFile(), QFileInfo( d.outputFile() ).completeBaseName() );
         }
         messageBar()->pushMessage( tr( "Raster calculator" ),
                                    tr( "Calculation complete." ),

--- a/src/providers/gdal/qgsgdalsourceselect.cpp
+++ b/src/providers/gdal/qgsgdalsourceselect.cpp
@@ -154,7 +154,7 @@ void QgsGdalSourceSelect::addButtonClicked()
 
     Q_FOREACH ( const QString &path, QgsFileWidget::splitFilePaths( mRasterPath ) )
     {
-      emit addRasterLayer( path, QFileInfo( path ).baseName(), QStringLiteral( "gdal" ) );
+      emit addRasterLayer( path, QFileInfo( path ).completeBaseName(), QStringLiteral( "gdal" ) );
     }
   }
   else if ( radioSrcProtocol->isChecked() )


### PR DESCRIPTION
## Description
This fix the truncating of layer name within the legend panel when add raster layer from datasource manager and on saving raster from raster calculator if _Add result to project_ option is checked. The issue occurs when filename contains periods.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
