### PR TITLE
[Style Manager] Mention "Color ramps" a bit more in the GUI

### DIFF
--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -67,7 +67,7 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget
 
   if ( mDialogMode == Import )
   {
-    setWindowTitle( tr( "Import Symbol(s)" ) );
+    setWindowTitle( tr( "Import Symbols or Color Ramps" ) );
     // populate the import types
     importTypeCombo->addItem( tr( "file specified below" ), QVariant( "file" ) );
     // importTypeCombo->addItem( "official QGIS repo online", QVariant( "official" ) );
@@ -79,12 +79,12 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget
     btnBrowse->setText( QStringLiteral( "Browse" ) );
     connect( btnBrowse, &QAbstractButton::clicked, this, &QgsStyleExportImportDialog::browse );
 
-    label->setText( tr( "Select symbols to import" ) );
+    label->setText( tr( "Select items to import" ) );
     buttonBox->button( QDialogButtonBox::Ok )->setText( tr( "Import" ) );
   }
   else
   {
-    setWindowTitle( tr( "Export Symbol(s)" ) );
+    setWindowTitle( tr( "Export Symbols or Color Ramps" ) );
     // hide import specific controls when exporting
     btnBrowse->setHidden( true );
     fromLabel->setHidden( true );
@@ -462,7 +462,7 @@ void QgsStyleExportImportDialog::selectByGroup()
   if ( ! mGroupSelectionDlg )
   {
     mGroupSelectionDlg = new QgsStyleGroupSelectionDialog( mStyle, this );
-    mGroupSelectionDlg->setWindowTitle( tr( "Select Symbols by Group" ) );
+    mGroupSelectionDlg->setWindowTitle( tr( "Select Symbols or Color Ramps by Group" ) );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::tagSelected, this, &QgsStyleExportImportDialog::selectTag );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::tagDeselected, this, &QgsStyleExportImportDialog::deselectTag );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::allSelected, this, &QgsStyleExportImportDialog::selectAll );
@@ -488,12 +488,12 @@ void QgsStyleExportImportDialog::importTypeChanged( int index )
   }
   else if ( type == QLatin1String( "official" ) )
   {
-    btnBrowse->setText( QStringLiteral( "Fetch Symbols" ) );
+    btnBrowse->setText( QStringLiteral( "Fetch Items" ) );
     locationLineEdit->setEnabled( false );
   }
   else
   {
-    btnBrowse->setText( QStringLiteral( "Fetch Symbols" ) );
+    btnBrowse->setText( QStringLiteral( "Fetch Items" ) );
     locationLineEdit->setEnabled( true );
   }
 }

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -67,7 +67,7 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget
 
   if ( mDialogMode == Import )
   {
-    setWindowTitle( tr( "Import Symbols or Color Ramps" ) );
+    setWindowTitle( tr( "Import Item(s)" ) );
     // populate the import types
     importTypeCombo->addItem( tr( "file specified below" ), QVariant( "file" ) );
     // importTypeCombo->addItem( "official QGIS repo online", QVariant( "official" ) );
@@ -84,7 +84,7 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget
   }
   else
   {
-    setWindowTitle( tr( "Export Symbols or Color Ramps" ) );
+    setWindowTitle( tr( "Export Item(s)" ) );
     // hide import specific controls when exporting
     btnBrowse->setHidden( true );
     fromLabel->setHidden( true );
@@ -122,7 +122,7 @@ void QgsStyleExportImportDialog::doExportImport()
   QModelIndexList selection = listItems->selectionModel()->selectedIndexes();
   if ( selection.isEmpty() )
   {
-    QMessageBox::warning( this, tr( "Export/import Symbols or Color Ramps" ),
+    QMessageBox::warning( this, tr( "Export/import Item(s)" ),
                           tr( "You should select at least one symbol/color ramp." ) );
     return;
   }
@@ -462,7 +462,7 @@ void QgsStyleExportImportDialog::selectByGroup()
   if ( ! mGroupSelectionDlg )
   {
     mGroupSelectionDlg = new QgsStyleGroupSelectionDialog( mStyle, this );
-    mGroupSelectionDlg->setWindowTitle( tr( "Select Symbols or Color Ramps by Group" ) );
+    mGroupSelectionDlg->setWindowTitle( tr( "Select Item(s) by Group" ) );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::tagSelected, this, &QgsStyleExportImportDialog::selectTag );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::tagDeselected, this, &QgsStyleExportImportDialog::deselectTag );
     connect( mGroupSelectionDlg, &QgsStyleGroupSelectionDialog::allSelected, this, &QgsStyleExportImportDialog::selectAll );

--- a/src/gui/symbology/qgsstylegroupselectiondialog.cpp
+++ b/src/gui/symbology/qgsstylegroupselectiondialog.cpp
@@ -31,7 +31,7 @@ QgsStyleGroupSelectionDialog::QgsStyleGroupSelectionDialog( QgsStyle *style, QWi
   QStandardItemModel *model = new QStandardItemModel( groupTree );
   groupTree->setModel( model );
 
-  QStandardItem *allSymbols = new QStandardItem( tr( "All Symbols" ) );
+  QStandardItem *allSymbols = new QStandardItem( tr( "All" ) );
   allSymbols->setData( "all", Qt::UserRole + 2 );
   allSymbols->setEditable( false );
   setBold( allSymbols );

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -83,10 +83,10 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent )
          );
 
   QMenu *shareMenu = new QMenu( tr( "Share Menu" ), this );
-  QAction *exportAction = new QAction( tr( "Export Symbol(s)…" ), this );
+  QAction *exportAction = new QAction( tr( "Export Symbols or Color Ramps…" ), this );
   exportAction->setIcon( QIcon( QgsApplication::iconPath( "mActionFileSave.svg" ) ) );
   shareMenu->addAction( exportAction );
-  QAction *importAction = new QAction( tr( "Import Symbol(s)…" ), this );
+  QAction *importAction = new QAction( tr( "Import Symbols or Color Ramps…" ), this );
   importAction->setIcon( QIcon( QgsApplication::iconPath( "mActionFileOpen.svg" ) ) );
   shareMenu->addAction( importAction );
   shareMenu->addSeparator();

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -83,10 +83,10 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent )
          );
 
   QMenu *shareMenu = new QMenu( tr( "Share Menu" ), this );
-  QAction *exportAction = new QAction( tr( "Export Symbols or Color Ramps…" ), this );
+  QAction *exportAction = new QAction( tr( "Export Item(s)…" ), this );
   exportAction->setIcon( QIcon( QgsApplication::iconPath( "mActionFileSave.svg" ) ) );
   shareMenu->addAction( exportAction );
-  QAction *importAction = new QAction( tr( "Import Symbols or Color Ramps…" ), this );
+  QAction *importAction = new QAction( tr( "Import Item(s)…" ), this );
   importAction->setIcon( QIcon( QgsApplication::iconPath( "mActionFileOpen.svg" ) ) );
   shareMenu->addAction( importAction );
   shareMenu->addSeparator();

--- a/src/ui/qgsstyleexportimportdialogbase.ui
+++ b/src/ui/qgsstyleexportimportdialogbase.ui
@@ -91,7 +91,7 @@
    <item row="1" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Select symbols to export</string>
+      <string>Select items to export</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
using "symbols or color ramps" expression when both are concerned by the action instead of "symbols". In short labels, replace by "items", already used in the GUI to refer to them