### PR TITLE
[server] Fixes spatial operator in WFS 1.1.0 GetCapabilities doc

### DIFF
--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -111,8 +111,7 @@ namespace QgsWfs
     for ( const QString &spatialOperator : spatialOperators )
     {
       QDomElement spatialOperatorElem = doc.createElement( QStringLiteral( "ogc:SpatialOperator" ) );
-      QDomText spatialOperatorText = doc.createTextNode( spatialOperator );
-      spatialOperatorElem.appendChild( spatialOperatorText );
+      spatialOperatorElem.setAttribute( QStringLiteral( "name" ), spatialOperator );
       spatialOperatorsElem.appendChild( spatialOperatorElem );
     }
     spatialCapabilitiesElement.appendChild( spatialOperatorsElem );

--- a/tests/testdata/qgis_server/wfs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wfs_getcapabilities.txt
@@ -113,17 +113,17 @@ Content-Type: text/xml; charset=utf-8
     <ogc:GeometryOperand>gml:Envelope</ogc:GeometryOperand>
    </ogc:GeometryOperands>
    <ogc:SpatialOperators>
-    <ogc:SpatialOperator>Equals</ogc:SpatialOperator>
-    <ogc:SpatialOperator>Disjoint</ogc:SpatialOperator>
-    <ogc:SpatialOperator>Touches</ogc:SpatialOperator>
-    <ogc:SpatialOperator>Within</ogc:SpatialOperator>
-    <ogc:SpatialOperator>Overlaps</ogc:SpatialOperator>
-    <ogc:SpatialOperator>Crosses</ogc:SpatialOperator>
-    <ogc:SpatialOperator>Intersects</ogc:SpatialOperator>
-    <ogc:SpatialOperator>Contains</ogc:SpatialOperator>
-    <ogc:SpatialOperator>DWithin</ogc:SpatialOperator>
-    <ogc:SpatialOperator>Beyond</ogc:SpatialOperator>
-    <ogc:SpatialOperator>BBOX</ogc:SpatialOperator>
+    <ogc:SpatialOperator name="Equals"/>
+    <ogc:SpatialOperator name="Disjoint"/>
+    <ogc:SpatialOperator name="Touches"/>
+    <ogc:SpatialOperator name="Within"/>
+    <ogc:SpatialOperator name="Overlaps"/>
+    <ogc:SpatialOperator name="Crosses"/>
+    <ogc:SpatialOperator name="Intersects"/>
+    <ogc:SpatialOperator name="Contains"/>
+    <ogc:SpatialOperator name="DWithin"/>
+    <ogc:SpatialOperator name="Beyond"/>
+    <ogc:SpatialOperator name="BBOX"/>
    </ogc:SpatialOperators>
   </ogc:Spatial_Capabilities>
   <ogc:Scalar_Capabilities>


### PR DESCRIPTION
## Description

The OGC testsuite for WFS 1.1.0 is raising an error about `ogc:SpatialOperator` element:

```
cvc-complex-type.2.3: Element 'ogc:SpatialOperator' cannot have character [children], because the type's content type is element-only.
```

Actually, the current `GetCapabilities` for WFS 1.1.0 returns:

```
<ogc:SpatialOperators>
    <ogc:SpatialOperator>Equals</ogc:SpatialOperator>
    <ogc:SpatialOperator>Disjoint</ogc:SpatialOperator>
    ...
    ...
</ogc:SpatialOperators>
```

instead of:

```
<ogc:SpatialOperators>
    <ogc:SpatialOperator name="Equals"/>
    <ogc:SpatialOperator name="Disjoint"/>
    ...
    ...
</ogc:SpatialOperators>
```

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
