### PR TITLE
[maptips] fix maptips showing after mouse leave the canvas area

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11739,20 +11739,24 @@ void QgisApp::removeMapToolMessage()
 // Show the maptip using tooltip
 void QgisApp::showMapTip()
 {
-  QPoint myPointerPos = mMapCanvas->mouseLastXY();
-
-  //  Make sure there is an active layer before proceeding
-  QgsMapLayer *mypLayer = mMapCanvas->currentLayer();
-  if ( mypLayer )
+  // Only show maptips if the mouse is still over the map canvas when timer is triggered
+  if ( mMapCanvas->underMouse() )
   {
-    //QgsDebugMsg("Current layer for maptip display is: " + mypLayer->source());
-    // only process vector layers
-    if ( mypLayer->type() == QgsMapLayer::VectorLayer )
+    QPoint myPointerPos = mMapCanvas->mouseLastXY();
+
+    //  Make sure there is an active layer before proceeding
+    QgsMapLayer *mypLayer = mMapCanvas->currentLayer();
+    if ( mypLayer )
     {
-      // Show the maptip if the maptips button is depressed
-      if ( mMapTipsVisible )
+      // QgsDebugMsg("Current layer for maptip display is: " + mypLayer->source());
+      // only process vector layers
+      if ( mypLayer->type() == QgsMapLayer::VectorLayer )
       {
-        mpMaptip->showMapTip( mypLayer, mLastMapPosition, myPointerPos, mMapCanvas );
+        // Show the maptip if the maptips button is depressed
+        if ( mMapTipsVisible )
+        {
+          mpMaptip->showMapTip( mypLayer, mLastMapPosition, myPointerPos, mMapCanvas );
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
This PR fixes maptips showing up after the mouse left the canvas area for features bordering the canvas edge which would have been the last point under mouse prior to leaving canvas.

This avoids some unwanted feature fetching, and makes maptips working like system tips (i.e., only shows up if your mouse is over a feature :smile:).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
