### PR TITLE
Fix crash in network content fetcher when run from non-main thread

### DIFF
--- a/src/core/qgsnetworkcontentfetcher.cpp
+++ b/src/core/qgsnetworkcontentfetcher.cpp
@@ -55,6 +55,7 @@ void QgsNetworkContentFetcher::fetchContent( const QNetworkRequest &request )
   }
 
   mReply = QgsNetworkAccessManager::instance()->get( request );
+  mReply->setParent( nullptr ); // we don't want thread locale QgsNetworkAccessManagers to delete the reply - we want ownership of it to belong to this object
   connect( mReply, &QNetworkReply::finished, this, [ = ] { contentLoaded(); } );
   connect( mReply, &QNetworkReply::downloadProgress, this, &QgsNetworkContentFetcher::downloadProgress );
 }


### PR DESCRIPTION
Because a QNetworkAccessManager is the parent for all QNetworkReplys created by it, if a reply is created in a thread then we need to ensure that this reply isn't deleted early by destruction of the
thread local QgsNetworkAcessManager instance. Work around this by unsetting the parent for the QNetworkReplys owned by QgsNetworkContentFetcher objects.

Exhibited as a crash during project load or shortly after project load.

Fixes #19452


