### PR TITLE
Fix bad ui form path restoration when loading projects

### DIFF
--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -275,7 +275,8 @@ void QgsEditFormConfig::readXml( const QDomNode &node, QgsReadWriteContext &cont
   if ( !editFormNode.isNull() )
   {
     QDomElement e = editFormNode.toElement();
-    setUiForm( context.pathResolver().readPath( e.text() ) );
+    if ( !e.text().isEmpty() )
+      setUiForm( context.pathResolver().readPath( e.text() ) );
   }
 
   QDomNode editFormInitNode = node.namedItem( QStringLiteral( "editforminit" ) );


### PR DESCRIPTION
A bug exists in 3.2 where restoring an existing project causes the ui form path to be set for every vector layer in which an explicit path was not set. This means that when the project is saved, this invalid path is written into the project. Subsequently opening these projects on different workstations causes a network request to be fired off for every vector layer with an invalid url (as the missing file is interpreted as a remote url which needs to be fetched).

This pr fixes the restoration bug on first load, and makes qgis be extra careful when reloading any potentially corrupted projects.