### PR TITLE
Fix path resolver sometimes returns non empty paths while resolving empty filenames

### DIFF
--- a/src/core/qgspathresolver.cpp
+++ b/src/core/qgspathresolver.cpp
@@ -28,6 +28,9 @@ QgsPathResolver::QgsPathResolver( const QString &baseFileName )
 
 QString QgsPathResolver::readPath( const QString &filename ) const
 {
+  if ( filename.isEmpty() )
+    return QString();
+
   QString src = filename;
 
   if ( mBaseFileName.isNull() )

--- a/tests/src/core/testqgsproject.cpp
+++ b/tests/src/core/testqgsproject.cpp
@@ -102,6 +102,8 @@ void TestQgsProject::testPathResolver()
 {
   // Test resolver with a non existing file path
   QgsPathResolver resolverLegacy( QStringLiteral( "/home/qgis/test.qgs" ) );
+  QCOMPARE( resolverLegacy.readPath( QString() ), QString() );
+  QCOMPARE( resolverLegacy.writePath( QString() ), QString() );
   QCOMPARE( resolverLegacy.writePath( "/home/qgis/file1.txt" ), QString( "./file1.txt" ) );
   QCOMPARE( resolverLegacy.writePath( "/home/qgis/subdir/file1.txt" ), QString( "./subdir/file1.txt" ) );
   QCOMPARE( resolverLegacy.writePath( "/home/file1.txt" ), QString( "../file1.txt" ) );
@@ -117,6 +119,8 @@ void TestQgsProject::testPathResolver()
   dir.mkpath( tmpDirName + "/home/qgis/" );
 
   QgsPathResolver resolverRel( QString( tmpDirName + "/home/qgis/test.qgs" ) );
+  QCOMPARE( resolverRel.readPath( QString() ), QString() );
+  QCOMPARE( resolverRel.writePath( QString() ), QString() );
   QCOMPARE( resolverRel.writePath( tmpDirName + "/home/qgis/file1.txt" ), QString( "./file1.txt" ) );
   QCOMPARE( resolverRel.writePath( tmpDirName + "/home/qgis/subdir/file1.txt" ), QString( "./subdir/file1.txt" ) );
   QCOMPARE( resolverRel.writePath( tmpDirName + "/home/file1.txt" ), QString( "../file1.txt" ) );


### PR DESCRIPTION
This is the underlying cause behind the project corruption from #7489  -- and it's likely other areas of code are affected by it too.