### PR TITLE
[server] Adds ServiceTypeVersion element in WFS 1.1.0 GetCapabilities doc

### DIFF
--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -187,8 +187,8 @@ namespace QgsWfs
     //Service type version
     QDomElement serviceTypeVersionElem = doc.createElement( QStringLiteral( "ows:ServiceTypeVersion" ) );
     QDomText serviceTypeVersionText = doc.createTextNode( "1.1.0" );
-    serviceTypeElem.appendChild( serviceTypeText );
-    serviceElem.appendChild( serviceTypeElem );
+    serviceTypeVersionElem.appendChild( serviceTypeVersionText );
+    serviceElem.appendChild( serviceTypeVersionElem );
 
     QDomElement feesElem = doc.createElement( QStringLiteral( "ows:Fees" ) );
     QDomText feesText = doc.createTextNode( "None" );

--- a/tests/testdata/qgis_server/wfs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wfs_getcapabilities.txt
@@ -6,6 +6,7 @@ Content-Type: text/xml; charset=utf-8
   <ows:Title>QGIS TestProject</ows:Title>
   <ows:Abstract><![CDATA[Some UTF8 text èòù]]></ows:Abstract>
   <ows:ServiceType>WFS</ows:ServiceType>
+  <ows:ServiceTypeVersion>1.1.0</ows:ServiceTypeVersion>
   <ows:Fees>None</ows:Fees>
   <ows:AccessConstraints>None</ows:AccessConstraints>
  </ows:ServiceIdentification>


### PR DESCRIPTION
## Description

The OGC testsuite for WFS 1.1.0 is raising an error about  `ServiceTypeVersion` element:

```
Invalid content was found starting with element 'ows:Fees'. One of '{"http://www.opengis.net/ows":ServiceTypeVersion}' is expected.
```

This PR adds the missing element in `ows:ServiceIdentification`:

```
<ows:ServiceType>WFS</ows:ServiceType>
<ows:ServiceTypeVersion>1.1.0</ows:ServiceTypeVersion>
<ows:Fees>conditions unknown</ows:Fees>
```


## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
