### PR TITLE
[FEATURE] Simple rendering of 3D linestrings

### DIFF
--- a/src/3d/qgs3dutils.cpp
+++ b/src/3d/qgs3dutils.cpp
@@ -149,6 +149,20 @@ Qt3DRender::QCullFace::CullingMode Qgs3DUtils::cullingModeFromString( const QStr
     return Qt3DRender::QCullFace::NoCulling;
 }
 
+float Qgs3DUtils::clampAltitude( const QgsPoint &p, AltitudeClamping altClamp, AltitudeBinding altBind, float height, const QgsPoint &centroid, const Qgs3DMapSettings &map )
+{
+  float terrainZ = 0;
+  if ( altClamp == AltClampRelative || altClamp == AltClampTerrain )
+  {
+    QgsPointXY pt = altBind == AltBindVertex ? p : centroid;
+    terrainZ = map.terrainGenerator()->heightAt( pt.x(), pt.y(), map );
+  }
+
+  float geomZ = altClamp == AltClampAbsolute || altClamp == AltClampRelative ? p.z() : 0;
+
+  float z = ( terrainZ + geomZ ) * map.terrainVerticalScale() + height;
+  return z;
+}
 
 void Qgs3DUtils::clampAltitudes( QgsLineString *lineString, AltitudeClamping altClamp, AltitudeBinding altBind, const QgsPoint &centroid, float height, const Qgs3DMapSettings &map )
 {

--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -81,6 +81,8 @@ class _3D_EXPORT Qgs3DUtils
     //! Converts a string to a value from CullingMode enum
     static Qt3DRender::QCullFace::CullingMode cullingModeFromString( const QString &str );
 
+    //! Clamps altitude of a vertex according to the settings, returns Z value
+    static float clampAltitude( const QgsPoint &p, AltitudeClamping altClamp, AltitudeBinding altBind, float height, const QgsPoint &centroid, const Qgs3DMapSettings &map );
     //! Clamps altitude of vertices of a linestring according to the settings
     static void clampAltitudes( QgsLineString *lineString, AltitudeClamping altClamp, AltitudeBinding altBind, const QgsPoint &centroid, float height, const Qgs3DMapSettings &map );
     //! Clamps altitude of vertices of a polygon according to the settings

--- a/src/3d/symbols/qgsline3dsymbol.cpp
+++ b/src/3d/symbols/qgsline3dsymbol.cpp
@@ -31,6 +31,7 @@ void QgsLine3DSymbol::writeXml( QDomElement &elem, const QgsReadWriteContext &co
   elemDataProperties.setAttribute( QStringLiteral( "alt-binding" ), Qgs3DUtils::altBindingToString( mAltBinding ) );
   elemDataProperties.setAttribute( QStringLiteral( "height" ), mHeight );
   elemDataProperties.setAttribute( QStringLiteral( "extrusion-height" ), mExtrusionHeight );
+  elemDataProperties.setAttribute( QStringLiteral( "simple-lines" ), mRenderAsSimpleLines ? "1" : "0" );
   elemDataProperties.setAttribute( QStringLiteral( "width" ), mWidth );
   elem.appendChild( elemDataProperties );
 
@@ -49,6 +50,7 @@ void QgsLine3DSymbol::readXml( const QDomElement &elem, const QgsReadWriteContex
   mHeight = elemDataProperties.attribute( QStringLiteral( "height" ) ).toFloat();
   mExtrusionHeight = elemDataProperties.attribute( QStringLiteral( "extrusion-height" ) ).toFloat();
   mWidth = elemDataProperties.attribute( QStringLiteral( "width" ) ).toFloat();
+  mRenderAsSimpleLines = elemDataProperties.attribute( QStringLiteral( "simple-lines" ), "0" ).toInt();
 
   QDomElement elemMaterial = elem.firstChildElement( QStringLiteral( "material" ) );
   mMaterial.readXml( elemMaterial );

--- a/src/3d/symbols/qgsline3dsymbol.h
+++ b/src/3d/symbols/qgsline3dsymbol.h
@@ -65,6 +65,11 @@ class _3D_EXPORT QgsLine3DSymbol : public QgsAbstract3DSymbol
     //! Sets extrusion height (in map units)
     void setExtrusionHeight( float extrusionHeight ) { mExtrusionHeight = extrusionHeight; }
 
+    //! Returns whether the renderer will render data with simple lines (otherwise it uses buffer)
+    bool renderAsSimpleLines() const { return mRenderAsSimpleLines; }
+    //! Sets whether the renderer will render data with simple lines (otherwise it uses buffer)
+    void setRenderAsSimpleLines( bool enabled ) { mRenderAsSimpleLines = enabled; }
+
     //! Returns material used for shading of the symbol
     QgsPhongMaterialSettings material() const { return mMaterial; }
     //! Sets material used for shading of the symbol
@@ -79,6 +84,7 @@ class _3D_EXPORT QgsLine3DSymbol : public QgsAbstract3DSymbol
     float mWidth = 2.0f;            //!< Line width (horizontally)
     float mHeight = 0.0f;           //!< Base height of polygons
     float mExtrusionHeight = 0.0f;  //!< How much to extrude (0 means no walls)
+    bool mRenderAsSimpleLines = false;   //!< Whether to render data with simple lines (otherwise it uses buffer)
     QgsPhongMaterialSettings mMaterial;  //!< Defines appearance of objects
 };
 

--- a/src/3d/symbols/qgsline3dsymbol_p.cpp
+++ b/src/3d/symbols/qgsline3dsymbol_p.cpp
@@ -175,13 +175,13 @@ Qt3DRender::QGeometryRenderer *QgsLine3DSymbolEntityNode::rendererSimple( const 
 
     QgsGeometry geom = f.geometry();
     const QgsAbstractGeometry *g = geom.constGet();
-    if ( QgsLineString *ls = qgsgeometry_cast<QgsLineString *>( g ) )
+    if ( const QgsLineString *ls = qgsgeometry_cast<const QgsLineString *>( g ) )
     {
       for ( int i = 0; i < ls->vertexCount(); ++i )
       {
-        QgsPoint p = ls->vertexAt( QgsVertexId( 0, 0, i ) );
+        QgsPoint p = ls->pointN( i );
         float z = Qgs3DUtils::clampAltitude( p, symbol.altitudeClamping(), symbol.altitudeBinding(), symbol.height(), centroid, map );
-        vertices << QVector3D( p.x() - map.origin().x(), z, p.y() - map.origin().y() );
+        vertices << QVector3D( p.x() - map.origin().x(), z, -( p.y() - map.origin().y() ) );
         indexes << vertices.count() - 1;
       }
     }
@@ -192,9 +192,9 @@ Qt3DRender::QGeometryRenderer *QgsLine3DSymbolEntityNode::rendererSimple( const 
         const QgsLineString *ls = qgsgeometry_cast<const QgsLineString *>( mls->geometryN( nGeom ) );
         for ( int i = 0; i < ls->vertexCount(); ++i )
         {
-          QgsPoint p = ls->vertexAt( QgsVertexId( 0, 0, i ) );
+          QgsPoint p = ls->pointN( i );
           float z = Qgs3DUtils::clampAltitude( p, symbol.altitudeClamping(), symbol.altitudeBinding(), symbol.height(), centroid, map );
-          vertices << QVector3D( p.x() - map.origin().x(), z, p.y() - map.origin().y() );
+          vertices << QVector3D( p.x() - map.origin().x(), z, -( p.y() - map.origin().y() ) );
           indexes << vertices.count() - 1;
         }
         indexes << 0;  // add primitive restart

--- a/src/3d/symbols/qgsline3dsymbol_p.h
+++ b/src/3d/symbols/qgsline3dsymbol_p.h
@@ -59,6 +59,7 @@ class QgsLine3DSymbolEntityNode : public Qt3DCore::QEntity
 
   private:
     Qt3DRender::QGeometryRenderer *renderer( const Qgs3DMapSettings &map, const QgsLine3DSymbol &symbol, const QgsVectorLayer *layer, const QgsFeatureRequest &req );
+    Qt3DRender::QGeometryRenderer *rendererSimple( const Qgs3DMapSettings &map, const QgsLine3DSymbol &symbol, const QgsVectorLayer *layer, const QgsFeatureRequest &request );
 
     QgsTessellatedPolygonGeometry *mGeometry = nullptr;
 };

--- a/src/app/3d/qgsline3dsymbolwidget.cpp
+++ b/src/app/3d/qgsline3dsymbolwidget.cpp
@@ -34,6 +34,8 @@ QgsLine3DSymbolWidget::QgsLine3DSymbolWidget( QWidget *parent )
   connect( spinExtrusion, static_cast<void ( QDoubleSpinBox::* )( double )>( &QDoubleSpinBox::valueChanged ), this, &QgsLine3DSymbolWidget::changed );
   connect( cboAltClamping, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLine3DSymbolWidget::changed );
   connect( cboAltBinding, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsLine3DSymbolWidget::changed );
+  connect( chkSimpleLines, &QCheckBox::clicked, this, &QgsLine3DSymbolWidget::changed );
+  connect( chkSimpleLines, &QCheckBox::clicked, this, &QgsLine3DSymbolWidget::updateGuiState );
   connect( widgetMaterial, &QgsPhongMaterialWidget::changed, this, &QgsLine3DSymbolWidget::changed );
 }
 
@@ -44,7 +46,9 @@ void QgsLine3DSymbolWidget::setSymbol( const QgsLine3DSymbol &symbol )
   spinExtrusion->setValue( symbol.extrusionHeight() );
   cboAltClamping->setCurrentIndex( ( int ) symbol.altitudeClamping() );
   cboAltBinding->setCurrentIndex( ( int ) symbol.altitudeBinding() );
+  chkSimpleLines->setChecked( symbol.renderAsSimpleLines() );
   widgetMaterial->setMaterial( symbol.material() );
+  updateGuiState();
 }
 
 QgsLine3DSymbol QgsLine3DSymbolWidget::symbol() const
@@ -55,6 +59,14 @@ QgsLine3DSymbol QgsLine3DSymbolWidget::symbol() const
   sym.setExtrusionHeight( spinExtrusion->value() );
   sym.setAltitudeClamping( ( AltitudeClamping ) cboAltClamping->currentIndex() );
   sym.setAltitudeBinding( ( AltitudeBinding ) cboAltBinding->currentIndex() );
+  sym.setRenderAsSimpleLines( chkSimpleLines->isChecked() );
   sym.setMaterial( widgetMaterial->material() );
   return sym;
+}
+
+void QgsLine3DSymbolWidget::updateGuiState()
+{
+  bool simple = chkSimpleLines->isChecked();
+  spinWidth->setEnabled( !simple );
+  spinExtrusion->setEnabled( !simple );
 }

--- a/src/app/3d/qgsline3dsymbolwidget.h
+++ b/src/app/3d/qgsline3dsymbolwidget.h
@@ -32,6 +32,9 @@ class QgsLine3DSymbolWidget : public QWidget, private Ui::Line3DSymbolWidget
     void setSymbol( const QgsLine3DSymbol &symbol );
     QgsLine3DSymbol symbol() const;
 
+  private slots:
+    void updateGuiState();
+
   signals:
     void changed();
 

--- a/src/ui/3d/line3dsymbolwidget.ui
+++ b/src/ui/3d/line3dsymbolwidget.ui
@@ -111,6 +111,13 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="chkSimpleLines">
+     <property name="text">
+      <string>Render as simple 3D lines</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This mode of 3D line rendering will use OpenGL line rendering
instead of buffering lines into polygons and rendering them as meshes.

The advantage is that the 3D lines do not loose their Z coordinate
which is the case currently with "ordinary" 3D rendering after buffering.

The disadvantage is that the lines cannot be wide (supported in Qt3D only
since 5.10, but even then their rendering won't have nice joins/caps)
and only ambient color is used from the material.

![image](https://user-images.githubusercontent.com/193367/43366474-f76dcbd6-933e-11e8-8f1a-54a5abec3cbc.png)

(cc @nirvn aka joyful sunday continues!)