### PR TITLE
Abort expression parsing after encountering a maximum of 10 errors

### DIFF
--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -31,6 +31,9 @@
 // don't redeclare malloc/free
 #define YYINCLUDED_STDLIB_H 1
 
+// maximum number of errors encountered before parser aborts
+#define MAX_ERRORS 10
+
 struct expression_parser_context;
 #include "qgsexpressionparser.hpp"
 
@@ -177,7 +180,10 @@ root: expression { parser_ctx->rootNode = $1; }
     | error expression
         {
             delete $2;
-            yyerrok;
+            if ( parser_ctx->parserErrors.count() < MAX_ERRORS )
+              yyerrok;
+            else
+              YYABORT;
         }
    ;
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -287,6 +287,14 @@ class TestQgsExpression: public QObject
       QCOMPARE( exp.parserErrors().first().lastColumn, lastColumn );
     }
 
+    void max_errors()
+    {
+      QgsExpression e( "wkt_geom&#x9;OBJECTID&#x9;id&#x9;a&#x9;b&#x9;c&#x9;d&#x9;e&#x9;f&#x9;g&#x9;h&#x9;i&#x9;j&#x9;k&#x9;l&#x9;m&#x9;n&#x9;o&#x9;p&#x9;q&#x9;r&#x9;" );
+      QVERIFY( e.hasParserError() );
+      // want parsing to abort after a maximum of 10 errors
+      QCOMPARE( e.parserErrors().count(), 10 );
+    }
+
     void parsing_with_locale()
     {
       // check that parsing of numbers works correctly even when using some other locale


### PR DESCRIPTION
Otherwise badly formed expressions can cause the expression parser to burn up lots of cpu trying to build a complete list of the expression errors.

