### PR TITLE
Fix regression in raster psuedo ramp rendering when only two classes exist

### DIFF
--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -359,9 +359,6 @@ bool QgsColorRampShader::shade( double value, int *returnRedValue, int *returnGr
     mLUTInitialized = true;
   }
 
-  if ( mLUT.empty() )
-    return false;
-
   // overflow indicates that value > maximum value + DOUBLE_DIFF_THRESHOLD
   // that way idx can point to the last valid item
   bool overflow = false;
@@ -379,6 +376,10 @@ bool QgsColorRampShader::shade( double value, int *returnRedValue, int *returnGr
     {
       overflow = true;
     }
+  }
+  else if ( lutIndex < 0 )
+  {
+    return false;
   }
   else
   {


### PR DESCRIPTION
Refs https://lists.osgeo.org/pipermail/qgis-user/2018-July/043018.html