### PR TITLE
Fix build for Qt >= 5.11

### DIFF
--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -19,8 +19,17 @@
 #include "qgis_3d.h"
 
 #include <Qt3DCore/QEntity>
+
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #include <Qt3DInput>
 #include <Qt3DRender>
+#else
+#include <Qt3DInput/Qt3DInput>
+#include <Qt3DRender/Qt3DRender>
+#endif
+
+
 
 #include "qgscamerapose.h"
 

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -25,6 +25,13 @@
 
 #include <Qt3DRender/QGeometryRenderer>
 
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+#include <Qt3DCore/QTransform>
+#endif
+
+
+
 ///@cond PRIVATE
 
 static void _heightMapMinMax( const QByteArray &heightMap, float &zMin, float &zMax )

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -18,6 +18,11 @@
 #include <Qt3DRender/QGeometryRenderer>
 #include <Qt3DExtras/QPlaneGeometry>
 
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+#include <Qt3DCore/QTransform>
+#endif
+
 #include "qgs3dmapsettings.h"
 #include "qgschunknode_p.h"
 #include "qgsterrainentity_p.h"

--- a/src/core/qgswebframe.h
+++ b/src/core/qgswebframe.h
@@ -21,7 +21,12 @@
 #include "qgis_core.h"
 
 #ifdef WITH_QTWEBKIT
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #include <QWebFrame>
+#else
+#include <qwebframe.h>
+#endif
 #else
 
 #include <QObject>

--- a/src/core/qgswebpage.h
+++ b/src/core/qgswebpage.h
@@ -23,7 +23,12 @@
 #include <QObject>
 
 #ifdef WITH_QTWEBKIT
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #include <QWebPage>
+#else
+#include <qwebpage.h>
+#endif
 #else
 
 #include "qgswebframe.h"

--- a/src/core/qgswebview.h
+++ b/src/core/qgswebview.h
@@ -22,7 +22,12 @@
 #include <QWidget>
 
 #ifdef WITH_QTWEBKIT
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #include <QWebView>
+#else
+#include <qwebview.h>
+#endif
 #include <QDesktopWidget>
 
 #include "qgis_core.h"

--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -24,7 +24,12 @@
 #include <QSettings>
 #include <QImageReader>
 #ifdef WITH_QTWEBKIT
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #include <QWebView>
+#else
+#include <qwebview.h>
+#endif
 #endif
 
 

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -30,7 +30,12 @@
 #include <QLabel>
 #include <QDesktopServices>
 #if WITH_QTWEBKIT
+#include <QtGlobal>
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 #include <QWebElement>
+#else
+#include <qwebelement.h>
+#endif
 #endif
 #include <QHBoxLayout>
 

--- a/src/plugins/grass/qgsgrassmoduleinput.cpp
+++ b/src/plugins/grass/qgsgrassmoduleinput.cpp
@@ -14,6 +14,12 @@
  *                                                                         *
  ***************************************************************************/
 
+
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+#include <QHeaderView>
+#endif
+
 #include <QCompleter>
 #include <QFileDialog>
 #include <QFileInfo>

--- a/src/plugins/grass/qgsgrassregion.cpp
+++ b/src/plugins/grass/qgsgrassregion.cpp
@@ -25,6 +25,13 @@
 #include "qgsmaptool.h"
 #include "qgsexception.h"
 
+
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+#include <QDoubleValidator>
+#include <QIntValidator>
+#endif
+
 #include <QButtonGroup>
 #include <QColorDialog>
 #include <QMessageBox>


### PR DESCRIPTION

fixes #19522 
In qt-5.11 there has been some tweaking of header files, which result in FTBFS when building qgis-3.2.1 (and maybe earlier qgis3 versions).

