### PR TITLE
Fix freeze with `get_feature`

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -799,6 +799,13 @@ Set a single custom expression variable.
 .. versionadded:: 3.0
 %End
 
+    int maxConcurrentConnectionsPerPool() const;
+%Docstring
+The maximum number of concurrent connections per connections pool
+
+.. versionadded:: 3.4
+%End
+
 %If (ANDROID)
     //dummy method to workaround sip generation issue
     bool x11EventFilter( XEvent *event );

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -801,7 +801,12 @@ Set a single custom expression variable.
 
     int maxConcurrentConnectionsPerPool() const;
 %Docstring
-The maximum number of concurrent connections per connections pool
+The maximum number of concurrent connections per connections pool.
+
+.. note::
+
+   QGIS may in some situations allocate more than this amount
+   of connections to avoid deadlocks.
 
 .. versionadded:: 3.4
 %End

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -659,6 +659,40 @@ at this moment. A negative value (which is set by default) will wait forever.
 .. versionadded:: 3.0
 %End
 
+    int freeConnectionsRequirement() const;
+%Docstring
+The amount of free connections required to start this request.
+The system will block the request until the specified amount of connections
+is available for usage.
+
+By default this amount is 3. This makes sure, that we have 2 spare connections
+that might be used by "nested" requests which are executed while iterating
+over the results of this request.
+
+This number should be changed to one, when we know that no nested requests happen
+and that this request might happen in a nested way. This is for example given for
+expression functions that do internal requests.
+
+.. versionadded:: 3.4
+%End
+
+    void setFreeConnectionsRequirement( int freeConnectionsRequirement );
+%Docstring
+The amount of free connections required to start this request.
+The system will block the request until the specified amount of connections
+is available for usage.
+
+By default this amount is 3. This makes sure, that we have 2 spare connections
+that might be used by "nested" requests which are executed while iterating
+over the results of this request.
+
+This number should be changed to one, when we know that no nested requests happen
+and that this request might happen in a nested way. This is for example given for
+expression functions that do internal requests.
+
+.. versionadded:: 3.4
+%End
+
   protected:
 };
 

--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -659,36 +659,30 @@ at this moment. A negative value (which is set by default) will wait forever.
 .. versionadded:: 3.0
 %End
 
-    int freeConnectionsRequirement() const;
+    bool requestMayBeNested() const;
 %Docstring
-The amount of free connections required to start this request.
-The system will block the request until the specified amount of connections
-is available for usage.
+In case this request may be run nested within another already running
+iteration on the same connection, set this to true.
 
-By default this amount is 3. This makes sure, that we have 2 spare connections
-that might be used by "nested" requests which are executed while iterating
-over the results of this request.
+If this flag is true, this request will be able to make use of "spare"
+connections to avoid deadlocks.
 
-This number should be changed to one, when we know that no nested requests happen
-and that this request might happen in a nested way. This is for example given for
-expression functions that do internal requests.
+For example, this should be set on requests that are issued from an
+expression function.
 
 .. versionadded:: 3.4
 %End
 
-    void setFreeConnectionsRequirement( int freeConnectionsRequirement );
+    void setRequestMayBeNested( bool requestMayBeNested );
 %Docstring
-The amount of free connections required to start this request.
-The system will block the request until the specified amount of connections
-is available for usage.
+In case this request may be run nested within another already running
+iteration on the same connection, set this to true.
 
-By default this amount is 3. This makes sure, that we have 2 spare connections
-that might be used by "nested" requests which are executed while iterating
-over the results of this request.
+If this flag is true, this request will be able to make use of "spare"
+connections to avoid deadlocks.
 
-This number should be changed to one, when we know that no nested requests happen
-and that this request might happen in a nested way. This is for example given for
-expression functions that do internal requests.
+For example, this should be set on requests that are issued from an
+expression function.
 
 .. versionadded:: 3.4
 %End

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3570,7 +3570,7 @@ static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressi
     QgsFeatureRequest req;
     req.setFilterFid( fid );
     req.setConnectionTimeout( 10000 );
-    req.setFreeConnectionsRequirement( 1 );
+    req.setRequestMayBeNested( true );
     QgsFeatureIterator fIt = vl->getFeatures( req );
 
     QgsFeature fet;
@@ -3612,7 +3612,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
                            QgsExpression::quotedString( attVal.toString() ) ) );
   req.setLimit( 1 );
   req.setConnectionTimeout( 10000 );
-  req.setFreeConnectionsRequirement( 1 );
+  req.setRequestMayBeNested( true );
   if ( !parent->needsGeometry() )
   {
     req.setFlags( QgsFeatureRequest::NoGeometry );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3569,6 +3569,8 @@ static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressi
 
     QgsFeatureRequest req;
     req.setFilterFid( fid );
+    req.setConnectionTimeout( 10000 );
+    req.setFreeConnectionsRequirement( 1 );
     QgsFeatureIterator fIt = vl->getFeatures( req );
 
     QgsFeature fet;
@@ -3609,6 +3611,8 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   req.setFilterExpression( QStringLiteral( "%1=%2" ).arg( QgsExpression::quotedColumnRef( attribute ),
                            QgsExpression::quotedString( attVal.toString() ) ) );
   req.setLimit( 1 );
+  req.setConnectionTimeout( 10000 );
+  req.setFreeConnectionsRequirement( 1 );
   if ( !parent->needsGeometry() )
   {
     req.setFlags( QgsFeatureRequest::NoGeometry );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -85,7 +85,7 @@
 #include <cpl_conv.h> // for setting gdal options
 #include <sqlite3.h>
 
-#define CONN_POOL_MAX_CONCURRENT_CONNS      6
+#define CONN_POOL_MAX_CONCURRENT_CONNS      4
 
 QObject *ABISYM( QgsApplication::mFileOpenEventReceiver );
 QStringList ABISYM( QgsApplication::mFileOpenEventList );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -85,6 +85,8 @@
 #include <cpl_conv.h> // for setting gdal options
 #include <sqlite3.h>
 
+#define CONN_POOL_MAX_CONCURRENT_CONNS      6
+
 QObject *ABISYM( QgsApplication::mFileOpenEventReceiver );
 QStringList ABISYM( QgsApplication::mFileOpenEventList );
 QString ABISYM( QgsApplication::mPrefixPath );
@@ -1461,6 +1463,10 @@ void QgsApplication::setCustomVariable( const QString &name, const QVariant &val
   emit instance()->customVariablesChanged();
 }
 
+int QgsApplication::maxConcurrentConnectionsPerPool() const
+{
+  return CONN_POOL_MAX_CONCURRENT_CONNS;
+}
 
 QString QgsApplication::nullRepresentation()
 {

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -733,7 +733,10 @@ class CORE_EXPORT QgsApplication : public QApplication
     static void setCustomVariable( const QString &name, const QVariant &value );
 
     /**
-     * The maximum number of concurrent connections per connections pool
+     * The maximum number of concurrent connections per connections pool.
+     *
+     * \note QGIS may in some situations allocate more than this amount
+     *       of connections to avoid deadlocks.
      *
      * \since QGIS 3.4
      */

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -732,6 +732,13 @@ class CORE_EXPORT QgsApplication : public QApplication
      */
     static void setCustomVariable( const QString &name, const QVariant &value );
 
+    /**
+     * The maximum number of concurrent connections per connections pool
+     *
+     * \since QGIS 3.4
+     */
+    int maxConcurrentConnectionsPerPool() const;
+
 #ifdef SIP_RUN
     SIP_IF_FEATURE( ANDROID )
     //dummy method to workaround sip generation issue

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -19,6 +19,7 @@
 #define SIP_NO_FILE
 
 #include "qgis.h"
+#include "qgsapplication.h"
 #include <QCoreApplication>
 #include <QMap>
 #include <QMutex>
@@ -29,7 +30,6 @@
 #include <QThread>
 
 
-#define CONN_POOL_MAX_CONCURRENT_CONNS      6
 #define CONN_POOL_EXPIRATION_TIME           60    // in seconds
 
 
@@ -59,8 +59,6 @@ class QgsConnectionPoolGroup
 {
   public:
 
-    static const int MAX_CONCURRENT_CONNECTIONS;
-
     struct Item
     {
       T c;
@@ -69,7 +67,7 @@ class QgsConnectionPoolGroup
 
     QgsConnectionPoolGroup( const QString &ci )
       : connInfo( ci )
-      , sem( CONN_POOL_MAX_CONCURRENT_CONNS )
+      , sem( QgsApplication::instance()->maxConcurrentConnectionsPerPool() )
     {
     }
 

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -123,218 +123,219 @@ class QgsConnectionPoolGroup
           {
             qgsConnectionPool_ConnectionDestroy( i.c );
             qgsConnectionPool_ConnectionCreate( connInfo, i.c );
-
-
-            // no need to run if nothing can expire
-            if ( conns.isEmpty() )
-            {
-              // will call the slot directly or queue the call (if the object lives in a different thread)
-              QMetaObject::invokeMethod( expirationTimer->parent(), "stopExpirationTimer" );
-            }
-
-            acquiredConns.append( i.c );
-
-            return i.c;
           }
-        }
 
-        T c;
-        qgsConnectionPool_ConnectionCreate( connInfo, c );
-        if ( !c )
-        {
-          // we didn't get connection for some reason, so release the lock
-          sem.release();
-          return nullptr;
-        }
 
-        connMutex.lock();
-        acquiredConns.append( c );
-        connMutex.unlock();
-        return c;
-      }
-
-      void release( T conn )
-      {
-        connMutex.lock();
-        acquiredConns.removeAll( conn );
-        if ( !qgsConnectionPool_ConnectionIsValid( conn ) )
-        {
-          qgsConnectionPool_ConnectionDestroy( conn );
-        }
-        else
-        {
-          Item i;
-          i.c = conn;
-          i.lastUsedTime = QTime::currentTime();
-          conns.push( i );
-
-          if ( !expirationTimer->isActive() )
+          // no need to run if nothing can expire
+          if ( conns.isEmpty() )
           {
             // will call the slot directly or queue the call (if the object lives in a different thread)
-            QMetaObject::invokeMethod( expirationTimer->parent(), "startExpirationTimer" );
+            QMetaObject::invokeMethod( expirationTimer->parent(), "stopExpirationTimer" );
           }
+
+          acquiredConns.append( i.c );
+
+          return i.c;
         }
-
-        connMutex.unlock();
-
-        sem.release(); // this can unlock a thread waiting in acquire()
       }
 
-      void invalidateConnections()
+      T c;
+      qgsConnectionPool_ConnectionCreate( connInfo, c );
+      if ( !c )
       {
-        connMutex.lock();
-        for ( const Item &i : qgis::as_const( conns ) )
-        {
-          qgsConnectionPool_ConnectionDestroy( i.c );
-        }
-        conns.clear();
-        for ( T c : qgis::as_const( acquiredConns ) )
-          qgsConnectionPool_InvalidateConnection( c );
-        connMutex.unlock();
+        // we didn't get connection for some reason, so release the lock
+        sem.release();
+        return nullptr;
       }
 
-    protected:
+      connMutex.lock();
+      acquiredConns.append( c );
+      connMutex.unlock();
+      return c;
+    }
 
-      void initTimer( QObject * parent )
+    void release( T conn )
+    {
+      connMutex.lock();
+      acquiredConns.removeAll( conn );
+      if ( !qgsConnectionPool_ConnectionIsValid( conn ) )
       {
-        expirationTimer = new QTimer( parent );
-        expirationTimer->setInterval( CONN_POOL_EXPIRATION_TIME * 1000 );
-        QObject::connect( expirationTimer, SIGNAL( timeout() ), parent, SLOT( handleConnectionExpired() ) );
-
-        // just to make sure the object belongs to main thread and thus will get events
-        if ( qApp )
-          parent->moveToThread( qApp->thread() );
+        qgsConnectionPool_ConnectionDestroy( conn );
       }
-
-      void onConnectionExpired()
+      else
       {
-        connMutex.lock();
+        Item i;
+        i.c = conn;
+        i.lastUsedTime = QTime::currentTime();
+        conns.push( i );
 
-        QTime now = QTime::currentTime();
-
-        // what connections have expired?
-        QList<int> toDelete;
-        for ( int i = 0; i < conns.count(); ++i )
+        if ( !expirationTimer->isActive() )
         {
-          if ( conns.at( i ).lastUsedTime.secsTo( now ) >= CONN_POOL_EXPIRATION_TIME )
-            toDelete.append( i );
+          // will call the slot directly or queue the call (if the object lives in a different thread)
+          QMetaObject::invokeMethod( expirationTimer->parent(), "startExpirationTimer" );
         }
-
-        // delete expired connections
-        for ( int j = toDelete.count() - 1; j >= 0; --j )
-        {
-          int index = toDelete[j];
-          qgsConnectionPool_ConnectionDestroy( conns[index].c );
-          conns.remove( index );
-        }
-
-        if ( conns.isEmpty() )
-          expirationTimer->stop();
-
-        connMutex.unlock();
       }
 
-    protected:
+      connMutex.unlock();
 
-      QString connInfo;
-      QStack<Item> conns;
-      QList<T> acquiredConns;
-      QMutex connMutex;
-      QSemaphore sem;
-      QTimer *expirationTimer = nullptr;
+      sem.release(); // this can unlock a thread waiting in acquire()
+    }
 
-    };
+    void invalidateConnections()
+    {
+      connMutex.lock();
+      for ( const Item &i : qgis::as_const( conns ) )
+      {
+        qgsConnectionPool_ConnectionDestroy( i.c );
+      }
+      conns.clear();
+      for ( T c : qgis::as_const( acquiredConns ) )
+        qgsConnectionPool_InvalidateConnection( c );
+      connMutex.unlock();
+    }
 
+  protected:
+
+    void initTimer( QObject *parent )
+    {
+      expirationTimer = new QTimer( parent );
+      expirationTimer->setInterval( CONN_POOL_EXPIRATION_TIME * 1000 );
+      QObject::connect( expirationTimer, SIGNAL( timeout() ), parent, SLOT( handleConnectionExpired() ) );
+
+      // just to make sure the object belongs to main thread and thus will get events
+      if ( qApp )
+        parent->moveToThread( qApp->thread() );
+    }
+
+    void onConnectionExpired()
+    {
+      connMutex.lock();
+
+      QTime now = QTime::currentTime();
+
+      // what connections have expired?
+      QList<int> toDelete;
+      for ( int i = 0; i < conns.count(); ++i )
+      {
+        if ( conns.at( i ).lastUsedTime.secsTo( now ) >= CONN_POOL_EXPIRATION_TIME )
+          toDelete.append( i );
+      }
+
+      // delete expired connections
+      for ( int j = toDelete.count() - 1; j >= 0; --j )
+      {
+        int index = toDelete[j];
+        qgsConnectionPool_ConnectionDestroy( conns[index].c );
+        conns.remove( index );
+      }
+
+      if ( conns.isEmpty() )
+        expirationTimer->stop();
+
+      connMutex.unlock();
+    }
+
+  protected:
+
+    QString connInfo;
+    QStack<Item> conns;
+    QList<T> acquiredConns;
+    QMutex connMutex;
+    QSemaphore sem;
+    QTimer *expirationTimer = nullptr;
+
+};
+
+
+/**
+ * \ingroup core
+ * Template class responsible for keeping a pool of open connections.
+ * This is desired to avoid the overhead of creation of new connection every time.
+ *
+ * The methods are thread safe.
+ *
+ * The connection pool has a limit on maximum number of concurrent connections
+ * (per server), once the limit is reached, the acquireConnection() function
+ * will block. All connections that have been acquired must be then released
+ * with releaseConnection() function.
+ *
+ * When the connections are not used for some time, they will get closed automatically
+ * to save resources.
+ * \note not available in Python bindings
+ */
+template <typename T, typename T_Group>
+class QgsConnectionPool
+{
+  public:
+
+    typedef QMap<QString, T_Group *> T_Groups;
+
+    virtual ~QgsConnectionPool()
+    {
+      mMutex.lock();
+      for ( T_Group *group : qgis::as_const( mGroups ) )
+      {
+        delete group;
+      }
+      mGroups.clear();
+      mMutex.unlock();
+    }
 
     /**
-     * \ingroup core
-     * Template class responsible for keeping a pool of open connections.
-     * This is desired to avoid the overhead of creation of new connection every time.
+     * Try to acquire a connection for a maximum of \a timeout milliseconds.
+     * If \a timeout is a negative value the calling thread will be blocked
+     * until a connection becomes available. This is the default behavior.
      *
-     * The methods are thread safe.
      *
-     * The connection pool has a limit on maximum number of concurrent connections
-     * (per server), once the limit is reached, the acquireConnection() function
-     * will block. All connections that have been acquired must be then released
-     * with releaseConnection() function.
      *
-     * When the connections are not used for some time, they will get closed automatically
-     * to save resources.
-     * \note not available in Python bindings
+     * \returns initialized connection or nullptr if unsuccessful
      */
-    template <typename T, typename T_Group>
-    class QgsConnectionPool
+    T acquireConnection( const QString &connInfo, int timeout = -1, bool requestMayBeNested = false )
     {
-      public:
+      mMutex.lock();
+      typename T_Groups::iterator it = mGroups.find( connInfo );
+      if ( it == mGroups.end() )
+      {
+        it = mGroups.insert( connInfo, new T_Group( connInfo ) );
+      }
+      T_Group *group = *it;
+      mMutex.unlock();
 
-        typedef QMap<QString, T_Group *> T_Groups;
+      return group->acquire( timeout, requestMayBeNested );
+    }
 
-        virtual ~QgsConnectionPool()
-        {
-          mMutex.lock();
-          for ( T_Group *group : qgis::as_const( mGroups ) )
-          {
-            delete group;
-          }
-          mGroups.clear();
-          mMutex.unlock();
-        }
+    //! Release an existing connection so it will get back into the pool and can be reused
+    void releaseConnection( T conn )
+    {
+      mMutex.lock();
+      typename T_Groups::iterator it = mGroups.find( qgsConnectionPool_ConnectionToName( conn ) );
+      Q_ASSERT( it != mGroups.end() );
+      T_Group *group = *it;
+      mMutex.unlock();
 
-        /**
-         * Try to acquire a connection for a maximum of \a timeout milliseconds.
-         * If \a timeout is a negative value the calling thread will be blocked
-         * until a connection becomes available. This is the default behavior.
-         *
-         *
-         *
-         * \returns initialized connection or nullptr if unsuccessful
-         */
-        T acquireConnection( const QString &connInfo, int timeout = -1, bool requestMayBeNested = false )
-        {
-          mMutex.lock();
-          typename T_Groups::iterator it = mGroups.find( connInfo );
-          if ( it == mGroups.end() )
-          {
-            it = mGroups.insert( connInfo, new T_Group( connInfo ) );
-          }
-          T_Group *group = *it;
-          mMutex.unlock();
+      group->release( conn );
+    }
 
-          return group->acquire( timeout, requestMayBeNested );
-        }
-
-        //! Release an existing connection so it will get back into the pool and can be reused
-        void releaseConnection( T conn )
-        {
-          mMutex.lock();
-          typename T_Groups::iterator it = mGroups.find( qgsConnectionPool_ConnectionToName( conn ) );
-          Q_ASSERT( it != mGroups.end() );
-          T_Group *group = *it;
-          mMutex.unlock();
-
-          group->release( conn );
-        }
-
-        /**
-         * Invalidates all connections to the specified resource.
-         * The internal state of certain handles (for instance OGR) are altered
-         * when a dataset is modified. Consquently, all open handles need to be
-         * invalidated when such datasets are changed to ensure the handles are
-         * refreshed. See the OGR provider for an example where this is needed.
-         */
-        void invalidateConnections( const QString &connInfo )
-        {
-          mMutex.lock();
-          if ( mGroups.contains( connInfo ) )
-            mGroups[connInfo]->invalidateConnections();
-          mMutex.unlock();
-        }
+    /**
+     * Invalidates all connections to the specified resource.
+     * The internal state of certain handles (for instance OGR) are altered
+     * when a dataset is modified. Consquently, all open handles need to be
+     * invalidated when such datasets are changed to ensure the handles are
+     * refreshed. See the OGR provider for an example where this is needed.
+     */
+    void invalidateConnections( const QString &connInfo )
+    {
+      mMutex.lock();
+      if ( mGroups.contains( connInfo ) )
+        mGroups[connInfo]->invalidateConnections();
+      mMutex.unlock();
+    }
 
 
-      protected:
-        T_Groups mGroups;
-        QMutex mMutex;
-    };
+  protected:
+    T_Groups mGroups;
+    QMutex mMutex;
+};
 
 
 #endif // QGSCONNECTIONPOOL_H

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -93,12 +93,13 @@ class QgsConnectionPoolGroup
      *
      * \returns initialized connection or nullptr if unsuccessful
      */
-    T acquire( int timeout, int freeConnectionRequirement )
+    T acquire( int timeout, bool requestMayBeNested )
     {
+      const int requiredFreeConnectionCount = requestMayBeNested ? 1 : 3;
       // we are going to acquire a resource - if no resource is available, we will block here
       if ( timeout >= 0 )
       {
-        if ( !sem.tryAcquire( freeConnectionRequirement, timeout ) )
+        if ( !sem.tryAcquire( requiredFreeConnectionCount, timeout ) )
           return nullptr;
       }
       else
@@ -107,9 +108,9 @@ class QgsConnectionPoolGroup
         // tryAcquire is broken on Qt > 5.8 with negative timeouts - see
         // https://bugreports.qt.io/browse/QTBUG-64413
         // https://lists.osgeo.org/pipermail/qgis-developer/2017-November/050456.html
-        sem.acquire( freeConnectionRequirement );
+        sem.acquire( requiredFreeConnectionCount );
       }
-      sem.release( freeConnectionRequirement - 1 );
+      sem.release( requiredFreeConnectionCount - 1 );
 
       // quick (preferred) way - use cached connection
       {
@@ -122,218 +123,218 @@ class QgsConnectionPoolGroup
           {
             qgsConnectionPool_ConnectionDestroy( i.c );
             qgsConnectionPool_ConnectionCreate( connInfo, i.c );
-          }
 
-          // no need to run if nothing can expire
-          if ( conns.isEmpty() )
+
+            // no need to run if nothing can expire
+            if ( conns.isEmpty() )
+            {
+              // will call the slot directly or queue the call (if the object lives in a different thread)
+              QMetaObject::invokeMethod( expirationTimer->parent(), "stopExpirationTimer" );
+            }
+
+            acquiredConns.append( i.c );
+
+            return i.c;
+          }
+        }
+
+        T c;
+        qgsConnectionPool_ConnectionCreate( connInfo, c );
+        if ( !c )
+        {
+          // we didn't get connection for some reason, so release the lock
+          sem.release();
+          return nullptr;
+        }
+
+        connMutex.lock();
+        acquiredConns.append( c );
+        connMutex.unlock();
+        return c;
+      }
+
+      void release( T conn )
+      {
+        connMutex.lock();
+        acquiredConns.removeAll( conn );
+        if ( !qgsConnectionPool_ConnectionIsValid( conn ) )
+        {
+          qgsConnectionPool_ConnectionDestroy( conn );
+        }
+        else
+        {
+          Item i;
+          i.c = conn;
+          i.lastUsedTime = QTime::currentTime();
+          conns.push( i );
+
+          if ( !expirationTimer->isActive() )
           {
             // will call the slot directly or queue the call (if the object lives in a different thread)
-            QMetaObject::invokeMethod( expirationTimer->parent(), "stopExpirationTimer" );
+            QMetaObject::invokeMethod( expirationTimer->parent(), "startExpirationTimer" );
           }
-
-          acquiredConns.append( i.c );
-
-          return i.c;
         }
+
+        connMutex.unlock();
+
+        sem.release(); // this can unlock a thread waiting in acquire()
       }
 
-      T c;
-      qgsConnectionPool_ConnectionCreate( connInfo, c );
-      if ( !c )
+      void invalidateConnections()
       {
-        // we didn't get connection for some reason, so release the lock
-        sem.release();
-        return nullptr;
-      }
-
-      connMutex.lock();
-      acquiredConns.append( c );
-      connMutex.unlock();
-      return c;
-    }
-
-    void release( T conn )
-    {
-      connMutex.lock();
-      acquiredConns.removeAll( conn );
-      if ( !qgsConnectionPool_ConnectionIsValid( conn ) )
-      {
-        qgsConnectionPool_ConnectionDestroy( conn );
-      }
-      else
-      {
-        Item i;
-        i.c = conn;
-        i.lastUsedTime = QTime::currentTime();
-        conns.push( i );
-
-        if ( !expirationTimer->isActive() )
+        connMutex.lock();
+        for ( const Item &i : qgis::as_const( conns ) )
         {
-          // will call the slot directly or queue the call (if the object lives in a different thread)
-          QMetaObject::invokeMethod( expirationTimer->parent(), "startExpirationTimer" );
+          qgsConnectionPool_ConnectionDestroy( i.c );
         }
+        conns.clear();
+        for ( T c : qgis::as_const( acquiredConns ) )
+          qgsConnectionPool_InvalidateConnection( c );
+        connMutex.unlock();
       }
 
-      connMutex.unlock();
+    protected:
 
-      sem.release(); // this can unlock a thread waiting in acquire()
-    }
-
-    void invalidateConnections()
-    {
-      connMutex.lock();
-      for ( const Item &i : qgis::as_const( conns ) )
+      void initTimer( QObject * parent )
       {
-        qgsConnectionPool_ConnectionDestroy( i.c );
+        expirationTimer = new QTimer( parent );
+        expirationTimer->setInterval( CONN_POOL_EXPIRATION_TIME * 1000 );
+        QObject::connect( expirationTimer, SIGNAL( timeout() ), parent, SLOT( handleConnectionExpired() ) );
+
+        // just to make sure the object belongs to main thread and thus will get events
+        if ( qApp )
+          parent->moveToThread( qApp->thread() );
       }
-      conns.clear();
-      for ( T c : qgis::as_const( acquiredConns ) )
-        qgsConnectionPool_InvalidateConnection( c );
-      connMutex.unlock();
-    }
 
-  protected:
-
-    void initTimer( QObject *parent )
-    {
-      expirationTimer = new QTimer( parent );
-      expirationTimer->setInterval( CONN_POOL_EXPIRATION_TIME * 1000 );
-      QObject::connect( expirationTimer, SIGNAL( timeout() ), parent, SLOT( handleConnectionExpired() ) );
-
-      // just to make sure the object belongs to main thread and thus will get events
-      if ( qApp )
-        parent->moveToThread( qApp->thread() );
-    }
-
-    void onConnectionExpired()
-    {
-      connMutex.lock();
-
-      QTime now = QTime::currentTime();
-
-      // what connections have expired?
-      QList<int> toDelete;
-      for ( int i = 0; i < conns.count(); ++i )
+      void onConnectionExpired()
       {
-        if ( conns.at( i ).lastUsedTime.secsTo( now ) >= CONN_POOL_EXPIRATION_TIME )
-          toDelete.append( i );
+        connMutex.lock();
+
+        QTime now = QTime::currentTime();
+
+        // what connections have expired?
+        QList<int> toDelete;
+        for ( int i = 0; i < conns.count(); ++i )
+        {
+          if ( conns.at( i ).lastUsedTime.secsTo( now ) >= CONN_POOL_EXPIRATION_TIME )
+            toDelete.append( i );
+        }
+
+        // delete expired connections
+        for ( int j = toDelete.count() - 1; j >= 0; --j )
+        {
+          int index = toDelete[j];
+          qgsConnectionPool_ConnectionDestroy( conns[index].c );
+          conns.remove( index );
+        }
+
+        if ( conns.isEmpty() )
+          expirationTimer->stop();
+
+        connMutex.unlock();
       }
 
-      // delete expired connections
-      for ( int j = toDelete.count() - 1; j >= 0; --j )
-      {
-        int index = toDelete[j];
-        qgsConnectionPool_ConnectionDestroy( conns[index].c );
-        conns.remove( index );
-      }
+    protected:
 
-      if ( conns.isEmpty() )
-        expirationTimer->stop();
+      QString connInfo;
+      QStack<Item> conns;
+      QList<T> acquiredConns;
+      QMutex connMutex;
+      QSemaphore sem;
+      QTimer *expirationTimer = nullptr;
 
-      connMutex.unlock();
-    }
+    };
 
-  protected:
-
-    QString connInfo;
-    QStack<Item> conns;
-    QList<T> acquiredConns;
-    QMutex connMutex;
-    QSemaphore sem;
-    QTimer *expirationTimer = nullptr;
-
-};
-
-
-/**
- * \ingroup core
- * Template class responsible for keeping a pool of open connections.
- * This is desired to avoid the overhead of creation of new connection every time.
- *
- * The methods are thread safe.
- *
- * The connection pool has a limit on maximum number of concurrent connections
- * (per server), once the limit is reached, the acquireConnection() function
- * will block. All connections that have been acquired must be then released
- * with releaseConnection() function.
- *
- * When the connections are not used for some time, they will get closed automatically
- * to save resources.
- * \note not available in Python bindings
- */
-template <typename T, typename T_Group>
-class QgsConnectionPool
-{
-  public:
-
-    typedef QMap<QString, T_Group *> T_Groups;
-
-    virtual ~QgsConnectionPool()
-    {
-      mMutex.lock();
-      for ( T_Group *group : qgis::as_const( mGroups ) )
-      {
-        delete group;
-      }
-      mGroups.clear();
-      mMutex.unlock();
-    }
 
     /**
-     * Try to acquire a connection for a maximum of \a timeout milliseconds.
-     * If \a timeout is a negative value the calling thread will be blocked
-     * until a connection becomes available. This is the default behavior.
+     * \ingroup core
+     * Template class responsible for keeping a pool of open connections.
+     * This is desired to avoid the overhead of creation of new connection every time.
      *
+     * The methods are thread safe.
      *
+     * The connection pool has a limit on maximum number of concurrent connections
+     * (per server), once the limit is reached, the acquireConnection() function
+     * will block. All connections that have been acquired must be then released
+     * with releaseConnection() function.
      *
-     * \returns initialized connection or nullptr if unsuccessful
+     * When the connections are not used for some time, they will get closed automatically
+     * to save resources.
+     * \note not available in Python bindings
      */
-    T acquireConnection( const QString &connInfo, int timeout = -1, int freeConnectionRequirement = 3 )
+    template <typename T, typename T_Group>
+    class QgsConnectionPool
     {
-      mMutex.lock();
-      typename T_Groups::iterator it = mGroups.find( connInfo );
-      if ( it == mGroups.end() )
-      {
-        it = mGroups.insert( connInfo, new T_Group( connInfo ) );
-      }
-      T_Group *group = *it;
-      mMutex.unlock();
+      public:
 
-      return group->acquire( timeout, freeConnectionRequirement );
-    }
+        typedef QMap<QString, T_Group *> T_Groups;
 
-    //! Release an existing connection so it will get back into the pool and can be reused
-    void releaseConnection( T conn )
-    {
-      mMutex.lock();
-      typename T_Groups::iterator it = mGroups.find( qgsConnectionPool_ConnectionToName( conn ) );
-      Q_ASSERT( it != mGroups.end() );
-      T_Group *group = *it;
-      mMutex.unlock();
+        virtual ~QgsConnectionPool()
+        {
+          mMutex.lock();
+          for ( T_Group *group : qgis::as_const( mGroups ) )
+          {
+            delete group;
+          }
+          mGroups.clear();
+          mMutex.unlock();
+        }
 
-      group->release( conn );
-    }
+        /**
+         * Try to acquire a connection for a maximum of \a timeout milliseconds.
+         * If \a timeout is a negative value the calling thread will be blocked
+         * until a connection becomes available. This is the default behavior.
+         *
+         *
+         *
+         * \returns initialized connection or nullptr if unsuccessful
+         */
+        T acquireConnection( const QString &connInfo, int timeout = -1, bool requestMayBeNested = false )
+        {
+          mMutex.lock();
+          typename T_Groups::iterator it = mGroups.find( connInfo );
+          if ( it == mGroups.end() )
+          {
+            it = mGroups.insert( connInfo, new T_Group( connInfo ) );
+          }
+          T_Group *group = *it;
+          mMutex.unlock();
 
-    /**
-     * Invalidates all connections to the specified resource.
-     * The internal state of certain handles (for instance OGR) are altered
-     * when a dataset is modified. Consquently, all open handles need to be
-     * invalidated when such datasets are changed to ensure the handles are
-     * refreshed. See the OGR provider for an example where this is needed.
-     */
-    void invalidateConnections( const QString &connInfo )
-    {
-      mMutex.lock();
-      if ( mGroups.contains( connInfo ) )
-        mGroups[connInfo]->invalidateConnections();
-      mMutex.unlock();
-    }
+          return group->acquire( timeout, requestMayBeNested );
+        }
+
+        //! Release an existing connection so it will get back into the pool and can be reused
+        void releaseConnection( T conn )
+        {
+          mMutex.lock();
+          typename T_Groups::iterator it = mGroups.find( qgsConnectionPool_ConnectionToName( conn ) );
+          Q_ASSERT( it != mGroups.end() );
+          T_Group *group = *it;
+          mMutex.unlock();
+
+          group->release( conn );
+        }
+
+        /**
+         * Invalidates all connections to the specified resource.
+         * The internal state of certain handles (for instance OGR) are altered
+         * when a dataset is modified. Consquently, all open handles need to be
+         * invalidated when such datasets are changed to ensure the handles are
+         * refreshed. See the OGR provider for an example where this is needed.
+         */
+        void invalidateConnections( const QString &connInfo )
+        {
+          mMutex.lock();
+          if ( mGroups.contains( connInfo ) )
+            mGroups[connInfo]->invalidateConnections();
+          mMutex.unlock();
+        }
 
 
-  protected:
-    T_Groups mGroups;
-    QMutex mMutex;
-};
+      protected:
+        T_Groups mGroups;
+        QMutex mMutex;
+    };
 
 
 #endif // QGSCONNECTIONPOOL_H

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -31,6 +31,7 @@
 
 
 #define CONN_POOL_EXPIRATION_TIME           60    // in seconds
+#define CONN_POOL_SPARE_CONNECTIONS          2    // number of spare connections in case all the base connections are used but we have a nested request with the risk of a deadlock
 
 
 /**
@@ -67,7 +68,7 @@ class QgsConnectionPoolGroup
 
     QgsConnectionPoolGroup( const QString &ci )
       : connInfo( ci )
-      , sem( QgsApplication::instance()->maxConcurrentConnectionsPerPool() )
+      , sem( QgsApplication::instance()->maxConcurrentConnectionsPerPool() + CONN_POOL_SPARE_CONNECTIONS )
     {
     }
 

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -86,6 +86,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mCrs = rh.mCrs;
   mTransformErrorCallback = rh.mTransformErrorCallback;
   mConnectionTimeout = rh.mConnectionTimeout;
+  mFreeConnectionsRequirement = rh.mFreeConnectionsRequirement;
   return *this;
 }
 
@@ -296,6 +297,16 @@ int QgsFeatureRequest::connectionTimeout() const
 void QgsFeatureRequest::setConnectionTimeout( int connectionTimeout )
 {
   mConnectionTimeout = connectionTimeout;
+}
+
+int QgsFeatureRequest::freeConnectionsRequirement() const
+{
+  return mFreeConnectionsRequirement;
+}
+
+void QgsFeatureRequest::setFreeConnectionsRequirement( int freeConnectionsRequirement )
+{
+  mFreeConnectionsRequirement = freeConnectionsRequirement;
 }
 
 

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -299,14 +299,14 @@ void QgsFeatureRequest::setConnectionTimeout( int connectionTimeout )
   mConnectionTimeout = connectionTimeout;
 }
 
-int QgsFeatureRequest::freeConnectionsRequirement() const
+bool QgsFeatureRequest::requestMayBeNested() const
 {
-  return mFreeConnectionsRequirement;
+  return mRequestMayBeNested;
 }
 
-void QgsFeatureRequest::setFreeConnectionsRequirement( int freeConnectionsRequirement )
+void QgsFeatureRequest::setRequestMayBeNested( bool requestMayBeNested )
 {
-  mFreeConnectionsRequirement = freeConnectionsRequirement;
+  mRequestMayBeNested = requestMayBeNested;
 }
 
 

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -86,7 +86,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mCrs = rh.mCrs;
   mTransformErrorCallback = rh.mTransformErrorCallback;
   mConnectionTimeout = rh.mConnectionTimeout;
-  mFreeConnectionsRequirement = rh.mFreeConnectionsRequirement;
+  mRequestMayBeNested = rh.mRequestMayBeNested;
   return *this;
 }
 

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -636,6 +636,40 @@ class CORE_EXPORT QgsFeatureRequest
      */
     void setConnectionTimeout( int connectionTimeout );
 
+    /**
+     * The amount of free connections required to start this request.
+     * The system will block the request until the specified amount of connections
+     * is available for usage.
+     *
+     * By default this amount is 3. This makes sure, that we have 2 spare connections
+     * that might be used by "nested" requests which are executed while iterating
+     * over the results of this request.
+     *
+     * This number should be changed to one, when we know that no nested requests happen
+     * and that this request might happen in a nested way. This is for example given for
+     * expression functions that do internal requests.
+     *
+     * \since QGIS 3.4
+     */
+    int freeConnectionsRequirement() const;
+
+    /**
+     * The amount of free connections required to start this request.
+     * The system will block the request until the specified amount of connections
+     * is available for usage.
+     *
+     * By default this amount is 3. This makes sure, that we have 2 spare connections
+     * that might be used by "nested" requests which are executed while iterating
+     * over the results of this request.
+     *
+     * This number should be changed to one, when we know that no nested requests happen
+     * and that this request might happen in a nested way. This is for example given for
+     * expression functions that do internal requests.
+     *
+     * \since QGIS 3.4
+     */
+    void setFreeConnectionsRequirement( int freeConnectionsRequirement );
+
   protected:
     FilterType mFilter = FilterNone;
     QgsRectangle mFilterRect;
@@ -654,6 +688,7 @@ class CORE_EXPORT QgsFeatureRequest
     QgsCoordinateReferenceSystem mCrs;
     QgsCoordinateTransformContext mTransformContext;
     int mConnectionTimeout = -1;
+    int mFreeConnectionsRequirement = 3;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureRequest::Flags )

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -637,38 +637,32 @@ class CORE_EXPORT QgsFeatureRequest
     void setConnectionTimeout( int connectionTimeout );
 
     /**
-     * The amount of free connections required to start this request.
-     * The system will block the request until the specified amount of connections
-     * is available for usage.
+     * In case this request may be run nested within another already running
+     * iteration on the same connection, set this to true.
      *
-     * By default this amount is 3. This makes sure, that we have 2 spare connections
-     * that might be used by "nested" requests which are executed while iterating
-     * over the results of this request.
+     * If this flag is true, this request will be able to make use of "spare"
+     * connections to avoid deadlocks.
      *
-     * This number should be changed to one, when we know that no nested requests happen
-     * and that this request might happen in a nested way. This is for example given for
-     * expression functions that do internal requests.
+     * For example, this should be set on requests that are issued from an
+     * expression function.
      *
      * \since QGIS 3.4
      */
-    int freeConnectionsRequirement() const;
+    bool requestMayBeNested() const;
 
     /**
-     * The amount of free connections required to start this request.
-     * The system will block the request until the specified amount of connections
-     * is available for usage.
+     * In case this request may be run nested within another already running
+     * iteration on the same connection, set this to true.
      *
-     * By default this amount is 3. This makes sure, that we have 2 spare connections
-     * that might be used by "nested" requests which are executed while iterating
-     * over the results of this request.
+     * If this flag is true, this request will be able to make use of "spare"
+     * connections to avoid deadlocks.
      *
-     * This number should be changed to one, when we know that no nested requests happen
-     * and that this request might happen in a nested way. This is for example given for
-     * expression functions that do internal requests.
+     * For example, this should be set on requests that are issued from an
+     * expression function.
      *
      * \since QGIS 3.4
      */
-    void setFreeConnectionsRequirement( int freeConnectionsRequirement );
+    void setRequestMayBeNested( bool requestMayBeNested );
 
   protected:
     FilterType mFilter = FilterNone;
@@ -688,7 +682,7 @@ class CORE_EXPORT QgsFeatureRequest
     QgsCoordinateReferenceSystem mCrs;
     QgsCoordinateTransformContext mTransformContext;
     int mConnectionTimeout = -1;
-    int mFreeConnectionsRequirement = 3;
+    int mRequestMayBeNested = false;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureRequest::Flags )

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -57,7 +57,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   {
     //QgsDebugMsg( "Feature iterator of " + mSource->mLayerName + ": acquiring connection");
     mConn = QgsOgrConnPool::instance()->acquireConnection( QgsOgrProviderUtils::connectionPoolId( mSource->mDataSource ), request.connectionTimeout(), request.requestMayBeNested() );
-    if ( !mConn->ds )
+    if ( !mConn || !mConn->ds )
     {
       return;
     }

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -56,7 +56,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   else
   {
     //QgsDebugMsg( "Feature iterator of " + mSource->mLayerName + ": acquiring connection");
-    mConn = QgsOgrConnPool::instance()->acquireConnection( QgsOgrProviderUtils::connectionPoolId( mSource->mDataSource ) );
+    mConn = QgsOgrConnPool::instance()->acquireConnection( QgsOgrProviderUtils::connectionPoolId( mSource->mDataSource ), request.connectionTimeout(), request.requestMayBeNested() );
     if ( !mConn->ds )
     {
       return;

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -29,7 +29,7 @@
 QgsOracleFeatureIterator::QgsOracleFeatureIterator( QgsOracleFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsOracleFeatureSource>( source, ownSource, request )
 {
-  mConnection = QgsOracleConnPool::instance()->acquireConnection( QgsOracleConn::toPoolName( mSource->mUri ) );
+  mConnection = QgsOracleConnPool::instance()->acquireConnection( QgsOracleConn::toPoolName( mSource->mUri ), request.connectionTimeout(), request.requestMayBeNested() );
   if ( !mConnection )
   {
     close();

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -38,7 +38,7 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
 
   if ( !source->mTransactionConnection )
   {
-    mConn = QgsPostgresConnPool::instance()->acquireConnection( mSource->mConnInfo );
+    mConn = QgsPostgresConnPool::instance()->acquireConnection( mSource->mConnInfo, request.connectionTimeout(), request.freeConnectionsRequirement() );
     mIsTransactionConnection = false;
   }
   else

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -38,7 +38,7 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
 
   if ( !source->mTransactionConnection )
   {
-    mConn = QgsPostgresConnPool::instance()->acquireConnection( mSource->mConnInfo, request.connectionTimeout(), request.freeConnectionsRequirement() );
+    mConn = QgsPostgresConnPool::instance()->acquireConnection( mSource->mConnInfo, request.connectionTimeout(), request.requestMayBeNested() );
     mIsTransactionConnection = false;
   }
   else

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -29,7 +29,7 @@
 QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsSpatiaLiteFeatureSource>( source, ownSource, request )
 {
-  mHandle = QgsSpatiaLiteConnPool::instance()->acquireConnection( mSource->mSqlitePath );
+  mHandle = QgsSpatiaLiteConnPool::instance()->acquireConnection( mSource->mSqlitePath, request.connectionTimeout(), request.requestMayBeNested() );
 
   mFetchGeometry = !mSource->mGeometryColumn.isNull() && !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
   mHasPrimaryKey = !mSource->mPrimaryKey.isEmpty();

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -905,7 +905,7 @@ class ProviderTestCase(FeatureSourceTestCase):
         # Run an expression that will also do a request and should use a spare
         # connection. It just should not deadlock here.
 
-        feat = next(it)
+        feat = next(iterators[0])
         context = QgsExpressionContext()
         context.setFeature(feat)
         exp = QgsExpression('get_feature(\'{layer}\', \'pk\', 5)'.format(layer=self.vl.id()))

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -25,6 +25,7 @@ from qgis.core import (
     QgsAbstractFeatureIterator,
     QgsExpressionContextScope,
     QgsExpressionContext,
+    QgsExpression,
     QgsVectorDataProvider,
     QgsVectorLayerFeatureSource,
     QgsFeatureSink,

--- a/tests/src/python/providertestbase.py
+++ b/tests/src/python/providertestbase.py
@@ -17,6 +17,7 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 __revision__ = '$Format:%H$'
 
 from qgis.core import (
+    QgsApplication,
     QgsRectangle,
     QgsFeatureRequest,
     QgsFeature,
@@ -886,3 +887,25 @@ class ProviderTestCase(FeatureSourceTestCase):
                 self.assertEqual(count, 5)
                 self.assertFalse(iterator.compileFailed())
                 self.disableCompiler()
+
+    def testConcurrency(self):
+        """
+        The connection pool has a maximum of 4 connections defined (+2 spare connections)
+        Make sure that if we exhaust those 4 connections and force another connection
+        it is actually using the spare connections and does not freeze.
+        This situation normally happens when (at least) 4 rendering threads are active
+        in parallel and one requires an expression to be evaluated.
+        """
+        # Acquire the maximum amount of concurrent connections
+        iterators = list()
+        for i in range(QgsApplication.instance().maxConcurrentConnectionsPerPool()):
+            iterators.append(self.vl.getFeatures())
+
+        # Run an expression that will also do a request and should use a spare
+        # connection. It just should not deadlock here.
+
+        feat = next(it)
+        context = QgsExpressionContext()
+        context.setFeature(feat)
+        exp = QgsExpression('get_feature(\'{layer}\', \'pk\', 5)'.format(layer=self.vl.id()))
+        exp.evaluate(context)

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -1143,32 +1143,6 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(g.childCount(), 1)
         self.assertTrue(g.childGeometry(0).vertexCount() > 3)
 
-    def testConcurrency(self):
-        """
-        The connection pool has a maximum of 4 connections defined (+2 spare connections)
-        Make sure that if we exhaust those 4 connections and force another connection
-        it is actually using the spare connections and does not freeze.
-        This situation normally happens when (at least) 4 rendering threads are active
-        in parallel and one requires an expression to be evaluated.
-        """
-        vl = QgsVectorLayer('{conn} srid=4326 table="qgis_test".{table} (geom) sql='.format(conn=self.dbconn, table='someData'), "testgeom", "postgres")
-        self.assertTrue(vl.isValid())
-        QgsProject.instance().addMapLayer(vl)
-
-        # Acquire the maximum amount of concurrent connections
-        iterators = list()
-        for i in range(QgsApplication.instance().maxConcurrentConnectionsPerPool()):
-            iterators.append(vl.getFeatures())
-
-        # Run an expression that will also do a request and should use a spare
-        # connection. It just should not deadlock here.
-
-        feat = next(it)
-        context = QgsExpressionContext()
-        context.setFeature(feat)
-        exp = QgsExpression('get_feature(\'{layer}\', \'pk\', 5)'.format(layer=vl.id()))
-        exp.evaluate(context)
-
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
 

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -44,7 +44,9 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsProject,
     QgsWkbTypes,
-    QgsGeometry
+    QgsGeometry,
+    QgsExpression,
+    QgsExpressionContext
 )
 from qgis.gui import QgsGui, QgsAttributeForm
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir, QObject
@@ -1140,6 +1142,27 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(g.wkbType(), QgsWkbTypes.MultiPolygon)
         self.assertEqual(g.childCount(), 1)
         self.assertTrue(g.childGeometry(0).vertexCount() > 3)
+
+    def testConcurrency(self):
+        """
+        The connection pool has a maximum of 4 connections defined (+2 spare connections)
+        Make sure that if we exhaust those 4 connections and force another connection
+        it is actually using the spare connections and does not freeze.
+        This situation normally happens when (at least) 4 rendering threads are active
+        in parallel and one requires an expression to be evaluated.
+        """
+        vl = QgsVectorLayer('{conn} srid=4326 table="qgis_test".{table} (geom) sql='.format(conn=self.dbconn, table='someData'), "testgeom", "postgres")
+        self.assertTrue(vl.isValid())
+        it = vl.getFeatures()
+        it2 = vl.getFeatures()
+        it3 = vl.getFeatures()
+        it4 = vl.getFeatures()
+        QgsProject.instance().addMapLayer(vl)
+        feat = next(it)
+        context = QgsExpressionContext()
+        context.setFeature(feat)
+        exp = QgsExpression('get_feature(\'{layer}\', \'pk\', 5)'.format(layer=vl.id()))
+        exp.evaluate(context)
 
 
 class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -44,9 +44,7 @@ from qgis.core import (
     QgsCoordinateReferenceSystem,
     QgsProject,
     QgsWkbTypes,
-    QgsGeometry,
-    QgsExpression,
-    QgsExpressionContext
+    QgsGeometry
 )
 from qgis.gui import QgsGui, QgsAttributeForm
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir, QObject


### PR DESCRIPTION
Using `get_feature` in a styling or labeling expression can lead to deadlocks of the rendering.

The reason for this is, when already 4 (maximum connection count) iterators are open and the `get_feature` function is executed and tries to acquire a new connection, it will not get one and wait forever, preventing the outer iterator to ever free the lock it holds on the connection pool. I assume this gets especially tricky if we have previews being rendered in parallel and then have four iterators with nested ones open, all in deadlock state.

This pull request increases the connection pool size by 2 (from 4 to 6) and keeps the 2 connections as "spare connections" around, which can be used by expression functions - or other critical pieces of code.

I'm not super excited about the new API that complicates QgsFeatureRequest, so if there is any input on how to improve that, it will be appreciated.

**TODO**

 - [x] Apply to Postgres Connection Pool
 - [x] Apply to OGR Connection Pool
 - [x] Apply to SpatiaLite Connection Pool
 - [x] Apply to Oracle Connection Pool