### PR TITLE
Thread safety for get_feature

### DIFF
--- a/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerfeatureiterator.sip.in
@@ -54,7 +54,15 @@ Returns the coordinate reference system for features retrieved from this source.
 .. versionadded:: 3.0
 %End
 
+    QString id() const;
+%Docstring
+Returns the layer id of the source layer.
+
+.. versionadded:: 3.4
+%End
+
   protected:
+
 
 
 

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -32,6 +32,7 @@ QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( const QgsVectorLayer *
   QMutexLocker locker( &layer->mFeatureSourceConstructorMutex );
   mProviderFeatureSource = layer->dataProvider()->featureSource();
   mFields = layer->fields();
+  mId = layer->id();
 
   // update layer's join caches if necessary
   if ( layer->mJoinBuffer->containsJoins() )
@@ -105,6 +106,11 @@ QgsFields QgsVectorLayerFeatureSource::fields() const
 QgsCoordinateReferenceSystem QgsVectorLayerFeatureSource::crs() const
 {
   return mCrs;
+}
+
+QString QgsVectorLayerFeatureSource::id() const
+{
+  return mId;
 }
 
 

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -78,6 +78,13 @@ class CORE_EXPORT QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
      */
     QgsCoordinateReferenceSystem crs() const;
 
+    /**
+     * Returns the layer id of the source layer.
+     *
+     * \since QGIS 3.4
+     */
+    QString id() const;
+
   protected:
 
     QgsAbstractFeatureSource *mProviderFeatureSource = nullptr;
@@ -87,6 +94,8 @@ class CORE_EXPORT QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
     QgsExpressionFieldBuffer *mExpressionFieldBuffer = nullptr;
 
     QgsFields mFields;
+
+    QString mId;
 
     QgsExpressionContextScope mLayerScope;
 


### PR DESCRIPTION
Some expression functions like `get_feature` internally use layers to work. The pointer to the layer itself is guarded with a weak pointer. But that still leaves room for concurrency issues in multi threading scenarios, where the layer is modified while the expression function is working on it.

This can be avoided by doing all this work while the main thread is blocked.

There are more calls like this inside expression functions, so this is a first validation of the approach. I think it can be merged and backported, but I'd continue the work in the bugfixing period of 3.4 (or someone else is welcome to continue of course.)

Feedback?

It will only work with Qt >= 5.10, but this keeps code complexity quite a bit lower and given the *relatively* low risk of this happening, I'd go for this solution which should soon apply to most installations.