### PR TITLE
Improved warnings on closing projects with unsaved layers and memory layers

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5218,7 +5218,7 @@ void QgisApp::fileExit()
     return;
   }
 
-  if ( saveDirty() )
+  if ( checkUnsavedLayerEdits() && saveDirty() )
   {
     closeProject();
     userProfileManager()->setDefaultFromActive();
@@ -5253,7 +5253,7 @@ bool QgisApp::fileNew( bool promptToSaveFlag, bool forceBlank )
 
   if ( promptToSaveFlag )
   {
-    if ( !saveDirty() )
+    if ( !checkUnsavedLayerEdits() || !saveDirty() )
     {
       return false; //cancel pressed
     }
@@ -5347,7 +5347,7 @@ bool QgisApp::fileNewFromTemplate( const QString &fileName )
   if ( checkTasksDependOnProject() )
     return false;
 
-  if ( !saveDirty() )
+  if ( !checkUnsavedLayerEdits() || !saveDirty() )
   {
     return false; //cancel pressed
   }
@@ -5646,7 +5646,7 @@ void QgisApp::fileOpen()
     return;
 
   // possibly save any pending work before opening a new project
-  if ( saveDirty() )
+  if ( checkUnsavedLayerEdits() && saveDirty() )
   {
     // Retrieve last used project dir from persistent settings
     QgsSettings settings;
@@ -5678,6 +5678,9 @@ void QgisApp::fileRevert()
   if ( QMessageBox::question( this, tr( "Revert Project" ),
                               tr( "Are you sure you want to discard all unsaved changes the current project?" ),
                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No ) == QMessageBox::No )
+    return;
+
+  if ( !checkUnsavedLayerEdits() )
     return;
 
   // re-open the current project
@@ -6107,7 +6110,7 @@ void QgisApp::openProject( QAction *action )
     return;
 
   QString debugme = action->data().toString();
-  if ( saveDirty() )
+  if ( checkUnsavedLayerEdits() && saveDirty() )
     addProject( debugme );
 }
 
@@ -6133,7 +6136,7 @@ void QgisApp::openProject( const QString &fileName )
     return;
 
   // possibly save any pending work before opening a different project
-  if ( saveDirty() )
+  if ( checkUnsavedLayerEdits() && saveDirty() )
   {
     // error handling and reporting is in addProject() function
     addProject( fileName );
@@ -10915,6 +10918,30 @@ bool QgisApp::saveDirty()
   freezeCanvases( false );
 
   return answer != QMessageBox::Cancel;
+}
+
+bool QgisApp::checkUnsavedLayerEdits()
+{
+  // check to see if there are any vector layers with unsaved provider edits
+  // to ensure user has opportunity to save any editing
+  if ( QgsProject::instance()->count() > 0 )
+  {
+    const QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();
+    for ( auto it = layers.begin(); it != layers.end(); ++it )
+    {
+      if ( QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( it.value() ) )
+      {
+        const bool hasUnsavedEdits = ( vl->isEditable() && vl->isModified() );
+        if ( !hasUnsavedEdits )
+          continue;
+
+        if ( !toggleEditing( vl, true ) )
+          return false;
+      }
+    }
+  }
+
+  return true;
 }
 
 bool QgisApp::checkTasksDependOnProject()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10973,6 +10973,9 @@ bool QgisApp::checkUnsavedLayerEdits()
 
 bool QgisApp::checkMemoryLayers()
 {
+  if ( !QgsSettings().value( QStringLiteral( "askToSaveMemoryLayers" ), true, QgsSettings::App ).toBool() )
+    return true;
+
   // check to see if there are any memory layers present (with features)
   bool hasMemoryLayers = false;
   const QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1798,6 +1798,18 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     bool checkUnsavedLayerEdits();
 
+    /**
+     * Checks whether memory layers (with features) exist in the project, and if so
+     * shows a warning to users that their contents will be lost on
+     * project unload.
+     *
+     * Returns true if there are no memory layers present, or if the
+     * user opted to discard their contents. Returns false if there
+     * are memory layers present and the user clicked 'Cancel' on
+     * the warning dialog.
+     */
+    bool checkMemoryLayers();
+
     //! Checks for running tasks dependent on the open project
     bool checkTasksDependOnProject();
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1787,6 +1787,17 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \returns true if saved or discarded, false if canceled
      */
     bool saveDirty();
+
+    /**
+     * Checks for unsaved changes in open layers and prompts the user to save
+     * or discard these changes for each layer.
+     *
+     * Returns true if there are no unsaved layer edits remaining, or the user
+     * opted to discard them all. Returns false if the user opted to cancel
+     * on any layer.
+     */
+    bool checkUnsavedLayerEdits();
+
     //! Checks for running tasks dependent on the open project
     bool checkTasksDependOnProject();
 


### PR DESCRIPTION
This PR:

1. Improves the current "unsaved changes in a layer" warnings on closing projects, to move this warning to occur BEFORE the "unsaved project" dialog. This now allows users to cancel the close when a layer has unsaved edits, where before they had no option but to either discard or save the changes. Sometimes you want to manually see and decide what action to take - which the new cancel option allows. It also fixes a bug where sometimes the "unsaved layer changes" warning wouldn't appear for some layers. Additionally, we now avoid showing the "unsaved layer changes" warning for memory layers -- it's misleading, because on project close clicking "save" to this warning has no effect -- the memory layer's contents are discarded anyway.

2. Adds a new warning on project close if a layer contains ANY memory layers with features present. These layers are temporary only, and their contents will be lost on project close. Again, the default action is to cancel the project close, allowing users the chance to manually save these layers out to a permanent location if desired.

Should help avoid data loss for users working with memory layers, especially memory layers created as a result of processing algorithms. And it'll pair very nicely with #7516!

Note that I believe this should be classified as a bug fix and intend to backport to 3.2.

Screencast:

![peek 2018-08-03 11-28](https://user-images.githubusercontent.com/1829991/43619414-fecbd51e-9710-11e8-869e-9f71a04048bc.gif)
