### PR TITLE
[FEATURE] Add a menu entry to memory layers to Make Permanent

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7349,11 +7349,13 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOpt
   if ( !vlayer )
     return;
 
-  auto onSuccess = [this, vlayer]( const QString & newFilename,
-                                   bool addToCanvas,
-                                   const QString & layerName,
-                                   const QString & encoding,
-                                   const QString & vectorFileName )
+  const QString layerId = vlayer->id();
+
+  auto onSuccess = [this, layerId]( const QString & newFilename,
+                                    bool addToCanvas,
+                                    const QString & layerName,
+                                    const QString & encoding,
+                                    const QString & vectorFileName )
   {
     if ( addToCanvas )
     {
@@ -7363,7 +7365,10 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOpt
       this->addVectorLayers( QStringList( uri ), encoding, QStringLiteral( "file" ) );
     }
 
-    this->emit layerSavedAs( vlayer, vectorFileName );
+    // We need to re-retrieve the map layer here, in case it's been deleted during the lifetime of the task
+    if ( QgsVectorLayer *vlayer = qobject_cast< QgsVectorLayer * >( QgsProject::instance()->mapLayer( layerId ) ) )
+      this->emit layerSavedAs( vlayer, vectorFileName );
+
     this->messageBar()->pushMessage( tr( "Layer Exported" ),
                                      tr( "Successfully saved vector layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ),
                                      Qgis::Success, messageTimeout() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7166,7 +7166,7 @@ void QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer )
       emit layerSavedAs( rlWeakPointer, fileName );
 
     messageBar()->pushMessage( tr( "Layer Exported" ),
-                               tr( "Successfully saved raster layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( QFileInfo( newFilename ).path() ).toString(), QDir::toNativeSeparators( newFilename ) ),
+                               tr( "Successfully saved raster layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ),
                                Qgis::Success, messageTimeout() );
   } );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4304,7 +4304,7 @@ void QgisApp::about()
 
     versionString += QLatin1String( "</tr><tr>" );
 
-#if PROJ_HAS_INFO
+#ifdef PROJ_HAS_INFO
     PJ_INFO info = proj_info();
     versionString += "<td>" + tr( "Compiled against PROJ" ) + "</td><td>" + QString::number( PJ_VERSION ) + "</td>";
     versionString += "<td>" + tr( "Running against PROJ" ) + "</td><td>" + info.version + "</td>";

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7224,7 +7224,7 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
       QgsDataProvider::ProviderOptions options;
       vl->setDataSource( QStringLiteral( "%1" ).arg( newFilename ), vl->name(), QStringLiteral( "ogr" ), options );
       this->messageBar()->pushMessage( tr( "Layer Saved" ),
-                                       tr( "Successfully saved scratch layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( QFileInfo( newFilename ).path() ).toString(), QDir::toNativeSeparators( newFilename ) ),
+                                       tr( "Successfully saved scratch layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ),
                                        Qgis::Success, messageTimeout() );
     }
   };
@@ -7363,10 +7363,10 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOpt
       this->addVectorLayers( QStringList( uri ), encoding, QStringLiteral( "file" ) );
     }
 
-    this->emit layerSavedAs( vlayer, vectorFilename );
+    this->emit layerSavedAs( vlayer, vectorFileName );
     this->messageBar()->pushMessage( tr( "Layer Exported" ),
-                                       tr( "Successfully saved vector layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ),
-                                       Qgis::Success, messageTimeout() );
+                                     tr( "Successfully saved vector layer to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( newFilename ).toString(), QDir::toNativeSeparators( newFilename ) ),
+                                     Qgis::Success, messageTimeout() );
   };
 
   auto onFailure = []( int error, const QString & errorMessage )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7463,17 +7463,10 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOpt
     } );
 
     // when an error occurs:
-    connect( writerTask, &QgsVectorFileWriterTask::errorOccurred, this, [ = ]( int error, const QString & errorMessage )
+    connect( writerTask, &QgsVectorFileWriterTask::errorOccurred, this, [onFailure]( int error, const QString & errorMessage )
     {
-      if ( error != QgsVectorFileWriter::Canceled )
-      {
-        QgsMessageViewer *m = new QgsMessageViewer( nullptr );
-        m->setWindowTitle( tr( "Save Error" ) );
-        m->setMessageAsPlainText( tr( "Export to vector file failed.\nError: %1" ).arg( errorMessage ) );
-        m->exec();
-      }
-    }
-           );
+      onFailure( error, errorMessage );
+    } );
 
     QgsApplication::taskManager()->addTask( writerTask );
   }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7240,7 +7240,7 @@ void QgisApp::makeMemoryLayerPermanent( QgsVectorLayer *layer )
     }
   };
 
-  saveAsVectorFileGeneral( layer, true, false, onSuccess, onFailure );
+  saveAsVectorFileGeneral( layer, true, false, onSuccess, onFailure, 0, tr( "Save Scratch Layer" ) );
 }
 
 void QgisApp::saveAsLayerDefinition()
@@ -7383,17 +7383,18 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOpt
   saveAsVectorFileGeneral( vlayer, symbologyOption, onlySelected, onSuccess, onFailure );
 }
 
-void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption, bool onlySelected, const std::function<void( const QString &, bool, const QString &, const QString &, const QString & )> &onSuccess, const std::function<void ( int, const QString & )> &onFailure )
+void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption, bool onlySelected, const std::function<void( const QString &, bool, const QString &, const QString &, const QString & )> &onSuccess, const std::function<void ( int, const QString & )> &onFailure, int options, const QString &dialogTitle )
 {
   QgsCoordinateReferenceSystem destCRS;
 
-  int options = QgsVectorLayerSaveAsDialog::AllOptions;
   if ( !symbologyOption )
   {
     options &= ~QgsVectorLayerSaveAsDialog::Symbology;
   }
 
   QgsVectorLayerSaveAsDialog *dialog = new QgsVectorLayerSaveAsDialog( vlayer, options, this );
+  if ( !dialogTitle.isEmpty() )
+    dialog->setWindowTitle( dialogTitle );
 
   dialog->setMapCanvas( mMapCanvas );
   dialog->setIncludeZ( QgsWkbTypes::hasZ( vlayer->wkbType() ) );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -695,6 +695,13 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
   public slots:
     //! save current vector layer
     void saveAsFile( QgsMapLayer *layer = nullptr, bool onlySelected = false );
+
+    /**
+     * Makes a memory layer permanent, by prompting users to save the layer to a disk-based (OGR)
+     * format, and then replacing the layer's data source in place.
+     */
+    void makeMemoryLayerPermanent( QgsVectorLayer *layer );
+
     //! save qml style for the current layer
     void saveStyleFile( QgsMapLayer *layer = nullptr );
     //! save qrl definition for the current layer
@@ -1828,6 +1835,13 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void setLayoutAtlasFeature( QgsPrintLayout *layout, QgsMapLayer *layer, const QgsFeature &feat );
 
     void saveAsVectorFileGeneral( QgsVectorLayer *vlayer = nullptr, bool symbologyOption = true, bool onlySelected = false );
+
+    void saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption, bool onlySelected,
+                                  const std::function< void ( const QString &newFilename,
+                                      bool addToCanvas,
+                                      const QString &layerName,
+                                      const QString &encoding,
+                                      const QString &vectorFileName )> &onSuccess, const std::function< void ( int error, const QString &errorMessage ) > &onFailure );
 
     //! Sets project properties, including map untis
     void projectProperties( const QString  &currentPage = QString() );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -156,6 +156,7 @@ class QgsLayoutQptDropHandler;
 #include "qgsoptionswidgetfactory.h"
 #include "qgsattributetablefiltermodel.h"
 #include "qgsmasterlayoutinterface.h"
+#include "ogr/qgsvectorlayersaveasdialog.h"
 #include "ui_qgisapp.h"
 #include "qgis_app.h"
 
@@ -1841,7 +1842,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
                                       bool addToCanvas,
                                       const QString &layerName,
                                       const QString &encoding,
-                                      const QString &vectorFileName )> &onSuccess, const std::function< void ( int error, const QString &errorMessage ) > &onFailure );
+                                      const QString &vectorFileName )> &onSuccess, const std::function< void ( int error, const QString &errorMessage ) > &onFailure,
+                                  int dialogOptions = QgsVectorLayerSaveAsDialog::AllOptions,
+                                  const QString &dialogTitle = QString() );
 
     //! Sets project properties, including map untis
     void projectProperties( const QString  &currentPage = QString() );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -263,9 +263,9 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       {
         if ( vlayer->dataProvider()->name() == QLatin1String( "memory" ) )
         {
-          QAction *actionMakePermenant = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ), tr( "Make Permanent…" ), menu );
-          connect( actionMakePermenant, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->makeMemoryLayerPermanent( vlayer ); } );
-          menu->addAction( actionMakePermenant );
+          QAction *actionMakePermanent = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ), tr( "Make Permanent…" ), menu );
+          connect( actionMakePermanent, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->makeMemoryLayerPermanent( vlayer ); } );
+          menu->addAction( actionMakePermanent );
         }
         // save as vector file
         QMenu *menuExportVector = new QMenu( tr( "Export" ), menu );

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -261,6 +261,12 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       if ( vlayer )
       {
+        if ( vlayer->dataProvider()->name() == QLatin1String( "memory" ) )
+        {
+          QAction *actionMakePermenant = new QAction( QgsApplication::getThemeIcon( QStringLiteral( "mActionFileSave.svg" ) ), tr( "Make Permanent…" ), menu );
+          connect( actionMakePermenant, &QAction::triggered, QgisApp::instance(), [ = ] { QgisApp::instance()->makeMemoryLayerPermanent( vlayer ); } );
+          menu->addAction( actionMakePermenant );
+        }
         // save as vector file
         QMenu *menuExportVector = new QMenu( tr( "Export" ), menu );
         QAction *actionSaveAs = new QAction( tr( "Save Features As…" ), menuExportVector );

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -50,6 +50,7 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, i
   , mAttributeTableItemChangedSlotEnabled( true )
   , mReplaceRawFieldValuesStateChangedSlotEnabled( true )
   , mActionOnExistingFile( QgsVectorFileWriter::CreateOrOverwriteFile )
+  , mOptions( static_cast< Options >( options ) )
 {
   if ( layer )
   {
@@ -58,13 +59,33 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, i
   }
   setup();
 
-  if ( !( options & Symbology ) )
+  if ( !( mOptions & Symbology ) )
   {
     mSymbologyExportLabel->hide();
     mSymbologyExportComboBox->hide();
     mScaleLabel->hide();
     mScaleWidget->hide();
   }
+
+  if ( !( mOptions & DestinationCrs ) )
+  {
+    mCrsLabel->hide();
+    mCrsSelector->hide();
+  }
+  if ( !( mOptions & Fields ) )
+    mAttributesSelection->hide();
+
+  if ( !( mOptions & SelectedOnly ) )
+    mSelectedOnly->hide();
+
+  if ( !( mOptions & AddToCanvas ) )
+    mAddToCanvas->hide();
+
+  if ( !( mOptions & GeometryType ) )
+    mGeometryGroupBox->hide();
+
+  if ( !( mOptions & Extent ) )
+    mExtentGroupBox->hide();
 
   mSelectedOnly->setEnabled( layer && layer->selectedFeatureCount() != 0 );
   buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
@@ -376,12 +397,13 @@ void QgsVectorLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( int idx )
   }
   else
   {
-    mAttributesSelection->setVisible( true );
+    if ( mOptions & Fields )
+      mAttributesSelection->setVisible( true );
     fieldsAsDisplayedValues = ( sFormat == QLatin1String( "CSV" ) || sFormat == QLatin1String( "XLS" ) || sFormat == QLatin1String( "XLSX" ) || sFormat == QLatin1String( "ODS" ) );
   }
 
   // Show symbology options only for some formats
-  if ( QgsVectorFileWriter::supportsFeatureStyles( sFormat ) )
+  if ( QgsVectorFileWriter::supportsFeatureStyles( sFormat ) && ( mOptions & Symbology ) )
   {
     mSymbologyExportLabel->setVisible( true );
     mSymbologyExportComboBox->setVisible( true );
@@ -878,7 +900,7 @@ QgsWkbTypes::Type QgsVectorLayerSaveAsDialog::geometryType() const
     return QgsWkbTypes::Unknown;
   }
 
-  return ( QgsWkbTypes::Type )currentIndexData;
+  return static_cast< QgsWkbTypes::Type >( currentIndexData );
 }
 
 bool QgsVectorLayerSaveAsDialog::automaticGeometryType() const

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -38,11 +38,18 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     Q_OBJECT
 
   public:
-    // bitmask of options to be shown
+
+    //! Bitmask of options to be shown
     enum Options
     {
-      Symbology = 1,
-      AllOptions = ~0
+      Symbology = 1, //!< Show symbology options
+      DestinationCrs = 1 << 2, //!< Show destination CRS (reprojection) option
+      Fields = 1 << 3, //!< Show field customisation group
+      AddToCanvas = 1 << 4, //!< Show add to map option
+      SelectedOnly = 1 << 5, //!< Show selected features only option
+      GeometryType = 1 << 6, //!< Show geometry group
+      Extent = 1 << 7, //!< Show extent group
+      AllOptions = ~0 //!< Show all options
     };
 
     QgsVectorLayerSaveAsDialog( long srsid, QWidget *parent = nullptr, Qt::WindowFlags fl = nullptr );
@@ -156,6 +163,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     bool mAttributeTableItemChangedSlotEnabled;
     bool mReplaceRawFieldValuesStateChangedSlotEnabled;
     QgsVectorFileWriter::ActionOnExistingFile mActionOnExistingFile;
+    Options mOptions = AllOptions;
 };
 
 #endif // QGSVECTORLAYERSAVEASDIALOG_H

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -44,7 +44,7 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     {
       Symbology = 1, //!< Show symbology options
       DestinationCrs = 1 << 2, //!< Show destination CRS (reprojection) option
-      Fields = 1 << 3, //!< Show field customisation group
+      Fields = 1 << 3, //!< Show field customization group
       AddToCanvas = 1 << 4, //!< Show add to map option
       SelectedOnly = 1 << 5, //!< Show selected features only option
       GeometryType = 1 << 6, //!< Show geometry group

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -24,7 +24,7 @@
     <widget class="QWidget" name="widget" native="true">
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="3" column="0">
-       <widget class="QLabel" name="label_3">
+       <widget class="QLabel" name="mCrsLabel">
         <property name="text">
          <string>CRS</string>
         </property>


### PR DESCRIPTION
Prompts for a location to save the layer to, then replaces it in place (keeping the same id, style, etc)

Goes best with a healthy serving of #7522  and #7516 

TODO: hide some of the vector file dialog settings which shouldn't be changed here, e.g. the field choices

![peek 2018-08-03 14-33](https://user-images.githubusercontent.com/1829991/43625336-d685aaf2-972f-11e8-940e-84920714fc3c.gif)

