### PR TITLE
[FEATURE] Welcome page Open Directory improvements

### DIFF
--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -19,6 +19,9 @@
 #include "qgsversioninfo.h"
 #include "qgsapplication.h"
 #include "qgssettings.h"
+#include "qgsgui.h"
+#include "qgsnative.h"
+#include "qgsfileutils.h"
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
@@ -151,9 +154,7 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
     QAction *openFolderAction = new QAction( tr( "Open Directory…" ), menu );
     connect( openFolderAction, &QAction::triggered, this, [path]
     {
-      QFileInfo fi( path );
-      QString folder = fi.path();
-      QDesktopServices::openUrl( QUrl::fromLocalFile( folder ) );
+      QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( path );
     } );
     menu->addAction( openFolderAction );
   }

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -166,6 +166,16 @@ void QgsWelcomePage::showContextMenuForProjects( QPoint point )
       mModel->recheckProject( index );
     } );
     menu->addAction( rescanAction );
+
+    // add an entry to open the closest existing path to the original project file location
+    // to help users re-find moved/renamed projects!
+    const QString closestPath = QgsFileUtils::findClosestExistingPath( path );
+    QAction *openFolderAction = new QAction( tr( "Open “%1”…" ).arg( QDir::toNativeSeparators( closestPath ) ), menu );
+    connect( openFolderAction, &QAction::triggered, this, [closestPath]
+    {
+      QDesktopServices::openUrl( QUrl::fromLocalFile( closestPath ) );
+    } );
+    menu->addAction( openFolderAction );
   }
   QAction *removeProjectAction = new QAction( tr( "Remove from List" ), menu );
   connect( removeProjectAction, &QAction::triggered, this, [this, index]


### PR DESCRIPTION
-  Make welcome page Open Directory action highlight project file

- Add Open Directory option to disabled welcome page projects . This allows users to open the closest existing path to the original project location in their file manager, to hopefully help them re-locate missing/moved/renamed projects.