### PR TITLE
Bugfix GUI offline_editing

### DIFF
--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -177,6 +177,7 @@ void QgsOfflineEditingPluginGui::mBrowseButton_clicked()
         mOfflineDataPath = QFileInfo( fileName ).absolutePath();
         mOfflineDataPathLineEdit->setText( fileName );
       }
+      break;
     }
     case QgsOfflineEditing::SpatiaLite:
     {
@@ -197,6 +198,7 @@ void QgsOfflineEditingPluginGui::mBrowseButton_clicked()
         mOfflineDataPath = QFileInfo( fileName ).absolutePath();
         mOfflineDataPathLineEdit->setText( fileName );
       }
+      break;
     }
   }
 }


### PR DESCRIPTION
On selecting GPKG file, the SQLite still opened because of missing `break;`
Stupid mistake and mine of this feature #7369 