### PR TITLE
Count and report progress based on expected total

### DIFF
--- a/python/plugins/processing/algs/qgis/RegularPoints.py
+++ b/python/plugins/processing/algs/qgis/RegularPoints.py
@@ -38,12 +38,11 @@ from qgis.core import (QgsApplication,
                        QgsFeature,
                        QgsWkbTypes,
                        QgsGeometry,
-                       QgsPointXY,
+                       QgsPoint,
                        QgsProcessing,
                        QgsProcessingException,
                        QgsProcessingParameterDistance,
                        QgsProcessingParameterExtent,
-                       QgsProcessingParameterNumber,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterCrs,
                        QgsProcessingParameterFeatureSink)
@@ -145,11 +144,11 @@ class RegularPoints(QgisAlgorithm):
                     break
 
                 if randomize:
-                    geom = QgsGeometry().fromPointXY(QgsPointXY(
+                    geom = QgsGeometry(QgsPoint(
                         uniform(x - (pSpacing / 2.0), x + (pSpacing / 2.0)),
                         uniform(y - (pSpacing / 2.0), y + (pSpacing / 2.0))))
                 else:
-                    geom = QgsGeometry().fromPointXY(QgsPointXY(x, y))
+                    geom = QgsGeometry(QgsPoint(x, y))
 
                 if extent_engine.intersects(geom.constGet()):
                     f.setAttributes([id])

--- a/python/plugins/processing/algs/qgis/RegularPoints.py
+++ b/python/plugins/processing/algs/qgis/RegularPoints.py
@@ -155,8 +155,10 @@ class RegularPoints(QgisAlgorithm):
                     f.setGeometry(geom)
                     sink.addFeature(f, QgsFeatureSink.FastInsert)
                     x += pSpacing
-                    count += 1
-                    feedback.setProgress(int(count * total))
+
+                count += 1
+                feedback.setProgress(int(count * total))
+                
             y = y - pSpacing
 
         return {self.OUTPUT: dest_id}

--- a/python/plugins/processing/algs/qgis/RegularPoints.py
+++ b/python/plugins/processing/algs/qgis/RegularPoints.py
@@ -130,6 +130,7 @@ class RegularPoints(QgisAlgorithm):
         f.setFields(fields)
 
         count = 0
+        id = 0
         total = 100.0 / (area / pSpacing)
         y = extent.yMaximum() - inset
 
@@ -151,10 +152,11 @@ class RegularPoints(QgisAlgorithm):
                     geom = QgsGeometry().fromPointXY(QgsPointXY(x, y))
 
                 if extent_engine.intersects(geom.constGet()):
-                    f.setAttribute('id', count)
+                    f.setAttributes([id])
                     f.setGeometry(geom)
                     sink.addFeature(f, QgsFeatureSink.FastInsert)
                     x += pSpacing
+                    id += 1
 
                 count += 1
                 feedback.setProgress(int(count * total))

--- a/python/plugins/processing/algs/qgis/RegularPoints.py
+++ b/python/plugins/processing/algs/qgis/RegularPoints.py
@@ -158,7 +158,7 @@ class RegularPoints(QgisAlgorithm):
 
                 count += 1
                 feedback.setProgress(int(count * total))
-                
+
             y = y - pSpacing
 
         return {self.OUTPUT: dest_id}


### PR DESCRIPTION
Algorithm appears to freeze without progress while `extent_engine.intersects(geom.constGet())` returns false. 

This keeps the progress bar continuous and smooth, even if the feature ends up not being added.

(noticed this because the algo hangs for 2 mins while processing a large dataset which I think is outside the extent somehow. None of the points going in. No apparent progress.)

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
