### PR TITLE
Add API to send native desktop notifications to QgsNative

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -416,8 +416,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      *
      * \param title
      * \param message
+     * \param replaceExisting set to true to replace any existing notifications, or false to add a new notification
      */
-    void showSystemNotification( const QString &title, const QString &message );
+    void showSystemNotification( const QString &title, const QString &message, bool replaceExisting = true );
 
 
     //! Actions to be inserted in menus and toolbars

--- a/src/native/linux/qgslinuxnative.cpp
+++ b/src/native/linux/qgslinuxnative.cpp
@@ -21,6 +21,12 @@
 #include <QString>
 #include <QtDBus/QtDBus>
 #include <QtDebug>
+#include <QImage>
+
+QgsNative::Capabilities QgsLinuxNative::capabilities() const
+{
+  return NativeDesktopNotifications;
+}
 
 void QgsLinuxNative::openFileExplorerAndSelectFile( const QString &path )
 {
@@ -40,4 +46,118 @@ void QgsLinuxNative::openFileExplorerAndSelectFile( const QString &path )
   {
     QgsNative::openFileExplorerAndSelectFile( path );
   }
+}
+
+/**
+ * Automatic marshaling of a QImage for org.freedesktop.Notifications.Notify
+ *
+ * This function is from the Clementine project (see
+ * http://www.clementine-player.org) and licensed under the GNU General Public
+ * License, version 3 or later.
+ *
+ * Copyright 2010, David Sansome <me@davidsansome.com>
+ */
+QDBusArgument &operator<<( QDBusArgument &arg, const QImage &image )
+{
+  if ( image.isNull() )
+  {
+    arg.beginStructure();
+    arg << 0 << 0 << 0 << false << 0 << 0 << QByteArray();
+    arg.endStructure();
+    return arg;
+  }
+
+  QImage scaled = image.scaledToHeight( 100, Qt::SmoothTransformation );
+  scaled = scaled.convertToFormat( QImage::Format_ARGB32 );
+
+#if Q_BYTE_ORDER == Q_LITTLE_ENDIAN
+  // ABGR -> ARGB
+  QImage i = scaled.rgbSwapped();
+#else
+  // ABGR -> GBAR
+  QImage i( scaled.size(), scaled.format() );
+  for ( int y = 0; y < i.height(); ++y )
+  {
+    QRgb *p = ( QRgb * ) scaled.scanLine( y );
+    QRgb *q = ( QRgb * ) i.scanLine( y );
+    QRgb *end = p + scaled.width();
+    while ( p < end )
+    {
+      *q = qRgba( qGreen( *p ), qBlue( *p ), qAlpha( *p ), qRed( *p ) );
+      p++;
+      q++;
+    }
+  }
+#endif
+
+  arg.beginStructure();
+  arg << i.width();
+  arg << i.height();
+  arg << i.bytesPerLine();
+  arg << i.hasAlphaChannel();
+  int channels = i.isGrayscale() ? 1 : ( i.hasAlphaChannel() ? 4 : 3 );
+  arg << i.depth() / channels;
+  arg << channels;
+  arg << QByteArray( reinterpret_cast<const char *>( i.bits() ), i.numBytes() );
+  arg.endStructure();
+  return arg;
+}
+
+const QDBusArgument &operator>>( const QDBusArgument &arg, QImage & )
+{
+  // This is needed to link but shouldn't be called.
+  Q_ASSERT( 0 );
+  return arg;
+}
+
+QgsNative::NotificationResult QgsLinuxNative::showDesktopNotification( const QString &summary, const QString &body, const NotificationSettings &settings )
+{
+  NotificationResult result;
+  result.successful = false;
+
+  if ( !QDBusConnection::sessionBus().isConnected() )
+  {
+    return result;
+  }
+
+  qDBusRegisterMetaType<QImage>();
+
+  QDBusInterface iface( QStringLiteral( "org.freedesktop.Notifications" ),
+                        QStringLiteral( "/org/freedesktop/Notifications" ),
+                        QStringLiteral( "org.freedesktop.Notifications" ),
+                        QDBusConnection::sessionBus() );
+
+  QVariantMap hints;
+  hints[QStringLiteral( "transient" )] = settings.transient;
+  if ( !settings.image.isNull() )
+    hints[QStringLiteral( "image_data" )] = settings.image;
+
+  QVariantList argumentList;
+  argumentList << "qgis"; //app_name
+  // replace_id
+  if ( settings.messageId.isValid() )
+    argumentList << static_cast< uint >( settings.messageId.toInt() );
+  else
+    argumentList << static_cast< uint >( 0 );
+  // app_icon
+  if ( !settings.svgAppIconPath.isEmpty() )
+    argumentList << settings.svgAppIconPath;
+  else
+    argumentList << "";
+  argumentList << summary; // summary
+  argumentList << body; // body
+  argumentList << QStringList();  // actions
+  argumentList << hints;  // hints
+  argumentList << -1; // timeout in ms "If -1, the notification's expiration time is dependent on the notification server's settings, and may vary for the type of notification."
+
+  QDBusMessage reply = iface.callWithArgumentList( QDBus::AutoDetect, QStringLiteral( "Notify" ), argumentList );
+  if ( reply.type() == QDBusMessage::ErrorMessage )
+  {
+    qDebug() << "D-Bus Error:" << reply.errorMessage();
+    return result;
+  }
+
+  result.successful = true;
+  result.messageId = reply.arguments().value( 0 );
+  return result;
 }

--- a/src/native/linux/qgslinuxnative.h
+++ b/src/native/linux/qgslinuxnative.h
@@ -20,10 +20,22 @@
 
 #include "qgsnative.h"
 
+/**
+ * Native implementation for linux platforms.
+ *
+ * Implements the native platform interface for Linux based platforms. This is
+ * intended to expose desktop-agnostic implementations of the QgsNative methods,
+ * so that they work without issue across the wide range of Linux desktop environments
+ * (e.g. Gnome/KDE).
+ *
+ * Typically, this means implementing methods using DBUS calls to freedesktop standards.
+ */
 class NATIVE_EXPORT QgsLinuxNative : public QgsNative
 {
   public:
+    QgsNative::Capabilities capabilities() const override;
     void openFileExplorerAndSelectFile( const QString &path ) override;
+    NotificationResult showDesktopNotification( const QString &summary, const QString &body, const NotificationSettings &settings = NotificationSettings() ) override;
 };
 
 #endif // QGSLINUXNATIVE_H

--- a/src/native/qgsnative.cpp
+++ b/src/native/qgsnative.cpp
@@ -47,7 +47,7 @@ void QgsNative::showUndefinedApplicationProgress()
 
 }
 
-void QgsNative::setApplicationProgress( double progress )
+void QgsNative::setApplicationProgress( double )
 {
 
 }

--- a/src/native/qgsnative.cpp
+++ b/src/native/qgsnative.cpp
@@ -21,6 +21,11 @@
 #include <QUrl>
 #include <QFileInfo>
 
+QgsNative::Capabilities QgsNative::capabilities() const
+{
+  return nullptr;
+}
+
 void QgsNative::initializeMainWindow( QWindow * )
 {
 
@@ -50,4 +55,11 @@ void QgsNative::setApplicationProgress( double progress )
 void QgsNative::hideApplicationProgress()
 {
 
+}
+
+QgsNative::NotificationResult QgsNative::showDesktopNotification( const QString &, const QString &, const NotificationSettings & )
+{
+  NotificationResult result;
+  result.successful = false;
+  return result;
 }

--- a/src/native/qgsnative.h
+++ b/src/native/qgsnative.h
@@ -19,6 +19,8 @@
 #define QGSNATIVE_H
 
 #include "qgis_native.h"
+#include <QImage>
+#include <QVariant>
 
 class QString;
 class QWindow;
@@ -34,7 +36,19 @@ class NATIVE_EXPORT QgsNative
 {
   public:
 
+    //! Native interface capabilities
+    enum Capability
+    {
+      NativeDesktopNotifications = 1 << 1, //!< Native desktop notifications are supported. See showDesktopNotification().
+    };
+    Q_DECLARE_FLAGS( Capabilities, Capability )
+
     virtual ~QgsNative() = default;
+
+    /**
+     * Returns the native interface's capabilities.
+     */
+    virtual Capabilities capabilities() const;
 
     /**
      * Initializes the native interface, using the specified \a window.
@@ -97,6 +111,59 @@ class NATIVE_EXPORT QgsNative
      */
     virtual void hideApplicationProgress();
 
+
+    /**
+     * Notification settings, for use with showDesktopNotification().
+     */
+    struct NotificationSettings
+    {
+      NotificationSettings() {}
+
+      //! Optional image to show in notification
+      QImage image;
+
+      //! Whether the notification should be transient (the meaning varies depending on platform)
+      bool transient = true;
+
+      //! Path to application icon in SVG format
+      QString svgAppIconPath;
+
+      //! Message ID, used to replace existing messages
+      QVariant messageId;
+    };
+
+    /**
+     * Result of sending a desktop notification, returned by showDesktopNotification().
+     */
+    struct NotificationResult
+    {
+      NotificationResult() {}
+
+      //! True if notification was successfully sent.
+      bool successful = false;
+
+      //! Unique notification message ID, used by some platforms to identify the notification
+      QVariant messageId;
+    };
+
+    /**
+     * Shows a native desktop notification.
+     *
+     * The \a summary argument specifies a short title for the notification, and the \a body argument
+     * specifies the complete notification message text.
+     *
+     * The \a settings argument allows fine-tuning of the notification, using a range of settings which
+     * may or may not be respected on all platforms. It is recommended to set as many of these properties
+     * as is applicable, and let the native implementation choose which to use based on the platform's
+     * capabilities.
+     *
+     * This method is only supported when the interface returns the NativeDesktopNotifications flag for capabilities().
+     *
+     * Returns true if notification was successfully sent.
+     */
+    virtual NotificationResult showDesktopNotification( const QString &summary, const QString &body, const NotificationSettings &settings = NotificationSettings() );
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsNative::Capabilities )
 
 #endif // QGSNATIVE_H


### PR DESCRIPTION
And use native desktop notifications on Linux (via dbus). This avoids unnecessary system tray icon creation, which is a pre-requisite for the Qt desktop notification implemention. This should avoid annoying notifications on certain Linux desktop environments, and should also allow us to use prettier Windows notifications (when implemented!)

OSX devs: https://wiki.qt.io/How_to_use_OS_X_Notification_Center or https://stackoverflow.com/questions/22142592/mac-os-usernotificationcenter-in-qt might help with implementing this! 