### PR TITLE
Refine QgsFeatureRequest timeout api, dox, avoid a UI block

### DIFF
--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -637,7 +637,7 @@ Check if a feature is accepted by this requests filter
 
     int connectionTimeout() const;
 %Docstring
-The timeout for how long we should wait for a connection if none is available from the pool
+Returns the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
 at this moment. A negative value (which is set by default) will wait forever.
 
 .. note::
@@ -647,9 +647,9 @@ at this moment. A negative value (which is set by default) will wait forever.
 .. versionadded:: 3.0
 %End
 
-    void setConnectionTimeout( int connectionTimeout );
+    QgsFeatureRequest &setConnectionTimeout( int connectionTimeout );
 %Docstring
-The timeout for how long we should wait for a connection if none is available from the pool
+Sets the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
 at this moment. A negative value (which is set by default) will wait forever.
 
 .. note::
@@ -673,7 +673,7 @@ expression function.
 .. versionadded:: 3.4
 %End
 
-    void setRequestMayBeNested( bool requestMayBeNested );
+    QgsFeatureRequest &setRequestMayBeNested( bool requestMayBeNested );
 %Docstring
 In case this request may be run nested within another already running
 iteration on the same connection, set this to true.

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -294,9 +294,10 @@ int QgsFeatureRequest::connectionTimeout() const
   return mConnectionTimeout;
 }
 
-void QgsFeatureRequest::setConnectionTimeout( int connectionTimeout )
+QgsFeatureRequest &QgsFeatureRequest::setConnectionTimeout( int connectionTimeout )
 {
   mConnectionTimeout = connectionTimeout;
+  return *this;
 }
 
 bool QgsFeatureRequest::requestMayBeNested() const
@@ -304,9 +305,10 @@ bool QgsFeatureRequest::requestMayBeNested() const
   return mRequestMayBeNested;
 }
 
-void QgsFeatureRequest::setRequestMayBeNested( bool requestMayBeNested )
+QgsFeatureRequest &QgsFeatureRequest::setRequestMayBeNested( bool requestMayBeNested )
 {
   mRequestMayBeNested = requestMayBeNested;
+  return *this;
 }
 
 

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -617,7 +617,7 @@ class CORE_EXPORT QgsFeatureRequest
     bool acceptFeature( const QgsFeature &feature );
 
     /**
-     * The timeout for how long we should wait for a connection if none is available from the pool
+     * Returns the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
      * at this moment. A negative value (which is set by default) will wait forever.
      *
      * \note Only works if the provider supports this option.
@@ -627,14 +627,14 @@ class CORE_EXPORT QgsFeatureRequest
     int connectionTimeout() const;
 
     /**
-     * The timeout for how long we should wait for a connection if none is available from the pool
+     * Sets the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
      * at this moment. A negative value (which is set by default) will wait forever.
      *
      * \note Only works if the provider supports this option.
      *
      * \since QGIS 3.0
      */
-    void setConnectionTimeout( int connectionTimeout );
+    QgsFeatureRequest &setConnectionTimeout( int connectionTimeout );
 
     /**
      * In case this request may be run nested within another already running
@@ -662,7 +662,7 @@ class CORE_EXPORT QgsFeatureRequest
      *
      * \since QGIS 3.4
      */
-    void setRequestMayBeNested( bool requestMayBeNested );
+    QgsFeatureRequest &setRequestMayBeNested( bool requestMayBeNested );
 
   protected:
     FilterType mFilter = FilterNone;

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -253,7 +253,8 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
   //get first feature from layer for previews
   if ( mVectorLayer )
   {
-    QgsFeatureIterator it = mVectorLayer->getFeatures( QgsFeatureRequest().setLimit( 1 ) );
+    // short timeout for request - it doesn't really matter if we don't get the feature, and this call is blocking UI
+    QgsFeatureIterator it = mVectorLayer->getFeatures( QgsFeatureRequest().setLimit( 1 ).setConnectionTimeout( 100 ) );
     it.nextFeature( mPreviewFeature );
     mPreviewExpressionContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mVectorLayer ) );
     mPreviewExpressionContext.setFeature( mPreviewFeature );


### PR DESCRIPTION
- Small refinements to QgsFeatureRequest API and docs,
- Add a short connection timeout for symbol selector preview feature fetching .Because we don't really care if we couldn't fulfill this request, and the request itself is blocking UI.