### PR TITLE
[wfs] Respect request timeout when retrieving features

### DIFF
--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -635,7 +635,7 @@ Check if a feature is accepted by this requests filter
 .. versionadded:: 2.1
 %End
 
-    int connectionTimeout() const;
+ int connectionTimeout() const /Deprecated/;
 %Docstring
 Returns the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
 at this moment. A negative value (which is set by default) will wait forever.
@@ -644,10 +644,12 @@ at this moment. A negative value (which is set by default) will wait forever.
 
    Only works if the provider supports this option.
 
+.. deprecated:: Use timeout() instead.
+
 .. versionadded:: 3.0
 %End
 
-    QgsFeatureRequest &setConnectionTimeout( int connectionTimeout );
+ QgsFeatureRequest &setConnectionTimeout( int connectionTimeout ) /Deprecated/;
 %Docstring
 Sets the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
 at this moment. A negative value (which is set by default) will wait forever.
@@ -656,7 +658,33 @@ at this moment. A negative value (which is set by default) will wait forever.
 
    Only works if the provider supports this option.
 
+.. deprecated:: Use setTimeout() instead.
+
 .. versionadded:: 3.0
+%End
+
+    int timeout() const;
+%Docstring
+Returns the timeout (in milliseconds) for the maximum time we should wait during feature requests before a
+feature is returned. A negative value (which is set by default) will wait forever.
+
+.. note::
+
+   Only works if the provider supports this option.
+
+.. versionadded:: 3.4
+%End
+
+    QgsFeatureRequest &setTimeout( int timeout );
+%Docstring
+Sets the ``timeout`` (in milliseconds) for the maximum time we should wait during feature requests before a
+feature is returned. A negative value (which is set by default) will wait forever.
+
+.. note::
+
+   Only works if the provider supports this option.
+
+.. versionadded:: 3.4
 %End
 
     bool requestMayBeNested() const;

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -3605,7 +3605,7 @@ static QVariant fcnGetFeatureById( const QVariantList &values, const QgsExpressi
 
     QgsFeatureRequest req;
     req.setFilterFid( fid );
-    req.setConnectionTimeout( 10000 );
+    req.setTimeout( 10000 );
     req.setRequestMayBeNested( true );
     QgsFeatureIterator fIt = vl->getFeatures( req );
 
@@ -3648,7 +3648,7 @@ static QVariant fcnGetFeature( const QVariantList &values, const QgsExpressionCo
   req.setFilterExpression( QStringLiteral( "%1=%2" ).arg( QgsExpression::quotedColumnRef( attribute ),
                            QgsExpression::quotedString( attVal.toString() ) ) );
   req.setLimit( 1 );
-  req.setConnectionTimeout( 10000 );
+  req.setTimeout( 10000 );
   req.setRequestMayBeNested( true );
   if ( !parent->needsGeometry() )
   {

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -85,7 +85,7 @@ QgsFeatureRequest &QgsFeatureRequest::operator=( const QgsFeatureRequest &rh )
   mOrderBy = rh.mOrderBy;
   mCrs = rh.mCrs;
   mTransformErrorCallback = rh.mTransformErrorCallback;
-  mConnectionTimeout = rh.mConnectionTimeout;
+  mTimeout = rh.mTimeout;
   mRequestMayBeNested = rh.mRequestMayBeNested;
   return *this;
 }
@@ -291,12 +291,23 @@ bool QgsFeatureRequest::acceptFeature( const QgsFeature &feature )
 
 int QgsFeatureRequest::connectionTimeout() const
 {
-  return mConnectionTimeout;
+  return mTimeout;
 }
 
 QgsFeatureRequest &QgsFeatureRequest::setConnectionTimeout( int connectionTimeout )
 {
-  mConnectionTimeout = connectionTimeout;
+  mTimeout = connectionTimeout;
+  return *this;
+}
+
+int QgsFeatureRequest::timeout() const
+{
+  return mTimeout;
+}
+
+QgsFeatureRequest &QgsFeatureRequest::setTimeout( int timeout )
+{
+  mTimeout = timeout;
   return *this;
 }
 

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -621,8 +621,8 @@ class CORE_EXPORT QgsFeatureRequest
      * at this moment. A negative value (which is set by default) will wait forever.
      *
      * \note Only works if the provider supports this option.
-     * \deprecated Use timeout() instead.
      *
+     * \deprecated Use timeout() instead.
      * \since QGIS 3.0
      */
     Q_DECL_DEPRECATED int connectionTimeout() const SIP_DEPRECATED;
@@ -632,8 +632,8 @@ class CORE_EXPORT QgsFeatureRequest
      * at this moment. A negative value (which is set by default) will wait forever.
      *
      * \note Only works if the provider supports this option.
-     * \deprecated Use setTimeout() instead.
      *
+     * \deprecated Use setTimeout() instead.
      * \since QGIS 3.0
      */
     Q_DECL_DEPRECATED QgsFeatureRequest &setConnectionTimeout( int connectionTimeout ) SIP_DEPRECATED;

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -621,20 +621,42 @@ class CORE_EXPORT QgsFeatureRequest
      * at this moment. A negative value (which is set by default) will wait forever.
      *
      * \note Only works if the provider supports this option.
+     * \deprecated Use timeout() instead.
      *
      * \since QGIS 3.0
      */
-    int connectionTimeout() const;
+    Q_DECL_DEPRECATED int connectionTimeout() const SIP_DEPRECATED;
 
     /**
      * Sets the timeout (in milliseconds) for how long we should wait for a connection if none is available from the pool
      * at this moment. A negative value (which is set by default) will wait forever.
      *
      * \note Only works if the provider supports this option.
+     * \deprecated Use setTimeout() instead.
      *
      * \since QGIS 3.0
      */
-    QgsFeatureRequest &setConnectionTimeout( int connectionTimeout );
+    Q_DECL_DEPRECATED QgsFeatureRequest &setConnectionTimeout( int connectionTimeout ) SIP_DEPRECATED;
+
+    /**
+     * Returns the timeout (in milliseconds) for the maximum time we should wait during feature requests before a
+     * feature is returned. A negative value (which is set by default) will wait forever.
+     *
+     * \note Only works if the provider supports this option.
+     *
+     * \since QGIS 3.4
+     */
+    int timeout() const;
+
+    /**
+     * Sets the \a timeout (in milliseconds) for the maximum time we should wait during feature requests before a
+     * feature is returned. A negative value (which is set by default) will wait forever.
+     *
+     * \note Only works if the provider supports this option.
+     *
+     * \since QGIS 3.4
+     */
+    QgsFeatureRequest &setTimeout( int timeout );
 
     /**
      * In case this request may be run nested within another already running
@@ -681,7 +703,7 @@ class CORE_EXPORT QgsFeatureRequest
     std::function< void( const QgsFeature & ) > mTransformErrorCallback;
     QgsCoordinateReferenceSystem mCrs;
     QgsCoordinateTransformContext mTransformContext;
-    int mConnectionTimeout = -1;
+    int mTimeout = -1;
     int mRequestMayBeNested = false;
 };
 

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -46,7 +46,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   , mSharedDS( source->mSharedDS )
 {
   // Since connection timeout for OGR connections is problematic and can lead to crashes, disable for now.
-  mRequest.setConnectionTimeout( -1 );
+  mRequest.setTimeout( -1 );
   if ( mSharedDS )
   {
     mOgrLayer = mSharedDS->createSQLResultLayer( mSource->mEncoding, mSource->mLayerName, mSource->mLayerIndex );
@@ -58,7 +58,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   else
   {
     //QgsDebugMsg( "Feature iterator of " + mSource->mLayerName + ": acquiring connection");
-    mConn = QgsOgrConnPool::instance()->acquireConnection( QgsOgrProviderUtils::connectionPoolId( mSource->mDataSource ), mRequest.connectionTimeout(), mRequest.requestMayBeNested() );
+    mConn = QgsOgrConnPool::instance()->acquireConnection( QgsOgrProviderUtils::connectionPoolId( mSource->mDataSource ), mRequest.timeout(), mRequest.requestMayBeNested() );
     if ( !mConn || !mConn->ds )
     {
       return;

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -38,7 +38,7 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
 
   if ( !source->mTransactionConnection )
   {
-    mConn = QgsPostgresConnPool::instance()->acquireConnection( mSource->mConnInfo, request.connectionTimeout(), request.requestMayBeNested() );
+    mConn = QgsPostgresConnPool::instance()->acquireConnection( mSource->mConnInfo, request.timeout(), request.requestMayBeNested() );
     mIsTransactionConnection = false;
   }
   else

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -29,7 +29,7 @@
 QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeatureSource *source, bool ownSource, const QgsFeatureRequest &request )
   : QgsAbstractFeatureIteratorFromSource<QgsSpatiaLiteFeatureSource>( source, ownSource, request )
 {
-  mHandle = QgsSpatiaLiteConnPool::instance()->acquireConnection( mSource->mSqlitePath, request.connectionTimeout(), request.requestMayBeNested() );
+  mHandle = QgsSpatiaLiteConnPool::instance()->acquireConnection( mSource->mSqlitePath, request.timeout(), request.requestMayBeNested() );
 
   mFetchGeometry = !mSource->mGeometryColumn.isNull() && !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
   mHasPrimaryKey = !mSource->mPrimaryKey.isEmpty();

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -1291,10 +1291,10 @@ bool QgsWFSFeatureIterator::fetchFeature( QgsFeature &f )
     QTimer timer( this );
     timer.start( 50 );
     QTimer requestTimeout( this );
-    if ( mRequest.connectionTimeout() > 0 )
+    if ( mRequest.timeout() > 0 )
     {
       connect( &requestTimeout, &QTimer::timeout, this, &QgsWFSFeatureIterator::timeout );
-      requestTimeout.start( mRequest.connectionTimeout() );
+      requestTimeout.start( mRequest.timeout() );
     }
     if ( mInterruptionChecker )
       connect( &timer, &QTimer::timeout, this, &QgsWFSFeatureIterator::checkInterruption );

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -1111,6 +1111,14 @@ void QgsWFSFeatureIterator::checkInterruption()
   }
 }
 
+void QgsWFSFeatureIterator::timeout()
+{
+  mTimeoutOccurred = true;
+  mDownloadFinished = true;
+  if ( mLoop )
+    mLoop->quit();
+}
+
 bool QgsWFSFeatureIterator::fetchFeature( QgsFeature &f )
 {
   f.setValid( false );
@@ -1123,6 +1131,9 @@ bool QgsWFSFeatureIterator::fetchFeature( QgsFeature &f )
   while ( mCacheIterator.nextFeature( cachedFeature ) )
   {
     if ( mInterruptionChecker && mInterruptionChecker->isCanceled() )
+      return false;
+
+    if ( mTimeoutOccurred )
       return false;
 
     //QgsDebugMsg(QString("QgsWFSSharedData::fetchFeature() : mCacheIterator.nextFeature(cachedFeature)") );
@@ -1279,6 +1290,12 @@ bool QgsWFSFeatureIterator::fetchFeature( QgsFeature &f )
     mLoop = &loop;
     QTimer timer( this );
     timer.start( 50 );
+    QTimer requestTimeout( this );
+    if ( mRequest.connectionTimeout() > 0 )
+    {
+      connect( &requestTimeout, &QTimer::timeout, this, &QgsWFSFeatureIterator::timeout );
+      requestTimeout.start( mRequest.connectionTimeout() );
+    }
     if ( mInterruptionChecker )
       connect( &timer, &QTimer::timeout, this, &QgsWFSFeatureIterator::checkInterruption );
     loop.exec( QEventLoop::ExcludeUserInputEvents );

--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -217,6 +217,7 @@ class QgsWFSFeatureIterator : public QObject,
     void featureReceivedSynchronous( const QVector<QgsWFSFeatureGmlIdPair> &list );
     void endOfDownload( bool success );
     void checkInterruption();
+    void timeout();
 
   private:
 
@@ -237,6 +238,7 @@ class QgsWFSFeatureIterator : public QObject,
     QEventLoop *mLoop = nullptr;
     QgsFeatureIterator mCacheIterator;
     QgsFeedback *mInterruptionChecker = nullptr;
+    bool mTimeoutOccurred = false;
 
     //! this mutex synchronizes the mWriterXXXX variables between featureReceivedSynchronous() and fetchFeature()
     QMutex mMutex;

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -366,7 +366,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         available in the connection pool
         """
         request = QgsFeatureRequest()
-        request.setConnectionTimeout(1)
+        request.setTimeout(1)
 
         iterators = list()
         for i in range(100):


### PR DESCRIPTION
The big question arising from this change is whether it's appropriate to use QgsFeatureRequest::connectionTimeout() in other contexts which aren't actually getting the connection.

Positives:
- Simpler API - you can set a timeout in a single place, instead of having a separate "setRequestTimeout" call.

Negatives:
- Slightly more restrictive API vs having a separate "setRequestTimeout" call
- The naming and dox for connectionTimeout don't reflect that the timeout can be used for requests themselves too (so we'd need to fix the dox, and then consider deprecating connectionTimeout() and replacing with a generic "timeout" method).

Thoughts?
