### PR TITLE
fix for 360+ degrees wedgebuffer

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -262,28 +262,40 @@ QgsGeometry QgsGeometry::createWedgeBuffer( const QgsPoint &center, const double
 {
   if ( angularWidth >= 360.0 )
   {
-    std::unique_ptr< QgsCompoundCurve > outer = qgis::make_unique< QgsCompoundCurve >();
+    std::unique_ptr< QgsCompoundCurve > outerCc = qgis::make_unique< QgsCompoundCurve >();
 
-    const QgsPoint outerP1 = center.project( outerRadius, azimuth );
-    const QgsPoint outerP2 = center.project( outerRadius, azimuth + 180.0 );
+    QgsPointSequence outerPs = QgsPointSequence()
+                               << QgsPoint( center.x(), center.y() + outerRadius )
+                               << QgsPoint( center.x() + outerRadius, center.y() )
+                               << QgsPoint( center.x(), center.y() - outerRadius )
+                               << QgsPoint( center.x() - outerRadius, center.y() )
+                               << QgsPoint( center.x(), center.y() + outerRadius );
 
-    outer->addCurve( new QgsCircularString( QgsCircularString::fromTwoPointsAndCenter( outerP1, outerP2, center ) ) );
-    outer->addCurve( new QgsCircularString( QgsCircularString::fromTwoPointsAndCenter( outerP2, outerP1, center ) ) );
+    QgsCircularString *outerCs =  new QgsCircularString;
+    outerCs->setPoints( outerPs );
+
+    outerCc->addCurve( outerCs );
 
     std::unique_ptr< QgsCurvePolygon > cp = qgis::make_unique< QgsCurvePolygon >();
-    cp->setExteriorRing( outer.release() );
+    cp->setExteriorRing( outerCc.release() );
 
     if ( !qgsDoubleNear( innerRadius, 0.0 ) && innerRadius > 0 )
     {
-      std::unique_ptr< QgsCompoundCurve > inner = qgis::make_unique< QgsCompoundCurve >();
+      std::unique_ptr< QgsCompoundCurve > innerCc = qgis::make_unique< QgsCompoundCurve >();
 
-      const QgsPoint innerP1 = center.project( innerRadius, azimuth );
-      const QgsPoint innerP2 = center.project( innerRadius, azimuth + 180.0 );
+      QgsPointSequence innerPs = QgsPointSequence()
+                                 << QgsPoint( center.x(), center.y() + innerRadius )
+                                 << QgsPoint( center.x() + innerRadius, center.y() )
+                                 << QgsPoint( center.x(), center.y() - innerRadius )
+                                 << QgsPoint( center.x() - innerRadius, center.y() )
+                                 << QgsPoint( center.x(), center.y() + innerRadius );
 
-      inner->addCurve( new QgsCircularString( QgsCircularString::fromTwoPointsAndCenter( innerP1, innerP2, center ) ) );
-      inner->addCurve( new QgsCircularString( QgsCircularString::fromTwoPointsAndCenter( innerP2, innerP1, center ) ) );
+      QgsCircularString *innerCs =  new QgsCircularString;
+      innerCs->setPoints( innerPs );
 
-      cp->setInteriorRings( { inner.release() } );
+      innerCc->addCurve( innerCs );
+
+      cp->setInteriorRings( { innerCc.release() } );
     }
 
     return QgsGeometry( std::move( cp ) );
@@ -3275,3 +3287,4 @@ QDataStream &operator>>( QDataStream &in, QgsGeometry &geometry )
   geometry.fromWkb( byteArray );
   return in;
 }
+

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -274,7 +274,7 @@ QgsGeometry QgsGeometry::createWedgeBuffer( const QgsPoint &center, const double
     {
       std::unique_ptr< QgsCompoundCurve > innerCc = qgis::make_unique< QgsCompoundCurve >();
 
-      QgsCircle innerCircle = QgsCircle( center, innerRadius);
+      QgsCircle innerCircle = QgsCircle( center, innerRadius );
       innerCc->addCurve( innerCircle.toCircularString() );
 
       cp->setInteriorRings( { innerCc.release() } );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -260,7 +260,7 @@ QgsGeometry QgsGeometry::collectGeometry( const QVector< QgsGeometry > &geometri
 
 QgsGeometry QgsGeometry::createWedgeBuffer( const QgsPoint &center, const double azimuth, const double angularWidth, const double outerRadius, const double innerRadius )
 {
-  if ( angularWidth >= 360.0 )
+  if ( abs( angularWidth ) >= 360.0 )
   {
     std::unique_ptr< QgsCompoundCurve > outerCc = qgis::make_unique< QgsCompoundCurve >();
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -264,17 +264,8 @@ QgsGeometry QgsGeometry::createWedgeBuffer( const QgsPoint &center, const double
   {
     std::unique_ptr< QgsCompoundCurve > outerCc = qgis::make_unique< QgsCompoundCurve >();
 
-    QgsPointSequence outerPs = QgsPointSequence()
-                               << QgsPoint( center.x(), center.y() + outerRadius )
-                               << QgsPoint( center.x() + outerRadius, center.y() )
-                               << QgsPoint( center.x(), center.y() - outerRadius )
-                               << QgsPoint( center.x() - outerRadius, center.y() )
-                               << QgsPoint( center.x(), center.y() + outerRadius );
-
-    QgsCircularString *outerCs =  new QgsCircularString;
-    outerCs->setPoints( outerPs );
-
-    outerCc->addCurve( outerCs );
+    QgsCircle outerCircle = QgsCircle( center, outerRadius );
+    outerCc->addCurve( outerCircle.toCircularString() );
 
     std::unique_ptr< QgsCurvePolygon > cp = qgis::make_unique< QgsCurvePolygon >();
     cp->setExteriorRing( outerCc.release() );
@@ -283,17 +274,8 @@ QgsGeometry QgsGeometry::createWedgeBuffer( const QgsPoint &center, const double
     {
       std::unique_ptr< QgsCompoundCurve > innerCc = qgis::make_unique< QgsCompoundCurve >();
 
-      QgsPointSequence innerPs = QgsPointSequence()
-                                 << QgsPoint( center.x(), center.y() + innerRadius )
-                                 << QgsPoint( center.x() + innerRadius, center.y() )
-                                 << QgsPoint( center.x(), center.y() - innerRadius )
-                                 << QgsPoint( center.x() - innerRadius, center.y() )
-                                 << QgsPoint( center.x(), center.y() + innerRadius );
-
-      QgsCircularString *innerCs =  new QgsCircularString;
-      innerCs->setPoints( innerPs );
-
-      innerCc->addCurve( innerCs );
+      QgsCircle innerCircle = QgsCircle( center, innerRadius);
+      innerCc->addCurve( innerCircle.toCircularString() );
 
       cp->setInteriorRings( { innerCc.release() } );
     }

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -4371,7 +4371,13 @@ class TestQgsGeometry(unittest.TestCase):
                  [QgsPoint(1, 11, 3), 0, 45, 2, 0,
                   'CurvePolygonZ (CompoundCurveZ (CircularStringZ (0.23463313526982044 12.84775906502257392 3, 1 13 3, 1.76536686473017967 12.84775906502257392 3),(1.76536686473017967 12.84775906502257392 3, 1 11 3),(1 11 3, 0.23463313526982044 12.84775906502257392 3)))'],
                  [QgsPoint(1, 11, m=3), 0, 45, 2, 0,
-                  'CurvePolygonM (CompoundCurveM (CircularStringM (0.23463313526982044 12.84775906502257392 3, 1 13 3, 1.76536686473017967 12.84775906502257392 3),(1.76536686473017967 12.84775906502257392 3, 1 11 3),(1 11 3, 0.23463313526982044 12.84775906502257392 3)))']
+                  'CurvePolygonM (CompoundCurveM (CircularStringM (0.23463313526982044 12.84775906502257392 3, 1 13 3, 1.76536686473017967 12.84775906502257392 3),(1.76536686473017967 12.84775906502257392 3, 1 11 3),(1 11 3, 0.23463313526982044 12.84775906502257392 3)))'],
+                 [QgsPoint(1, 11), 0, 360, 2, 0,
+                  'CurvePolygon (CompoundCurve (CircularString (1 13, 3 11, 1 9, -1 11, 1 13)))'],
+                 [QgsPoint(1, 11), 0, -1000, 2, 0,
+                  'CurvePolygon (CompoundCurve (CircularString (1 13, 3 11, 1 9, -1 11, 1 13)))'],
+                 [QgsPoint(1, 11), 0, 360, 2, 1,
+                  'CurvePolygon (CompoundCurve (CircularString (1 13, 3 11, 1 9, -1 11, 1 13)),CompoundCurve (CircularString (1 12, 2 11, 1 10, 0 11, 1 12)))']
                  ]
         for t in tests:
             input = t[0]


### PR DESCRIPTION
## Description
Geometry function createWedgeBuffer() now handles the case of angularWidth >= 360, which should return either a full circle geometry or a donut geometry in case there is an innerRadius.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
