### PR TITLE
[layouts] Try to avoid incorrect page margin handling while printing

### DIFF
--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1112,6 +1112,7 @@ void QgsLayoutExporter::updatePrinterPageSize( QgsLayout *layout, QPrinter &prin
   QPageLayout pageLayout( QPageSize( pageSizeMM.toQSizeF(), QPageSize::Millimeter ),
                           QPageLayout::Portrait,
                           QMarginsF( 0, 0, 0, 0 ) );
+  pageLayout.setMode( QPageLayout::FullPageMode );
   printer.setPageLayout( pageLayout );
 }
 


### PR DESCRIPTION
Sometimes direct layout -> printer printing is causing doubled page margin offsets.