### PR TITLE
Simplify QgsTask::waitForFinished, hopefully fix bugs

### DIFF
--- a/python/core/auto_generated/qgstaskmanager.sip.in
+++ b/python/core/auto_generated/qgstaskmanager.sip.in
@@ -169,7 +169,7 @@ be canceled if any of these layers are about to be removed.
 .. seealso:: :py:func:`setDependentLayers`
 %End
 
-    bool waitForFinished( unsigned long timeout = 30000 );
+    bool waitForFinished( int timeout = 30000 );
 %Docstring
 Blocks the current thread until the task finishes or a maximum of ``timeout`` milliseconds.
 If ``timeout`` is ``0`` the thread will be blocked forever.

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -195,7 +195,7 @@ class CORE_EXPORT QgsTask : public QObject
      *
      * The result will be false if the wait timed out and true in any other case.
      */
-    bool waitForFinished( unsigned long timeout = 30000 );
+    bool waitForFinished( int timeout = 30000 );
 
   signals:
 
@@ -302,8 +302,6 @@ class CORE_EXPORT QgsTask : public QObject
     double mTotalProgress = 0.0;
     bool mShouldTerminate = false;
     int mStartCount = 0;
-
-    QWaitCondition mTaskFinished;
 
     struct SubTask
     {


### PR DESCRIPTION
I don't think the QWaitCondition is required here, and I think it's causing issues. At least valgrind reports lots of access out of bounds errors when it's present, and none when it's not.