### PR TITLE
[Oracle][2.18] Set field type to QVariant::Int for Double and LongLong without precision

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -784,6 +784,16 @@ bool QgsOracleProvider::loadFields()
       // date types are incorrectly detected as datetime
       type = QVariant::Date;
     }
+    else if ( type == QVariant::Double && field.precision() == 0 )
+    {
+      // integer are Double with null precision
+      type = QVariant::Int;
+    }
+    else if ( type == QVariant::LongLong && field.precision() == 0 )
+    {
+      // integer are longlong with null precision
+      type = QVariant::Int;
+    }
 
     mAttributeFields.append( QgsField( field.name(), type, types.value( field.name() ), field.length(), field.precision(), comments.value( field.name() ) ) );
     mDefaultValues.append( defvalues.value( field.name(), QVariant() ) );

--- a/src/server/qgswfsprojectparser.cpp
+++ b/src/server/qgswfsprojectparser.cpp
@@ -467,10 +467,15 @@ void QgsWFSProjectParser::describeFeatureType( const QString& aTypeName, QDomEle
           QDomElement attElem = doc.createElement( "element"/*xsd:element*/ );
           attElem.setAttribute( "name", attributeName.replace( " ", "_" ).replace( mCleanTagNameRegExp, "" ) );
           QVariant::Type attributeType = fields[idx].type();
+          int attributePrec = fields[idx].precision();
           if ( attributeType == QVariant::Int )
+            attElem.setAttribute( "type", "integer" );
+          else if ( attributeType == QVariant::LongLong && attributePrec == 0 )
             attElem.setAttribute( "type", "integer" );
           else if ( attributeType == QVariant::LongLong )
             attElem.setAttribute( "type", "long" );
+          else if ( attributeType == QVariant::Double && attributePrec == 0 )
+            attElem.setAttribute( "type", "integer" );
           else if ( attributeType == QVariant::Double )
             attElem.setAttribute( "type", "double" );
           else if ( attributeType == QVariant::Bool )


### PR DESCRIPTION
## Description
Some fields have been detected to Double or LongLong but without precision or with a precision equal to 0. A Double or a LongLong without precision or with a precision equal to 0 is an Integer. This code fixes the type to QVariant::Int for Double and LongLong without precision.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
