### PR TITLE
Don't show system notifications for short tasks

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -28,6 +28,12 @@ connections-xyz\OpenStreetMap\username=
 connections-xyz\OpenStreetMap\zmax=19
 connections-xyz\OpenStreetMap\zmin=0
 
+[app]
+
+# Minimum time (in seconds) for a background task to execute in order for a system
+# notification to be shown when the task completes.
+minTaskLengthForSystemNotification=10
+
 [core]
 # Whether or not to anonymize newly created projects
 # If set to 1, then project metadata items like AUTHOR and CREATION DATE

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -32,7 +32,7 @@ connections-xyz\OpenStreetMap\zmin=0
 
 # Minimum time (in seconds) for a background task to execute in order for a system
 # notification to be shown when the task completes.
-minTaskLengthForSystemNotification=10
+minTaskLengthForSystemNotification=5
 
 [core]
 # Whether or not to anonymize newly created projects

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12914,10 +12914,12 @@ void QgisApp::newProfile()
 
 void QgisApp::onTaskCompleteShowNotify( long taskId, int status )
 {
-  if ( status == QgsTask::Complete && !this->isActiveWindow() )
+  long long minTime = QgsSettings().value( QStringLiteral( "minTaskLengthForSystemNotification" ), 10, QgsSettings::App ).toLongLong() * 1000;
+
+  if ( status == QgsTask::Complete )
   {
     QgsTask *task = QgsApplication::taskManager()->task( taskId );
-    if ( task )
+    if ( task && task->elapsedTime() >= minTime )
     {
       showSystemNotification( tr( "Task complete" ), task->description() );
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12914,7 +12914,7 @@ void QgisApp::newProfile()
 
 void QgisApp::onTaskCompleteShowNotify( long taskId, int status )
 {
-  long long minTime = QgsSettings().value( QStringLiteral( "minTaskLengthForSystemNotification" ), 10, QgsSettings::App ).toLongLong() * 1000;
+  long long minTime = QgsSettings().value( QStringLiteral( "minTaskLengthForSystemNotification" ), 5, QgsSettings::App ).toLongLong() * 1000;
 
   if ( status == QgsTask::Complete )
   {


### PR DESCRIPTION
Too annoying! Otherwise we spam notifications for very short tasks like layer feature count updating.