### PR TITLE
[FEATURE] Add hyperlink to local vector,raster datasets in information panel

### DIFF
--- a/python/core/auto_generated/qgsproviderregistry.sip.in
+++ b/python/core/auto_generated/qgsproviderregistry.sip.in
@@ -78,7 +78,7 @@ Sets library directory where to search for plugins
 %Docstring
 Creates a new instance of a provider.
 
-:param providerKey: identificator of the provider
+:param providerKey: identifier of the provider
 :param dataSource: string containing data source for the provider
 :param options: provider options
 
@@ -89,9 +89,25 @@ Creates a new instance of a provider.
 %Docstring
 Returns the provider capabilities
 
-:param providerKey: identificator of the provider
+:param providerKey: identifier of the provider
 
 .. versionadded:: 2.6
+%End
+
+    QVariantMap decodeUri( const QString &providerKey, const QString &uri );
+%Docstring
+Returns the components (e.g. file path, layer name) of a provider uri
+
+:param providerKey: identifier of the provider
+:param uri: uri string
+
+:return: map containing components
+
+.. note::
+
+   this function may not be supported by all providers, an empty map will be returned in such case
+
+.. versionadded:: 3.4
 %End
 
     QWidget *createSelectionWidget( const QString &providerKey,
@@ -109,7 +125,7 @@ responsible for deleting the returned widget.
 %Docstring
 Gets pointer to provider function
 
-:param providerKey: identificator of the provider
+:param providerKey: identifier of the provider
 :param functionName: name of function
 
 :return: pointer to function or NULL on error. If the provider uses direct provider

--- a/src/app/qgsrasterlayerproperties.h
+++ b/src/app/qgsrasterlayerproperties.h
@@ -137,6 +137,8 @@ class APP_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     //! Make GUI reflect the layer's state
     void syncToLayer();
 
+    void urlClicked( const QUrl &url );
+
   signals:
     //! Emitted when changes to layer were saved to update legend
     void refreshLegend( const QString &layerID, bool expandItem );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -39,6 +39,7 @@
 #include "qgsmaplayerconfigwidgetfactory.h"
 #include "qgsmaplayerstyleguiutils.h"
 #include "qgsmetadatawidget.h"
+#include "qgsnative.h"
 #include "qgspluginmetadata.h"
 #include "qgspluginregistry.h"
 #include "qgsproject.h"
@@ -65,6 +66,7 @@
 #include "layertree/qgslayertreelayer.h"
 #include "qgslayertree.h"
 
+#include <QDesktopServices>
 #include <QMessageBox>
 #include <QDir>
 #include <QFile>
@@ -75,6 +77,7 @@
 #include <QCheckBox>
 #include <QHeaderView>
 #include <QColorDialog>
+#include <QUrl>
 
 #include "qgsrendererpropertiesdialog.h"
 #include "qgsstyle.h"
@@ -348,6 +351,8 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   teMetadataViewer->clear();
   teMetadataViewer->document()->setDefaultStyleSheet( myStyle );
   teMetadataViewer->setHtml( htmlMetadata() );
+  teMetadataViewer->setOpenLinks( false );
+  connect( teMetadataViewer, &QTextBrowser::anchorClicked, this, &QgsVectorLayerProperties::urlClicked );
   mMetadataFilled = true;
 
   QgsSettings settings;
@@ -796,6 +801,15 @@ void QgsVectorLayerProperties::onCancel()
     mLayer->importNamedStyle( doc, myMessage );
     syncToLayer();
   }
+}
+
+void QgsVectorLayerProperties::urlClicked( const QUrl &url )
+{
+  QFileInfo file( url.toLocalFile() );
+  if ( file.exists() && !file.isDir() )
+    QgsGui::instance()->nativePlatformInterface()->openFileExplorerAndSelectFile( url.toLocalFile() );
+  else
+    QDesktopServices::openUrl( url );
 }
 
 void QgsVectorLayerProperties::pbnQueryBuilder_clicked()

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -169,6 +169,8 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     void onAuxiliaryLayerExport();
 
+    void urlClicked( const QUrl &url );
+
   private:
 
     enum PropertyType

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1190,7 +1190,6 @@ QString QgsApplication::reportStyleSheet()
             "}"
             "a{  color: #729FCF;"
             "  font-family: arial,sans-serif;"
-            "  font-size: small;"
             "}"
             "label{  background-color: #FFFFCC;"
             "  border: 1px solid black;"

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -43,6 +43,8 @@ typedef QString databaseDrivers_t();
 typedef QString directoryDrivers_t();
 typedef QString protocolDrivers_t();
 typedef void initProviderFunction_t();
+typedef QVariantMap decodeUri_t( const QString &uri );
+
 //typedef int dataCapabilities_t();
 //typedef QgsDataItem * dataItem_t(QString);
 
@@ -437,6 +439,22 @@ QgsDataProvider *QgsProviderRegistry::createProvider( QString const &providerKey
   QgsDebugMsg( QString( "Instantiated the data provider plugin: %1" ).arg( dataProvider->name() ) );
   return dataProvider;
 } // QgsProviderRegistry::setDataProvider
+
+QVariantMap QgsProviderRegistry::decodeUri( const QString &providerKey, const QString &uri )
+{
+  std::unique_ptr< QLibrary > library( createProviderLibrary( providerKey ) );
+  if ( !library )
+  {
+    return QVariantMap();
+  }
+
+  decodeUri_t *decodeUri = reinterpret_cast< decodeUri_t *>( cast_to_fptr( library->resolve( "decodeUri" ) ) );
+  if ( !decodeUri )
+  {
+    return QVariantMap();
+  }
+  return decodeUri( uri );
+}
 
 int QgsProviderRegistry::providerCapabilities( const QString &providerKey ) const
 {

--- a/src/core/qgsproviderregistry.h
+++ b/src/core/qgsproviderregistry.h
@@ -91,7 +91,7 @@ class CORE_EXPORT QgsProviderRegistry
 
     /**
      * Creates a new instance of a provider.
-     * \param providerKey identificator of the provider
+     * \param providerKey identifier of the provider
      * \param dataSource  string containing data source for the provider
      * \param options provider options
      * \returns new instance of provider or NULL on error
@@ -102,10 +102,20 @@ class CORE_EXPORT QgsProviderRegistry
 
     /**
      * Returns the provider capabilities
-        \param providerKey identificator of the provider
+        \param providerKey identifier of the provider
         \since QGIS 2.6
      */
     int providerCapabilities( const QString &providerKey ) const;
+
+    /**
+     * Returns the components (e.g. file path, layer name) of a provider uri
+        \param providerKey identifier of the provider
+        \param uri uri string
+        \returns map containing components
+        \note this function may not be supported by all providers, an empty map will be returned in such case
+        \since QGIS 3.4
+     */
+    QVariantMap decodeUri( const QString &providerKey, const QString &uri );
 
     /**
      * Returns a new widget for selecting layers from a provider.
@@ -119,7 +129,7 @@ class CORE_EXPORT QgsProviderRegistry
 
     /**
      * Gets pointer to provider function
-     * \param providerKey identificator of the provider
+     * \param providerKey identifier of the provider
      * \param functionName name of function
      * \returns pointer to function or NULL on error. If the provider uses direct provider
      * function pointers instead of a library nullptr will be returned.

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -23,6 +23,7 @@
 
 #include <limits>
 
+#include <QFile>
 #include <QImage>
 #include <QPainter>
 #include <QPainterPath>
@@ -32,6 +33,7 @@
 #include <QDomNode>
 #include <QVector>
 #include <QStringBuilder>
+#include <QUrl>
 #if QT_VERSION >= 0x050900
 #include <QUndoCommand>
 #endif
@@ -4162,7 +4164,11 @@ QString QgsVectorLayer::htmlMetadata() const
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );
 
   // data source
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>" ) + publicSource() + QStringLiteral( "</td></tr>\n" );
+  QVariantMap uriComponents = QgsProviderRegistry::instance()->decodeUri( mProviderKey, publicSource() );
+  QString path;
+  if ( uriComponents.contains( QStringLiteral( "path" ) ) )
+    path = uriComponents[QStringLiteral( "path" )].toString();
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( QFile::exists( path ) ? QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( path ).toString(), publicSource() ) : publicSource() ) + QStringLiteral( "</td></tr>\n" );
 
   // storage type
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Storage" ) + QStringLiteral( "</td><td>" ) + storageType() + QStringLiteral( "</td></tr>\n" );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -23,6 +23,7 @@
 
 #include <limits>
 
+#include <QDir>
 #include <QFile>
 #include <QImage>
 #include <QPainter>
@@ -4163,12 +4164,19 @@ QString QgsVectorLayer::htmlMetadata() const
   // name
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );
 
-  // data source
+  // local path
   QVariantMap uriComponents = QgsProviderRegistry::instance()->decodeUri( mProviderKey, publicSource() );
   QString path;
   if ( uriComponents.contains( QStringLiteral( "path" ) ) )
+  {
     path = uriComponents[QStringLiteral( "path" )].toString();
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( QFile::exists( path ) ? QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( path ).toString(), publicSource() ) : publicSource() ) + QStringLiteral( "</td></tr>\n" );
+    if ( QFile::exists( path ) )
+      myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Path" ) + QStringLiteral( "</td><td>%1" ).arg( QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( path ).toString(), QDir::toNativeSeparators( path ) ) ) + QStringLiteral( "</td></tr>\n" );
+  }
+
+  // data source
+  if ( publicSource() != path )
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( publicSource() ) + QStringLiteral( "</td></tr>\n" );
 
   // storage type
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Storage" ) + QStringLiteral( "</td><td>" ) + storageType() + QStringLiteral( "</td></tr>\n" );

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -318,7 +318,11 @@ QString QgsRasterLayer::htmlMetadata() const
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );
 
   // data source
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>" ) + publicSource() + QStringLiteral( "</td></tr>\n" );
+  QVariantMap uriComponents = QgsProviderRegistry::instance()->decodeUri( mProviderKey, publicSource() );
+  QString path;
+  if ( uriComponents.contains( QStringLiteral( "path" ) ) )
+    path = uriComponents[QStringLiteral( "path" )].toString();
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( QFile::exists( path ) ? QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( path ).toString(), publicSource() ) : publicSource() ) + QStringLiteral( "</td></tr>\n" );
 
   // storage type
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Provider" ) + QStringLiteral( "</td><td>" ) + providerType() + QStringLiteral( "</td></tr>\n" );

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -57,6 +57,7 @@ email                : tim at linfiniti.com
 
 #include <QApplication>
 #include <QCursor>
+#include <QDir>
 #include <QDomElement>
 #include <QDomNode>
 #include <QFile>
@@ -318,14 +319,21 @@ QString QgsRasterLayer::htmlMetadata() const
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Name" ) + QStringLiteral( "</td><td>" ) + name() + QStringLiteral( "</td></tr>\n" );
 
   // data source
+  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( publicSource() ) + QStringLiteral( "</td></tr>\n" );
+
+  // local path
   QVariantMap uriComponents = QgsProviderRegistry::instance()->decodeUri( mProviderKey, publicSource() );
   QString path;
   if ( uriComponents.contains( QStringLiteral( "path" ) ) )
+  {
     path = uriComponents[QStringLiteral( "path" )].toString();
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( QFile::exists( path ) ? QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( path ).toString(), publicSource() ) : publicSource() ) + QStringLiteral( "</td></tr>\n" );
+    if ( QFile::exists( path ) )
+      myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Path" ) + QStringLiteral( "</td><td>%1" ).arg( QStringLiteral( "<a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( path ).toString(), QDir::toNativeSeparators( path ) ) ) + QStringLiteral( "</td></tr>\n" );
+  }
 
-  // storage type
-  myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Provider" ) + QStringLiteral( "</td><td>" ) + providerType() + QStringLiteral( "</td></tr>\n" );
+  // data source
+  if ( publicSource() != path )
+    myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "Source" ) + QStringLiteral( "</td><td>%1" ).arg( publicSource() ) + QStringLiteral( "</td></tr>\n" );
 
   // EPSG
   myMetadata += QStringLiteral( "<tr><td class=\"highlight\">" ) + tr( "CRS" ) + QStringLiteral( "</td><td>" );

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1135,6 +1135,13 @@ QString  QgsDelimitedTextProvider::description() const
   return TEXT_PROVIDER_DESCRIPTION;
 }
 
+QGISEXTERN QVariantMap decodeUri( const QString &uri )
+{
+  QVariantMap components;
+  components.insert( QStringLiteral( "path" ), QUrl( uri ).toLocalFile() );
+  return components;
+}
+
 /**
  * Class factory to return a pointer to a newly created
  * QgsDelimitedTextProvider object

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -1974,6 +1974,30 @@ QStringList QgsGdalProvider::subLayers() const
   return mSubLayers;
 }
 
+
+QGISEXTERN QVariantMap decodeUri( const QString &uri )
+{
+  QString path = uri;
+  QString layerName;
+
+  QString vsiPrefix = qgsVsiPrefix( path );
+  if ( !path.isEmpty() )
+    path = path.mid( vsiPrefix.count() );
+
+  if ( path.indexOf( ':' ) != -1 )
+  {
+    QStringList parts = path.split( ':' );
+    path  = parts[1];
+    if ( parts.count() > 2 )
+      layerName = parts[2];
+  }
+
+  QVariantMap uriComponents;
+  uriComponents.insert( QStringLiteral( "path" ), path );
+  uriComponents.insert( QStringLiteral( "layerName" ), layerName );
+  return uriComponents;
+}
+
 /**
  * Class factory to return a pointer to a newly created
  * QgsGdalProvider object

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -3021,6 +3021,39 @@ QString createFilters( const QString &type )
   }
 }
 
+QGISEXTERN QVariantMap decodeUri( const QString &uri )
+{
+  QString path = uri;
+  QString layerName;
+  int layerId = -1;
+
+  int pipeIndex = path.indexOf( '|' );
+  if ( pipeIndex != -1 )
+  {
+    if ( path.indexOf( QLatin1String( "|layername=" ) ) != -1 )
+    {
+      QRegularExpression regex( QStringLiteral( "\\|layername=([^|]*)" ) );
+      layerName = regex.match( path ).captured( 1 );
+    }
+    else if ( path.indexOf( QLatin1String( "|layerid=" ) ) )
+    {
+      QRegularExpression regex( QStringLiteral( "\\|layerid=([^|]*)" ) );
+      layerId = regex.match( path ).captured( 1 ).toInt();
+    }
+
+    path = path.left( pipeIndex );
+  }
+
+  QString vsiPrefix = qgsVsiPrefix( path );
+  if ( !vsiPrefix.isEmpty() )
+    path = path.mid( vsiPrefix.count() );
+
+  QVariantMap uriComponents;
+  uriComponents.insert( QStringLiteral( "path" ), path );
+  uriComponents.insert( QStringLiteral( "layerName" ), layerName );
+  uriComponents.insert( QStringLiteral( "layerId" ), layerId > -1 ? layerId : QVariant() ) ;
+  return uriComponents;
+}
 
 QGISEXTERN QString fileVectorFilters()
 {

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -96,7 +96,6 @@ class QgsOgrProvider : public QgsVectorDataProvider
      */
     QString dataSourceUri( bool expandAuthConfig = false ) const override;
 
-
     QgsAbstractFeatureSource *featureSource() const override;
 
     QgsCoordinateReferenceSystem crs() const override;

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -5294,6 +5294,16 @@ void QgsSpatiaLiteProvider::invalidateConnections( const QString &connection )
   QgsSpatiaLiteConnPool::instance()->invalidateConnections( connection );
 }
 
+QGISEXTERN QVariantMap decodeUri( const QString &uri )
+{
+  QgsDataSourceUri dsUri = QgsDataSourceUri( uri );
+
+  QVariantMap components;
+  components.insert( QStringLiteral( "path" ), dsUri.database() );
+  components.insert( QStringLiteral( "layerName" ), dsUri.table() );
+  return components;
+}
+
 /**
  * Class factory to return a pointer to a newly created
  * QgsSpatiaLiteProvider object

--- a/tests/src/providers/testqgsgdalprovider.cpp
+++ b/tests/src/providers/testqgsgdalprovider.cpp
@@ -44,6 +44,7 @@ class TestQgsGdalProvider : public QObject
     void init() {}// will be called before each testfunction is executed.
     void cleanup() {}// will be called after every testfunction.
 
+    void decodeUri(); // test decode URI implementation
     void scaleDataType(); //test resultant data types for int raster with float scale (#11573)
     void warpedVrt(); //test loading raster which requires a warped vrt
     void noData();
@@ -80,6 +81,20 @@ void TestQgsGdalProvider::cleanupTestCase()
     myQTextStream << mReport;
     myFile.close();
   }
+}
+
+void TestQgsGdalProvider::decodeUri()
+{
+  QString uri = QStringLiteral( "/home/to/path/raster.tif" );
+  QVariantMap components;
+
+  components = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
+  QCOMPARE( components[QStringLiteral( "path" )].toString(), uri );
+
+  uri = QStringLiteral( "gpkg:/home/to/path/my_file.gpkg:layer_name" );
+  components = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), uri );
+  QCOMPARE( components[QStringLiteral( "path" )].toString(), QStringLiteral( "/home/to/path/my_file.gpkg" ) );
+  QCOMPARE( components[QStringLiteral( "layerName" )].toString(), QStringLiteral( "layer_name" ) );
 }
 
 void TestQgsGdalProvider::scaleDataType()

--- a/tests/src/python/test_provider_ogr_gpkg.py
+++ b/tests/src/python/test_provider_ogr_gpkg.py
@@ -28,6 +28,7 @@ from qgis.core import (QgsFeature,
                        QgsField,
                        QgsFieldConstraints,
                        QgsGeometry,
+                       QgsProviderRegistry,
                        QgsRectangle,
                        QgsSettings,
                        QgsVectorLayer,
@@ -94,6 +95,25 @@ class TestPyQgsOGRProviderGpkg(unittest.TestCase):
         shutil.rmtree(cls.basetestpath, True)
 
         QgsSettings().clear()
+
+    def testDecodeUri(self):
+
+        filename = '/home/to/path/my_file.gpkg'
+
+        registry = QgsProviderRegistry.instance()
+        uri = filename
+        components = registry.decodeUri('ogr', uri)
+        self.assertEqual(components["path"], filename)
+
+        uri = '{}|layername=test'.format(filename)
+        components = registry.decodeUri('ogr', uri)
+        self.assertEqual(components["path"], filename)
+        self.assertEqual(components["layerName"], 'test')
+
+        uri = '{}|layerid=0'.format(filename)
+        components = registry.decodeUri('ogr', uri)
+        self.assertEqual(components["path"], filename)
+        self.assertEqual(components["layerId"], 0)
 
     def testSingleToMultiPolygonPromotion(self):
 

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -20,7 +20,8 @@ import sys
 import shutil
 import tempfile
 
-from qgis.core import (QgsVectorLayer,
+from qgis.core import (QgsProviderRegistry,
+                       QgsVectorLayer,
                        QgsVectorDataProvider,
                        QgsPointXY,
                        QgsFeature,
@@ -741,6 +742,15 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(subSet_vl.setSubsetString(''))
         self.assertEqual(subSet_vl.featureCount(), 8)
         self.assertEqual(_lessdigits(subSet_vl.extent().toString()), unfiltered_extent)
+
+    def testDecodeUri(self):
+        """Check that the provider URI decoding returns expected values"""
+
+        filename = '/home/to/path/test.db'
+        uri = 'dbname=\'{}\' table="test" (geometry) sql='.format(filename)
+        registry = QgsProviderRegistry.instance()
+        components = registry.decodeUri('spatialite', uri)
+        self.assertEqual(components['path'], filename)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsdelimitedtextprovider.py
+++ b/tests/src/python/test_qgsdelimitedtextprovider.py
@@ -820,6 +820,14 @@ class TestQgsDelimitedTextProviderOther(unittest.TestCase):
         requests = None
         self.runTest(filename, requests, **params)
 
+    def test_043_decodeuri(self):
+        # URI decoding
+        filename = '/home/to/path/test.csv'
+        uri = 'file://{}?geomType=none'.format(filename)
+        registry = QgsProviderRegistry.instance()
+        components = registry.decodeUri('delimitedtext', uri)
+        self.assertEqual(components['path'], filename)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
GIF:
![peek 2018-08-08 12-22](https://user-images.githubusercontent.com/1728657/43817880-0bf28564-9b06-11e8-83e7-75960986c9c9.gif)

I've often wished for a quick way to open my file manager to the directory of a given local vector or raster dataset. This PR does just that by adding an hyperlink in the properties window's informational panel.

@nyalldawson , as discussed; your reviewing most welcome.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
