### PR TITLE
Added isclose function to VoronoyPolygons.py to avoid numerical issue…

### DIFF
--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -198,7 +198,7 @@ class VoronoiPolygons(QgisAlgorithm):
         (xmin, ymin, xmax, ymax) = xyminmax
 
         def isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
-            return abs(a - b) <= max( rel_tol * max(abs(a), abs(b)), abs_tol )
+            return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol )
 
         def clip_line(x1, y1, x2, y2, w, h):
             if x1 < 0 and x2 < 0:

--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -198,7 +198,7 @@ class VoronoiPolygons(QgisAlgorithm):
         (xmin, ymin, xmax, ymax) = xyminmax
 
         def isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
-            return abs(a-b) <= max( rel_tol * max(abs(a), abs(b)), abs_tol )
+            return abs(a - b) <= max( rel_tol * max(abs(a), abs(b)), abs_tol )
 
         def clip_line(x1, y1, x2, y2, w, h):
             if x1 < 0 and x2 < 0:

--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -197,6 +197,9 @@ class VoronoiPolygons(QgisAlgorithm):
         pt_y = point.y() - extent.yMinimum()
         (xmin, ymin, xmax, ymax) = xyminmax
 
+        def isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
+            return abs(a-b) <= max( rel_tol * max(abs(a), abs(b)), abs_tol )
+
         def clip_line(x1, y1, x2, y2, w, h):
             if x1 < 0 and x2 < 0:
                 # Completely to the left
@@ -210,6 +213,7 @@ class VoronoiPolygons(QgisAlgorithm):
             if y1 > h and y2 > h:
                 # Completely above
                 return [0, 0, 0, 0]
+            # Clip on the left envelope boundary
             if x1 < 0:
                 # First point to the left
                 y1 = (y1 * x2 - y2 * x1) / (x2 - x1)
@@ -218,6 +222,7 @@ class VoronoiPolygons(QgisAlgorithm):
                 # Last point to the left
                 y2 = (y1 * x2 - y2 * x1) / (x2 - x1)
                 x2 = 0
+            # Clip on the right envelope boundary
             if x1 > w:
                 # First point to the right
                 y1 = y1 + (w - x1) * (y2 - y1) / (x2 - x1)
@@ -226,8 +231,9 @@ class VoronoiPolygons(QgisAlgorithm):
                 # Last point to the right
                 y2 = y1 + (w - x1) * (y2 - y1) / (x2 - x1)
                 x2 = w
-            if x1 == x2 and y1 == y2:
+            if isclose(x1, x2) and isclose(y1, y2):
                 return [0, 0, 0, 0]
+            # Clip on the bottom envelope boundary
             if y1 < 0:
                 # First point below
                 x1 = (x1 * y2 - x2 * y1) / (y2 - y1)
@@ -236,6 +242,7 @@ class VoronoiPolygons(QgisAlgorithm):
                 # Second point below
                 x2 = (x1 * y2 - x2 * y1) / (y2 - y1)
                 y2 = 0
+            # Clip on the top envelope boundary
             if y1 > h:
                 # First point above
                 x1 = x1 + (h - y1) * (x2 - x1) / (y2 - y1)
@@ -244,6 +251,8 @@ class VoronoiPolygons(QgisAlgorithm):
                 # Second point above
                 x2 = x1 + (h - y1) * (x2 - x1) / (y2 - y1)
                 y2 = h
+            if isclose(x1, x2) and isclose(y1, y2):
+                return [0, 0, 0, 0]
             return [x1, y1, x2, y2]
 
         bndpoints = []

--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -198,7 +198,7 @@ class VoronoiPolygons(QgisAlgorithm):
         (xmin, ymin, xmax, ymax) = xyminmax
 
         def isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
-            return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol )
+            return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
         def clip_line(x1, y1, x2, y2, w, h):
             if x1 < 0 and x2 < 0:

--- a/python/plugins/processing/tests/testdata/airports.gml
+++ b/python/plugins/processing/tests/testdata/airports.gml
@@ -1,0 +1,774 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ airports.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-4480198.522214464</gml:X><gml:Y>1433525.79887208</gml:Y></gml:coord>
+      <gml:coord><gml:X>4615124.978985116</gml:X><gml:Y>6502586.830347195</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                
+  <gml:featureMember>
+    <ogr:airports fid="airports.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1258616.90434692,6502586.8303472</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>1</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>78.000</ogr:ELEV>
+      <ogr:NAME>NOATAK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-551138.448089009,6267485.60458368</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>2</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>264.000</ogr:ELEV>
+      <ogr:NAME>AMBLER</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>356882.262165953,6188622.20902555</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>3</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>585.000</ogr:ELEV>
+      <ogr:NAME>BETTLES</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1237904.32606354,6251122.97941402</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>4</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>9.000</ogr:ELEV>
+      <ogr:NAME>RALPH WIEN MEM</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-872273.253176902,6106465.43122864</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>5</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>21.000</ogr:ELEV>
+      <ogr:NAME>SELAWIK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>44546.2318545772,5845664.54916261</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>6</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>1113.000</ogr:ELEV>
+      <ogr:NAME>INDIAN MOUNTAIN LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1065841.88799411,5899198.95850236</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>7</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>21.000</ogr:ELEV>
+      <ogr:NAME>BUCKLAND</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-2095798.81434869,5909537.34029712</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>8</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>243.000</ogr:ELEV>
+      <ogr:NAME>TIN CITY LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1107924.86745609,5691643.86460755</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>9</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>1329.000</ogr:ELEV>
+      <ogr:NAME>GRANITE MOUNTAIN AFS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.9">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1959538.96615581,5765851.88861944</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>10</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>9.000</ogr:ELEV>
+      <ogr:NAME>PORT CLARENCE CGS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.10">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>291155.217641036,5550660.44018469</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>11</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>207.000</ogr:ELEV>
+      <ogr:NAME>RALPH M CALHOUN</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.11">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1107943.52926096,5518548.44209076</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>12</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>108.000</ogr:ELEV>
+      <ogr:NAME>KOYUK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.12">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-458394.105109243,5396346.69645954</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>13</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>138.000</ogr:ELEV>
+      <ogr:NAME>EDWARD G PITKA SR</ogr:NAME>
+      <ogr:USE>Joint Military/Civilian</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.13">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1256990.34973972,5448639.11367461</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>14</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>12.000</ogr:ELEV>
+      <ogr:NAME>MOSES POINT</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.14">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1792919.53785368,5459156.18792796</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>15</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>33.000</ogr:ELEV>
+      <ogr:NAME>NOME</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.15">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-448577.898451724,5281732.65539347</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>16</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>1461.000</ogr:ELEV>
+      <ogr:NAME>KALAKAKET CREEK  AS</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.16">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1091682.67266343,5131737.52623345</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>17</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>18.000</ogr:ELEV>
+      <ogr:NAME>UNALAKLEET</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.17">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>273852.873746379,5076413.95394157</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>18</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>624.000</ogr:ELEV>
+      <ogr:NAME>MINCHUMINA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.18">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-2830822.88899081,5411496.42827483</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>19</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>24.000</ogr:ELEV>
+      <ogr:NAME>GAMBELL</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.19">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-2644310.15859399,5331877.43880641</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>20</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>48.000</ogr:ELEV>
+      <ogr:NAME>SAVOONGA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.20">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-266253.978775606,4736123.65519117</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>21</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>306.000</ogr:ELEV>
+      <ogr:NAME>MC GRATH</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.21">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-328414.977549975,4716360.60340439</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>22</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>858.000</ogr:ELEV>
+      <ogr:NAME>TATALINA LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.22">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1744270.17833722,4809531.82606294</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>23</ogr:ID>
+      <ogr:fk_region>24</ogr:fk_region>
+      <ogr:ELEV>12.000</ogr:ELEV>
+      <ogr:NAME>EMMONAK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.23">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1036446.84250516,4669664.47875566</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>24</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>282.000</ogr:ELEV>
+      <ogr:NAME>ANVIK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.24">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>662363.379506244,4520425.34521129</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>25</ogr:ID>
+      <ogr:fk_region>15</ogr:fk_region>
+      <ogr:ELEV>327.000</ogr:ELEV>
+      <ogr:NAME>TALKEETNA</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.25">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1585048.33561554,4516822.91413498</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>26</ogr:ID>
+      <ogr:fk_region>24</ogr:fk_region>
+      <ogr:ELEV>282.000</ogr:ELEV>
+      <ogr:NAME>ST MARYS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.26">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-2065491.90144689,4490538.99258053</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>27</ogr:ID>
+      <ogr:fk_region>24</ogr:fk_region>
+      <ogr:ELEV>417.000</ogr:ELEV>
+      <ogr:NAME>CAPE ROMANZOF LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.27">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-960987.783243345,4270023.34852798</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>28</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>78.000</ogr:ELEV>
+      <ogr:NAME>ANIAK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.28">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-277226.015425198,4055442.19472923</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>29</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>1449.000</ogr:ELEV>
+      <ogr:NAME>SPARREVOHN LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.29">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1392094.8617294,4017915.62673836</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>30</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>111.000</ogr:ELEV>
+      <ogr:NAME>BETHEL</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.30">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>493563.148473374,3869619.29283125</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>31</ogr:ID>
+      <ogr:fk_region>11</ogr:fk_region>
+      <ogr:ELEV>87.000</ogr:ELEV>
+      <ogr:NAME>KENAI MUNI</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.31">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>532621.792751025,3835669.1912304</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>32</ogr:ID>
+      <ogr:fk_region>11</ogr:fk_region>
+      <ogr:ELEV>96.000</ogr:ELEV>
+      <ogr:NAME>SOLDOTNA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.32">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-2199782.26979038,3989629.62660148</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>33</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>42.000</ogr:ELEV>
+      <ogr:NAME>MEKORYUK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.33">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>1275304.53351584,6140755.19817713</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>34</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>393.000</ogr:ELEV>
+      <ogr:NAME>FORT YUKON</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.34">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>992911.925203977,5471034.03474524</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>35</ogr:ID>
+      <ogr:fk_region>8</ogr:fk_region>
+      <ogr:ELEV>408.000</ogr:ELEV>
+      <ogr:NAME>WAINWRIGHT AAF</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.35">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>955711.987725424,5458755.99369258</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>36</ogr:ID>
+      <ogr:fk_region>8</ogr:fk_region>
+      <ogr:ELEV>396.000</ogr:ELEV>
+      <ogr:NAME>FAIRBANKS INTL</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.36">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>1078903.57950769,5416425.61228487</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>37</ogr:ID>
+      <ogr:fk_region>8</ogr:fk_region>
+      <ogr:ELEV>501.000</ogr:ELEV>
+      <ogr:NAME>EIELSON AFB</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.37">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>774426.618812869,5346412.97825657</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>38</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>330.000</ogr:ELEV>
+      <ogr:NAME>NENANA MUNI</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.38">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>773769.172698093,5255402.67199543</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>39</ogr:ID>
+      <ogr:fk_region>6</ogr:fk_region>
+      <ogr:ELEV>504.000</ogr:ELEV>
+      <ogr:NAME>CLEAR</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.39">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>1324133.08673014,5197270.68603839</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>40</ogr:ID>
+      <ogr:fk_region>22</ogr:fk_region>
+      <ogr:ELEV>1167.000</ogr:ELEV>
+      <ogr:NAME>ALLEN AAF</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.40">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>1739099.96376506,5027295.7900878</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>41</ogr:ID>
+      <ogr:fk_region>22</ogr:fk_region>
+      <ogr:ELEV>1416.000</ogr:ELEV>
+      <ogr:NAME>TANACROSS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.41">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>1993396.51652079,4917592.03147465</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>42</ogr:ID>
+      <ogr:fk_region>22</ogr:fk_region>
+      <ogr:ELEV>1569.000</ogr:ELEV>
+      <ogr:NAME>NORTHWAY</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.42">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>1452800.41345615,4533758.62287071</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>43</ogr:ID>
+      <ogr:fk_region>23</ogr:fk_region>
+      <ogr:ELEV>1443.000</ogr:ELEV>
+      <ogr:NAME>GULKANA</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.43">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>852046.67455286,4266202.29577301</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>44</ogr:ID>
+      <ogr:fk_region>15</ogr:fk_region>
+      <ogr:ELEV>225.000</ogr:ELEV>
+      <ogr:NAME>PALMER MUNI</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.44">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>727860.875968354,4235917.75765553</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>45</ogr:ID>
+      <ogr:fk_region>15</ogr:fk_region>
+      <ogr:ELEV>135.000</ogr:ELEV>
+      <ogr:NAME>BIG LAKE</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.45">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>762040.156085172,4137711.27332171</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>46</ogr:ID>
+      <ogr:fk_region>3</ogr:fk_region>
+      <ogr:ELEV>345.000</ogr:ELEV>
+      <ogr:NAME>BRYANT AHP</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.46">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>735724.851524277,4131921.19448171</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>47</ogr:ID>
+      <ogr:fk_region>3</ogr:fk_region>
+      <ogr:ELEV>192.000</ogr:ELEV>
+      <ogr:NAME>ELMENDORF AFB</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.47">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>729627.977482664,4117944.04434256</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>48</ogr:ID>
+      <ogr:fk_region>3</ogr:fk_region>
+      <ogr:ELEV>123.000</ogr:ELEV>
+      <ogr:NAME>MERRILL FLD</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.48">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>704210.589185948,4101648.70066557</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>49</ogr:ID>
+      <ogr:fk_region>3</ogr:fk_region>
+      <ogr:ELEV>129.000</ogr:ELEV>
+      <ogr:NAME>ANCHORAGE INTL</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.49">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>1362457.14584891,4145200.52866123</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>50</ogr:ID>
+      <ogr:fk_region>23</ogr:fk_region>
+      <ogr:ELEV>108.000</ogr:ELEV>
+      <ogr:NAME>VALDEZ</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.50">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>1527332.93978634,3928110.32484302</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>51</ogr:ID>
+      <ogr:fk_region>23</ogr:fk_region>
+      <ogr:ELEV>36.000</ogr:ELEV>
+      <ogr:NAME>MERLE K MUDHOLE SMITH</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.51">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>832047.619452091,3724788.63657217</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>52</ogr:ID>
+      <ogr:fk_region>11</ogr:fk_region>
+      <ogr:ELEV>18.000</ogr:ELEV>
+      <ogr:NAME>SEWARD</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.52">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-168132.279124333,3559985.03711351</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>53</ogr:ID>
+      <ogr:fk_region>14</ogr:fk_region>
+      <ogr:ELEV>189.000</ogr:ELEV>
+      <ogr:NAME>ILIAMNA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.53">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>465449.542162955,3528313.49175374</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>54</ogr:ID>
+      <ogr:fk_region>11</ogr:fk_region>
+      <ogr:ELEV>75.000</ogr:ELEV>
+      <ogr:NAME>HOMER</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.54">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-233313.190535476,3417552.33259703</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>55</ogr:ID>
+      <ogr:fk_region>14</ogr:fk_region>
+      <ogr:ELEV>606.000</ogr:ELEV>
+      <ogr:NAME>BIG MOUNTAIN AFS</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.55">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-844018.148242018,3327975.14268592</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>56</ogr:ID>
+      <ogr:fk_region>7</ogr:fk_region>
+      <ogr:ELEV>78.000</ogr:ELEV>
+      <ogr:NAME>DILLINGHAM</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.56">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-501987.385118986,3174126.26693856</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>57</ogr:ID>
+      <ogr:fk_region>5</ogr:fk_region>
+      <ogr:ELEV>51.000</ogr:ELEV>
+      <ogr:NAME>KING SALMON</ogr:NAME>
+      <ogr:USE>Joint Military/Civilian</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.57">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1526155.00352845,3246053.69856383</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>58</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>492.000</ogr:ELEV>
+      <ogr:NAME>CAPE NEWENHAM LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.58">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>293805.834881559,2827765.92066546</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>59</ogr:ID>
+      <ogr:fk_region>13</ogr:fk_region>
+      <ogr:ELEV>66.000</ogr:ELEV>
+      <ogr:NAME>KODIAK</ogr:NAME>
+      <ogr:USE>Joint Military/Civilian</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.59">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-3179671.30658296,3001250.92951221</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>60</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>57.000</ogr:ELEV>
+      <ogr:NAME>ST PAUL ISLAND</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.60">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-921344.980200693,2566989.23502851</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>61</ogr:ID>
+      <ogr:fk_region>14</ogr:fk_region>
+      <ogr:ELEV>78.000</ogr:ELEV>
+      <ogr:NAME>PORT HEIDEN</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.61">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-3122511.0606503,2765349.90342551</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>62</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>114.000</ogr:ELEV>
+      <ogr:NAME>ST GEORGE</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.62">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-1816198.8982036,2012829.17872896</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>63</ogr:ID>
+      <ogr:fk_region>1</ogr:fk_region>
+      <ogr:ELEV>87.000</ogr:ELEV>
+      <ogr:NAME>COLD BAY</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.63">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-2692920.78368346,1671951.44666441</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>64</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>18.000</ogr:ELEV>
+      <ogr:NAME>UNALASKA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.64">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-3257915.42438495,1433525.79887208</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>65</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>66.000</ogr:ELEV>
+      <ogr:NAME>NIKOLSKI AS</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.65">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>-4480198.52221446,1492348.0273686</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>66</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>51.000</ogr:ELEV>
+      <ogr:NAME>ATKA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.66">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>2634420.20177029,3752745.91014988</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>67</ogr:ID>
+      <ogr:fk_region>21</ogr:fk_region>
+      <ogr:ELEV>30.000</ogr:ELEV>
+      <ogr:NAME>YAKUTAT</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.67">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>3418277.20783493,3935405.15295654</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>68</ogr:ID>
+      <ogr:fk_region>21</ogr:fk_region>
+      <ogr:ELEV>39.000</ogr:ELEV>
+      <ogr:NAME>SKAGWAY</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.68">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>3403121.71957609,3849074.35123106</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>69</ogr:ID>
+      <ogr:fk_region>9</ogr:fk_region>
+      <ogr:ELEV>12.000</ogr:ELEV>
+      <ogr:NAME>HAINES</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.69">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>3451748.54373565,3549955.36564365</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>70</ogr:ID>
+      <ogr:fk_region>21</ogr:fk_region>
+      <ogr:ELEV>30.000</ogr:ELEV>
+      <ogr:NAME>GUSTAVUS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.70">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>3539731.0832131,3449869.1315306</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>71</ogr:ID>
+      <ogr:fk_region>21</ogr:fk_region>
+      <ogr:ELEV>18.000</ogr:ELEV>
+      <ogr:NAME>HOONAH</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.71">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>3941104.35942502,3135887.32834426</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>72</ogr:ID>
+      <ogr:fk_region>25</ogr:fk_region>
+      <ogr:ELEV>156.000</ogr:ELEV>
+      <ogr:NAME>KAKE</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.72">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>4141889.52314928,3139116.18098233</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>73</ogr:ID>
+      <ogr:fk_region>25</ogr:fk_region>
+      <ogr:ELEV>96.000</ogr:ELEV>
+      <ogr:NAME>PETERSBURG JAMES A JOHNSON</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.73">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>4288271.50007927,3065425.98399915</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>74</ogr:ID>
+      <ogr:fk_region>25</ogr:fk_region>
+      <ogr:ELEV>39.000</ogr:ELEV>
+      <ogr:NAME>WRANGELL</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.74">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>4255605.43195212,2705772.04736206</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>75</ogr:ID>
+      <ogr:fk_region>19</ogr:fk_region>
+      <ogr:ELEV>72.000</ogr:ELEV>
+      <ogr:NAME>KLAWOCK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airports fid="airports.75">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:2964"><gml:coordinates>4615124.97898512,2620432.35721463</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:ID>76</ogr:ID>
+      <ogr:fk_region>19</ogr:fk_region>
+      <ogr:ELEV>108.000</ogr:ELEV>
+      <ogr:NAME>ANNETTE ISLAND</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airports>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/airportsvoronoidiagram.gml
+++ b/python/plugins/processing/tests/testdata/expected/airportsvoronoidiagram.gml
@@ -1,0 +1,774 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ airportsvoronoidiagram.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-4480198.52221446</gml:X><gml:Y>1433525.79887208</gml:Y></gml:coord>
+      <gml:coord><gml:X>4615124.978985121</gml:X><gml:Y>6502586.8303472</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                   
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-532210.542246117,5828994.34280271 -867465.492896212,6497618.84486669 -865814.588242209,6502586.8303472 -73284.3652815837,6502586.8303472 -92271.7107692221,6283969.52616539 -404850.810863799,5842553.4830259 -532210.542246117,5828994.34280271</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>2</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>264.000</ogr:ELEV>
+      <ogr:NAME>AMBLER</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.59">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-4257402.15821445,2615234.57362352 -4480198.52221446,2807263.32147344 -4480198.52221446,4419851.71285355 -3475466.84282692,4274431.23322233 -2359483.84821908,3168033.95363344 -2346203.14462923,3078329.65826566 -4257402.15821445,2615234.57362352</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>60</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>57.000</ogr:ELEV>
+      <ogr:NAME>ST PAUL ISLAND</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.18">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-3475466.84282692,4274431.23322233 -4480198.52221446,4419851.71285355 -4480198.52221446,6502586.8303472 -3033884.38577758,6502586.8303472 -2555923.55589311,5797197.5576577 -3142972.87893425,4421995.82690179 -3475466.84282692,4274431.23322233</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>19</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>24.000</ogr:ELEV>
+      <ogr:NAME>GAMBELL</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.68">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3039382.44519938,3636430.3647804 2998252.78123352,3964645.32146959 3919722.31800637,3802880.10596924 3789817.32142783,3758426.18091992 3039382.44519938,3636430.3647804</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>69</ogr:ID>
+      <ogr:fk_region>9</ogr:fk_region>
+      <ogr:ELEV>12.000</ogr:ELEV>
+      <ogr:NAME>HAINES</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.20">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>142500.810269319,4389105.6969406 -191861.125604844,4394495.34191808 -384348.408637802,4999928.24235185 -112454.237666202,5090786.00124191 192907.945405541,4606116.8579141 142500.810269319,4389105.6969406</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>21</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>306.000</ogr:ELEV>
+      <ogr:NAME>MC GRATH</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.46">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>753008.574860625,4116063.67120329 697330.712403195,4140350.51873155 660646.456176626,4178539.55203128 737975.594442057,4184386.99962494 753008.574860625,4116063.67120329</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>47</ogr:ID>
+      <ogr:fk_region>3</ogr:fk_region>
+      <ogr:ELEV>192.000</ogr:ELEV>
+      <ogr:NAME>ELMENDORF AFB</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.34">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>999973.828357832,5387144.82378439 817733.22413706,5939296.34811879 1238062.25619146,5762061.67465738 999973.828357832,5387144.82378439</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>35</ogr:ID>
+      <ogr:fk_region>8</ogr:fk_region>
+      <ogr:ELEV>408.000</ogr:ELEV>
+      <ogr:NAME>WAINWRIGHT AAF</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.67">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3919722.31800637,3802880.10596924 2998252.78123352,3964645.32146959 2843941.64650615,4626850.32249363 4136908.69757344,6502586.8303472 4615124.97898512,6502586.8303472 4615124.97898512,4296088.70125129 4130363.04321519,3855570.59907405 3919722.31800637,3802880.10596924</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>68</ogr:ID>
+      <ogr:fk_region>21</ogr:fk_region>
+      <ogr:ELEV>39.000</ogr:ELEV>
+      <ogr:NAME>SKAGWAY</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>668986.686473399,5834100.44317414 367608.721872584,5865150.39611119 -92271.7107692221,6283969.52616539 -73284.3652815837,6502586.8303472 833704.22218952,6502586.8303472 804665.393700446,5945420.08135738 668986.686473399,5834100.44317414</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>3</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>585.000</ogr:ELEV>
+      <ogr:NAME>BETTLES</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.24">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>258958.1450125,4277763.00280427 188566.730389057,4296020.49596635 142500.810269319,4389105.6969406 192907.945405541,4606116.8579141 617907.740024255,4903095.75741392 1008554.55965487,4843882.61271837 1052970.73242852,4800455.73824729 1056076.93018678,4616310.93862514 755562.039362293,4392087.93906584 258958.1450125,4277763.00280427</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>25</ogr:ID>
+      <ogr:fk_region>15</ogr:fk_region>
+      <ogr:ELEV>327.000</ogr:ELEV>
+      <ogr:NAME>TALKEETNA</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.4">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-686580.022432604,5739023.03826023 -1082711.81956336,6108975.25566275 -967581.708648672,6399973.86930819 -867465.492896212,6497618.84486669 -532210.542246117,5828994.34280271 -686580.022432604,5739023.03826023</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>5</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>21.000</ogr:ELEV>
+      <ogr:NAME>SELAWIK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.47">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>829582.629708969,3934064.69857467 697330.712403195,4140350.51873155 753008.574860625,4116063.67120329 859285.336307107,3941802.45447267 829582.629708969,3934064.69857467</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>48</ogr:ID>
+      <ogr:fk_region>3</ogr:fk_region>
+      <ogr:ELEV>123.000</ogr:ELEV>
+      <ogr:NAME>MERRILL FLD</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.50">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1842186.34443699,2333560.7772499 1506066.19892295,2710363.99306304 1177587.42194549,3833640.47977771 1741429.80645786,4261867.82107174 2027421.53589256,4297062.64647408 2144474.87074749,4241928.43272808 1842186.34443699,2333560.7772499</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>51</ogr:ID>
+      <ogr:fk_region>23</ogr:fk_region>
+      <ogr:ELEV>36.000</ogr:ELEV>
+      <ogr:NAME>MERLE K MUDHOLE SMITH</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.26">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1806059.54813635,4152531.1097911 -2994539.17079009,4471154.35210752 -2241629.0067928,4989136.32579263 -1829102.17371467,4573727.05561027 -1806059.54813635,4152531.1097911</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>27</ogr:ID>
+      <ogr:fk_region>24</ogr:fk_region>
+      <ogr:ELEV>417.000</ogr:ELEV>
+      <ogr:NAME>CAPE ROMANZOF LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.41">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2144474.87074749,4241928.43272808 2027421.53589256,4297062.64647408 1745923.67004111,4693528.00329071 2266531.91732379,5900313.29755793 3292415.53533174,6502586.8303472 4136908.69757344,6502586.8303472 2843941.64650615,4626850.32249363 2144474.87074749,4241928.43272808</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>42</ogr:ID>
+      <ogr:fk_region>22</ogr:fk_region>
+      <ogr:ELEV>1569.000</ogr:ELEV>
+      <ogr:NAME>NORTHWAY</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.74">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2285314.5486575,1433525.79887208 2444078.8034502,1679364.08968231 2582061.27097481,1812113.04298182 4045601.57598573,2882256.36493373 4113260.7693229,2900011.1377858 4483615.92503234,2866373.11657917 4143498.82394333,1433525.79887208 2285314.5486575,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>75</ogr:ID>
+      <ogr:fk_region>19</ogr:fk_region>
+      <ogr:ELEV>72.000</ogr:ELEV>
+      <ogr:NAME>KLAWOCK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.35">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>960272.8403224,5271605.39917333 928771.011941672,5299790.48750266 655972.926763175,5739998.55311571 668986.686473399,5834100.44317414 804665.393700446,5945420.08135738 817733.22413706,5939296.34811879 999973.828357832,5387144.82378439 960272.8403224,5271605.39917333</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>36</ogr:ID>
+      <ogr:fk_region>8</ogr:fk_region>
+      <ogr:ELEV>396.000</ogr:ELEV>
+      <ogr:NAME>FAIRBANKS INTL</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.56">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-288158.165076436,2578035.14996072 -812747.41735766,2940375.89954451 -558236.937068588,3506193.57857019 -102915.543205044,3003646.29201722 -288158.165076436,2578035.14996072</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>57</ogr:ID>
+      <ogr:fk_region>5</ogr:fk_region>
+      <ogr:ELEV>51.000</ogr:ELEV>
+      <ogr:NAME>KING SALMON</ogr:NAME>
+      <ogr:USE>Joint Military/Civilian</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.69">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2868760.7079488,2948755.39477712 3039382.44519938,3636430.3647804 3789817.32142783,3758426.18091992 2868760.7079488,2948755.39477712</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>70</ogr:ID>
+      <ogr:fk_region>21</ogr:fk_region>
+      <ogr:ELEV>30.000</ogr:ELEV>
+      <ogr:NAME>GUSTAVUS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.70">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2444078.8034502,1679364.08968231 2868760.7079488,2948755.39477712 3789817.32142783,3758426.18091992 3919722.31800637,3802880.10596924 4130363.04321519,3855570.59907405 4032984.01476301,3666875.35498447 2582061.27097481,1812113.04298182 2444078.8034502,1679364.08968231</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>71</ogr:ID>
+      <ogr:fk_region>21</ogr:fk_region>
+      <ogr:ELEV>18.000</ogr:ELEV>
+      <ogr:NAME>HOONAH</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.16">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1365648.01009993,4864649.98976949 -1493540.2366218,5123679.76192065 -1107985.60249709,5324799.42644423 -805733.878620532,5337505.56201804 -794182.820057185,5309860.43798449 -708661.094065839,4943185.66266439 -1365648.01009993,4864649.98976949</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>17</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>18.000</ogr:ELEV>
+      <ogr:NAME>UNALAKLEET</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.9">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-2222898.10359645,5424168.28484731 -2313304.25809385,5566820.7618436 -1695620.31949794,6152583.05525282 -1521899.91100483,5894247.73127063 -1520265.23261742,5883292.05523027 -1527345.09308833,5802043.30788609 -2222898.10359645,5424168.28484731</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>10</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>9.000</ogr:ELEV>
+      <ogr:NAME>PORT CLARENCE CGS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.14">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-2175020.66333305,5103907.40966864 -2222898.10359645,5424168.28484731 -1527345.09308833,5802043.30788609 -1518627.00928159,5776356.60900819 -1530876.51095748,5152146.36480785 -2175020.66333305,5103907.40966864</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>15</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>33.000</ogr:ELEV>
+      <ogr:NAME>NOME</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.38">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1008554.55965487,4843882.61271837 617907.740024255,4903095.75741392 474701.790514883,5303070.62200315 928771.011941672,5299790.48750266 960272.8403224,5271605.39917333 1038145.86717796,5124037.97919375 1008554.55965487,4843882.61271837</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>39</ogr:ID>
+      <ogr:fk_region>6</ogr:fk_region>
+      <ogr:ELEV>504.000</ogr:ELEV>
+      <ogr:NAME>CLEAR</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1767876.60302699,6334055.16732344 -1887262.38480209,6502586.8303472 -865814.588242209,6502586.8303472 -867465.492896212,6497618.84486669 -967581.708648672,6399973.86930819 -1767876.60302699,6334055.16732344</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>1</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>78.000</ogr:ELEV>
+      <ogr:NAME>NOATAK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.21">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-555205.627463031,4366353.85319612 -671783.749666031,4531574.54458752 -698272.254649272,4933207.56497712 -384348.408637802,4999928.24235185 -191861.125604844,4394495.34191808 -555205.627463031,4366353.85319612</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>22</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>858.000</ogr:ELEV>
+      <ogr:NAME>TATALINA LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.32">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-2359483.84821908,3168033.95363344 -3475466.84282692,4274431.23322233 -3142972.87893425,4421995.82690179 -2994539.17079009,4471154.35210752 -1806059.54813635,4152531.1097911 -1800939.1344639,4146560.44947372 -1784899.74234856,3688566.56621623 -2359483.84821908,3168033.95363344</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>33</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>42.000</ogr:ELEV>
+      <ogr:NAME>MEKORYUK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.13">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1493540.2366218,5123679.76192065 -1530876.51095748,5152146.36480785 -1518627.00928159,5776356.60900819 -1239463.39731665,5605110.33380644 -1107985.60249709,5324799.42644423 -1493540.2366218,5123679.76192065</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>14</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>12.000</ogr:ELEV>
+      <ogr:NAME>MOSES POINT</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.65">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-4480198.52221446,1433525.79887208 -4480198.52221446,2807263.32147344 -4257402.15821445,2615234.57362352 -3835269.32564703,2165019.64097425 -3870472.37966974,1433525.79887208 -4480198.52221446,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>66</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>51.000</ogr:ELEV>
+      <ogr:NAME>ATKA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.33">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1536108.29808077,5681246.90731179 1238062.25619146,5762061.67465738 817733.22413706,5939296.34811879 804665.393700446,5945420.08135738 833704.22218952,6502586.8303472 3292415.53533174,6502586.8303472 2266531.91732379,5900313.29755793 1769620.32878559,5693331.95425295 1536108.29808077,5681246.90731179</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>34</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>393.000</ogr:ELEV>
+      <ogr:NAME>FORT YUKON</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.11">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1107985.60249709,5324799.42644423 -1239463.39731665,5605110.33380644 -755398.382112958,5605058.14567387 -805733.878620532,5337505.56201804 -1107985.60249709,5324799.42644423</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>12</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>108.000</ogr:ELEV>
+      <ogr:NAME>KOYUK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.51">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1506066.19892295,2710363.99306304 966141.314630114,3034335.87036614 634956.118344489,3652286.07621602 726331.84342838,3899040.36156378 829582.629708969,3934064.69857467 859285.336307107,3941802.45447267 1064305.44439099,3976561.84141049 1177587.42194549,3833640.47977771 1506066.19892295,2710363.99306304</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>52</ogr:ID>
+      <ogr:fk_region>11</ogr:fk_region>
+      <ogr:ELEV>18.000</ogr:ELEV>
+      <ogr:NAME>SEWARD</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.71">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2582061.27097481,1812113.04298182 4032984.01476301,3666875.35498447 4045601.57598573,2882256.36493373 2582061.27097481,1812113.04298182</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>72</ogr:ID>
+      <ogr:fk_region>25</ogr:fk_region>
+      <ogr:ELEV>156.000</ogr:ELEV>
+      <ogr:NAME>KAKE</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.75">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4143498.82394333,1433525.79887208 4483615.92503234,2866373.11657917 4615124.97898512,2962968.18941804 4615124.97898512,1433525.79887208 4143498.82394333,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>76</ogr:ID>
+      <ogr:fk_region>19</ogr:fk_region>
+      <ogr:ELEV>108.000</ogr:ELEV>
+      <ogr:NAME>ANNETTE ISLAND</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.8">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-755398.382112958,5605058.14567387 -1239463.39731665,5605110.33380644 -1518627.00928159,5776356.60900819 -1527345.09308833,5802043.30788609 -1520265.23261742,5883292.05523027 -704134.682823943,5717816.92994783 -755398.382112958,5605058.14567387</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>9</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>1329.000</ogr:ELEV>
+      <ogr:NAME>GRANITE MOUNTAIN AFS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.61">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-3206836.34772619,2101127.89488382 -3835269.32564703,2165019.64097425 -4257402.15821445,2615234.57362352 -2346203.14462923,3078329.65826566 -2252179.23151447,2766088.22241046 -2468021.60290778,2391404.16964088 -3206836.34772619,2101127.89488382</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>62</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>114.000</ogr:ELEV>
+      <ogr:NAME>ST GEORGE</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.37">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>928771.011941672,5299790.48750266 474701.790514883,5303070.62200315 472801.125056393,5306594.42446535 655972.926763175,5739998.55311571 928771.011941672,5299790.48750266</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>38</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>330.000</ogr:ELEV>
+      <ogr:NAME>NENANA MUNI</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.57">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1563327.4666973,2604076.15931251 -2252179.23151447,2766088.22241046 -2346203.14462923,3078329.65826566 -2359483.84821908,3168033.95363344 -1784899.74234856,3688566.56621623 -1221560.61734796,3590723.51913508 -1147542.53956386,2974395.77546458 -1563327.4666973,2604076.15931251</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>58</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>492.000</ogr:ELEV>
+      <ogr:NAME>CAPE NEWENHAM LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.31">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>634956.118344489,3652286.07621602 386195.220154139,3706652.49733074 615543.99323177,3970511.85918109 726331.84342838,3899040.36156378 634956.118344489,3652286.07621602</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>32</ogr:ID>
+      <ogr:fk_region>11</ogr:fk_region>
+      <ogr:ELEV>96.000</ogr:ELEV>
+      <ogr:NAME>SOLDOTNA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.53">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>966141.314630114,3034335.87036614 154051.048259547,3233309.05893981 138138.522548066,3333696.95696242 157722.606426642,3725471.9521855 386195.220154139,3706652.49733074 634956.118344489,3652286.07621602 966141.314630114,3034335.87036614</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>54</ogr:ID>
+      <ogr:fk_region>11</ogr:fk_region>
+      <ogr:ELEV>75.000</ogr:ELEV>
+      <ogr:NAME>HOMER</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.72">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4045601.57598573,2882256.36493373 4032984.01476301,3666875.35498447 4130363.04321519,3855570.59907405 4615124.97898512,4296088.70125129 4615124.97898512,3896939.87686262 4113260.7693229,2900011.1377858 4045601.57598573,2882256.36493373</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>73</ogr:ID>
+      <ogr:fk_region>25</ogr:fk_region>
+      <ogr:ELEV>96.000</ogr:ELEV>
+      <ogr:NAME>PETERSBURG JAMES A JOHNSON</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-86156.1601291532,5485825.18018908 -404850.810863799,5842553.4830259 -92271.7107692221,6283969.52616539 367608.721872584,5865150.39611119 -86156.1601291532,5485825.18018908</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>6</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>1113.000</ogr:ELEV>
+      <ogr:NAME>INDIAN MOUNTAIN LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.15">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-698272.254649272,4933207.56497712 -708661.094065839,4943185.66266439 -794182.820057185,5309860.43798449 -62824.9142113505,5372498.14168655 -45743.5827064952,5325512.9386109 -112454.237666202,5090786.00124191 -384348.408637802,4999928.24235185 -698272.254649272,4933207.56497712</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>16</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>1461.000</ogr:ELEV>
+      <ogr:NAME>KALAKAKET CREEK  AS</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.58">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-42541.4469267707,1433525.79887208 -288158.165076436,2578035.14996072 -102915.543205044,3003646.29201722 154051.048259547,3233309.05893981 966141.314630114,3034335.87036614 1506066.19892295,2710363.99306304 1842186.34443699,2333560.7772499 2197868.32119173,1433525.79887208 -42541.4469267707,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>59</ogr:ID>
+      <ogr:fk_region>13</ogr:fk_region>
+      <ogr:ELEV>66.000</ogr:ELEV>
+      <ogr:NAME>KODIAK</ogr:NAME>
+      <ogr:USE>Joint Military/Civilian</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.39">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1052970.73242852,4800455.73824729 1008554.55965487,4843882.61271837 1038145.86717796,5124037.97919375 1536108.29808077,5681246.90731179 1769620.32878559,5693331.95425295 1434167.52397575,4874376.88429362 1052970.73242852,4800455.73824729</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>40</ogr:ID>
+      <ogr:fk_region>22</ogr:fk_region>
+      <ogr:ELEV>1167.000</ogr:ELEV>
+      <ogr:NAME>ALLEN AAF</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.7">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-2313304.25809385,5566820.7618436 -2555923.55589311,5797197.5576577 -3033884.38577758,6502586.8303472 -1887262.38480209,6502586.8303472 -1767876.60302699,6334055.16732344 -1695620.31949794,6152583.05525282 -2313304.25809385,5566820.7618436</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>8</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>243.000</ogr:ELEV>
+      <ogr:NAME>TIN CITY LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.64">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-3870472.37966974,1433525.79887208 -3835269.32564703,2165019.64097425 -3206836.34772619,2101127.89488382 -2925110.73345932,1433525.79887208 -3870472.37966974,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>65</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>66.000</ogr:ELEV>
+      <ogr:NAME>NIKOLSKI AS</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.12">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-794182.820057185,5309860.43798449 -805733.878620532,5337505.56201804 -755398.382112958,5605058.14567387 -704134.682823943,5717816.92994783 -686580.022432604,5739023.03826023 -532210.542246117,5828994.34280271 -404850.810863799,5842553.4830259 -86156.1601291532,5485825.18018908 -62824.9142113505,5372498.14168655 -794182.820057185,5309860.43798449</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>13</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>138.000</ogr:ELEV>
+      <ogr:NAME>EDWARD G PITKA SR</ogr:NAME>
+      <ogr:USE>Joint Military/Civilian</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.10">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>472801.125056393,5306594.42446535 -45743.5827064952,5325512.9386109 -62824.9142113505,5372498.14168655 -86156.1601291532,5485825.18018908 367608.721872584,5865150.39611119 668986.686473399,5834100.44317414 655972.926763175,5739998.55311571 472801.125056393,5306594.42446535</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>11</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>207.000</ogr:ELEV>
+      <ogr:NAME>RALPH M CALHOUN</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1521899.91100483,5894247.73127063 -1695620.31949794,6152583.05525282 -1767876.60302699,6334055.16732344 -967581.708648672,6399973.86930819 -1082711.81956336,6108975.25566275 -1521899.91100483,5894247.73127063</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>4</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>9.000</ogr:ELEV>
+      <ogr:NAME>RALPH WIEN MEM</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.45">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>859285.336307107,3941802.45447267 753008.574860625,4116063.67120329 737975.594442057,4184386.99962494 800874.52764628,4206278.02109485 1063736.85497316,4022145.91234793 1064305.44439099,3976561.84141049 859285.336307107,3941802.45447267</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>46</ogr:ID>
+      <ogr:fk_region>3</ogr:fk_region>
+      <ogr:ELEV>345.000</ogr:ELEV>
+      <ogr:NAME>BRYANT AHP</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.60">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-838435.682023881,1433525.79887208 -1563327.4666973,2604076.15931251 -1147542.53956386,2974395.77546458 -812747.41735766,2940375.89954451 -288158.165076436,2578035.14996072 -42541.4469267707,1433525.79887208 -838435.682023881,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>61</ogr:ID>
+      <ogr:fk_region>14</ogr:fk_region>
+      <ogr:ELEV>78.000</ogr:ELEV>
+      <ogr:NAME>PORT HEIDEN</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.52">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>138138.522548066,3333696.95696242 -581221.623391829,3662894.87610879 -602244.382885205,3724137.89381064 87299.7222286621,3875967.25304952 157722.606426642,3725471.9521855 138138.522548066,3333696.95696242</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>53</ogr:ID>
+      <ogr:fk_region>14</ogr:fk_region>
+      <ogr:ELEV>189.000</ogr:ELEV>
+      <ogr:NAME>ILIAMNA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.44">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>660646.456176626,4178539.55203128 320382.023886799,4238474.07146496 258958.1450125,4277763.00280427 755562.039362293,4392087.93906584 800874.52764628,4206278.02109485 737975.594442057,4184386.99962494 660646.456176626,4178539.55203128</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>45</ogr:ID>
+      <ogr:fk_region>15</ogr:fk_region>
+      <ogr:ELEV>135.000</ogr:ELEV>
+      <ogr:NAME>BIG LAKE</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.73">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4483615.92503234,2866373.11657917 4113260.7693229,2900011.1377858 4615124.97898512,3896939.87686262 4615124.97898512,2962968.18941804 4483615.92503234,2866373.11657917</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>74</ogr:ID>
+      <ogr:fk_region>25</ogr:fk_region>
+      <ogr:ELEV>39.000</ogr:ELEV>
+      <ogr:NAME>WRANGELL</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.42">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1741429.80645786,4261867.82107174 1153001.5175226,4398682.71482167 1056076.93018678,4616310.93862514 1052970.73242852,4800455.73824729 1434167.52397575,4874376.88429362 1745923.67004111,4693528.00329071 2027421.53589256,4297062.64647408 1741429.80645786,4261867.82107174</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>43</ogr:ID>
+      <ogr:fk_region>23</ogr:fk_region>
+      <ogr:ELEV>1443.000</ogr:ELEV>
+      <ogr:NAME>GULKANA</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.27">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-969911.125883067,3790629.49569518 -1292948.42330816,4343026.9571707 -1262492.30134292,4420038.69845963 -671783.749666031,4531574.54458752 -555205.627463031,4366353.85319612 -726393.055733294,3820865.97362168 -969911.125883067,3790629.49569518</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>28</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>78.000</ogr:ELEV>
+      <ogr:NAME>ANIAK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.40">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1745923.67004111,4693528.00329071 1434167.52397575,4874376.88429362 1769620.32878559,5693331.95425295 2266531.91732379,5900313.29755793 1745923.67004111,4693528.00329071</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>41</ogr:ID>
+      <ogr:fk_region>22</ogr:fk_region>
+      <ogr:ELEV>1416.000</ogr:ELEV>
+      <ogr:NAME>TANACROSS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.62">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-2095589.46447355,1433525.79887208 -2468021.60290778,2391404.16964088 -2252179.23151447,2766088.22241046 -1563327.4666973,2604076.15931251 -838435.682023881,1433525.79887208 -2095589.46447355,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>63</ogr:ID>
+      <ogr:fk_region>1</ogr:fk_region>
+      <ogr:ELEV>87.000</ogr:ELEV>
+      <ogr:NAME>COLD BAY</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.22">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1829102.17371467,4573727.05561027 -2241629.0067928,4989136.32579263 -2175020.66333305,5103907.40966864 -1530876.51095748,5152146.36480785 -1493540.2366218,5123679.76192065 -1365648.01009993,4864649.98976949 -1374243.31641777,4821151.92887451 -1829102.17371467,4573727.05561027</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>23</ogr:ID>
+      <ogr:fk_region>24</ogr:fk_region>
+      <ogr:ELEV>12.000</ogr:ELEV>
+      <ogr:NAME>EMMONAK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.63">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-2925110.73345932,1433525.79887208 -3206836.34772619,2101127.89488382 -2468021.60290778,2391404.16964088 -2095589.46447355,1433525.79887208 -2925110.73345932,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>64</ogr:ID>
+      <ogr:fk_region>2</ogr:fk_region>
+      <ogr:ELEV>18.000</ogr:ELEV>
+      <ogr:NAME>UNALASKA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.28">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-602244.382885205,3724137.89381064 -726393.055733294,3820865.97362168 -555205.627463031,4366353.85319612 -191861.125604844,4394495.34191808 142500.810269319,4389105.6969406 188566.730389057,4296020.49596635 87299.7222286621,3875967.25304952 -602244.382885205,3724137.89381064</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>29</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>1449.000</ogr:ELEV>
+      <ogr:NAME>SPARREVOHN LRRS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.66">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2197868.32119173,1433525.79887208 1842186.34443699,2333560.7772499 2144474.87074749,4241928.43272808 2843941.64650615,4626850.32249363 2998252.78123352,3964645.32146959 3039382.44519938,3636430.3647804 2868760.7079488,2948755.39477712 2444078.8034502,1679364.08968231 2285314.5486575,1433525.79887208 2197868.32119173,1433525.79887208</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>67</ogr:ID>
+      <ogr:fk_region>21</ogr:fk_region>
+      <ogr:ELEV>30.000</ogr:ELEV>
+      <ogr:NAME>YAKUTAT</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.49">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1177587.42194549,3833640.47977771 1064305.44439099,3976561.84141049 1063736.85497316,4022145.91234793 1153001.5175226,4398682.71482167 1741429.80645786,4261867.82107174 1177587.42194549,3833640.47977771</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>50</ogr:ID>
+      <ogr:fk_region>23</ogr:fk_region>
+      <ogr:ELEV>108.000</ogr:ELEV>
+      <ogr:NAME>VALDEZ</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.17">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>192907.945405541,4606116.8579141 -112454.237666202,5090786.00124191 -45743.5827064952,5325512.9386109 472801.125056393,5306594.42446535 474701.790514883,5303070.62200315 617907.740024255,4903095.75741392 192907.945405541,4606116.8579141</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>18</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>624.000</ogr:ELEV>
+      <ogr:NAME>MINCHUMINA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.48">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>726331.84342838,3899040.36156378 615543.99323177,3970511.85918109 320382.023886799,4238474.07146496 660646.456176626,4178539.55203128 697330.712403195,4140350.51873155 829582.629708969,3934064.69857467 726331.84342838,3899040.36156378</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>49</ogr:ID>
+      <ogr:fk_region>3</ogr:fk_region>
+      <ogr:ELEV>129.000</ogr:ELEV>
+      <ogr:NAME>ANCHORAGE INTL</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.25">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1800939.1344639,4146560.44947372 -1806059.54813635,4152531.1097911 -1829102.17371467,4573727.05561027 -1374243.31641777,4821151.92887451 -1262492.30134292,4420038.69845963 -1292948.42330816,4343026.9571707 -1800939.1344639,4146560.44947372</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>26</ogr:ID>
+      <ogr:fk_region>24</ogr:fk_region>
+      <ogr:ELEV>282.000</ogr:ELEV>
+      <ogr:NAME>ST MARYS</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.29">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1221560.61734796,3590723.51913508 -1784899.74234856,3688566.56621623 -1800939.1344639,4146560.44947372 -1292948.42330816,4343026.9571707 -969911.125883067,3790629.49569518 -1221560.61734796,3590723.51913508</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>30</ogr:ID>
+      <ogr:fk_region>4</ogr:fk_region>
+      <ogr:ELEV>111.000</ogr:ELEV>
+      <ogr:NAME>BETHEL</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.6">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-704134.682823943,5717816.92994783 -1520265.23261742,5883292.05523027 -1521899.91100483,5894247.73127063 -1082711.81956336,6108975.25566275 -686580.022432604,5739023.03826023 -704134.682823943,5717816.92994783</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>7</ogr:ID>
+      <ogr:fk_region>18</ogr:fk_region>
+      <ogr:ELEV>21.000</ogr:ELEV>
+      <ogr:NAME>BUCKLAND</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.43">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1063736.85497316,4022145.91234793 800874.52764628,4206278.02109485 755562.039362293,4392087.93906584 1056076.93018678,4616310.93862514 1153001.5175226,4398682.71482167 1063736.85497316,4022145.91234793</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>44</ogr:ID>
+      <ogr:fk_region>15</ogr:fk_region>
+      <ogr:ELEV>225.000</ogr:ELEV>
+      <ogr:NAME>PALMER MUNI</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.19">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-3142972.87893425,4421995.82690179 -2555923.55589311,5797197.5576577 -2313304.25809385,5566820.7618436 -2222898.10359645,5424168.28484731 -2175020.66333305,5103907.40966864 -2241629.0067928,4989136.32579263 -2994539.17079009,4471154.35210752 -3142972.87893425,4421995.82690179</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>20</ogr:ID>
+      <ogr:fk_region>16</ogr:fk_region>
+      <ogr:ELEV>48.000</ogr:ELEV>
+      <ogr:NAME>SAVOONGA</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.23">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1262492.30134292,4420038.69845963 -1374243.31641777,4821151.92887451 -1365648.01009993,4864649.98976949 -708661.094065839,4943185.66266439 -698272.254649272,4933207.56497712 -671783.749666031,4531574.54458752 -1262492.30134292,4420038.69845963</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>24</ogr:ID>
+      <ogr:fk_region>26</ogr:fk_region>
+      <ogr:ELEV>282.000</ogr:ELEV>
+      <ogr:NAME>ANVIK</ogr:NAME>
+      <ogr:USE>Other</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.36">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1038145.86717796,5124037.97919375 960272.8403224,5271605.39917333 999973.828357832,5387144.82378439 1238062.25619146,5762061.67465738 1536108.29808077,5681246.90731179 1038145.86717796,5124037.97919375</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>37</ogr:ID>
+      <ogr:fk_region>8</ogr:fk_region>
+      <ogr:ELEV>501.000</ogr:ELEV>
+      <ogr:NAME>EIELSON AFB</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.30">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>386195.220154139,3706652.49733074 157722.606426642,3725471.9521855 87299.7222286621,3875967.25304952 188566.730389057,4296020.49596635 258958.1450125,4277763.00280427 320382.023886799,4238474.07146496 615543.99323177,3970511.85918109 386195.220154139,3706652.49733074</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>31</ogr:ID>
+      <ogr:fk_region>11</ogr:fk_region>
+      <ogr:ELEV>87.000</ogr:ELEV>
+      <ogr:NAME>KENAI MUNI</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.54">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-102915.543205044,3003646.29201722 -558236.937068588,3506193.57857019 -581221.623391829,3662894.87610879 138138.522548066,3333696.95696242 154051.048259547,3233309.05893981 -102915.543205044,3003646.29201722</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>55</ogr:ID>
+      <ogr:fk_region>14</ogr:fk_region>
+      <ogr:ELEV>606.000</ogr:ELEV>
+      <ogr:NAME>BIG MOUNTAIN AFS</ogr:NAME>
+      <ogr:USE>Military</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:airportsvoronoidiagram fid="airports.55">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:2964"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-812747.41735766,2940375.89954451 -1147542.53956386,2974395.77546458 -1221560.61734796,3590723.51913508 -969911.125883067,3790629.49569518 -726393.055733294,3820865.97362168 -602244.382885205,3724137.89381064 -581221.623391829,3662894.87610879 -558236.937068588,3506193.57857019 -812747.41735766,2940375.89954451</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:ID>56</ogr:ID>
+      <ogr:fk_region>7</ogr:fk_region>
+      <ogr:ELEV>78.000</ogr:ELEV>
+      <ogr:NAME>DILLINGHAM</ogr:NAME>
+      <ogr:USE>Civilian/Public</ogr:USE>
+    </ogr:airportsvoronoidiagram>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -3595,6 +3595,18 @@ tests:
         name: expected/pointsvoronoi1diagram.gml
         type: vector
 
+  - algorithm: qgis:voronoipolygons
+    name: Vornoi with configuration that may cause numerical issues
+    params:
+      BUFFER: 0.0
+      INPUT:
+        name: airports.gml
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/airportsvoronoidiagram.gml
+        type: vector
+
   - algorithm: native:explodelines
     name: Explode lines
     params:


### PR DESCRIPTION
…s (Fixes #8002 - hopefully)

## Description
The issue reported in #8002 with the airport dataset was due to numerical problems when comparing for equality.  This commit adds the isclose function (https://www.python.org/dev/peps/pep-0485/) to handle this.  Seems to fix the issue.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
