### PR TITLE
Add a QgsTask subclass for proxying progress reports from a non-background task

### DIFF
--- a/python/core/auto_generated/qgsproxyprogresstask.sip.in
+++ b/python/core/auto_generated/qgsproxyprogresstask.sip.in
@@ -1,0 +1,61 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsproxyprogresstask.h                                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsProxyProgressTask : QgsTask
+{
+%Docstring
+
+A QgsTask shell which proxies progress reports.
+
+Simple task shell which runs until finalized and reports progress only.
+This is usually used to expose a blocking operation's progress via
+task manager.
+
+.. versionadded:: 3.4
+%End
+
+%TypeHeaderCode
+#include "qgsproxyprogresstask.h"
+%End
+  public:
+
+    QgsProxyProgressTask( const QString &description );
+%Docstring
+Constructor for QgsProxyProgressTask, with the specified ``description``.
+%End
+
+    void finalize( bool result );
+%Docstring
+Finalizes the task, with the specified ``result``.
+
+This should be called when the operation being proxied has completed,
+to remove this proxy task from the task manager.
+%End
+
+    virtual bool run();
+
+
+    void setProxyProgress( double progress );
+%Docstring
+Sets the ``progress`` (from 0 to 100) for the proxied operation.
+
+This method is safe to call from the main thread.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsproxyprogresstask.h                                      *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -346,6 +346,7 @@
 %Include auto_generated/qgspluginlayer.sip
 %Include auto_generated/qgspointxy.sip
 %Include auto_generated/qgsproject.sip
+%Include auto_generated/qgsproxyprogresstask.sip
 %Include auto_generated/qgsrelationmanager.sip
 %Include auto_generated/qgsrelation.sip
 %Include auto_generated/qgsrunprocess.sip

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -253,6 +253,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsprojectstorageregistry.h"
 #include "qgsproviderregistry.h"
 #include "qgspythonrunner.h"
+#include "qgsproxyprogresstask.h"
 #include "qgsquerybuilder.h"
 #include "qgsrastercalcdialog.h"
 #include "qgsrasterfilewriter.h"
@@ -3367,7 +3368,22 @@ void QgisApp::setupConnections()
   connect( QgsProject::instance(), &QgsProject::oldProjectVersionWarning,
            this, &QgisApp::oldProjectVersionWarning );
   connect( QgsProject::instance(), &QgsProject::layerLoaded,
-           this, &QgisApp::showProgress );
+           this, [this]( int i, int n )
+  {
+    if ( !mProjectLoadingProxyTask )
+    {
+      const QString name = QgsProject::instance()->title().isEmpty() ? QgsProject::instance()->fileName() : QgsProject::instance()->title();
+      mProjectLoadingProxyTask = new QgsProxyProgressTask( tr( "Loading “%1”" ).arg( name ) );
+      QgsApplication::taskManager()->addTask( mProjectLoadingProxyTask );
+    }
+
+    mProjectLoadingProxyTask->setProxyProgress( 100.0 * static_cast< double >( i ) / n );
+    if ( i == n )
+    {
+      mProjectLoadingProxyTask->finalize( true );
+      mProjectLoadingProxyTask = nullptr;
+    }
+  } );
   connect( QgsProject::instance(), &QgsProject::loadingLayer,
            this, &QgisApp::showStatusMessage );
   connect( QgsProject::instance(), &QgsProject::loadingLayerMessageReceived,

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -133,7 +133,7 @@ class QgsDataSourceManagerDialog;
 class QgsBrowserModel;
 class QgsGeoCmsProviderRegistry;
 class QgsLayoutQptDropHandler;
-
+class QgsProxyProgressTask;
 
 #include <QMainWindow>
 #include <QToolBar>
@@ -2282,6 +2282,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QMap< QString, QString > mOptionsPagesMap;
     QMap< QString, QString > mProjectPropertiesPagesMap;
     QMap< QString, QString > mSettingPagesMap;
+
+    QgsProxyProgressTask *mProjectLoadingProxyTask = nullptr;
 
     friend class TestQgisAppPython;
 };

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -276,6 +276,7 @@ SET(QGIS_CORE_SRCS
   qgspropertytransformer.cpp
   qgsprovidermetadata.cpp
   qgsproviderregistry.cpp
+  qgsproxyprogresstask.cpp
   qgspythonrunner.cpp
   qgsreadwritecontext.cpp
   qgsrelation.cpp
@@ -627,6 +628,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgspointxy.h
   qgspointlocator.h
   qgsproject.h
+  qgsproxyprogresstask.h
   qgsrelationmanager.h
   qgsrelation.h
   qgsrunprocess.h

--- a/src/core/qgsproxyprogresstask.cpp
+++ b/src/core/qgsproxyprogresstask.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+                             qgsproxyprogresstask.cpp
+                             ------------------------
+    begin                : August 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsproxyprogresstask.h"
+
+QgsProxyProgressTask::QgsProxyProgressTask( const QString &description )
+  : QgsTask( description, QgsTask::Flags() )
+{
+}
+
+void QgsProxyProgressTask::finalize( bool result )
+{
+  mResult = result;
+  mNotFinishedWaitCondition.wakeAll();
+}
+
+bool QgsProxyProgressTask::run()
+{
+  mNotFinishedMutex.lock();
+  mNotFinishedWaitCondition.wait( &mNotFinishedMutex );
+  mNotFinishedMutex.unlock();
+
+  return mResult;
+}
+
+void QgsProxyProgressTask::setProxyProgress( double progress )
+{
+  QMetaObject::invokeMethod( this, "setProgress", Qt::AutoConnection, Q_ARG( double, progress ) );
+}

--- a/src/core/qgsproxyprogresstask.h
+++ b/src/core/qgsproxyprogresstask.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+                             qgsproxyprogresstask.h
+                             ----------------------
+    begin                : August 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROXYPROGRESSTASK_H
+#define QGSPROXYPROGRESSTASK_H
+
+#include "qgsvectorlayer.h"
+#include "qgsvirtuallayerdefinition.h"
+#include "qgstaskmanager.h"
+
+/**
+ * \ingroup core
+ *
+ * A QgsTask shell which proxies progress reports.
+ *
+ * Simple task shell which runs until finalized and reports progress only.
+ * This is usually used to expose a blocking operation's progress via
+ * task manager.
+ *
+ * \since QGIS 3.4
+ */
+class CORE_EXPORT QgsProxyProgressTask : public QgsTask
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProxyProgressTask, with the specified \a description.
+     */
+    QgsProxyProgressTask( const QString &description );
+
+    /**
+     * Finalizes the task, with the specified \a result.
+     *
+     * This should be called when the operation being proxied has completed,
+     * to remove this proxy task from the task manager.
+     */
+    void finalize( bool result );
+
+    bool run() override;
+
+    /**
+     * Sets the \a progress (from 0 to 100) for the proxied operation.
+     *
+     * This method is safe to call from the main thread.
+     */
+    void setProxyProgress( double progress );
+
+  private:
+
+    QWaitCondition mNotFinishedWaitCondition;
+    QMutex mNotFinishedMutex;
+    bool mResult = true;
+
+};
+
+#endif // QGSPROXYPROGRESSTASK_H


### PR DESCRIPTION
Allows use of the task manager progress reporting system from operations which are blocking (and cannot be made background tasks!), e.g. layout exporting, project loading. By making a dummy task which follows the progress of these blocking operations, we get some nice benefits:

- progress reports in the task manager status bar widget (although this is only really useful for operations which have a yucky processEvents call somewhere)
- progress reports in the taskbar (depending on operating system - works at the moment for Windows and ubuntu/KDE) 
- system notifications on completion of the operation (depending on operating system - works everywhere except OSX)

Plus, it's a step toward removing the second progress bar from the status bar. 