### PR TITLE
Wkt copy paste qgis3

### DIFF
--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -255,11 +255,22 @@ QgsFields QgsClipboard::retrieveFields() const
   QgsFields f = QgsOgrUtils::stringToFields( string, QTextCodec::codecForName( "System" ) );
   if ( f.size() < 1 )
   {
+    if ( string.isEmpty() )
+    {
+      return f;
+    }
+
     //wkt?
     QStringList lines = string.split( "\n" );
     if ( lines.size() > 0 )
     {
       QStringList fieldNames = lines.at( 0 ).split( "\t" );
+      //wkt / text always has wkt_geom as first attribute (however values can be NULL)
+      if ( fieldNames.at( 0 ) != "wkt_geom" )
+      {
+        return f;
+      }
+
       for ( int i = 0; i < fieldNames.size(); ++i )
       {
         QString fieldName = fieldNames.at( i );

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -221,7 +221,7 @@ QgsFeatureList QgsClipboard::stringToFeatureList( const QString &string, const Q
     feature.initAttributes( fieldValues.size() - 1 );
 
     //skip header line
-    if ( fieldValues.at( 0 ) == "wkt_geom" )
+    if ( fieldValues.at( 0 ) == QLatin1String( "wkt_geom" ) )
     {
       continue;
     }

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -261,12 +261,12 @@ QgsFields QgsClipboard::retrieveFields() const
     }
 
     //wkt?
-    QStringList lines = string.split( "\n" );
-    if ( lines.size() > 0 )
+    QStringList lines = string.split( '\n' );
+    if ( !lines.empty() )
     {
-      QStringList fieldNames = lines.at( 0 ).split( "\t" );
+      QStringList fieldNames = lines.at( 0 ).split( '\t' );
       //wkt / text always has wkt_geom as first attribute (however values can be NULL)
-      if ( fieldNames.at( 0 ) != "wkt_geom" )
+      if ( fieldNames.at( 0 ) != QLatin1String( "wkt_geom" ) )
       {
         return f;
       }
@@ -274,7 +274,7 @@ QgsFields QgsClipboard::retrieveFields() const
       for ( int i = 0; i < fieldNames.size(); ++i )
       {
         QString fieldName = fieldNames.at( i );
-        if ( fieldName == "wkt_geom" )
+        if ( fieldName == QLatin1String( "wkt_geom" ) )
         {
           continue;
         }

--- a/tests/src/app/testqgisappclipboard.cpp
+++ b/tests/src/app/testqgisappclipboard.cpp
@@ -241,10 +241,10 @@ void TestQgisAppClipboard::pasteWkt()
   QCOMPARE( point->x(), 125.0 );
   QCOMPARE( point->y(), 10.0 );
 
-  // only fields => no geom so no feature list is returned
+  //clipboard now supports features without geometry
   mQgisApp->clipboard()->setText( QStringLiteral( "MNL		11	282	km			\nMNL		11	347.80000000000001	km				" ) );
   features = mQgisApp->clipboard()->copyOf();
-  QCOMPARE( features.length(), 0 );
+  QCOMPARE( features.length(), 2 );
 }
 
 void TestQgisAppClipboard::pasteGeoJson()


### PR DESCRIPTION
When copy/paste features between different projects (e.g. two running QGIS instances), attributes are not copied. This  PR provides a fix.