### PR TITLE
Rename "Run in background" to "Run"

### DIFF
--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -143,9 +143,6 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
     textShortHelp->setHtml( algHelp );
     connect( textShortHelp, &QTextBrowser::anchorClicked, this, &QgsProcessingAlgorithmDialogBase::linkClicked );
   }
-
-  if ( !( algorithm->flags() & QgsProcessingAlgorithm::FlagNoThreading ) )
-    mButtonRun->setText( tr( "Run in Background" ) );
 }
 
 QgsProcessingAlgorithm *QgsProcessingAlgorithmDialogBase::algorithm()


### PR DESCRIPTION
The user has no other option anyway, so the only thing the extra text could possibly make a user do is look for the other button which is not there.

Fix #19573 (https://issues.qgis.org/issues/19573)
