### PR TITLE
[mesh] [feature] function to get value for the point on map

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -183,6 +183,11 @@ Returns whether dataset group has scalar data
 Returns whether dataset group data is defined on vertices
 %End
 
+    bool isOnFaces() const;
+%Docstring
+Returns whether dataset group data is defined on faces
+%End
+
 };
 
 class QgsMeshDatasetMetadata

--- a/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataprovider.sip.in
@@ -140,6 +140,13 @@ such as whether the data is vector or scalar, name
 #include "qgsmeshdataprovider.h"
 %End
   public:
+
+    enum DataType
+    {
+      DataOnFaces,
+      DataOnVertices
+    };
+
     QgsMeshDatasetGroupMetadata();
 %Docstring
 Constructs an empty metadata object
@@ -178,14 +185,9 @@ Returns whether dataset group has vector data
 Returns whether dataset group has scalar data
 %End
 
-    bool isOnVertices() const;
+    DataType dataType() const;
 %Docstring
-Returns whether dataset group data is defined on vertices
-%End
-
-    bool isOnFaces() const;
-%Docstring
-Returns whether dataset group data is defined on faces
+Returns whether dataset group data is defined on vertices or faces
 %End
 
 };

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -195,22 +195,33 @@ Returns active vector dataset
 %Docstring
 Interpolates the value on the given point from given dataset.
 
-Returns NaN for NaN values, for values outside range or when
-triangular mesh is not yet initialized on given point
+.. note::
+
+   It uses previously cached and indexed triangular mesh
+   and so if the layer has not been rendered previously
+   (e.g. when used in a script) it returns NaN value
+
+:param index: dataset index specifying group and dataset to extract value from
+:param point: point to query in map coordinates
+
+:return: interpolated value at the point. Returns NaN values for values
+         outside the mesh layer, nodata values and in case triangular mesh was not
+         previously used for rendering
+
 
 .. versionadded:: 3.4
 %End
 
   signals:
 
-    void activeScalarDatasetChanged( QgsMeshDatasetIndex index );
+    void activeScalarDatasetChanged( const QgsMeshDatasetIndex &index );
 %Docstring
 Emitted when active scalar dataset is changed
 
 .. versionadded:: 3.4
 %End
 
-    void activeVectorDatasetChanged( QgsMeshDatasetIndex index );
+    void activeVectorDatasetChanged( const QgsMeshDatasetIndex &index );
 %Docstring
 Emitted when active vector dataset is changed
 

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -191,6 +191,30 @@ If dataset is not vector based, do nothing. Triggers repaint
 Returns active vector dataset
 %End
 
+    QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point ) const;
+%Docstring
+Interpolates the value on the given point from given dataset.
+
+Returns NaN for NaN values, for values outside range or when
+triangular mesh is not yet initialized on given point
+%End
+
+  signals:
+
+    void activeScalarDatasetChanged( QgsMeshDatasetIndex index );
+%Docstring
+Emitted when active scalar dataset is changed
+
+.. versionadded:: 3.4
+%End
+
+    void activeVectorDatasetChanged( QgsMeshDatasetIndex index );
+%Docstring
+Emitted when active vector dataset is changed
+
+.. versionadded:: 3.4
+%End
+
   private: // Private methods
     QgsMeshLayer( const QgsMeshLayer &rhs );
 };

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -197,6 +197,8 @@ Interpolates the value on the given point from given dataset.
 
 Returns NaN for NaN values, for values outside range or when
 triangular mesh is not yet initialized on given point
+
+.. versionadded:: 3.4
 %End
 
   signals:

--- a/src/app/mesh/qgsmeshrendereractivedatasetwidget.cpp
+++ b/src/app/mesh/qgsmeshrendereractivedatasetwidget.cpp
@@ -126,8 +126,8 @@ void QgsMeshRendererActiveDatasetWidget::updateMetadata( QgsMeshDatasetIndex dat
 
     const QgsMeshDatasetGroupMetadata gmeta = mMeshLayer->dataProvider()->datasetGroupMetadata( datasetIndex );
     msg += QStringLiteral( "<tr><td>%1</td><td>%2</td></tr>" )
-           .arg( tr( "Is on vertices" ) )
-           .arg( gmeta.isOnVertices() ? tr( "Yes" ) : tr( "No" ) );
+           .arg( tr( "Data Type" ) )
+           .arg( gmeta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices ? tr( "Defined on vertices" ) : tr( "Defined on faces" ) );
 
     msg += QStringLiteral( "<tr><td>%1</td><td>%2</td></tr>" )
            .arg( tr( "Is vector" ) )

--- a/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -112,7 +112,7 @@ void QgsMeshRendererScalarSettingsWidget::calcMinMax( QgsMeshDatasetIndex datase
     return;
 
   const QgsMeshDatasetGroupMetadata metadata = mMeshLayer->dataProvider()->datasetGroupMetadata( datasetIndex );
-  bool scalarDataOnVertices = metadata.isOnVertices();
+  bool scalarDataOnVertices = metadata.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices;
   int count;
   if ( scalarDataOnVertices )
     count = mMeshLayer->dataProvider()->vertexCount();

--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -161,20 +161,16 @@ bool QgsMeshDatasetGroupMetadata::isScalar() const
   return mIsScalar;
 }
 
+
+
 QString QgsMeshDatasetGroupMetadata::name() const
 {
   return mName;
 }
 
-
-bool QgsMeshDatasetGroupMetadata::isOnVertices() const
+QgsMeshDatasetGroupMetadata::DataType QgsMeshDatasetGroupMetadata::dataType() const
 {
-  return mIsOnVertices;
-}
-
-bool QgsMeshDatasetGroupMetadata::isOnFaces() const
-{
-  return !mIsOnVertices;
+  return ( mIsOnVertices ) ? DataType::DataOnVertices : DataType::DataOnFaces;
 }
 
 int QgsMeshDatasetSourceInterface::datasetCount( QgsMeshDatasetIndex index ) const

--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -172,6 +172,11 @@ bool QgsMeshDatasetGroupMetadata::isOnVertices() const
   return mIsOnVertices;
 }
 
+bool QgsMeshDatasetGroupMetadata::isOnFaces() const
+{
+  return !mIsOnVertices;
+}
+
 int QgsMeshDatasetSourceInterface::datasetCount( QgsMeshDatasetIndex index ) const
 {
   return datasetCount( index.group() );

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -127,6 +127,14 @@ class CORE_EXPORT QgsMeshDatasetValue
 class CORE_EXPORT QgsMeshDatasetGroupMetadata
 {
   public:
+
+    //! Location of where data is specified for datasets in the dataset group
+    enum DataType
+    {
+      DataOnFaces, //!< Data is defined on faces
+      DataOnVertices //!< Data is defined on vertices
+    };
+
     //! Constructs an empty metadata object
     QgsMeshDatasetGroupMetadata() = default;
 
@@ -164,14 +172,9 @@ class CORE_EXPORT QgsMeshDatasetGroupMetadata
     bool isScalar() const;
 
     /**
-     * \brief Returns whether dataset group data is defined on vertices
+     * \brief Returns whether dataset group data is defined on vertices or faces
      */
-    bool isOnVertices() const;
-
-    /**
-     * \brief Returns whether dataset group data is defined on faces
-     */
-    bool isOnFaces() const;
+    DataType dataType() const;
 
   private:
     QString mName;

--- a/src/core/mesh/qgsmeshdataprovider.h
+++ b/src/core/mesh/qgsmeshdataprovider.h
@@ -168,6 +168,11 @@ class CORE_EXPORT QgsMeshDatasetGroupMetadata
      */
     bool isOnVertices() const;
 
+    /**
+     * \brief Returns whether dataset group data is defined on faces
+     */
+    bool isOnFaces() const;
+
   private:
     QString mName;
     bool mIsScalar = false;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -195,8 +195,8 @@ QgsMeshDatasetValue QgsMeshLayer::datasetValue( const QgsMeshDatasetIndex &index
       bool isOnFaces = dataProvider()->datasetGroupMetadata( index ).isOnFaces();
       if ( isOnFaces )
       {
-        int native_face_index = mTriangularMesh->trianglesToNativeFaces().at( face_index );
-        return dataProvider()->datasetValue( index, native_face_index );
+        int nativeFaceIndex = mTriangularMesh->trianglesToNativeFaces().at( face_index );
+        return dataProvider()->datasetValue( index, nativeFaceIndex );
       }
       else
       {

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include <cstddef>
+#include <limits>
 
 #include <QUuid>
 
@@ -27,6 +28,7 @@
 #include "qgsproviderregistry.h"
 #include "qgsreadwritecontext.h"
 #include "qgstriangularmesh.h"
+#include "qgsmeshlayerinterpolator.h"
 
 QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
                             const QString &baseName,
@@ -154,6 +156,8 @@ void QgsMeshLayer::setActiveScalarDataset( QgsMeshDatasetIndex index )
     mActiveScalarDataset = QgsMeshDatasetIndex();
 
   triggerRepaint();
+
+  emit activeScalarDatasetChanged( mActiveScalarDataset );
 }
 
 void QgsMeshLayer::setActiveVectorDataset( QgsMeshDatasetIndex index )
@@ -175,6 +179,44 @@ void QgsMeshLayer::setActiveVectorDataset( QgsMeshDatasetIndex index )
   }
 
   triggerRepaint();
+
+  emit activeVectorDatasetChanged( mActiveVectorDataset );
+}
+
+QgsMeshDatasetValue QgsMeshLayer::datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point ) const
+{
+  QgsMeshDatasetValue value;
+
+  if ( mTriangularMesh && dataProvider() && dataProvider()->isValid() && index.isValid() )
+  {
+    int face_index = mTriangularMesh->faceIndexForPoint( point ) ;
+    if ( face_index >= 0 )
+    {
+      bool isOnFaces = dataProvider()->datasetGroupMetadata( index ).isOnFaces();
+      if ( isOnFaces )
+      {
+        int native_face_index = mTriangularMesh->trianglesToNativeFaces().at( face_index );
+        return dataProvider()->datasetValue( index, native_face_index );
+      }
+      else
+      {
+        const QgsMeshFace &face = mTriangularMesh->triangles()[face_index];
+        const int v1 = face[0], v2 = face[1], v3 = face[2];
+        const QgsPoint p1 = mTriangularMesh->vertices()[v1], p2 = mTriangularMesh->vertices()[v2], p3 = mTriangularMesh->vertices()[v3];
+        const QgsMeshDatasetValue val1 = dataProvider()->datasetValue( index, v1 );
+        const QgsMeshDatasetValue val2 = dataProvider()->datasetValue( index, v2 );
+        const QgsMeshDatasetValue val3 = dataProvider()->datasetValue( index, v3 );
+        const double x = QgsMeshLayerInterpolator::interpolateFromVerticesData( p1, p2, p3, val1.x(), val2.x(), val3.x(), point );
+        double y = std::numeric_limits<double>::quiet_NaN();
+        bool isVector = dataProvider()->datasetGroupMetadata( index ).isVector();
+        if ( isVector )
+          y = QgsMeshLayerInterpolator::interpolateFromVerticesData( p1, p2, p3, val1.y(), val2.y(), val3.y(), point );
+
+        return QgsMeshDatasetValue( x, y );
+      }
+    }
+  }
+  return value;
 }
 
 void QgsMeshLayer::fillNativeMesh()

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -189,18 +189,17 @@ QgsMeshDatasetValue QgsMeshLayer::datasetValue( const QgsMeshDatasetIndex &index
 
   if ( mTriangularMesh && dataProvider() && dataProvider()->isValid() && index.isValid() )
   {
-    int face_index = mTriangularMesh->faceIndexForPoint( point ) ;
-    if ( face_index >= 0 )
+    int faceIndex = mTriangularMesh->faceIndexForPoint( point ) ;
+    if ( faceIndex >= 0 )
     {
-      bool isOnFaces = dataProvider()->datasetGroupMetadata( index ).isOnFaces();
-      if ( isOnFaces )
+      if ( dataProvider()->datasetGroupMetadata( index ).dataType() == QgsMeshDatasetGroupMetadata::DataOnFaces )
       {
-        int nativeFaceIndex = mTriangularMesh->trianglesToNativeFaces().at( face_index );
+        int nativeFaceIndex = mTriangularMesh->trianglesToNativeFaces().at( faceIndex );
         return dataProvider()->datasetValue( index, nativeFaceIndex );
       }
       else
       {
-        const QgsMeshFace &face = mTriangularMesh->triangles()[face_index];
+        const QgsMeshFace &face = mTriangularMesh->triangles()[faceIndex];
         const int v1 = face[0], v2 = face[1], v3 = face[2];
         const QgsPoint p1 = mTriangularMesh->vertices()[v1], p2 = mTriangularMesh->vertices()[v2], p3 = mTriangularMesh->vertices()[v3];
         const QgsMeshDatasetValue val1 = dataProvider()->datasetValue( index, v1 );

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -183,6 +183,30 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     //! Returns active vector dataset
     QgsMeshDatasetIndex activeVectorDataset() const { return mActiveVectorDataset; }
 
+    /**
+      * Interpolates the value on the given point from given dataset.
+      *
+      * Returns NaN for NaN values, for values outside range or when
+      * triangular mesh is not yet initialized on given point
+      */
+    QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point ) const;
+
+  signals:
+
+    /**
+     * Emitted when active scalar dataset is changed
+     *
+     * \since QGIS 3.4
+     */
+    void activeScalarDatasetChanged( QgsMeshDatasetIndex index );
+
+    /**
+     * Emitted when active vector dataset is changed
+     *
+     * \since QGIS 3.4
+     */
+    void activeVectorDatasetChanged( QgsMeshDatasetIndex index );
+
   private: // Private methods
 
     /**

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -186,8 +186,15 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     /**
       * Interpolates the value on the given point from given dataset.
       *
-      * Returns NaN for NaN values, for values outside range or when
-      * triangular mesh is not yet initialized on given point
+      * \note It uses previously cached and indexed triangular mesh
+      * and so if the layer has not been rendered previously
+      * (e.g. when used in a script) it returns NaN value
+      *
+      * \param index dataset index specifying group and dataset to extract value from
+      * \param point point to query in map coordinates
+      * \returns interpolated value at the point. Returns NaN values for values
+      * outside the mesh layer, nodata values and in case triangular mesh was not
+      * previously used for rendering
       *
       * \since QGIS 3.4
       */
@@ -200,14 +207,14 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      *
      * \since QGIS 3.4
      */
-    void activeScalarDatasetChanged( QgsMeshDatasetIndex index );
+    void activeScalarDatasetChanged( const QgsMeshDatasetIndex &index );
 
     /**
      * Emitted when active vector dataset is changed
      *
      * \since QGIS 3.4
      */
-    void activeVectorDatasetChanged( QgsMeshDatasetIndex index );
+    void activeVectorDatasetChanged( const QgsMeshDatasetIndex &index );
 
   private: // Private methods
 

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -188,6 +188,8 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       *
       * Returns NaN for NaN values, for values outside range or when
       * triangular mesh is not yet initialized on given point
+      *
+      * \since QGIS 3.4
       */
     QgsMeshDatasetValue datasetValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point ) const;
 

--- a/src/core/mesh/qgsmeshlayerinterpolator.cpp
+++ b/src/core/mesh/qgsmeshlayerinterpolator.cpp
@@ -88,9 +88,8 @@ static bool E3T_physicalToBarycentric( const QgsPointXY &pA, const QgsPointXY &p
   return true;
 }
 
-
-double interpolateFromVerticesData( const QgsPointXY &p1, const QgsPointXY &p2, const QgsPointXY &p3,
-                                    double val1, double val2, double val3, const QgsPointXY &pt )
+double QgsMeshLayerInterpolator::interpolateFromVerticesData( const QgsPointXY &p1, const QgsPointXY &p2, const QgsPointXY &p3,
+    double val1, double val2, double val3, const QgsPointXY &pt )
 {
   double lam1, lam2, lam3;
   if ( !E3T_physicalToBarycentric( p1, p2, p3, pt, lam1, lam2, lam3 ) )

--- a/src/core/mesh/qgsmeshlayerinterpolator.h
+++ b/src/core/mesh/qgsmeshlayerinterpolator.h
@@ -59,6 +59,12 @@ class QgsMeshLayerInterpolator : public QgsRasterInterface
     int bandCount() const override;
     QgsRasterBlock *block( int, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override;
 
+
+    static double interpolateFromVerticesData( const QgsPointXY &p1,
+        const QgsPointXY &p2,
+        const QgsPointXY &p3,
+        double val1, double val2, double val3, const QgsPointXY &pt );
+
   private:
     const QgsTriangularMesh &mTriangularMesh;
     const QVector<double> &mDatasetValues;

--- a/src/core/mesh/qgsmeshlayerinterpolator.h
+++ b/src/core/mesh/qgsmeshlayerinterpolator.h
@@ -59,11 +59,21 @@ class QgsMeshLayerInterpolator : public QgsRasterInterface
     int bandCount() const override;
     QgsRasterBlock *block( int, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) override;
 
-
-    static double interpolateFromVerticesData( const QgsPointXY &p1,
-        const QgsPointXY &p2,
-        const QgsPointXY &p3,
-        double val1, double val2, double val3, const QgsPointXY &pt );
+    /*
+    * Interpolates value based on known values on the vertices of a triangle
+    * \param p1 first vertex of the triangle
+    * \param p2 second vertex of the triangle
+    * \param p3 third vertex of the triangle
+    * \param val1 value on p1 of the triangle
+    * \param val2 value on p2 of the triangle
+    * \param val3 value on p3 of the triangle
+    * \param pt point where to calculate value
+    * \returns value on the point pt or NaN in case the point is outside the triangle
+    */
+    static double interpolateFromVerticesData(
+      const QgsPointXY &p1, const QgsPointXY &p2, const QgsPointXY &p3,
+      double val1, double val2, double val3, const QgsPointXY &pt
+    );
 
   private:
     const QgsTriangularMesh &mTriangularMesh;

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -229,17 +229,7 @@ void QgsMeshLayerRenderer::renderMesh( const std::unique_ptr<QgsSymbol> &symbol,
     const QgsMeshFace &face = faces[i];
     QgsFeature feat;
     feat.setFields( fields );
-    QVector<QgsPointXY> ring;
-    for ( int j = 0; j < face.size(); ++j )
-    {
-      int vertex_id = face[j];
-      Q_ASSERT( vertex_id < mTriangularMesh.vertices().size() ); //Triangular mesh vertices contains also native mesh vertices
-      const QgsPoint &vertex = mTriangularMesh.vertices()[vertex_id];
-      ring.append( vertex );
-    }
-    QgsPolygonXY polygon;
-    polygon.append( ring );
-    QgsGeometry geom = QgsGeometry::fromPolygonXY( polygon );
+    QgsGeometry geom = QgsMeshUtils::toGeometry( face, mTriangularMesh.vertices() ); //Triangular mesh vertices contains also native mesh vertices
     feat.setGeometry( geom );
     renderer.renderFeature( feat, mContext );
   }

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -140,7 +140,7 @@ void QgsMeshLayerRenderer::copyScalarDatasetValues( QgsMeshLayer *layer )
   if ( datasetIndex.isValid() )
   {
     const QgsMeshDatasetGroupMetadata metadata = layer->dataProvider()->datasetGroupMetadata( datasetIndex );
-    mScalarDataOnVertices = metadata.isOnVertices();
+    mScalarDataOnVertices = metadata.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices;
     int count;
     if ( mScalarDataOnVertices )
       count = mNativeMesh.vertices.count();
@@ -172,7 +172,7 @@ void QgsMeshLayerRenderer::copyVectorDatasetValues( QgsMeshLayer *layer )
     }
     else
     {
-      mVectorDataOnVertices = metadata.isOnVertices();
+      mVectorDataOnVertices = metadata.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices;
       int count;
       if ( mVectorDataOnVertices )
         count = mNativeMesh.vertices.count();

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -180,8 +180,8 @@ const QVector<int> &QgsTriangularMesh::trianglesToNativeFaces() const
 
 int QgsTriangularMesh::faceIndexForPoint( const QgsPointXY &point ) const
 {
-  const QList<QgsFeatureId> face_indexes = mSpatialIndex.intersects( QgsRectangle( point, point ) );
-  for ( QgsFeatureId fid : face_indexes )
+  const QList<QgsFeatureId> faceIndexes = mSpatialIndex.intersects( QgsRectangle( point, point ) );
+  for ( const QgsFeatureId fid : faceIndexes )
   {
     int faceIndex = static_cast<int>( fid );
     const QgsMeshFace &face = mTriangularMesh.faces.at( faceIndex );

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -65,7 +65,7 @@ class CORE_EXPORT QgsTriangularMesh
     void update( QgsMesh *nativeMesh, QgsRenderContext *context );
 
     /**
-     * Returns vertices in map CRS
+     * Returns vertices in map coordinate system
      *
      * The list of consist of vertices from native mesh (0-N) and
      * extra vertices needed to create triangles (N+1 - len)
@@ -81,8 +81,11 @@ class CORE_EXPORT QgsTriangularMesh
     const QVector<int> &trianglesToNativeFaces() const ;
 
     /**
-     * Returns triangle index that contains the given point, -1 if no such triangle exists
+     * Finds index of triangle at given point
      * It uses spatial indexing
+     *
+     * \param point point in map coordinate system
+     * \returns triangle index that contains the given point, -1 if no such triangle exists
      *
      * \since QGIS 3.4
      */

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -83,6 +83,8 @@ class CORE_EXPORT QgsTriangularMesh
     /**
      * Returns triangle index that contains the given point, -1 if no such triangle exists
      * It uses spatial indexing
+     *
+     * \since QGIS 3.4
      */
     int faceIndexForPoint( const QgsPointXY &point ) const ;
 

--- a/tests/src/core/testqgsmeshlayer.cpp
+++ b/tests/src/core/testqgsmeshlayer.cpp
@@ -162,7 +162,7 @@ void TestQgsMeshLayer::test_read_vertex_scalar_dataset()
       }
       QCOMPARE( meta.name(), QString( "VertexScalarDataset" ) );
       QVERIFY( meta.isScalar() );
-      QVERIFY( meta.isOnVertices() );
+      QVERIFY( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices );
 
       const QgsMeshDatasetMetadata dmeta = dp->datasetMetadata( ds );
       QVERIFY( qgsDoubleNear( dmeta.time(), i ) );
@@ -200,7 +200,7 @@ void TestQgsMeshLayer::test_read_vertex_vector_dataset()
         QCOMPARE( meta.extraOptions()["description"], QString( "Vertex Vector Dataset" ) );
       QCOMPARE( meta.name(), QString( "VertexVectorDataset" ) );
       QVERIFY( !meta.isScalar() );
-      QVERIFY( meta.isOnVertices() );
+      QVERIFY( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices );
 
       const QgsMeshDatasetMetadata dmeta = dp->datasetMetadata( ds );
       QVERIFY( qgsDoubleNear( dmeta.time(), i ) );
@@ -238,7 +238,7 @@ void TestQgsMeshLayer::test_read_face_scalar_dataset()
         QCOMPARE( meta.extraOptions()["description"], QString( "Face Scalar Dataset" ) );
       QCOMPARE( meta.name(), QString( "FaceScalarDataset" ) );
       QVERIFY( meta.isScalar() );
-      QVERIFY( !meta.isOnVertices() );
+      QVERIFY( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnFaces );
 
       const QgsMeshDatasetMetadata dmeta = dp->datasetMetadata( ds );
       QVERIFY( qgsDoubleNear( dmeta.time(), i ) );
@@ -274,7 +274,7 @@ void TestQgsMeshLayer::test_read_face_vector_dataset()
         QCOMPARE( meta.extraOptions()["description"], QString( "Face Vector Dataset" ) );
       QCOMPARE( meta.name(), QString( "FaceVectorDataset" ) );
       QVERIFY( !meta.isScalar() );
-      QVERIFY( !meta.isOnVertices() );
+      QVERIFY( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnFaces );
 
       const QgsMeshDatasetMetadata dmeta = dp->datasetMetadata( ds );
       QVERIFY( qgsDoubleNear( dmeta.time(), i ) );


### PR DESCRIPTION
To be able to create some nice plots, we need a way how to get a (scalar) value from a dataset for particular point. The face (triangle) of the that contains point is identified by spatial index. Value is interpolated similarly to raster (contours) rendering of the mesh layer.

Probably the plots for mesh layers will not make it to QGIS 3.4, but see the example of the usage of the new function from python (Crayfish library for QGIS 3.4, not released yet = WIP)

![mesh_plots](https://user-images.githubusercontent.com/804608/43906696-358d4f1e-9bf4-11e8-8b51-af326ae1a424.gif)

