### PR TITLE
[FEATURE] add conversion from float to DMS format

### DIFF
--- a/resources/function_help/json/to_dm
+++ b/resources/function_help/json/to_dm
@@ -1,0 +1,15 @@
+{
+  "name": "to_dm",
+  "type": "function",
+  "description": "Convert a coordinate to degree, minute.",
+  "arguments": [
+    {"arg":"coordinate","description":"A latitude or longitude value."},
+    {"arg":"axis","description":"The axis of the coordinate. Either 'x' or 'y'."},
+    {"arg":"precision", "description":"Number of decimals."},
+    {"arg":"formatting", "optional": true, "default":"", "description":"Designates the formatting type. Acceptable values are NULL, 'aligned' or 'suffix'."}
+  ],
+    "examples": [
+       { "expression":"to_dm(6.3545681, 'x', 3)", "returns":"6°21.274′"},
+       { "expression":"to_dm(6.3545681, 'y', 4, 'suffix')", "returns":"6°21.2741′N"}
+  ]
+}

--- a/resources/function_help/json/to_dms
+++ b/resources/function_help/json/to_dms
@@ -1,0 +1,15 @@
+{
+  "name": "to_dms",
+  "type": "function",
+  "description": "Convert a coordinate to degree, minute, second.",
+  "arguments": [
+    {"arg":"coordinate","description":"A latitude or longitude value."},
+    {"arg":"axis","description":"The axis of the coordinate. Either 'x' or 'y'."},
+    {"arg":"precision", "description":"Number of decimals."},
+    {"arg":"formatting", "optional": true, "default":"", "description":"Designates the formatting type. Acceptable values are NULL, 'aligned' or 'suffix'."}
+  ],
+    "examples": [
+    { "expression":"to_dms(6.3545681, 'x', 3)", "returns":"6°21′16.445″"},
+    { "expression":"to_dms(6.3545681, 'y', 4, 'suffix')", "returns":"6°21′16.4452″N"}
+  ]
+}

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -709,6 +709,16 @@ class TestQgsExpression: public QObject
       QTest::newRow( "double to text" ) << "tostring(1.23)" << false << QVariant( "1.23" );
       QTest::newRow( "null to text" ) << "tostring(null)" << false << QVariant();
 
+      // DMS conversion
+      QTest::newRow( "X coordinate to degree minute aligned" ) << "to_dm(6.3545681,'x',2,'aligned')" << false << QVariant( "6°21.27′E" );
+      QTest::newRow( "X coordinate to degree minute with suffix" ) << "to_dm(6.3545681,'x',2,'suffix')" << false << QVariant( "6°21.27′E" );
+      QTest::newRow( "X coordinate to degree minute without formatting" ) << "to_dm(6.3545681,'x',2,'')" << false << QVariant( "6°21.27′" );
+      QTest::newRow( "X coordinate to degree minute" ) << "to_dm(6.3545681,'x',2)" << false << QVariant( "6°21.27′" );
+      QTest::newRow( "Y coordinate to degree minute second aligned" ) << "to_dms(6.3545681,'y',2,'aligned')" << false << QVariant( "6°21′16.45″N" );
+      QTest::newRow( "Y coordinate to degree minute second with suffix" ) << "to_dms(6.3545681,'y',2,'suffix')" << false << QVariant( "6°21′16.45″N" );
+      QTest::newRow( "Y coordinate to degree minute second without formatting" ) << "to_dms(6.3545681,'y',2,'')" << false << QVariant( "6°21′16.45″" );
+      QTest::newRow( "Y coordinate to degree minute second" ) << "to_dms(6.3545681,'y',2)" << false << QVariant( "6°21′16.45″" );
+
       // geometry functions
       QTest::newRow( "num_points" ) << "num_points(geom_from_wkt('GEOMETRYCOLLECTION(LINESTRING(0 0, 1 0),POINT(6 5))'))" << false << QVariant( 3 );
       QTest::newRow( "num_interior_rings not geom" ) << "num_interior_rings('g')" << true << QVariant();


### PR DESCRIPTION
## Description

![screenshot from 2018-08-10 17-18-15](https://user-images.githubusercontent.com/1609292/43981837-8a84c236-9cc1-11e8-9dba-a2f8728cb47a.png)

Some of my colleagues need to export the attribute table with coordinates in DMS format.
We had to use these expressions: https://gis.stackexchange.com/questions/214136/display-coordinates-of-points-in-dms-format-in-print-composer

But it's complicated to tweak, for instance the number of decimals in the output.

Waiting for feedbacks before to continue the same for Y (name of expressions)

WIP

Todo:
* [x] Tests
* [x] Add Y
* [x] Review help files

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
