### PR TITLE
Update .gitignore to not track default windows build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ ms-windows/osgeo4w/binary-*
 ms-windows/osgeo4w/nsis/
 ms-windows/osgeo4w/packages-x86/
 ms-windows/osgeo4w/packages-x86_64/
+ms-windows/osgeo4w/build-qgis-test-x86/
+ms-windows/osgeo4w/build-qgis-test-x86_64/
 ms-windows/osgeo4w/unpacked/
 ms-windows/osgeo4w/untgz/
 ms-windows/packages/


### PR DESCRIPTION
## Description
The default Windows build directory is not included in `.gitignore`, which means that whenever I build from source, there are 300+ changes which overwhelm whatever I'm working on. This PR adds these default directories to `.gitignore` to keep the list of changes clean.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
