### PR TITLE
Fix freeze with redirected WFS

### DIFF
--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -351,8 +351,8 @@ void QgsWfsRequest::replyFinished()
             emit downloadFinished();
             return;
           }
-          connect( mReply, &QNetworkReply::finished, this, &QgsWfsRequest::replyFinished );
-          connect( mReply, &QNetworkReply::downloadProgress, this, &QgsWfsRequest::replyProgress );
+          connect( mReply, &QNetworkReply::finished, this, &QgsWfsRequest::replyFinished, Qt::DirectConnection );
+          connect( mReply, &QNetworkReply::downloadProgress, this, &QgsWfsRequest::replyProgress, Qt::DirectConnection );
           return;
         }
       }


### PR DESCRIPTION
When loading a layer with a WFS provider that is redirected, QGIS was freezing and crashing.