### PR TITLE
Fix freeze with redirected WFS

### DIFF
--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -351,8 +351,8 @@ void QgsWfsRequest::replyFinished()
             emit downloadFinished();
             return;
           }
-          connect( mReply, &QNetworkReply::finished, this, &QgsWfsRequest::replyFinished );
-          connect( mReply, &QNetworkReply::downloadProgress, this, &QgsWfsRequest::replyProgress );
+          connect( mReply, &QNetworkReply::finished, this, &QgsWfsRequest::replyFinished, Qt::DirectConnection );
+          connect( mReply, &QNetworkReply::downloadProgress, this, &QgsWfsRequest::replyProgress, Qt::DirectConnection );
           return;
         }
       }


### PR DESCRIPTION
## Description

QGIS will freeze with a redirected WFS. This is bad. We better fix it. That's what this PR (pull request) is for. No screenshots available. It looks a bit [like this](https://www.google.com/search?client=firefox-b-ab&biw=1227&bih=803&tbm=isch&sa=1&ei=mOtxW_PBApGWkwX_hYSoCQ&q=+application+is+not+responding&oq=+application+is+not+responding&gs_l=img.3..0i7i30k1j0i24k1.1862.1862.0.2360.1.1.0.0.0.0.83.83.1.1.0....0...1c..64.img..0.1.82....0.qiSAzdqwT8A).