### PR TITLE
Resurrect display of interpolated z/m in identify results

### DIFF
--- a/src/core/geometry/qgscircle.cpp
+++ b/src/core/geometry/qgscircle.cpp
@@ -249,8 +249,8 @@ int QgsCircle::intersections( const QgsCircle &other, QgsPoint &intersection1, Q
   if ( res == 0 )
     return 0;
 
-  intersection1 = QgsPoint( int1.x(), int1.y() );
-  intersection2 = QgsPoint( int2.x(), int2.y() );
+  intersection1 = QgsPoint( int1 );
+  intersection2 = QgsPoint( int2 );
   if ( useZ && mCenter.is3D() )
   {
     intersection1.addZValue( mCenter.z() );

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -589,7 +589,7 @@ QgsPoint QgsGeometry::vertexAt( int atVertex ) const
 double QgsGeometry::sqrDistToVertexAt( QgsPointXY &point, int atVertex ) const
 {
   QgsPointXY vertexPoint = vertexAt( atVertex );
-  return QgsGeometryUtils::sqrDistance2D( QgsPoint( vertexPoint.x(), vertexPoint.y() ), QgsPoint( point.x(), point.y() ) );
+  return QgsGeometryUtils::sqrDistance2D( QgsPoint( vertexPoint ), QgsPoint( point ) );
 }
 
 QgsGeometry QgsGeometry::nearestPoint( const QgsGeometry &other ) const
@@ -640,7 +640,7 @@ double QgsGeometry::closestSegmentWithContext( const QgsPointXY &point,
   QgsPoint segmentPt;
   QgsVertexId vertexAfter;
 
-  double sqrDist = d->geometry->closestSegment( QgsPoint( point.x(), point.y() ), segmentPt,  vertexAfter, leftOf, epsilon );
+  double sqrDist = d->geometry->closestSegment( QgsPoint( point ), segmentPt,  vertexAfter, leftOf, epsilon );
   if ( sqrDist < 0 )
     return -1;
 

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -45,7 +45,7 @@ QgsPointXY QgsMapTool::toMapCoordinates( QPoint point )
 QgsPoint QgsMapTool::toMapCoordinates( const QgsMapLayer *layer, const QgsPoint &point )
 {
   QgsPointXY result = mCanvas->mapSettings().layerToMapCoordinates( layer, QgsPointXY( point.x(), point.y() ) );
-  return QgsPoint( result.x(), result.y() );
+  return QgsPoint( result );
 }
 
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -376,7 +376,7 @@ void QgsMapToolIdentify::closestVertexAttributes( const QgsAbstractGeometry &geo
 
 void QgsMapToolIdentify::closestPointAttributes( const QgsAbstractGeometry &geometry, const QgsPointXY &layerPoint, QMap<QString, QString> &derivedAttributes )
 {
-  QgsPoint closestPoint = QgsGeometryUtils::closestPoint( geometry, QgsPoint( layerPoint.x(), layerPoint.y() ) );
+  QgsPoint closestPoint = QgsGeometryUtils::closestPoint( geometry, QgsPoint( layerPoint ) );
 
   derivedAttributes.insert( tr( "Closest X" ), formatXCoordinate( closestPoint ) );
   derivedAttributes.insert( tr( "Closest Y" ), formatYCoordinate( closestPoint ) );
@@ -433,7 +433,7 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
     geometryType = feature.geometry().type();
     wkbType = feature.geometry().wkbType();
     //find closest vertex to clicked point
-    closestPoint = QgsGeometryUtils::closestVertex( *feature.geometry().constGet(), QgsPoint( layerPoint.x(), layerPoint.y() ), vId );
+    closestPoint = QgsGeometryUtils::closestVertex( *feature.geometry().constGet(), QgsPoint( layerPoint ), vId );
   }
 
   if ( QgsWkbTypes::isMultiType( wkbType ) )

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -374,6 +374,25 @@ void QgsMapToolIdentify::closestVertexAttributes( const QgsAbstractGeometry &geo
   }
 }
 
+void QgsMapToolIdentify::closestPointAttributes( const QgsAbstractGeometry &geometry, const QgsPointXY &layerPoint, QMap<QString, QString> &derivedAttributes )
+{
+  QgsPoint closestPoint = QgsGeometryUtils::closestPoint( geometry, QgsPoint( layerPoint.x(), layerPoint.y() ) );
+
+  derivedAttributes.insert( tr( "Closest X" ), formatXCoordinate( closestPoint ) );
+  derivedAttributes.insert( tr( "Closest Y" ), formatYCoordinate( closestPoint ) );
+
+  if ( closestPoint.is3D() )
+  {
+    const QString str = QLocale().toString( closestPoint.z(), 'g', 10 );
+    derivedAttributes.insert( tr( "Interpolated Z" ), str );
+  }
+  if ( closestPoint.isMeasure() )
+  {
+    const QString str = QLocale().toString( closestPoint.m(), 'g', 10 );
+    derivedAttributes.insert( tr( "Interpolated M" ), str );
+  }
+}
+
 QString QgsMapToolIdentify::formatCoordinate( const QgsPointXY &canvasPoint ) const
 {
   return QgsCoordinateUtils::formatCoordinateForProject( QgsProject::instance(), canvasPoint, mCanvas->mapSettings().destinationCrs(),
@@ -451,6 +470,7 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
       derivedAttributes.insert( tr( "Vertices" ), str );
       //add details of closest vertex to identify point
       closestVertexAttributes( *geom, vId, layer, derivedAttributes );
+      closestPointAttributes( *geom, layerPoint, derivedAttributes );
 
       if ( const QgsCurve *curve = qgsgeometry_cast< const QgsCurve * >( geom ) )
       {
@@ -498,6 +518,7 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
 
     //add details of closest vertex to identify point
     closestVertexAttributes( *feature.geometry().constGet(), vId, layer, derivedAttributes );
+    closestPointAttributes( *feature.geometry().constGet(), layerPoint, derivedAttributes );
   }
   else if ( geometryType == QgsWkbTypes::PointGeometry )
   {

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -224,7 +224,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
 
   if ( !layer->isInScaleRange( mCanvas->mapSettings().scale() ) )
   {
-    QgsDebugMsg( "Out of scale limits" );
+    QgsDebugMsg( QStringLiteral( "Out of scale limits" ) );
     return false;
   }
 
@@ -620,8 +620,8 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
     // are similar to source width and height used to reproject layer for drawing.
     // TODO: may be very dangerous, because it may result in different resolutions
     // in source CRS, and WMS server (QGIS server) calcs wrong coor using average resolution.
-    int width = std::round( viewExtent.width() / mapUnitsPerPixel );
-    int height = std::round( viewExtent.height() / mapUnitsPerPixel );
+    int width = static_cast< int >( std::round( viewExtent.width() / mapUnitsPerPixel ) );
+    int height = static_cast< int >( std::round( viewExtent.height() / mapUnitsPerPixel ) );
 
     QgsDebugMsg( QStringLiteral( "viewExtent.width = %1 viewExtent.height = %2" ).arg( viewExtent.width() ).arg( viewExtent.height() ) );
     QgsDebugMsg( QStringLiteral( "width = %1 height = %2" ).arg( width ).arg( height ) );
@@ -695,7 +695,7 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
         for ( const QgsFeatureStore &featureStore : featureStoreList )
         {
           const QgsFeatureList storeFeatures = featureStore.features();
-          for ( QgsFeature feature : storeFeatures )
+          for ( const QgsFeature &feature : storeFeatures )
           {
             attributes.clear();
             // WMS sublayer and feature type, a sublayer may contain multiple feature types.

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -347,18 +347,18 @@ void QgsMapToolIdentify::closestVertexAttributes( const QgsAbstractGeometry &geo
   QgsPoint closestPoint = geometry.vertexAt( vId );
 
   QgsPointXY closestPointMapCoords = mCanvas->mapSettings().layerToMapCoordinates( layer, QgsPointXY( closestPoint.x(), closestPoint.y() ) );
-  derivedAttributes.insert( QStringLiteral( "Closest vertex X" ), formatXCoordinate( closestPointMapCoords ) );
-  derivedAttributes.insert( QStringLiteral( "Closest vertex Y" ), formatYCoordinate( closestPointMapCoords ) );
+  derivedAttributes.insert( tr( "Closest vertex X" ), formatXCoordinate( closestPointMapCoords ) );
+  derivedAttributes.insert( tr( "Closest vertex Y" ), formatYCoordinate( closestPointMapCoords ) );
 
   if ( closestPoint.is3D() )
   {
     str = QLocale().toString( closestPoint.z(), 'g', 10 );
-    derivedAttributes.insert( QStringLiteral( "Closest vertex Z" ), str );
+    derivedAttributes.insert( tr( "Closest vertex Z" ), str );
   }
   if ( closestPoint.isMeasure() )
   {
     str = QLocale().toString( closestPoint.m(), 'g', 10 );
-    derivedAttributes.insert( QStringLiteral( "Closest vertex M" ), str );
+    derivedAttributes.insert( tr( "Closest vertex M" ), str );
   }
 
   if ( vId.type == QgsVertexId::CurveVertex )
@@ -527,19 +527,19 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( const Qgs
       // Include the x and y coordinates of the point as a derived attribute
       QgsPointXY pnt = mCanvas->mapSettings().layerToMapCoordinates( layer, feature.geometry().asPoint() );
       QString str = formatXCoordinate( pnt );
-      derivedAttributes.insert( QStringLiteral( "X" ), str );
+      derivedAttributes.insert( tr( "X" ), str );
       str = formatYCoordinate( pnt );
-      derivedAttributes.insert( QStringLiteral( "Y" ), str );
+      derivedAttributes.insert( tr( "Y" ), str );
 
       if ( QgsWkbTypes::hasZ( wkbType ) )
       {
         str = QLocale().toString( static_cast<const QgsPoint *>( feature.geometry().constGet() )->z(), 'g', 10 );
-        derivedAttributes.insert( QStringLiteral( "Z" ), str );
+        derivedAttributes.insert( tr( "Z" ), str );
       }
       if ( QgsWkbTypes::hasM( wkbType ) )
       {
         str = QLocale().toString( static_cast<const QgsPoint *>( feature.geometry().constGet() )->m(), 'g', 10 );
-        derivedAttributes.insert( QStringLiteral( "M" ), str );
+        derivedAttributes.insert( tr( "M" ), str );
       }
     }
     else

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -218,6 +218,11 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
      */
     void closestVertexAttributes( const QgsAbstractGeometry &geometry, QgsVertexId vId, QgsMapLayer *layer, QMap< QString, QString > &derivedAttributes );
 
+    /**
+     * Adds details of the closest point to derived attributes
+    */
+    void closestPointAttributes( const QgsAbstractGeometry &geometry, const QgsPointXY &layerPoint, QMap< QString, QString > &derivedAttributes );
+
     QString formatCoordinate( const QgsPointXY &canvasPoint ) const;
     QString formatXCoordinate( const QgsPointXY &canvasPoint ) const;
     QString formatYCoordinate( const QgsPointXY &canvasPoint ) const;


### PR DESCRIPTION
Fixes https://issues.qgis.org/issues/19403, and adds tests