### PR TITLE
The qgstranslationcontext.h is missing in an install folder after build.

### DIFF
--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -121,6 +121,7 @@
 %Include auto_generated/qgsstringutils.sip
 %Include auto_generated/qgstextrenderer.sip
 %Include auto_generated/qgstracer.sip
+%Include auto_generated/qgstranslationcontext.sip
 %Include auto_generated/qgsvectordataprovider.sip
 %Include auto_generated/qgsvectorlayercache.sip
 %Include auto_generated/qgsvectorfilewriter.sip
@@ -442,5 +443,4 @@
 %Include auto_generated/layertree/qgslayertreeregistrybridge.sip
 %Include auto_generated/qgsuserprofilemanager.sip
 %Include auto_generated/symbology/qgsarrowsymbollayer.sip
-%Include auto_generated/qgstranslationcontext.sip
 %Include auto_generated/qgsuserprofile.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -937,6 +937,7 @@ SET(QGIS_CORE_HDRS
   qgstextrenderer.h
   qgstextrenderer_p.h
   qgstracer.h
+  qgstranslationcontext.h
 
   qgsvectordataprovider.h
   qgsvectorlayercache.h


### PR DESCRIPTION
Qgsapplication.h was complaining about qgstranslation.h include - it was missing in installation /src/core/ folder, so couldnt be found.
Related to https://github.com/qgis/QGIS/pull/7456