### PR TITLE
[QgsQuick][FEATURE] Added identify mode for identify tool

### DIFF
--- a/src/quickgui/qgsquickidentifykit.cpp
+++ b/src/quickgui/qgsquickidentifykit.cpp
@@ -86,6 +86,12 @@ QgsQuickFeatureLayerPairs QgsQuickIdentifyKit::identify( const QPointF &point, Q
           results.append( QgsQuickFeatureLayerPair( feature, vl ) );
         }
       }
+      if ( mIdentifyMode == IdentifyMode::TopDownStopAtFirst && !results.isEmpty() )
+      {
+        QgsDebugMsg( QStringLiteral( "IdentifyKit identified %1 results with TopDownStopAtFirst mode." ).arg( results.count() ) );
+        return results;
+      }
+
     }
 
     QgsDebugMsg( QStringLiteral( "IdentifyKit identified %1 results" ).arg( results.count() ) );

--- a/src/quickgui/qgsquickidentifykit.h
+++ b/src/quickgui/qgsquickidentifykit.h
@@ -66,7 +66,35 @@ class QUICK_EXPORT QgsQuickIdentifyKit : public QObject
      */
     Q_PROPERTY( int featuresLimit READ featuresLimit WRITE setFeaturesLimit NOTIFY featuresLimitChanged )
 
+    /**
+     * Defines behavior of the identify tool (See description of IdentifyMode enum).
+     *
+     * Default is TopDownAll.
+     */
+    Q_PROPERTY( IdentifyMode identifyMode MEMBER mIdentifyMode NOTIFY identifyModeChanged )
+
   public:
+
+    /**
+     * IdentifyMode enums used to define identify tool behavior on identifiable layers.
+     */
+    enum IdentifyMode
+    {
+
+      /**
+       * Identification is performed from top to bottom down layers returning all
+       * identified features;
+       */
+      TopDownAll = 0,
+
+      /**
+       * Identification is performed from top to bottom down layers and stops on the first layer
+       * returning non-empty list of identified features. Identification on rest layers is skipped.
+       */
+      TopDownStopAtFirst
+    };
+    Q_ENUM( IdentifyMode )
+
     //! Constructor of new identify kit.
     explicit QgsQuickIdentifyKit( QObject *parent = nullptr );
 
@@ -91,8 +119,10 @@ class QUICK_EXPORT QgsQuickIdentifyKit : public QObject
     /**
       * Gets the closest feature to the point within the search radius
       *
-      * If layer is nullptr, identifies the closest feature from all identifiable layers
-      * If layer is not nullptr, identifies the closest feature from given layer
+      * If layer is nullptr, identifies the closest feature from either
+      * all identifiable layers (IdentifyMode::TopDownAll) or the first layer from top to bottom layers
+      * with non-empty identified feature list (IdentifyMode::TopDownStopAtFirst)
+      * If layer is not nullptr, identifies the closest feature from given layer regardless identify mode.
       *
       * To modify search radius, use QgsQuickIdentifyKit::searchRadiusMm
       *
@@ -104,8 +134,10 @@ class QUICK_EXPORT QgsQuickIdentifyKit : public QObject
     /**
       * Gets all features in the search radius
       *
-      * If layer is nullptr, identifies features from all identifiable layers
-      * If layer is not nullptr, identifies only features from given layer
+      * If layer is nullptr, identifies features from either
+      * all identifiable layers (IdentifyMode::TopDownAll) or the first layer from top to bottom layers
+      * with non-empty identified feature list (IdentifyMode::TopDownStopAtFirst)
+      * If layer is not nullptr, identifies only features from given layer regardless identify mode.
       *
       * To limit number of results, use QgsQuickIdentifyKit::featuresLimit
       * To modify search radius, use QgsQuickIdentifyKit::searchRadiusMm
@@ -122,6 +154,8 @@ class QUICK_EXPORT QgsQuickIdentifyKit : public QObject
     void searchRadiusMmChanged();
     //! \copydoc QgsQuickIdentifyKit::featuresLimit
     void featuresLimitChanged();
+    //! \copydoc QgsQuickIdentifyKit::identifyMode
+    void identifyModeChanged();
 
   private:
     QgsQuickMapSettings *mMapSettings = nullptr; // not owned
@@ -134,6 +168,7 @@ class QUICK_EXPORT QgsQuickIdentifyKit : public QObject
 
     double mSearchRadiusMm = 8;
     int mFeaturesLimit = 100;
+    IdentifyMode mIdentifyMode = IdentifyMode::TopDownAll;
 };
 
 #endif // QGSQUICKIDENTIFYKIT_H


### PR DESCRIPTION
Introducing identify mode for QgsQuickIndtifyKit with related IdentifyMode enum.
The first value is **TopDownAll** where identification is performed from top to bottom down identifiable layers returning all identified features. In case of **TopDownStopAtFirst**, identification is performed from top to bottom down identifiable layers and stops on the first layer returning non-empty list of identified features. Identification on rest layers is skipped.

The reason to add identify mode is to slightly increase useability of the identify tool. When a user clicks on canvas to identify a feature, polyline feature has the priority. Current implementation searches among all layers and returns all features within tolerance radius. The result list is passed to _closestFeature function which selects the closest feature from the list. Since there are features from both types point and polyline layers, in most cases polyline feature is selected as the closest one from screen point (obviously). By adding identify mode - TopDownStopAtFirst, the chance of selecting point feature has increased depending on layers order (still using _closestFeature function). Indeed, features from the first layer will be still prefered so on canvas with high feature density with many layers could be still problematic.