### PR TITLE
 Add hidden configuration setting to set toolbar padding 

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -249,6 +249,8 @@ class ModelerDialog(BASE, WIDGET):
 
         if iface is not None:
             self.mToolbar.setIconSize(iface.iconSize())
+            self.setStyleSheet(iface.mainWindow().styleSheet())
+
         self.mActionOpen.setIcon(
             QgsApplication.getThemeIcon('/mActionFileOpen.svg'))
         self.mActionSave.setIcon(

--- a/python/plugins/processing/script/ScriptEditorDialog.py
+++ b/python/plugins/processing/script/ScriptEditorDialog.py
@@ -68,7 +68,9 @@ class ScriptEditorDialog(BASE, WIDGET):
         self.editor.initLexer()
         self.searchWidget.setVisible(False)
 
-        self.toolBar.setIconSize(iface.iconSize())
+        if iface is not None:
+            self.toolBar.setIconSize(iface.iconSize())
+            self.setStyleSheet(iface.mainWindow().styleSheet())
 
         self.actionOpenScript.setIcon(
             QgsApplication.getThemeIcon('/mActionScriptOpen.svg'))

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -28,6 +28,11 @@ connections-xyz\OpenStreetMap\username=
 connections-xyz\OpenStreetMap\zmax=19
 connections-xyz\OpenStreetMap\zmin=0
 
+# application stylesheet
+
+# Padding (in pixels) to add to toolbar icons, if blank then default padding will be used
+stylesheet\toolbarSpacing=
+
 [app]
 
 # Maximum number of recent projects to show on the welcome page

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -82,6 +82,8 @@ QMap<QString, QVariant> QgisAppStyleSheet::defaultOptions()
   bool gbxCustom = ( mMacStyle );
   opts.insert( QStringLiteral( "groupBoxCustom" ), settings.value( QStringLiteral( "groupBoxCustom" ), QVariant( gbxCustom ) ) );
 
+  opts.insert( QStringLiteral( "toolbarSpacing" ), settings.value( QStringLiteral( "toolbarSpacing" ), QString() ) );
+
   settings.endGroup(); // "qgis/stylesheet"
 
   opts.insert( QStringLiteral( "iconSize" ), settings.value( QStringLiteral( "/qgis/iconSize" ), QGIS_ICON_SIZE ) );
@@ -184,6 +186,17 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
                  "}" )
         .arg( palette.highlight().color().name(),
               palette.highlightedText().color().name() );
+
+  QString toolbarSpacing = opts.value( QStringLiteral( "toolbarSpacing" ), QString() ).toString();
+  if ( !toolbarSpacing.isEmpty() )
+  {
+    bool ok = false;
+    int toolbarSpacingInt = toolbarSpacing.toInt( &ok );
+    if ( ok )
+    {
+      ss += QStringLiteral( "QToolBar > QToolButton { padding: %1px; } " ).arg( toolbarSpacingInt );
+    }
+  }
 
   QgsDebugMsg( QString( "Stylesheet built: %1" ).arg( ss ) );
 


### PR DESCRIPTION
Can be tweaked for better appearance on hidpi screens, e.g. on my display a padding of 8 px looks best and the default padding feels very claustrophobic

E.g. default:
![before](https://user-images.githubusercontent.com/1829991/44141100-7be8af24-a0bf-11e8-9549-46fa242ff655.png)


with 8 px padding

![after](https://user-images.githubusercontent.com/1829991/44141108-7e406adc-a0bf-11e8-95ce-1f29974e9a24.png)

But this is all subjective, so I'm adding it as a hidden option only (so that I at least can have QGIS default to my preferred padding!)