### PR TITLE
Disable feature fetching for symbol selector widget preview

### DIFF
--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -253,11 +253,15 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
   //get first feature from layer for previews
   if ( mVectorLayer )
   {
+#if 0 // this is too expensive to do for many providers. TODO revisit when support for connection timeouts is complete across all providers
     // short timeout for request - it doesn't really matter if we don't get the feature, and this call is blocking UI
     QgsFeatureIterator it = mVectorLayer->getFeatures( QgsFeatureRequest().setLimit( 1 ).setConnectionTimeout( 100 ) );
     it.nextFeature( mPreviewFeature );
+#endif
     mPreviewExpressionContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( mVectorLayer ) );
+#if 0
     mPreviewExpressionContext.setFeature( mPreviewFeature );
+#endif
   }
   else
   {


### PR DESCRIPTION
It's just too expensive for any remote provider, e.g. wfs, and causes many ui lockups. Revisit when support for iterator timeouts is more mature.

This will cause a slight regression in that symbol previews which rely on data defined parameters and size will no longer give an accurate preview, but that's a trade off I'm willing to make to avoid hangs and lockups!
