### PR TITLE
Update Danish national CSW

### DIFF
--- a/python/plugins/MetaSearch/resources/connections-default.xml
+++ b/python/plugins/MetaSearch/resources/connections-default.xml
@@ -2,7 +2,7 @@
 <!-- Guidance: https://docs.qgis.org/2.18/en/docs/user_manual/plugins/plugins_metasearch.html#managing-catalog-services -->
 <qgsCSWConnections version="1.0">
     <csw name="USA: Data.gov CSW" url="https://catalog.data.gov/csw-all"/>
-    <csw name="Danmark: National CSW" url="http://www.geodata-info.dk/registrant/srv/en/csw"/>
+    <csw name="Danmark: National CSW (geodata-info)" url="https://geodata-info.dk/srv/dan/csw"/>
     <csw name="Finland: National CSW (Paikkatietohakemisto)" url="http://www.paikkatietohakemisto.fi/geonetwork/srv/fi/csw"/>
     <csw name="Greece: Geodata.gov.gr CSW" url="http://geodata.gov.gr/csw"/>
     <csw name="Iceland: National CSW (Iceland Service)" url="http://gatt.lmi.is/geoportal122/csw"/>


### PR DESCRIPTION
geodata-info has been modernised (upgrade of GeoNetwork installation) and as a consequence, the CSW endpoint was changed from http://www.geodata-info.dk/registrant/srv/en/csw to https://geodata-info.dk/srv/dan/csw.

## Description
The old endpoint gives an error in QGIS:
![billede](https://user-images.githubusercontent.com/11427611/44197099-3e8f9e80-a12d-11e8-9602-944ea9e41429.png)

With the new endpoint, it works fine:
![billede](https://user-images.githubusercontent.com/11427611/44197075-30418280-a12d-11e8-9ec7-4ca73a5e3ca9.png)
