### PR TITLE
Mesh color ramp fixes

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -92,15 +92,15 @@ Returns color ramp shader function
 Sets color ramp shader function
 %End
 
-    double classificationMin() const;
+    double classificationMinimum() const;
 %Docstring
 Returns min value used for creation of the color ramp shader
 %End
-    double classificationMax() const;
+    double classificationMaximum() const;
 %Docstring
 Returns max value used for creation of the color ramp shader
 %End
-    void setClassificationMinMax( double vMin, double vMax );
+    void setClassificationMinimumMaximum( double minimum, double maximum );
 %Docstring
 Sets min/max values used for creation of the color ramp shader
 %End

--- a/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshrenderersettings.sip.in
@@ -92,6 +92,19 @@ Returns color ramp shader function
 Sets color ramp shader function
 %End
 
+    double classificationMin() const;
+%Docstring
+Returns min value used for creation of the color ramp shader
+%End
+    double classificationMax() const;
+%Docstring
+Returns max value used for creation of the color ramp shader
+%End
+    void setClassificationMinMax( double vMin, double vMax );
+%Docstring
+Sets min/max values used for creation of the color ramp shader
+%End
+
     QDomElement writeXml( QDomDocument &doc ) const;
 %Docstring
 Writes configuration to a new DOM element

--- a/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -45,6 +45,7 @@ QgsMeshRendererScalarSettings QgsMeshRendererScalarSettingsWidget::settings() co
 {
   QgsMeshRendererScalarSettings settings;
   settings.setColorRampShader( mScalarColorRampShaderWidget->shader() );
+  settings.setClassificationMinMax( lineEditValue( mScalarMinLineEdit ), lineEditValue( mScalarMaxLineEdit ) );
   return settings;
 }
 
@@ -59,8 +60,8 @@ void QgsMeshRendererScalarSettingsWidget::syncToLayer( )
   const QgsMeshRendererSettings rendererSettings = mMeshLayer->rendererSettings();
   const QgsMeshRendererScalarSettings settings = rendererSettings.scalarSettings( mActiveDatasetGroup );
   const QgsColorRampShader shader = settings.colorRampShader();
-  whileBlocking( mScalarMinLineEdit )->setText( QString::number( shader.minimumValue() ) );
-  whileBlocking( mScalarMaxLineEdit )->setText( QString::number( shader.maximumValue() ) );
+  whileBlocking( mScalarMinLineEdit )->setText( QString::number( settings.classificationMin() ) );
+  whileBlocking( mScalarMaxLineEdit )->setText( QString::number( settings.classificationMax() ) );
   whileBlocking( mScalarColorRampShaderWidget )->setFromShader( shader );
 }
 

--- a/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
+++ b/src/app/mesh/qgsmeshrendererscalarsettingswidget.cpp
@@ -45,7 +45,7 @@ QgsMeshRendererScalarSettings QgsMeshRendererScalarSettingsWidget::settings() co
 {
   QgsMeshRendererScalarSettings settings;
   settings.setColorRampShader( mScalarColorRampShaderWidget->shader() );
-  settings.setClassificationMinMax( lineEditValue( mScalarMinLineEdit ), lineEditValue( mScalarMaxLineEdit ) );
+  settings.setClassificationMinimumMaximum( lineEditValue( mScalarMinLineEdit ), lineEditValue( mScalarMaxLineEdit ) );
   return settings;
 }
 
@@ -60,8 +60,8 @@ void QgsMeshRendererScalarSettingsWidget::syncToLayer( )
   const QgsMeshRendererSettings rendererSettings = mMeshLayer->rendererSettings();
   const QgsMeshRendererScalarSettings settings = rendererSettings.scalarSettings( mActiveDatasetGroup );
   const QgsColorRampShader shader = settings.colorRampShader();
-  whileBlocking( mScalarMinLineEdit )->setText( QString::number( settings.classificationMin() ) );
-  whileBlocking( mScalarMaxLineEdit )->setText( QString::number( settings.classificationMax() ) );
+  whileBlocking( mScalarMinLineEdit )->setText( QString::number( settings.classificationMinimum() ) );
+  whileBlocking( mScalarMaxLineEdit )->setText( QString::number( settings.classificationMaximum() ) );
   whileBlocking( mScalarColorRampShaderWidget )->setFromShader( shader );
 }
 

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -216,7 +216,7 @@ void QgsMeshLayer::assignDefaultStyleToDatasetGroup( int groupIndex )
   fcn.classifyColorRamp( 5, -1, QgsRectangle(), nullptr );
 
   QgsMeshRendererScalarSettings scalarSettings;
-  scalarSettings.setClassificationMinMax( groupMin, groupMax );
+  scalarSettings.setClassificationMinimumMaximum( groupMin, groupMax );
   scalarSettings.setColorRampShader( fcn );
   mRendererSettings.setScalarSettings( groupIndex, scalarSettings );
 }

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -216,6 +216,7 @@ void QgsMeshLayer::assignDefaultStyleToDatasetGroup( int groupIndex )
   fcn.classifyColorRamp( 5, -1, QgsRectangle(), nullptr );
 
   QgsMeshRendererScalarSettings scalarSettings;
+  scalarSettings.setClassificationMinMax( groupMin, groupMax );
   scalarSettings.setColorRampShader( fcn );
   mRendererSettings.setScalarSettings( groupIndex, scalarSettings );
 }

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -205,13 +205,14 @@ void QgsMeshLayerRenderer::renderScalarDataset()
   if ( !index.isValid() )
     return; // no shader
 
-  QgsColorRampShader *fcn = new QgsColorRampShader( mRendererSettings.scalarSettings( index.group() ).colorRampShader() );
+  const QgsMeshRendererScalarSettings scalarSettings = mRendererSettings.scalarSettings( index.group() );
+  QgsColorRampShader *fcn = new QgsColorRampShader( scalarSettings.colorRampShader() );
   QgsRasterShader *sh = new QgsRasterShader();
   sh->setRasterShaderFunction( fcn );  // takes ownership of fcn
   QgsMeshLayerInterpolator interpolator( mTriangularMesh, mScalarDatasetValues, mScalarDataOnVertices, mContext, mOutputSize );
   QgsSingleBandPseudoColorRenderer renderer( &interpolator, 0, sh );  // takes ownership of sh
-  renderer.setClassificationMin( fcn->minimumValue() );
-  renderer.setClassificationMax( fcn->maximumValue() );
+  renderer.setClassificationMin( scalarSettings.classificationMin() );
+  renderer.setClassificationMax( scalarSettings.classificationMax() );
 
   std::unique_ptr<QgsRasterBlock> bl( renderer.block( 0, mContext.extent(), mOutputSize.width(), mOutputSize.height(), mFeedback.get() ) );
   QImage img = bl->image();

--- a/src/core/mesh/qgsmeshlayerrenderer.cpp
+++ b/src/core/mesh/qgsmeshlayerrenderer.cpp
@@ -211,8 +211,8 @@ void QgsMeshLayerRenderer::renderScalarDataset()
   sh->setRasterShaderFunction( fcn );  // takes ownership of fcn
   QgsMeshLayerInterpolator interpolator( mTriangularMesh, mScalarDatasetValues, mScalarDataOnVertices, mContext, mOutputSize );
   QgsSingleBandPseudoColorRenderer renderer( &interpolator, 0, sh );  // takes ownership of sh
-  renderer.setClassificationMin( scalarSettings.classificationMin() );
-  renderer.setClassificationMax( scalarSettings.classificationMax() );
+  renderer.setClassificationMin( scalarSettings.classificationMinimum() );
+  renderer.setClassificationMax( scalarSettings.classificationMaximum() );
 
   std::unique_ptr<QgsRasterBlock> bl( renderer.block( 0, mContext.extent(), mOutputSize.width(), mOutputSize.height(), mFeedback.get() ) );
   QImage img = bl->image();

--- a/src/core/mesh/qgsmeshrenderersettings.cpp
+++ b/src/core/mesh/qgsmeshrenderersettings.cpp
@@ -78,17 +78,17 @@ void QgsMeshRendererScalarSettings::setColorRampShader( const QgsColorRampShader
   mColorRampShader = shader;
 }
 
-void QgsMeshRendererScalarSettings::setClassificationMinMax( double vMin, double vMax )
+void QgsMeshRendererScalarSettings::setClassificationMinimumMaximum( double minimum, double maximum )
 {
-  mClassificationMin = vMin;
-  mClassificationMax = vMax;
+  mClassificationMinimum = minimum;
+  mClassificationMaximum = maximum;
 }
 
 QDomElement QgsMeshRendererScalarSettings::writeXml( QDomDocument &doc ) const
 {
   QDomElement elem = doc.createElement( "scalar-settings" );
-  elem.setAttribute( "min-val", mClassificationMin );
-  elem.setAttribute( "max-val", mClassificationMax );
+  elem.setAttribute( "min-val", mClassificationMinimum );
+  elem.setAttribute( "max-val", mClassificationMaximum );
   QDomElement elemShader = mColorRampShader.writeXml( doc );
   elem.appendChild( elemShader );
   return elem;
@@ -96,8 +96,8 @@ QDomElement QgsMeshRendererScalarSettings::writeXml( QDomDocument &doc ) const
 
 void QgsMeshRendererScalarSettings::readXml( const QDomElement &elem )
 {
-  mClassificationMin = elem.attribute( "min-val" ).toDouble();
-  mClassificationMax = elem.attribute( "max-val" ).toDouble();
+  mClassificationMinimum = elem.attribute( "min-val" ).toDouble();
+  mClassificationMaximum = elem.attribute( "max-val" ).toDouble();
   QDomElement elemShader = elem.firstChildElement( QStringLiteral( "colorrampshader" ) );
   mColorRampShader.readXml( elemShader );
 }

--- a/src/core/mesh/qgsmeshrenderersettings.cpp
+++ b/src/core/mesh/qgsmeshrenderersettings.cpp
@@ -78,9 +78,17 @@ void QgsMeshRendererScalarSettings::setColorRampShader( const QgsColorRampShader
   mColorRampShader = shader;
 }
 
+void QgsMeshRendererScalarSettings::setClassificationMinMax( double vMin, double vMax )
+{
+  mClassificationMin = vMin;
+  mClassificationMax = vMax;
+}
+
 QDomElement QgsMeshRendererScalarSettings::writeXml( QDomDocument &doc ) const
 {
   QDomElement elem = doc.createElement( "scalar-settings" );
+  elem.setAttribute( "min-val", mClassificationMin );
+  elem.setAttribute( "max-val", mClassificationMax );
   QDomElement elemShader = mColorRampShader.writeXml( doc );
   elem.appendChild( elemShader );
   return elem;
@@ -88,6 +96,8 @@ QDomElement QgsMeshRendererScalarSettings::writeXml( QDomDocument &doc ) const
 
 void QgsMeshRendererScalarSettings::readXml( const QDomElement &elem )
 {
+  mClassificationMin = elem.attribute( "min-val" ).toDouble();
+  mClassificationMax = elem.attribute( "max-val" ).toDouble();
   QDomElement elemShader = elem.firstChildElement( QStringLiteral( "colorrampshader" ) );
   mColorRampShader.readXml( elemShader );
 }

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -82,6 +82,13 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
     //! Sets color ramp shader function
     void setColorRampShader( const QgsColorRampShader &shader );
 
+    //! Returns min value used for creation of the color ramp shader
+    double classificationMin() const { return mClassificationMin; }
+    //! Returns max value used for creation of the color ramp shader
+    double classificationMax() const { return mClassificationMax; }
+    //! Sets min/max values used for creation of the color ramp shader
+    void setClassificationMinMax( double vMin, double vMax );
+
     //! Writes configuration to a new DOM element
     QDomElement writeXml( QDomDocument &doc ) const;
     //! Reads configuration from the given DOM element
@@ -89,6 +96,8 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
 
   private:
     QgsColorRampShader mColorRampShader;
+    double mClassificationMin = 0;
+    double mClassificationMax = 0;
 };
 
 /**

--- a/src/core/mesh/qgsmeshrenderersettings.h
+++ b/src/core/mesh/qgsmeshrenderersettings.h
@@ -83,11 +83,11 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
     void setColorRampShader( const QgsColorRampShader &shader );
 
     //! Returns min value used for creation of the color ramp shader
-    double classificationMin() const { return mClassificationMin; }
+    double classificationMinimum() const { return mClassificationMinimum; }
     //! Returns max value used for creation of the color ramp shader
-    double classificationMax() const { return mClassificationMax; }
+    double classificationMaximum() const { return mClassificationMaximum; }
     //! Sets min/max values used for creation of the color ramp shader
-    void setClassificationMinMax( double vMin, double vMax );
+    void setClassificationMinimumMaximum( double minimum, double maximum );
 
     //! Writes configuration to a new DOM element
     QDomElement writeXml( QDomDocument &doc ) const;
@@ -96,8 +96,8 @@ class CORE_EXPORT QgsMeshRendererScalarSettings
 
   private:
     QgsColorRampShader mColorRampShader;
-    double mClassificationMin = 0;
-    double mClassificationMax = 0;
+    double mClassificationMinimum = 0;
+    double mClassificationMaximum = 0;
 };
 
 /**

--- a/src/gui/raster/qgscolorrampshaderwidget.cpp
+++ b/src/gui/raster/qgscolorrampshaderwidget.cpp
@@ -97,12 +97,12 @@ void QgsColorRampShaderWidget::initializeForUseWithRasterLayer()
 {
   Q_ASSERT( mClassificationModeComboBox->findData( QgsColorRampShader::Quantile < 0 ) );
   mClassificationModeComboBox->addItem( tr( "Quantile" ), QgsColorRampShader::Quantile );
-  mLoadFromBandButton->setVisible( bool( mRasterDataProvider ) ); // only for raster version
 }
 
 void QgsColorRampShaderWidget::setRasterDataProvider( QgsRasterDataProvider *dp )
 {
   mRasterDataProvider = dp;
+  mLoadFromBandButton->setVisible( bool( mRasterDataProvider ) ); // only for raster version
 }
 
 void QgsColorRampShaderWidget::setRasterBand( int band )

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -143,18 +143,6 @@ void QgsSingleBandPseudoColorRendererWidget::setMapCanvas( QgsMapCanvas *canvas 
   mColorRampShaderWidget->setExtent( mMinMaxWidget->extent() );
 }
 
-void QgsSingleBandPseudoColorRendererWidget::mLoadFromBandButton_clicked()
-{
-  if ( !mRasterLayer || !mRasterLayer->dataProvider() )
-  {
-    return;
-  }
-
-  int bandIndex = mBandComboBox->currentBand();
-  mColorRampShaderWidget->setRasterBand( bandIndex );
-  emit widgetChanged();
-}
-
 void QgsSingleBandPseudoColorRendererWidget::setFromRenderer( const QgsRasterRenderer *r )
 {
   const QgsSingleBandPseudoColorRenderer *pr = dynamic_cast<const QgsSingleBandPseudoColorRenderer *>( r );
@@ -162,6 +150,7 @@ void QgsSingleBandPseudoColorRendererWidget::setFromRenderer( const QgsRasterRen
   {
     mBandComboBox->setBand( pr->band() );
     mMinMaxWidget->setBands( QList< int >() << pr->band() );
+    mColorRampShaderWidget->setRasterBand( pr->band() );
 
     const QgsRasterShader *rasterShader = pr->shader();
     if ( rasterShader )

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.h
@@ -66,7 +66,6 @@ class GUI_EXPORT QgsSingleBandPseudoColorRendererWidget: public QgsRasterRendere
     void loadMinMaxFromTree( double min, double max );
 
   private slots:
-    void mLoadFromBandButton_clicked();
     void bandChanged();
     void mMinLineEdit_textChanged( const QString & );
     void mMaxLineEdit_textChanged( const QString & );

--- a/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendererscalarsettingswidgetbase.ui
@@ -47,7 +47,7 @@
      <item>
       <widget class="QPushButton" name="mScalarRecalculateMinMaxButton">
        <property name="text">
-        <string>Recalculate</string>
+        <string>Load</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
In fact this is a combination of two separate bug fixes:
- mesh layers - fix storage and viewing of min/max values for shading
- raster layers - bring back missing "load from band" button (regression since the recent refactoring of the color ramp widget)
