### PR TITLE
add map_layers_ids variable for MapLayoutItem

### DIFF
--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1155,7 +1155,18 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_definition" ), mapCrs.toProj4(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapCrs.mapUnits() ), true ) );
 
+  QVariantList layers_ids;
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_layers_ids" ), layers_ids, true ) );
+
   context.appendScope( scope );
+
+  // The scope map_layers_ids has been added to the context, only now we can call layersToRender
+  const QList<QgsMapLayer *> layersInMap = layersToRender( &context );
+  for ( QgsMapLayer *layer : layersInMap )
+  {
+    layers_ids << layer->id();
+  }
+  scope->setVariable( QStringLiteral( "map_layers_ids" ), layers_ids );
 
   return context;
 }

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -995,6 +995,14 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_definition" ), mapSettings.destinationCrs().toProj4(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapSettings.mapUnits() ), true ) );
 
+  QVariantList layers_ids;
+  const QList<QgsMapLayer *> layersInMap = mapSettings.layers();
+  for ( QgsMapLayer *layer : layersInMap )
+  {
+    layers_ids << layer->id();
+  }
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_layers_ids" ), layers_ids, true ) );
+
   scope->addFunction( QStringLiteral( "is_layer_visible" ), new GetLayerVisibility( mapSettings.layers() ) );
 
   return scope;

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -1431,6 +1431,12 @@ void TestQgsLayoutItem::itemVariablesFunction()
   QgsExpression e4( QStringLiteral( "map_get( item_variables( 'Map_id' ), 'map_units' )" ) );
   r = e4.evaluate( &c );
   QCOMPARE( r.toString(), QString( "degrees" ) );
+
+  QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=id_a:integer" ), QStringLiteral( "A" ), QStringLiteral( "memory" ) );
+  map->setLayers( QList<QgsMapLayer *>() << layer );
+  QgsExpression e5( QStringLiteral( "map_get( item_variables( 'Map_id' ), 'map_layers_ids' )" ) );
+  r = e5.evaluate( &c );
+  QCOMPARE( r.toStringList().join( ',' ), layer->id() );
 }
 
 void TestQgsLayoutItem::variables()


### PR DESCRIPTION
## Description

I'm trying to generate my source label automatically according to layers which are visible in my layout.

So with this PR and with #7628 I can do an expression like this:
![screenshot from 2018-08-16 13-47-40](https://user-images.githubusercontent.com/1609292/44225257-01da9c00-a15b-11e8-8fb0-84fe71bdd574.png)

* [ ] Needs tests

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
