### PR TITLE
Avoid doing work (and also crashes)

### DIFF
--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -260,7 +260,7 @@ QgsGpsInformationWidget::QgsGpsInformationWidget( QgsMapCanvas *thepCanvas, QWid
   //SLM - added functionality
   mLogFile = nullptr;
 
-  connect( QgisApp::instance()->layerTreeView(), &QgsLayerTreeView::currentLayerChanged,
+  connect( QgisApp::instance(), &QgisApp::activeLayerChanged,
            this, &QgsGpsInformationWidget::updateCloseFeatureButton );
 
   mStackedWidget->setCurrentIndex( 3 ); // force to Options

--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -109,7 +109,7 @@ class QgsGpsInformationWidget: public QWidget, private Ui::QgsGpsInformationWidg
     QList<QgsPointXY> mCaptureList;
     FixStatus mLastFixStatus;
     QString mDateTimeFormat; // user specified format string in registry (no UI presented)
-    QgsVectorLayer *mpLastLayer = nullptr;
+    QPointer< QgsVectorLayer > mpLastLayer;
     QFile *mLogFile = nullptr;
     QTextStream mLogFileTextStream;
     QIntValidator *mAcquisitionIntValidator = nullptr;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -567,9 +567,13 @@ void QgisApp::layerTreeViewDoubleClicked( const QModelIndex &index )
   }
 }
 
-void QgisApp::activeLayerChanged( QgsMapLayer *layer )
+void QgisApp::onActiveLayerChanged( QgsMapLayer *layer )
 {
-  Q_FOREACH ( QgsMapCanvas *canvas, mapCanvases() )
+  if ( mBlockActiveLayerChanged )
+    return;
+
+  const QList< QgsMapCanvas * > canvases = mapCanvases();
+  for ( QgsMapCanvas *canvas : canvases )
     canvas->setCurrentLayer( layer );
 
   if ( mUndoWidget )
@@ -584,6 +588,8 @@ void QgisApp::activeLayerChanged( QgsMapLayer *layer )
     }
     updateUndoActions();
   }
+
+  emit activeLayerChanged( layer );
 }
 
 /*
@@ -1702,6 +1708,10 @@ QVector<QPointer<QgsLayoutCustomDropHandler> > QgisApp::customLayoutDropHandlers
 
 void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
 {
+  // avoid unnecessary work when adding lots of layers at once - defer emitting the active layer changed signal until we've
+  // added all layers, and only emit the signal once for the final layer added
+  mBlockActiveLayerChanged = true;
+
   // insert items in reverse order as each one is inserted on top of previous one
   for ( int i = lst.size() - 1 ; i >= 0 ; i-- )
   {
@@ -1742,8 +1752,10 @@ void QgisApp::handleDropUriList( const QgsMimeDataUtils::UriList &lst )
       openFile( u.uri, QStringLiteral( "project" ) );
     }
   }
-}
 
+  mBlockActiveLayerChanged = false;
+  emit activeLayerChanged( activeLayer() );
+}
 
 bool QgisApp::event( QEvent *event )
 {
@@ -3339,9 +3351,9 @@ void QgisApp::setupConnections()
   } );
 
   // connect legend signals
-  connect( mLayerTreeView, &QgsLayerTreeView::currentLayerChanged,
+  connect( this, &QgisApp::activeLayerChanged,
            this, &QgisApp::activateDeactivateLayerRelatedActions );
-  connect( mLayerTreeView, &QgsLayerTreeView::currentLayerChanged,
+  connect( this, &QgisApp::activeLayerChanged,
            this, &QgisApp::setMapStyleDockLayer );
 
   connect( mLayerTreeView->selectionModel(), &QItemSelectionModel::selectionChanged,
@@ -3837,7 +3849,7 @@ void QgisApp::initLayerTreeView()
   setupLayerTreeViewFromSettings();
 
   connect( mLayerTreeView, &QAbstractItemView::doubleClicked, this, &QgisApp::layerTreeViewDoubleClicked );
-  connect( mLayerTreeView, &QgsLayerTreeView::currentLayerChanged, this, &QgisApp::activeLayerChanged );
+  connect( mLayerTreeView, &QgsLayerTreeView::currentLayerChanged, this, &QgisApp::onActiveLayerChanged );
   connect( mLayerTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgisApp::updateNewLayerInsertionPoint );
   connect( QgsProject::instance()->layerTreeRegistryBridge(), &QgsLayerTreeRegistryBridge::addedLayersToLayerTree,
            this, &QgisApp::autoSelectAddedLayer );
@@ -11172,7 +11184,14 @@ void QgisApp::closeProject()
   mMapCanvas->clearCache();
   mOverviewCanvas->setLayers( QList<QgsMapLayer *>() );
   mMapCanvas->freeze( false );
+
+  // Avoid unnecessary layer changed handling for each layer removed - instead,
+  // defer the handling until we've removed all layers
+  mBlockActiveLayerChanged = true;
   QgsProject::instance()->clear();
+  mBlockActiveLayerChanged = false;
+
+  emit activeLayerChanged( activeLayer() );
 }
 
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -719,7 +719,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void updateNewLayerInsertionPoint();
     //! connected to layer tree registry bridge, selects first of the newly added map layers
     void autoSelectAddedLayer( QList<QgsMapLayer *> layers );
-    void activeLayerChanged( QgsMapLayer *layer );
+
     //! Zoom to full extent
     void zoomFull();
     //! Zoom to the previous extent
@@ -1664,6 +1664,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! handle project crs changes
     void projectCrsChanged();
 
+    void onActiveLayerChanged( QgsMapLayer *layer );
+
   signals:
 
     /**
@@ -1736,6 +1738,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
        \since QGIS 2.7
      */
     void layerSavedAs( QgsMapLayer *l, const QString &path );
+
+    /**
+     * Emitted when the active layer is changed.
+     */
+    void activeLayerChanged( QgsMapLayer *layer );
 
   private:
     void startProfile( const QString &name );
@@ -2284,6 +2291,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QMap< QString, QString > mSettingPagesMap;
 
     QgsProxyProgressTask *mProjectLoadingProxyTask = nullptr;
+
+    //! True if we are blocking the activeLayerChanged signal from being emitted
+    bool mBlockActiveLayerChanged = false;
 
     friend class TestQgisAppPython;
 };

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -53,7 +53,7 @@ QgisAppInterface::QgisAppInterface( QgisApp *_qgis )
   , pluginManagerIface( _qgis->pluginManager() )
 {
   // connect signals
-  connect( qgis->layerTreeView(), &QgsLayerTreeView::currentLayerChanged,
+  connect( qgis, &QgisApp::activeLayerChanged,
            this, &QgisInterface::currentLayerChanged );
   connect( qgis, &QgisApp::currentThemeChanged,
            this, &QgisAppInterface::currentThemeChanged );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -277,7 +277,7 @@ void QgsMapCanvas::enableMapTileRendering( bool flag )
 QgsMapLayer *QgsMapCanvas::layer( int index )
 {
   QList<QgsMapLayer *> layers = mapSettings().layers();
-  if ( index >= 0 && index < ( int ) layers.size() )
+  if ( index >= 0 && index < layers.size() )
     return layers[index];
   else
     return nullptr;
@@ -347,7 +347,7 @@ void QgsMapCanvas::setLayersPrivate( const QList<QgsMapLayer *> &layers )
     }
   }
 
-  QgsDebugMsg( "Layers have changed, refreshing" );
+  QgsDebugMsg( QStringLiteral( "Layers have changed, refreshing" ) );
   emit layersChanged();
 
   updateAutoRefreshTimer();
@@ -377,7 +377,7 @@ void QgsMapCanvas::setDestinationCrs( const QgsCoordinateReferenceSystem &crs )
     catch ( QgsCsException &e )
     {
       Q_UNUSED( e );
-      QgsDebugMsg( QString( "Transform error caught: %1" ).arg( e.what() ) );
+      QgsDebugMsg( QStringLiteral( "Transform error caught: %1" ).arg( e.what() ) );
     }
   }
 
@@ -389,7 +389,7 @@ void QgsMapCanvas::setDestinationCrs( const QgsCoordinateReferenceSystem &crs )
   mSettings.setDestinationCrs( crs );
   updateScale();
 
-  QgsDebugMsg( "refreshing after destination CRS changed" );
+  QgsDebugMsg( QStringLiteral( "refreshing after destination CRS changed" ) );
   refresh();
 
   emit destinationCrsChanged();
@@ -478,25 +478,25 @@ void QgsMapCanvas::refresh()
 {
   if ( !mSettings.hasValidSettings() )
   {
-    QgsDebugMsg( "CANVAS refresh - invalid settings -> nothing to do" );
+    QgsDebugMsg( QStringLiteral( "CANVAS refresh - invalid settings -> nothing to do" ) );
     return;
   }
 
   if ( !mRenderFlag || mFrozen )
   {
-    QgsDebugMsg( "CANVAS render flag off" );
+    QgsDebugMsg( QStringLiteral( "CANVAS render flag off" ) );
     return;
   }
 
   if ( mRefreshScheduled )
   {
-    QgsDebugMsg( "CANVAS refresh already scheduled" );
+    QgsDebugMsg( QStringLiteral( "CANVAS refresh already scheduled" ) );
     return;
   }
 
   mRefreshScheduled = true;
 
-  QgsDebugMsg( "CANVAS refresh scheduling" );
+  QgsDebugMsg( QStringLiteral( "CANVAS refresh scheduling" ) );
 
   // schedule a refresh
   mRefreshTimer->start( 1 );
@@ -506,7 +506,7 @@ void QgsMapCanvas::refreshMap()
 {
   Q_ASSERT( mRefreshScheduled );
 
-  QgsDebugMsgLevel( "CANVAS refresh!", 3 );
+  QgsDebugMsgLevel( QStringLiteral( "CANVAS refresh!" ), 3 );
 
   stopRendering(); // if any...
   stopPreviewJobs();
@@ -582,7 +582,7 @@ void QgsMapCanvas::mapThemeChanged( const QString &theme )
 
 void QgsMapCanvas::rendererJobFinished()
 {
-  QgsDebugMsg( QString( "CANVAS finish! %1" ).arg( !mJobCanceled ) );
+  QgsDebugMsg( QStringLiteral( "CANVAS finish! %1" ).arg( !mJobCanceled ) );
 
   mMapUpdateTimer.stop();
 
@@ -627,7 +627,7 @@ void QgsMapCanvas::rendererJobFinished()
       p.setBrush( QColor( 0, 0, 0, 110 ) );
       p.drawRect( r );
       p.setPen( Qt::white );
-      QString msg = QStringLiteral( "%1 :: %2 ms" ).arg( mUseParallelRendering ? "PARALLEL" : "SEQUENTIAL" ).arg( mJob->renderingTime() );
+      QString msg = QStringLiteral( "%1 :: %2 ms" ).arg( mUseParallelRendering ? QStringLiteral( "PARALLEL" ) : QStringLiteral( "SEQUENTIAL" ) ).arg( mJob->renderingTime() );
       p.drawText( r, msg, QTextOption( Qt::AlignCenter ) );
     }
 
@@ -707,7 +707,7 @@ void QgsMapCanvas::stopRendering()
 {
   if ( mJob )
   {
-    QgsDebugMsg( "CANVAS stop rendering!" );
+    QgsDebugMsg( QStringLiteral( "CANVAS stop rendering!" ) );
     mJobCanceled = true;
     disconnect( mJob, &QgsMapRendererJob::finished, this, &QgsMapCanvas::rendererJobFinished );
     connect( mJob, &QgsMapRendererQImageJob::finished, mJob, &QgsMapRendererQImageJob::deleteLater );
@@ -811,12 +811,12 @@ void QgsMapCanvas::setExtent( const QgsRectangle &r, bool magnified )
     if ( !mSettings.hasValidSettings() )
     {
       // we can't even just move the map center
-      QgsDebugMsg( "Empty extent - ignoring" );
+      QgsDebugMsg( QStringLiteral( "Empty extent - ignoring" ) );
       return;
     }
 
     // ### QGIS 3: do not allow empty extent - require users to call setCenter() explicitly
-    QgsDebugMsg( "Empty extent - keeping old scale with new center!" );
+    QgsDebugMsg( QStringLiteral( "Empty extent - keeping old scale with new center!" ) );
     setCenter( r.center() );
   }
   else
@@ -884,7 +884,7 @@ void QgsMapCanvas::setRotation( double degrees )
 {
   double current = rotation();
 
-  if ( degrees == current )
+  if ( qgsDoubleNear( degrees, current ) )
     return;
 
   mSettings.setRotation( degrees );
@@ -1220,25 +1220,25 @@ void QgsMapCanvas::keyPressEvent( QKeyEvent *e )
     switch ( e->key() )
     {
       case Qt::Key_Left:
-        QgsDebugMsg( "Pan left" );
+        QgsDebugMsg( QStringLiteral( "Pan left" ) );
         setCenter( center() - QgsVector( dx, 0 ).rotateBy( rotation() * M_PI / 180.0 ) );
         refresh();
         break;
 
       case Qt::Key_Right:
-        QgsDebugMsg( "Pan right" );
+        QgsDebugMsg( QStringLiteral( "Pan right" ) );
         setCenter( center() + QgsVector( dx, 0 ).rotateBy( rotation() * M_PI / 180.0 ) );
         refresh();
         break;
 
       case Qt::Key_Up:
-        QgsDebugMsg( "Pan up" );
+        QgsDebugMsg( QStringLiteral( "Pan up" ) );
         setCenter( center() + QgsVector( 0, dy ).rotateBy( rotation() * M_PI / 180.0 ) );
         refresh();
         break;
 
       case Qt::Key_Down:
-        QgsDebugMsg( "Pan down" );
+        QgsDebugMsg( QStringLiteral( "Pan down" ) );
         setCenter( center() - QgsVector( 0, dy ).rotateBy( rotation() * M_PI / 180.0 ) );
         refresh();
         break;
@@ -1246,7 +1246,7 @@ void QgsMapCanvas::keyPressEvent( QKeyEvent *e )
 
 
       case Qt::Key_Space:
-        QgsDebugMsg( "Pressing pan selector" );
+        QgsDebugMsg( QStringLiteral( "Pressing pan selector" ) );
 
         //mCanvasProperties->dragging = true;
         if ( ! e->isAutoRepeat() )
@@ -1258,12 +1258,12 @@ void QgsMapCanvas::keyPressEvent( QKeyEvent *e )
         break;
 
       case Qt::Key_PageUp:
-        QgsDebugMsg( "Zoom in" );
+        QgsDebugMsg( QStringLiteral( "Zoom in" ) );
         zoomIn();
         break;
 
       case Qt::Key_PageDown:
-        QgsDebugMsg( "Zoom out" );
+        QgsDebugMsg( QStringLiteral( "Zoom out" ) );
         zoomOut();
         break;
 
@@ -1297,14 +1297,14 @@ void QgsMapCanvas::keyPressEvent( QKeyEvent *e )
 
 void QgsMapCanvas::keyReleaseEvent( QKeyEvent *e )
 {
-  QgsDebugMsg( "keyRelease event" );
+  QgsDebugMsg( QStringLiteral( "keyRelease event" ) );
 
   switch ( e->key() )
   {
     case Qt::Key_Space:
       if ( !e->isAutoRepeat() && mCanvasProperties->panSelectorDown )
       {
-        QgsDebugMsg( "Releasing pan selector" );
+        QgsDebugMsg( QStringLiteral( "Releasing pan selector" ) );
         QApplication::restoreOverrideCursor();
         mCanvasProperties->panSelectorDown = false;
         panActionEnd( mCanvasProperties->mouseLastXY );
@@ -1372,8 +1372,8 @@ void QgsMapCanvas::endZoomRect( QPoint pos )
   // set center and zoom
   const QSize &zoomRectSize = mZoomRect.size();
   const QSize &canvasSize = mSettings.outputSize();
-  double sfx = ( double )zoomRectSize.width() / canvasSize.width();
-  double sfy = ( double )zoomRectSize.height() / canvasSize.height();
+  double sfx = static_cast< double >( zoomRectSize.width() ) / canvasSize.width();
+  double sfy = static_cast< double >( zoomRectSize.height() ) / canvasSize.height();
   double sf = std::max( sfx, sfy );
 
   QgsPointXY c = mSettings.mapToPixel().toMapCoordinates( mZoomRect.center() );
@@ -1452,8 +1452,8 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent *e )
       // right button was pressed in zoom tool? return to previous non zoom tool
       if ( e->button() == Qt::RightButton && mMapTool->flags() & QgsMapTool::Transient )
       {
-        QgsDebugMsg( "Right click in map tool zoom or pan, last tool is " +
-                     QString( mLastNonZoomMapTool ? "not null." : "null." ) );
+        QgsDebugMsg( QStringLiteral( "Right click in map tool zoom or pan, last tool is %1." ).arg(
+                       mLastNonZoomMapTool ? QStringLiteral( "not null" ) : QStringLiteral( "null" ) ) );
 
         QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCurrentLayer );
 
@@ -2028,7 +2028,7 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
   }
   else
   {
-    QgsDebugMsg( "Couldn't read mapcanvas information from project" );
+    QgsDebugMsg( QStringLiteral( "Couldn't read mapcanvas information from project" ) );
   }
 }
 
@@ -2039,7 +2039,7 @@ void QgsMapCanvas::writeProject( QDomDocument &doc )
   QDomNodeList nl = doc.elementsByTagName( QStringLiteral( "qgis" ) );
   if ( !nl.count() )
   {
-    QgsDebugMsg( "Unable to find qgis element in project file" );
+    QgsDebugMsg( QStringLiteral( "Unable to find qgis element in project file" ) );
     return;
   }
   QDomNode qgisNode = nl.item( 0 );  // there should only be one, so zeroth element OK
@@ -2126,7 +2126,7 @@ void QgsMapCanvas::dragEnterEvent( QDragEnterEvent *e )
 
 void QgsMapCanvas::mapToolDestroyed()
 {
-  QgsDebugMsg( "maptool destroyed" );
+  QgsDebugMsg( QStringLiteral( "maptool destroyed" ) );
   mMapTool = nullptr;
 }
 
@@ -2261,7 +2261,7 @@ void QgsMapCanvas::startPreviewJob( int number )
     context.lastRenderingTimeMs = mLastLayerRenderTime.value( layer->id(), 0 );
     if ( !layer->dataProvider()->renderInPreview( context ) )
     {
-      QgsDebugMsgLevel( QString( "Layer %1 not rendered because it does not match the renderInPreview criterion %2" ).arg( layer->id() ).arg( mLastLayerRenderTime.value( layer->id() ) ), 3 );
+      QgsDebugMsgLevel( QStringLiteral( "Layer %1 not rendered because it does not match the renderInPreview criterion %2" ).arg( layer->id() ).arg( mLastLayerRenderTime.value( layer->id() ) ), 3 );
       continue;
     }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -285,6 +285,9 @@ QgsMapLayer *QgsMapCanvas::layer( int index )
 
 void QgsMapCanvas::setCurrentLayer( QgsMapLayer *layer )
 {
+  if ( mCurrentLayer == layer )
+    return;
+
   mCurrentLayer = layer;
   emit currentLayerChanged( layer );
 }

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -928,7 +928,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     bool mRenderFlag = true;
 
     //! current layer in legend
-    QgsMapLayer *mCurrentLayer = nullptr;
+    QPointer< QgsMapLayer > mCurrentLayer;
 
     //! graphics scene manages canvas items
     QGraphicsScene *mScene = nullptr;


### PR DESCRIPTION
When multiple layers are added to QGIS (e.g. as a result of drag and drop), or when multiple layers are removed (e.g. clearing project), we are doing a bunch of unnecessary processing by firing off active layer changed signals for every layer added/removed, which results in a whole lot of other stuff happening (like style dock updating, action enabling/disabling,... not to mention whatever plugins are doing here too).

Instead, defer the active layer changed handling until all layers have been added/removed, and then only do it for the last layer added/removed.

Also fix some crashes encountered while doing this with various classes storing current map layer pointers, which potentially point to removed layers.



