### PR TITLE
[wfs] Remove download progress dialog, move to proxy task

### DIFF
--- a/python/core/auto_generated/qgsproxyprogresstask.sip.in
+++ b/python/core/auto_generated/qgsproxyprogresstask.sip.in
@@ -32,6 +32,11 @@ task manager.
 Constructor for QgsProxyProgressTask, with the specified ``description``.
 %End
 
+    virtual bool run();
+
+
+  public slots:
+
     void finalize( bool result );
 %Docstring
 Finalizes the task, with the specified ``result``.
@@ -39,9 +44,6 @@ Finalizes the task, with the specified ``result``.
 This should be called when the operation being proxied has completed,
 to remove this proxy task from the task manager.
 %End
-
-    virtual bool run();
-
 
     void setProxyProgress( double progress );
 %Docstring

--- a/src/core/qgsproxyprogresstask.h
+++ b/src/core/qgsproxyprogresstask.h
@@ -44,6 +44,10 @@ class CORE_EXPORT QgsProxyProgressTask : public QgsTask
      */
     QgsProxyProgressTask( const QString &description );
 
+    bool run() override;
+
+  public slots:
+
     /**
      * Finalizes the task, with the specified \a result.
      *
@@ -51,8 +55,6 @@ class CORE_EXPORT QgsProxyProgressTask : public QgsTask
      * to remove this proxy task from the task manager.
      */
     void finalize( bool result );
-
-    bool run() override;
 
     /**
      * Sets the \a progress (from 0 to 100) for the proxied operation.

--- a/src/providers/wfs/qgswfsfeatureiterator.h
+++ b/src/providers/wfs/qgswfsfeatureiterator.h
@@ -32,6 +32,7 @@ class QgsWFSProvider;
 class QgsWFSSharedData;
 class QgsVectorDataProvider;
 class QProgressDialog;
+class QgsProxyProgressTask;
 
 typedef QPair<QgsFeature, QString> QgsWFSFeatureGmlIdPair;
 
@@ -59,25 +60,6 @@ class QgsWFSFeatureHitsAsyncRequest: public QgsWfsRequest
 
   private:
     int mNumberMatched;
-};
-
-
-//! Utility class for QgsWFSFeatureDownloader
-class QgsWFSProgressDialog: public QProgressDialog
-{
-    Q_OBJECT
-  public:
-    //! Constructor
-    QgsWFSProgressDialog( const QString &labelText, const QString &cancelButtonText, int minimum, int maximum, QWidget *parent );
-
-    void resizeEvent( QResizeEvent *ev ) override;
-
-  signals:
-    void hideRequest();
-
-  private:
-    QPushButton *mCancel = nullptr;
-    QPushButton *mHide = nullptr;
 };
 
 /**
@@ -128,11 +110,10 @@ class QgsWFSFeatureDownloader: public QgsWfsRequest
     QString errorMessageWithReason( const QString &reason ) override;
 
   private slots:
-    void createProgressDialog();
+    void createProgressTask();
     void startHitsRequest();
     void gotHitsResponse();
     void setStopFlag();
-    void hideProgressDialog();
 
   private:
     QUrl buildURL( qint64 startIndex, int maxFeatures, bool forHits );
@@ -143,13 +124,9 @@ class QgsWFSFeatureDownloader: public QgsWfsRequest
     QgsWFSSharedData *mShared = nullptr;
     //! Whether the download should stop
     bool mStop;
-    //! Progress dialog
-    QgsWFSProgressDialog *mProgressDialog = nullptr;
 
-    /**
-     * If the progress dialog should be shown immediately, or if it should be
-        let to QProgressDialog logic to decide when to show it */
-    bool mProgressDialogShowImmediately;
+    QgsProxyProgressTask *mProgressTask = nullptr;
+
     int mPageSize;
     bool mRemoveNSPrefix;
     int mNumberMatched;


### PR DESCRIPTION
The WFS download progress dialogs are not good UX - they popup over the main window and get in the way of users, and often you get multiple dialogs at once popping up.

Instead, move the progress reports to a proxy task, so that progress reports are shown through the task manager and gain all the nice integration features that task manager has.

This is a WIP - it's not thread safe yet, and doesn't support cancelling the download like the dialog does.
