### PR TITLE
osgeo4w: remove registering of wrong classes

### DIFF
--- a/ms-windows/osgeo4w/qgis.reg.tmpl
+++ b/ms-windows/osgeo4w/qgis.reg.tmpl
@@ -20,15 +20,6 @@ Windows Registry Editor Version 5.00
 [HKEY_CLASSES_ROOT\.qgz]
 @="QGIS Project"
 
-[HKEY_CLASSES_ROOT\QGIS Layer Definition]
-@="QGIS Layer Definition"
-
-[HKEY_CLASSES_ROOT\QGIS Layer Definition\DefaultIcon]
-@="@osgeo4w@\\apps\\@package@\\icons\\qgis-qml.ico"
-
-[HKEY_CLASSES_ROOT\.qml]
-@="QGIS Layer Definition"
-
 [HKEY_CLASSES_ROOT\QGIS Composer Template]
 @="QGIS Composer Template"
 


### PR DESCRIPTION
## Description
"QGIS Layer Definition" and .qml classes are registered two times: the first time with wrong values, so we should remove the related lines of qgis.reg.tmpl

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
