### PR TITLE
QgsFeaturePool fixes/optimizations

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -169,7 +169,6 @@ SET(QGIS_ANALYSIS_MOC_HDRS
 
   processing/qgsalgorithmfiledownloader.h
 
-  vector/geometry_checker/qgsfeaturepool.h
   vector/geometry_checker/qgsgeometrychecker.h
   vector/geometry_checker/qgsgeometryanglecheck.h
   vector/geometry_checker/qgsgeometryareacheck.h
@@ -255,6 +254,7 @@ SET(QGIS_ANALYSIS_HDRS
   vector/qgsgeometrysnapper.h
   vector/qgszonalstatistics.h
   vector/geometry_checker/qgsgeometrycheckerutils.h
+  vector/geometry_checker/qgsfeaturepool.h
 
   interpolation/qgsinterpolator.h
   interpolation/qgsgridfilewriter.h

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -20,10 +20,8 @@
 #include "qgsgeometry.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
-#include "qgsgeometryutils.h"
 
 #include <QMutexLocker>
-#include <limits>
 
 QgsFeaturePool::QgsFeaturePool( QgsVectorLayer *layer, double layerToMapUnits, const QgsCoordinateTransform &layerToMapTransform, bool selectedOnly )
   : mFeatureCache( CACHE_SIZE )

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -102,7 +102,7 @@ void QgsFeaturePool::updateFeature( QgsFeature &feature )
   get( feature.id(), origFeature );
 
   QgsGeometryMap geometryMap;
-  geometryMap.insert( feature.id(), QgsGeometry( feature.geometry().constGet()->clone() ) );
+  geometryMap.insert( feature.id(), feature.geometry() );
   QgsChangedAttributesMap changedAttributesMap;
   QgsAttributeMap attribMap;
   for ( int i = 0, n = feature.attributes().size(); i < n; ++i )

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -32,25 +32,23 @@ QgsFeaturePool::QgsFeaturePool( QgsVectorLayer *layer, double layerToMapUnits, c
   , mLayerToMapTransform( layerToMapTransform )
   , mSelectedOnly( selectedOnly )
 {
-  if ( selectedOnly )
-  {
-    mFeatureIds = layer->selectedFeatureIds();
-  }
-  else
-  {
-    mFeatureIds = layer->allFeatureIds();
-  }
-
   // Build spatial index
   QgsFeature feature;
   QgsFeatureRequest req;
   req.setSubsetOfAttributes( QgsAttributeList() );
+  if ( selectedOnly )
+  {
+    mFeatureIds = layer->selectedFeatureIds();
+    req.setFilterFids( mFeatureIds );
+  }
+
   QgsFeatureIterator it = layer->getFeatures( req );
   while ( it.nextFeature( feature ) )
   {
-    if ( mFeatureIds.contains( feature.id() ) && feature.geometry() )
+    if ( feature.geometry() )
     {
       mIndex.insertFeature( feature );
+      mFeatureIds.insert( feature.id() );
     }
     else
     {

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -123,7 +123,7 @@ void QgsFeaturePool::updateFeature( QgsFeature &feature )
   mIndexMutex.unlock();
 }
 
-void QgsFeaturePool::deleteFeature( const QgsFeatureId &fid )
+void QgsFeaturePool::deleteFeature( QgsFeatureId fid )
 {
   QgsFeature origFeature;
   if ( get( fid, origFeature ) )

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -44,19 +44,10 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QObject
     const QgsFeatureIds &getFeatureIds() const { return mFeatureIds; }
     double getLayerToMapUnits() const { return mLayerToMapUnits; }
     const QgsCoordinateTransform &getLayerToMapTransform() const { return mLayerToMapTransform; }
-    bool getSelectedOnly() const { return mSelectedOnly; }
+
     void clearLayer() { mLayer = nullptr; }
 
   private:
-    struct MapEntry
-    {
-      MapEntry( QgsFeature *_feature, QLinkedList<QgsFeatureId>::iterator _ageIt )
-        : feature( _feature )
-        , ageIt( _ageIt )
-      {}
-      QgsFeature *feature = nullptr;
-      QLinkedList<QgsFeatureId>::iterator ageIt;
-    };
 
     static const int CACHE_SIZE = 1000;
 
@@ -66,11 +57,9 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QObject
     QMutex mLayerMutex;
     mutable QMutex mIndexMutex;
     QgsSpatialIndex mIndex;
-    double mLayerToMapUnits;
+    double mLayerToMapUnits = 1.0;
     QgsCoordinateTransform mLayerToMapTransform;
-    bool mSelectedOnly;
-
-    bool getTouchingWithSharedEdge( QgsFeature &feature, QgsFeatureId &touchingId, const double & ( *comparator )( const double &, const double & ), double init );
+    bool mSelectedOnly = false;
 };
 
 #endif // QGS_FEATUREPOOL_H

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -38,7 +38,7 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QObject
     bool get( QgsFeatureId id, QgsFeature &feature );
     void addFeature( QgsFeature &feature );
     void updateFeature( QgsFeature &feature );
-    void deleteFeature( const QgsFeatureId &fid );
+    void deleteFeature( QgsFeatureId fid );
     QgsFeatureIds getIntersects( const QgsRectangle &rect ) const;
     QgsVectorLayer *getLayer() const { return mLayer; }
     const QgsFeatureIds &getFeatureIds() const { return mFeatureIds; }

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -20,19 +20,16 @@
 #define QGS_FEATUREPOOL_H
 
 #include <QCache>
-#include <QLinkedList>
-#include <QMap>
 #include <QMutex>
 #include "qgis_analysis.h"
 #include "qgsfeature.h"
 #include "qgsspatialindex.h"
-#include "qgsgeometrycheckerutils.h"
 
 class QgsVectorLayer;
 
-class ANALYSIS_EXPORT QgsFeaturePool : public QObject
+class ANALYSIS_EXPORT QgsFeaturePool
 {
-    Q_OBJECT
+
   public:
     QgsFeaturePool( QgsVectorLayer *layer, double layerToMapUnits, const QgsCoordinateTransform &layerToMapTransform, bool selectedOnly = false );
     bool get( QgsFeatureId id, QgsFeature &feature );

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -255,7 +255,7 @@ void QgsGeometryCheckerSetupTab::runChecks()
   QgsVectorLayer *followBoundaryCheckLayer = ui.comboBoxFollowBoundaries->isEnabled() ? dynamic_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( ui.comboBoxFollowBoundaries->currentData().toString() ) ) : nullptr;
   if ( layers.contains( lineLayerCheckLayer ) || layers.contains( followBoundaryCheckLayer ) )
   {
-    QMessageBox::critical( this, tr( "Check Geometries" ), tr( "The test layer set contains a layer selected for a topology check." ) );
+    QMessageBox::critical( this, tr( "Check Geometries" ), tr( "The selected input layers cannot contain a layer also selected for a topology check." ) );
     return;
   }
 

--- a/src/plugins/geometry_checker/qgsgeometrycheckfactory.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckfactory.cpp
@@ -254,9 +254,12 @@ template<> void QgsGeometryCheckFactoryT<QgsGeometryFollowBoundariesCheck>::rest
 
 template<> bool QgsGeometryCheckFactoryT<QgsGeometryFollowBoundariesCheck>::checkApplicability( Ui::QgsGeometryCheckerSetupTab &ui, int /*nPoint*/, int nLineString, int nPolygon ) const
 {
-  ui.checkBoxFollowBoundaries->setEnabled( nLineString + nPolygon > 0 );
-  ui.checkBoxFollowBoundaries->setEnabled( nLineString + nPolygon > 0 );
-  return ui.checkBoxFollowBoundaries->isEnabled();
+  const bool enabled = nPolygon > 0;
+  if ( !enabled )
+    ui.checkBoxFollowBoundaries->setChecked( false );
+  ui.checkBoxFollowBoundaries->setEnabled( enabled );
+  ui.comboBoxFollowBoundaries->setEnabled( enabled && ui.checkBoxFollowBoundaries->isChecked() );
+  return enabled;
 }
 
 template<> QgsGeometryCheck *QgsGeometryCheckFactoryT<QgsGeometryFollowBoundariesCheck>::createInstance( QgsGeometryCheckerContext *context, const Ui::QgsGeometryCheckerSetupTab &ui ) const
@@ -371,9 +374,12 @@ template<> void QgsGeometryCheckFactoryT<QgsGeometryLineLayerIntersectionCheck>:
 
 template<> bool QgsGeometryCheckFactoryT<QgsGeometryLineLayerIntersectionCheck>::checkApplicability( Ui::QgsGeometryCheckerSetupTab &ui, int /*nPoint*/, int nLineString, int /*nPolygon*/ ) const
 {
-  ui.checkLineLayerIntersection->setEnabled( nLineString > 0 );
-  ui.comboLineLayerIntersection->setEnabled( nLineString > 0 );
-  return ui.checkLineLayerIntersection->isEnabled();
+  const bool enabled = nLineString > 0;
+  if ( !enabled )
+    ui.checkLineLayerIntersection->setChecked( false );
+  ui.checkLineLayerIntersection->setEnabled( enabled );
+  ui.comboLineLayerIntersection->setEnabled( enabled && ui.checkLineLayerIntersection->isChecked() );
+  return enabled;
 }
 
 template<> QgsGeometryCheck *QgsGeometryCheckFactoryT<QgsGeometryLineLayerIntersectionCheck>::createInstance( QgsGeometryCheckerContext *context, const Ui::QgsGeometryCheckerSetupTab &ui ) const


### PR DESCRIPTION
@m-kuhn 
Saw you were working on cleaning up geometry checker so thought I'd take the opportunity to push some fixes to a class which has been bothering me - QgsFeaturePool.

This is just the easy stuff - but I think the future of QgsFeaturePool needs to be rethought. The biggest thing which worries me is all the mutexes used here, which hints that the class is being used from non-main threads. Yet the mutexes protect stuff which isn't safe to call from background threads, like data provider methods such as add/change/delete feature, and worse, QgsVectorLayer::selectedFeatureIds/selectByIds.