### PR TITLE
[processing] Remove extraneous parameter value check

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -126,14 +126,6 @@ class Processing(object):
             feedback.reportError(msg)
             raise QgsProcessingException(msg)
 
-        # check for any mandatory parameters which were not specified
-        for param in alg.parameterDefinitions():
-            if param.name() not in parameters:
-                if not param.flags() & QgsProcessingParameterDefinition.FlagOptional:
-                    msg = Processing.tr('Error: Missing parameter value for parameter {0}.').format(param.name())
-                    feedback.reportError(msg)
-                    raise QgsProcessingException(msg)
-
         if context is None:
             context = dataobjects.createContext(feedback)
 


### PR DESCRIPTION
The subsequent call to checkParameterValues covers the same checks, but in a more flexible way.

Refs discussion at https://github.com/qgis/QGIS-Documentation/pull/2797
