### PR TITLE
Don't use system notification for auth messages

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12983,9 +12983,9 @@ void QgisApp::onTaskCompleteShowNotify( long taskId, int status )
     if ( task && task->elapsedTime() >= minTime )
     {
       if ( status == QgsTask::Complete )
-        showSystemNotification( tr( "Task complete" ), task->description() );
+        showTaskCompletionNotification( tr( "Task complete" ), task->description() );
       else if ( status == QgsTask::Terminated )
-        showSystemNotification( tr( "Task failed" ), task->description() );
+        showTaskCompletionNotification( tr( "Task failed" ), task->description() );
     }
   }
 }
@@ -13901,7 +13901,7 @@ QMenu *QgisApp::createPopupMenu()
 }
 
 
-void QgisApp::showSystemNotification( const QString &title, const QString &message, bool replaceExisting )
+void QgisApp::showTaskCompletionNotification( const QString &title, const QString &message, bool replaceExisting )
 {
   static QVariant sLastMessageId;
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13749,17 +13749,8 @@ void QgisApp::eraseAuthenticationDatabase()
 
 void QgisApp::authMessageOut( const QString &message, const QString &authtag, QgsAuthManager::MessageLevel level )
 {
-  // Use system notifications if the main window is not the active one,
-  // push message to the message bar if the main window is active
-  if ( qApp->activeWindow() != this )
-  {
-    showSystemNotification( tr( "QGIS Authentication" ), message );
-  }
-  else
-  {
-    int levelint = static_cast< int >( level );
-    messageBar()->pushMessage( authtag, message, static_cast< Qgis::MessageLevel >( levelint ), 7 );
-  }
+  int levelint = static_cast< int >( level );
+  messageBar()->pushMessage( authtag, message, static_cast< Qgis::MessageLevel >( levelint ), 7 );
 }
 
 void QgisApp::completeInitialization()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -408,17 +408,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsVectorLayerTools *vectorLayerTools() { return mVectorLayerTools; }
 
     /**
-     * Notify the user by using the system tray notifications
-     *
-     * \note usage of the system tray notifications should be limited
-     *       to long running tasks and to when the user needs to be notified
-     *       about interaction with OS services, like the password manager.
-     *
-     * \param title
-     * \param message
-     * \param replaceExisting set to true to replace any existing notifications, or false to add a new notification
+     * Notify the user of long running task completion.
      */
-    void showSystemNotification( const QString &title, const QString &message, bool replaceExisting = true );
+    void showTaskCompletionNotification( const QString &title, const QString &message, bool replaceExisting = true );
 
 
     //! Actions to be inserted in menus and toolbars


### PR DESCRIPTION
This mechanism was designed for use only by task manager, where extra logic is in place to avoid showing notifications for short duration operations.  Instead always use the more appropriate message bar here.