### PR TITLE
Subtle security warnings

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -169,8 +169,9 @@ class ShellOutputScintilla(QsciScintilla):
 
     def insertInitText(self):
         txtInit = QCoreApplication.translate("PythonConsole",
-                                             "Python Console \n"
-                                             "Use iface to access QGIS API interface or Type help(iface) for more info")
+                                             "Python Console\n"
+                                             "Use iface to access QGIS API interface or Type help(iface) for more info\n"
+                                             "Security warning: typing commands from an untrusted source can lead to data loss and/or leak")
 
         # some translation string for the console header ends without '\n'
         # and the first command in console will be appended at the header text.

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1367,8 +1367,28 @@ void QgsPluginManager::mZipFileWidget_fileChanged( const QString &filePath )
 
 void QgsPluginManager::buttonInstallFromZip_clicked()
 {
-  QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.instance().installFromZipFile(r'%1')" ).arg( mZipFileWidget->filePath() ) );
-  mZipFileWidget->setFilePath( "" );
+  QgsSettings settings;
+  bool showInstallFromZipWarning = settings.value( QStringLiteral( "UI/showInstallFromZipWarning" ), true ).toBool();
+
+  QMessageBox msgbox;
+  if ( showInstallFromZipWarning )
+  {
+    msgbox.setText( tr( "Security warning: installing a plugin from an untrusted source can lead to data loss and/or leak. Continue?" ) );
+    msgbox.setIcon( QMessageBox::Icon::Warning );
+    msgbox.addButton( QMessageBox::Yes );
+    msgbox.addButton( QMessageBox::No );
+    msgbox.setDefaultButton( QMessageBox::No );
+    QCheckBox *cb = new QCheckBox( tr( "Don't show this again." ) );
+    msgbox.setCheckBox( cb );
+    msgbox.exec();
+    settings.setValue( QStringLiteral( "UI/showInstallFromZipWarning" ), !msgbox.checkBox()->isChecked() );
+  }
+
+  if ( !showInstallFromZipWarning || msgbox.result() == QMessageBox::Yes )
+  {
+    QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.instance().installFromZipFile(r'%1')" ).arg( mZipFileWidget->filePath() ) );
+    mZipFileWidget->setFilePath( "" );
+  }
 }
 
 


### PR DESCRIPTION
## Description
Python console security warning:
![screenshot from 2018-08-20 13-37-12](https://user-images.githubusercontent.com/1728657/44324099-b1c34880-a47e-11e8-86fa-f6e9091306d6.png)
_That mimics what Firefox does, which IMHO is a good reminder_

Plugin manager's Install from ZIP panel:
![screenshot from 2018-08-20 13-37-22](https://user-images.githubusercontent.com/1728657/44324121-ca336300-a47e-11e8-9ebf-dba602dce3db.png)

Neither are intrusive, just subtle texts to make people think a bit :)

@elpaso , this takes into account your comment on the console in the last script PR. Cheers.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
