### PR TITLE
[processing][needs-docs] Rename "Save Selected Features" to "Extract selected features"

### DIFF
--- a/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
@@ -37,12 +37,12 @@ QString QgsSaveSelectedFeatures::name() const
 
 QString QgsSaveSelectedFeatures::displayName() const
 {
-  return QObject::tr( "Save Selected Features" );
+  return QObject::tr( "Extract selected features" );
 }
 
 QStringList QgsSaveSelectedFeatures::tags() const
 {
-  return QObject::tr( "selection,save" ).split( ',' );
+  return QObject::tr( "selection,save,by" ).split( ',' );
 }
 
 QString QgsSaveSelectedFeatures::group() const


### PR DESCRIPTION
As noted in the bug report, this adds consistency with other extraction algorithms, and fixes inconsistent capitalization

Fixes #19656
