### PR TITLE
[processing][needs-docs] Refine names for 'Import into PostGIS' algs

### DIFF
--- a/python/plugins/processing/algs/gdal/OgrToPostGis.py
+++ b/python/plugins/processing/algs/gdal/OgrToPostGis.py
@@ -163,7 +163,15 @@ class OgrToPostGis(GdalAlgorithm):
         return 'importvectorintopostgisdatabasenewconnection'
 
     def displayName(self):
-        return self.tr('Import vector into PostGIS database (new connection)')
+        return self.tr('Export to PostgreSQL (new connection)')
+
+    def shortDescription(self):
+        return self.tr('Exports a vector layer to a new PostgreSQL database connection')
+
+    def tags(self):
+        t = self.tr('import,into,postgis,database,vector').split(',')
+        t.extend(super().tags())
+        return t
 
     def group(self):
         return self.tr('Vector miscellaneous')

--- a/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
@@ -171,7 +171,15 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
         return 'importvectorintopostgisdatabaseavailableconnections'
 
     def displayName(self):
-        return self.tr('Import vector into PostGIS database (available connections)')
+        return self.tr('Export to PostgreSQL (available connections)')
+
+    def shortDescription(self):
+        return self.tr('Exports a vector layer to an existing PostgreSQL database connection')
+
+    def tags(self):
+        t = self.tr('import,into,postgis,database,vector').split(',')
+        t.extend(super().tags())
+        return t
 
     def group(self):
         return self.tr('Vector miscellaneous')

--- a/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoPostGIS.py
@@ -115,7 +115,13 @@ class ImportIntoPostGIS(QgisAlgorithm):
         return 'importintopostgis'
 
     def displayName(self):
-        return self.tr('Import into PostGIS')
+        return self.tr('Export to PostgreSQL')
+
+    def shortDescription(self):
+        return self.tr('Exports a vector layer to a PostgreSQL database')
+
+    def tags(self):
+        return self.tr('import,postgis,table,layer,into,copy').split(',')
 
     def processAlgorithm(self, parameters, context, feedback):
         connection = self.parameterAsString(parameters, self.DATABASE, context)

--- a/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
+++ b/python/plugins/processing/algs/qgis/ImportIntoSpatialite.py
@@ -84,7 +84,13 @@ class ImportIntoSpatialite(QgisAlgorithm):
         return 'importintospatialite'
 
     def displayName(self):
-        return self.tr('Import into Spatialite')
+        return self.tr('Export to SpatiaLite')
+
+    def shortDescription(self):
+        return self.tr('Exports a vector layer to a SpatiaLite database')
+
+    def tags(self):
+        return self.tr('import,table,layer,into,copy').split(',')
 
     def processAlgorithm(self, parameters, context, feedback):
         database = self.parameterAsVectorLayer(parameters, self.DATABASE, context)

--- a/python/plugins/processing/algs/qgis/PostGISExecuteAndLoadSQL.py
+++ b/python/plugins/processing/algs/qgis/PostGISExecuteAndLoadSQL.py
@@ -89,7 +89,13 @@ class PostGISExecuteAndLoadSQL(QgisAlgorithm):
         return 'postgisexecuteandloadsql'
 
     def displayName(self):
-        return self.tr('PostGIS execute and load SQL')
+        return self.tr('PostgreSQL execute and load SQL')
+
+    def shortDescription(self):
+        return self.tr('Executes a SQL command on a PostgreSQL database and loads the result as a table')
+
+    def tags(self):
+        return self.tr('postgis,table,database').split(',')
 
     def processAlgorithm(self, parameters, context, feedback):
         connection = self.parameterAsString(parameters, self.DATABASE, context)

--- a/python/plugins/processing/algs/qgis/PostGISExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/PostGISExecuteSQL.py
@@ -58,7 +58,13 @@ class PostGISExecuteSQL(QgisAlgorithm):
         return 'postgisexecutesql'
 
     def displayName(self):
-        return self.tr('PostGIS execute SQL')
+        return self.tr('PostgreSQL execute SQL')
+
+    def shortDescription(self):
+        return self.tr('Executes a SQL command on a PostgreSQL database')
+
+    def tags(self):
+        return self.tr('postgis,database').split(',')
 
     def processAlgorithm(self, parameters, context, feedback):
         connection = self.parameterAsString(parameters, self.DATABASE, context)

--- a/python/plugins/processing/algs/qgis/SpatialiteExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/SpatialiteExecuteSQL.py
@@ -60,6 +60,9 @@ class SpatialiteExecuteSQL(QgisAlgorithm):
     def displayName(self):
         return self.tr('SpatiaLite execute SQL')
 
+    def shortDescription(self):
+        return self.tr('Executes a SQL command on a SpatiaLite database')
+
     def flags(self):
         return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
 


### PR DESCRIPTION
Renames the existing algorithms for clarity and consistency to the format 'Export to PostgreSQL...'. Add tags so that they still show when searching for the old names, and add descriptions to make their use more obvious from the toolbox.

Fixes #19658
