### PR TITLE
Add qFloor, qCeil, qSqrt to banned keywords

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
@@ -52,7 +52,7 @@ void QgsGeometryAngleCheck::collectErrors( QList<QgsGeometryCheckError *> &error
             continue;
           }
 
-          double angle = qAcos( v21 * v23 ) / M_PI * 180.0;
+          double angle = std::acos( v21 * v23 ) / M_PI * 180.0;
           if ( angle < mMinAngle )
           {
             errors.append( new QgsGeometryCheckError( this, layerFeature, p2, QgsVertexId( iPart, iRing, iVert ), angle ) );

--- a/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
@@ -41,7 +41,7 @@ void QgsGeometrySegmentLengthCheck::collectErrors( QList<QgsGeometryCheckError *
         {
           QgsPoint pi = geom->vertexAt( QgsVertexId( iPart, iRing, iVert ) );
           QgsPoint pj = geom->vertexAt( QgsVertexId( iPart, iRing, jVert ) );
-          double dist = qSqrt( QgsGeometryUtils::sqrDistance2D( pi, pj ) );
+          double dist = pi.distance( pj );
           // Don't report very small lengths, they are either duplicate nodes or degenerate geometries
           if ( dist < minLength && dist > mContext->tolerance )
           {
@@ -85,7 +85,7 @@ void QgsGeometrySegmentLengthCheck::fixError( QgsGeometryCheckError *error, int 
 
   QgsPoint pi = geom->vertexAt( error->vidx() );
   QgsPoint pj = geom->vertexAt( QgsVertexId( vidx.part, vidx.ring, ( vidx.vertex - 1 + nVerts ) % nVerts ) );
-  double dist = qSqrt( QgsGeometryUtils::sqrDistance2D( pi, pj ) );
+  double dist = pi.distance( pj );
   double layerToMapUnits = featurePool->getLayerToMapUnits();
   double minLength = mMinLengthMapUnits / layerToMapUnits;
   if ( dist >= minLength )

--- a/tests/code_layout/test_banned_keywords.sh
+++ b/tests/code_layout/test_banned_keywords.sh
@@ -107,6 +107,15 @@ HINTS[27]="Use std::shared_ptr instead"
 KEYWORDS[28]="QOverload"
 HINTS[28]="Use qgis::overload instead"
 
+KEYWORDS[29]="qFloor"
+HINTS[29]="Use std::floor instead"
+
+KEYWORDS[30]="qCeil"
+HINTS[30]="Use std::ceil instead"
+
+KEYWORDS[31]="qSqrt"
+HINTS[31]="Use std::sqrt instead"
+
 RES=
 DIR=$(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
Since these have a very uncertain future, may as well make it easier for future Qt upgrades by using the std methods instead.