### PR TITLE
[layouts] Default to more modern scalebar settings

### DIFF
--- a/src/core/layout/qgslayoutitemscalebar.cpp
+++ b/src/core/layout/qgslayoutitemscalebar.cpp
@@ -473,8 +473,8 @@ void QgsLayoutItemScaleBar::applyDefaultSize( QgsUnitTypes::DistanceUnit units )
     mSettings.setUnitsPerSegment( unitsPerSegment );
     mSettings.setMapUnitsPerScaleBarUnit( upperMagnitudeMultiplier );
 
-    mSettings.setNumberOfSegments( 4 );
-    mSettings.setNumberOfSegmentsLeft( 2 );
+    mSettings.setNumberOfSegments( 2 );
+    mSettings.setNumberOfSegmentsLeft( 0 );
   }
 
   refreshSegmentMillimeters();


### PR DESCRIPTION
Use 2 normal segments/0 left segments by default. Left segments are a specific use case and shouldn't be the default.

Refs: informal discussion with colleagues who all hate the left segments default, and some conversation on Twitter I can't find anymore :stuck_out_tongue_winking_eye: 