### PR TITLE
[ui] Add tooltip when changing slider value in tile scale panel

### DIFF
--- a/src/providers/wms/qgstilescalewidget.cpp
+++ b/src/providers/wms/qgstilescalewidget.cpp
@@ -35,8 +35,8 @@ QgsTileScaleWidget::QgsTileScaleWidget( QgsMapCanvas *mapCanvas, QWidget *parent
   , mMapCanvas( mapCanvas )
 {
   setupUi( this );
-  connect( mSlider, &QSlider::valueChanged, this, &QgsTileScaleWidget::mSlider_valueChanged );
 
+  connect( mSlider, &QSlider::valueChanged, this, &QgsTileScaleWidget::mSlider_valueChanged );
   connect( mMapCanvas, &QgsMapCanvas::scaleChanged, this, &QgsTileScaleWidget::scaleChanged );
 
   layerChanged( mMapCanvas->currentLayer() );
@@ -110,6 +110,11 @@ void QgsTileScaleWidget::mSlider_valueChanged( int value )
   mMapCanvas->zoomByFactor( mResolutions.at( mSlider->value() ) / mMapCanvas->mapUnitsPerPixel() );
 }
 
+void QgsTileScaleWidget::locationChanged( Qt::DockWidgetArea area )
+{
+  mSlider->setOrientation( area == Qt::TopDockWidgetArea || area == Qt::BottomDockWidgetArea ? Qt::Horizontal : Qt::Vertical );
+}
+
 void QgsTileScaleWidget::showTileScale( QMainWindow *mainWindow )
 {
   QgsDockWidget *dock = mainWindow->findChild<QgsDockWidget *>( QStringLiteral( "theTileScaleDock" ) );
@@ -144,7 +149,9 @@ void QgsTileScaleWidget::showTileScale( QMainWindow *mainWindow )
   //create the dock widget
   dock = new QgsDockWidget( tr( "Tile Scale" ), mainWindow );
   dock->setObjectName( QStringLiteral( "theTileScaleDock" ) );
-  dock->setAllowedAreas( Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea );
+
+  connect( dock, &QDockWidget::dockLocationChanged, tws, &QgsTileScaleWidget::locationChanged );
+
   mainWindow->addDockWidget( Qt::RightDockWidgetArea, dock );
 
   // add to the Panel submenu

--- a/src/providers/wms/qgstilescalewidget.cpp
+++ b/src/providers/wms/qgstilescalewidget.cpp
@@ -106,7 +106,7 @@ void QgsTileScaleWidget::mSlider_valueChanged( int value )
   QgsDebugMsg( QString( "slider released at %1: %2" ).arg( mSlider->value() ).arg( mResolutions.at( mSlider->value() ) ) );
 
   // Invert value in tooltip to match expectation (i.e. 0 = zoomed out, maximum = zoomed in)
-  QToolTip::showText( QCursor::pos(), QString( "Zoom level: %1\nResolution: %2" ).arg( mSlider->maximum() - value ).arg( mResolutions.at( value ) ), this );
+  QToolTip::showText( QCursor::pos(), tr( "Zoom level: %1" ).arg( mSlider->maximum() - value ) + "\n" + tr( "Resolution: %2" ).arg( mResolutions.at( value ) ), this );
   mMapCanvas->zoomByFactor( mResolutions.at( mSlider->value() ) / mMapCanvas->mapUnitsPerPixel() );
 }
 

--- a/src/providers/wms/qgstilescalewidget.cpp
+++ b/src/providers/wms/qgstilescalewidget.cpp
@@ -28,6 +28,7 @@
 #include <QMainWindow>
 #include <QMenu>
 #include <QGraphicsView>
+#include <QToolTip>
 
 QgsTileScaleWidget::QgsTileScaleWidget( QgsMapCanvas *mapCanvas, QWidget *parent, Qt::WindowFlags f )
   : QWidget( parent, f )
@@ -102,8 +103,10 @@ void QgsTileScaleWidget::scaleChanged( double scale )
 
 void QgsTileScaleWidget::mSlider_valueChanged( int value )
 {
-  Q_UNUSED( value );
   QgsDebugMsg( QString( "slider released at %1: %2" ).arg( mSlider->value() ).arg( mResolutions.at( mSlider->value() ) ) );
+
+  // Invert value in tooltip to match expectation (i.e. 0 = zoomed out, maximum = zoomed in)
+  QToolTip::showText( QCursor::pos(), QString( "Zoom level: %1\nResolution: %2" ).arg( mSlider->maximum() - value ).arg( mResolutions.at( value ) ), this );
   mMapCanvas->zoomByFactor( mResolutions.at( mSlider->value() ) / mMapCanvas->mapUnitsPerPixel() );
 }
 

--- a/src/providers/wms/qgstilescalewidget.h
+++ b/src/providers/wms/qgstilescalewidget.h
@@ -36,6 +36,7 @@ class QgsTileScaleWidget : public QWidget, private Ui::QgsTileScaleWidget
     void scaleChanged( double );
     void mSlider_valueChanged( int );
     void scaleEnabled( bool );
+    void locationChanged( Qt::DockWidgetArea area );
 
   private:
     QgsTileScaleWidget( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );


### PR DESCRIPTION
## Description
Quick tip to let users know which zoom level he/she/they settled on:
![tips](https://user-images.githubusercontent.com/1728657/44440949-a09c4800-a5f4-11e8-9081-cc29e762121f.gif)

@jef-n , I never got to thank you for this useful panel to begin with -- thanks :)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
