### PR TITLE
Replace dashes with underscores in layer name when saving layer as KML

### DIFF
--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -257,6 +257,12 @@ QList<QPair<QLabel *, QWidget *> > QgsVectorLayerSaveAsDialog::createControls( c
 
 void QgsVectorLayerSaveAsDialog::accept()
 {
+  if ( format() == QLatin1String( "KML" ) )
+  {
+    // The KML driver transforms dashes to underscores, not adjusting accordingly breaks automatic addition of dataset upon saving
+    leLayername->setText( leLayername->text().replace( '-', '_' ) );
+  }
+
   if ( QFile::exists( filename() ) )
   {
     QgsVectorFileWriter::EditionCapabilities caps =


### PR DESCRIPTION
## Description
Blah, I stumbled on this issue one time too many.

When saving a vector layer as KML, the OGR KML driver automatically replaces dashes (-) character with underscores (_). Since we do not adjust our own layer name in this case, it leads to a subsequent failure to automatically [x] add the saved dataset since the code forms the following URI: `/home/to/my/file.kml|layername=test-dashes`, which is wrong since OGR transformed the layer name to `test_dashes`.

This PR insures that out layer name is adjusted when saving as KML.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
