### PR TITLE
Remove tray icon notification fallback, use message bar instead

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1334,13 +1334,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
     QgsGui::instance()->nativePlatformInterface()->hideApplicationProgress();
   } );
 
-  if ( !( QgsGui::nativePlatformInterface()->capabilities() & QgsNative::NativeDesktopNotifications ) )
-  {
-    mTray = new QSystemTrayIcon();
-    mTray->setIcon( QIcon( QgsApplication::appIconPath() ) );
-    mTray->hide();
-  }
-
   // supposedly all actions have been added, now register them to the shortcut manager
   QgsGui::shortcutsManager()->registerAllChildren( this );
   QgsGui::shortcutsManager()->registerAllChildren( mSnappingWidget );
@@ -1521,7 +1514,6 @@ QgisApp::~QgisApp()
   delete mPythonUtils;
 #endif
 
-  delete mTray;
   delete mDataSourceManagerDialog;
   qDeleteAll( mCustomDropHandlers );
   qDeleteAll( mCustomLayoutDropHandlers );
@@ -13862,15 +13854,8 @@ void QgisApp::showSystemNotification( const QString &title, const QString &messa
 
   if ( !result.successful )
   {
-    // fallback - use system tray notification
-    if ( mTray )
-    {
-      // Menubar icon is hidden by default. Show to enable notification bubbles
-      mTray->show();
-      mTray->showMessage( title, message );
-      // Re-hide menubar icon
-      mTray->hide();
-    }
+    // fallback - use message bar notification
+    messageBar()->pushInfo( title, message );
   }
   else
   {

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -36,7 +36,6 @@ class QStringList;
 class QToolButton;
 class QTcpSocket;
 class QValidator;
-class QSystemTrayIcon;
 
 class QgisAppInterface;
 class QgisAppStyleSheet;
@@ -2258,8 +2257,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     bool gestureEvent( QGestureEvent *event );
     void tapAndHoldTriggered( QTapAndHoldGesture *gesture );
-
-    QSystemTrayIcon *mTray = nullptr;
 
     QgsLocatorWidget *mLocatorWidget = nullptr;
 


### PR DESCRIPTION
Now that all the major platforms have native notification support (Linux/OSX/Win 10), remove the tray icon notification fallback and just use messagebar messages instead.

Rationale:
- It's inconsistent, and doesn't work on some platforms (e.g. on Windows 7 the messages never appear)
- It's incorrect use of a tray icon - we aren't a long-running background application, so it's effectively 
abusing this UI element.
- It causes strange issues like constant system tray pop outs under older Gnome versions

So if native notifications aren't supported on a platform, it's actually better experience and safer to use the message bar for notifications. This ensures that users always get the notification at least!
