### PR TITLE
[vector writer] Insure proper layer name used is returned

### DIFF
--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -250,6 +250,30 @@ Creates a clone of the FieldValueConverter.
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
                                                                );
+%Docstring
+Write contents of vector layer to an (OGR supported) vector format
+
+:param layer: layer to write
+:param fileName: file name to write to
+:param fileEncoding: encoding to use
+:param destCRS: CRS to reproject exported geometries to, or invalid CRS for no reprojection
+:param driverName: OGR driver to use
+:param onlySelected: write only selected features of layer
+:param errorMessage: pointer to buffer fo error message
+:param datasourceOptions: list of OGR data source creation options
+:param layerOptions: list of OGR layer creation options
+:param skipAttributeCreation: only write geometries
+:param newFilename: QString pointer which will contain the new file name created (in case it is different to fileName).
+:param symbologyExport: symbology to export
+:param symbologyScale: scale of symbology
+:param filterExtent: if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
+:param overrideGeometryType: set to a valid geometry type to override the default geometry type for the layer. This parameter
+                             allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
+:param forceMulti: set to true to force creation of multi* geometries (added in QGIS 2.14)
+:param includeZ: set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
+:param attributes: attributes to export (empty means all unless skipAttributeCreation is set)
+:param fieldValueConverter: field value converter (added in QGIS 2.16)
+%End
 
 
     static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
@@ -272,7 +296,33 @@ Creates a clone of the FieldValueConverter.
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
                                                                );
+%Docstring
+Writes a layer out to a vector file.
 
+:param layer: layer to write
+:param fileName: file name to write to
+:param fileEncoding: encoding to use
+:param ct: coordinate transform to reproject exported geometries with, or invalid transform
+           for no transformation
+:param driverName: OGR driver to use
+:param onlySelected: write only selected features of layer
+:param errorMessage: pointer to buffer fo error message
+:param datasourceOptions: list of OGR data source creation options
+:param layerOptions: list of OGR layer creation options
+:param skipAttributeCreation: only write geometries
+:param newFilename: QString pointer which will contain the new file name created (in case it is different to fileName).
+:param symbologyExport: symbology to export
+:param symbologyScale: scale of symbology
+:param filterExtent: if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
+:param overrideGeometryType: set to a valid geometry type to override the default geometry type for the layer. This parameter
+                             allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
+:param forceMulti: set to true to force creation of multi* geometries (added in QGIS 2.14)
+:param includeZ: set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
+:param attributes: attributes to export (empty means all unless skipAttributeCreation is set)
+:param fieldValueConverter: field value converter (added in QGIS 2.16)
+
+.. versionadded:: 2.2
+%End
 
     class SaveVectorOptions
 {
@@ -337,6 +387,17 @@ Constructor
         QString *newFilename = 0,
         QString *errorMessage /Out/ = 0
                                                                );
+%Docstring
+Writes a layer out to a vector file.
+
+:param layer: source layer to write
+:param fileName: file name to write to
+:param options: options.
+:param newFilename: QString pointer which will contain the new file name created (in case it is different to fileName).
+:param errorMessage: pointer to buffer fo error message
+
+.. versionadded:: 3.0
+%End
 
     QgsVectorFileWriter( const QString &vectorFileName,
                          const QString &fileEncoding,

--- a/python/core/auto_generated/qgsvectorfilewriter.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewriter.sip.in
@@ -229,6 +229,7 @@ Creates a clone of the FieldValueConverter.
       AppendToLayerAddFields
     };
 
+
     static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QString &fileEncoding,
@@ -249,30 +250,7 @@ Creates a clone of the FieldValueConverter.
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
                                                                );
-%Docstring
-Write contents of vector layer to an (OGR supported) vector formt
 
-:param layer: layer to write
-:param fileName: file name to write to
-:param fileEncoding: encoding to use
-:param destCRS: CRS to reproject exported geometries to, or invalid CRS for no reprojection
-:param driverName: OGR driver to use
-:param onlySelected: write only selected features of layer
-:param errorMessage: pointer to buffer fo error message
-:param datasourceOptions: list of OGR data source creation options
-:param layerOptions: list of OGR layer creation options
-:param skipAttributeCreation: only write geometries
-:param newFilename: QString pointer which will contain the new file name created (in case it is different to fileName).
-:param symbologyExport: symbology to export
-:param symbologyScale: scale of symbology
-:param filterExtent: if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
-:param overrideGeometryType: set to a valid geometry type to override the default geometry type for the layer. This parameter
-                             allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
-:param forceMulti: set to true to force creation of multi* geometries (added in QGIS 2.14)
-:param includeZ: set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
-:param attributes: attributes to export (empty means all unless skipAttributeCreation is set)
-:param fieldValueConverter: field value converter (added in QGIS 2.16)
-%End
 
     static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
@@ -294,33 +272,6 @@ Write contents of vector layer to an (OGR supported) vector formt
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = 0
                                                                );
-%Docstring
-Writes a layer out to a vector file.
-
-:param layer: layer to write
-:param fileName: file name to write to
-:param fileEncoding: encoding to use
-:param ct: coordinate transform to reproject exported geometries with, or invalid transform
-           for no transformation
-:param driverName: OGR driver to use
-:param onlySelected: write only selected features of layer
-:param errorMessage: pointer to buffer fo error message
-:param datasourceOptions: list of OGR data source creation options
-:param layerOptions: list of OGR layer creation options
-:param skipAttributeCreation: only write geometries
-:param newFilename: QString pointer which will contain the new file name created (in case it is different to fileName).
-:param symbologyExport: symbology to export
-:param symbologyScale: scale of symbology
-:param filterExtent: if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
-:param overrideGeometryType: set to a valid geometry type to override the default geometry type for the layer. This parameter
-                             allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
-:param forceMulti: set to true to force creation of multi* geometries (added in QGIS 2.14)
-:param includeZ: set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
-:param attributes: attributes to export (empty means all unless skipAttributeCreation is set)
-:param fieldValueConverter: field value converter (added in QGIS 2.16)
-
-.. versionadded:: 2.2
-%End
 
 
     class SaveVectorOptions
@@ -379,22 +330,13 @@ Constructor
         QgsFeedback *feedback;
     };
 
+
     static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = 0,
-        QString *errorMessage /Out/ = 0 );
-%Docstring
-Writes a layer out to a vector file.
-
-:param layer: source layer to write
-:param fileName: file name to write to
-:param options: options.
-:param newFilename: QString pointer which will contain the new file name created (in case it is different to fileName).
-:param errorMessage: pointer to buffer fo error message
-
-.. versionadded:: 3.0
-%End
+        QString *errorMessage /Out/ = 0
+                                                               );
 
     QgsVectorFileWriter( const QString &vectorFileName,
                          const QString &fileEncoding,
@@ -407,9 +349,6 @@ Writes a layer out to a vector file.
                          QString *newFilename = 0,
                          QgsVectorFileWriter::SymbologyExport symbologyExport = QgsVectorFileWriter::NoSymbology
                        );
-%Docstring
-Create a new vector file writer
-%End
 
 
 

--- a/python/core/auto_generated/qgsvectorfilewritertask.sip.in
+++ b/python/core/auto_generated/qgsvectorfilewritertask.sip.in
@@ -45,7 +45,12 @@ and save ``options``.
 %Docstring
 Emitted when writing the layer is successfully completed. The ``newFilename``
 parameter indicates the file path for the written file.
+
+.. note::
+
+   this signal is deprecated in favor of completed().
 %End
+
 
     void errorOccurred( int error, const QString &errorMessage );
 %Docstring

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7446,13 +7446,12 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOpt
     options.fieldValueConverter = converterPtr;
 
     bool addToCanvas = dialog->addToCanvas();
-    QString layerName = dialog->layername();
     QgsVectorFileWriterTask *writerTask = new QgsVectorFileWriterTask( vlayer, vectorFilename, options );
 
     // when writer is successful:
-    connect( writerTask, &QgsVectorFileWriterTask::writeComplete, this, [onSuccess, addToCanvas, layerName, encoding, vectorFilename]( const QString & newFilename )
+    connect( writerTask, &QgsVectorFileWriterTask::completed, this, [onSuccess, addToCanvas, encoding, vectorFilename]( const QString & newFilename, const QString & newLayer )
     {
-      onSuccess( newFilename, addToCanvas, layerName, encoding, vectorFilename );
+      onSuccess( newFilename, addToCanvas, newLayer, encoding, vectorFilename );
     } );
 
     // when an error occurs:

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -345,9 +345,10 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = nullptr
 #ifndef SIP_RUN
-            , QString *newLayer = nullptr
-#endif
+            , QString *newLayer = nullptr );
+#else
                                                                );
+#endif
 
 #ifndef SIP_RUN
 
@@ -425,10 +426,10 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = nullptr
 #ifndef SIP_RUN
-            , QString *newLayer = nullptr
-#endif
+            , QString *newLayer = nullptr );
+#else
                                                                );
-
+#endif
 
     /**
      * \ingroup core
@@ -528,7 +529,6 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param options options.
      * \param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
      * \param errorMessage pointer to buffer fo error message
-     * \param newLayer QString pointer which will contain the new layer name created (in case it is different to the provided layer name) (added in QGIS 3.4, not available in python)
      * \since QGIS 3.0
      */
 #endif
@@ -538,9 +538,10 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         QString *newFilename = nullptr,
         QString *errorMessage SIP_OUT = nullptr
 #ifndef SIP_RUN
-                                        , QString *newLayer = nullptr
-#endif
+                                        , QString *newLayer = nullptr );
+#else
                                                                );
+#endif
 
     //! Create a new vector file writer
     QgsVectorFileWriter( const QString &vectorFileName,

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -273,8 +273,36 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
       AppendToLayerAddFields
     };
 
+#ifndef SIP_RUN
+
     /**
-     * Write contents of vector layer to an (OGR supported) vector formt
+     * Write contents of vector layer to an (OGR supported) vector format
+     * \param layer layer to write
+     * \param fileName file name to write to
+     * \param fileEncoding encoding to use
+     * \param destCRS CRS to reproject exported geometries to, or invalid CRS for no reprojection
+     * \param driverName OGR driver to use
+     * \param onlySelected write only selected features of layer
+     * \param errorMessage pointer to buffer fo error message
+     * \param datasourceOptions list of OGR data source creation options
+     * \param layerOptions list of OGR layer creation options
+     * \param skipAttributeCreation only write geometries
+     * \param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
+     * \param symbologyExport symbology to export
+     * \param symbologyScale scale of symbology
+     * \param filterExtent if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
+     * \param overrideGeometryType set to a valid geometry type to override the default geometry type for the layer. This parameter
+     * allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
+     * \param forceMulti set to true to force creation of multi* geometries (added in QGIS 2.14)
+     * \param includeZ set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
+     * \param attributes attributes to export (empty means all unless skipAttributeCreation is set)
+     * \param fieldValueConverter field value converter (added in QGIS 2.16)
+     * \param newLayer QString pointer which will contain the new layer name created (in case it is different to the provided layer name) (added in QGIS 3.4, not available in python)
+     */
+#else
+
+    /**
+     * Write contents of vector layer to an (OGR supported) vector format
      * \param layer layer to write
      * \param fileName file name to write to
      * \param fileEncoding encoding to use
@@ -296,6 +324,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param attributes attributes to export (empty means all unless skipAttributeCreation is set)
      * \param fieldValueConverter field value converter (added in QGIS 2.16)
      */
+#endif
     static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QString &fileEncoding,
@@ -315,7 +344,40 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         bool includeZ = false,
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = nullptr
+#ifndef SIP_RUN
+            , QString *newLayer = nullptr
+#endif
                                                                );
+
+#ifndef SIP_RUN
+
+    /**
+     * Writes a layer out to a vector file.
+     * \param layer layer to write
+     * \param fileName file name to write to
+     * \param fileEncoding encoding to use
+     * \param ct coordinate transform to reproject exported geometries with, or invalid transform
+     * for no transformation
+     * \param driverName OGR driver to use
+     * \param onlySelected write only selected features of layer
+     * \param errorMessage pointer to buffer fo error message
+     * \param datasourceOptions list of OGR data source creation options
+     * \param layerOptions list of OGR layer creation options
+     * \param skipAttributeCreation only write geometries
+     * \param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
+     * \param symbologyExport symbology to export
+     * \param symbologyScale scale of symbology
+     * \param filterExtent if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
+     * \param overrideGeometryType set to a valid geometry type to override the default geometry type for the layer. This parameter
+     * allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
+     * \param forceMulti set to true to force creation of multi* geometries (added in QGIS 2.14)
+     * \param includeZ set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
+     * \param attributes attributes to export (empty means all unless skipAttributeCreation is set)
+     * \param fieldValueConverter field value converter (added in QGIS 2.16)
+     * \param newLayer QString pointer which will contain the new layer name created (in case it is different to the provided layer name) (added in QGIS 3.4, not available in python)
+     * \since QGIS 2.2
+     */
+#else
 
     /**
      * Writes a layer out to a vector file.
@@ -342,6 +404,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param fieldValueConverter field value converter (added in QGIS 2.16)
      * \since QGIS 2.2
      */
+#endif
     static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QString &fileEncoding,
@@ -361,6 +424,9 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         bool includeZ = false,
         const QgsAttributeList &attributes = QgsAttributeList(),
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = nullptr
+#ifndef SIP_RUN
+            , QString *newLayer = nullptr
+#endif
                                                                );
 
 
@@ -441,6 +507,8 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         QgsFeedback *feedback = nullptr;
     };
 
+#ifndef SIP_RUN
+
     /**
      * Writes a layer out to a vector file.
      * \param layer source layer to write
@@ -448,13 +516,31 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param options options.
      * \param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
      * \param errorMessage pointer to buffer fo error message
+     * \param newLayer QString pointer which will contain the new layer name created (in case it is different to the provided layer name) (added in QGIS 3.4, not available in python)
      * \since QGIS 3.0
      */
+#else
+
+    /**
+     * Writes a layer out to a vector file.
+     * \param layer source layer to write
+     * \param fileName file name to write to
+     * \param options options.
+     * \param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
+     * \param errorMessage pointer to buffer fo error message
+     * \param newLayer QString pointer which will contain the new layer name created (in case it is different to the provided layer name) (added in QGIS 3.4, not available in python)
+     * \since QGIS 3.0
+     */
+#endif
     static QgsVectorFileWriter::WriterError writeAsVectorFormat( QgsVectorLayer *layer,
         const QString &fileName,
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = nullptr,
-        QString *errorMessage SIP_OUT = nullptr );
+        QString *errorMessage SIP_OUT = nullptr
+#ifndef SIP_RUN
+                                        , QString *newLayer = nullptr
+#endif
+                                                               );
 
     //! Create a new vector file writer
     QgsVectorFileWriter( const QString &vectorFileName,
@@ -467,6 +553,9 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
                          const QStringList &layerOptions = QStringList(),
                          QString *newFilename = nullptr,
                          QgsVectorFileWriter::SymbologyExport symbologyExport = QgsVectorFileWriter::NoSymbology
+#ifndef SIP_RUN
+                             , QString *newLayer = nullptr
+#endif
                        );
 
     /**
@@ -484,6 +573,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
      * \param fieldValueConverter field value converter (added in QGIS 2.16)
      * \param layerName layer name. If let empty, it will be derived from the filename (added in QGIS 3.0)
      * \param action action on existing file (added in QGIS 3.0)
+     * \param newLayer potentially modified layer name (output parameter) (added in QGIS 3.4)
      * \note not available in Python bindings
      */
     QgsVectorFileWriter( const QString &vectorFileName,
@@ -498,7 +588,8 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
                          QgsVectorFileWriter::SymbologyExport symbologyExport,
                          QgsVectorFileWriter::FieldValueConverter *fieldValueConverter,
                          const QString &layerName,
-                         QgsVectorFileWriter::ActionOnExistingFile action
+                         QgsVectorFileWriter::ActionOnExistingFile action,
+                         QString *newLayer = nullptr
                        ) SIP_SKIP;
 
     //! QgsVectorFileWriter cannot be copied.
@@ -779,7 +870,8 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
         const QString &fileName,
         const QgsVectorFileWriter::SaveVectorOptions &options,
         QString *newFilename = nullptr,
-        QString *errorMessage SIP_OUT = nullptr );
+        QString *errorMessage SIP_OUT = nullptr,
+        QString *newLayer = nullptr );
 
     void init( QString vectorFileName, QString fileEncoding, const QgsFields &fields,
                QgsWkbTypes::Type geometryType, QgsCoordinateReferenceSystem srs,
@@ -787,7 +879,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
                QStringList layerOptions, QString *newFilename,
                QgsVectorFileWriter::FieldValueConverter *fieldValueConverter,
                const QString &layerName,
-               QgsVectorFileWriter::ActionOnExistingFile action );
+               QgsVectorFileWriter::ActionOnExistingFile action, QString *newLayer );
     void resetMap( const QgsAttributeList &attributes );
 
     std::unique_ptr< QgsFeatureRenderer > mRenderer;

--- a/src/core/qgsvectorfilewritertask.cpp
+++ b/src/core/qgsvectorfilewritertask.cpp
@@ -54,14 +54,19 @@ bool QgsVectorFileWriterTask::run()
 
 
   mError = QgsVectorFileWriter::writeAsVectorFormat(
-             mWriterDetails, mDestFileName, mOptions, &mNewFilename, &mErrorMessage );
+             mWriterDetails, mDestFileName, mOptions, &mNewFilename, &mErrorMessage, &mNewLayer );
   return mError == QgsVectorFileWriter::NoError;
 }
 
 void QgsVectorFileWriterTask::finished( bool result )
 {
   if ( result )
+  {
     emit writeComplete( mNewFilename );
+    emit completed( mNewFilename, mNewLayer );
+  }
   else
+  {
     emit errorOccurred( mError, mErrorMessage );
+  }
 }

--- a/src/core/qgsvectorfilewritertask.h
+++ b/src/core/qgsvectorfilewritertask.h
@@ -54,8 +54,16 @@ class CORE_EXPORT QgsVectorFileWriterTask : public QgsTask
     /**
      * Emitted when writing the layer is successfully completed. The \a newFilename
      * parameter indicates the file path for the written file.
+     * \note this signal is deprecated in favor of completed().
      */
     void writeComplete( const QString &newFilename );
+
+    /**
+     * Emitted when writing the layer is successfully completed. The \a newFilename
+     * parameter indicates the file path for the written file. When applicable, the
+     * \a newLayer parameter indicates the layer name used.
+     */
+    void completed( const QString &newFilename, const QString &newLayer ) SIP_SKIP;
 
     /**
      * Emitted when an error occurs which prevented the file being written (or if
@@ -76,6 +84,7 @@ class CORE_EXPORT QgsVectorFileWriterTask : public QgsTask
     QgsVectorFileWriter::WriterError mError = QgsVectorFileWriter::NoError;
 
     QString mNewFilename;
+    QString mNewLayer;
     QString mErrorMessage;
 
     QgsVectorFileWriter::SaveVectorOptions mOptions;

--- a/tests/src/python/test_qgsvectorfilewritertask.py
+++ b/tests/src/python/test_qgsvectorfilewritertask.py
@@ -37,11 +37,18 @@ def create_temp_filename(base_file):
 class TestQgsVectorFileWriterTask(unittest.TestCase):
 
     def setUp(self):
+        self.new_filename = ''
+        self.new_layer = ''
         self.success = False
         self.fail = False
 
     def onSuccess(self):
         self.success = True
+
+    def onComplete(self, filename, layer):
+        self.success = True
+        self.new_filename = filename
+        self.new_layer = layer
 
     def onFail(self):
         self.fail = True
@@ -77,6 +84,26 @@ class TestQgsVectorFileWriterTask(unittest.TestCase):
         while not self.success and not self.fail:
             QCoreApplication.processEvents()
 
+        self.assertTrue(self.success)
+        self.assertFalse(self.fail)
+
+    def testSuccessWithLayer(self):
+        """test successfully writing to a layer-enabled format"""
+        self.layer = self.createLayer()
+        options = QgsVectorFileWriter.SaveVectorOptions()
+        options.driverName = "KML"
+        options.layerName = "test-dashes"
+        tmp = create_temp_filename('successlayer.kml')
+        task = QgsVectorFileWriterTask(self.layer, tmp, options)
+
+        task.completed.connect(self.onComplete)
+        task.errorOccurred.connect(self.onFail)
+
+        QgsApplication.taskManager().addTask(task)
+        while not self.success and not self.fail:
+            QCoreApplication.processEvents()
+
+        self.assertEqual(self.new_layer, "test_dashes")
         self.assertTrue(self.success)
         self.assertFalse(self.fail)
 


### PR DESCRIPTION
## Description
Until now, we assumed that a given layer named passed onto the vector writer would not be modified. This is wrong in at least one case, whereas OGR's KML driver replaces dashes (-) with underscores (_). 

This PR modifies QgsVectorFileWriter to add a QString *newLayer parameter, with its value being the actual layer name returned by OGR_DS_CreateLayer().

@nyalldawson , review appreciated.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
