### PR TITLE
QgsMessageLogConsole in cerr

### DIFF
--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -47,7 +47,7 @@ QgsMessageLogConsole::QgsMessageLogConsole()
 
 void QgsMessageLogConsole::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level )
 {
-  std::cout
+  std::cerr
       << tag.toLocal8Bit().data() << "[" <<
       ( level == Qgis::Info ? "INFO"
         : level == Qgis::Warning ? "WARNING"


### PR DESCRIPTION
## Description

`QgsMessageLogConsole` should probably log in `std::cerr` instead of `std::cout`. What do you think?

BTW, this class doesn't seem to be used in qgis source code. Do we want to keep it for plugins or is it just a forgotten class?


## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
