### PR TITLE
Improvements of translation-featurs of .qgs project data

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2218,4 +2218,10 @@ void QgsProjectProperties::onGenerateTsFileButton() const
 {
   QString l = cbtsLocale->currentData().toString();
   QgsProject::instance()->generateTsFile( l );
+  QMessageBox::information( nullptr, tr( "General TS file generated" ), tr( "TS file generated with source language %1.\n"
+                            "- open it with Qt Linguist\n"
+                            "- translate strings\n"
+                            "- save it with the postfix of the target language (eg. de)\n"
+                            "- release to get qm file including postfix (eg. aproject_de.qm)\n"
+                            "When you open it again in QGIS having set the target language (de), the project will be translated and saved with postfix (eg. aproject_de.qgs)." ).arg( l ) ) ;
 }

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2820,7 +2820,7 @@ void QgsProject::generateTsFile( const QString &locale )
 {
   QgsTranslationContext translationContext;
   translationContext.setProject( this );
-  translationContext.setFileName( QStringLiteral( "%1/%2_%3.ts" ).arg( absolutePath(), baseName(), locale ) );
+  translationContext.setFileName( QStringLiteral( "%1/%2.ts" ).arg( absolutePath(), baseName() ) );
 
   emit QgsApplication::instance()->collectTranslatableObjects( &translationContext );
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -479,10 +479,18 @@ void QgsProject::registerTranslatableObjects( QgsTranslationContext *translation
       const QgsFields fields = vlayer->fields();
       for ( const QgsField &field : fields )
       {
+        QString fieldName;
         if ( field.alias().isEmpty() )
-          translationContext->registerTranslation( QStringLiteral( "project:layers:%1:fieldaliases" ).arg( vlayer->id() ), field.name() );
+          fieldName = field.name();
         else
-          translationContext->registerTranslation( QStringLiteral( "project:layers:%1:fieldaliases" ).arg( vlayer->id() ), field.alias() );
+          fieldName = field.alias();
+
+        translationContext->registerTranslation( QStringLiteral( "project:layers:%1:fieldaliases" ).arg( vlayer->id() ), fieldName );
+
+        if ( field.editorWidgetSetup().type() == QStringLiteral( "ValueRelation" ) )
+        {
+          translationContext->registerTranslation( QStringLiteral( "project:layers:%1:fields:%2:valuerelationvalue" ).arg( vlayer->id(), field.name() ), field.editorWidgetSetup().config().value( QStringLiteral( "Value" ) ).toString() );
+        }
       }
 
       //register formcontainers

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -2834,5 +2834,11 @@ QString QgsProject::translate( const QString &context, const QString &sourceText
     return sourceText;
   }
 
-  return mTranslator->translate( context.toUtf8(), sourceText.toUtf8(), disambiguation, n );
+  QString result = mTranslator->translate( context.toUtf8(), sourceText.toUtf8(), disambiguation, n );
+
+  if ( result.isEmpty() )
+  {
+    return sourceText;
+  }
+  return result;
 }

--- a/src/core/qgstranslationcontext.cpp
+++ b/src/core/qgstranslationcontext.cpp
@@ -52,14 +52,11 @@ void QgsTranslationContext::registerTranslation( const QString &context, const Q
 
 void QgsTranslationContext::writeTsFile( const QString &locale )
 {
-  QgsSettings settings;
-
   //write xml
   QDomDocument doc( QStringLiteral( "TS" ) );
 
   QDomElement tsElement = doc.createElement( QStringLiteral( "TS" ) );
-  tsElement.setAttribute( QStringLiteral( "language" ), locale );
-  tsElement.setAttribute( QStringLiteral( "sourcelanguage" ), settings.value( QStringLiteral( "locale/userLocale" ), "" ).toString() );
+  tsElement.setAttribute( QStringLiteral( "sourcelanguage" ), locale );
   doc.appendChild( tsElement );
 
   for ( const TranslatableObject &translatableObject : mTranslatableObjects )

--- a/src/core/qgstranslationcontext.cpp
+++ b/src/core/qgstranslationcontext.cpp
@@ -81,8 +81,7 @@ void QgsTranslationContext::writeTsFile( const QString &locale )
     messageElement.appendChild( sourceElement );
 
     QDomElement translationElement = doc.createElement( QStringLiteral( "translation" ) );
-    QDomText translationText = doc.createTextNode( translatableObject.source );
-    translationElement.appendChild( translationText );
+    translationElement.setAttribute( QStringLiteral( "type" ), QStringLiteral( "unfinished" ) );
     messageElement.appendChild( translationElement );
   }
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2035,6 +2035,10 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
     const QDomElement cfgElem = fieldConfigElement.elementsByTagName( QStringLiteral( "config" ) ).at( 0 ).toElement();
     const QDomElement optionsElem = cfgElem.childNodes().at( 0 ).toElement();
     QVariantMap optionsMap = QgsXmlUtils::readVariant( optionsElem ).toMap();
+    if ( widgetType == QStringLiteral( "ValueRelation" ) )
+    {
+      optionsMap[ QStringLiteral( "Value" ) ] = context.projectTranslator()->translate( QStringLiteral( "project:layers:%1:fields:%2:valuerelationvalue" ).arg( layerNode.namedItem( QStringLiteral( "id" ) ).toElement().text(), fieldName ), optionsMap[ QStringLiteral( "Value" ) ].toString() );
+    }
     QgsEditorWidgetSetup setup = QgsEditorWidgetSetup( widgetType, optionsMap );
     mFieldWidgetSetups[fieldName] = setup;
   }

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -807,6 +807,13 @@
                  </property>
                  <layout class="QHBoxLayout" name="horizontalLayout_4">
                   <item>
+                   <widget class="QLabel" name="sourceLanguageLabel">
+                    <property name="text">
+                     <string>Source language</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QComboBox" name="cbtsLocale"/>
                   </item>
                   <item>
@@ -2921,6 +2928,7 @@
   <tabstop>teOWSChecker</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>

--- a/tests/src/core/testqgstranslateproject.cpp
+++ b/tests/src/core/testqgstranslateproject.cpp
@@ -71,7 +71,7 @@ void TestQgsTranslateProject::cleanupTestCase()
 
   //delete created ts file
   QString tsFileName( TEST_DATA_DIR );
-  tsFileName = tsFileName + "/project_translation/points_translation_de.ts";
+  tsFileName = tsFileName + "/project_translation/points_translation.ts";
   QFile tsFile( tsFileName );
   tsFile.remove();
 }
@@ -99,7 +99,7 @@ void TestQgsTranslateProject::createTsFile()
 
   //check if ts file is created
   QString tsFileName( TEST_DATA_DIR );
-  tsFileName = tsFileName + "/project_translation/points_translation_de.ts";
+  tsFileName = tsFileName + "/project_translation/points_translation.ts";
   QFile tsFile( tsFileName );
   QVERIFY( tsFile.exists() );
 


### PR DESCRIPTION
## Description

Implementation of requested changes #7456 and some improvements including the integration of value relation widget translation. 


- Per default, the translation will be empty: `<source>apiary</source><translation type="unfinished"></translation>` instead of beeing translated with the original value: `<source>apiary</source><translation>apiary</translation>` So in QtLinguist it's displayed as untranslated.

- If there is no translation (empty) in the loaded qm file, the value in the original language is taken in the translated project (instead of leaving it empty)

- The source language is selectable on **Generate TS file** instead of the target language \* The generated ts files do not contain a target language anymore and do not have a filename postfix (language).

- Write a Feedback after generating TS file (Messagebox) with the further steps.

- Integration of Value Relation values - means the selected values can be changed by translation.

\* Because the workflow makes more sence like this: Generating (general) ts file, edit it for one language -> save as <name>_de, then edit it with another language -> save as <name>_eo etc. Instead of: Select "de" -> Generating (de) ts file, edit it for de-> save it, then Select "eo" -> Generating (eo) ts file, edit it for eo etc... 
