### PR TITLE
Improve documentation of QgsRasterLayer constructor

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterlayer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterlayer.sip.in
@@ -130,8 +130,6 @@ The main tasks carried out by the constructor are:
 -Determine whether the layer is gray, paletted or multiband.
 
 -Assign sensible defaults for the red, green, blue and gray bands.
-
--
 %End
 
     ~QgsRasterLayer();

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -93,8 +93,7 @@ typedef QList < QPair< QString, QColor > > QgsLegendColorList;
  *
  * \code{.cpp}
  *     QString myFileNameQString = "/path/to/file";
- *     QFileInfo myFileInfo(myFileNameQString);
- *     QString myBaseNameQString = myFileInfo.baseName();
+ *     QString myBaseNameQString = "my layer";
  *     QgsRasterLayer *myRasterLayer = new QgsRasterLayer(myFileNameQString, myBaseNameQString);
  * \endcode
  *
@@ -197,8 +196,6 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
      * -Determine whether the layer is gray, paletted or multiband.
      *
      * -Assign sensible defaults for the red, green, blue and gray bands.
-     *
-     * -
      * */
     explicit QgsRasterLayer( const QString &uri,
                              const QString &baseName = QString(),


### PR DESCRIPTION
- baseName is just passed on to the parent constructor to be the display name, use a literal string in  the example to avoid misunderstanding.

- Remove stray bullet.

---

## Description
Use of QFileInfo.baseName() in the example may mislead the reader in believing this parameter is used for more than just display.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/master/CONTRIBUTE.md#contributing-to-qgis) before each commit
