### PR TITLE
Initialize capture mode none

### DIFF
--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -51,6 +51,8 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
 
   connect( canvas, &QgsMapCanvas::currentLayerChanged,
            this, &QgsMapToolCapture::currentLayerChanged );
+
+  currentLayerChanged( canvas->currentLayer() );
 }
 
 QgsMapToolCapture::~QgsMapToolCapture()

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -42,7 +42,6 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas *canvas, QgsAdvancedDigitizin
   : QgsMapToolAdvancedDigitizing( canvas, cadDockWidget )
   , mCaptureMode( mode )
 {
-  mCaptureModeFromLayer = mode == CaptureNone;
   mCapturing = false;
 
   mSnapIndicator.reset( new QgsSnapIndicator( canvas ) );
@@ -96,10 +95,8 @@ void QgsMapToolCapture::validationFinished()
 
 void QgsMapToolCapture::currentLayerChanged( QgsMapLayer *layer )
 {
-  if ( !mCaptureModeFromLayer )
+  if ( mCaptureMode != CaptureNone )
     return;
-
-  mCaptureMode = CaptureNone;
 
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
   if ( !vlayer )

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -268,8 +268,6 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     QList< QgsGeometry::Error > mGeomErrors;
     QList< QgsVertexMarker * > mGeomErrorMarkers;
 
-    bool mCaptureModeFromLayer;
-
     std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 
     /**


### PR DESCRIPTION
When the captureMode is set to CaptureNone, it should be initialized from the layer on create and not only on the first layer change.

This broke the duplicate feature and digitize action.