### PR TITLE
 [FEATURE][processing] gdal's rearrange band algorithm 

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -585,6 +585,13 @@ Evaluates the parameter with matching ``name`` to a static double value.
 Evaluates the parameter with matching ``name`` to a static integer value.
 %End
 
+    QList<int> parameterAsInts( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
+%Docstring
+Evaluates the parameter with matching ``name`` to a list of integer values.
+
+.. versionadded:: 3.4
+%End
+
     int parameterAsEnum( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 %Docstring
 Evaluates the parameter with matching ``name`` to a enum value.

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -536,6 +536,20 @@ Evaluates the parameter with matching ``definition`` and ``value`` to a static i
 .. versionadded:: 3.4
 %End
 
+    static QList<int> parameterAsInts( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
+%Docstring
+Evaluates the parameter with matching ``definition`` to a list of integer values.
+
+.. versionadded:: 3.4
+%End
+
+    static QList<int> parameterAsInts( const QgsProcessingParameterDefinition *definition, const QVariant &value, const QgsProcessingContext &context );
+%Docstring
+Evaluates the parameter with matching ``definition`` and ``value`` to a list of integer values.
+
+.. versionadded:: 3.4
+%End
+
     static int parameterAsEnum( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
 %Docstring
 Evaluates the parameter with matching ``definition`` to a enum value.

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -2473,7 +2473,8 @@ A raster band parameter for Processing algorithms.
 
     QgsProcessingParameterBand( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
                                 const QString &parentLayerParameterName = QString(),
-                                bool optional = false );
+                                bool optional = false,
+                                bool allowMultiple = false );
 %Docstring
 Constructor for QgsProcessingParameterBand.
 %End
@@ -2516,6 +2517,24 @@ Sets the name of the parent layer parameter. Use an empty string if this is not 
     static QgsProcessingParameterBand *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) /Factory/;
 %Docstring
 Creates a new parameter using the definition from a script code.
+%End
+
+    bool allowMultiple() const;
+%Docstring
+Returns whether multiple band selections are permitted.
+
+.. seealso:: :py:func:`setAllowMultiple`
+
+.. versionadded:: 3.4
+%End
+
+    void setAllowMultiple( bool allowMultiple );
+%Docstring
+Sets whether multiple band selections are permitted.
+
+.. seealso:: :py:func:`allowMultiple`
+
+.. versionadded:: 3.4
 %End
 
 };

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -60,6 +60,7 @@ from .pct2rgb import pct2rgb
 from .polygonize import polygonize
 from .proximity import proximity
 from .rasterize import rasterize
+from .rearrange_bands import rearrange_bands
 from .retile import retile
 from .rgb2pct import rgb2pct
 from .roughness import roughness
@@ -166,6 +167,7 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
             polygonize(),
             proximity(),
             rasterize(),
+            rearrange_bands(),
             retile(),
             rgb2pct(),
             roughness(),

--- a/python/plugins/processing/algs/gdal/rearrange_bands.py
+++ b/python/plugins/processing/algs/gdal/rearrange_bands.py
@@ -119,10 +119,7 @@ class rearrange_bands(GdalAlgorithm):
 
         bands = self.parameterAsFields(parameters, self.BANDS, context)
         for band in bands:
-            match = re.search('(?:\A|[^0-9])([0-9]+)(?:\Z|[^0-9]|)', band)
-            if match:
-                band_nb = match.group(1)
-                arguments.append('-b {}'.format(band_nb))
+            arguments.append('-b {}'.format(band))
 
         arguments.append('-ot')
         arguments.append(self.TYPES[self.parameterAsEnum(parameters, self.DATA_TYPE, context)])

--- a/python/plugins/processing/algs/gdal/rearrange_bands.py
+++ b/python/plugins/processing/algs/gdal/rearrange_bands.py
@@ -117,7 +117,7 @@ class rearrange_bands(GdalAlgorithm):
 
         arguments = []
 
-        bands = self.parameterAsFields(parameters, self.BANDS, context)
+        bands = self.parameterAsInts(parameters, self.BANDS, context)
         for band in bands:
             arguments.append('-b {}'.format(band))
 

--- a/python/plugins/processing/algs/gdal/rearrange_bands.py
+++ b/python/plugins/processing/algs/gdal/rearrange_bands.py
@@ -103,7 +103,7 @@ class rearrange_bands(GdalAlgorithm):
 
     def shortHelpString(self):
         return self.tr("This algorithm creates a new raster using selected band(s) from a given raster layer.\n\n"
-                       "The reordering of bands is possible by dragging individual band names in the multiple selection dialog.")
+                       "The algorithm also makes it possible to reorder the bands for the newly-created raster.")
 
     def commandName(self):
         return 'gdal_translate'

--- a/python/plugins/processing/algs/gdal/rearrange_bands.py
+++ b/python/plugins/processing/algs/gdal/rearrange_bands.py
@@ -2,7 +2,7 @@
 
 """
 ***************************************************************************
-    translate.py
+    rearrange_bands.py
     ---------------------
     Date                 : August 2018
     Copyright            : (C) 2018 by Mathieu Pellerin

--- a/python/plugins/processing/algs/gdal/rearrange_bands.py
+++ b/python/plugins/processing/algs/gdal/rearrange_bands.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    translate.py
+    ---------------------
+    Date                 : August 2018
+    Copyright            : (C) 2018 by Mathieu Pellerin
+    Email                : nirvn dot asia at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Mathieu Pellerin'
+__date__ = 'August 2018'
+__copyright__ = '(C) 2018, Mathieu Pellerin'
+
+# This will get replaced with a git SHA1 when you do a git archive
+
+__revision__ = '$Format:%H$'
+
+import os
+import re
+
+from qgis.PyQt.QtGui import QIcon
+
+from qgis.core import (QgsRasterFileWriter,
+                       QgsProcessingException,
+                       QgsProcessingParameterEnum,
+                       QgsProcessingParameterDefinition,
+                       QgsProcessingParameterRasterLayer,
+                       QgsProcessingParameterBand,
+                       QgsProcessingParameterString,
+                       QgsProcessingParameterRasterDestination)
+from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
+from processing.algs.gdal.GdalUtils import GdalUtils
+
+pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
+
+
+class rearrange_bands(GdalAlgorithm):
+
+    INPUT = 'INPUT'
+    BANDS = 'BANDS'
+    OPTIONS = 'OPTIONS'
+    DATA_TYPE = 'DATA_TYPE'
+    OUTPUT = 'OUTPUT'
+
+    TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
+
+    def __init__(self):
+        super().__init__()
+
+    def initAlgorithm(self, config=None):
+        self.addParameter(QgsProcessingParameterRasterLayer(self.INPUT, self.tr('Input layer')))
+        self.addParameter(QgsProcessingParameterBand(self.BANDS,
+                                                     self.tr('Selected band(s)'),
+                                                     None,
+                                                     self.INPUT,
+                                                     allowMultiple=True))
+
+        options_param = QgsProcessingParameterString(self.OPTIONS,
+                                                     self.tr('Additional creation options'),
+                                                     defaultValue='',
+                                                     optional=True)
+        options_param.setFlags(options_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        options_param.setMetadata({
+            'widget_wrapper': {
+                'class': 'processing.algs.gdal.ui.RasterOptionsWidget.RasterOptionsWidgetWrapper'}})
+        self.addParameter(options_param)
+
+        dataType_param = QgsProcessingParameterEnum(self.DATA_TYPE,
+                                                    self.tr('Output data type'),
+                                                    self.TYPES,
+                                                    allowMultiple=False,
+                                                    defaultValue=5)
+        dataType_param.setFlags(dataType_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(dataType_param)
+
+        self.addParameter(QgsProcessingParameterRasterDestination(self.OUTPUT,
+                                                                  self.tr('Converted')))
+
+    def name(self):
+        return 'rearrange_bands'
+
+    def displayName(self):
+        return self.tr('Rearrange bands')
+
+    def group(self):
+        return self.tr('Raster conversion')
+
+    def groupId(self):
+        return 'rasterconversion'
+
+    def icon(self):
+        return QIcon(os.path.join(pluginPath, 'images', 'gdaltools', 'translate.png'))
+
+    def shortHelpString(self):
+        return self.tr("This algorithm creates a new raster using selected band(s) from a given raster layer.\n\n"
+                       "The reordering of bands is possible by dragging individual band names in the multiple selection dialog.")
+
+    def commandName(self):
+        return 'gdal_translate'
+
+    def getConsoleCommands(self, parameters, context, feedback, executing=True):
+        inLayer = self.parameterAsRasterLayer(parameters, self.INPUT, context)
+        if inLayer is None:
+            raise QgsProcessingException(self.invalidRasterError(parameters, self.INPUT))
+
+        out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
+
+        arguments = []
+
+        bands = self.parameterAsFields(parameters, self.BANDS, context)
+        for band in bands:
+            match = re.search('(?:\A|[^0-9])([0-9]+)(?:\Z|[^0-9]|)', band)
+            if match:
+                band_nb = match.group(1)
+                arguments.append('-b {}'.format(band_nb))
+
+        arguments.append('-ot')
+        arguments.append(self.TYPES[self.parameterAsEnum(parameters, self.DATA_TYPE, context)])
+
+        arguments.append('-of')
+        arguments.append(QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1]))
+
+        options = self.parameterAsString(parameters, self.OPTIONS, context)
+        if options:
+            arguments.extend(GdalUtils.parseCreationOptions(options))
+
+        arguments.append(inLayer.source())
+        arguments.append(out)
+
+        return [self.commandName(), GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -28,6 +28,7 @@ __revision__ = '$Format:%H$'
 
 import locale
 import os
+import re
 from functools import cmp_to_key
 from inspect import isclass
 from copy import deepcopy
@@ -1726,10 +1727,8 @@ class BandWidgetWrapper(WidgetWrapper):
 
                 for v in value:
                     for i, opt in enumerate(options):
-                        if opt == v:
-                            selected.append(i)
-                        # case insensitive check - only do if matching case value is not present
-                        elif v not in options and opt.lower() == v.lower():
+                        match = re.search('(?:\A|[^0-9]){}(?:\Z|[^0-9]|)'.format(v), opt)
+                        if match:
                             selected.append(i)
 
                 self.widget.setSelectedItems(selected)
@@ -1741,7 +1740,12 @@ class BandWidgetWrapper(WidgetWrapper):
     def value(self):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
             if self.param.allowMultiple():
-                return [self.widget.options[i] for i in self.widget.selectedoptions]
+                bands = []
+                for i in self.widget.selectedoptions:
+                    match = re.search('(?:\A|[^0-9])([0-9]+)(?:\Z|[^0-9]|)', self.widget.options[i])
+                    if match:
+                        bands.append(match.group(1))
+                return bands
             else:
                 f = self.widget.currentBand()
                 if self.param.flags() & QgsProcessingParameterDefinition.FlagOptional and not f:

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -52,6 +52,7 @@ from processing.algs.gdal.retile import retile
 from processing.algs.gdal.translate import translate
 from processing.algs.gdal.warp import warp
 from processing.algs.gdal.fillnodata import fillnodata
+from processing.algs.gdal.rearrange_bands import rearrange_bands
 
 from qgis.core import (QgsProcessingContext,
                        QgsProcessingFeedback,
@@ -1531,6 +1532,33 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
              '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
+
+    def testRearrangeBands(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'dem.tif')
+        outsource = 'd:/temp/check.tif'
+
+        alg = rearrange_bands()
+        alg.initAlgorithm()
+
+        # single band
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'BANDS': 1,
+                                    'OUTPUT': outsource}, context, feedback),
+            ['gdal_translate', '-b 1 ' +
+             '-ot Float32 -of GTiff ' +
+             source + ' ' + outsource])
+
+        # three bands, re-ordered
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'BANDS': [3, 2, 1],
+                                    'OUTPUT': outsource}, context, feedback),
+            ['gdal_translate', '-b 3 -b 2 -b 1 ' +
+             '-ot Float32 -of GTiff ' +
+             source + ' ' + outsource])
 
     def testFillnodata(self):
         context = QgsProcessingContext()

--- a/src/core/processing/qgsprocessingalgorithm.cpp
+++ b/src/core/processing/qgsprocessingalgorithm.cpp
@@ -565,6 +565,11 @@ int QgsProcessingAlgorithm::parameterAsInt( const QVariantMap &parameters, const
   return QgsProcessingParameters::parameterAsInt( parameterDefinition( name ), parameters, context );
 }
 
+QList<int> QgsProcessingAlgorithm::parameterAsInts( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const
+{
+  return QgsProcessingParameters::parameterAsInts( parameterDefinition( name ), parameters, context );
+}
+
 int QgsProcessingAlgorithm::parameterAsEnum( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const
 {
   return QgsProcessingParameters::parameterAsEnum( parameterDefinition( name ), parameters, context );

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -583,6 +583,12 @@ class CORE_EXPORT QgsProcessingAlgorithm
     int parameterAsInt( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
 
     /**
+     * Evaluates the parameter with matching \a name to a list of integer values.
+     * \since QGIS 3.4
+     */
+    QList<int> parameterAsInts( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;
+
+    /**
      * Evaluates the parameter with matching \a name to a enum value.
      */
     int parameterAsEnum( const QVariantMap &parameters, const QString &name, const QgsProcessingContext &context ) const;

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -2346,7 +2346,8 @@ class CORE_EXPORT QgsProcessingParameterBand : public QgsProcessingParameterDefi
      */
     QgsProcessingParameterBand( const QString &name, const QString &description = QString(), const QVariant &defaultValue = QVariant(),
                                 const QString &parentLayerParameterName = QString(),
-                                bool optional = false );
+                                bool optional = false,
+                                bool allowMultiple = false );
 
     /**
      * Returns the type name for the parameter class.
@@ -2379,9 +2380,24 @@ class CORE_EXPORT QgsProcessingParameterBand : public QgsProcessingParameterDefi
      */
     static QgsProcessingParameterBand *fromScriptCode( const QString &name, const QString &description, bool isOptional, const QString &definition ) SIP_FACTORY;
 
+    /**
+     * Returns whether multiple band selections are permitted.
+     * \see setAllowMultiple()
+     * \since QGIS 3.4
+     */
+    bool allowMultiple() const;
+
+    /**
+     * Sets whether multiple band selections are permitted.
+     * \see allowMultiple()
+     * \since QGIS 3.4
+     */
+    void setAllowMultiple( bool allowMultiple );
+
   private:
 
     QString mParentLayerParameterName;
+    bool mAllowMultiple = false;
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -603,6 +603,18 @@ class CORE_EXPORT QgsProcessingParameters
     static int parameterAsInt( const QgsProcessingParameterDefinition *definition, const QVariant &value, const QgsProcessingContext &context );
 
     /**
+     * Evaluates the parameter with matching \a definition to a list of integer values.
+     * \since QGIS 3.4
+     */
+    static QList<int> parameterAsInts( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );
+
+    /**
+     * Evaluates the parameter with matching \a definition and \a value to a list of integer values.
+     * \since QGIS 3.4
+     */
+    static QList<int> parameterAsInts( const QgsProcessingParameterDefinition *definition, const QVariant &value, const QgsProcessingContext &context );
+
+    /**
      * Evaluates the parameter with matching \a definition to a enum value.
      */
     static int parameterAsEnum( const QgsProcessingParameterDefinition *definition, const QVariantMap &parameters, const QgsProcessingContext &context );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -1703,6 +1703,7 @@ void TestQgsProcessing::parameters()
   params.insert( QStringLiteral( "string" ), QStringLiteral( "a string" ) );
   params.insert( QStringLiteral( "double" ), 5.2 );
   params.insert( QStringLiteral( "int" ), 15 );
+  params.insert( QStringLiteral( "ints" ), QVariant( QList<QVariant>() << 3 << 2 << 1 ) );
   params.insert( QStringLiteral( "bool" ), true );
 
   QgsProcessingContext context;
@@ -1762,6 +1763,12 @@ void TestQgsProcessing::parameters()
   QCOMPARE( QgsProcessingParameters::parameterAsInt( def.get(), params, context ), 15 );
   def->setName( QStringLiteral( "prop" ) );
   QCOMPARE( QgsProcessingParameters::parameterAsInt( def.get(), params, context ), 6 );
+
+  // as ints
+  def->setName( QStringLiteral( "int" ) );
+  QCOMPARE( QgsProcessingParameters::parameterAsInts( def.get(), params, context ), QList<int>() << 15 );
+  def->setName( QStringLiteral( "ints" ) );
+  QCOMPARE( QgsProcessingParameters::parameterAsInts( def.get(), params, context ), QList<int>() << 3 << 2 << 1 );
 
   // as bool
   def->setName( QStringLiteral( "double" ) );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -5105,23 +5105,23 @@ void TestQgsProcessing::parameterBand()
 
   // multiple
   def.reset( new QgsProcessingParameterBand( "non_optional", QString(), QVariant(), QString(), false, true ) );
-  QVERIFY( def->checkValueIsAcceptable( QStringList() << "Band 1" << "Band 2" ) );
-  QVERIFY( def->checkValueIsAcceptable( QVariantList() << "Band 1" << "Band 2" ) );
+  QVERIFY( def->checkValueIsAcceptable( QStringList() << "1" << "2" ) );
+  QVERIFY( def->checkValueIsAcceptable( QVariantList() << 1 << 2 ) );
   QVERIFY( !def->checkValueIsAcceptable( "" ) );
   QVERIFY( !def->checkValueIsAcceptable( QVariant() ) );
   QVERIFY( !def->checkValueIsAcceptable( QStringList() ) );
   QVERIFY( !def->checkValueIsAcceptable( QVariantList() ) );
 
-  params.insert( "non_optional", QString( "Band 1;Band 2" ) );
-  QStringList bands = QgsProcessingParameters::parameterAsFields( def.get(), params, context );
-  QCOMPARE( bands, QStringList() << "Band 1" << "Band 2" );
-  params.insert( "non_optional", QVariantList() << "Band 1" << "Band 2" );
-  bands = QgsProcessingParameters::parameterAsFields( def.get(), params, context );
-  QCOMPARE( bands, QStringList() << "Band 1" << "Band 2" );
+  params.insert( "non_optional", QString( "1;2" ) );
+  QList<int> bands = QgsProcessingParameters::parameterAsInts( def.get(), params, context );
+  QCOMPARE( bands, QList<int>() << 1 << 2 );
+  params.insert( "non_optional", QVariantList() << 1 << 2 );
+  bands = QgsProcessingParameters::parameterAsInts( def.get(), params, context );
+  QCOMPARE( bands, QList<int>() << 1 << 2 );
 
   QCOMPARE( def->valueAsPythonString( QVariant(), context ), QStringLiteral( "None" ) );
-  QCOMPARE( def->valueAsPythonString( QStringList() << "Band 1" << "Band 2", context ), QStringLiteral( "['Band 1','Band 2']" ) );
-  QCOMPARE( def->valueAsPythonString( QVariantList() << "Band 1" << "Band 2", context ), QStringLiteral( "['Band 1','Band 2']" ) );
+  QCOMPARE( def->valueAsPythonString( QStringList() << "1" << "2", context ), QStringLiteral( "[1,2]" ) );
+  QCOMPARE( def->valueAsPythonString( QVariantList() << 1 << 2, context ), QStringLiteral( "[1,2]" ) );
 
   QVariantMap map = def->toVariantMap();
   QgsProcessingParameterBand fromMap( "x" );


### PR DESCRIPTION
## Description
This PR adds a new gdal-based algorithm, namely "Rearrange bands": 
![image](https://user-images.githubusercontent.com/1728657/44570058-b3ef1500-a7a6-11e8-89bb-3f2fe0c681e2.png)

To achieve that, the PR also modifies the QgsProcessingParameterBand class to add a allowMultiple parameter.

@nyalldawson , your review is _most_ needed. You'll notice I use `parameterAsFields()` ATM to retrieve list of bands, that has to change, but need some brainstorming with you first :)

Since I'm using this multiple band selection method not only to come up with a list of band but also to _re-order_, I figured out I couldn't simply use the option index as band(s) values. I'm therefore using strings (i.e. Band 1 (Gray), Band 2, etc.), which can be re-ordered, and I subsequently use a regular expression to extract the band number.

I'm not 100% happy with that, but I couldn't find another way to allow band selection + re-ordering using the multiple selection panel.

TODO:
- [x] Find a `parameterAsSomething()` and use that instead of `parameterAsFields()`

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
