### PR TITLE
[FEATURE] 3D maps in print layouts (part 2)

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -702,6 +702,7 @@
         <file>themes/default/mIconGPU.svg</file>
         <file>themes/default/mAddToProject.svg</file>
         <file>themes/default/mDockify.svg</file>
+        <file>themes/default/mActionAdd3DMap.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mActionAdd3DMap.svg
+++ b/images/themes/default/mActionAdd3DMap.svg
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg23"
+   sodipodi:docname="mActionAdd3DMap.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs27">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient918">
+      <stop
+         style="stop-color:#bfbfbf;stop-opacity:1"
+         offset="0"
+         id="stop914" />
+      <stop
+         style="stop-color:#e1e1e1;stop-opacity:1"
+         offset="1"
+         id="stop916" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient918"
+       id="linearGradient920"
+       x1="3.1228814"
+       y1="12.46981"
+       x2="8.275053"
+       y2="14.920922"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1871"
+     inkscape:window-height="1025"
+     id="namedview25"
+     showgrid="false"
+     inkscape:zoom="2"
+     inkscape:cx="141.16464"
+     inkscape:cy="18.121147"
+     inkscape:window-x="49"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg23" />
+  <linearGradient
+     id="a"
+     gradientUnits="userSpaceOnUse"
+     x1="3.5"
+     x2="11.5"
+     y1="19.5"
+     y2="19.5"
+     gradientTransform="translate(41.288136,10.305085)">
+    <stop
+       offset="0"
+       stop-color="#b7b7b7"
+       id="stop2" />
+    <stop
+       offset="1"
+       stop-color="#e6e6e6"
+       id="stop4" />
+  </linearGradient>
+  <path
+     style="fill:url(#linearGradient920);fill-opacity:1;stroke:none;stroke-width:0.99999982px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 21.221115,4.8048602 -0.983202,0.43846 -3.16343,-0.4307914 -2.54778,0.1286093 L 9.8801462,4.3893472 6.454113,6.5957888 5.0087476,6.5827232 3.8477042,11.243014 l -2.87303007,4.437033 3.14407087,0.06429 9.540628,2.572195 7.850231,-0.563536 z"
+     id="path847-3"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <g
+     id="g952"
+     style="stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke:#aaaaaa;stroke-opacity:1">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path849-6"
+       d="M 13.053454,4.7153071 9.3797338,8.3492956 6.7214087,11.611531 5.7301688,13.429378 4.1818687,15.744345"
+       style="fill:none;stroke:#aaaaaa;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path851-7"
+       d="m 17.256619,5.0413044 -4.393208,5.1728316 -1.864108,2.721474 -0.951918,4.105895"
+       style="fill:none;stroke:#aaaaaa;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="path853-5"
+       d="m 20.237913,5.2433202 -0.481796,3.4228902 -2.192507,3.0912416 -2.155672,1.623494 -0.758428,2.046017 -0.735466,2.889576"
+       style="fill:none;stroke:#aaaaaa;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path855-3"
+       d="m 4.0595127,11.593921 2.661896,0.01761 4.2778943,1.324079 c 2.194869,-0.350329 4.377703,-0.778818 6.564307,-1.178158 l 3.629577,3.248202"
+       style="fill:none;stroke:#aaaaaa;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path857-5"
+       d="m 6.2173238,6.8859807 4.0432972,0.6004049 2.682193,2.5228974 6.813303,-1.3430726 1.793563,1.9437616"
+       style="fill:none;stroke:#aaaaaa;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <path
+     style="fill:none;fill-opacity:1;stroke:#9a9a9a;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 21.221115,4.8048602 19.806458,5.1354565 17.074483,4.8125289 14.526703,4.9411382 9.8801462,4.3893472 6.454113,6.5957888 5.0087476,6.5827232 3.8477042,11.243014 l -2.87303007,4.437033 3.14407087,0.06429 9.540628,2.572195 7.850231,-0.563536 z"
+     id="path847-3-9"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <g
+     id="g19"
+     transform="matrix(0.69230769,0,0,0.69230769,1.8461539,1.8461539)">
+    <rect
+       style="fill:#5a8c5a"
+       id="rect11"
+       y="19"
+       x="19"
+       width="13"
+       ry="2.6149368"
+       rx="2.6149371"
+       height="13" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path13"
+       style="overflow:visible;fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round"
+       d="m 21.6,25.499999 h 7.8" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path15"
+       style="overflow:visible;fill:#ffffff;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round"
+       d="M 25.5,29.399999 V 21.6" />
+    <path
+       style="opacity:0.3;fill:#fcffff;fill-rule:evenodd"
+       inkscape:connector-curvature="0"
+       id="path17"
+       d="m 20.3,25.499999 h 10.4 c 0,0 0,0 0,-2.6 C 30.7,20.3 30.05,20.3 25.5,20.3 c -4.55,0 -5.2,0 -5.2,2.599999 0,2.6 0,2.6 0,2.6 z" />
+  </g>
+</svg>

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -54,6 +54,7 @@ SET(QGIS_3D_MOC_HDRS
   qgs3dmapsettings.h
   qgsabstract3dengine.h
   qgscameracontroller.h
+  qgslayoutitem3dmap.h
   qgsoffscreen3dengine.h
   qgswindow3dengine.h
 

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -63,6 +63,13 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
               elemOrigin.attribute( "y" ).toDouble(),
               elemOrigin.attribute( "z" ).toDouble() );
 
+  QDomElement elemColor = elem.firstChildElement( "color" );
+  if ( !elemColor.isNull() )
+  {
+    mBackgroundColor = QgsSymbolLayerUtils::decodeColor( elemColor.attribute( "background" ) );
+    mSelectionColor = QgsSymbolLayerUtils::decodeColor( elemColor.attribute( "selection" ) );
+  }
+
   QDomElement elemCrs = elem.firstChildElement( "crs" );
   mCrs.readXml( elemCrs );
 
@@ -146,6 +153,11 @@ QDomElement Qgs3DMapSettings::writeXml( QDomDocument &doc, const QgsReadWriteCon
   elemOrigin.setAttribute( "y", QString::number( mOrigin.y() ) );
   elemOrigin.setAttribute( "z", QString::number( mOrigin.z() ) );
   elem.appendChild( elemOrigin );
+
+  QDomElement elemColor = doc.createElement( "color" );
+  elemColor.setAttribute( "background", QgsSymbolLayerUtils::encodeColor( mBackgroundColor ) );
+  elemColor.setAttribute( "selection", QgsSymbolLayerUtils::encodeColor( mSelectionColor ) );
+  elem.appendChild( elemColor );
 
   QDomElement elemCrs = doc.createElement( "crs" );
   mCrs.writeXml( elemCrs, doc );

--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -419,6 +419,9 @@ void QgsCameraController::setLookingAtPoint( const QgsVector3D &point, float dis
 
 void QgsCameraController::setCameraPose( const QgsCameraPose &camPose )
 {
+  if ( camPose == mCameraPose )
+    return;
+
   mCameraPose = camPose;
 
   if ( mCamera )

--- a/src/3d/qgscamerapose.cpp
+++ b/src/3d/qgscamerapose.cpp
@@ -17,6 +17,31 @@
 
 #include <Qt3DRender/QCamera>
 
+#include <QDomDocument>
+
+QDomElement QgsCameraPose::writeXml( QDomDocument &doc ) const
+{
+  QDomElement elemCamera = doc.createElement( "camera-pose" );
+  elemCamera.setAttribute( QStringLiteral( "x" ), mCenterPoint.x() );
+  elemCamera.setAttribute( QStringLiteral( "y" ), mCenterPoint.y() );
+  elemCamera.setAttribute( QStringLiteral( "z" ), mCenterPoint.z() );
+  elemCamera.setAttribute( QStringLiteral( "dist" ), mDistanceFromCenterPoint );
+  elemCamera.setAttribute( QStringLiteral( "pitch" ), mPitchAngle );
+  elemCamera.setAttribute( QStringLiteral( "heading" ), mHeadingAngle );
+  return elemCamera;
+}
+
+void QgsCameraPose::readXml( const QDomElement &elem )
+{
+  double x = elem.attribute( QStringLiteral( "x" ) ).toDouble();
+  double y = elem.attribute( QStringLiteral( "y" ) ).toDouble();
+  double z = elem.attribute( QStringLiteral( "z" ) ).toDouble();
+  mCenterPoint = QgsVector3D( x, y, z );
+
+  mDistanceFromCenterPoint = elem.attribute( QStringLiteral( "dist" ) ).toFloat();
+  mPitchAngle = elem.attribute( QStringLiteral( "pitch" ) ).toFloat();
+  mHeadingAngle = elem.attribute( QStringLiteral( "heading" ) ).toFloat();
+}
 
 void QgsCameraPose::updateCamera( Qt3DRender::QCamera *camera )
 {

--- a/src/3d/qgscamerapose.h
+++ b/src/3d/qgscamerapose.h
@@ -25,6 +25,9 @@ namespace Qt3DRender
   class QCamera;
 }
 
+class QDomDocument;
+class QDomElement;
+
 /**
  * \ingroup 3d
  * Class that encapsulates camera pose in a 3D scene. The pose is defined with the following parameters:
@@ -61,6 +64,11 @@ class _3D_EXPORT QgsCameraPose
 
     //! Update Qt3D camera view matrix based on the pose
     void updateCamera( Qt3DRender::QCamera *camera );
+
+    //! Writes configuration to a new DOM element and returns it
+    QDomElement writeXml( QDomDocument &doc ) const;
+    //! Reads configuration from a DOM element previously written using writeXml()
+    void readXml( const QDomElement &elem );
 
     bool operator==( const QgsCameraPose &other ) const
     {

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -181,6 +181,13 @@ void QgsLayoutItem3DMap::setMapSettings( Qgs3DMapSettings *settings )
   update();
 }
 
+void QgsLayoutItem3DMap::refresh()
+{
+  QgsLayoutItem::refresh();
+
+  mCapturedImage = QImage();
+}
+
 void QgsLayoutItem3DMap::setCameraPose( const QgsCameraPose &pose )
 {
   if ( mCameraPose == pose )

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -67,6 +67,38 @@ void QgsLayoutItem3DMap::draw( QgsLayoutItemRenderContext &context )
   ctx.painter()->drawImage( 0, 0, img );
 }
 
+bool QgsLayoutItem3DMap::writePropertiesToElement( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const
+{
+  if ( mSettings )
+  {
+    QDomElement elemSettings = mSettings->writeXml( document, context );
+    element.appendChild( elemSettings );
+  }
+
+  QDomElement elemCameraPose = mCameraPose.writeXml( document );
+  element.appendChild( elemCameraPose );
+
+  return true;
+}
+
+bool QgsLayoutItem3DMap::readPropertiesFromElement( const QDomElement &element, const QDomDocument &document, const QgsReadWriteContext &context )
+{
+  QDomElement elemSettings = element.firstChildElement( "qgis3d" );
+  if ( !elemSettings.isNull() )
+  {
+    mSettings.reset( new Qgs3DMapSettings );
+    mSettings->readXml( elemSettings, context );
+    if ( mLayout->project() )
+      mSettings->resolveReferences( *mLayout->project() );
+  }
+
+  QDomElement elemCameraPose = element.firstChildElement( "camera-pose" );
+  if ( !elemCameraPose.isNull() )
+    mCameraPose.readXml( elemCameraPose );
+
+  return true;
+}
+
 void QgsLayoutItem3DMap::setMapSettings( Qgs3DMapSettings *settings )
 {
   mSettings.reset( settings );

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -26,8 +26,10 @@
 QgsLayoutItem3DMap::QgsLayoutItem3DMap( QgsLayout *layout )
   : QgsLayoutItem( layout )
 {
-
 }
+
+QgsLayoutItem3DMap::~QgsLayoutItem3DMap() = default;
+
 
 QgsLayoutItem3DMap *QgsLayoutItem3DMap::create( QgsLayout *layout )
 {
@@ -41,6 +43,9 @@ int QgsLayoutItem3DMap::type() const
 
 void QgsLayoutItem3DMap::draw( QgsLayoutItemRenderContext &context )
 {
+  if ( !mSettings )
+    return;
+
   QgsOffscreen3DEngine engine;
   QSizeF sizePixels = mLayout->renderContext().measurementConverter().convert( sizeWithUnits(), QgsUnitTypes::LayoutPixels ).toQSizeF();
   engine.setSize( QSize( static_cast<int>( std::ceil( sizePixels.width() ) ),

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -89,6 +89,16 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
     //! Returns map scene. May be a null pointer if not yet configured.
     Qgs3DMapSettings *mapSettings() const { return mSettings.get(); }
 
+    /**
+     * Sets the map id() to a number not yet used in the layout. The existing id() is kept if it is not in use.
+    */
+    void assignFreeId();
+
+    //! overridden to show "3D Map 1" type names
+    QString displayName() const override;
+
+    void finalizeRestoreFromXml() override;
+
   public slots:
     void refresh() override;
 
@@ -103,12 +113,19 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
     void onSizePositionChanged();
 
   private:
+    //! Resets the item tooltip to reflect current map id
+    void updateToolTip();
+
+  private:
     std::unique_ptr<Qgs3DMapSettings> mSettings;
     std::unique_ptr<QgsOffscreen3DEngine> mEngine;
     Qgs3DMapScene *mScene = nullptr;  //!< 3D scene (owned by the 3D engine)
     QImage mCapturedImage;
     QgsCameraPose mCameraPose;
     bool mDrawing = false;
+
+    //! Unique identifier
+    int mMapId = 1;
 };
 
 #endif // QGSLAYOUTITEM3DMAP_H

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -34,6 +34,7 @@ class Qgs3DMapSettings;
  */
 class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
 {
+    Q_OBJECT
 
 #ifdef SIP_RUN
     SIP_CONVERT_TO_SUBCLASS_CODE
@@ -60,6 +61,8 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
      * Ownership is transferred to the layout.
      */
     QgsLayoutItem3DMap( QgsLayout *layout SIP_TRANSFERTHIS );
+
+    ~QgsLayoutItem3DMap();
 
     /**
      * Returns a new 3D map item for the specified \a layout.

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -73,8 +73,6 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
 
     virtual int type() const override;
 
-    virtual void draw( QgsLayoutItemRenderContext &context ) override;
-
     //! Configures camera view
     void setCameraPose( const QgsCameraPose &pose ) { mCameraPose = pose; }
     //! Returns camera view
@@ -88,6 +86,11 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
     void setMapSettings( Qgs3DMapSettings *settings SIP_TRANSFER );
     //! Returns map scene. May be a null pointer if not yet configured.
     Qgs3DMapSettings *mapSettings() const { return mSettings.get(); }
+
+  protected:
+    void draw( QgsLayoutItemRenderContext &context ) override;
+    bool writePropertiesToElement( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const override;
+    bool readPropertiesFromElement( const QDomElement &element, const QDomDocument &document, const QgsReadWriteContext &context ) override;
 
   private:
     std::unique_ptr<Qgs3DMapSettings> mSettings;

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -89,6 +89,9 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
     //! Returns map scene. May be a null pointer if not yet configured.
     Qgs3DMapSettings *mapSettings() const { return mSettings.get(); }
 
+  public slots:
+    void refresh() override;
+
   protected:
     void draw( QgsLayoutItemRenderContext &context ) override;
     bool writePropertiesToElement( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const override;

--- a/src/3d/qgslayoutitem3dmap.h
+++ b/src/3d/qgslayoutitem3dmap.h
@@ -23,7 +23,9 @@
 #include "qgscamerapose.h"
 
 
+class Qgs3DMapScene;
 class Qgs3DMapSettings;
+class QgsOffscreen3DEngine;
 
 /**
  * \ingroup 3d
@@ -74,7 +76,7 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
     virtual int type() const override;
 
     //! Configures camera view
-    void setCameraPose( const QgsCameraPose &pose ) { mCameraPose = pose; }
+    void setCameraPose( const QgsCameraPose &pose );
     //! Returns camera view
     QgsCameraPose cameraPose() const { return mCameraPose; }
 
@@ -92,9 +94,18 @@ class _3D_EXPORT QgsLayoutItem3DMap : public QgsLayoutItem
     bool writePropertiesToElement( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const override;
     bool readPropertiesFromElement( const QDomElement &element, const QDomDocument &document, const QgsReadWriteContext &context ) override;
 
+  private slots:
+    void onImageCaptured( const QImage &img );
+    void onSceneStateChanged();
+    void onSizePositionChanged();
+
   private:
     std::unique_ptr<Qgs3DMapSettings> mSettings;
+    std::unique_ptr<QgsOffscreen3DEngine> mEngine;
+    Qgs3DMapScene *mScene = nullptr;  //!< 3D scene (owned by the 3D engine)
+    QImage mCapturedImage;
     QgsCameraPose mCameraPose;
+    bool mDrawing = false;
 };
 
 #endif // QGSLAYOUTITEM3DMAP_H

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -446,6 +446,7 @@ IF (WITH_3D)
     3d/qgspolygon3dsymbolwidget.cpp
     3d/qgsphongmaterialwidget.cpp
     3d/qgsvectorlayer3drendererwidget.cpp
+    layout/qgslayout3dmapwidget.cpp
   )
 
   SET (QGIS_APP_MOC_HDRS
@@ -459,6 +460,7 @@ IF (WITH_3D)
     3d/qgspolygon3dsymbolwidget.h
     3d/qgsphongmaterialwidget.h
     3d/qgsvectorlayer3drendererwidget.h
+    layout/qgslayout3dmapwidget.h
   )
 ENDIF (WITH_3D)
 

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -27,6 +27,11 @@ QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
 {
   setupUi( this );
 
+  mCenterXSpinBox->setClearValue( 0 );
+  mCenterYSpinBox->setClearValue( 0 );
+  mCenterZSpinBox->setClearValue( 0 );
+  mDistanceToCenterSpinBox->setClearValue( 1000 );
+
   //add widget for general composer item properties
   mItemPropertiesWidget = new QgsLayoutItemPropertiesWidget( this, map3D );
   mainLayout->addWidget( mItemPropertiesWidget );
@@ -58,7 +63,7 @@ QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
   mHeadingAngleSpinBox->setValue( pose.headingAngle() );
 
   QList<QgsDoubleSpinBox *> lst;
-  lst << mCenterXSpinBox << mCenterXSpinBox << mCenterXSpinBox << mDistanceToCenterSpinBox << mPitchAngleSpinBox << mHeadingAngleSpinBox;
+  lst << mCenterXSpinBox << mCenterYSpinBox << mCenterZSpinBox << mDistanceToCenterSpinBox << mPitchAngleSpinBox << mHeadingAngleSpinBox;
   for ( QgsDoubleSpinBox *spinBox : lst )
     connect( spinBox, qgis::overload<double>::of( &QgsDoubleSpinBox::valueChanged ), this, &QgsLayout3DMapWidget::updateCameraPose );
 }

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -27,6 +27,10 @@ QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
 {
   setupUi( this );
 
+  //add widget for general composer item properties
+  mItemPropertiesWidget = new QgsLayoutItemPropertiesWidget( this, map3D );
+  mainLayout->addWidget( mItemPropertiesWidget );
+
   mMenu3DCanvases = new QMenu( this );
   mCopySettingsButton->setMenu( mMenu3DCanvases );
   connect( mMenu3DCanvases, &QMenu::aboutToShow, this, [ = ]

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -19,7 +19,56 @@
 #include "qgs3dmapcanvas.h"
 #include "qgs3dmapcanvasdockwidget.h"
 #include "qgs3dmapsettings.h"
+#include "qgscameracontroller.h"
 #include <QMenu>
+
+
+float _normalizedAngle( float x )
+{
+  x = std::fmod( x, 360 );
+  if ( x < 0 ) x += 360;
+  return x;
+}
+
+template<typename Func1>
+void _prepare3DViewsMenu( QMenu *menu, QgsLayout3DMapWidget *w, Func1 slot )
+{
+  QObject::connect( menu, &QMenu::aboutToShow, w, [menu, w, slot]
+  {
+    const QList<Qgs3DMapCanvasDockWidget *> lst = QgisApp::instance()->findChildren<Qgs3DMapCanvasDockWidget *>();
+    menu->clear();
+    for ( auto dock : lst )
+    {
+      QAction *a = menu->addAction( dock->mapCanvas3D()->objectName(), w, slot );
+      // need to use a custom property for identification because Qt likes to add "&" to the action text
+      a->setProperty( "name", dock->mapCanvas3D()->objectName() );
+    }
+    if ( lst.isEmpty() )
+    {
+      menu->addAction( QObject::tr( "No 3D maps defined" ) )->setEnabled( false );
+    }
+  } );
+}
+
+Qgs3DMapCanvasDockWidget *_dock3DViewFromSender( QObject *sender )
+{
+  QAction *action = qobject_cast<QAction *>( sender );
+  if ( !action )
+    return nullptr;
+
+  QString actionText = action->property( "name" ).toString();
+  const QList<Qgs3DMapCanvasDockWidget *> lst = QgisApp::instance()->findChildren<Qgs3DMapCanvasDockWidget *>();
+  for ( auto dock : lst )
+  {
+    QString objName = dock->mapCanvas3D()->objectName();
+    if ( objName == actionText )
+    {
+      return dock;
+    }
+  }
+  return nullptr;
+}
+
 
 QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
   : QgsLayoutItemBaseWidget( nullptr, map3D )
@@ -38,52 +87,45 @@ QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
 
   mMenu3DCanvases = new QMenu( this );
   mCopySettingsButton->setMenu( mMenu3DCanvases );
-  connect( mMenu3DCanvases, &QMenu::aboutToShow, this, [ = ]
-  {
-    const QList<Qgs3DMapCanvasDockWidget *> lst = QgisApp::instance()->findChildren<Qgs3DMapCanvasDockWidget *>();
-    mMenu3DCanvases->clear();
-    for ( auto dock : lst )
-    {
-      QAction *a = mMenu3DCanvases->addAction( dock->mapCanvas3D()->objectName(), this, &QgsLayout3DMapWidget::copy3DMapSettings );
-      // need to use a custom property for identification because Qt likes to add "&" to the action text
-      a->setProperty( "name", dock->mapCanvas3D()->objectName() );
-    }
-    if ( lst.isEmpty() )
-    {
-      mMenu3DCanvases->addAction( tr( "No 3D maps defined" ) )->setEnabled( false );
-    }
-  } );
+  _prepare3DViewsMenu( mMenu3DCanvases, this, &QgsLayout3DMapWidget::copy3DMapSettings );
 
-  QgsCameraPose pose = mMap3D->cameraPose();
-  mCenterXSpinBox->setValue( pose.centerPoint().x() );
-  mCenterYSpinBox->setValue( pose.centerPoint().y() );
-  mCenterZSpinBox->setValue( pose.centerPoint().z() );
-  mDistanceToCenterSpinBox->setValue( pose.distanceFromCenterPoint() );
-  mPitchAngleSpinBox->setValue( pose.pitchAngle() );
-  mHeadingAngleSpinBox->setValue( pose.headingAngle() );
+  mMenu3DCanvasesPose = new QMenu( this );
+  mPoseFromViewButton->setMenu( mMenu3DCanvasesPose );
+  _prepare3DViewsMenu( mMenu3DCanvasesPose, this, &QgsLayout3DMapWidget::copeCameraPose );
 
   QList<QgsDoubleSpinBox *> lst;
   lst << mCenterXSpinBox << mCenterYSpinBox << mCenterZSpinBox << mDistanceToCenterSpinBox << mPitchAngleSpinBox << mHeadingAngleSpinBox;
   for ( QgsDoubleSpinBox *spinBox : lst )
     connect( spinBox, qgis::overload<double>::of( &QgsDoubleSpinBox::valueChanged ), this, &QgsLayout3DMapWidget::updateCameraPose );
+
+  updateCameraPoseWidgetsFromItem();
+}
+
+void QgsLayout3DMapWidget::updateCameraPoseWidgetsFromItem()
+{
+  QgsCameraPose pose = mMap3D->cameraPose();
+  whileBlocking( mCenterXSpinBox )->setValue( pose.centerPoint().x() );
+  whileBlocking( mCenterYSpinBox )->setValue( pose.centerPoint().y() );
+  whileBlocking( mCenterZSpinBox )->setValue( pose.centerPoint().z() );
+  whileBlocking( mDistanceToCenterSpinBox )->setValue( pose.distanceFromCenterPoint() );
+  whileBlocking( mPitchAngleSpinBox )->setValue( _normalizedAngle( pose.pitchAngle() ) );
+  whileBlocking( mHeadingAngleSpinBox )->setValue( _normalizedAngle( pose.headingAngle() ) );
 }
 
 void QgsLayout3DMapWidget::copy3DMapSettings()
 {
-  QAction *action = qobject_cast<QAction *>( sender() );
-  if ( !action )
-    return;
+  Qgs3DMapCanvasDockWidget *dock = _dock3DViewFromSender( sender() );
+  if ( dock )
+    mMap3D->setMapSettings( new Qgs3DMapSettings( *dock->mapCanvas3D()->map() ) );
+}
 
-  QString actionText = action->property( "name" ).toString();
-  const QList<Qgs3DMapCanvasDockWidget *> lst = QgisApp::instance()->findChildren<Qgs3DMapCanvasDockWidget *>();
-  for ( auto dock : lst )
+void QgsLayout3DMapWidget::copeCameraPose()
+{
+  Qgs3DMapCanvasDockWidget *dock = _dock3DViewFromSender( sender() );
+  if ( dock )
   {
-    QString objName = dock->mapCanvas3D()->objectName();
-    if ( objName == actionText )
-    {
-      mMap3D->setMapSettings( new Qgs3DMapSettings( *dock->mapCanvas3D()->map() ) );
-      break;
-    }
+    mMap3D->setCameraPose( dock->mapCanvas3D()->cameraController()->cameraPose() );
+    updateCameraPoseWidgetsFromItem();
   }
 }
 

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -15,10 +15,75 @@
 
 #include "qgslayout3dmapwidget.h"
 
+#include "qgisapp.h"
+#include "qgs3dmapcanvas.h"
+#include "qgs3dmapcanvasdockwidget.h"
+#include "qgs3dmapsettings.h"
+#include <QMenu>
 
 QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
   : QgsLayoutItemBaseWidget( nullptr, map3D )
   , mMap3D( map3D )
 {
   setupUi( this );
+
+  mMenu3DCanvases = new QMenu( this );
+  mCopySettingsButton->setMenu( mMenu3DCanvases );
+  connect( mMenu3DCanvases, &QMenu::aboutToShow, this, [ = ]
+  {
+    const QList<Qgs3DMapCanvasDockWidget *> lst = QgisApp::instance()->findChildren<Qgs3DMapCanvasDockWidget *>();
+    mMenu3DCanvases->clear();
+    for ( auto dock : lst )
+    {
+      QAction *a = mMenu3DCanvases->addAction( dock->mapCanvas3D()->objectName(), this, &QgsLayout3DMapWidget::copy3DMapSettings );
+      // need to use a custom property for identification because Qt likes to add "&" to the action text
+      a->setProperty( "name", dock->mapCanvas3D()->objectName() );
+    }
+    if ( lst.isEmpty() )
+    {
+      mMenu3DCanvases->addAction( tr( "No 3D maps defined" ) )->setEnabled( false );
+    }
+  } );
+
+  QgsCameraPose pose = mMap3D->cameraPose();
+  mCenterXSpinBox->setValue( pose.centerPoint().x() );
+  mCenterYSpinBox->setValue( pose.centerPoint().y() );
+  mCenterZSpinBox->setValue( pose.centerPoint().z() );
+  mDistanceToCenterSpinBox->setValue( pose.distanceFromCenterPoint() );
+  mPitchAngleSpinBox->setValue( pose.pitchAngle() );
+  mHeadingAngleSpinBox->setValue( pose.headingAngle() );
+
+  QList<QgsDoubleSpinBox *> lst;
+  lst << mCenterXSpinBox << mCenterXSpinBox << mCenterXSpinBox << mDistanceToCenterSpinBox << mPitchAngleSpinBox << mHeadingAngleSpinBox;
+  for ( QgsDoubleSpinBox *spinBox : lst )
+    connect( spinBox, qgis::overload<double>::of( &QgsDoubleSpinBox::valueChanged ), this, &QgsLayout3DMapWidget::updateCameraPose );
+}
+
+void QgsLayout3DMapWidget::copy3DMapSettings()
+{
+  QAction *action = qobject_cast<QAction *>( sender() );
+  if ( !action )
+    return;
+
+  QString actionText = action->property( "name" ).toString();
+  const QList<Qgs3DMapCanvasDockWidget *> lst = QgisApp::instance()->findChildren<Qgs3DMapCanvasDockWidget *>();
+  for ( auto dock : lst )
+  {
+    QString objName = dock->mapCanvas3D()->objectName();
+    if ( objName == actionText )
+    {
+      mMap3D->setMapSettings( new Qgs3DMapSettings( *dock->mapCanvas3D()->map() ) );
+      break;
+    }
+  }
+}
+
+void QgsLayout3DMapWidget::updateCameraPose()
+{
+  QgsCameraPose pose;
+  pose.setCenterPoint( QgsVector3D( mCenterXSpinBox->value(), mCenterYSpinBox->value(), mCenterZSpinBox->value() ) );
+  pose.setDistanceFromCenterPoint( mDistanceToCenterSpinBox->value() );
+  pose.setPitchAngle( mPitchAngleSpinBox->value() );
+  pose.setHeadingAngle( mHeadingAngleSpinBox->value() );
+  mMap3D->setCameraPose( pose );
 }

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -1,0 +1,24 @@
+/***************************************************************************
+  qgslayout3dmapwidget.cpp
+  --------------------------------------
+  Date                 : August 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayout3dmapwidget.h"
+
+
+QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
+  : QgsLayoutItemBaseWidget( nullptr, map3D )
+  , mMap3D( map3D )
+{
+  setupUi( this );
+}

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -138,3 +138,17 @@ void QgsLayout3DMapWidget::updateCameraPose()
   pose.setHeadingAngle( mHeadingAngleSpinBox->value() );
   mMap3D->setCameraPose( pose );
 }
+
+bool QgsLayout3DMapWidget::setNewItem( QgsLayoutItem *item )
+{
+  QgsLayoutItem3DMap *newItem = qobject_cast< QgsLayoutItem3DMap * >( item );
+  if ( !newItem )
+    return false;
+
+  mMap3D = newItem;
+  mItemPropertiesWidget->setItem( newItem );
+
+  updateCameraPoseWidgetsFromItem();
+
+  return true;
+}

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -34,6 +34,7 @@ class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayo
 
   private:
     QPointer< QgsLayoutItem3DMap > mMap3D;
+    QgsLayoutItemPropertiesWidget *mItemPropertiesWidget = nullptr;
     QMenu *mMenu3DCanvases = nullptr;
 };
 

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -1,0 +1,35 @@
+/***************************************************************************
+  qgslayout3dmapwidget.h
+  --------------------------------------
+  Date                 : August 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYOUT3DMAPWIDGET_H
+#define QGSLAYOUT3DMAPWIDGET_H
+
+#include "qgslayoutitemwidget.h"
+#include "ui_qgslayout3dmapwidgetbase.h"
+#include "qgslayoutitem3dmap.h"
+
+class QgsLayoutItem3DMap;
+
+class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayout3DMapWidgetBase
+{
+    Q_OBJECT
+  public:
+    explicit QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D );
+
+  private:
+    QPointer< QgsLayoutItem3DMap > mMap3D;
+};
+
+#endif // QGSLAYOUT3DMAPWIDGET_H

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -28,8 +28,13 @@ class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayo
   public:
     explicit QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D );
 
+  private slots:
+    void copy3DMapSettings();
+    void updateCameraPose();
+
   private:
     QPointer< QgsLayoutItem3DMap > mMap3D;
+    QMenu *mMenu3DCanvases = nullptr;
 };
 
 #endif // QGSLAYOUT3DMAPWIDGET_H

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -28,6 +28,9 @@ class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayo
   public:
     explicit QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D );
 
+  protected:
+    bool setNewItem( QgsLayoutItem *item ) override;
+
   private:
     void updateCameraPoseWidgetsFromItem();
 

--- a/src/app/layout/qgslayout3dmapwidget.h
+++ b/src/app/layout/qgslayout3dmapwidget.h
@@ -28,14 +28,19 @@ class QgsLayout3DMapWidget : public QgsLayoutItemBaseWidget, private Ui::QgsLayo
   public:
     explicit QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D );
 
+  private:
+    void updateCameraPoseWidgetsFromItem();
+
   private slots:
     void copy3DMapSettings();
+    void copeCameraPose();
     void updateCameraPose();
 
   private:
     QPointer< QgsLayoutItem3DMap > mMap3D;
     QgsLayoutItemPropertiesWidget *mItemPropertiesWidget = nullptr;
     QMenu *mMenu3DCanvases = nullptr;
+    QMenu *mMenu3DCanvasesPose = nullptr;
 };
 
 #endif // QGSLAYOUT3DMAPWIDGET_H

--- a/src/app/layout/qgslayoutapputils.cpp
+++ b/src/app/layout/qgslayoutapputils.cpp
@@ -96,6 +96,16 @@ void QgsLayoutAppUtils::registerGuiForKnownItemTypes()
   } );
   registry->addLayoutItemGuiMetadata( mapItemMetadata.release() );
 
+  // 3D map item
+#ifdef HAVE_3D
+  std::unique_ptr< QgsLayoutItemGuiMetadata > map3dMetadata = qgis::make_unique< QgsLayoutItemGuiMetadata>(
+        QgsLayoutItemRegistry::Layout3DMap, QObject::tr( "3D Map" ), QgsApplication::getThemeIcon( QStringLiteral( "/mActionAdd3DMap.svg" ) ),
+        [ = ]( QgsLayoutItem * item )->QgsLayoutItemBaseWidget *
+  {
+    return new QgsLayout3DMapWidget( qobject_cast< QgsLayoutItem3DMap * >( item ) );
+  }, createRubberBand );
+  registry->addLayoutItemGuiMetadata( map3dMetadata.release() );
+#endif
 
   // picture item
 
@@ -345,15 +355,4 @@ void QgsLayoutAppUtils::registerGuiForKnownItemTypes()
     return f;
   } );
   registry->addLayoutItemGuiMetadata( attributeTableItemMetadata .release() );
-
-  // 3D map item
-#ifdef HAVE_3D
-  std::unique_ptr< QgsLayoutItemGuiMetadata > map3dMetadata = qgis::make_unique< QgsLayoutItemGuiMetadata>(
-        QgsLayoutItemRegistry::Layout3DMap, QObject::tr( "3D Map" ), QgsApplication::getThemeIcon( QStringLiteral( "/mActionAdd3DMap.svg" ) ),
-        [ = ]( QgsLayoutItem * item )->QgsLayoutItemBaseWidget *
-  {
-    return new QgsLayout3DMapWidget( qobject_cast< QgsLayoutItem3DMap * >( item ) );
-  }, createRubberBand );
-  registry->addLayoutItemGuiMetadata( map3dMetadata.release() );
-#endif
 }

--- a/src/app/layout/qgslayoutapputils.cpp
+++ b/src/app/layout/qgslayoutapputils.cpp
@@ -43,6 +43,10 @@
 #include "qgisapp.h"
 #include "qgsmapcanvas.h"
 
+#ifdef HAVE_3D
+#include "qgslayout3dmapwidget.h"
+#endif
+
 void QgsLayoutAppUtils::registerGuiForKnownItemTypes()
 {
   QgsLayoutItemGuiRegistry *registry = QgsGui::layoutItemGuiRegistry();
@@ -341,4 +345,15 @@ void QgsLayoutAppUtils::registerGuiForKnownItemTypes()
     return f;
   } );
   registry->addLayoutItemGuiMetadata( attributeTableItemMetadata .release() );
+
+  // 3D map item
+#ifdef HAVE_3D
+  std::unique_ptr< QgsLayoutItemGuiMetadata > map3dMetadata = qgis::make_unique< QgsLayoutItemGuiMetadata>(
+        QgsLayoutItemRegistry::Layout3DMap, QObject::tr( "3D Map" ), QgsApplication::getThemeIcon( QStringLiteral( "/mActionAdd3DMap.svg" ) ),
+        [ = ]( QgsLayoutItem * item )->QgsLayoutItemBaseWidget *
+  {
+    return new QgsLayout3DMapWidget( qobject_cast< QgsLayoutItem3DMap * >( item ) );
+  }, createRubberBand );
+  registry->addLayoutItemGuiMetadata( map3dMetadata.release() );
+#endif
 }

--- a/src/ui/layout/qgslayout3dmapwidgetbase.ui
+++ b/src/ui/layout/qgslayout3dmapwidgetbase.ui
@@ -54,7 +54,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-65</y>
         <width>510</width>
         <height>635</height>
        </rect>
@@ -90,7 +90,7 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="mCenterXLineEdit">
+           <widget class="QgsDoubleSpinBox" name="mCenterXSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
@@ -110,7 +110,7 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="mCenterYLineEdit">
+           <widget class="QgsDoubleSpinBox" name="mCenterYSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
@@ -130,7 +130,7 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="mCenterZLineEdit">
+           <widget class="QgsDoubleSpinBox" name="mCenterZSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
@@ -150,7 +150,7 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="mDistanceToCenterLineEdit">
+           <widget class="QgsDoubleSpinBox" name="mDistanceToCenterSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
@@ -167,7 +167,7 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="mPitchAngleLineEdit">
+           <widget class="QgsDoubleSpinBox" name="mPitchAngleSpinBox">
             <property name="suffix">
              <string> °</string>
             </property>
@@ -187,7 +187,7 @@
            </widget>
           </item>
           <item row="5" column="1">
-           <widget class="QDoubleSpinBox" name="mHeadingAngleLineEdit">
+           <widget class="QgsDoubleSpinBox" name="mHeadingAngleSpinBox">
             <property name="suffix">
              <string> °</string>
             </property>
@@ -208,6 +208,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/layout/qgslayout3dmapwidgetbase.ui
+++ b/src/ui/layout/qgslayout3dmapwidgetbase.ui
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsLayout3DMapWidgetBase</class>
+ <widget class="QWidget" name="QgsLayout3DMapWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>540</width>
+    <height>613</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>3D Map</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="mLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">padding: 2px; font-weight: bold; background-color: rgb(200, 200, 200);</string>
+     </property>
+     <property name="text">
+      <string>3D Map</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>510</width>
+        <height>635</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Scene settings</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QPushButton" name="mCopySettingsButton">
+            <property name="text">
+             <string>Copy settings from a 3D view...</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Camera pose</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Center X</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="mCenterXLineEdit">
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>-999999.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Center Y</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="mCenterYLineEdit">
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>-999999.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Center Z</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="mCenterZLineEdit">
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>-999999.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Distance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="mDistanceToCenterLineEdit">
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Pitch</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="mPitchAngleLineEdit">
+            <property name="suffix">
+             <string> °</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>360.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Heading</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QDoubleSpinBox" name="mHeadingAngleLineEdit">
+            <property name="suffix">
+             <string> °</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>360.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/layout/qgslayout3dmapwidgetbase.ui
+++ b/src/ui/layout/qgslayout3dmapwidgetbase.ui
@@ -54,12 +54,12 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-65</y>
+        <y>0</y>
         <width>510</width>
         <height>635</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_6">
+      <layout class="QVBoxLayout" name="mainLayout">
        <item>
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">

--- a/src/ui/layout/qgslayout3dmapwidgetbase.ui
+++ b/src/ui/layout/qgslayout3dmapwidgetbase.ui
@@ -54,9 +54,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-128</y>
         <width>510</width>
-        <height>635</height>
+        <height>698</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -82,33 +82,6 @@
           <string>Camera pose</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Center X</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QgsDoubleSpinBox" name="mCenterXSpinBox">
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>-9999999.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>9999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Center Y</string>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="1">
            <widget class="QgsDoubleSpinBox" name="mCenterYSpinBox">
             <property name="decimals">
@@ -122,30 +95,10 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
             <property name="text">
-             <string>Center Z</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QgsDoubleSpinBox" name="mCenterZSpinBox">
-            <property name="decimals">
-             <number>1</number>
-            </property>
-            <property name="minimum">
-             <double>-9999999.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>9999999.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Distance</string>
+             <string>Center X</string>
             </property>
            </widget>
           </item>
@@ -156,6 +109,40 @@
             </property>
             <property name="maximum">
              <double>9999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Center Z</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Center Y</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QgsDoubleSpinBox" name="mHeadingAngleSpinBox">
+            <property name="suffix">
+             <string> °</string>
+            </property>
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <double>360.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Heading</string>
             </property>
            </widget>
           </item>
@@ -179,23 +166,43 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Heading</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QgsDoubleSpinBox" name="mHeadingAngleSpinBox">
-            <property name="suffix">
-             <string> °</string>
-            </property>
+          <item row="0" column="1">
+           <widget class="QgsDoubleSpinBox" name="mCenterXSpinBox">
             <property name="decimals">
              <number>1</number>
             </property>
+            <property name="minimum">
+             <double>-9999999.000000000000000</double>
+            </property>
             <property name="maximum">
-             <double>360.000000000000000</double>
+             <double>9999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Distance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QgsDoubleSpinBox" name="mCenterZSpinBox">
+            <property name="decimals">
+             <number>1</number>
+            </property>
+            <property name="minimum">
+             <double>-9999999.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>9999999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="2">
+           <widget class="QPushButton" name="mPoseFromViewButton">
+            <property name="text">
+             <string>Set from a 3D view...</string>
             </property>
            </widget>
           </item>

--- a/src/ui/layout/qgslayout3dmapwidgetbase.ui
+++ b/src/ui/layout/qgslayout3dmapwidgetbase.ui
@@ -95,10 +95,10 @@
              <number>1</number>
             </property>
             <property name="minimum">
-             <double>-999999.000000000000000</double>
+             <double>-9999999.000000000000000</double>
             </property>
             <property name="maximum">
-             <double>999999.000000000000000</double>
+             <double>9999999.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -115,10 +115,10 @@
              <number>1</number>
             </property>
             <property name="minimum">
-             <double>-999999.000000000000000</double>
+             <double>-9999999.000000000000000</double>
             </property>
             <property name="maximum">
-             <double>999999.000000000000000</double>
+             <double>9999999.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -135,10 +135,10 @@
              <number>1</number>
             </property>
             <property name="minimum">
-             <double>-999999.000000000000000</double>
+             <double>-9999999.000000000000000</double>
             </property>
             <property name="maximum">
-             <double>999999.000000000000000</double>
+             <double>9999999.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -155,7 +155,7 @@
              <number>1</number>
             </property>
             <property name="maximum">
-             <double>999999.000000000000000</double>
+             <double>9999999.000000000000000</double>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Here we go - this pull request adds GUI for 3D map items in print layouts.

One can use an existing 3D view from main window to configure the 3D scene of 3D map items. Then there are spin boxes to configure the camera pose.

Kudos go to:
- @nyalldawson for making print layouts so nicely extensible
- @nirvn for the nice new icon to add 3D maps in print layouts
- everyone who supported the "More QGIS 3D" crowdfunding campaign

Obligatory screenshot:

![image](https://user-images.githubusercontent.com/193367/44595749-5a004680-a7ca-11e8-86bd-3835101fc3f2.png)
