### PR TITLE
Fix crash when relations would be recursively nested

### DIFF
--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -48,7 +48,7 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
 
 void QgsRelationWidgetWrapper::aboutToSave()
 {
-  if ( !mRelation.isValid() )
+  if ( !mRelation.isValid() || !widget() || !widget()->isVisible() )
     return;
 
   // Calling isModified() will emit a beforeModifiedCheck()


### PR DESCRIPTION
There is already code, that avoids building up widgets in such a situation. With this patch
it also avoids recursively calling methods on relations which are hidden (because of nesting or other reasons).

Backport