### PR TITLE
Snap to grid for maptools [FEATURE]

### DIFF
--- a/python/gui/auto_generated/qgsmapmouseevent.sip.in
+++ b/python/gui/auto_generated/qgsmapmouseevent.sip.in
@@ -119,6 +119,13 @@ Alias to pos()
 :return: Mouse position in pixel coordinates
 %End
 
+    void snapToGrid( double precision );
+%Docstring
+Snaps the mapPoint to a grid with the given ``precision``.
+
+.. versionadded:: 3.4
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsmapmouseevent.sip.in
+++ b/python/gui/auto_generated/qgsmapmouseevent.sip.in
@@ -123,7 +123,7 @@ Alias to pos()
 %Docstring
 Snaps the mapPoint to a grid with the given ``precision``.
 The snapping will be done in the specified ``crs``. If this crs is
-different from the mapCanvas crs, it will add some overhead.
+different from the mapCanvas crs, it will be reprojected on the fly.
 
 .. versionadded:: 3.4
 %End

--- a/python/gui/auto_generated/qgsmapmouseevent.sip.in
+++ b/python/gui/auto_generated/qgsmapmouseevent.sip.in
@@ -119,9 +119,11 @@ Alias to pos()
 :return: Mouse position in pixel coordinates
 %End
 
-    void snapToGrid( double precision );
+    void snapToGrid( double precision, const QgsCoordinateReferenceSystem &crs );
 %Docstring
 Snaps the mapPoint to a grid with the given ``precision``.
+The snapping will be done in the specified ``crs``. If this crs is
+different from the mapCanvas crs, it will add some overhead.
 
 .. versionadded:: 3.4
 %End

--- a/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
+++ b/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
@@ -151,6 +151,20 @@ construction mode.
 :param e: Mouse events prepared by the cad system
 %End
 
+    bool snapToGridEnabled() const;
+%Docstring
+Enables or disables snap to grid of mouse events.
+
+.. versionadded:: 3.4
+%End
+
+    void setSnapToGridEnabled( bool snapToGridEnabled );
+%Docstring
+Enables or disables snap to grid of mouse events.
+
+.. versionadded:: 3.4
+%End
+
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
+++ b/python/gui/auto_generated/qgsmaptooladvanceddigitizing.sip.in
@@ -151,16 +151,18 @@ construction mode.
 :param e: Mouse events prepared by the cad system
 %End
 
-    bool snapToGridEnabled() const;
+    bool snapToLayerGridEnabled() const;
 %Docstring
 Enables or disables snap to grid of mouse events.
+The snapping will occur in the layer's CRS.
 
 .. versionadded:: 3.4
 %End
 
-    void setSnapToGridEnabled( bool snapToGridEnabled );
+    void setSnapToLayerGridEnabled( bool snapToLayerGridEnabled );
 %Docstring
 Enables or disables snap to grid of mouse events.
+The snapping will occur in the layer's CRS.
 
 .. versionadded:: 3.4
 %End

--- a/python/gui/auto_generated/qgssnaptogridcanvasitem.sip.in
+++ b/python/gui/auto_generated/qgssnaptogridcanvasitem.sip.in
@@ -1,0 +1,91 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssnaptogridcanvasitem.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsSnapToGridCanvasItem : QObject, QgsMapCanvasItem
+{
+%Docstring
+
+Shows a grid on the map canvas given a spatial resolution.
+
+.. versionadded:: 3.4
+%End
+
+%TypeHeaderCode
+#include "qgssnaptogridcanvasitem.h"
+%End
+  public:
+
+    QgsSnapToGridCanvasItem( QgsMapCanvas *mapCanvas );
+%Docstring
+Will automatically be added to the ``mapCanvas``.
+%End
+
+    virtual void paint( QPainter *painter );
+
+
+    QgsPointXY point() const;
+%Docstring
+A point that will be highlighted on the map canvas.
+The point needs to be in map coordinates. The closest point on the
+grid will be highlighted.
+%End
+
+    void setPoint( const QgsPointXY &point );
+%Docstring
+A point that will be highlighted on the map canvas.
+The point needs to be in map coordinates. The closest point on the
+grid will be highlighted.
+%End
+
+    double precision() const;
+%Docstring
+The resolution of the grid in map units.
+If a crs has been specified it will be in CRS units.
+%End
+
+    void setPrecision( double precision );
+%Docstring
+The resolution of the grid in map units.
+If a crs has been specified it will be in CRS units.
+%End
+
+    QgsCoordinateReferenceSystem crs() const;
+%Docstring
+The CRS in which the grid should be calculated.
+By default will be an invalid QgsCoordinateReferenceSystem and
+as such equal to the CRS of the map canvas.
+%End
+
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+%Docstring
+The CRS in which the grid should be calculated.
+By default will be an invalid QgsCoordinateReferenceSystem and
+as such equal to the CRS of the map canvas.
+%End
+
+    bool enabled() const;
+%Docstring
+Enable this item. It will be hidden if disabled.
+%End
+
+    void setEnabled( bool enabled );
+%Docstring
+Enable this item. It will be hidden if disabled.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgssnaptogridcanvasitem.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/auto_generated/qgssnaptogridcanvasitem.sip.in
+++ b/python/gui/auto_generated/qgssnaptogridcanvasitem.sip.in
@@ -23,7 +23,7 @@ Shows a grid on the map canvas given a spatial resolution.
 %End
   public:
 
-    QgsSnapToGridCanvasItem( QgsMapCanvas *mapCanvas );
+    QgsSnapToGridCanvasItem( QgsMapCanvas *mapCanvas /TransferThis/ );
 %Docstring
 Will automatically be added to the ``mapCanvas``.
 %End

--- a/python/gui/auto_generated/qgssnaptogridcanvasitem.sip.in
+++ b/python/gui/auto_generated/qgssnaptogridcanvasitem.sip.in
@@ -8,6 +8,7 @@
 
 
 
+
 class QgsSnapToGridCanvasItem : QObject, QgsMapCanvasItem
 {
 %Docstring

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -192,6 +192,7 @@
 %Include auto_generated/qgssearchquerybuilder.sip
 %Include auto_generated/qgsshortcutsmanager.sip
 %Include auto_generated/qgsslider.sip
+%Include auto_generated/qgssnaptogridcanvasitem.sip
 %Include auto_generated/qgsstatusbar.sip
 %Include auto_generated/qgssublayersdialog.sip
 %Include auto_generated/qgssubstitutionlistwidget.sip

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -39,7 +39,7 @@ void QgsMapToolAddPart::canvasReleaseEvent( QgsMapMouseEvent *e )
 {
   if ( checkSelection() )
   {
-    QgsMapToolCapture::canvasReleaseEvent( e );
+    QgsMapToolAdvancedDigitizing::canvasReleaseEvent( e );
   }
   else
   {

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -39,7 +39,7 @@ void QgsMapToolAddPart::canvasReleaseEvent( QgsMapMouseEvent *e )
 {
   if ( checkSelection() )
   {
-    QgsMapToolAdvancedDigitizing::canvasReleaseEvent( e );
+    QgsMapToolCapture::canvasReleaseEvent( e );
   }
   else
   {

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -27,6 +27,7 @@ QgsMapToolSplitFeatures::QgsMapToolSplitFeatures( QgsMapCanvas *canvas )
   : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine )
 {
   mToolName = tr( "Split features" );
+  setSnapToGridEnabled( false );
 }
 
 void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -27,7 +27,7 @@ QgsMapToolSplitFeatures::QgsMapToolSplitFeatures( QgsMapCanvas *canvas )
   : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine )
 {
   mToolName = tr( "Split features" );
-  setSnapToGridEnabled( false );
+  setSnapToLayerGridEnabled( false );
 }
 
 void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -27,6 +27,7 @@ QgsMapToolSplitParts::QgsMapToolSplitParts( QgsMapCanvas *canvas )
   : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine )
 {
   mToolName = tr( "Split parts" );
+  setSnapToGridEnabled( false );
 }
 
 void QgsMapToolSplitParts::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -27,7 +27,7 @@ QgsMapToolSplitParts::QgsMapToolSplitParts( QgsMapCanvas *canvas )
   : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CaptureLine )
 {
   mToolName = tr( "Split parts" );
-  setSnapToGridEnabled( false );
+  setSnapToLayerGridEnabled( false );
 }
 
 void QgsMapToolSplitParts::cadCanvasReleaseEvent( QgsMapMouseEvent *e )

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -46,7 +46,7 @@ bool QgsVectorLayerEditUtils::insertVertex( double x, double y, QgsFeatureId atF
 
   geometry.insertVertex( x, y, beforeVertex );
 
-  mLayer->editBuffer()->changeGeometry( atFeatureId, geometry );
+  mLayer->changeGeometry( atFeatureId, geometry );
   return true;
 }
 
@@ -63,7 +63,7 @@ bool QgsVectorLayerEditUtils::insertVertex( const QgsPoint &point, QgsFeatureId 
 
   geometry.insertVertex( point, beforeVertex );
 
-  mLayer->editBuffer()->changeGeometry( atFeatureId, geometry );
+  mLayer->changeGeometry( atFeatureId, geometry );
   return true;
 }
 
@@ -86,7 +86,7 @@ bool QgsVectorLayerEditUtils::moveVertex( const QgsPoint &p, QgsFeatureId atFeat
 
   geometry.moveVertex( p, atVertex );
 
-  mLayer->editBuffer()->changeGeometry( atFeatureId, geometry );
+  mLayer->changeGeometry( atFeatureId, geometry );
   return true;
 }
 
@@ -111,7 +111,7 @@ QgsVectorLayer::EditResult QgsVectorLayerEditUtils::deleteVertex( QgsFeatureId f
     geometry.set( nullptr );
   }
 
-  mLayer->editBuffer()->changeGeometry( featureId, geometry );
+  mLayer->changeGeometry( featureId, geometry );
   return !geometry.isNull() ? QgsVectorLayer::Success : QgsVectorLayer::EmptyGeometry;
 }
 
@@ -158,7 +158,7 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::addRing( QgsCurve *ring, c
     if ( addRingReturnCode == 0 )
       if ( addRingReturnCode == QgsGeometry::Success )
       {
-        mLayer->editBuffer()->changeGeometry( f.id(), g );
+        mLayer->changeGeometry( f.id(), g );
         if ( modifiedFeatureId )
           *modifiedFeatureId = f.id();
 
@@ -211,7 +211,7 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::addPart( const QgsPointSeq
       //convert back to single part if required by layer
       geometry.convertToSingleType();
     }
-    mLayer->editBuffer()->changeGeometry( featureId, geometry );
+    mLayer->changeGeometry( featureId, geometry );
   }
   return errorCode;
 }
@@ -246,7 +246,7 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::addPart( QgsCurve *ring, Q
       //convert back to single part if required by layer
       geometry.convertToSingleType();
     }
-    mLayer->editBuffer()->changeGeometry( featureId, geometry );
+    mLayer->changeGeometry( featureId, geometry );
   }
   return errorCode;
 }
@@ -266,7 +266,7 @@ int QgsVectorLayerEditUtils::translateFeature( QgsFeatureId featureId, double dx
   int errorCode = geometry.translate( dx, dy );
   if ( errorCode == 0 )
   {
-    mLayer->editBuffer()->changeGeometry( featureId, geometry );
+    mLayer->changeGeometry( featureId, geometry );
   }
   return errorCode;
 }
@@ -347,13 +347,13 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitFeatures( const QVect
     if ( splitFunctionReturn == QgsGeometry::OperationResult::Success )
     {
       //change this geometry
-      mLayer->editBuffer()->changeGeometry( feat.id(), featureGeom );
+      mLayer->changeGeometry( feat.id(), featureGeom );
 
       //insert new features
       for ( int i = 0; i < newGeometries.size(); ++i )
       {
         QgsFeature f = QgsVectorLayerUtils::createFeature( mLayer, newGeometries.at( i ), feat.attributes().toMap() );
-        mLayer->editBuffer()->addFeature( f );
+        mLayer->addFeature( f );
       }
 
       if ( topologicalEditing )
@@ -469,7 +469,7 @@ QgsGeometry::OperationResult QgsVectorLayerEditUtils::splitParts( const QVector<
 
       if ( !addPartRet )
       {
-        mLayer->editBuffer()->changeGeometry( feat.id(), featureGeom );
+        mLayer->changeGeometry( feat.id(), featureGeom );
       }
 
       if ( topologicalEditing )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -355,6 +355,7 @@ SET(QGIS_GUI_SRCS
   qgsshortcutsmanager.cpp
   qgsslider.cpp
   qgssnapindicator.cpp
+  qgssnaptogridcanvasitem.cpp
   qgssublayersdialog.cpp
   qgssubstitutionlistwidget.cpp
   qgssqlcomposerdialog.cpp
@@ -524,6 +525,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgssearchquerybuilder.h
   qgsshortcutsmanager.h
   qgsslider.h
+  qgssnaptogridcanvasitem.h
   qgssqlcomposerdialog.h
   qgsstatusbar.h
   qgssublayersdialog.h

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -71,6 +71,19 @@ void QgsMapMouseEvent::setMapPoint( const QgsPointXY &point )
   mPixelPoint = mapToPixelCoordinates( point );
 }
 
+void QgsMapMouseEvent::snapToGrid( double precision )
+{
+  if ( precision <= 0 )
+    return;
+
+  mMapPoint.setX( std::round( mMapPoint.x() / precision ) * precision );
+  mMapPoint.setY( std::round( mMapPoint.y() / precision ) * precision );
+
+  // mSnapMatch = QgsPointLocator::Match( mSnapMatch.type(), mSnapMatch.layer(), mSnapMatch.featureId(), mSnapMatch.distance(), mMapPoint, mSnapMatch.vertexIndex(), mSnapMatch.edgePoints() );
+
+  setMapPoint( mMapPoint );
+}
+
 QPoint QgsMapMouseEvent::mapToPixelCoordinates( const QgsPointXY &point )
 {
   double x = point.x(), y = point.y();

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -71,17 +71,21 @@ void QgsMapMouseEvent::setMapPoint( const QgsPointXY &point )
   mPixelPoint = mapToPixelCoordinates( point );
 }
 
-void QgsMapMouseEvent::snapToGrid( double precision )
+void QgsMapMouseEvent::snapToGrid( double precision, const QgsCoordinateReferenceSystem &crs )
 {
   if ( precision <= 0 )
     return;
 
-  mMapPoint.setX( std::round( mMapPoint.x() / precision ) * precision );
-  mMapPoint.setY( std::round( mMapPoint.y() / precision ) * precision );
+  QgsCoordinateTransform ct( mMapCanvas->mapSettings().destinationCrs(), crs, mMapCanvas->mapSettings().transformContext() );
 
-  // mSnapMatch = QgsPointLocator::Match( mSnapMatch.type(), mSnapMatch.layer(), mSnapMatch.featureId(), mSnapMatch.distance(), mMapPoint, mSnapMatch.vertexIndex(), mSnapMatch.edgePoints() );
+  QgsPointXY pt = ct.transform( mMapPoint );
 
-  setMapPoint( mMapPoint );
+  pt.setX( std::round( mMapPoint.x() / precision ) * precision );
+  pt.setY( std::round( mMapPoint.y() / precision ) * precision );
+
+  pt = ct.transform( pt, QgsCoordinateTransform::ReverseTransform );
+
+  setMapPoint( pt );
 }
 
 QPoint QgsMapMouseEvent::mapToPixelCoordinates( const QgsPointXY &point )

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -76,16 +76,23 @@ void QgsMapMouseEvent::snapToGrid( double precision, const QgsCoordinateReferenc
   if ( precision <= 0 )
     return;
 
-  QgsCoordinateTransform ct( mMapCanvas->mapSettings().destinationCrs(), crs, mMapCanvas->mapSettings().transformContext() );
+  try
+  {
+    QgsCoordinateTransform ct( mMapCanvas->mapSettings().destinationCrs(), crs, mMapCanvas->mapSettings().transformContext() );
 
-  QgsPointXY pt = ct.transform( mMapPoint );
+    QgsPointXY pt = ct.transform( mMapPoint );
 
-  pt.setX( std::round( pt.x() / precision ) * precision );
-  pt.setY( std::round( pt.y() / precision ) * precision );
+    pt.setX( std::round( pt.x() / precision ) * precision );
+    pt.setY( std::round( pt.y() / precision ) * precision );
 
-  pt = ct.transform( pt, QgsCoordinateTransform::ReverseTransform );
+    pt = ct.transform( pt, QgsCoordinateTransform::ReverseTransform );
 
-  setMapPoint( pt );
+    setMapPoint( pt );
+  }
+  catch ( QgsCsException &e )
+  {
+    Q_UNUSED( e )
+  }
 }
 
 QPoint QgsMapMouseEvent::mapToPixelCoordinates( const QgsPointXY &point )

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -80,8 +80,8 @@ void QgsMapMouseEvent::snapToGrid( double precision, const QgsCoordinateReferenc
 
   QgsPointXY pt = ct.transform( mMapPoint );
 
-  pt.setX( std::round( mMapPoint.x() / precision ) * precision );
-  pt.setY( std::round( mMapPoint.y() / precision ) * precision );
+  pt.setX( std::round( pt.x() / precision ) * precision );
+  pt.setY( std::round( pt.y() / precision ) * precision );
 
   pt = ct.transform( pt, QgsCoordinateTransform::ReverseTransform );
 

--- a/src/gui/qgsmapmouseevent.h
+++ b/src/gui/qgsmapmouseevent.h
@@ -126,6 +126,13 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
      */
     QPoint originalPixelPoint() const { return pos(); }
 
+    /**
+     * Snaps the mapPoint to a grid with the given \a precision.
+     *
+     * \since QGIS 3.4
+     */
+    void snapToGrid( double precision );
+
   private:
 
     QPoint mapToPixelCoordinates( const QgsPointXY &point );

--- a/src/gui/qgsmapmouseevent.h
+++ b/src/gui/qgsmapmouseevent.h
@@ -128,10 +128,12 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
 
     /**
      * Snaps the mapPoint to a grid with the given \a precision.
+     * The snapping will be done in the specified \a crs. If this crs is
+     * different from the mapCanvas crs, it will add some overhead.
      *
      * \since QGIS 3.4
      */
-    void snapToGrid( double precision );
+    void snapToGrid( double precision, const QgsCoordinateReferenceSystem &crs );
 
   private:
 

--- a/src/gui/qgsmapmouseevent.h
+++ b/src/gui/qgsmapmouseevent.h
@@ -129,7 +129,7 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
     /**
      * Snaps the mapPoint to a grid with the given \a precision.
      * The snapping will be done in the specified \a crs. If this crs is
-     * different from the mapCanvas crs, it will add some overhead.
+     * different from the mapCanvas crs, it will be reprojected on the fly.
      *
      * \since QGIS 3.4
      */

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -25,6 +25,7 @@ QgsMapToolAdvancedDigitizing::QgsMapToolAdvancedDigitizing( QgsMapCanvas *canvas
   : QgsMapToolEdit( canvas )
   , mCadDockWidget( cadDockWidget )
 {
+  connect( canvas, &QgsMapCanvas::currentLayerChanged, this, &QgsMapToolAdvancedDigitizing::onCurrentLayerChanged );
 }
 
 void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
@@ -141,6 +142,20 @@ void QgsMapToolAdvancedDigitizing::cadPointChanged( const QgsPointXY &point )
   Q_UNUSED( point );
   QMouseEvent *ev = new QMouseEvent( QEvent::MouseMove, mCanvas->mouseLastXY(), Qt::NoButton, Qt::NoButton, Qt::NoModifier );
   qApp->postEvent( mCanvas->viewport(), ev );  // event queue will delete the event when processed
+}
+
+void QgsMapToolAdvancedDigitizing::onCurrentLayerChanged()
+{
+  QgsVectorLayer *layer = currentVectorLayer();
+  if ( mSnapToGridCanvasItem && layer && mSnapToGridEnabled )
+  {
+    mSnapToGridCanvasItem->setPrecision( layer->geometryFixes()->geometryPrecision() );
+    mSnapToGridCanvasItem->setCrs( layer->crs() );
+    mSnapToGridCanvasItem->setEnabled( true );
+  }
+
+  if ( !layer )
+    mSnapToGridCanvasItem->setEnabled( false );
 }
 
 bool QgsMapToolAdvancedDigitizing::snapToGridEnabled() const

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -40,7 +40,7 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
   }
 
   QgsVectorLayer *layer = currentVectorLayer();
-  if ( layer )
+  if ( mSnapToGridEnabled && layer )
   {
     e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
   }
@@ -80,7 +80,7 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
   }
 
   QgsVectorLayer *layer = currentVectorLayer();
-  if ( layer )
+  if ( mSnapToGridEnabled && layer )
   {
     e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
   }
@@ -105,7 +105,7 @@ void QgsMapToolAdvancedDigitizing::canvasMoveEvent( QgsMapMouseEvent *e )
   }
 
   QgsVectorLayer *layer = currentVectorLayer();
-  if ( layer )
+  if ( mSnapToGridEnabled && layer )
   {
     e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
   }
@@ -132,4 +132,14 @@ void QgsMapToolAdvancedDigitizing::cadPointChanged( const QgsPointXY &point )
   Q_UNUSED( point );
   QMouseEvent *ev = new QMouseEvent( QEvent::MouseMove, mCanvas->mouseLastXY(), Qt::NoButton, Qt::NoButton, Qt::NoModifier );
   qApp->postEvent( mCanvas->viewport(), ev );  // event queue will delete the event when processed
+}
+
+bool QgsMapToolAdvancedDigitizing::snapToGridEnabled() const
+{
+  return mSnapToGridEnabled;
+}
+
+void QgsMapToolAdvancedDigitizing::setSnapToGridEnabled( bool snapToGridEnabled )
+{
+  mSnapToGridEnabled = snapToGridEnabled;
 }

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -39,8 +39,11 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
     e->snapPoint();
   }
 
-  if ( currentVectorLayer() )
-    e->snapToGrid( currentVectorLayer()->geometryOptions().geometryPrecision );
+  QgsVectorLayer *layer = currentVectorLayer();
+  if ( layer )
+  {
+    e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
+  }
 
   cadCanvasPressEvent( e );
 }
@@ -76,8 +79,11 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
     e->snapPoint();
   }
 
-  if ( currentVectorLayer() )
-    e->snapToGrid( currentVectorLayer()->geometryOptions().geometryPrecision );
+  QgsVectorLayer *layer = currentVectorLayer();
+  if ( layer )
+  {
+    e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
+  }
 
   cadCanvasReleaseEvent( e );
 }
@@ -98,8 +104,11 @@ void QgsMapToolAdvancedDigitizing::canvasMoveEvent( QgsMapMouseEvent *e )
     e->snapPoint();
   }
 
-  if ( currentVectorLayer() )
-    e->snapToGrid( currentVectorLayer()->geometryOptions().geometryPrecision );
+  QgsVectorLayer *layer = currentVectorLayer();
+  if ( layer )
+  {
+    e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
+  }
 
   cadCanvasMoveEvent( e );
 }

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -18,6 +18,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsadvanceddigitizingdockwidget.h"
 #include "qgsvectorlayer.h"
+#include "qgsgeometryfixes.h"
 
 QgsMapToolAdvancedDigitizing::QgsMapToolAdvancedDigitizing( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QgsMapToolEdit( canvas )
@@ -42,7 +43,7 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
   QgsVectorLayer *layer = currentVectorLayer();
   if ( mSnapToGridEnabled && layer )
   {
-    e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
+    e->snapToGrid( layer->geometryFixes()->geometryPrecision(), layer->crs() );
   }
 
   cadCanvasPressEvent( e );
@@ -82,7 +83,7 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
   QgsVectorLayer *layer = currentVectorLayer();
   if ( mSnapToGridEnabled && layer )
   {
-    e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
+    e->snapToGrid( layer->geometryFixes()->geometryPrecision(), layer->crs() );
   }
 
   cadCanvasReleaseEvent( e );
@@ -107,7 +108,7 @@ void QgsMapToolAdvancedDigitizing::canvasMoveEvent( QgsMapMouseEvent *e )
   QgsVectorLayer *layer = currentVectorLayer();
   if ( mSnapToGridEnabled && layer )
   {
-    e->snapToGrid( layer->geometryOptions().geometryPrecision, layer->crs() );
+    e->snapToGrid( layer->geometryFixes()->geometryPrecision(), layer->crs() );
   }
 
   cadCanvasMoveEvent( e );

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -17,6 +17,7 @@
 #include "qgsmaptooladvanceddigitizing.h"
 #include "qgsmapcanvas.h"
 #include "qgsadvanceddigitizingdockwidget.h"
+#include "qgsvectorlayer.h"
 
 QgsMapToolAdvancedDigitizing::QgsMapToolAdvancedDigitizing( QgsMapCanvas *canvas, QgsAdvancedDigitizingDockWidget *cadDockWidget )
   : QgsMapToolEdit( canvas )
@@ -37,6 +38,9 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
   {
     e->snapPoint();
   }
+
+  if ( currentVectorLayer() )
+    e->snapToGrid( currentVectorLayer()->geometryOptions().geometryPrecision );
 
   cadCanvasPressEvent( e );
 }
@@ -72,6 +76,9 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
     e->snapPoint();
   }
 
+  if ( currentVectorLayer() )
+    e->snapToGrid( currentVectorLayer()->geometryOptions().geometryPrecision );
+
   cadCanvasReleaseEvent( e );
 }
 
@@ -90,6 +97,9 @@ void QgsMapToolAdvancedDigitizing::canvasMoveEvent( QgsMapMouseEvent *e )
   {
     e->snapPoint();
   }
+
+  if ( currentVectorLayer() )
+    e->snapToGrid( currentVectorLayer()->geometryOptions().geometryPrecision );
 
   cadCanvasMoveEvent( e );
 }

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -150,9 +150,10 @@ bool QgsMapToolAdvancedDigitizing::snapToGridEnabled() const
 
 void QgsMapToolAdvancedDigitizing::setSnapToGridEnabled( bool snapToGridEnabled )
 {
+  mSnapToGridEnabled = snapToGridEnabled;
+
   if ( mSnapToGridCanvasItem )
   {
-    mSnapToGridEnabled = snapToGridEnabled;
     mSnapToGridCanvasItem->setEnabled( snapToGridEnabled );
   }
 }

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -43,7 +43,7 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
   }
 
   QgsVectorLayer *layer = currentVectorLayer();
-  if ( mSnapToGridEnabled && layer )
+  if ( mSnapToLayerGridEnabled && layer )
   {
     e->snapToGrid( layer->geometryFixes()->geometryPrecision(), layer->crs() );
   }
@@ -83,7 +83,7 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
   }
 
   QgsVectorLayer *layer = currentVectorLayer();
-  if ( mSnapToGridEnabled && layer )
+  if ( mSnapToLayerGridEnabled && layer )
   {
     e->snapToGrid( layer->geometryFixes()->geometryPrecision(), layer->crs() );
   }
@@ -108,7 +108,7 @@ void QgsMapToolAdvancedDigitizing::canvasMoveEvent( QgsMapMouseEvent *e )
   }
 
   QgsVectorLayer *layer = currentVectorLayer();
-  if ( mSnapToGridEnabled && layer )
+  if ( mSnapToLayerGridEnabled && layer )
   {
     e->snapToGrid( layer->geometryFixes()->geometryPrecision(), layer->crs() );
     mSnapToGridCanvasItem->setPoint( e->mapPoint() );
@@ -129,7 +129,7 @@ void QgsMapToolAdvancedDigitizing::activate()
     mSnapToGridCanvasItem->setCrs( currentVectorLayer()->crs() );
     mSnapToGridCanvasItem->setPrecision( currentVectorLayer()->geometryFixes()->geometryPrecision() );
   }
-  mSnapToGridCanvasItem->setEnabled( mSnapToGridEnabled );
+  mSnapToGridCanvasItem->setEnabled( mSnapToLayerGridEnabled );
 }
 
 void QgsMapToolAdvancedDigitizing::deactivate()
@@ -153,7 +153,7 @@ void QgsMapToolAdvancedDigitizing::onCurrentLayerChanged()
   if ( mSnapToGridCanvasItem )
   {
     QgsVectorLayer *layer = currentVectorLayer();
-    if ( layer && mSnapToGridEnabled )
+    if ( layer && mSnapToLayerGridEnabled )
     {
       mSnapToGridCanvasItem->setPrecision( layer->geometryFixes()->geometryPrecision() );
       mSnapToGridCanvasItem->setCrs( layer->crs() );
@@ -162,18 +162,18 @@ void QgsMapToolAdvancedDigitizing::onCurrentLayerChanged()
     if ( !layer )
       mSnapToGridCanvasItem->setEnabled( false );
     else
-      mSnapToGridCanvasItem->setEnabled( mSnapToGridEnabled );
+      mSnapToGridCanvasItem->setEnabled( mSnapToLayerGridEnabled );
   }
 }
 
-bool QgsMapToolAdvancedDigitizing::snapToGridEnabled() const
+bool QgsMapToolAdvancedDigitizing::snapToLayerGridEnabled() const
 {
-  return mSnapToGridEnabled;
+  return mSnapToLayerGridEnabled;
 }
 
-void QgsMapToolAdvancedDigitizing::setSnapToGridEnabled( bool snapToGridEnabled )
+void QgsMapToolAdvancedDigitizing::setSnapToLayerGridEnabled( bool snapToGridEnabled )
 {
-  mSnapToGridEnabled = snapToGridEnabled;
+  mSnapToLayerGridEnabled = snapToGridEnabled;
 
   if ( mSnapToGridCanvasItem )
   {

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -123,8 +123,12 @@ void QgsMapToolAdvancedDigitizing::activate()
   connect( mCadDockWidget, &QgsAdvancedDigitizingDockWidget::pointChanged, this, &QgsMapToolAdvancedDigitizing::cadPointChanged );
   mCadDockWidget->enable();
   mSnapToGridCanvasItem = new QgsSnapToGridCanvasItem( mCanvas );
-  mSnapToGridCanvasItem->setCrs( currentVectorLayer()->crs() );
-  mSnapToGridCanvasItem->setPrecision( currentVectorLayer()->geometryFixes()->geometryPrecision() );
+  QgsVectorLayer *layer = currentVectorLayer();
+  if ( layer )
+  {
+    mSnapToGridCanvasItem->setCrs( currentVectorLayer()->crs() );
+    mSnapToGridCanvasItem->setPrecision( currentVectorLayer()->geometryFixes()->geometryPrecision() );
+  }
   mSnapToGridCanvasItem->setEnabled( mSnapToGridEnabled );
 }
 
@@ -146,16 +150,20 @@ void QgsMapToolAdvancedDigitizing::cadPointChanged( const QgsPointXY &point )
 
 void QgsMapToolAdvancedDigitizing::onCurrentLayerChanged()
 {
-  QgsVectorLayer *layer = currentVectorLayer();
-  if ( mSnapToGridCanvasItem && layer && mSnapToGridEnabled )
+  if ( mSnapToGridCanvasItem )
   {
-    mSnapToGridCanvasItem->setPrecision( layer->geometryFixes()->geometryPrecision() );
-    mSnapToGridCanvasItem->setCrs( layer->crs() );
-    mSnapToGridCanvasItem->setEnabled( true );
-  }
+    QgsVectorLayer *layer = currentVectorLayer();
+    if ( layer && mSnapToGridEnabled )
+    {
+      mSnapToGridCanvasItem->setPrecision( layer->geometryFixes()->geometryPrecision() );
+      mSnapToGridCanvasItem->setCrs( layer->crs() );
+    }
 
-  if ( !layer )
-    mSnapToGridCanvasItem->setEnabled( false );
+    if ( !layer )
+      mSnapToGridCanvasItem->setEnabled( false );
+    else
+      mSnapToGridCanvasItem->setEnabled( mSnapToGridEnabled );
+  }
 }
 
 bool QgsMapToolAdvancedDigitizing::snapToGridEnabled() const

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -140,6 +140,20 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
      */
     virtual void cadCanvasMoveEvent( QgsMapMouseEvent *e ) { Q_UNUSED( e ) }
 
+    /**
+     * Enables or disables snap to grid of mouse events.
+     *
+     * \since QGIS 3.4
+     */
+    bool snapToGridEnabled() const;
+
+    /**
+     * Enables or disables snap to grid of mouse events.
+     *
+     * \since QGIS 3.4
+     */
+    void setSnapToGridEnabled( bool snapToGridEnabled );
+
   private slots:
 
     /**
@@ -159,6 +173,8 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     bool mAdvancedDigitizingAllowed = true;
     //! Whether to snap mouse cursor to map before passing coordinates to cadCanvas*Event()
     bool mAutoSnapEnabled = true;
+    //! Whether to snap to grid before passing coordinates to cadCanvas*Event()
+    bool mSnapToGridEnabled = true;
 };
 
 #endif // QGSMAPTOOLADVANCEDDIGITIZE_H

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -143,17 +143,19 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
 
     /**
      * Enables or disables snap to grid of mouse events.
+     * The snapping will occur in the layer's CRS.
      *
      * \since QGIS 3.4
      */
-    bool snapToGridEnabled() const;
+    bool snapToLayerGridEnabled() const;
 
     /**
      * Enables or disables snap to grid of mouse events.
+     * The snapping will occur in the layer's CRS.
      *
      * \since QGIS 3.4
      */
-    void setSnapToGridEnabled( bool snapToGridEnabled );
+    void setSnapToLayerGridEnabled( bool snapToLayerGridEnabled );
 
   private slots:
 
@@ -177,7 +179,7 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     //! Whether to snap mouse cursor to map before passing coordinates to cadCanvas*Event()
     bool mAutoSnapEnabled = true;
     //! Whether to snap to grid before passing coordinates to cadCanvas*Event()
-    bool mSnapToGridEnabled = true;
+    bool mSnapToLayerGridEnabled = true;
     QgsSnapToGridCanvasItem *mSnapToGridCanvasItem = nullptr;
 };
 

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -22,6 +22,7 @@
 
 class QgsMapMouseEvent;
 class QgsAdvancedDigitizingDockWidget;
+class QgsSnapToGridCanvasItem;
 
 /**
  * \ingroup gui
@@ -175,6 +176,7 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     bool mAutoSnapEnabled = true;
     //! Whether to snap to grid before passing coordinates to cadCanvas*Event()
     bool mSnapToGridEnabled = true;
+    QgsSnapToGridCanvasItem *mSnapToGridCanvasItem = nullptr;
 };
 
 #endif // QGSMAPTOOLADVANCEDDIGITIZE_H

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -167,6 +167,8 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
      */
     void cadPointChanged( const QgsPointXY &point );
 
+    void onCurrentLayerChanged();
+
   private:
     QgsAdvancedDigitizingDockWidget *mCadDockWidget = nullptr;
 

--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -1,0 +1,142 @@
+#include "qgssnaptogridcanvasitem.h"
+#include "qgsmapcanvas.h"
+
+QgsSnapToGridCanvasItem::QgsSnapToGridCanvasItem( QgsMapCanvas *mapCanvas )
+  : QgsMapCanvasItem( mapCanvas )
+  , mGridPen( QPen( QColor( 127, 127, 127, 150 ), 1 ) )
+  , mCurrentPointPen( QPen( QColor( 200, 200, 200, 150 ), 3 ) )
+{
+  updateMapCanvasCrs();
+  connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsSnapToGridCanvasItem::updateZoomFactor );
+  connect( mMapCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsSnapToGridCanvasItem::updateMapCanvasCrs );
+}
+
+void QgsSnapToGridCanvasItem::paint( QPainter *painter )
+{
+  painter->save();
+  QgsRectangle mapRect = mMapCanvas->extent();
+  if ( rect() != mapRect )
+    setRect( mapRect );
+
+  painter->setRenderHints( QPainter::Antialiasing );
+  painter->setCompositionMode( QPainter::CompositionMode_Difference );
+
+  if ( mEnabled && mAvailableByZoomFactor )
+  {
+    const QgsRectangle layerExtent = mTransform.transformBoundingBox( mapRect, QgsCoordinateTransform::ReverseTransform );
+    const QgsPointXY layerPt = mTransform.transform( mPoint, QgsCoordinateTransform::ReverseTransform );
+
+    const double gridXMin = std::ceil( layerExtent.xMinimum() / mPrecision ) * mPrecision;
+    const double gridXMax = std::ceil( layerExtent.xMaximum() / mPrecision ) * mPrecision;
+    const double gridYMin = std::ceil( layerExtent.yMinimum() / mPrecision ) * mPrecision;
+    const double gridYMax = std::ceil( layerExtent.yMaximum() / mPrecision ) * mPrecision;
+
+    for ( int x = gridXMin ; x < gridXMax; x += mPrecision )
+    {
+      for ( int y = gridYMin ; y < gridYMax; y += mPrecision )
+      {
+        const QgsPointXY pt = mTransform.transform( x, y );
+        const QPointF canvasPt = toCanvasCoordinates( pt );
+
+        if ( qgsDoubleNear( layerPt.x(), x, mPrecision / 3 ) && qgsDoubleNear( layerPt.y(), y, mPrecision / 3 ) )
+        {
+          painter->setPen( mCurrentPointPen );
+        }
+        else
+        {
+          painter->setPen( mGridPen );
+        }
+        painter->drawLine( canvasPt.x() - 3, canvasPt.y(), canvasPt.x() + 3, canvasPt.y() );
+        painter->drawLine( canvasPt.x(), canvasPt.y() - 3, canvasPt.x(), canvasPt.y() + 3 );
+      }
+    }
+  }
+
+  painter->restore();
+}
+
+QgsPointXY QgsSnapToGridCanvasItem::point() const
+{
+  return mPoint;
+}
+
+void QgsSnapToGridCanvasItem::setPoint( const QgsPointXY &point )
+{
+  mPoint = point;
+  update();
+}
+
+double QgsSnapToGridCanvasItem::precision() const
+{
+  return mPrecision;
+}
+
+void QgsSnapToGridCanvasItem::setPrecision( double precision )
+{
+  mPrecision = precision;
+  updateZoomFactor();
+}
+
+QgsCoordinateReferenceSystem QgsSnapToGridCanvasItem::crs() const
+{
+  return mTransform.sourceCrs();
+}
+
+void QgsSnapToGridCanvasItem::setCrs( const QgsCoordinateReferenceSystem &crs )
+{
+  mTransform.setSourceCrs( crs );
+  updateZoomFactor();
+}
+
+bool QgsSnapToGridCanvasItem::enabled() const
+{
+  return mEnabled;
+}
+
+void QgsSnapToGridCanvasItem::setEnabled( bool enabled )
+{
+  mEnabled = enabled;
+  update();
+}
+
+void QgsSnapToGridCanvasItem::updateMapCanvasCrs()
+{
+  mTransform.setContext( mMapCanvas->mapSettings().transformContext() );
+  mTransform.setDestinationCrs( mMapCanvas->mapSettings().destinationCrs() );
+  update();
+}
+
+
+
+void QgsSnapToGridCanvasItem::updateZoomFactor()
+{
+  if ( !isVisible() )
+    return;
+
+  try
+  {
+    const int threshold = 5;
+
+    const QgsPointXY centerPoint = mMapCanvas->extent().center();
+    const QPointF canvasCenter = toCanvasCoordinates( centerPoint );
+
+    const QgsPointXY pt1 = mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( canvasCenter.x() - threshold, canvasCenter.y() - threshold );
+    const QgsPointXY pt2 = mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( canvasCenter.x() + threshold, canvasCenter.y() + threshold );
+
+    const QgsPointXY layerPt1 = mTransform.transform( pt1, QgsCoordinateTransform::ReverseTransform );
+    const QgsPointXY layerPt2 = mTransform.transform( pt2, QgsCoordinateTransform::ReverseTransform );
+
+    const double dist = layerPt1.distance( layerPt2 );
+
+    if ( dist < mPrecision )
+      mAvailableByZoomFactor = true;
+    else
+      mAvailableByZoomFactor = false;
+  }
+  catch ( QgsCsException &e )
+  {
+    // transform errors?
+    // you've probably got worse problems than the grid with your digitizing operations in the current projection.
+    mAvailableByZoomFactor = false;
+  }
+}

--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -37,6 +37,12 @@ void QgsSnapToGridCanvasItem::paint( QPainter *painter )
   painter->setRenderHints( QPainter::Antialiasing );
   painter->setCompositionMode( QPainter::CompositionMode_Difference );
 
+  double scaleFactor = painter->fontMetrics().xHeight() * .2;
+
+  mGridPen.setWidth( scaleFactor );
+  mCurrentPointPen.setWidth( scaleFactor * 3 );
+  const int gridMarkerLength = scaleFactor * 3;
+
   try
   {
     const QgsRectangle layerExtent = mTransform.transformBoundingBox( mapRect, QgsCoordinateTransform::ReverseTransform );
@@ -54,7 +60,7 @@ void QgsSnapToGridCanvasItem::paint( QPainter *painter )
         const QgsPointXY pt = mTransform.transform( x, y );
         const QPointF canvasPt = toCanvasCoordinates( pt );
 
-        if ( qgsDoubleNear( layerPt.x(), x, mPrecision / 3 ) && qgsDoubleNear( layerPt.y(), y, mPrecision / 3 ) )
+        if ( qgsDoubleNear( layerPt.x(), x, mPrecision / 2 ) && qgsDoubleNear( layerPt.y(), y, mPrecision / 2 ) )
         {
           painter->setPen( mCurrentPointPen );
         }
@@ -62,8 +68,8 @@ void QgsSnapToGridCanvasItem::paint( QPainter *painter )
         {
           painter->setPen( mGridPen );
         }
-        painter->drawLine( canvasPt.x() - 3, canvasPt.y(), canvasPt.x() + 3, canvasPt.y() );
-        painter->drawLine( canvasPt.x(), canvasPt.y() - 3, canvasPt.x(), canvasPt.y() + 3 );
+        painter->drawLine( canvasPt.x() - gridMarkerLength, canvasPt.y(), canvasPt.x() + gridMarkerLength, canvasPt.y() );
+        painter->drawLine( canvasPt.x(), canvasPt.y() - gridMarkerLength, canvasPt.x(), canvasPt.y() + gridMarkerLength );
 
       }
     }

--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -18,8 +18,6 @@
 
 QgsSnapToGridCanvasItem::QgsSnapToGridCanvasItem( QgsMapCanvas *mapCanvas )
   : QgsMapCanvasItem( mapCanvas )
-  , mGridPen( QPen( QColor( 127, 127, 127, 150 ), 1 ) )
-  , mCurrentPointPen( QPen( QColor( 200, 200, 200, 150 ), 3 ) )
 {
   updateMapCanvasCrs();
   connect( mMapCanvas, &QgsMapCanvas::extentsChanged, this, &QgsSnapToGridCanvasItem::updateZoomFactor );

--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -38,32 +38,41 @@ void QgsSnapToGridCanvasItem::paint( QPainter *painter )
 
   if ( mEnabled && mAvailableByZoomFactor )
   {
-    const QgsRectangle layerExtent = mTransform.transformBoundingBox( mapRect, QgsCoordinateTransform::ReverseTransform );
-    const QgsPointXY layerPt = mTransform.transform( mPoint, QgsCoordinateTransform::ReverseTransform );
-
-    const double gridXMin = std::ceil( layerExtent.xMinimum() / mPrecision ) * mPrecision;
-    const double gridXMax = std::ceil( layerExtent.xMaximum() / mPrecision ) * mPrecision;
-    const double gridYMin = std::ceil( layerExtent.yMinimum() / mPrecision ) * mPrecision;
-    const double gridYMax = std::ceil( layerExtent.yMaximum() / mPrecision ) * mPrecision;
-
-    for ( int x = gridXMin ; x < gridXMax; x += mPrecision )
+    try
     {
-      for ( int y = gridYMin ; y < gridYMax; y += mPrecision )
-      {
-        const QgsPointXY pt = mTransform.transform( x, y );
-        const QPointF canvasPt = toCanvasCoordinates( pt );
+      const QgsRectangle layerExtent = mTransform.transformBoundingBox( mapRect, QgsCoordinateTransform::ReverseTransform );
+      const QgsPointXY layerPt = mTransform.transform( mPoint, QgsCoordinateTransform::ReverseTransform );
 
-        if ( qgsDoubleNear( layerPt.x(), x, mPrecision / 3 ) && qgsDoubleNear( layerPt.y(), y, mPrecision / 3 ) )
+      const double gridXMin = std::ceil( layerExtent.xMinimum() / mPrecision ) * mPrecision;
+      const double gridXMax = std::ceil( layerExtent.xMaximum() / mPrecision ) * mPrecision;
+      const double gridYMin = std::ceil( layerExtent.yMinimum() / mPrecision ) * mPrecision;
+      const double gridYMax = std::ceil( layerExtent.yMaximum() / mPrecision ) * mPrecision;
+
+      for ( int x = gridXMin ; x < gridXMax; x += mPrecision )
+      {
+        for ( int y = gridYMin ; y < gridYMax; y += mPrecision )
         {
-          painter->setPen( mCurrentPointPen );
+          const QgsPointXY pt = mTransform.transform( x, y );
+          const QPointF canvasPt = toCanvasCoordinates( pt );
+
+          if ( qgsDoubleNear( layerPt.x(), x, mPrecision / 3 ) && qgsDoubleNear( layerPt.y(), y, mPrecision / 3 ) )
+          {
+            painter->setPen( mCurrentPointPen );
+          }
+          else
+          {
+            painter->setPen( mGridPen );
+          }
+          painter->drawLine( canvasPt.x() - 3, canvasPt.y(), canvasPt.x() + 3, canvasPt.y() );
+          painter->drawLine( canvasPt.x(), canvasPt.y() - 3, canvasPt.x(), canvasPt.y() + 3 );
+
         }
-        else
-        {
-          painter->setPen( mGridPen );
-        }
-        painter->drawLine( canvasPt.x() - 3, canvasPt.y(), canvasPt.x() + 3, canvasPt.y() );
-        painter->drawLine( canvasPt.x(), canvasPt.y() - 3, canvasPt.x(), canvasPt.y() + 3 );
       }
+    }
+    catch ( QgsCsException &e )
+    {
+      Q_UNUSED( e )
+      mAvailableByZoomFactor = false;
     }
   }
 

--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -1,3 +1,18 @@
+/***************************************************************************
+    qgssnaptogridcanvasitem.cpp
+    ----------------------
+    begin                : August 2018
+    copyright            : (C) Matthias Kuhn
+    email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "qgssnaptogridcanvasitem.h"
 #include "qgsmapcanvas.h"
 

--- a/src/gui/qgssnaptogridcanvasitem.h
+++ b/src/gui/qgssnaptogridcanvasitem.h
@@ -1,0 +1,98 @@
+#ifndef QGSSNAPTOGRIDCANVASITEM_H
+#define QGSSNAPTOGRIDCANVASITEM_H
+
+#include <QObject>
+#include <QPen>
+
+#include "qgscoordinatereferencesystem.h"
+#include "qgsmapcanvasitem.h"
+#include "qgscoordinatetransform.h"
+
+/**
+ * \ingroup gui
+ *
+ * Shows a grid on the map canvas given a spatial resolution.
+ *
+ * \since QGIS 3.4
+ */
+class GUI_EXPORT QgsSnapToGridCanvasItem : public QObject, public QgsMapCanvasItem
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Will automatically be added to the \a mapCanvas.
+     */
+    QgsSnapToGridCanvasItem( QgsMapCanvas *mapCanvas );
+
+    void paint( QPainter *painter ) override;
+
+    /**
+     * A point that will be highlighted on the map canvas.
+     * The point needs to be in map coordinates. The closest point on the
+     * grid will be highlighted.
+     */
+    QgsPointXY point() const;
+
+    /**
+     * A point that will be highlighted on the map canvas.
+     * The point needs to be in map coordinates. The closest point on the
+     * grid will be highlighted.
+     */
+    void setPoint( const QgsPointXY &point );
+
+    /**
+     * The resolution of the grid in map units.
+     * If a crs has been specified it will be in CRS units.
+     */
+    double precision() const;
+
+    /**
+     * The resolution of the grid in map units.
+     * If a crs has been specified it will be in CRS units.
+     */
+    void setPrecision( double precision );
+
+    /**
+     * The CRS in which the grid should be calculated.
+     * By default will be an invalid QgsCoordinateReferenceSystem and
+     * as such equal to the CRS of the map canvas.
+     */
+    QgsCoordinateReferenceSystem crs() const;
+
+    /**
+     * The CRS in which the grid should be calculated.
+     * By default will be an invalid QgsCoordinateReferenceSystem and
+     * as such equal to the CRS of the map canvas.
+     */
+    void setCrs( const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Enable this item. It will be hidden if disabled.
+     */
+    bool enabled() const;
+
+    /**
+     * Enable this item. It will be hidden if disabled.
+     */
+    void setEnabled( bool enabled );
+
+  private slots:
+    void updateMapCanvasCrs();
+
+    void updateZoomFactor();
+
+  private:
+    QPen mGridPen;
+    QPen mCurrentPointPen;
+
+    bool mEnabled = true;
+    bool mAvailableByZoomFactor = false;
+
+    double mPrecision = 0.0;
+    QgsCoordinateTransform mTransform;
+    QgsPointXY mPoint;
+};
+
+#endif // QGSSNAPTOGRIDCANVASITEM_H

--- a/src/gui/qgssnaptogridcanvasitem.h
+++ b/src/gui/qgssnaptogridcanvasitem.h
@@ -99,8 +99,8 @@ class GUI_EXPORT QgsSnapToGridCanvasItem : public QObject, public QgsMapCanvasIt
     void updateZoomFactor();
 
   private:
-    QPen mGridPen;
-    QPen mCurrentPointPen;
+    QPen mGridPen = QPen( QColor( 127, 127, 127, 150 ) );
+    QPen mCurrentPointPen = QPen( QColor( 200, 200, 200, 150 ) );
 
     bool mEnabled = true;
     bool mAvailableByZoomFactor = false;

--- a/src/gui/qgssnaptogridcanvasitem.h
+++ b/src/gui/qgssnaptogridcanvasitem.h
@@ -39,7 +39,7 @@ class GUI_EXPORT QgsSnapToGridCanvasItem : public QObject, public QgsMapCanvasIt
     /**
      * Will automatically be added to the \a mapCanvas.
      */
-    QgsSnapToGridCanvasItem( QgsMapCanvas *mapCanvas );
+    QgsSnapToGridCanvasItem( QgsMapCanvas *mapCanvas SIP_TRANSFERTHIS );
 
     void paint( QPainter *painter ) override;
 

--- a/src/gui/qgssnaptogridcanvasitem.h
+++ b/src/gui/qgssnaptogridcanvasitem.h
@@ -1,3 +1,18 @@
+/***************************************************************************
+    qgssnaptogridcanvasitem.h
+    ----------------------
+    begin                : August 2018
+    copyright            : (C) Matthias Kuhn
+    email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #ifndef QGSSNAPTOGRIDCANVASITEM_H
 #define QGSSNAPTOGRIDCANVASITEM_H
 


### PR DESCRIPTION
## Description

Map tools based on QgsMapToolAdvancedDigitizing will automatically snap to grid if layer precision has been activated for the current layer.
Depending on the zoom level, a grid is shown.

The grid has been disabled for the split feature and split part tools. There are probably others that will need to disable it as well.

Followup https://github.com/qgis/QGIS/pull/7672

![peek 2018-08-26 09-15](https://user-images.githubusercontent.com/588407/44625738-b9686e80-a910-11e8-99a3-89fc24e1ac43.gif)
