### PR TITLE
Always show deprecated plugins

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -724,14 +724,12 @@ class Plugins(QObject):
             self.mPlugins[i] = self.localCache[i].copy()
         settings = QgsSettings()
         allowExperimental = settings.value(settingsGroup + "/allowExperimental", False, type=bool)
-        allowDeprecated = settings.value(settingsGroup + "/allowDeprecated", False, type=bool)
         for i in list(self.repoCache.values()):
             for j in i:
                 plugin = j.copy()  # do not update repoCache elements!
                 key = plugin["id"]
                 # check if the plugin is allowed and if there isn't any better one added already.
                 if (allowExperimental or not plugin["experimental"]) \
-                   and (allowDeprecated or not plugin["deprecated"]) \
                    and not (key in self.mPlugins and self.mPlugins[key]["version_available"] and compareVersions(self.mPlugins[key]["version_available"], plugin["version_available"]) < 2):
                     # The mPlugins dict contains now locally installed plugins.
                     # Now, add the available one if not present yet or update it if present already.

--- a/src/app/pluginmanager/qgspluginitemdelegate.cpp
+++ b/src/app/pluginmanager/qgspluginitemdelegate.cpp
@@ -21,6 +21,7 @@
 #include <QStyleOptionViewItem>
 #include <QModelIndex>
 #include <QApplication>
+#include "qgsapplication.h"
 #include "qgspluginsortfilterproxymodel.h"
 
 
@@ -65,11 +66,17 @@ void QgsPluginItemDelegate::paint( QPainter *painter, const QStyleOptionViewItem
 
   // Draw the icon
   QPixmap iconPixmap = index.data( Qt::DecorationRole ).value<QPixmap>();
+  int iconSize = pixelsHigh;
 
   if ( !iconPixmap.isNull() )
   {
-    int iconSize = pixelsHigh;
     painter->drawPixmap( option.rect.left() + 1.2 * pixelsHigh, option.rect.top() + 0.2 * pixelsHigh, iconSize, iconSize, iconPixmap );
+  }
+
+  if ( index.data( PLUGIN_DEPRECATED_ROLE ).toString() == QLatin1String( "true" ) )
+  {
+    QPixmap warningPixmap = QPixmap( QgsApplication::defaultThemePath() + "/mIconWarning.svg" );
+    painter->drawPixmap( option.rect.right() - 1.2 * pixelsHigh, option.rect.top() + 0.2 * pixelsHigh, iconSize, iconSize, warningPixmap );
   }
 
   // Draw the text

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -533,6 +533,7 @@ void QgsPluginManager::reloadModelData()
       mypDetailItem->setData( it->value( QStringLiteral( "downloads" ) ).rightJustified( 10, '0' ), PLUGIN_DOWNLOADS_ROLE );
       mypDetailItem->setData( it->value( QStringLiteral( "zip_repository" ) ), PLUGIN_REPOSITORY_ROLE );
       mypDetailItem->setData( it->value( QStringLiteral( "average_vote" ) ), PLUGIN_VOTE_ROLE );
+      mypDetailItem->setData( it->value( QStringLiteral( "deprecated" ) ), PLUGIN_DEPRECATED_ROLE );
 
       if ( QFileInfo( iconPath ).isFile() )
       {

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -81,7 +81,6 @@ QgsPluginManager::QgsPluginManager( QWidget *parent, bool pluginsAreEnabled, Qt:
   connect( buttonDeleteRep, &QPushButton::clicked, this, &QgsPluginManager::buttonDeleteRep_clicked );
   connect( buttonRefreshRepos, &QPushButton::clicked, this, &QgsPluginManager::buttonRefreshRepos_clicked );
   connect( ckbExperimental, &QgsCollapsibleGroupBox::toggled, this, &QgsPluginManager::ckbExperimental_toggled );
-  connect( ckbDeprecated, &QgsCollapsibleGroupBox::toggled, this, &QgsPluginManager::ckbDeprecated_toggled );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsPluginManager::showHelp );
 
   // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,
@@ -228,11 +227,6 @@ void QgsPluginManager::setPythonUtils( QgsPythonUtils *pythonUtils )
   if ( settings.value( settingsGroup + "/allowExperimental", false ).toBool() )
   {
     ckbExperimental->setChecked( true );
-  }
-
-  if ( settings.value( settingsGroup + "/allowDeprecated", false ).toBool() )
-  {
-    ckbDeprecated->setChecked( true );
   }
 
   int interval = settings.value( settingsGroup + "/checkOnStartInterval", "" ).toInt();
@@ -1480,16 +1474,6 @@ void QgsPluginManager::ckbExperimental_toggled( bool state )
   QgsPythonRunner::eval( QStringLiteral( "pyplugin_installer.instance().exportSettingsGroup()" ), settingsGroup );
   QgsSettings settings;
   settings.setValue( settingsGroup + "/allowExperimental", QVariant( state ) );
-  QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.installer_data.plugins.rebuild()" ) );
-  QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.instance().exportPluginsToManager()" ) );
-}
-
-void QgsPluginManager::ckbDeprecated_toggled( bool state )
-{
-  QString settingsGroup;
-  QgsPythonRunner::eval( QStringLiteral( "pyplugin_installer.instance().exportSettingsGroup()" ), settingsGroup );
-  QgsSettings settings;
-  settings.setValue( settingsGroup + "/allowDeprecated", QVariant( state ) );
   QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.installer_data.plugins.rebuild()" ) );
   QgsPythonRunner::run( QStringLiteral( "pyplugin_installer.instance().exportPluginsToManager()" ) );
 }

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -165,9 +165,6 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     //! Reload plugin metadata registry after allowing/disallowing experimental plugins
     void ckbExperimental_toggled( bool state );
 
-    //! Reload plugin metadata registry after allowing/disallowing deprecated plugins
-    void ckbDeprecated_toggled( bool state );
-
     //! Open help browser
     void showHelp();
 

--- a/src/app/pluginmanager/qgspluginsortfilterproxymodel.h
+++ b/src/app/pluginmanager/qgspluginsortfilterproxymodel.h
@@ -30,6 +30,7 @@ const int PLUGIN_STATUS_ROLE = Qt::UserRole + 6;       // for filtering and sort
 const int PLUGIN_DOWNLOADS_ROLE = Qt::UserRole + 7;    // for sorting
 const int PLUGIN_VOTE_ROLE = Qt::UserRole + 8;         // for sorting
 const int PLUGIN_REPOSITORY_ROLE = Qt::UserRole + 9;   // for sorting
+const int PLUGIN_DEPRECATED_ROLE = Qt::UserRole + 10;  // for styling
 const int SPACER_ROLE = Qt::UserRole + 20;  // for sorting
 
 

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>875</width>
-    <height>471</height>
+    <width>913</width>
+    <height>538</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -60,7 +60,16 @@
        <property name="spacing">
         <number>0</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -236,7 +245,16 @@
        <property name="spacing">
         <number>6</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -355,7 +373,16 @@
                   <enum>QFrame::Sunken</enum>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_12">
-                  <property name="margin">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
                    <number>0</number>
                   </property>
                   <item>
@@ -767,7 +794,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_3">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -783,8 +819,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>460</width>
-                   <height>613</height>
+                   <width>430</width>
+                   <height>565</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -800,7 +836,7 @@
                      </sizepolicy>
                     </property>
                     <property name="title">
-                     <string>Check for updates on startup</string>
+                     <string>Check for &amp;updates on startup</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -884,7 +920,7 @@ p, li { white-space: pre-wrap; }
                   <item>
                    <widget class="QgsCollapsibleGroupBox" name="ckbExperimental">
                     <property name="title">
-                     <string>Show also experimental plugins</string>
+                     <string>Show a&amp;lso experimental plugins</string>
                     </property>
                     <property name="checkable">
                      <bool>true</bool>
@@ -922,62 +958,6 @@ p, li { white-space: pre-wrap; }
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'DejaVu Sans'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Experimental plugins are generally unsuitable for production use. These plugins are in early stages of development, and should be considered 'incomplete' or 'proof of concept' tools. QGIS does not recommend installing these plugins unless you intend to use them for testing purposes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                       </property>
-                       <property name="textFormat">
-                        <enum>Qt::RichText</enum>
-                       </property>
-                       <property name="alignment">
-                        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-                       </property>
-                       <property name="wordWrap">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QgsCollapsibleGroupBox" name="ckbDeprecated">
-                    <property name="title">
-                     <string>Show also deprecated plugins</string>
-                    </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checked">
-                     <bool>false</bool>
-                    </property>
-                    <property name="collapsed" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="saveCheckedState" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                    <property name="saveCollapsedState" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_11">
-                     <item>
-                      <widget class="QLabel" name="lblDeprecated">
-                       <property name="sizePolicy">
-                        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-                         <horstretch>0</horstretch>
-                         <verstretch>0</verstretch>
-                        </sizepolicy>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>0</width>
-                         <height>0</height>
-                        </size>
-                       </property>
-                       <property name="text">
-                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Droid Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt; font-weight:600;&quot;&gt;Note:&lt;/span&gt;&lt;span style=&quot; font-family:'DejaVu Sans'; font-size:9pt;&quot;&gt; Deprecated plugins are generally unsuitable for production use. These plugins are unmaintained, and should be considered 'obsolete' tools. QGIS does not recommend installing these plugins unless you still need it and there are no other alternatives available.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="textFormat">
                         <enum>Qt::RichText</enum>


### PR DESCRIPTION
Always show deprecated plugins by removing the option in the Plugin manager to hide them (fixes https://issues.qgis.org/issues/19125 ).
Also mark them by a warning sign on the list (currently we don't have any deprecated 3.0 plugins yet, so I made a fake one):

![screenshot_20180826_152426](https://user-images.githubusercontent.com/1000043/44628647-32cd8480-a944-11e8-95bb-ec678dd003d7.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
