### PR TITLE
Fix references to contributors.json

### DIFF
--- a/debian/qgis-common.install
+++ b/debian/qgis-common.install
@@ -5,7 +5,6 @@ usr/share/qgis/doc/INSTALL
 usr/share/qgis/doc/INSTALL.html
 usr/share/qgis/doc/SPONSORS
 usr/share/qgis/doc/TRANSLATORS
-usr/share/qgis/doc/contributors.json
 usr/share/qgis/doc/developersmap.html
 usr/share/qgis/doc/favicon.ico
 usr/share/qgis/doc/images

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -23,7 +23,7 @@ ELSE(TXT2TAGS_EXECUTABLE)
   )
 ENDIF(TXT2TAGS_EXECUTABLE)
 
-SET(QGIS_DOC_FILES ${QGIS_DOC_FILES} index.html news.html developersmap.html nohelp.html contributors.json favicon.ico style.css AUTHORS CONTRIBUTORS SPONSORS DONORS TRANSLATORS LICENSE)
+SET(QGIS_DOC_FILES ${QGIS_DOC_FILES} index.html news.html developersmap.html nohelp.html favicon.ico style.css AUTHORS CONTRIBUTORS SPONSORS DONORS TRANSLATORS LICENSE)
 
 INSTALL(FILES ${QGIS_DOC_FILES} DESTINATION ${QGIS_DATA_DIR}/doc)
 INSTALL(FILES ../images/icons/qgis-icon-60x60.png DESTINATION ${QGIS_DATA_DIR}/doc/images)

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -200,7 +200,7 @@ but don't have commit access. *
 %Docstring
 Returns the path to the developers map file.
 The developers map was created by using leaflet framework,
-it shows the doc/contributors.json file.
+it shows the contributors.json file.
 
 .. versionadded:: 2.7
 %End

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     /**
      * Returns the path to the developers map file.
      * The developers map was created by using leaflet framework,
-     * it shows the doc/contributors.json file.
+     * it shows the contributors.json file.
      * \since QGIS 2.7 */
     static QString developersMapFilePath();
 


### PR DESCRIPTION
## Description
@timlinux , a couple of cleanups following your new Easter eggs. Feel free to merge at will.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
