### PR TITLE
Fix "Pole of inaccessibility" parameter's label

### DIFF
--- a/python/plugins/processing/algs/qgis/PoleOfInaccessibility.py
+++ b/python/plugins/processing/algs/qgis/PoleOfInaccessibility.py
@@ -75,7 +75,7 @@ class PoleOfInaccessibility(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterFeatureSource(self.INPUT, self.tr('Input layer'),
                                                               [QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterDistance(self.TOLERANCE,
-                                                         self.tr('Tolerance (layer units)'),
+                                                         self.tr('Tolerance'),
                                                          parentParameterName=self.INPUT,
                                                          defaultValue=1.0, minValue=0.0))
 


### PR DESCRIPTION
Because all values are in layer units now and they can be overridden