### PR TITLE
[mac] display icon in notification

### DIFF
--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -115,8 +115,9 @@ QgsGui::~QgsGui()
 QgsGui::QgsGui()
 {
 #ifdef Q_OS_MAC
-  const QString iconPath = QgsApplication::iconsPath() + QStringLiteral( "qgis-icon-macos.png" );
-  mNative = new QgsMacNative( iconPath );
+  QgsMacNative *macNative = new QgsMacNative();
+  macNative->setIconPath( QgsApplication::iconsPath() + QStringLiteral( "qgis-icon-macos.png" ) );
+  mNative = macNative;
 #elif defined (Q_OS_WIN)
   mNative = new QgsWinNative();
 #elif defined(Q_OS_LINUX)

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -115,7 +115,8 @@ QgsGui::~QgsGui()
 QgsGui::QgsGui()
 {
 #ifdef Q_OS_MAC
-  mNative = new QgsMacNative();
+  const QString iconPath = QgsApplication::iconsPath() + QStringLiteral( "qgis-icon-macos.png" );
+  mNative = new QgsMacNative( iconPath );
 #elif defined (Q_OS_WIN)
   mNative = new QgsWinNative();
 #elif defined(Q_OS_LINUX)

--- a/src/native/mac/qgsmacnative.h
+++ b/src/native/mac/qgsmacnative.h
@@ -26,8 +26,11 @@ class QString;
 class NATIVE_EXPORT QgsMacNative : public QgsNative
 {
   public:
-    explicit QgsMacNative( const QString &iconPath = QString() );
+    explicit QgsMacNative();
     ~QgsMacNative() override;
+
+    //! reset the application icon used in the notification
+    void setIconPath( const QString &iconPath = QString() );
 
     virtual const char *currentAppLocalizedName();
     void currentAppActivateIgnoringOtherApps() override;

--- a/src/native/mac/qgsmacnative.h
+++ b/src/native/mac/qgsmacnative.h
@@ -26,7 +26,7 @@ class QString;
 class NATIVE_EXPORT QgsMacNative : public QgsNative
 {
   public:
-    explicit QgsMacNative();
+    explicit QgsMacNative( const QString &iconPath = QString() );
     ~QgsMacNative() override;
 
     virtual const char *currentAppLocalizedName();

--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -45,18 +45,22 @@ class QgsMacNative::QgsUserNotificationCenter
     NSImage *_qgisIcon;
 };
 
-QgsMacNative::QgsMacNative( const QString &iconPath )
+QgsMacNative::QgsMacNative()
   : mQgsUserNotificationCenter( new QgsMacNative::QgsUserNotificationCenter() )
 {
   mQgsUserNotificationCenter->_qgsUserNotificationCenter = [[QgsUserNotificationCenterDelegate alloc] init];
   [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate: mQgsUserNotificationCenter->_qgsUserNotificationCenter];
-  mQgsUserNotificationCenter->_qgisIcon = QtMac::toNSImage( QPixmap( iconPath ) );
 }
 
 QgsMacNative::~QgsMacNative()
 {
   [mQgsUserNotificationCenter->_qgsUserNotificationCenter dealloc];
   delete mQgsUserNotificationCenter;
+}
+
+void QgsMacNative::setIconPath( const QString &iconPath )
+{
+  mQgsUserNotificationCenter->_qgisIcon = QtMac::toNSImage( QPixmap( iconPath ) );
 }
 
 const char *QgsMacNative::currentAppLocalizedName()

--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -42,13 +42,15 @@ class QgsMacNative::QgsUserNotificationCenter
 {
   public:
     QgsUserNotificationCenterDelegate *_qgsUserNotificationCenter;
+    NSImage *_qgisIcon;
 };
 
-QgsMacNative::QgsMacNative()
+QgsMacNative::QgsMacNative( const QString &iconPath )
   : mQgsUserNotificationCenter( new QgsMacNative::QgsUserNotificationCenter() )
 {
   mQgsUserNotificationCenter->_qgsUserNotificationCenter = [[QgsUserNotificationCenterDelegate alloc] init];
   [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate: mQgsUserNotificationCenter->_qgsUserNotificationCenter];
+  mQgsUserNotificationCenter->_qgisIcon = QtMac::toNSImage( QPixmap( iconPath ) );
 }
 
 QgsMacNative::~QgsMacNative()
@@ -92,7 +94,10 @@ QgsNative::NotificationResult QgsMacNative::showDesktopNotification( const QStri
   NSImage *image = nil;
   if ( settings.image.isNull() )
   {
-    image = [[NSImage imageNamed:@"NSApplicationIcon"] retain];
+    // image application (qgis.icns) seems not to be set for now, although present in the plist
+    // whenever fixed, try following line (and remove corresponding code in QgsMacNative::QgsUserNotificationCenter)
+    // image = [[NSImage imageNamed:@"NSApplicationIcon"] retain]
+    image = mQgsUserNotificationCenter->_qgisIcon;
   }
   else
   {


### PR DESCRIPTION
there is 2 icons in notifications, one from the app itself and one set from the notification
the icon application seems not to be set correctly on mac for now
only the windon icon is set in main.cpp with myApp.setWindowIcon
the icon defined in application plist does not seem to be correctly set
...so in this PR we set the notification icon to be the QGIS one, so it looks nicer

