### PR TITLE
Fix trusty build (QStringLiteral is Qt5; followup 9241e2d)

### DIFF
--- a/tests/src/app/testqgisappclipboard.cpp
+++ b/tests/src/app/testqgisappclipboard.cpp
@@ -296,7 +296,7 @@ void TestQgisAppClipboard::pasteWkt()
   QCOMPARE( features.at( 1 ).attributes().at( 0 ).toString(), QString( "3" ) );
   QCOMPARE( features.at( 1 ).attributes().at( 1 ).toString(), QString( "c3" ) );
   QCOMPARE( features.at( 1 ).attributes().at( 2 ).toString(), QString( "4" ) );
-  QCOMPARE( features.at( 2 ).constGeometry()->exportToWkt(), QStringLiteral( "Point (5 4)" ) );
+  QCOMPARE( features.at( 2 ).constGeometry()->exportToWkt(), QString( "Point (5 4)" ) );
   QCOMPARE( features.at( 2 ).attributes().count(), 3 );
   QCOMPARE( features.at( 2 ).attributes().at( 0 ).toString(), QString( "2" ) );
   QCOMPARE( features.at( 2 ).attributes().at( 1 ).toString(), QString( "b2" ) );


### PR DESCRIPTION
## Description
When cherry-picking 079c9fa: Expand unit test coverage, all the QStringLiteral were not replaced by QString.

## Checklist
- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
