### PR TITLE
Fix Virtual layers incorrectly displaying when expression filter is empty

### DIFF
--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -65,7 +65,7 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
     QStringList wheres;
     QString offset;
     QString subset = mSource->mSubset;
-    if ( !subset.isNull() )
+    if ( !subset.isEmpty() )
     {
       wheres << subset;
     }


### PR DESCRIPTION
## Description
Fixes [#19721](https://issues.qgis.org/issues/19721)

Virtual layers incorrectly show no feature when the expression filter string is empty, instead of correctly showing all the features.

QGIS 2.18.23 and QGIS 3.3.0-master are affected.

Subset string needs to be tested against Empty instead of Null in order to correctly populate the wheres list and prepare a well formed SQL query string.

@mhugo, could you please review/test this PR?

See also [[QGIS-Developer] "Filter on joined fields" and Virtual layers not working as expected](http://osgeo-org.1560.x6.nabble.com/QGIS-Developer-quot-Filter-on-joined-fields-quot-and-Virtual-layers-not-working-as-expected-td5375672.html)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
