### PR TITLE
[processing] Fix 'equals' predicate in SpatialJoin

### DIFF
--- a/python/plugins/processing/algs/qgis/SpatialJoin.py
+++ b/python/plugins/processing/algs/qgis/SpatialJoin.py
@@ -83,7 +83,7 @@ class SpatialJoin(QgisAlgorithm):
 
         self.reversed_predicates = {'intersects': 'intersects',
                                     'contains': 'within',
-                                    'isEqual': 'isEqual',
+                                    'equals': 'equals',
                                     'touches': 'touches',
                                     'overlaps': 'overlaps',
                                     'within': 'contains',


### PR DESCRIPTION
## Description
This fixes a typo in SpatialJoin.py "Join attributes by location" algorithm that prevents the 'equals' predicate to work.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
