### PR TITLE
[processing] Fix 'equals' predicate in SpatialJoin and SpatialJoinSummary

### DIFF
--- a/python/plugins/processing/algs/qgis/SpatialJoin.py
+++ b/python/plugins/processing/algs/qgis/SpatialJoin.py
@@ -75,7 +75,7 @@ class SpatialJoin(QgisAlgorithm):
         self.predicates = (
             ('intersects', self.tr('intersects')),
             ('contains', self.tr('contains')),
-            ('equals', self.tr('equals')),
+            ('isEqual', self.tr('equals')),
             ('touches', self.tr('touches')),
             ('overlaps', self.tr('overlaps')),
             ('within', self.tr('within')),

--- a/python/plugins/processing/algs/qgis/SpatialJoinSummary.py
+++ b/python/plugins/processing/algs/qgis/SpatialJoinSummary.py
@@ -85,7 +85,7 @@ class SpatialJoinSummary(QgisAlgorithm):
         self.predicates = (
             ('intersects', self.tr('intersects')),
             ('contains', self.tr('contains')),
-            ('equals', self.tr('equals')),
+            ('isEqual', self.tr('equals')),
             ('touches', self.tr('touches')),
             ('overlaps', self.tr('overlaps')),
             ('within', self.tr('within')),

--- a/python/plugins/processing/tests/testdata/custom/polys_2.gml
+++ b/python/plugins/processing/tests/testdata/custom/polys_2.gml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ polys_2.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>6.5</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                     
+  <gml:featureMember>
+    <ogr:polys_2 fid="polys_2.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1,-1 -1,3 3,3 3,2 2,2 2,-1 -1,-1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>-0.5,1.5 1.5,1.5 1.5,-0.5 -0.5,-0.5 -0.5,1.5</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aaaaa</ogr:name>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+    </ogr:polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polys_2 fid="polys_2.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>5.70060344827592,5.27698275862071 6.70060344827592,4.27698275862071 4.70060344827592,4.27698275862071 5.70060344827592,5.27698275862071</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>Aaaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0</ogr:floatval>
+    </ogr:polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polys_2 fid="polys_2.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2.2,5.2 2.2,5.8 2.8,5.8 2.8,5.2 2.2,5.2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bbaaa</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polys_2 fid="polys_2.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 10,1 10,-3 6,-3 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>7,0 7,-2 9,-2 9,0 7,0</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+    </ogr:polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polys_2 fid="polys_2.4">
+      <ogr:name xsi:nil="true"/>
+      <ogr:intval>120</ogr:intval>
+      <ogr:floatval>-100291.43213</ogr:floatval>
+    </ogr:polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:polys_2 fid="polys_2.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>1.5,6.5 3.5,6.5 3.5,4.5 1.5,4.5 1.5,6.5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>1.8,6.2 3.2,6.2 3.2,4.8 1.8,4.8 1.8,6.2</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>ghgd4</ogr:name>
+      <ogr:intval>15</ogr:intval>
+      <ogr:floatval>6.3</ogr:floatval>
+    </ogr:polys_2>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/custom/polys_2.xsd
+++ b/python/plugins/processing/tests/testdata/custom/polys_2.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="polys_2" type="ogr:polys_2_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="polys_2_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="255"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/join_by_location_equals.gml
+++ b/python/plugins/processing/tests/testdata/expected/join_by_location_equals.gml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ join_by_location_equals.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>6</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>10</gml:X><gml:Y>1</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                        
+  <gml:featureMember>
+    <ogr:join_by_location_equals fid="polys.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6,1 10,1 10,-3 6,-3 6,1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs><gml:innerBoundaryIs><gml:LinearRing><gml:coordinates>7,0 7,-2 9,-2 9,0 7,0</gml:coordinates></gml:LinearRing></gml:innerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+      <ogr:floatval xsi:nil="true"/>
+      <ogr:J_fid>polys_2.3</ogr:J_fid>
+    </ogr:join_by_location_equals>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/join_by_location_equals.xsd
+++ b/python/plugins/processing/tests/testdata/expected/join_by_location_equals.xsd
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="join_by_location_equals" type="ogr:join_by_location_equals_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="join_by_location_equals_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PolygonPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="5"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="intval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="floatval" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="J_fid" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+              <xs:maxLength value="255"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -4757,6 +4757,27 @@ tests:
         name: expected/join_by_location_unjoinable.gml
         type: vector
 
+  - algorithm: qgis:joinattributesbylocation
+    name: Join by location (equals)
+    params:
+      DISCARD_NONMATCHING: true
+      INPUT:
+        name: polys.gml
+        type: vector
+      JOIN:
+        name: custom/polys_2.gml
+        type: vector
+      JOIN_FIELDS:
+      - fid
+      METHOD: 0
+      PREDICATE:
+      - 2
+      PREFIX: J_
+    results:
+      OUTPUT:
+        name: expected/join_by_location_equals.gml
+        type: vector
+
   - algorithm: qgis:joinbylocationsummary
     name: Join by location (summary), intersects
     params:


### PR DESCRIPTION
## Description
This fixes two typos in SpatialJoin.py "Join attributes by location" and SpatialJoinSummary.py "Join attributes by location (summary)" algorithms that prevent the 'equals' predicate to work

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
