### PR TITLE
[Processing][Needs-docs] Allow optional "value" in "select by attribu…

### DIFF
--- a/python/plugins/processing/algs/qgis/SelectByAttribute.py
+++ b/python/plugins/processing/algs/qgis/SelectByAttribute.py
@@ -106,7 +106,8 @@ class SelectByAttribute(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterEnum(self.OPERATOR,
                                                      self.tr('Operator'), self.operators))
         self.addParameter(QgsProcessingParameterString(self.VALUE,
-                                                       self.tr('Value')))
+                                                       self.tr('Value'),
+                                                       optional=True))
         self.addParameter(QgsProcessingParameterEnum(self.METHOD,
                                                      self.tr('Modify current selection by'),
                                                      self.methods,


### PR DESCRIPTION
…te" algorithm because it's not needed to run null checks (fixes #19469 which is actually reported in the wrong way).
This mimics the extract by attribute algorithm.