### PR TITLE
Mark a Python plugin without an __init__.py as broken

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -600,6 +600,10 @@ class Plugins(QObject):
         errorDetails = ""
         version = None
 
+        if not os.path.exists(os.path.join(path, '__init__.py')):
+            error = "broken"
+            errorDetails = QCoreApplication.translate("QgsPluginInstaller", "Missing __init__.py")
+
         metadataFile = os.path.join(path, 'metadata.txt')
         if os.path.exists(metadataFile):
             version = normalizeVersion(pluginMetadata("version"))


### PR DESCRIPTION
utils.findPlugins() checks for the existence of an `__init__.py` which
results in an attempt to enable a plugin without an `__init__.py` being
blocked with the only notification being a message in the Plugins log:
```
WARNING    Plugin "<name>" is not compatible with this version of QGIS.
             It will be disabled.
```
This is not very informative, especially because it is the same message
used for a metadata version mismatch.

Adding this check to Plugins.getInstalledPlugin(), which already
duplicates the metadata checks from utils.findPlugins(), results in the
plugin being marked as broken in the Plugins dialog.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
