### PR TITLE
Legend tree in 'Identify Layers'

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -1498,6 +1498,18 @@ Make layer read-only (editing disabled) or not
 :return: false if the layer is in editing yet
 %End
 
+    bool searchable() const;
+%Docstring
+Returns true if the provider is in read-only mode
+%End
+
+    void setSearchable( bool searchable );
+%Docstring
+Make layer searchable or not
+
+.. versionadded:: 3.4
+%End
+
     bool changeGeometry( QgsFeatureId fid, QgsGeometry &geometry, bool skipDefaultValue = false );
 %Docstring
 Changes a feature's ``geometry`` within the layer's edit buffer
@@ -2581,6 +2593,13 @@ Emitted when the read only state of this layer is changed.
 Only applies to manually set readonly state, not to the edit mode.
 
 .. versionadded:: 3.0
+%End
+
+    void searchableChanged();
+%Docstring
+Emitted when the search state of this layer is changed.
+
+.. versionadded:: 3.4
 %End
 
     void symbolFeatureCountMapChanged();

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -54,6 +54,7 @@ SET(QGIS_APP_SRCS
   qgslabelengineconfigdialog.cpp
   qgslabelinggui.cpp
   qgslabelingwidget.cpp
+  qgslayercapabilitiesmodel.cpp
   qgslayertreeviewembeddedindicator.cpp
   qgslayertreeviewfilterindicator.cpp
   qgslayertreeviewmemoryindicator.cpp
@@ -275,6 +276,7 @@ SET (QGIS_APP_MOC_HDRS
   qgslabelinggui.h
   qgslabelingwidget.h
   qgslabelpropertydialog.h
+  qgslayercapabilitiesmodel.h
   qgslayertreeviewembeddedindicator.h
   qgslayertreeviewmemoryindicator.h
   qgslayertreeviewfilterindicator.h

--- a/src/app/qgslayercapabilitiesmodel.cpp
+++ b/src/app/qgslayercapabilitiesmodel.cpp
@@ -174,6 +174,15 @@ QgsMapLayer *QgsLayerCapabilitiesModel::mapLayer( const QModelIndex &idx ) const
   return QgsLayerTree::toLayer( node )->layer();
 }
 
+void QgsLayerCapabilitiesModel::setShowSpatialLayersOnly( bool only )
+{
+  if ( only == mShowSpatialLayersOnly )
+    return;
+
+  mShowSpatialLayersOnly = only;
+  invalidateFilter();
+}
+
 QModelIndex QgsLayerCapabilitiesModel::index( int row, int column, const QModelIndex &parent ) const
 {
   QModelIndex newIndex = QSortFilterProxyModel::index( row, LayerColumn, parent );
@@ -298,6 +307,8 @@ bool QgsLayerCapabilitiesModel::nodeShown( QgsLayerTreeNode *node ) const
   else
   {
     QgsMapLayer *layer = QgsLayerTree::toLayer( node )->layer();
-    return layer && ( mFilterText.isEmpty() || layer->name().contains( mFilterText, Qt::CaseInsensitive ) );
+    return layer
+           && ( mFilterText.isEmpty() || layer->name().contains( mFilterText, Qt::CaseInsensitive ) )
+           && ( !mShowSpatialLayersOnly || layer->isSpatial() );
   }
 }

--- a/src/app/qgslayercapabilitiesmodel.cpp
+++ b/src/app/qgslayercapabilitiesmodel.cpp
@@ -55,16 +55,15 @@ void QgsLayerCapabilitiesModel::setFilterText( const QString &filterText )
   invalidateFilter();
 }
 
-void QgsLayerCapabilitiesModel::checkSelectedItems( const QModelIndexList &checkedIndexes, bool check )
+void QgsLayerCapabilitiesModel::toggleSelectedItems( const QModelIndexList &checkedIndexes )
 {
   QVector<int> roles = QVector<int>() << Qt::CheckStateRole;
-  // beginResetModel();
   for ( const QModelIndex &index : checkedIndexes )
   {
-    if ( setData( index, check ? Qt::Checked : Qt::Unchecked, Qt::CheckStateRole ) )
-      emit dataChanged( index, index ); //), roles);
+    bool isChecked = data( index, Qt::CheckStateRole ) == Qt::Checked;
+    if ( setData( index, isChecked ? Qt::Unchecked : Qt::Checked, Qt::CheckStateRole ) )
+      emit dataChanged( index, index );
   }
-  //endResetModel();
 }
 
 QStringList QgsLayerCapabilitiesModel::nonIdentifiableLayers() const

--- a/src/app/qgslayercapabilitiesmodel.cpp
+++ b/src/app/qgslayercapabilitiesmodel.cpp
@@ -246,6 +246,7 @@ bool QgsLayerCapabilitiesModel::setData( const QModelIndex &index, const QVarian
           mNonIdentifiableLayers.removeAll( layer->id() );
         if ( !containsLayer && nonIdentifiable )
           mNonIdentifiableLayers.append( layer->id() );
+        emit dataChanged( index, index );
         return true;
       }
       else if ( index.column() == ReadOnlyColumn )
@@ -254,6 +255,7 @@ bool QgsLayerCapabilitiesModel::setData( const QModelIndex &index, const QVarian
         if ( vl )
         {
           mReadOnlyLayers.insert( layer, value == Qt::Checked );
+          emit dataChanged( index, index );
           return true;
         }
       }
@@ -263,6 +265,7 @@ bool QgsLayerCapabilitiesModel::setData( const QModelIndex &index, const QVarian
         if ( vl )
         {
           mSearchableLayers.insert( layer, value == Qt::Checked );
+          emit dataChanged( index, index );
           return true;
         }
       }

--- a/src/app/qgslayercapabilitiesmodel.h
+++ b/src/app/qgslayercapabilitiesmodel.h
@@ -35,7 +35,8 @@ class APP_EXPORT QgsLayerCapabilitiesModel : public QSortFilterProxyModel
       LayerColumn = 0,
       IdentifiableColumn,
       ReadOnlyColumn,
-      SearchableColumn
+      SearchableColumn,
+      RequiredColumn,
     };
 
     QgsLayerCapabilitiesModel( QgsProject *project, QObject *parent = nullptr );
@@ -43,6 +44,7 @@ class APP_EXPORT QgsLayerCapabilitiesModel : public QSortFilterProxyModel
     QgsLayerTreeModel *layerTreeModel() const;
     void setLayerTreeModel( QgsLayerTreeModel *layerTreeModel );
     QStringList nonIdentifiableLayers() const;
+    QSet<QgsMapLayer *> requiredLayers() const;
     bool readOnly( QgsMapLayer *layer ) const;
     bool searchable( QgsMapLayer *layer ) const;
     QgsMapLayer *mapLayer( const QModelIndex &idx ) const;
@@ -70,6 +72,7 @@ class APP_EXPORT QgsLayerCapabilitiesModel : public QSortFilterProxyModel
     QString mFilterText;
     bool mShowSpatialLayersOnly = false;
     QStringList mNonIdentifiableLayers;
+    QSet<QgsMapLayer *> mRequiredLayers;
     QHash<QgsMapLayer *, bool> mReadOnlyLayers;
     QHash<QgsMapLayer *, bool> mSearchableLayers;
     QgsLayerTreeModel *mLayerTreeModel = nullptr;

--- a/src/app/qgslayercapabilitiesmodel.h
+++ b/src/app/qgslayercapabilitiesmodel.h
@@ -59,7 +59,7 @@ class APP_EXPORT QgsLayerCapabilitiesModel : public QSortFilterProxyModel
 
   public slots:
     void setFilterText( const QString &filterText = QString() );
-    void checkSelectedItems( const QModelIndexList &checkedIndexes, bool check );
+    void toggleSelectedItems( const QModelIndexList &checkedIndexes );
 
   protected:
     bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;

--- a/src/app/qgslayercapabilitiesmodel.h
+++ b/src/app/qgslayercapabilitiesmodel.h
@@ -1,0 +1,76 @@
+/***************************************************************************
+                        qgslayercapabilitiesmodel.h
+                        ----------------------------
+   begin                : August 2018
+   copyright            : (C) 2018 by Denis Rouzaud
+   email                : denis@opengis.ch
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERCAPABILITIESMODEL_H
+#define QGSLAYERCAPABILITIESMODEL_H
+
+#include <QObject>
+
+#include "qgis_app.h"
+#include "qgsproject.h"
+
+class QgsLayerTreeModel;
+class QgsLayerTreeNode;
+
+class APP_EXPORT QgsLayerCapabilitiesModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+  public:
+    enum Columns
+    {
+      LayerColumn = 0,
+      IdentifiableColumn,
+      ReadOnlyColumn,
+      SearchableColumn
+    };
+
+    QgsLayerCapabilitiesModel( QgsProject *project, QObject *parent = nullptr );
+
+    QgsLayerTreeModel *layerTreeModel() const;
+    void setLayerTreeModel( QgsLayerTreeModel *layerTreeModel );
+    QStringList nonIdentifiableLayers() const;
+    bool readOnly( QgsMapLayer *layer ) const;
+    bool searchable( QgsMapLayer *layer ) const;
+    QgsMapLayer *mapLayer( const QModelIndex &idx ) const;
+
+    int columnCount( const QModelIndex &parent ) const override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+    Qt::ItemFlags flags( const QModelIndex &idx ) const override;
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const override;
+    QModelIndex parent( const QModelIndex &child ) const override;
+    QModelIndex sibling( int row, int column, const QModelIndex &idx ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role ) override;
+
+  public slots:
+    void setFilterText( const QString &filterText = QString() );
+    void checkSelectedItems( const QModelIndexList &checkedIndexes, bool check );
+
+  protected:
+    bool filterAcceptsRow( int sourceRow, const QModelIndex &sourceParent ) const override;
+
+  private:
+    bool nodeShown( QgsLayerTreeNode *node ) const;
+
+    QString mFilterText;
+    QStringList mNonIdentifiableLayers;
+    QHash<QgsMapLayer *, bool> mReadOnlyLayers;
+    QHash<QgsMapLayer *, bool> mSearchableLayers;
+    QgsLayerTreeModel *mLayerTreeModel = nullptr;
+};
+
+#endif // QGSLAYERCAPABILITIESMODEL_H

--- a/src/app/qgslayercapabilitiesmodel.h
+++ b/src/app/qgslayercapabilitiesmodel.h
@@ -46,6 +46,7 @@ class APP_EXPORT QgsLayerCapabilitiesModel : public QSortFilterProxyModel
     bool readOnly( QgsMapLayer *layer ) const;
     bool searchable( QgsMapLayer *layer ) const;
     QgsMapLayer *mapLayer( const QModelIndex &idx ) const;
+    void setShowSpatialLayersOnly( bool only );
 
     int columnCount( const QModelIndex &parent ) const override;
     QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
@@ -67,6 +68,7 @@ class APP_EXPORT QgsLayerCapabilitiesModel : public QSortFilterProxyModel
     bool nodeShown( QgsLayerTreeNode *node ) const;
 
     QString mFilterText;
+    bool mShowSpatialLayersOnly = false;
     QStringList mNonIdentifiableLayers;
     QHash<QgsMapLayer *, bool> mReadOnlyLayers;
     QHash<QgsMapLayer *, bool> mSearchableLayers;

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -363,9 +363,19 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   mLayerCapabilitiesTree->setSelectionBehavior( QAbstractItemView::SelectItems );
   mLayerCapabilitiesTree->setSelectionMode( QAbstractItemView::MultiSelection );
   mLayerCapabilitiesTree->expandAll();
+  connect( mLayerCapabilitiesTree->selectionModel(), &QItemSelectionModel::selectionChanged, this,
+           [ = ]( const QItemSelection & selected, const QItemSelection & deselected )
+  {
+    Q_UNUSED( selected );
+    Q_UNUSED( deselected );
+    bool hasSelection = !mLayerCapabilitiesTree->selectionModel()->selectedIndexes().isEmpty();
+    mLayerCapabilitiesCheckButton->setEnabled( hasSelection );
+    mLayerCapabilitiesUncheckButton->setEnabled( hasSelection );
+  } );
 
   mLayerCapabilitiesTreeFilterLineEdit->setShowClearButton( true );
   mLayerCapabilitiesTreeFilterLineEdit->setShowSearchIcon( true );
+  mLayerCapabilitiesTreeFilterLineEdit->setPlaceholderText( tr( "Filter layers…" ) );
   connect( mLayerCapabilitiesTreeFilterLineEdit, &QgsFilterLineEdit::textChanged, this, [ = ]( const QString & filterText )
   {
     mLayerCapabilitiesModel->setFilterText( filterText );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -387,6 +387,11 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
     mLayerCapabilitiesTree->repaint();
   } );
 
+  connect( mShowSpatialLayersCheckBox, &QCheckBox::stateChanged, this, [ = ]( int state )
+  {
+    mLayerCapabilitiesModel->setShowSpatialLayersOnly( static_cast<bool>( state ) );
+  } );
+
   grpOWSServiceCapabilities->setChecked( QgsProject::instance()->readBoolEntry( QStringLiteral( "WMSServiceCapabilities" ), QStringLiteral( "/" ), false ) );
   mWMSTitle->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSServiceTitle" ), QStringLiteral( "/" ) ) );
   mWMSName->setText( QgsProject::instance()->readEntry( QStringLiteral( "WMSRootName" ), QStringLiteral( "/" ) ) );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -369,8 +369,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
     Q_UNUSED( selected );
     Q_UNUSED( deselected );
     bool hasSelection = !mLayerCapabilitiesTree->selectionModel()->selectedIndexes().isEmpty();
-    mLayerCapabilitiesCheckButton->setEnabled( hasSelection );
-    mLayerCapabilitiesUncheckButton->setEnabled( hasSelection );
+    mLayerCapabilitiesToggleSelectionButton->setEnabled( hasSelection );
   } );
 
   mLayerCapabilitiesTreeFilterLineEdit->setShowClearButton( true );
@@ -382,18 +381,11 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
     mLayerCapabilitiesTree->expandAll();
   } );
 
-  connect( mLayerCapabilitiesCheckButton, &QToolButton::clicked, this, [ = ]( bool clicked )
+  connect( mLayerCapabilitiesToggleSelectionButton, &QToolButton::clicked, this, [ = ]( bool clicked )
   {
     Q_UNUSED( clicked );
     const QModelIndexList indexes = mLayerCapabilitiesTree->selectionModel()->selectedIndexes();
-    mLayerCapabilitiesModel->checkSelectedItems( indexes, true );
-    mLayerCapabilitiesTree->repaint();
-  } );
-  connect( mLayerCapabilitiesUncheckButton, &QToolButton::clicked, this, [ = ]( bool clicked )
-  {
-    Q_UNUSED( clicked );
-    const QModelIndexList indexes = mLayerCapabilitiesTree->selectionModel()->selectedIndexes();
-    mLayerCapabilitiesModel->checkSelectedItems( indexes, false );
+    mLayerCapabilitiesModel->toggleSelectedItems( indexes );
     mLayerCapabilitiesTree->repaint();
   } );
 

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -32,6 +32,7 @@ class QgsExpressionContext;
 class QgsLayerTreeGroup;
 class QgsMetadataWidget;
 class QgsTreeWidgetItem;
+class QgsLayerCapabilitiesModel;
 
 /**
  * Dialog to set project level properties
@@ -187,6 +188,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     QgsMapCanvas *mMapCanvas = nullptr;
     QgsStyle *mStyle = nullptr;
     QgsMetadataWidget *mMetadataWidget = nullptr;
+    QgsLayerCapabilitiesModel *mLayerCapabilitiesModel = nullptr;
 
     QgsCoordinateReferenceSystem mCrs;
 

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -240,7 +240,4 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     void updateGuiForMapUnits();
 
     void showHelp();
-
-    void populateRequiredLayers();
-    void applyRequiredLayers();
 };

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -247,7 +247,8 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement,  QgsReadWriteCo
   QDomNode srsNode = layerElement.namedItem( QStringLiteral( "srs" ) );
   mCRS.readXml( srsNode );
   mCRS.setValidationHint( tr( "Specify CRS for layer %1" ).arg( mne.text() ) );
-  mCRS.validate();
+  if ( isSpatial() )
+    mCRS.validate();
   savedCRS = mCRS;
 
   // Do not validate any projections in children, they will be overwritten anyway.

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2070,6 +2070,8 @@ bool QgsVectorLayer::readSymbology( const QDomNode &layerNode, QString &errorMes
   QDomElement mapLayerNode = layerNode.toElement();
   if ( mapLayerNode.attribute( QStringLiteral( "readOnly" ), QStringLiteral( "0" ) ).toInt() == 1 )
     mReadOnly = true;
+  if ( mapLayerNode.attribute( QStringLiteral( "searchable" ), QStringLiteral( "0" ) ).toInt() == 1 )
+    mSearchable = true;
 
   updateFields();
 
@@ -2375,6 +2377,9 @@ bool QgsVectorLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString 
 
   // save readonly state
   node.toElement().setAttribute( QStringLiteral( "readOnly" ), mReadOnly );
+
+  // save searchable state
+  node.toElement().setAttribute( QStringLiteral( "searchable" ), mSearchable );
 
   // save preview expression
   QDomElement prevExpElem = doc.createElement( QStringLiteral( "previewExpression" ) );
@@ -3105,6 +3110,19 @@ bool QgsVectorLayer::setReadOnly( bool readonly )
   mReadOnly = readonly;
   emit readOnlyChanged();
   return true;
+}
+
+bool QgsVectorLayer::searchable() const
+{
+  return mSearchable;
+}
+
+void QgsVectorLayer::setSearchable( bool searchable )
+{
+  if ( searchable == mSearchable )
+    return;
+  mSearchable = searchable;
+  emit searchableChanged();
 }
 
 bool QgsVectorLayer::isModified() const

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -361,6 +361,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     Q_PROPERTY( QgsEditFormConfig editFormConfig READ editFormConfig WRITE setEditFormConfig NOTIFY editFormConfigChanged )
     Q_PROPERTY( bool readOnly READ isReadOnly WRITE setReadOnly NOTIFY readOnlyChanged )
     Q_PROPERTY( double opacity READ opacity WRITE setOpacity NOTIFY opacityChanged )
+    Q_PROPERTY( bool searchable READ searchable WRITE setSearchable NOTIFY searchableChanged )
 
   public:
 
@@ -1379,9 +1380,20 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     /**
      * Make layer read-only (editing disabled) or not
-     *  \returns false if the layer is in editing yet
+     * \returns false if the layer is in editing yet
      */
     bool setReadOnly( bool readonly = true );
+
+    /**
+     * Returns true if the provider is in read-only mode
+     */
+    bool searchable() const;
+
+    /**
+     * Make layer searchable or not
+     * \since QGIS 3.4
+     */
+    void setSearchable( bool searchable );
 
     /**
      * Changes a feature's \a geometry within the layer's edit buffer
@@ -2311,6 +2323,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void readOnlyChanged();
 
     /**
+     * Emitted when the search state of this layer is changed.
+     * \since QGIS 3.4
+     */
+    void searchableChanged();
+
+    /**
      * Emitted when the feature count for symbols on this layer has been recalculated.
      *
      * \since QGIS 3.0
@@ -2375,6 +2393,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     //! Flag indicating whether the layer is in read-only mode (editing disabled) or not
     bool mReadOnly = false;
+
+    //! Indicates whether the layer is searchable or not
+    bool mSearchable = true;
 
     /**
      * Set holding the feature IDs that are activated.  Note that if a feature

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -277,7 +277,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>676</width>
+                <width>563</width>
                 <height>833</height>
                </rect>
               </property>
@@ -875,8 +875,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>676</width>
-                <height>764</height>
+                <width>547</width>
+                <height>152</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>676</width>
-                <height>764</height>
+                <width>271</width>
+                <height>597</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1414,30 +1414,10 @@
                   <property name="verticalSpacing">
                    <number>0</number>
                   </property>
-                  <item row="1" column="0" colspan="4">
-                   <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
+                  <item row="3" column="3">
+                   <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
                   </item>
                   <item row="3" column="1">
-                   <widget class="QPushButton" name="mLayerCapabilitiesCheckButton">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="text">
-                     <string>Check Selected</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QPushButton" name="mLayerCapabilitiesUncheckButton">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="text">
-                     <string>Uncheck Selected</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="2">
                    <spacer name="horizontalSpacer_5">
                     <property name="orientation">
                      <enum>Qt::Horizontal</enum>
@@ -1450,10 +1430,20 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="3" column="3">
-                   <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
+                  <item row="3" column="0">
+                   <widget class="QPushButton" name="mLayerCapabilitiesToggleSelectionButton">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="text">
+                     <string>Toggle Selection</string>
+                    </property>
+                   </widget>
                   </item>
-                  <item row="4" column="3">
+                  <item row="1" column="0" colspan="4">
+                   <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
+                  </item>
+                  <item row="3" column="2">
                    <widget class="QCheckBox" name="mShowSpatialLayersCheckBox">
                     <property name="layoutDirection">
                      <enum>Qt::LeftToRight</enum>
@@ -1591,8 +1581,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>676</width>
-                <height>764</height>
+                <width>157</width>
+                <height>59</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1653,7 +1643,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>676</width>
+                <width>603</width>
                 <height>2666</height>
                </rect>
               </property>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -277,7 +277,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>563</width>
+                <width>676</width>
                 <height>833</height>
                </rect>
               </property>
@@ -875,8 +875,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>547</width>
-                <height>152</height>
+                <width>676</width>
+                <height>764</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>271</width>
-                <height>597</height>
+                <width>676</width>
+                <height>764</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1411,8 +1411,31 @@
                   <string>Project Layers</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_20">
-                  <item row="3" column="3">
-                   <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
+                  <property name="verticalSpacing">
+                   <number>0</number>
+                  </property>
+                  <item row="1" column="0" colspan="4">
+                   <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
+                  </item>
+                  <item row="3" column="1">
+                   <widget class="QPushButton" name="mLayerCapabilitiesCheckButton">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="text">
+                     <string>Check Selected</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QPushButton" name="mLayerCapabilitiesUncheckButton">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="text">
+                     <string>Uncheck Selected</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="3" column="2">
                    <spacer name="horizontalSpacer_5">
@@ -1427,29 +1450,18 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="3" column="0">
-                   <widget class="QPushButton" name="mLayerCapabilitiesUncheckButton">
-                    <property name="text">
-                     <string>uncheck selection</string>
-                    </property>
-                   </widget>
+                  <item row="3" column="3">
+                   <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
                   </item>
-                  <item row="3" column="1">
-                   <widget class="QPushButton" name="mLayerCapabilitiesCheckButton">
-                    <property name="text">
-                     <string>check selection</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="3">
+                  <item row="4" column="3">
                    <widget class="QCheckBox" name="mShowSpatialLayersCheckBox">
+                    <property name="layoutDirection">
+                     <enum>Qt::LeftToRight</enum>
+                    </property>
                     <property name="text">
-                     <string>show spatial layers only</string>
+                     <string>Show spatial layers only</string>
                     </property>
                    </widget>
-                  </item>
-                  <item row="1" column="0" colspan="4">
-                   <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
                   </item>
                  </layout>
                 </widget>
@@ -1579,8 +1591,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>157</width>
-                <height>59</height>
+                <width>676</width>
+                <height>764</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1641,7 +1653,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>603</width>
+                <width>676</width>
                 <height>2666</height>
                </rect>
               </property>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -277,7 +277,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>676</width>
+                <width>563</width>
                 <height>833</height>
                </rect>
               </property>
@@ -875,8 +875,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>676</width>
-                <height>764</height>
+                <width>547</width>
+                <height>152</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>676</width>
-                <height>764</height>
+                <width>271</width>
+                <height>597</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1411,17 +1411,10 @@
                   <string>Project Layers</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_20">
-                  <item row="0" column="2">
-                   <widget class="QPushButton" name="mLayerCapabilitiesCheckButton">
-                    <property name="text">
-                     <string>check selection</string>
-                    </property>
-                   </widget>
+                  <item row="3" column="3">
+                   <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
                   </item>
-                  <item row="1" column="0" colspan="4">
-                   <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
-                  </item>
-                  <item row="0" column="0">
+                  <item row="3" column="2">
                    <spacer name="horizontalSpacer_5">
                     <property name="orientation">
                      <enum>Qt::Horizontal</enum>
@@ -1434,15 +1427,29 @@
                     </property>
                    </spacer>
                   </item>
-                  <item row="0" column="3">
-                   <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
-                  </item>
-                  <item row="0" column="1">
+                  <item row="3" column="0">
                    <widget class="QPushButton" name="mLayerCapabilitiesUncheckButton">
                     <property name="text">
                      <string>uncheck selection</string>
                     </property>
                    </widget>
+                  </item>
+                  <item row="3" column="1">
+                   <widget class="QPushButton" name="mLayerCapabilitiesCheckButton">
+                    <property name="text">
+                     <string>check selection</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="3">
+                   <widget class="QCheckBox" name="mShowSpatialLayersCheckBox">
+                    <property name="text">
+                     <string>show spatial layers only</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0" colspan="4">
+                   <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
                   </item>
                  </layout>
                 </widget>
@@ -1635,7 +1642,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>603</width>
-                <height>2365</height>
+                <height>2666</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -139,7 +139,7 @@
          </item>
          <item>
           <property name="text">
-           <string>Identify Layers</string>
+           <string>Layers</string>
           </property>
           <property name="toolTip">
            <string>Identifiable layers</string>
@@ -248,7 +248,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>4</number>
          </property>
          <widget class="QWidget" name="mProjOptsGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -276,9 +276,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-147</y>
-                <width>680</width>
-                <height>923</height>
+                <y>0</y>
+                <width>676</width>
+                <height>833</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -875,8 +875,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>580</width>
-                <height>154</height>
+                <width>676</width>
+                <height>764</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -950,8 +950,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>685</width>
-                <height>778</height>
+                <width>676</width>
+                <height>764</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1388,8 +1388,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>120</width>
-                <height>100</height>
+                <width>676</width>
+                <height>764</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -1410,32 +1410,38 @@
                  <property name="title">
                   <string>Project Layers</string>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_22">
-                  <item>
-                   <widget class="QTableWidget" name="twIdentifyLayers">
-                    <property name="sortingEnabled">
-                     <bool>true</bool>
+                 <layout class="QGridLayout" name="gridLayout_20">
+                  <item row="0" column="2">
+                   <widget class="QPushButton" name="mLayerCapabilitiesCheckButton">
+                    <property name="text">
+                     <string>check selection</string>
                     </property>
-                    <column>
-                     <property name="text">
-                      <string>Layer</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>Type</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>Identifiable</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>Read Only</string>
-                     </property>
-                    </column>
+                   </widget>
+                  </item>
+                  <item row="1" column="0" colspan="4">
+                   <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
+                  </item>
+                  <item row="0" column="0">
+                   <spacer name="horizontalSpacer_5">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item row="0" column="3">
+                   <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QPushButton" name="mLayerCapabilitiesUncheckButton">
+                    <property name="text">
+                     <string>uncheck selection</string>
+                    </property>
                    </widget>
                   </item>
                  </layout>
@@ -1566,8 +1572,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>155</width>
-                <height>52</height>
+                <width>157</width>
+                <height>59</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1628,8 +1634,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>622</width>
-                <height>2646</height>
+                <width>603</width>
+                <height>2365</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2942,7 +2948,6 @@
   <tabstop>mButtonImportColors</tabstop>
   <tabstop>mButtonExportColors</tabstop>
   <tabstop>scrollArea_3</tabstop>
-  <tabstop>twIdentifyLayers</tabstop>
   <tabstop>mAutoTransaction</tabstop>
   <tabstop>mEvaluateDefaultValues</tabstop>
   <tabstop>mTrustProjectCheckBox</tabstop>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -19,8 +19,8 @@
   <property name="windowTitle">
    <string>Project Properties</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_21">
+   <item row="0" column="0">
     <widget class="QSplitter" name="mOptionsSplitter">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -139,18 +139,6 @@
          </item>
          <item>
           <property name="text">
-           <string>Layers</string>
-          </property>
-          <property name="toolTip">
-           <string>Identifiable layers</string>
-          </property>
-          <property name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/propertyicons/map_tools.svg</normaloff>:/images/themes/default/propertyicons/map_tools.svg</iconset>
-          </property>
-         </item>
-         <item>
-          <property name="text">
            <string>Data Sources</string>
           </property>
           <property name="toolTip">
@@ -242,7 +230,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -277,7 +265,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>563</width>
+                <width>676</width>
                 <height>833</height>
                </rect>
               </property>
@@ -875,8 +863,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>547</width>
-                <height>152</height>
+                <width>676</width>
+                <height>764</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -950,8 +938,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>271</width>
-                <height>597</height>
+                <width>676</width>
+                <height>764</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1361,107 +1349,6 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mProjOptsLayers">
-          <layout class="QVBoxLayout" name="verticalLayout_9">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QgsScrollArea" name="scrollArea_3">
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-             </property>
-             <property name="widgetResizable">
-              <bool>true</bool>
-             </property>
-             <widget class="QWidget" name="scrollAreaWidgetContents_3">
-              <property name="geometry">
-               <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>676</width>
-                <height>764</height>
-               </rect>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_10">
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QGroupBox" name="groupBox_3">
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>100</height>
-                  </size>
-                 </property>
-                 <property name="title">
-                  <string>Project Layers</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_20">
-                  <property name="verticalSpacing">
-                   <number>0</number>
-                  </property>
-                  <item row="3" column="3">
-                   <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
-                  </item>
-                  <item row="3" column="1">
-                   <spacer name="horizontalSpacer_5">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="3" column="0">
-                   <widget class="QPushButton" name="mLayerCapabilitiesToggleSelectionButton">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="text">
-                     <string>Toggle Selection</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0" colspan="4">
-                   <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
-                  </item>
-                  <item row="3" column="2">
-                   <widget class="QCheckBox" name="mShowSpatialLayersCheckBox">
-                    <property name="layoutDirection">
-                     <enum>Qt::LeftToRight</enum>
-                    </property>
-                    <property name="text">
-                     <string>Show spatial layers only</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </widget>
-           </item>
-          </layout>
-         </widget>
          <widget class="QWidget" name="mTab_DataSources">
           <layout class="QFormLayout" name="formLayout">
            <item row="0" column="0" colspan="2">
@@ -1474,7 +1361,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="1" column="0" colspan="2">
             <widget class="QCheckBox" name="mEvaluateDefaultValues">
              <property name="toolTip">
               <string>When enabled, default values will be evaluated as early as possible. This will fill default values in the add feature form already and not only create them on commit. Only supported for postgres provider.</string>
@@ -1496,22 +1383,57 @@
            </item>
            <item row="4" column="0" colspan="2">
             <widget class="QgsCollapsibleGroupBox" name="groupBox_5">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="title">
-              <string>Required Layers</string>
+              <string>Layers Capabilities</string>
              </property>
              <layout class="QGridLayout" name="gridLayout_19">
-              <item row="0" column="0" colspan="2">
-               <widget class="QLabel" name="label_31">
-                <property name="text">
-                 <string>Checked layers in this list are protected from inadvertent removal from the project.</string>
+              <property name="verticalSpacing">
+               <number>0</number>
+              </property>
+              <item row="3" column="1">
+               <spacer name="horizontalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
-                <property name="wordWrap">
-                 <bool>true</bool>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="0" colspan="4">
+               <widget class="QTreeView" name="mLayerCapabilitiesTree"/>
+              </item>
+              <item row="3" column="0">
+               <widget class="QPushButton" name="mLayerCapabilitiesToggleSelectionButton">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="text">
+                 <string>Toggle Selection</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="0" colspan="2">
-               <widget class="QListView" name="mViewRequiredLayers"/>
+              <item row="3" column="2">
+               <widget class="QCheckBox" name="mShowSpatialLayersCheckBox">
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="text">
+                 <string>Show spatial layers only</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="QgsFilterLineEdit" name="mLayerCapabilitiesTreeFilterLineEdit"/>
               </item>
              </layout>
             </widget>
@@ -2806,7 +2728,7 @@
      </widget>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QFrame" name="mButtonBoxFrame">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -2956,7 +2878,6 @@
   <tabstop>mButtonPasteColors</tabstop>
   <tabstop>mButtonImportColors</tabstop>
   <tabstop>mButtonExportColors</tabstop>
-  <tabstop>scrollArea_3</tabstop>
   <tabstop>mAutoTransaction</tabstop>
   <tabstop>mEvaluateDefaultValues</tabstop>
   <tabstop>mTrustProjectCheckBox</tabstop>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/127259/44862915-69790700-ac84-11e8-9f41-2037ba549fb6.png)

This PRs replaces the current table in 'Identify Layers' tab in project properties.
It uses a legend tree with a possibility to filter layers.
You can select elements by cell and check/uncheck selection.
This make working in this table a bit more easy.

There is also a new 'searchable' option for layers, so they can be removed from searchable layers.
see #7752 