### PR TITLE
[Processing][needs-docs] Improve some vector overlay algorithms descr…

### DIFF
--- a/src/analysis/processing/qgsalgorithmclip.cpp
+++ b/src/analysis/processing/qgsalgorithmclip.cpp
@@ -49,18 +49,19 @@ QString QgsClipAlgorithm::groupId() const
 void QgsClipAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Clip layer" ), QList< int >() << QgsProcessing::TypeVectorPolygon ) );
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Overlay layer" ), QList< int >() << QgsProcessing::TypeVectorPolygon ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Clipped" ) ) );
 }
 
 QString QgsClipAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm clips a vector layer using the polygons of an additional polygons layer. Only the parts of the features "
-                      "in the input layer that falls within the polygons of the clipping layer will be added to the resulting layer.\n\n"
-                      "The attributes of the features are not modified, although properties such as area or length of the features will "
-                      "be modified by the clipping operation. If such properties are stored as attributes, those attributes will have to "
-                      "be manually updated." );
+  return QObject::tr( "This algorithm clips a vector layer using the features of an additional polygon layer. Only the parts of the features "
+                      "in the Input layer that fall within the polygons of the Overlay layer will be added to the resulting layer." )
+         + QStringLiteral( "\n\n" )
+         + QObject::tr( "The attributes of the features are not modified, although properties such as area or length of the features will "
+                        "be modified by the clipping operation. If such properties are stored as attributes, those attributes will have to "
+                        "be manually updated." );
 }
 
 QgsClipAlgorithm *QgsClipAlgorithm::createInstance() const

--- a/src/analysis/processing/qgsalgorithmdifference.cpp
+++ b/src/analysis/processing/qgsalgorithmdifference.cpp
@@ -42,9 +42,13 @@ QString QgsDifferenceAlgorithm::groupId() const
 
 QString QgsDifferenceAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm extracts features from the Input layer that fall outside, or partially overlap, features in the Difference layer. Input layer features that partially overlap the difference layer feature(s) are split along the boundary of the difference layer feature(s) and only the portions outside the difference layer features are retained." )
+  return QObject::tr( "This algorithm extracts features from the Input layer that fall outside, or partially overlap, features in the Overlay layer. "
+                      "Input layer features that partially overlap feature(s) in the Overlay layer are split along those features' boundary "
+                      "and only the portions outside the Overlay layer features are retained." )
          + QStringLiteral( "\n\n" )
-         + QObject::tr( "Attributes are not modified." );
+         + QObject::tr( "Attributes are not modified, although properties such as area or length of the features will "
+                        "be modified by the difference operation. If such properties are stored as attributes, those attributes will have to "
+                        "be manually updated." );
 }
 
 QgsProcessingAlgorithm *QgsDifferenceAlgorithm::createInstance() const
@@ -55,7 +59,7 @@ QgsProcessingAlgorithm *QgsDifferenceAlgorithm::createInstance() const
 void QgsDifferenceAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Difference layer" ) ) );
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Overlay layer" ) ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Difference" ) ) );
 }
 

--- a/src/analysis/processing/qgsalgorithmintersection.cpp
+++ b/src/analysis/processing/qgsalgorithmintersection.cpp
@@ -44,7 +44,9 @@ QString QgsIntersectionAlgorithm::groupId() const
 
 QString QgsIntersectionAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm extracts the overlapping portions of features in the Input and Overlay layers. Features in the Overlay layer are assigned the attributes of the overlapping features from both the Input and Overlay layers." );
+  return QObject::tr( "This algorithm extracts the overlapping portions of features in the Input and Overlay layers. "
+                      "Features in the output Intersection layer are assigned the attributes of the overlapping features "
+                      "from both the Input and Overlay layers." );
 }
 
 QgsProcessingAlgorithm *QgsIntersectionAlgorithm::createInstance() const
@@ -55,7 +57,7 @@ QgsProcessingAlgorithm *QgsIntersectionAlgorithm::createInstance() const
 void QgsIntersectionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Intersection layer" ) ) );
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Overlay layer" ) ) );
 
   addParameter( new QgsProcessingParameterField(
                   QStringLiteral( "INPUT_FIELDS" ),

--- a/src/analysis/processing/qgsalgorithmsymmetricaldifference.cpp
+++ b/src/analysis/processing/qgsalgorithmsymmetricaldifference.cpp
@@ -41,7 +41,9 @@ QString QgsSymmetricalDifferenceAlgorithm::groupId() const
 
 QString QgsSymmetricalDifferenceAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm creates a layer containing features from both the Input and Difference layers but with the overlapping areas between the two layers removed. The attribute table of the Symmetrical Difference layer contains attributes from both the Input and Difference layers." );
+  return QObject::tr( "This algorithm extracts the portions of features from both the Input and Overlay layers that do not overlap. "
+                      "Overlapping areas between the two layers are removed. The attribute table of the Symmetrical Difference layer "
+                      "contains original attributes from both the Input and Difference layers." );
 }
 
 QgsProcessingAlgorithm *QgsSymmetricalDifferenceAlgorithm::createInstance() const
@@ -52,7 +54,7 @@ QgsProcessingAlgorithm *QgsSymmetricalDifferenceAlgorithm::createInstance() cons
 void QgsSymmetricalDifferenceAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Difference layer" ) ) );
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Overlay layer" ) ) );
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Symmetrical difference" ) ) );
 }
 

--- a/src/analysis/processing/qgsalgorithmunion.cpp
+++ b/src/analysis/processing/qgsalgorithmunion.cpp
@@ -42,7 +42,14 @@ QString QgsUnionAlgorithm::groupId() const
 
 QString QgsUnionAlgorithm::shortHelpString() const
 {
-  return QObject::tr( "This algorithm creates a layer containing all the features from both input layers. In the case of polygon layers, separate features are created for overlapping and non-overlapping features. The attribute table of the union layer contains attribute values from the respective input layer for non-overlapping features, and attribute values from both input layers for overlapping features." );
+  return QObject::tr( "This algorithm checks overlaps between features within the Input layer and creates separate features for overlapping "
+                      "and non-overlapping parts. The area of overlap will create as many identical overlapping features as there are "
+                      "features that participate in that overlap." )
+         + QStringLiteral( "\n\n" )
+         + QObject::tr( "An Overlay layer can also be used, in which case features from each layer are split at their overlap with features from "
+                        "the other one, creating a layer containing all the portions from both Input and Overlay layers. "
+                        "The attribute table of the Union layer is filled with attribute values from the respective original layer "
+                        "for non-overlapping features, and attribute values from both layers for overlapping features." );
 }
 
 QgsProcessingAlgorithm *QgsUnionAlgorithm::createInstance() const
@@ -53,7 +60,7 @@ QgsProcessingAlgorithm *QgsUnionAlgorithm::createInstance() const
 void QgsUnionAlgorithm::initAlgorithm( const QVariantMap & )
 {
   addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "INPUT" ), QObject::tr( "Input layer" ) ) );
-  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Union layer" ), QList< int >(), QVariant(), true ) );
+  addParameter( new QgsProcessingParameterFeatureSource( QStringLiteral( "OVERLAY" ), QObject::tr( "Overlay layer" ), QList< int >(), QVariant(), true ) );
 
   addParameter( new QgsProcessingParameterFeatureSink( QStringLiteral( "OUTPUT" ), QObject::tr( "Union" ) ) );
 }


### PR DESCRIPTION
…iption

* Some algorithms used almost the same label for the second layer and the output one (eg, "difference layer" vs "difference"), making hard to understand the description, in English and once translated.  Overlay label is now used to name the second layer, also matching the parameter identifier
* Add more details to description and try to harmonize as far as possible (more convenient for readers and translators)
* The union algorithm behavior changed deeply but its description got no updates

I think "Split with lines" and "Line intersections" algorithms may also deserve some label renaming but no inspiration