### PR TITLE
Use QLocale for categorized renderer range

### DIFF
--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -228,7 +228,7 @@ QString QgsRendererRangeLabelFormat::formatNumber( double value ) const
 {
   if ( mPrecision > 0 )
   {
-    QString valueStr = QString::number( value, 'f', mPrecision );
+    QString valueStr = QLocale().toString( value, 'f', mPrecision );
     if ( mTrimTrailingZeroes )
       valueStr = valueStr.remove( mReTrailingZeroes );
     if ( mReNegativeZero.exactMatch( valueStr ) )
@@ -237,7 +237,7 @@ QString QgsRendererRangeLabelFormat::formatNumber( double value ) const
   }
   else
   {
-    QString valueStr = QString::number( value * mNumberScale, 'f', 0 );
+    QString valueStr = QLocale().toString( value * mNumberScale, 'f', 0 );
     if ( valueStr == QLatin1String( "-0" ) )
       valueStr = '0';
     if ( valueStr != QLatin1String( "0" ) )

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -152,7 +152,7 @@ QVariant QgsGraduatedSymbolRendererModel::data( const QModelIndex &index, int ro
       {
         int decimalPlaces = mRenderer->labelFormat().precision() + 2;
         if ( decimalPlaces < 0 ) decimalPlaces = 0;
-        return QString::number( range.lowerValue(), 'f', decimalPlaces ) + " - " + QString::number( range.upperValue(), 'f', decimalPlaces );
+        return QLocale().toString( range.lowerValue(), 'f', decimalPlaces ) + " - " + QLocale().toString( range.upperValue(), 'f', decimalPlaces );
       }
       case 2:
         return range.label();
@@ -1008,8 +1008,8 @@ void QgsGraduatedSymbolRendererWidget::changeRange( int rangeIdx )
   // Ensures users can see if legend is not completely honest!
   int decimalPlaces = mRenderer->labelFormat().precision() + 2;
   if ( decimalPlaces < 0 ) decimalPlaces = 0;
-  dialog.setLowerValue( QString::number( range.lowerValue(), 'f', decimalPlaces ) );
-  dialog.setUpperValue( QString::number( range.upperValue(), 'f', decimalPlaces ) );
+  dialog.setLowerValue( QLocale().toString( range.lowerValue(), 'f', decimalPlaces ) );
+  dialog.setUpperValue( QLocale().toString( range.upperValue(), 'f', decimalPlaces ) );
 
   if ( dialog.exec() == QDialog::Accepted )
   {


### PR DESCRIPTION
## Description

Use locale settings when formatting categorized renderer range labels

Before:

![qgis-categorized-no-locale](https://user-images.githubusercontent.com/142164/44920871-4eb89800-ad41-11e8-9dd8-3ec5ceb554e9.png)


After:

![qgis-categorized-locale](https://user-images.githubusercontent.com/142164/44920878-52e4b580-ad41-11e8-9041-73fde3c1897d.png)

