### PR TITLE
Fix pyfuture installation under CMake 3.12

### DIFF
--- a/python/ext-libs/CMakeLists.txt
+++ b/python/ext-libs/CMakeLists.txt
@@ -49,8 +49,8 @@ IF(NOT ENABLE_PYTHON3)
       FILE(GLOB_RECURSE files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/future future/*)
       ADD_CUSTOM_COMMAND(TARGET pyfuture
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${item} "${PYTHON_OUTPUT_DIRECTORY}/"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${item} "${PYTHON_OUTPUT_DIRECTORY}/${item}"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/future
         DEPENDS ${files}
       )
       PY_COMPILE(pyfuture "${PYTHON_OUTPUT_DIRECTORY}/${item}")


### PR DESCRIPTION
The logic here was incorrect, but managed to do the right thing
anyway. Under CMake 3.12, this is a hard error.

## Description

The cmake installation logic for pyfuture intends to glob over the contents of the `python/ext-libs/future` directory, and copy each item to `build/output/python`. However the `WORKING_DIRECTORY` specified is one level too high, and so most of the commands are copying a non-existent directory. Under CMake < 3.12, this was silently ignored. Since the `python/ext-libs/future` directory contains an item named `future`, one of the generated commands has the desired effect. As of CMake 3.12 attempting to copy a directory that doesn't exist is now a hard error and fails the build. See, https://lists.osgeo.org/pipermail/qgis-developer/2018-August/054209.html for an example. This change restores the original intent.

Note that the base branch is `release-2_18`. The affected code was removed by 88e4410af11ecb53f616f1d98f5f9ee49827ccd5.

Before:

```
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory _dummy_thread qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory _markupbase qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory _thread qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory builtins qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory configparser qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory copyreg qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory future qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory future-0.15.2.dist-info qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory html qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory http qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory libfuturize qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory libpasteurize qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory past qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory queue qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory reprlib qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory socketserver qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory tkinter qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory winreg qgis-2.18.22/build/output/python/
cd qgis-2.18.22/python/ext-libs && cmake -E copy_directory xmlrpc qgis-2.18.22/build/output/python/
```

After:
```cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory _dummy_thread qgis-2.18.22/build/output/python/_dummy_thread
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory _markupbase qgis-2.18.22/build/output/python/_markupbase
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory _thread qgis-2.18.22/build/output/python/_thread
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory builtins qgis-2.18.22/build/output/python/builtins
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory configparser qgis-2.18.22/build/output/python/configparser
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory copyreg qgis-2.18.22/build/output/python/copyreg
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory future qgis-2.18.22/build/output/python/future
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory future-0.15.2.dist-info qgis-2.18.22/build/output/python/future-0.15.2.dist-info
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory html qgis-2.18.22/build/output/python/html
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory http qgis-2.18.22/build/output/python/http
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory libfuturize qgis-2.18.22/build/output/python/libfuturize
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory libpasteurize qgis-2.18.22/build/output/python/libpasteurize
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory past qgis-2.18.22/build/output/python/past
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory queue qgis-2.18.22/build/output/python/queue
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory reprlib qgis-2.18.22/build/output/python/reprlib
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory socketserver qgis-2.18.22/build/output/python/socketserver
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory tkinter qgis-2.18.22/build/output/python/tkinter
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory winreg qgis-2.18.22/build/output/python/winreg
cd qgis-2.18.22/python/ext-libs/future && cmake -E copy_directory xmlrpc qgis-2.18.22/build/output/python/xmlrpc
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
