### PR TITLE
[processing] Ensure that model child algorithm parameters which are set to dynamic values are preserved across save/restore

### DIFF
--- a/python/core/auto_generated/qgsxmlutils.sip.in
+++ b/python/core/auto_generated/qgsxmlutils.sip.in
@@ -59,6 +59,7 @@ Supported types are
 - QVariant.Int
 - QVariant.Double
 - QVariant.String
+- :py:class:`QgsProperty` (since QGIS 3.4)
 %End
 
     static QVariant readVariant( const QDomElement &element );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -164,6 +164,7 @@ void QgsApplication::init( QString profileFolder )
   qRegisterMetaType<QgsUnitTypes::LayoutUnit>( "QgsUnitTypes::LayoutUnit" );
   qRegisterMetaType<QgsFeatureId>( "QgsFeatureId" );
   qRegisterMetaType<QgsFeatureIds>( "QgsFeatureIds" );
+  qRegisterMetaType<QgsProperty>( "QgsProperty" );
   qRegisterMetaType<Qgis::MessageLevel>( "Qgis::MessageLevel" );
   qRegisterMetaType<QgsReferencedRectangle>( "QgsReferencedRectangle" );
   qRegisterMetaType<QgsReferencedPointXY>( "QgsReferencedPointXY" );

--- a/src/core/qgsxmlutils.h
+++ b/src/core/qgsxmlutils.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsXmlUtils
      * - QVariant::Int
      * - QVariant::Double
      * - QVariant::String
-     *
+     * - QgsProperty (since QGIS 3.4)
      */
     static QDomElement writeVariant( const QVariant &value, QDomDocument &doc );
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -5840,7 +5840,8 @@ void TestQgsProcessing::modelerAlgorithm()
   alg5c1.addParameterSources( "zm", QgsProcessingModelChildParameterSources() << QgsProcessingModelChildParameterSource::fromStaticValue( 6 )
                               << QgsProcessingModelChildParameterSource::fromModelParameter( "p2" )
                               << QgsProcessingModelChildParameterSource::fromChildOutput( "cx2", "out4" )
-                              << QgsProcessingModelChildParameterSource::fromExpression( "1+2" ) );
+                              << QgsProcessingModelChildParameterSource::fromExpression( "1+2" )
+                              << QgsProcessingModelChildParameterSource::fromStaticValue( QgsProperty::fromExpression( "1+8" ) ) );
   alg5c1.setActive( true );
   alg5c1.setOutputsCollapsed( true );
   alg5c1.setParametersCollapsed( true );
@@ -5896,7 +5897,7 @@ void TestQgsProcessing::modelerAlgorithm()
   QCOMPARE( alg6c1.parameterSources().value( "z" ).at( 0 ).staticValue().toInt(), 5 );
   QCOMPARE( alg6c1.parameterSources().value( "a" ).at( 0 ).source(), QgsProcessingModelChildParameterSource::Expression );
   QCOMPARE( alg6c1.parameterSources().value( "a" ).at( 0 ).expression(), QStringLiteral( "2*2" ) );
-  QCOMPARE( alg6c1.parameterSources().value( "zm" ).count(), 4 );
+  QCOMPARE( alg6c1.parameterSources().value( "zm" ).count(), 5 );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 0 ).source(), QgsProcessingModelChildParameterSource::StaticValue );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 0 ).staticValue().toInt(), 6 );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 1 ).source(), QgsProcessingModelChildParameterSource::ModelParameter );
@@ -5906,6 +5907,9 @@ void TestQgsProcessing::modelerAlgorithm()
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 2 ).outputName(), QStringLiteral( "out4" ) );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 3 ).source(), QgsProcessingModelChildParameterSource::Expression );
   QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 3 ).expression(), QStringLiteral( "1+2" ) );
+  QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).source(), QgsProcessingModelChildParameterSource::StaticValue );
+  QVERIFY( alg6c1.parameterSources().value( "zm" ).at( 4 ).staticValue().canConvert< QgsProperty >() );
+  QCOMPARE( alg6c1.parameterSources().value( "zm" ).at( 4 ).staticValue().value< QgsProperty >().expressionString(), QStringLiteral( "1+8" ) );
 
   QCOMPARE( alg6c1.modelOutputs().count(), 1 );
   QCOMPARE( alg6c1.modelOutputs().value( QStringLiteral( "a" ) ).description(), QStringLiteral( "my output" ) );

--- a/tests/src/python/test_qgsxmlutils.py
+++ b/tests/src/python/test_qgsxmlutils.py
@@ -14,7 +14,8 @@ __revision__ = '$Format:%H$'
 
 import qgis  # NOQA switch sip api
 
-from qgis.core import QgsXmlUtils
+from qgis.core import (QgsXmlUtils,
+                       QgsProperty)
 
 from qgis.PyQt.QtXml import QDomDocument
 
@@ -101,6 +102,33 @@ class TestQgsXmlUtils(unittest.TestCase):
         prop2 = QgsXmlUtils.readVariant(elem)
 
         self.assertEqual(my_properties, prop2)
+
+    def test_property(self):
+        """
+        Test that QgsProperty values are correctly loaded and written
+        """
+        doc = QDomDocument("properties")
+
+        prop = QgsProperty.fromValue(1001)
+        elem = QgsXmlUtils.writeVariant(prop, doc)
+
+        prop2 = QgsXmlUtils.readVariant(elem)
+
+        self.assertEqual(prop, prop2)
+
+        prop = QgsProperty.fromExpression('1+2=5')
+        elem = QgsXmlUtils.writeVariant(prop, doc)
+
+        prop2 = QgsXmlUtils.readVariant(elem)
+
+        self.assertEqual(prop, prop2)
+
+        prop = QgsProperty.fromField('oid')
+        elem = QgsXmlUtils.writeVariant(prop, doc)
+
+        prop2 = QgsXmlUtils.readVariant(elem)
+
+        self.assertEqual(prop, prop2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With tests.

This is not exposed via gui yet, but supported by the backend. This fix is cherry-picked from #7761 as a self-contained change.