### PR TITLE
better looking shadows for hackfests and contributors styles

### DIFF
--- a/resources/data/contributors.qml
+++ b/resources/data/contributors.qml
@@ -115,14 +115,14 @@
       <effect type="dropShadow">
         <prop v="13" k="blend_mode"/>
         <prop v="3" k="blur_level"/>
-        <prop v="124,124,124,255" k="color"/>
+        <prop v="0,0,0,255" k="color"/>
         <prop v="2" k="draw_mode"/>
         <prop v="1" k="enabled"/>
         <prop v="135" k="offset_angle"/>
         <prop v="2" k="offset_distance"/>
         <prop v="MM" k="offset_unit"/>
         <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
-        <prop v="1" k="opacity"/>
+        <prop v="0.5" k="opacity"/>
       </effect>
       <effect type="outerGlow">
         <prop v="0" k="blend_mode"/>

--- a/resources/data/qgis-hackfests.qml
+++ b/resources/data/qgis-hackfests.qml
@@ -115,14 +115,14 @@
       <effect type="dropShadow">
         <prop v="13" k="blend_mode"/>
         <prop v="3" k="blur_level"/>
-        <prop v="124,124,124,255" k="color"/>
+        <prop v="0,0,0,255" k="color"/>
         <prop v="2" k="draw_mode"/>
         <prop v="1" k="enabled"/>
         <prop v="135" k="offset_angle"/>
         <prop v="2" k="offset_distance"/>
         <prop v="MM" k="offset_unit"/>
         <prop v="3x:0,0,0,0,0,0" k="offset_unit_scale"/>
-        <prop v="1" k="opacity"/>
+        <prop v="0.5" k="opacity"/>
       </effect>
       <effect type="outerGlow">
         <prop v="0" k="blend_mode"/>


### PR DESCRIPTION
## Description
Shadow was a 50% gray fill with a 100% opacity and will now be a black fill with 50% opacity, looking more natural and being a better shadow example for users. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
