### PR TITLE
Throw an assert when using an unsupported variant type with QgsXmlUtils::writeVariant

### DIFF
--- a/src/core/qgsxmlutils.cpp
+++ b/src/core/qgsxmlutils.cpp
@@ -154,8 +154,7 @@ QDomElement QgsXmlUtils::writeVariant( const QVariant &value, QDomDocument &doc 
       break;
 
     default:
-      element.setAttribute( QStringLiteral( "type" ), QStringLiteral( "Unknown" ) );
-      element.setAttribute( QStringLiteral( "value" ), value.toString() );
+      Q_ASSERT_X( false, "QgsXmlUtils::writeVariant", "unsupported variant type" );
       break;
   }
 


### PR DESCRIPTION
These were previously written as strings yet could not be restored by QgsXmlUtils::readVariant. Better to throw an assert so that it's clear that these types are unsupported and that support needs to be added.