### PR TITLE
fix requesting CRS for layer without geometry

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -247,7 +247,8 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement,  QgsReadWriteCo
   QDomNode srsNode = layerElement.namedItem( QStringLiteral( "srs" ) );
   mCRS.readXml( srsNode );
   mCRS.setValidationHint( tr( "Specify CRS for layer %1" ).arg( mne.text() ) );
-  mCRS.validate();
+  if ( isSpatial() )
+    mCRS.validate();
   savedCRS = mCRS;
 
   // Do not validate any projections in children, they will be overwritten anyway.


### PR DESCRIPTION
I have a project with a non spatial vector layer (gpkg) and QGIS asks for a CRS.
This PR fixes this but I am not 100% sure this is the right place to solve this.