### PR TITLE
A few layout legend item fixes

### DIFF
--- a/src/app/layout/qgslayoutlegendwidget.cpp
+++ b/src/app/layout/qgslayoutlegendwidget.cpp
@@ -856,6 +856,7 @@ void QgsLayoutLegendWidget::mFilterByMapToolButton_toggled( bool checked )
   mLegend->beginCommand( tr( "Update Legend" ) );
   mLegend->setLegendFilterByMapEnabled( checked );
   mLegend->adjustBoxSize();
+  mLegend->update();
   mLegend->endCommand();
 }
 

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -42,6 +42,8 @@ QgsLayoutItemLegend::QgsLayoutItemLegend( QgsLayout *layout )
   connect( &layout->atlasComposition(), &QgsAtlasComposition::renderEnded, this, &QgsLayoutItemLegend::onAtlasEnded );
 #endif
 
+  mTitle = mSettings.title();
+
   // Connect to the main layertreeroot.
   // It serves in "auto update mode" as a medium between the main app legend and this one
   connect( mLayout->project()->layerTreeRoot(), &QgsLayerTreeNode::customPropertyChanged, this, &QgsLayoutItemLegend::nodeCustomPropertyChanged );

--- a/src/core/qgslegendsettings.cpp
+++ b/src/core/qgslegendsettings.cpp
@@ -18,8 +18,7 @@
 #include <QPainter>
 
 QgsLegendSettings::QgsLegendSettings()
-  : mTitle( QObject::tr( "Legend" ) )
-  , mFontColor( QColor( 0, 0, 0 ) )
+  : mFontColor( QColor( 0, 0, 0 ) )
   , mSymbolSize( 7, 4 )
   , mWmsLegendSize( 50, 25 )
   , mRasterStrokeColor( Qt::black )

--- a/tests/src/core/testqgslegendrenderer.cpp
+++ b/tests/src/core/testqgslegendrenderer.cpp
@@ -56,8 +56,9 @@ static void _setStandardTestFont( QgsLegendSettings &settings, const QString &st
   }
 }
 
-static void _renderLegend( const QString &testName, QgsLayerTreeModel *legendModel, const QgsLegendSettings &settings )
+static void _renderLegend( const QString &testName, QgsLayerTreeModel *legendModel, QgsLegendSettings &settings )
 {
+  settings.setTitle( QStringLiteral( "Legend" ) );
   QgsLegendRenderer legendRenderer( legendModel, settings );
   QSizeF size = legendRenderer.minimumSize();
 

--- a/tests/src/python/test_qgslayoutatlas.py
+++ b/tests/src/python/test_qgslayoutatlas.py
@@ -554,6 +554,7 @@ class TestQgsLayoutAtlas(unittest.TestCase):
 
         # add a legend
         legend = QgsLayoutItemLegend(self.layout)
+        legend.setTitle("Legend")
         legend.attemptMove(QgsLayoutPoint(200, 100))
         # sets the legend filter parameter
         legend.setLinkedMap(self.atlas_map)

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -73,6 +73,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         map.setExtent(point_layer.extent())
 
         legend = QgsLayoutItemLegend(layout)
+        legend.setTitle("Legend")
         legend.attemptSetSceneRect(QRectF(120, 20, 80, 80))
         legend.setFrameEnabled(True)
         legend.setFrameStrokeWidth(QgsLayoutMeasurement(2))
@@ -127,6 +128,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         map.setExtent(point_layer.extent())
 
         legend = QgsLayoutItemLegend(layout)
+        legend.setTitle("Legend")
         legend.attemptSetSceneRect(QRectF(120, 20, 80, 80))
         legend.setFrameEnabled(True)
         legend.setFrameStrokeWidth(QgsLayoutMeasurement(2))
@@ -166,6 +168,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         map.setExtent(point_layer.extent())
 
         legend = QgsLayoutItemLegend(layout)
+        legend.setTitle("Legend")
         legend.attemptSetSceneRect(QRectF(120, 20, 80, 80))
         legend.setFrameEnabled(True)
         legend.setFrameStrokeWidth(QgsLayoutMeasurement(2))
@@ -209,6 +212,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         map.setExtent(point_layer.extent())
 
         legend = QgsLayoutItemLegend(layout)
+        legend.setTitle("Legend")
         legend.attemptSetSceneRect(QRectF(120, 20, 20, 20))
         legend.setFrameEnabled(True)
         legend.setFrameStrokeWidth(QgsLayoutMeasurement(2))
@@ -253,6 +257,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         layout.initializeDefaults()
 
         legend = QgsLayoutItemLegend(layout)
+        legend.setTitle("Legend")
         layout.addLayoutItem(legend)
 
         legend.setColumnCount(2)


### PR DESCRIPTION
## Description
@nyalldawson , quick layout fix for the legend item. Prior to the PR, creating a legend item would lead to an empty title line edit in the item's properties panel. It was due to the legend object's mTitle string not synchronized with its mSettings's (default) mTitle string.

I don't see any reason why we need to maintain a dual title string, which risks (and did) get out of sync. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
