### PR TITLE
fid is the default if the ID column is empty when we create a geopackage

### DIFF
--- a/src/gui/qgsnewgeopackagelayerdialog.cpp
+++ b/src/gui/qgsnewgeopackagelayerdialog.cpp
@@ -44,6 +44,8 @@
 #include <cpl_error.h>
 #include <cpl_string.h>
 
+#define DEFAULT_OGR_FID_COLUMN_TITLE "fid" // default value from OGR
+
 QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::WindowFlags fl )
   : QDialog( parent, fl )
 {
@@ -85,7 +87,7 @@ QgsNewGeoPackageLayerDialog::QgsNewGeoPackageLayerDialog( QWidget *parent, Qt::W
   mGeometryWithMCheckBox->setEnabled( false );
   mGeometryColumnEdit->setEnabled( false );
   mGeometryColumnEdit->setText( "geometry" );
-  mFeatureIdColumnEdit->setText( "fid" );
+  mFeatureIdColumnEdit->setPlaceholderText( DEFAULT_OGR_FID_COLUMN_TITLE );
   mCheckBoxCreateSpatialIndex->setEnabled( false );
   mCrsSelector->setEnabled( false );
 
@@ -192,7 +194,8 @@ void QgsNewGeoPackageLayerDialog::mAddAttributeButton_clicked()
   if ( !mFieldNameEdit->text().isEmpty() )
   {
     QString myName = mFieldNameEdit->text();
-    if ( myName == mFeatureIdColumnEdit->text() )
+    const QString featureId = mFeatureIdColumnEdit->text().isEmpty() ? DEFAULT_OGR_FID_COLUMN_TITLE : mFeatureIdColumnEdit->text();
+    if ( myName.compare( featureId, Qt::CaseInsensitive ) == 0 )
     {
       QMessageBox::critical( this, tr( "Add Field" ), tr( "The field cannot have the same name as the feature identifier." ) );
       return;


### PR DESCRIPTION
## Description

* set `fid` as a placeholder in the create geopackage layer

If the field is empty, `fid` will be added automatically

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
