### PR TITLE
[3d] When first applying a 3D map settings from a dock, also copy its camera settings

### DIFF
--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -115,6 +115,14 @@ void QgsLayout3DMapWidget::updateCameraPoseWidgetsFromItem()
 void QgsLayout3DMapWidget::copy3DMapSettings()
 {
   Qgs3DMapCanvasDockWidget *dock = _dock3DViewFromSender( sender() );
+
+  // if this is the first settings passed on, also copy camera details
+  if ( !mMap3D->mapSettings() )
+  {
+    mMap3D->setCameraPose( dock->mapCanvas3D()->cameraController()->cameraPose() );
+    updateCameraPoseWidgetsFromItem();
+  }
+
   if ( dock )
     mMap3D->setMapSettings( new Qgs3DMapSettings( *dock->mapCanvas3D()->map() ) );
 }


### PR DESCRIPTION
## Description
@wonder-sk , this is a must-have for large 3D scenes, it avoids loading tiles that users probably don't want, and I'd argue this behavior is always better UX than setting camera to 0,0,0. It also harmonizes the behavior of the 3D map item, quasi-matching the behavior of creating a new 2D map item (which automatically sets its extent to the main window canvas).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
