### PR TITLE
[needs-docs][processing] Use input layer data type for gdal algorithms when appropriate...

### DIFF
--- a/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByExtent.py
@@ -54,7 +54,7 @@ class ClipRasterByExtent(GdalAlgorithm):
     DATA_TYPE = 'DATA_TYPE'
     OUTPUT = 'OUTPUT'
 
-    TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
+    TYPES = ['Use input layer data type', 'Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
 
     def __init__(self):
         super().__init__()
@@ -84,7 +84,7 @@ class ClipRasterByExtent(GdalAlgorithm):
                                                     self.tr('Output data type'),
                                                     self.TYPES,
                                                     allowMultiple=False,
-                                                    defaultValue=5)
+                                                    defaultValue=0)
         dataType_param.setFlags(dataType_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(dataType_param)
 
@@ -132,8 +132,9 @@ class ClipRasterByExtent(GdalAlgorithm):
         if nodata is not None:
             arguments.append('-a_nodata {}'.format(nodata))
 
-        arguments.append('-ot')
-        arguments.append(self.TYPES[self.parameterAsEnum(parameters, self.DATA_TYPE, context)])
+        data_type = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        if data_type:
+            arguments.append('-ot ' + self.TYPES[data_type])
 
         arguments.append('-of')
         arguments.append(QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1]))

--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -58,7 +58,7 @@ class ClipRasterByMask(GdalAlgorithm):
     DATA_TYPE = 'DATA_TYPE'
     OUTPUT = 'OUTPUT'
 
-    TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
+    TYPES = ['Use input layer data type', 'Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
 
     def __init__(self):
         super().__init__()
@@ -98,7 +98,7 @@ class ClipRasterByMask(GdalAlgorithm):
                                                     self.tr('Output data type'),
                                                     self.TYPES,
                                                     allowMultiple=False,
-                                                    defaultValue=5)
+                                                    defaultValue=0)
         dataType_param.setFlags(dataType_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(dataType_param)
 
@@ -138,8 +138,10 @@ class ClipRasterByMask(GdalAlgorithm):
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
 
         arguments = []
-        arguments.append('-ot')
-        arguments.append(self.TYPES[self.parameterAsEnum(parameters, self.DATA_TYPE, context)])
+
+        data_type = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        if data_type:
+            arguments.append('-ot ' + self.TYPES[data_type])
 
         arguments.append('-of')
         arguments.append(QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1]))

--- a/python/plugins/processing/algs/gdal/rearrange_bands.py
+++ b/python/plugins/processing/algs/gdal/rearrange_bands.py
@@ -52,7 +52,7 @@ class rearrange_bands(GdalAlgorithm):
     DATA_TYPE = 'DATA_TYPE'
     OUTPUT = 'OUTPUT'
 
-    TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
+    TYPES = ['Use input layer data type', 'Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
 
     def __init__(self):
         super().__init__()
@@ -79,7 +79,7 @@ class rearrange_bands(GdalAlgorithm):
                                                     self.tr('Output data type'),
                                                     self.TYPES,
                                                     allowMultiple=False,
-                                                    defaultValue=5)
+                                                    defaultValue=0)
         dataType_param.setFlags(dataType_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(dataType_param)
 
@@ -121,8 +121,9 @@ class rearrange_bands(GdalAlgorithm):
         for band in bands:
             arguments.append('-b {}'.format(band))
 
-        arguments.append('-ot')
-        arguments.append(self.TYPES[self.parameterAsEnum(parameters, self.DATA_TYPE, context)])
+        data_type = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        if data_type:
+            arguments.append('-ot ' + self.TYPES[data_type])
 
         arguments.append('-of')
         arguments.append(QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1]))

--- a/python/plugins/processing/algs/gdal/translate.py
+++ b/python/plugins/processing/algs/gdal/translate.py
@@ -55,7 +55,7 @@ class translate(GdalAlgorithm):
     DATA_TYPE = 'DATA_TYPE'
     OUTPUT = 'OUTPUT'
 
-    TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
+    TYPES = ['Use input layer data type', 'Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
 
     def __init__(self):
         super().__init__()
@@ -89,7 +89,7 @@ class translate(GdalAlgorithm):
                                                     self.tr('Output data type'),
                                                     self.TYPES,
                                                     allowMultiple=False,
-                                                    defaultValue=5)
+                                                    defaultValue=0)
         dataType_param.setFlags(dataType_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(dataType_param)
 
@@ -139,8 +139,9 @@ class translate(GdalAlgorithm):
         if self.parameterAsBool(parameters, self.COPY_SUBDATASETS, context):
             arguments.append('-sds')
 
-        arguments.append('-ot')
-        arguments.append(self.TYPES[self.parameterAsEnum(parameters, self.DATA_TYPE, context)])
+        data_type = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        if data_type:
+            arguments.append('-ot ' + self.TYPES[data_type])
 
         arguments.append('-of')
         arguments.append(QgsRasterFileWriter.driverForExtension(os.path.splitext(out)[1]))

--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -61,7 +61,7 @@ class warp(GdalAlgorithm):
     MULTITHREADING = 'MULTITHREADING'
     OUTPUT = 'OUTPUT'
 
-    TYPES = ['Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
+    TYPES = ['Use input layer data type', 'Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
 
     def __init__(self):
         super().__init__()
@@ -117,7 +117,7 @@ class warp(GdalAlgorithm):
                                                     self.tr('Output data type'),
                                                     self.TYPES,
                                                     allowMultiple=False,
-                                                    defaultValue=5)
+                                                    defaultValue=0)
         dataType_param.setFlags(dataType_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(dataType_param)
 
@@ -216,8 +216,9 @@ class warp(GdalAlgorithm):
         if self.parameterAsBool(parameters, self.MULTITHREADING, context):
             arguments.append('-multi')
 
-        arguments.append('-ot')
-        arguments.append(self.TYPES[self.parameterAsEnum(parameters, self.DATA_TYPE, context)])
+        data_type = self.parameterAsEnum(parameters, self.DATA_TYPE, context)
+        if data_type:
+            arguments.append('-ot ' + self.TYPES[data_type])
 
         out = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
         arguments.append('-of')

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -348,7 +348,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
             translate_alg.getConsoleCommands({'INPUT': source,
                                               'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
-             '-ot Float32 -of JPEG ' +
+             '-of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
         # with None NODATA value
@@ -357,7 +357,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                               'NODATA': None,
                                               'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
-             '-ot Float32 -of JPEG ' +
+             '-of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
         # with NODATA value
@@ -367,7 +367,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                               'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
              '-a_nodata 9999.0 ' +
-             '-ot Float32 -of JPEG ' +
+             '-of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
         # with "0" NODATA value
@@ -377,9 +377,21 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                               'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
              '-a_nodata 0.0 ' +
+             '-of JPEG ' +
+             source + ' ' +
+             'd:/temp/check.jpg'])
+        # with "0" NODATA value and custom data type
+        self.assertEqual(
+            translate_alg.getConsoleCommands({'INPUT': source,
+                                              'NODATA': 0,
+                                              'DATA_TYPE': 6,
+                                              'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdal_translate',
+             '-a_nodata 0.0 ' +
              '-ot Float32 -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
+
         # with target srs
         self.assertEqual(
             translate_alg.getConsoleCommands({'INPUT': source,
@@ -387,7 +399,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                               'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
              '-a_srs EPSG:3111 ' +
-             '-ot Float32 -of JPEG ' +
+             '-of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -399,7 +411,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                               'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
              '-a_srs EPSG:20936 ' +
-             '-ot Float32 -of JPEG ' +
+             '-of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -411,7 +423,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                               'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
              '-a_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" ' +
-             '-ot Float32 -of JPEG ' +
+             '-of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -422,7 +434,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                               'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
              '-a_srs EPSG:3111 ' +
-             '-ot Float32 -of JPEG ' +
+             '-of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -433,7 +445,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                               'OUTPUT': 'd:/temp/check.tif'}, context, feedback),
             ['gdal_translate',
              '-sds ' +
-             '-ot Float32 -of GTiff ' +
+             '-of GTiff ' +
              source + ' ' +
              'd:/temp/check.tif'])
 
@@ -451,7 +463,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'EXTENT': extent,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
-             '-projwin 0.0 0.0 0.0 0.0 -ot Float32 -of JPEG ' +
+             '-projwin 0.0 0.0 0.0 0.0 -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
         # with NODATA value
@@ -461,7 +473,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'NODATA': 9999,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
-             '-projwin 0.0 0.0 0.0 0.0 -a_nodata 9999.0 -ot Float32 -of JPEG ' +
+             '-projwin 0.0 0.0 0.0 0.0 -a_nodata 9999.0 -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
         # with "0" NODATA value
@@ -469,6 +481,17 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
             alg.getConsoleCommands({'INPUT': source,
                                     'EXTENT': extent,
                                     'NODATA': 0,
+                                    'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdal_translate',
+             '-projwin 0.0 0.0 0.0 0.0 -a_nodata 0.0 -of JPEG ' +
+             source + ' ' +
+             'd:/temp/check.jpg'])
+        # with "0" NODATA value and custom data type
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'EXTENT': extent,
+                                    'NODATA': 0,
+                                    'DATA_TYPE': 6,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdal_translate',
              '-projwin 0.0 0.0 0.0 0.0 -a_nodata 0.0 -ot Float32 -of JPEG ' +
@@ -489,7 +512,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'MASK': mask,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-ot Float32 -of JPEG -cutline ' +
+             '-of JPEG -cutline ' +
              mask + ' -crop_to_cutline ' + source + ' ' +
              'd:/temp/check.jpg'])
         # with NODATA value
@@ -499,7 +522,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'NODATA': 9999,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-ot Float32 -of JPEG -cutline ' +
+             '-of JPEG -cutline ' +
              mask + ' -crop_to_cutline -dstnodata 9999.0 ' + source + ' ' +
              'd:/temp/check.jpg'])
         # with "0" NODATA value
@@ -507,6 +530,17 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
             alg.getConsoleCommands({'INPUT': source,
                                     'MASK': mask,
                                     'NODATA': 0,
+                                    'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdalwarp',
+             '-of JPEG -cutline ' +
+             mask + ' -crop_to_cutline -dstnodata 0.0 ' + source + ' ' +
+             'd:/temp/check.jpg'])
+        # with "0" NODATA value and custom data type
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'MASK': mask,
+                                    'NODATA': 0,
+                                    'DATA_TYPE': 6,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
              '-ot Float32 -of JPEG -cutline ' +
@@ -1431,7 +1465,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'SOURCE_CRS': 'EPSG:3111',
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
         # with None NODATA value
@@ -1441,7 +1475,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'SOURCE_CRS': 'EPSG:3111',
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
         # with NODATA value
@@ -1451,13 +1485,24 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'SOURCE_CRS': 'EPSG:3111',
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs EPSG:3111 -t_srs EPSG:4326 -dstnodata 9999.0 -r near -ot Float32 -of JPEG ' +
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -dstnodata 9999.0 -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
         # with "0" NODATA value
         self.assertEqual(
             alg.getConsoleCommands({'INPUT': source,
                                     'NODATA': 0,
+                                    'SOURCE_CRS': 'EPSG:3111',
+                                    'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
+            ['gdalwarp',
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -dstnodata 0.0 -r near -of JPEG ' +
+             source + ' ' +
+             'd:/temp/check.jpg'])
+        # with "0" NODATA value and custom data type
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'NODATA': 0,
+                                    'DATA_TYPE': 6,
                                     'SOURCE_CRS': 'EPSG:3111',
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
@@ -1473,7 +1518,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'TARGET_CRS': custom_crs,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs EPSG:20936 -t_srs EPSG:20936 -r near -ot Float32 -of JPEG ' +
+             '-s_srs EPSG:20936 -t_srs EPSG:20936 -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -1485,7 +1530,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'TARGET_CRS': custom_crs,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -t_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -r near -ot Float32 -of JPEG ' +
+             '-s_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -t_srs "+proj=utm +zone=36 +south +a=63785 +b=6357 +towgs84=-143,-90,-294,0,0,0,0 +units=m +no_defs" -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -1496,7 +1541,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'TARGET_CRS': 'POSTGIS:3111',
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs EPSG:3111 -t_srs EPSG:3111 -r near -ot Float32 -of JPEG ' +
+             '-s_srs EPSG:3111 -t_srs EPSG:3111 -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -1507,7 +1552,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'TARGET_RESOLUTION': None,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -1518,7 +1563,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'TARGET_RESOLUTION': 10.0,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs EPSG:3111 -t_srs EPSG:4326 -tr 10.0 10.0 -r near -ot Float32 -of JPEG ' +
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -tr 10.0 10.0 -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -1529,7 +1574,7 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'TARGET_RESOLUTION': 0.0,
                                     'OUTPUT': 'd:/temp/check.jpg'}, context, feedback),
             ['gdalwarp',
-             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -ot Float32 -of JPEG ' +
+             '-s_srs EPSG:3111 -t_srs EPSG:4326 -r near -of JPEG ' +
              source + ' ' +
              'd:/temp/check.jpg'])
 
@@ -1548,13 +1593,21 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                                     'BANDS': 1,
                                     'OUTPUT': outsource}, context, feedback),
             ['gdal_translate', '-b 1 ' +
-             '-ot Float32 -of GTiff ' +
+             '-of GTiff ' +
              source + ' ' + outsource])
-
         # three bands, re-ordered
         self.assertEqual(
             alg.getConsoleCommands({'INPUT': source,
                                     'BANDS': [3, 2, 1],
+                                    'OUTPUT': outsource}, context, feedback),
+            ['gdal_translate', '-b 3 -b 2 -b 1 ' +
+             '-of GTiff ' +
+             source + ' ' + outsource])
+        # three bands, re-ordered with custom data type
+        self.assertEqual(
+            alg.getConsoleCommands({'INPUT': source,
+                                    'BANDS': [3, 2, 1],
+                                    'DATA_TYPE': 6,
                                     'OUTPUT': outsource}, context, feedback),
             ['gdal_translate', '-b 3 -b 2 -b 1 ' +
              '-ot Float32 -of GTiff ' +

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -20,7 +20,7 @@ tests:
   - algorithm: gdal:cliprasterbyextent
     name: Clip raster by extent (gdal_transform)
     params:
-      DATA_TYPE: 5
+      DATA_TYPE: 6
       INPUT:
         name: dem.tif
         type: raster
@@ -35,7 +35,7 @@ tests:
   - algorithm: gdal:cliprasterbyextent
     name: Test (gdal:cliprasterbyextent)
     params:
-      DATA_TYPE: 5
+      DATA_TYPE: 6
       INPUT:
         name: dem.tif
         type: raster
@@ -53,7 +53,7 @@ tests:
     params:
       ALPHA_BAND: false
       CROP_TO_CUTLINE: true
-      DATA_TYPE: 5
+      DATA_TYPE: 6
       INPUT:
         name: dem.tif
         type: raster
@@ -458,7 +458,7 @@ tests:
   - algorithm: gdal:warpreproject
     name: Warp (gdalwarp)
     params:
-      DATA_TYPE: 5
+      DATA_TYPE: 6
       INPUT:
         name: dem.tif
         type: raster


### PR DESCRIPTION
## Description
This PR changes the handling of data type for the following gdal algorithms:
- warp (i.e. reproject)
- translate (i.e. file format conversion)
- rearrange bands
- clip by extent/mask

For those algorithms, by default the data type will match that of the input layer.

The idea here is to have a default behavior that better matches expectations of users. For e.g., if someone reprojects a raster layer via the gdal warp algorithm, there's an expectation the data type will not change by default. It's especially true since we (not wrongly) hide the data type setting under a collapsed advanced settings section.

@nyalldawson , @alexbruy , all good with you?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
