### PR TITLE
[ui] use lowercase group name for help text in expression builder

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -548,7 +548,10 @@ QString QgsExpression::helpText( QString name )
 
   name = f.mName;
   if ( f.mType == tr( "group" ) )
+  {
     name = group( name );
+    name = name.toLower();
+  }
 
   name = name.toHtmlEscaped();
 


### PR DESCRIPTION
## Description
Once you see it, it can't be unseen, hence the PR:
![image](https://user-images.githubusercontent.com/1728657/45009781-4cea1f80-b034-11e8-8125-18eb8d9f5b98.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
