### PR TITLE
Add the grid frame MARGIN In the "Print Layout" map grid [FEATURE]

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmapgrid.sip.in
@@ -750,6 +750,22 @@ framePenSize method.
 .. seealso:: :py:func:`setFrameWidth`
 %End
 
+    void setGridFrameMargin( const double margin );
+%Docstring
+Sets the grid frame margin (in layout units).
+This property controls distance between the map frame and the grid frame.
+
+.. seealso:: GridFrameMargin
+%End
+
+    double GridFrameMargin() const;
+%Docstring
+Sets the grid frame Margin (in layout units).
+This property controls distance between the map frame and the grid frame.
+
+.. seealso:: :py:func:`setGridFrameMargin`
+%End
+
     void setFramePenSize( const double width );
 %Docstring
 Sets the ``width`` of the stroke drawn in the grid frame.

--- a/src/app/layout/qgslayoutmapgridwidget.cpp
+++ b/src/app/layout/qgslayoutmapgridwidget.cpp
@@ -39,6 +39,7 @@ QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, Q
   connect( mOffsetYSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mOffsetYSpinBox_valueChanged );
   connect( mCrossWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mCrossWidthSpinBox_valueChanged );
   connect( mFrameWidthSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mFrameWidthSpinBox_valueChanged );
+  connect( mGridFrameMarginSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mGridFrameMarginSpinBox_valueChanged );
   connect( mFrameStyleComboBox, static_cast<void ( QComboBox::* )( const QString & )>( &QComboBox::currentIndexChanged ), this, &QgsLayoutMapGridWidget::mFrameStyleComboBox_currentIndexChanged );
   connect( mGridFramePenSizeSpinBox, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsLayoutMapGridWidget::mGridFramePenSizeSpinBox_valueChanged );
   connect( mGridFramePenColorButton, &QgsColorButton::colorChanged, this, &QgsLayoutMapGridWidget::mGridFramePenColorButton_colorChanged );
@@ -196,6 +197,7 @@ void QgsLayoutMapGridWidget::blockAllSignals( bool block )
   mCrossWidthSpinBox->blockSignals( block );
   mFrameStyleComboBox->blockSignals( block );
   mFrameWidthSpinBox->blockSignals( block );
+  mGridFrameMarginSpinBox->blockSignals( block );
   mGridLineStyleButton->blockSignals( block );
   mMapGridUnitComboBox->blockSignals( block );
   mGridFramePenSizeSpinBox->blockSignals( block );
@@ -281,11 +283,13 @@ void QgsLayoutMapGridWidget::toggleFrameControls( bool frameEnabled, bool frameF
 {
   //set status of frame controls
   mFrameWidthSpinBox->setEnabled( frameSizeEnabled );
+  mGridFrameMarginSpinBox->setEnabled( frameEnabled );
   mGridFramePenSizeSpinBox->setEnabled( frameEnabled );
   mGridFramePenColorButton->setEnabled( frameEnabled );
   mGridFrameFill1ColorButton->setEnabled( frameFillEnabled );
   mGridFrameFill2ColorButton->setEnabled( frameFillEnabled );
   mFrameWidthLabel->setEnabled( frameSizeEnabled );
+  mFrameMarginLabel->setEnabled( frameEnabled );
   mFramePenLabel->setEnabled( frameEnabled );
   mFrameFillLabel->setEnabled( frameFillEnabled );
   mCheckGridLeftSide->setEnabled( frameEnabled );
@@ -458,6 +462,7 @@ void QgsLayoutMapGridWidget::setGridItems()
   mOffsetYSpinBox->setValue( mMapGrid->offsetY() );
   mCrossWidthSpinBox->setValue( mMapGrid->crossLength() );
   mFrameWidthSpinBox->setValue( mMapGrid->frameWidth() );
+  mGridFrameMarginSpinBox->setValue( mMapGrid->GridFrameMargin() );
   mGridFramePenSizeSpinBox->setValue( mMapGrid->framePenSize() );
   mGridFramePenColorButton->setColor( mMapGrid->framePenColor() );
   mGridFrameFill1ColorButton->setColor( mMapGrid->frameFillColor1() );
@@ -514,6 +519,7 @@ void QgsLayoutMapGridWidget::setGridItems()
 
   //grid frame
   mFrameWidthSpinBox->setValue( mMapGrid->frameWidth() );
+  mGridFrameMarginSpinBox->setValue( mMapGrid->GridFrameMargin() );
   QgsLayoutItemMapGrid::FrameStyle gridFrameStyle = mMapGrid->frameStyle();
   switch ( gridFrameStyle )
   {
@@ -683,6 +689,20 @@ void QgsLayoutMapGridWidget::mFrameWidthSpinBox_valueChanged( double val )
 
   mMap->beginCommand( tr( "Change Frame Width" ) );
   mMapGrid->setFrameWidth( val );
+  mMap->updateBoundingRect();
+  mMap->update();
+  mMap->endCommand();
+}
+
+void QgsLayoutMapGridWidget::mGridFrameMarginSpinBox_valueChanged( double val )
+{
+  if ( !mMapGrid || !mMap )
+  {
+    return;
+  }
+
+  mMap->beginCommand( tr( "Change Grid Frame Margin" ) );
+  mMapGrid->setGridFrameMargin( val );
   mMap->updateBoundingRect();
   mMap->update();
   mMap->endCommand();

--- a/src/app/layout/qgslayoutmapgridwidget.h
+++ b/src/app/layout/qgslayoutmapgridwidget.h
@@ -42,6 +42,7 @@ class QgsLayoutMapGridWidget: public QgsLayoutItemBaseWidget, private Ui::QgsLay
     void mOffsetYSpinBox_valueChanged( double value );
     void mCrossWidthSpinBox_valueChanged( double val );
     void mFrameWidthSpinBox_valueChanged( double val );
+    void mGridFrameMarginSpinBox_valueChanged( double val );
     void mFrameStyleComboBox_currentIndexChanged( const QString &text );
     void mGridFramePenSizeSpinBox_valueChanged( double d );
     void mGridFramePenColorButton_colorChanged( const QColor &newColor );

--- a/src/core/layout/qgslayoutitemmapgrid.h
+++ b/src/core/layout/qgslayoutitemmapgrid.h
@@ -725,6 +725,20 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
     double frameWidth() const { return mGridFrameWidth; }
 
     /**
+     * Sets the grid frame margin (in layout units).
+     * This property controls distance between the map frame and the grid frame.
+     * \see GridFrameMargin()
+     */
+    void setGridFrameMargin( const double margin ) { mGridFrameMargin = margin; }
+
+    /**
+     * Sets the grid frame Margin (in layout units).
+     * This property controls distance between the map frame and the grid frame.
+     * \see setGridFrameMargin()
+     */
+    double GridFrameMargin() const { return mGridFrameMargin; }
+
+    /**
      * Sets the \a width of the stroke drawn in the grid frame.
      * \see framePenSize()
      * \see setFramePenColor()
@@ -867,6 +881,7 @@ class CORE_EXPORT QgsLayoutItemMapGrid : public QgsLayoutItemMapItem
     QColor mGridFrameFillColor1 = Qt::white;
     QColor mGridFrameFillColor2 = Qt::black;
     double mCrossLength = 3.0;
+    double mGridFrameMargin = 0.0;
 
     //! Divisions for frame on left map side
     DisplayMode mLeftFrameDivisions = QgsLayoutItemMapGrid::ShowAll;

--- a/src/ui/layout/qgslayoutmapgridwidgetbase.ui
+++ b/src/ui/layout/qgslayoutmapgridwidgetbase.ui
@@ -19,22 +19,7 @@
   <property name="windowTitle">
    <string>Map Options</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <property name="spacing">
-    <number>0</number>
-   </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QgsScrollArea" name="scrollArea">
      <property name="frameShape">
@@ -48,8 +33,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>389</width>
-        <height>1417</height>
+        <width>371</width>
+        <height>1590</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -330,14 +315,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="mFramePenLabel">
             <property name="text">
              <string>Frame line thickness</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QgsDoubleSpinBox" name="mGridFramePenSizeSpinBox">
             <property name="suffix">
              <string> mm</string>
@@ -347,7 +332,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
+          <item row="3" column="2">
            <widget class="QgsColorButton" name="mGridFramePenColorButton">
             <property name="minimumSize">
              <size>
@@ -366,14 +351,14 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="mFrameFillLabel">
             <property name="text">
              <string>Frame fill colors</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QgsColorButton" name="mGridFrameFill1ColorButton">
             <property name="minimumSize">
              <size>
@@ -392,7 +377,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="2">
+          <item row="4" column="2">
            <widget class="QgsColorButton" name="mGridFrameFill2ColorButton">
             <property name="minimumSize">
              <size>
@@ -411,7 +396,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="3">
+          <item row="9" column="0" colspan="3">
            <layout class="QGridLayout" name="gridLayout_4">
             <item row="0" column="0">
              <widget class="QCheckBox" name="mCheckGridLeftSide">
@@ -487,45 +472,62 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="mRightDivisionsLabel">
             <property name="text">
              <string>Right divisions</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="mLeftDivisionsLabel">
             <property name="text">
              <string>Left divisions</string>
             </property>
            </widget>
           </item>
-          <item row="6" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="mTopDivisionsLabel">
             <property name="text">
              <string>Top divisions</string>
             </property>
            </widget>
           </item>
-          <item row="7" column="0">
+          <item row="8" column="0">
            <widget class="QLabel" name="mBottomDivisionsLabel">
             <property name="text">
              <string>Bottom divisions</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1" colspan="2">
+          <item row="5" column="1" colspan="2">
            <widget class="QComboBox" name="mFrameDivisionsLeftComboBox"/>
           </item>
-          <item row="5" column="1" colspan="2">
+          <item row="6" column="1" colspan="2">
            <widget class="QComboBox" name="mFrameDivisionsRightComboBox"/>
           </item>
-          <item row="6" column="1" colspan="2">
+          <item row="7" column="1" colspan="2">
            <widget class="QComboBox" name="mFrameDivisionsTopComboBox"/>
           </item>
-          <item row="7" column="1" colspan="2">
+          <item row="8" column="1" colspan="2">
            <widget class="QComboBox" name="mFrameDivisionsBottomComboBox"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="mFrameMarginLabel">
+            <property name="text">
+             <string>Frame margin</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="QgsDoubleSpinBox" name="mGridFrameMarginSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="showClearButton" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -536,7 +538,7 @@
           <bool>true</bool>
          </property>
          <property name="title">
-          <string>Draw coordinates</string>
+          <string>&amp;Draw coordinates</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -814,6 +816,7 @@
   <tabstop>mGridFrameGroupBox</tabstop>
   <tabstop>mFrameStyleComboBox</tabstop>
   <tabstop>mFrameWidthSpinBox</tabstop>
+  <tabstop>mGridFrameMarginSpinBox</tabstop>
   <tabstop>mGridFramePenSizeSpinBox</tabstop>
   <tabstop>mGridFramePenColorButton</tabstop>
   <tabstop>mGridFrameFill1ColorButton</tabstop>


### PR DESCRIPTION
## Description
Proposed changes.
In the "Print Layout" section when building a map grid, it is necessary to add the possibility of a frame shift relative to the map.
It will be very easy to form a different framework for drawing up maps.

What changed :

-    UI - add label "margin" and QgsDoubleSpinBox
-    "margin" - from 0 to 99 ( default -0)
-    Add corners for "zebra" and frame boarder.
    If you use the default offset to "0", there will be no changes from the current version. Only for "zebra" corners will be drawn more correctly.

Why it is very important to make this small change.
Now QGIS does not have the means to design a standard scale frame of nautical charts. It is not possible to make standard designs for topographic maps.
Some applications, such as ArcGIS or my plugin for QGIS - the geogrid, create static vector layers for the map sections. When making the proposed add-on, we can very easily create a dynamic design that will meet the requirements of the standards.

![default](https://user-images.githubusercontent.com/17308458/45020438-ab64cd00-b037-11e8-99d1-571a07c55762.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
