### PR TITLE
[wfs] Fix possible race condition/ maybe fix provider issues?

### DIFF
--- a/src/providers/wfs/qgswfsrequest.h
+++ b/src/providers/wfs/qgswfsrequest.h
@@ -124,7 +124,7 @@ class DownloaderThread : public QThread
     Q_OBJECT
 
   public:
-    DownloaderThread( std::function<bool()> function, QObject *parent = nullptr )
+    DownloaderThread( std::function<void()> function, QObject *parent = nullptr )
       : QThread( parent )
       , mFunction( function )
     {
@@ -132,17 +132,11 @@ class DownloaderThread : public QThread
 
     void run() override
     {
-      mSuccess = mFunction();
-    }
-
-    bool success() const
-    {
-      return mSuccess;
+      mFunction();
     }
 
   private:
-    std::function<bool()> mFunction;
-    bool mSuccess = false;
+    std::function<void()> mFunction;
 };
 
 #endif // QGSWFSREQUEST_H


### PR DESCRIPTION
Possibly fixes the recent WFS hangs by avoiding a race condition where the downloader thread has finished doing the important stuff, but hasn't yet cleaned up enough to report true to QThread::isFinished().

@m-kuhn for your consideration!