### PR TITLE
 Move QgsFeatureId to own header 

### DIFF
--- a/python/core/auto_generated/qgsattributes.sip.in
+++ b/python/core/auto_generated/qgsattributes.sip.in
@@ -26,7 +26,7 @@ typedef QVector<QVariant> QgsAttributes;
 %MappedType QgsAttributes
 {
 %TypeHeaderCode
-#include <qgsfeature.h>
+#include "qgsfeature.h"
 %End
 
 %ConvertFromTypeCode

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -14,8 +14,6 @@
 
 
 
-
-
 class QgsFeature
 {
 %Docstring
@@ -526,9 +524,6 @@ typedef QMap<qint64, QMap<int, QVariant> > QgsChangedAttributesMap;
 
 
 typedef QMap<qint64, QgsGeometry> QgsGeometryMap;
-
-
-typedef QSet<qint64> QgsFeatureIds;
 
 typedef QList<QgsFeature> QgsFeatureList;
 

--- a/python/core/auto_generated/qgsfeatureid.sip.in
+++ b/python/core/auto_generated/qgsfeatureid.sip.in
@@ -1,0 +1,21 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsfeatureid.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+typedef QSet<qint64> QgsFeatureIds;
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsfeatureid.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -44,6 +44,7 @@
 %Include auto_generated/qgsexpressioncontextscopegenerator.sip
 %Include auto_generated/qgsexpressionfieldbuffer.sip
 %Include auto_generated/qgsfeaturefilterprovider.sip
+%Include auto_generated/qgsfeatureid.sip
 %Include auto_generated/qgsfeatureiterator.sip
 %Include auto_generated/qgsfeaturerequest.sip
 %Include auto_generated/qgsfeaturesink.sip

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -317,6 +317,7 @@
 %Include auto_generated/qgsdataitem.sip
 %Include auto_generated/qgsdataprovider.sip
 %Include auto_generated/qgsdatasourceuri.sip
+%Include auto_generated/qgsfeature.sip
 %Include auto_generated/qgsfeedback.sip
 %Include auto_generated/qgsfield.sip
 %Include auto_generated/qgsfieldconstraints.sip
@@ -445,5 +446,4 @@
 %Include auto_generated/layertree/qgslayertreeregistrybridge.sip
 %Include auto_generated/qgsuserprofilemanager.sip
 %Include auto_generated/symbology/qgsarrowsymbollayer.sip
-%Include auto_generated/qgsfeature.sip
 %Include auto_generated/qgsuserprofile.sip

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -317,7 +317,6 @@
 %Include auto_generated/qgsdataitem.sip
 %Include auto_generated/qgsdataprovider.sip
 %Include auto_generated/qgsdatasourceuri.sip
-%Include auto_generated/qgsfeature.sip
 %Include auto_generated/qgsfeedback.sip
 %Include auto_generated/qgsfield.sip
 %Include auto_generated/qgsfieldconstraints.sip
@@ -446,4 +445,5 @@
 %Include auto_generated/layertree/qgslayertreeregistrybridge.sip
 %Include auto_generated/qgsuserprofilemanager.sip
 %Include auto_generated/symbology/qgsarrowsymbollayer.sip
+%Include auto_generated/qgsfeature.sip
 %Include auto_generated/qgsuserprofile.sip

--- a/python/gui/auto_generated/attributetable/qgsifeatureselectionmanager.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsifeatureselectionmanager.sip.in
@@ -9,7 +9,6 @@
 
 
 
-
 class QgsIFeatureSelectionManager : QObject
 {
 %Docstring

--- a/src/analysis/network/qgsgraphbuilder.cpp
+++ b/src/analysis/network/qgsgraphbuilder.cpp
@@ -21,7 +21,6 @@
 #include "qgsgraphbuilder.h"
 #include "qgsgraph.h"
 
-#include "qgsfeature.h"
 #include "qgsgeometry.h"
 
 QgsGraphBuilder::QgsGraphBuilder( const QgsCoordinateReferenceSystem &crs, bool otfEnabled, double topologyTolerance, const QString &ellipsoidID )

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
@@ -24,9 +24,8 @@
 #include <QMutex>
 #include <QStringList>
 #include "qgis_analysis.h"
+#include "qgsfeatureid.h"
 
-typedef qint64 QgsFeatureId;
-typedef QSet<QgsFeatureId> QgsFeatureIds;
 struct QgsGeometryCheckerContext;
 class QgsGeometryCheck;
 class QgsGeometryCheckError;

--- a/src/app/qgsattributerelationedit.h
+++ b/src/app/qgsattributerelationedit.h
@@ -19,7 +19,6 @@
 #include "ui_qgsattributerelationedit.h"
 
 #include "qgseditorconfigwidget.h"
-#include "qgsfeature.h"
 #include "qgsvectordataprovider.h"
 #include "qgshelp.h"
 #include "qgis_app.h"

--- a/src/app/qgsattributesforminitcode.h
+++ b/src/app/qgsattributesforminitcode.h
@@ -19,7 +19,6 @@
 #include "ui_qgsattributesforminitcode.h"
 
 #include "qgseditorconfigwidget.h"
-#include "qgsfeature.h"
 #include "qgsvectordataprovider.h"
 #include "qgshelp.h"
 #include "qgis_app.h"

--- a/src/app/qgsmaptooldigitizefeature.h
+++ b/src/app/qgsmaptooldigitizefeature.h
@@ -19,6 +19,8 @@
 #include "qgsmaptoolcapture.h"
 #include "qgis_app.h"
 
+class QgsFeature;
+
 //! This tool digitizes geometry of new point/line/polygon features on already existing vector layers
 class APP_EXPORT QgsMapToolDigitizeFeature : public QgsMapToolCapture
 {

--- a/src/app/qgsmaptooloffsetcurve.h
+++ b/src/app/qgsmaptooloffsetcurve.h
@@ -26,6 +26,7 @@ class QGridLayout;
 class QgsSnapIndicator;
 class QgsDoubleSpinBox;
 class QGraphicsProxyWidget;
+class QgsFeature;
 
 class APP_EXPORT QgsOffsetUserWidget : public QWidget, private Ui::QgsOffsetUserInputBase
 {

--- a/src/app/qgsmaptoolshowhidelabels.h
+++ b/src/app/qgsmaptoolshowhidelabels.h
@@ -19,7 +19,7 @@
 #define QGSMAPTOOLSHOWHIDELABELS_H
 
 #include "qgsmaptoollabel.h"
-#include "qgsfeature.h"
+#include "qgsfeatureid.h"
 #include "qgis_app.h"
 
 

--- a/src/app/qgsmaptoolsimplify.h
+++ b/src/app/qgsmaptoolsimplify.h
@@ -20,7 +20,6 @@
 #include "ui_qgssimplifytolerancedialog.h"
 
 #include <QVector>
-#include "qgsfeature.h"
 #include "qgstolerance.h"
 #include "qgis_app.h"
 

--- a/src/app/qgsmaptoolsimplify.h
+++ b/src/app/qgsmaptoolsimplify.h
@@ -23,6 +23,7 @@
 #include "qgstolerance.h"
 #include "qgsgeometry.h"
 #include "qgis_app.h"
+#include "qgsfeature.h"
 
 class QgsRubberBand;
 class QgsMapToolSimplify;

--- a/src/app/qgsmaptoolsimplify.h
+++ b/src/app/qgsmaptoolsimplify.h
@@ -21,6 +21,7 @@
 
 #include <QVector>
 #include "qgstolerance.h"
+#include "qgsgeometry.h"
 #include "qgis_app.h"
 
 class QgsRubberBand;

--- a/src/app/vertextool/qgsselectedfeature.h
+++ b/src/app/vertextool/qgsselectedfeature.h
@@ -16,8 +16,8 @@
 #ifndef QGSSELECTEDFEATURE_H
 #define QGSSELECTEDFEATURE_H
 
-#include "qgsfeature.h"
 #include "qgsgeometry.h"
+#include "qgsfeatureid.h"
 
 #include <QObject>
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -851,6 +851,7 @@ SET(QGIS_CORE_HDRS
   qgsexpressioncontextscopegenerator.h
   qgsexpressionfieldbuffer.h
   qgsfeaturefilterprovider.h
+  qgsfeatureid.h
   qgsfeatureiterator.h
   qgsfeaturerequest.h
   qgsfeaturesink.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -591,7 +591,6 @@ SET(QGIS_CORE_MOC_HDRS
   qgsdataprovider.h
   qgsdatasourceuri.h
   qgsdbfilterproxymodel.h
-  qgsfeature.h
   qgsfeedback.h
   qgsfield.h
   qgsfieldconstraints.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -591,6 +591,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgsdataprovider.h
   qgsdatasourceuri.h
   qgsdbfilterproxymodel.h
+  qgsfeature.h
   qgsfeedback.h
   qgsfield.h
   qgsfieldconstraints.h

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -29,9 +29,9 @@ email                : morb at ozemail dot com dot au
 #include "qgis.h"
 
 #include "qgsabstractgeometry.h"
-#include "qgsfeature.h"
 #include "qgspointxy.h"
 #include "qgspoint.h"
+#include "qgsfeatureid.h"
 
 
 class QgsGeometryEngine;

--- a/src/core/geometry/qgsgeometryeditutils.h
+++ b/src/core/geometry/qgsgeometryeditutils.h
@@ -23,8 +23,8 @@ class QgsVectorLayer;
 
 #define SIP_NO_FILE
 
-#include "qgsfeature.h"
 #include "qgsgeometry.h"
+#include "qgsfeatureid.h"
 #include <QMap>
 #include <memory>
 

--- a/src/core/layout/qgslayoutrendercontext.cpp
+++ b/src/core/layout/qgslayoutrendercontext.cpp
@@ -15,7 +15,6 @@
  ***************************************************************************/
 
 #include "qgslayoutrendercontext.h"
-#include "qgsfeature.h"
 #include "qgslayout.h"
 
 QgsLayoutRenderContext::QgsLayoutRenderContext( QgsLayout *layout )

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -24,6 +24,7 @@
 #include "qgscoordinatetransform.h"
 #include "qgsfeatureid.h"
 #include "qgsgeometry.h"
+#include "qgsretangle.h"
 
 static void ENP_centroid_step( const QPolygonF &pX, double &cx, double &cy, double &signedArea, int i, int i1 )
 {

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -24,7 +24,7 @@
 #include "qgscoordinatetransform.h"
 #include "qgsfeatureid.h"
 #include "qgsgeometry.h"
-#include "qgsretangle.h"
+#include "qgsrectangle.h"
 
 static void ENP_centroid_step( const QPolygonF &pX, double &cx, double &cy, double &signedArea, int i, int i1 )
 {

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -23,6 +23,7 @@
 #include "qgsrendercontext.h"
 #include "qgscoordinatetransform.h"
 #include "qgsfeatureid.h"
+#include "qgsgeometry.h"
 
 static void ENP_centroid_step( const QPolygonF &pX, double &cx, double &cy, double &signedArea, int i, int i1 )
 {

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -17,12 +17,12 @@
 
 #include <memory>
 #include <QList>
-#include "qgsfeature.h"
 #include "qgspolygon.h"
 #include "qgslinestring.h"
 #include "qgstriangularmesh.h"
 #include "qgsrendercontext.h"
 #include "qgscoordinatetransform.h"
+#include "qgsfeatureid.h"
 
 static void ENP_centroid_step( const QPolygonF &pX, double &cx, double &cy, double &signedArea, int i, int i1 )
 {

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -25,6 +25,7 @@
 #include "qgis_core.h"
 #include "qgsmeshdataprovider.h"
 #include "qgsgeometry.h"
+#include "qgsfeatureid.h"
 #include "qgsspatialindex.h"
 
 class QgsRenderContext;

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -33,7 +33,6 @@
 #include "qgsfields.h"
 
 
-class QgsGeometry;
 class QgsRectangle;
 class QgsFeature;
 class QgsFeaturePrivate;

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -130,7 +130,7 @@ typedef QVector<QVariant> QgsAttributes;
 % MappedType QgsAttributes
 {
   % TypeHeaderCode
-#include <qgsfeature.h>
+#include "qgsfeature.h"
   % End
 
   % ConvertFromTypeCode

--- a/src/core/qgscacheindex.h
+++ b/src/core/qgscacheindex.h
@@ -17,7 +17,7 @@
 #define QGSCACHEINDEX_H
 
 #include "qgis_core.h"
-#include "qgsfeature.h" // QgsFeatureIds
+#include "qgsfeatureid.h"
 
 class QgsFeatureRequest;
 class QgsFeatureIterator;

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -29,6 +29,7 @@ email                : sherman at mrcc.com
 
 #include "qgsattributes.h"
 #include "qgsfields.h"
+#include "qgsfeatureid.h"
 
 class QgsFeature;
 class QgsFeaturePrivate;
@@ -42,15 +43,6 @@ class QgsRectangle;
  * full unit tests in testqgsfeature.cpp.
  * See details in QEP #17
  ****************************************************************************/
-
-// feature id class (currently 64 bit)
-
-// 64 bit feature ids
-typedef qint64 QgsFeatureId SIP_SKIP;
-#define FID_IS_NEW(fid)     (fid<0)
-#define FID_TO_NUMBER(fid)  static_cast<qint64>(fid)
-#define FID_TO_STRING(fid)  QString::number( fid )
-#define STRING_TO_FID(str)  (str).toLongLong()
 
 
 /**
@@ -538,13 +530,6 @@ typedef QMap<qint64, QMap<int, QVariant> > QgsChangedAttributesMap;
 typedef QMap<QgsFeatureId, QgsGeometry> QgsGeometryMap;
 #else
 typedef QMap<qint64, QgsGeometry> QgsGeometryMap;
-#endif
-
-
-#ifndef SIP_RUN
-typedef QSet<QgsFeatureId> QgsFeatureIds;
-#else
-typedef QSet<qint64> QgsFeatureIds;
 #endif
 
 typedef QList<QgsFeature> QgsFeatureList;

--- a/src/core/qgsfeatureid.h
+++ b/src/core/qgsfeatureid.h
@@ -1,0 +1,36 @@
+/***************************************************************************
+                      qgsfeatureid.h
+                     --------------------------------------
+Date                 : 3.9.2018
+Copyright            : (C) 2018 by Matthias Kuhn
+email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSFEATUREID_H
+#define QGSFEATUREID_H
+
+#include <QSet>
+
+// feature id (currently 64 bit)
+
+// 64 bit feature ids
+typedef qint64 QgsFeatureId SIP_SKIP;
+#define FID_IS_NEW(fid)     (fid<0)
+#define FID_TO_NUMBER(fid)  static_cast<qint64>(fid)
+#define FID_TO_STRING(fid)  QString::number( fid )
+#define STRING_TO_FID(str)  (str).toLongLong()
+
+#ifndef SIP_RUN
+typedef QSet<QgsFeatureId> QgsFeatureIds;
+#else
+typedef QSet<qint64> QgsFeatureIds;
+#endif
+
+#endif

--- a/src/core/qgsfeatureid.h
+++ b/src/core/qgsfeatureid.h
@@ -17,6 +17,7 @@ email                : matthias@opengis.ch
 #define QGSFEATUREID_H
 
 #include <QSet>
+#include "qgis_sip.h"
 
 // feature id (currently 64 bit)
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -22,10 +22,10 @@ class QgsFeatureRenderer;
 class QgsRenderContext;
 
 #include "qgis_core.h"
-#include "qgsfeature.h"
 #include "qgspointxy.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransform.h"
+#include "qgsfeatureid.h"
 #include <memory>
 
 class QgsPointLocator_VisitorNearestVertex;

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -20,6 +20,7 @@ class QgsPointXY;
 class QgsVectorLayer;
 class QgsFeatureRenderer;
 class QgsRenderContext;
+class QgsRectangle;
 
 #include "qgis_core.h"
 #include "qgspointxy.h"

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -26,6 +26,7 @@ class QgsRenderContext;
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransform.h"
 #include "qgsfeatureid.h"
+#include "qgsgeometry.h"
 #include <memory>
 
 class QgsPointLocator_VisitorNearestVertex;

--- a/src/core/qgspropertytransformer.cpp
+++ b/src/core/qgspropertytransformer.cpp
@@ -18,7 +18,6 @@
 #include "qgslogger.h"
 #include "qgsexpression.h"
 #include "qgsexpressionnodeimpl.h"
-#include "qgsfeature.h"
 #include "qgssymbollayerutils.h"
 #include "qgscolorramp.h"
 

--- a/src/core/qgspropertytransformer.cpp
+++ b/src/core/qgspropertytransformer.cpp
@@ -20,6 +20,7 @@
 #include "qgsexpressionnodeimpl.h"
 #include "qgssymbollayerutils.h"
 #include "qgscolorramp.h"
+#include "qgspointxy.h"
 
 
 //

--- a/src/core/qgsspatialindexkdbush.h
+++ b/src/core/qgsspatialindexkdbush.h
@@ -18,7 +18,6 @@
 #ifndef QGSSPATIALINDEXKDBUSH_H
 #define QGSSPATIALINDEXKDBUSH_H
 
-class QgsPointXY;
 class QgsFeatureIterator;
 class QgsFeedback;
 class QgsFeatureSource;
@@ -27,6 +26,7 @@ class QgsRectangle;
 
 #include "qgis_core.h"
 #include "qgsspatialindexkdbushdata.h"
+#include "qgspointxy.h"
 #include <memory>
 #include <QList>
 

--- a/src/core/qgsspatialindexkdbush.h
+++ b/src/core/qgsspatialindexkdbush.h
@@ -26,7 +26,6 @@ class QgsSpatialIndexKDBushPrivate;
 class QgsRectangle;
 
 #include "qgis_core.h"
-#include "qgsfeature.h"
 #include "qgsspatialindexkdbushdata.h"
 #include <memory>
 #include <QList>

--- a/src/core/qgsspatialindexkdbushdata.h
+++ b/src/core/qgsspatialindexkdbushdata.h
@@ -19,6 +19,7 @@
 #define QGSSPATIALINDEXKDBUSHDATA_H
 
 #include "qgsfeatureid.h"
+#include "qgspointxy.h"
 
 /**
  * \class QgsSpatialIndexKDBushData

--- a/src/core/qgsspatialindexkdbushdata.h
+++ b/src/core/qgsspatialindexkdbushdata.h
@@ -18,7 +18,7 @@
 #ifndef QGSSPATIALINDEXKDBUSHDATA_H
 #define QGSSPATIALINDEXKDBUSHDATA_H
 
-#include "qgsfeature.h"
+#include "qgsfeatureid.h"
 
 /**
  * \class QgsSpatialIndexKDBushData

--- a/src/core/qgstracer.h
+++ b/src/core/qgstracer.h
@@ -26,6 +26,7 @@ class QgsVectorLayer;
 #include "qgsfeatureid.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsrectangle.h"
+#include "qgsgeometry.h"
 
 struct QgsTracerGraph;
 

--- a/src/core/qgstracer.h
+++ b/src/core/qgstracer.h
@@ -23,8 +23,8 @@ class QgsVectorLayer;
 #include <QVector>
 #include <memory>
 
+#include "qgsfeatureid.h"
 #include "qgscoordinatereferencesystem.h"
-#include "qgsfeature.h"
 #include "qgsrectangle.h"
 
 struct QgsTracerGraph;

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -18,9 +18,9 @@
 
 #include "qgis_core.h"
 #include "qgis.h"
-#include "qgsfeature.h"
 #include "qgsgeometry.h"
 #include "qgsvectorlayer.h"
+#include "qgsfeatureid.h"
 
 class QgsCurve;
 

--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -36,10 +36,10 @@ typedef QList<int> QgsAttributeList;
 
 #include "qgis.h"
 #include "qgsfields.h"  // QgsFields
-#include "qgsfeature.h"  // QgsFeatureIds
 #include "qgsfeatureiterator.h"
 #include "qgsvectorsimplifymethod.h"
 #include "qgsfeedback.h"
+#include "qgsfeatureid.h"
 
 #include "qgsmaplayerrenderer.h"
 

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -19,8 +19,8 @@
 #include <QTableView>
 #include "qgis.h"
 #include <QAction>
+#include "qgsfeatureid.h"
 
-#include "qgsfeature.h" // For QgsFeatureIds
 #include "qgis_gui.h"
 
 class QgsAttributeTableDelegate;

--- a/src/gui/attributetable/qgsfeaturemodel.h
+++ b/src/gui/attributetable/qgsfeaturemodel.h
@@ -16,7 +16,7 @@
 #define QGSFEATUREMODEL_H
 
 #include "qgis_gui.h"
-#include "qgsfeature.h" // QgsFeatureId
+#include "qgsfeatureid.h"
 #include <QModelIndex>
 
 /**

--- a/src/gui/attributetable/qgsfeatureselectionmodel.h
+++ b/src/gui/attributetable/qgsfeatureselectionmodel.h
@@ -17,8 +17,8 @@
 
 #include <QItemSelectionModel>
 #include "qgis.h"
+#include "qgsfeatureid.h"
 
-#include "qgsfeature.h"
 #include "qgis_gui.h"
 
 class QgsVectorLayer;

--- a/src/gui/attributetable/qgsgenericfeatureselectionmanager.h
+++ b/src/gui/attributetable/qgsgenericfeatureselectionmanager.h
@@ -16,9 +16,9 @@
 #ifndef QGSGENERICFEATURESELECTIONMANAGER_H
 #define QGSGENERICFEATURESELECTIONMANAGER_H
 
-#include "qgsfeature.h"
 #include "qgsifeatureselectionmanager.h"
 #include "qgis_gui.h"
+#include "qgsfeatureid.h"
 
 SIP_NO_FILE
 

--- a/src/gui/attributetable/qgsifeatureselectionmanager.h
+++ b/src/gui/attributetable/qgsifeatureselectionmanager.h
@@ -18,9 +18,8 @@
 
 #include <QObject>
 #include "qgis_sip.h"
-
-#include "qgsfeature.h"
 #include "qgis_gui.h"
+#include "qgsfeatureid.h"
 
 /**
  * \ingroup gui

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -21,7 +21,6 @@
 #include "ui_qgsexpressionbuilder.h"
 #include "qgsdistancearea.h"
 #include "qgsexpressioncontext.h"
-#include "qgsfeature.h"
 
 #include "QStandardItemModel"
 #include "QStandardItem"

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -22,9 +22,9 @@
 #include "qgis_sip.h"
 
 #include "qgsexpressioncontext.h"
-#include "qgsfeature.h"
 #include "qgsmessagebar.h"
 #include "qgsrectangle.h"
+#include "qgsfeatureid.h"
 #include "qgis.h"
 
 #include <QDomDocument>

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -25,6 +25,7 @@
 #include "qgsmessagebar.h"
 #include "qgsrectangle.h"
 #include "qgsfeatureid.h"
+#include "qgsgeometry.h"
 #include "qgis.h"
 
 #include <QDomDocument>

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -19,6 +19,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
+#include "qgsrectangle.h"
 #include <QPainter>
 
 QgsRubberBand::QgsRubberBand( QgsMapCanvas *mapCanvas, QgsWkbTypes::GeometryType geometryType )

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -14,7 +14,6 @@
  ***************************************************************************/
 
 #include "qgsrubberband.h"
-#include "qgsfeature.h"
 #include "qgsgeometry.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"

--- a/src/gui/qgsvariableeditorwidget.cpp
+++ b/src/gui/qgsvariableeditorwidget.cpp
@@ -15,7 +15,6 @@
 
 #include "qgsvariableeditorwidget.h"
 #include "qgsexpressioncontext.h"
-#include "qgsfeature.h"
 #include "qgsapplication.h"
 #include "qgssettings.h"
 

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.h
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.h
@@ -19,7 +19,6 @@
 
 #include <QMutex>
 
-#include "qgsfeature.h"
 #include "ui_qgsgeometrycheckersetuptab.h"
 
 class QgisInterface;

--- a/src/plugins/globe/featuresource/qgsglobefeaturesource.h
+++ b/src/plugins/globe/featuresource/qgsglobefeaturesource.h
@@ -22,6 +22,7 @@
 
 #include "qgsglobefeatureoptions.h"
 #include "qgsfeatureid.h"
+#include "qgsgeometry.h"
 
 class QgsGlobeFeatureSource : public QObject, public osgEarth::Features::FeatureSource
 {

--- a/src/plugins/globe/featuresource/qgsglobefeaturesource.h
+++ b/src/plugins/globe/featuresource/qgsglobefeaturesource.h
@@ -21,7 +21,7 @@
 #include <QObject>
 
 #include "qgsglobefeatureoptions.h"
-#include "qgsfeature.h"
+#include "qgsfeatureid.h"
 
 class QgsGlobeFeatureSource : public QObject, public osgEarth::Features::FeatureSource
 {

--- a/src/plugins/globe/globe_plugin.cpp
+++ b/src/plugins/globe/globe_plugin.cpp
@@ -30,7 +30,6 @@
 #include <qgsapplication.h>
 #include <qgsmapcanvas.h>
 #include <qgsvectorlayer.h>
-#include <qgsfeature.h>
 #include <qgsgeometry.h>
 #include <qgspoint.h>
 #include <qgsdistancearea.h>

--- a/src/plugins/globe/globe_plugin.cpp
+++ b/src/plugins/globe/globe_plugin.cpp
@@ -39,6 +39,7 @@
 #include <qgssettings.h>
 #include <qgsvectorlayerlabeling.h>
 #include <qgsproject.h>
+#include <qgsrectangle.h>
 
 #include <QAction>
 #include <QDir>

--- a/src/plugins/grass/qgsgrassmodule.cpp
+++ b/src/plugins/grass/qgsgrassmodule.cpp
@@ -27,7 +27,6 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransform.h"
 
-#include "qgsfeature.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
 

--- a/src/plugins/grass/qgsgrassmoduleparam.h
+++ b/src/plugins/grass/qgsgrassmoduleparam.h
@@ -25,7 +25,6 @@
 #include <QVBoxLayout>
 
 #include "qgis.h"
-#include "qgsfeature.h"
 #include "qgsfields.h"
 #include "qgscoordinatereferencesystem.h"
 

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -18,7 +18,6 @@
 #include <QStringList>
 #include <QVariant>
 #include "geometry/qgswkbtypes.h"
-#include "qgsfeature.h"
 
 class QNetworkReply;
 class QgsNetworkAccessManager;

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -17,12 +17,12 @@
 
 #include <QStringList>
 #include <QVariant>
-#include "geometry/qgswkbtypes.h"
+#include "qgswkbtypes.h"
+#include "qgsrectangle.h"
 
 class QNetworkReply;
 class QgsNetworkAccessManager;
 class QgsFields;
-class QgsRectangle;
 class QgsAbstractGeometry;
 class QgsCoordinateReferenceSystem;
 class QgsFeedback;

--- a/src/providers/gpx/gpsdata.h
+++ b/src/providers/gpx/gpsdata.h
@@ -25,8 +25,8 @@
 #include <QTextStream>
 #include <QStack>
 
-#include "qgsfeature.h"
 #include "qgsrectangle.h"
+#include "qgsfeatureid.h"
 
 // workaround for MSVC compiler which already has defined macro max
 // that interferes with calling std::numeric_limits<int>::max

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -55,6 +55,7 @@
 #include <QHash>
 #include <QTextCodec>
 
+
 extern "C"
 {
 #ifndef Q_OS_WIN

--- a/src/providers/grass/qgsgrass.h
+++ b/src/providers/grass/qgsgrass.h
@@ -33,7 +33,6 @@ extern "C"
 #include <stdexcept>
 #include "qgsapplication.h"
 #include "qgsexception.h"
-#include "qgsfeature.h"
 #include "qgsfields.h"
 #include "qgsrectangle.h"
 #include <QFileSystemWatcher>

--- a/src/providers/grass/qgsgrass.h
+++ b/src/providers/grass/qgsgrass.h
@@ -45,6 +45,7 @@ extern "C"
 #include "qgis_grass_lib.h"
 class QgsCoordinateReferenceSystem;
 class QgsRectangle;
+class QgsAttributes;
 
 // Make the release string because it may be for example 0beta1
 #define STR(x) #x


### PR DESCRIPTION
## Description

Move QgsFeatureId to own header 

Some other headers only need `QgsFeatureId`, so including the full-blown `qgsfeature.h` is an overkill.