### PR TITLE
Add threadsafe method to get featuresource from layer

### DIFF
--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -498,12 +498,15 @@ QgsFeature QgsVectorLayerUtils::duplicateFeature( QgsVectorLayer *layer, const Q
   return newFeature;
 }
 
-std::unique_ptr<QgsVectorLayerFeatureSource> QgsVectorLayerUtils::getFeatureSource( QWeakPointer<QgsVectorLayer> layer )
+std::unique_ptr<QgsVectorLayerFeatureSource> QgsVectorLayerUtils::getFeatureSource( QPointer<QgsVectorLayer> layer )
 {
   std::unique_ptr<QgsVectorLayerFeatureSource> featureSource;
 
   auto getFeatureSource = [ layer, &featureSource ]
   {
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+    Q_ASSERT( QThread::currentThread() == qApp->thread() );
+#endif
     QgsVectorLayer *lyr = layer.data();
 
     if ( lyr )

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -19,6 +19,7 @@
 #include "qgis_core.h"
 #include "qgsvectorlayer.h"
 #include "qgsgeometry.h"
+#include "qgsvectorlayerfeatureiterator.h"
 
 /**
  * \ingroup core
@@ -155,6 +156,17 @@ class CORE_EXPORT QgsVectorLayerUtils
      */
     static QgsFeature duplicateFeature( QgsVectorLayer *layer, const QgsFeature &feature, QgsProject *project, int depth, QgsDuplicateFeatureContext &duplicateFeatureContext SIP_OUT );
 
+    /**
+     * Gets the feature source from a weak QgsVectorLayer pointer.
+     * This method is thread-safe but will block the main thread for execution. Executing it from the main
+     * thread is safe too.
+     * This should be used in scenarios, where a ``QWeakPointer<QgsVectorLayer>`` is kept in a thread
+     * and features should be fetched from this layer. Using the layer directly is not safe to do.
+     *
+     * \note Requires Qt >= 5.10 to make use of the thread-safe implementation
+     * \since QGIS 3.4
+     */
+    static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( QWeakPointer<QgsVectorLayer> layer ) SIP_SKIP;
 };
 
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -157,7 +157,7 @@ class CORE_EXPORT QgsVectorLayerUtils
     static QgsFeature duplicateFeature( QgsVectorLayer *layer, const QgsFeature &feature, QgsProject *project, int depth, QgsDuplicateFeatureContext &duplicateFeatureContext SIP_OUT );
 
     /**
-     * Gets the feature source from a weak QgsVectorLayer pointer.
+     * Gets the feature source from a QgsVectorLayer pointer.
      * This method is thread-safe but will block the main thread for execution. Executing it from the main
      * thread is safe too.
      * This should be used in scenarios, where a ``QWeakPointer<QgsVectorLayer>`` is kept in a thread
@@ -166,7 +166,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      * \note Requires Qt >= 5.10 to make use of the thread-safe implementation
      * \since QGIS 3.4
      */
-    static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( QWeakPointer<QgsVectorLayer> layer ) SIP_SKIP;
+    static std::unique_ptr<QgsVectorLayerFeatureSource> getFeatureSource( QPointer<QgsVectorLayer> layer ) SIP_SKIP;
 };
 
 

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -162,6 +162,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      * thread is safe too.
      * This should be used in scenarios, where a ``QWeakPointer<QgsVectorLayer>`` is kept in a thread
      * and features should be fetched from this layer. Using the layer directly is not safe to do.
+     * The result will be ``nullptr`` if the layer has been deleted.
      *
      * \note Requires Qt >= 5.10 to make use of the thread-safe implementation
      * \since QGIS 3.4

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -192,6 +192,7 @@ SET(TESTS
  testqgsvectorlayercache.cpp
  testqgsvectorlayerjoinbuffer.cpp
  testqgsvectorlayer.cpp
+ testqgsvectorlayerutils.cpp
  testziplayer.cpp
  testqgsmeshlayer.cpp
  testqgsmeshlayerrenderer.cpp

--- a/tests/src/core/testqgsvectorlayerutils.cpp
+++ b/tests/src/core/testqgsvectorlayerutils.cpp
@@ -79,7 +79,7 @@ class FeatureFetcher : public QThread
     void resultReady( const QVariant &attribute );
 
   private:
-    QPoinst<QgsVectorLayer> mLayer;
+    QPointer<QgsVectorLayer> mLayer;
 };
 
 
@@ -97,7 +97,7 @@ void TestQgsVectorLayerUtils::testGetFeatureSource()
   QgsVectorLayerUtils::getFeatureSource( vlPtr ).get()->getFeatures().nextFeature( feat );
   QCOMPARE( feat.attribute( QStringLiteral( "col1" ) ).toInt(), 10 );
 
-  FeatureFetcher *thread = new FeatureFetcher();
+  FeatureFetcher *thread = new FeatureFetcher( vlPtr );
 
   bool finished = false;
   QVariant result;

--- a/tests/src/core/testqgsvectorlayerutils.cpp
+++ b/tests/src/core/testqgsvectorlayerutils.cpp
@@ -1,0 +1,120 @@
+/***************************************************************************
+     test_template.cpp
+     --------------------------------------
+    Date                 : Sun Sep 16 12:22:23 AKDT 2007
+    Copyright            : (C) 2007 by Gary E. Sherman
+    Email                : sherman at mrcc dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+
+#include "qgsvectorlayerutils.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the vector layer class.
+ */
+class TestQgsVectorLayerUtils : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsVectorLayerUtils() = default;
+
+  private:
+    bool mTestHasError =  false ;
+    QgsMapLayer *mpPointsLayer = nullptr;
+    QgsMapLayer *mpLinesLayer = nullptr;
+    QgsMapLayer *mpPolysLayer = nullptr;
+    QgsVectorLayer *mpNonSpatialLayer = nullptr;
+    QString mTestDataDir;
+    QString mReport;
+
+  private slots:
+
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+
+    void testGetFeatureSource();
+};
+
+void TestQgsVectorLayerUtils::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsApplication::showSettings();
+
+}
+
+void TestQgsVectorLayerUtils::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+class FeatureFetcher : public QThread
+{
+    Q_OBJECT
+
+  public:
+    FeatureFetcher( QPointer<QgsVectorLayer> layer )
+      : mLayer( layer )
+    {
+    }
+
+    void run() override
+    {
+      QgsFeature feat;
+      QgsVectorLayerUtils::getFeatureSource( mLayer ).get()->getFeatures().nextFeature( feat );
+      emit resultReady( feat.attribute( QStringLiteral( "col1" ) ) );
+    }
+
+  signals:
+    void resultReady( const QVariant &attribute );
+
+  private:
+    QPoinst<QgsVectorLayer> mLayer;
+};
+
+
+void TestQgsVectorLayerUtils::testGetFeatureSource()
+{
+  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+  vl->startEditing();
+  QgsFeature f1( vl->fields(), 1 );
+  f1.setAttribute( QStringLiteral( "col1" ), 10 );
+  vl->addFeature( f1 );
+
+  QPointer<QgsVectorLayer> vlPtr( vl );
+
+  QgsFeature feat;
+  QgsVectorLayerUtils::getFeatureSource( vlPtr ).get()->getFeatures().nextFeature( feat );
+  QCOMPARE( feat.attribute( QStringLiteral( "col1" ) ).toInt(), 10 );
+
+  FeatureFetcher *thread = new FeatureFetcher();
+
+  bool finished = false;
+  QVariant result;
+  connect( thread, &FeatureFetcher::resultReady, this, [finished, result]( const QVariant & res )
+  {
+    finished = true;
+    result = res;
+  } );
+  connect( thread, &QThread::finished, thread, &QThread::deleteLater );
+
+  thread->start();
+  while ( !finished )
+    QCoreApplication::processEvents();
+  QCOMPARE( result.toInt(), 10 );
+
+  thread->quit();
+}
+
+QGSTEST_MAIN( TestQgsVectorLayerUtils )
+#include "testqgsvectorlayerutils.moc"


### PR DESCRIPTION
Adds a thread-safe method to get a feature source given a weak map layer pointer.
Works only starting in a safe manner with Qt >= 5.10.
Opinions on that?