### PR TITLE
Only include qgsvectorlayer.h where required

### DIFF
--- a/.ci/travis/code_layout/script.sh
+++ b/.ci/travis/code_layout/script.sh
@@ -20,6 +20,6 @@ pushd build
 export CTEST_BUILD_DIR=${TRAVIS_BUILD_DIR}
 export CTEST_BUILD_COMMAND="/usr/bin/make -j3 -i -k"
 
-python3 "${TRAVIS_BUILD_DIR}/.ci/travis/scripts/ctest2travis.py" xvfb-run ctest -V --output-on-failure -S "${TRAVIS_BUILD_DIR}/.ci/travis/travis.ctest"
+python3 "${TRAVIS_BUILD_DIR}/.ci/travis/scripts/ctest2travis.py" xvfb-run ctest -VV --output-on-failure -S "${TRAVIS_BUILD_DIR}/.ci/travis/travis.ctest"
 
 popd

--- a/python/core/auto_generated/layout/qgslayoutreportcontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutreportcontext.sip.in
@@ -7,6 +7,7 @@
  ************************************************************************/
 
 
+
 class QgsLayoutReportContext : QObject
 {
 %Docstring

--- a/python/core/auto_generated/qgsjsonutils.sip.in
+++ b/python/core/auto_generated/qgsjsonutils.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsJsonExporter
 {
 %Docstring

--- a/python/core/auto_generated/qgsvectorlayerundopassthroughcommand.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerundopassthroughcommand.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 class QgsVectorLayerUndoPassthroughCommand : QgsVectorLayerUndoCommand
 {
 %Docstring

--- a/python/gui/auto_generated/qgsfieldvalueslineedit.sip.in
+++ b/python/gui/auto_generated/qgsfieldvalueslineedit.sip.in
@@ -10,6 +10,8 @@
 
 
 
+
+
 class QgsFieldValuesLineEdit: QgsFilterLineEdit
 {
 %Docstring

--- a/python/gui/auto_generated/qgsnewauxiliarylayerdialog.sip.in
+++ b/python/gui/auto_generated/qgsnewauxiliarylayerdialog.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsNewAuxiliaryLayerDialog: QDialog
 {
 %Docstring

--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsalgorithmextractbylocation.h"
 #include "qgsgeometryengine.h"
+#include "qgsvectorlayer.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmimportphotos.cpp
+++ b/src/analysis/processing/qgsalgorithmimportphotos.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsalgorithmimportphotos.h"
 #include "qgsogrutils.h"
+#include "qgsvectorlayer.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmmergevector.cpp
+++ b/src/analysis/processing/qgsalgorithmmergevector.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsalgorithmmergevector.h"
+#include "qgsvectorlayer.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmpackage.cpp
+++ b/src/analysis/processing/qgsalgorithmpackage.cpp
@@ -19,6 +19,7 @@
 #include "qgsgeometryengine.h"
 #include "qgsogrutils.h"
 #include "qgsvectorfilewriter.h"
+#include "qgsvectorlayer.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmsaveselectedfeatures.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsalgorithmsaveselectedfeatures.h"
+#include "qgsvectorlayer.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
@@ -17,6 +17,7 @@
 #include "qgscurvepolygon.h"
 #include "qgsgeometrycheck.h"
 #include "qgsfeaturepool.h"
+#include "qgsvectorlayer.h"
 
 QgsGeometryCheckerContext::QgsGeometryCheckerContext( int _precision, const QgsCoordinateReferenceSystem &_mapCrs, const QMap<QString, QgsFeaturePool *> &_featurePools )
   : tolerance( std::pow( 10, -_precision ) )

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -23,7 +23,6 @@
 #include <QStringList>
 #include "qgis_analysis.h"
 #include "qgsfeature.h"
-#include "qgsvectorlayer.h"
 #include "geometry/qgsgeometry.h"
 #include "qgsgeometrycheckerutils.h"
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
@@ -18,6 +18,7 @@
 #include "qgsgeometrycheck.h"
 #include "qgsfeaturepool.h"
 #include "qgsproject.h"
+#include "qgsvectorlayer.h"
 
 #include <QtConcurrentMap>
 #include <QFutureWatcher>

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
@@ -22,6 +22,8 @@
 #include "qgsgeos.h"
 #include "qgsgeometrycollection.h"
 #include "qgssurface.h"
+#include "qgsvectorlayer.h"
+
 #include <qmath.h>
 
 namespace QgsGeometryCheckerUtils
@@ -45,7 +47,22 @@ namespace QgsGeometryCheckerUtils
   double LayerFeature::layerToMapUnits() const { return mFeaturePool->getLayerToMapUnits(); }
   const QgsCoordinateTransform &LayerFeature::layerToMapTransform() const { return mFeaturePool->getLayerToMapTransform(); }
 
-/////////////////////////////////////////////////////////////////////////////
+  QString LayerFeature::id() const
+  {
+    return QString( "%1:%2" ).arg( layer().name() ).arg( mFeature.id() );
+  }
+
+  bool LayerFeature::operator==( const LayerFeature &other ) const
+  {
+    return layer().id() == other.layer().id() && feature().id() == other.feature().id();
+  }
+
+  bool LayerFeature::operator!=( const LayerFeature &other ) const
+  {
+    return layer().id() != other.layer().id() || feature().id() != other.feature().id();
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
 
   LayerFeatures::iterator::iterator( const QStringList::const_iterator &layerIt, const LayerFeatures *parent )
     : mLayerIt( layerIt )

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
@@ -20,7 +20,6 @@
 #define QGS_GEOMETRYCHECKERUTILS_H
 
 #include "qgsfeature.h"
-#include "qgsvectorlayer.h"
 #include "geometry/qgsabstractgeometry.h"
 #include "geometry/qgspoint.h"
 #include <qmath.h>
@@ -41,9 +40,9 @@ namespace QgsGeometryCheckerUtils
       const QgsCoordinateTransform &layerToMapTransform() const;
       const QgsAbstractGeometry *geometry() const { return mGeometry; }
       QString geometryCrs() const { return mMapCrs ? layerToMapTransform().destinationCrs().authid() : layerToMapTransform().sourceCrs().authid(); }
-      QString id() const { return QString( "%1:%2" ).arg( layer().name() ).arg( mFeature.id() ); }
-      bool operator==( const LayerFeature &other ) const { return layer().id() == other.layer().id() && feature().id() == other.feature().id(); }
-      bool operator!=( const LayerFeature &other ) const { return layer().id() != other.layer().id() || feature().id() != other.feature().id(); }
+      QString id() const;
+      bool operator==( const LayerFeature &other ) const;
+      bool operator!=( const LayerFeature &other ) const;
 
     private:
       const QgsFeaturePool *mFeaturePool;

--- a/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.cpp
@@ -16,6 +16,7 @@
 #include "qgsgeometryengine.h"
 #include "qgsgeometrycontainedcheck.h"
 #include "qgsfeaturepool.h"
+#include "qgsvectorlayer.h"
 
 
 void QgsGeometryContainedCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.h
@@ -19,6 +19,7 @@
 #define QGS_GEOMETRY_COVER_CHECK_H
 
 #include "qgsgeometrycheck.h"
+#include "qgsvectorlayer.h"
 
 class ANALYSIS_EXPORT QgsGeometryContainedCheckError : public QgsGeometryCheckError
 {

--- a/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsgeometrydanglecheck.h"
 #include "qgslinestring.h"
+#include "qgsvectorlayer.h"
 
 void QgsGeometryDangleCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
@@ -18,6 +18,7 @@
 #include "qgsspatialindex.h"
 #include "qgsgeometry.h"
 #include "qgsfeaturepool.h"
+#include "qgsvectorlayer.h"
 
 QString QgsGeometryDuplicateCheckError::duplicatesString( const QMap<QString, QgsFeaturePool *> &featurePools, const QMap<QString, QList<QgsFeatureId>> &duplicates )
 {

--- a/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
@@ -17,7 +17,7 @@
 #include "qgsgeometryengine.h"
 #include "qgsproject.h"
 #include "qgsspatialindex.h"
-
+#include "qgsvectorlayer.h"
 
 QgsGeometryFollowBoundariesCheck::QgsGeometryFollowBoundariesCheck( QgsGeometryCheckerContext *context, QgsVectorLayer *checkLayer )
   : QgsGeometryCheck( FeatureNodeCheck, {QgsWkbTypes::PolygonGeometry}, context )

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -17,6 +17,8 @@
 #include "qgsgeometrygapcheck.h"
 #include "qgsgeometrycollection.h"
 #include "qgsfeaturepool.h"
+#include "qgsvectorlayer.h"
+
 #include "geos_c.h"
 
 void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsgeometrylineintersectioncheck.h"
 #include "qgslinestring.h"
+#include "qgsvectorlayer.h"
 
 void QgsGeometryLineIntersectionCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {

--- a/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.h
@@ -19,6 +19,7 @@
 #define QGS_GEOMETRY_OVERLAP_CHECK_H
 
 #include "qgsgeometrycheck.h"
+#include "qgsvectorlayer.h"
 
 class ANALYSIS_EXPORT QgsGeometryOverlapCheckError : public QgsGeometryCheckError
 {

--- a/src/app/layout/qgslayoutmapgridwidget.cpp
+++ b/src/app/layout/qgslayoutmapgridwidget.cpp
@@ -26,6 +26,7 @@
 #include "qgslayout.h"
 #include "qgsmapsettings.h"
 #include "qgsexpressionbuilderdialog.h"
+#include "qgsvectorlayer.h"
 
 QgsLayoutMapGridWidget::QgsLayoutMapGridWidget( QgsLayoutItemMapGrid *mapGrid, QgsLayoutItemMap *map )
   : QgsLayoutItemBaseWidget( nullptr, mapGrid )

--- a/src/app/layout/qgslayoutpagepropertieswidget.cpp
+++ b/src/app/layout/qgslayoutpagepropertieswidget.cpp
@@ -20,6 +20,7 @@
 #include "qgslayout.h"
 #include "qgslayoutpagecollection.h"
 #include "qgslayoutundostack.h"
+#include "qgsvectorlayer.h"
 
 QgsLayoutPagePropertiesWidget::QgsLayoutPagePropertiesWidget( QWidget *parent, QgsLayoutItem *layoutItem )
   : QgsLayoutItemBaseWidget( parent, layoutItem )

--- a/src/app/layout/qgslayoutpolygonwidget.cpp
+++ b/src/app/layout/qgslayoutpolygonwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgslayoutitemregistry.h"
 #include "qgslayoutundostack.h"
+#include "qgsvectorlayer.h"
 
 QgsLayoutPolygonWidget::QgsLayoutPolygonWidget( QgsLayoutItemPolygon *polygon )
   : QgsLayoutItemBaseWidget( nullptr, polygon )

--- a/src/app/layout/qgslayoutpolylinewidget.cpp
+++ b/src/app/layout/qgslayoutpolylinewidget.cpp
@@ -21,6 +21,7 @@
 #include "qgslayoutitemregistry.h"
 #include "qgslayout.h"
 #include "qgslayoutundostack.h"
+#include "qgsvectorlayer.h"
 
 #include <QButtonGroup>
 #include <QFileDialog>

--- a/src/app/layout/qgslayoutshapewidget.cpp
+++ b/src/app/layout/qgslayoutshapewidget.cpp
@@ -20,6 +20,7 @@
 #include "qgslayoutitemshape.h"
 #include "qgslayout.h"
 #include "qgslayoutundostack.h"
+#include "qgsvectorlayer.h"
 
 QgsLayoutShapeWidget::QgsLayoutShapeWidget( QgsLayoutItemShape *shape )
   : QgsLayoutItemBaseWidget( nullptr, shape )

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -30,7 +30,6 @@
 #include <QHBoxLayout>
 #include <QFormLayout>
 
-#include "qgsvectorlayer.h"
 #include "ui_qgsattributesformproperties.h"
 #include "qgis_app.h"
 #include "qgsaddattrdialog.h"

--- a/src/app/qgslayercapabilitiesmodel.cpp
+++ b/src/app/qgslayercapabilitiesmodel.cpp
@@ -19,6 +19,7 @@
 
 #include "qgslayertree.h"
 #include "qgslayertreemodel.h"
+#include "qgsvectorlayer.h"
 
 QgsLayerCapabilitiesModel::QgsLayerCapabilitiesModel( QgsProject *project, QObject *parent )
   : QSortFilterProxyModel( parent )

--- a/src/app/qgsloadstylefromdbdialog.h
+++ b/src/app/qgsloadstylefromdbdialog.h
@@ -19,7 +19,6 @@
 #include "ui_qgsloadstylefromdbdialog.h"
 #include "qgsguiutils.h"
 #include "qgis_app.h"
-#include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 
 class APP_EXPORT QgsLoadStyleFromDBDialog : public QDialog, private Ui::QgsLoadStyleFromDBDialogLayout

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -16,10 +16,11 @@ email                : jpalmer at linz dot govt dot nz
 #ifndef QGSMAPTOOLSELECTUTILS_H
 #define QGSMAPTOOLSELECTUTILS_H
 
-#include "qgsvectorlayer.h"
 #include <Qt>
 #include <QRect>
 #include <QPoint>
+
+#include "qgsvectorlayer.h"
 
 class QMouseEvent;
 class QgsMapCanvas;

--- a/src/app/qgssourcefieldsproperties.cpp
+++ b/src/app/qgssourcefieldsproperties.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #include "qgssourcefieldsproperties.h"
+#include "qgsvectorlayer.h"
 
 QgsSourceFieldsProperties::QgsSourceFieldsProperties( QgsVectorLayer *layer, QWidget *parent )
   : QWidget( parent )

--- a/src/app/qgssourcefieldsproperties.h
+++ b/src/app/qgssourcefieldsproperties.h
@@ -31,7 +31,6 @@
 #include <QHBoxLayout>
 #include <QFormLayout>
 
-#include "qgsvectorlayer.h"
 #include "ui_qgssourcefieldsproperties.h"
 #include "qgis_app.h"
 #include "qgsaddattrdialog.h"

--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -26,6 +26,8 @@
 #include "qgsfeedback.h"
 #include "qgsvectorlayerutils.h"
 #include "qgstaskmanager.h"
+#include "qgsvectorlayer.h"
+
 #include "qgis_app.h"
 
 class QMenu;

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -24,7 +24,6 @@
 #include "qgsguiutils.h"
 #include "qgshelp.h"
 #include "qgsmaplayerstylemanager.h"
-#include "qgsvectorlayer.h"
 #include "qgsvectorlayerjoininfo.h"
 #include "layertree/qgslayertree.h"
 #include "layertree/qgslayertreemodel.h"

--- a/src/core/expression/qgsexpressionutils.cpp
+++ b/src/core/expression/qgsexpressionutils.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsexpressionutils.h"
 #include "qgsexpressionnode.h"
+#include "qgsvectorlayer.h"
 
 ///@cond PRIVATE
 
@@ -35,3 +36,5 @@ QgsExpressionUtils::TVL QgsExpressionUtils::OR[3][3] =
 QgsExpressionUtils::TVL QgsExpressionUtils::NOT[3] = { True, False, Unknown };
 
 ///@endcond
+
+

--- a/src/core/expression/qgsexpressionutils.h
+++ b/src/core/expression/qgsexpressionutils.h
@@ -22,12 +22,11 @@
 #include "qgsfeature.h"
 #include "qgsexpression.h"
 #include "qgscolorramp.h"
-#include "qgsvectorlayer.h"
 #include "qgsvectorlayerfeatureiterator.h"
 #include "qgsrasterlayer.h"
 #include "qgsproject.h"
 #include "qgsrelationmanager.h"
-
+#include "qgsvectorlayer.h"
 
 #define ENSURE_NO_EVAL_ERROR   {  if ( parent->hasEvalError() ) return QVariant(); }
 #define SET_EVAL_ERROR(x)   { parent->setEvalErrorString( x ); return QVariant(); }

--- a/src/core/layout/qgsabstractreportsection.cpp
+++ b/src/core/layout/qgsabstractreportsection.cpp
@@ -19,6 +19,7 @@
 #include "qgsreport.h"
 #include "qgsreportsectionfieldgroup.h"
 #include "qgsreportsectionlayout.h"
+#include "qgsvectorlayer.h"
 
 ///@cond NOT_STABLE
 

--- a/src/core/layout/qgscompositionconverter.cpp
+++ b/src/core/layout/qgscompositionconverter.cpp
@@ -29,6 +29,7 @@
 #include "qgssymbollayer.h"
 #include "qgsproject.h"
 #include "qgsmaplayerstylemanager.h"
+#include "qgsvectorlayer.h"
 
 #include "qgsprintlayout.h"
 #include "qgslayoutatlas.h"

--- a/src/core/layout/qgslayout.cpp
+++ b/src/core/layout/qgslayout.cpp
@@ -28,6 +28,7 @@
 #include "qgslayoutitemmap.h"
 #include "qgslayoutundostack.h"
 #include "qgscompositionconverter.h"
+#include "qgsvectorlayer.h"
 
 QgsLayout::QgsLayout( QgsProject *project )
   : mProject( project )

--- a/src/core/layout/qgslayoutatlas.cpp
+++ b/src/core/layout/qgslayoutatlas.cpp
@@ -21,6 +21,9 @@
 #include "qgslayoutatlas.h"
 #include "qgslayout.h"
 #include "qgsmessagelog.h"
+#include "qgsfeaturerequest.h"
+#include "qgsfeatureiterator.h"
+#include "qgsvectorlayer.h"
 
 QgsLayoutAtlas::QgsLayoutAtlas( QgsLayout *layout )
   : QObject( layout )

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -29,6 +29,7 @@ class QgsLayout;
 class QPainter;
 class QgsLayoutItemMap;
 class QgsAbstractLayoutIterator;
+class QgsFeedback;
 
 /**
  * \ingroup core

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -28,6 +28,8 @@
 #include "qgsmaplayerref.h"
 #include "qgsmaplayerlistutils.h"
 #include "qgsmaplayerstylemanager.h"
+#include "qgsvectorlayer.h"
+
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>
 

--- a/src/core/layout/qgslayoutitemregistry.cpp
+++ b/src/core/layout/qgslayoutitemregistry.cpp
@@ -31,6 +31,8 @@
 #include "qgslayoutframe.h"
 #include "qgsgloweffect.h"
 #include "qgseffectstack.h"
+#include "qgsvectorlayer.h"
+
 #include <QPainter>
 
 QgsLayoutItemRegistry::QgsLayoutItemRegistry( QObject *parent )

--- a/src/core/layout/qgslayoutmultiframeundocommand.cpp
+++ b/src/core/layout/qgslayoutmultiframeundocommand.cpp
@@ -20,6 +20,7 @@
 #include "qgsreadwritecontext.h"
 #include "qgslayout.h"
 #include "qgsproject.h"
+#include "qgsfeedback.h"
 
 ///@cond PRIVATE
 QgsLayoutMultiFrameUndoCommand::QgsLayoutMultiFrameUndoCommand( QgsLayoutMultiFrame *frame, const QString &text, int id, QUndoCommand *parent )

--- a/src/core/layout/qgslayoutobject.cpp
+++ b/src/core/layout/qgslayoutobject.cpp
@@ -21,6 +21,7 @@
 #include "qgslayoutrendercontext.h"
 #include "qgslayoutreportcontext.h"
 #include "qgslayoutobject.h"
+#include "qgsfeedback.h"
 
 
 QgsPropertiesDefinition QgsLayoutObject::sPropertyDefinitions;

--- a/src/core/layout/qgslayoutreportcontext.cpp
+++ b/src/core/layout/qgslayoutreportcontext.cpp
@@ -17,6 +17,7 @@
 #include "qgslayoutreportcontext.h"
 #include "qgsfeature.h"
 #include "qgslayout.h"
+#include "qgsvectorlayer.h"
 
 QgsLayoutReportContext::QgsLayoutReportContext( QgsLayout *layout )
   : QObject( layout )

--- a/src/core/layout/qgslayoutreportcontext.h
+++ b/src/core/layout/qgslayoutreportcontext.h
@@ -18,8 +18,10 @@
 
 #include "qgis_core.h"
 #include "qgsfeature.h"
-#include "qgsvectorlayer.h"
+#include "qgslayout.h"
+
 #include <QtGlobal>
+#include <QPointer>
 
 /**
  * \ingroup core

--- a/src/core/layout/qgsreportsectionfieldgroup.h
+++ b/src/core/layout/qgsreportsectionfieldgroup.h
@@ -18,6 +18,7 @@
 
 #include "qgis_core.h"
 #include "qgsabstractreportsection.h"
+#include "qgsfeatureiterator.h"
 
 
 ///@cond NOT_STABLE

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -21,6 +21,8 @@
 #include "qgsprocessingutils.h"
 #include "qgsxmlutils.h"
 #include "qgsexception.h"
+#include "qgsvectorlayer.h"
+
 #include <QFile>
 #include <QTextStream>
 

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -28,6 +28,8 @@
 #include "qgsprocessingregistry.h"
 #include "qgsprocessingparametertype.h"
 #include "qgsrasterfilewriter.h"
+#include "qgsvectorlayer.h"
+
 #include <functional>
 
 

--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -28,6 +28,7 @@
 #include "qgsvectorlayerfeatureiterator.h"
 #include "qgsexpressioncontextscopegenerator.h"
 #include "qgsfileutils.h"
+#include "qgsvectorlayer.h"
 
 QList<QgsRasterLayer *> QgsProcessingUtils::compatibleRasterLayers( QgsProject *project, bool sort )
 {

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -21,10 +21,11 @@
 #include "qgis_core.h"
 
 #include "qgsrasterlayer.h"
-#include "qgsvectorlayer.h"
 #include "qgsmessagelog.h"
 #include "qgsspatialindex.h"
 #include "qgsprocessing.h"
+#include "qgsfeaturesink.h"
+#include "qgsfeaturesource.h"
 
 class QgsProject;
 class QgsProcessingContext;

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -25,6 +25,7 @@
 #include "qgsvectorlayerjoininfo.h"
 #include "qgsproperty.h"
 #include "qgsspatialiteutils.h"
+#include "qgsvectorlayer.h"
 #include <QString>
 
 class QgsProject;

--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -16,6 +16,7 @@
 #include "qgscachedfeatureiterator.h"
 #include "qgsvectorlayercache.h"
 #include "qgsexception.h"
+#include "qgsvectorlayer.h"
 
 QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache, const QgsFeatureRequest &featureRequest )
   : QgsAbstractFeatureIterator( featureRequest )

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -16,6 +16,7 @@
 #include "qgsfeaturefiltermodel.h"
 #include "qgsfeaturefiltermodel_p.h"
 
+#include "qgsvectorlayer.h"
 #include "qgsconditionalstyle.h"
 
 QgsFeatureFilterModel::QgsFeatureFilterModel( QObject *parent )

--- a/src/core/qgsfeaturefiltermodel.h
+++ b/src/core/qgsfeaturefiltermodel.h
@@ -18,7 +18,6 @@
 
 #include <QAbstractItemModel>
 
-#include "qgsvectorlayer.h"
 #include "qgsconditionalstyle.h"
 
 class QgsFieldExpressionValuesGatherer;

--- a/src/core/qgsfeaturefiltermodel_p.h
+++ b/src/core/qgsfeaturefiltermodel_p.h
@@ -17,7 +17,6 @@
 #define QGSFEATUREFILTERMODEL_P_H
 
 #include <QThread>
-#include "qgsvectorlayer.h"
 #include "qgsfeaturefiltermodel.h"
 #include "qgslogger.h"
 #include "qgsvectorlayerfeatureiterator.h"

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -21,7 +21,8 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransform.h"
 #include "qgsfields.h"
-#include "qgsvectorlayer.h"
+
+#include <QPointer>
 
 class QTextCodec;
 

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -37,6 +37,7 @@
 #include "qgslayertree.h"
 #include "qgsogrutils.h"
 #include "qgsvectorfilewriter.h"
+#include "qgsvectorlayer.h"
 
 #include <QDir>
 #include <QDomDocument>

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -21,7 +21,6 @@
 
 #include "qgis_core.h"
 #include "qgsfeature.h"
-#include "qgsvectorlayer.h"
 #include "qgssqliteutils.h"
 
 #include <QObject>

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -22,6 +22,7 @@
 #include "qgswkbptr.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsrectangle.h"
+#include "qgsvectorlayer.h"
 
 #include <QColor>
 #include <QStringList>

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -31,13 +31,13 @@ class QgsExpression;
 class QgsGeometry;
 class QgsPointXY;
 class QgsRectangle;
+class QgsVectorLayer;
 
 #include "qgsgeometry.h"
 #include "qgsexpression.h"
 #include "qgsexpressionnode.h"
 #include "qgsexpressionnodeimpl.h"
 #include "qgssqlstatement.h"
-#include "qgsvectorlayer.h"
 
 /**
  * \ingroup core

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -46,8 +46,8 @@
 #include "qgsreadwritecontext.h"
 #include "qgsprojectmetadata.h"
 #include "qgstranslationcontext.h"
-#include "qgsvectorlayer.h"
 #include "qgsprojecttranslator.h"
+#include "qgsattributeeditorelement.h"
 
 class QFileInfo;
 class QDomDocument;

--- a/src/core/qgsproxyprogresstask.h
+++ b/src/core/qgsproxyprogresstask.h
@@ -18,7 +18,6 @@
 #ifndef QGSPROXYPROGRESSTASK_H
 #define QGSPROXYPROGRESSTASK_H
 
-#include "qgsvectorlayer.h"
 #include "qgsvirtuallayerdefinition.h"
 #include "qgstaskmanager.h"
 

--- a/src/core/qgsrelation_p.h
+++ b/src/core/qgsrelation_p.h
@@ -31,7 +31,6 @@
 //
 
 #include "qgsrelation.h"
-#include "qgsvectorlayer.h"
 
 #include <QSharedData>
 #include <QPointer>

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -25,10 +25,10 @@
 #include "qgsfeedback.h"
 #include "qgssymbol.h"
 #include "qgstaskmanager.h"
-#include "qgsvectorlayer.h"
 #include "qgsogrutils.h"
 #include "qgsrenderer.h"
 #include "qgsgeometryengine.h"
+#include "qgsfeaturesink.h"
 #include <ogr_api.h>
 
 class QgsSymbolLayer;

--- a/src/core/qgsvectorfilewritertask.h
+++ b/src/core/qgsvectorfilewritertask.h
@@ -21,7 +21,6 @@
 #include "qgis_core.h"
 #include "qgsvectorfilewriter.h"
 #include "qgstaskmanager.h"
-#include "qgsvectorlayer.h"
 
 /**
  * \class QgsVectorFileWriterTask

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1,6 +1,5 @@
 
 /***************************************************************************
-                          qgsvectorlayer.h  -  description
                              -------------------
     begin                : Oct 29, 2003
     copyright            : (C) 2003 by Gary E.Sherman

--- a/src/core/qgsvectorlayercache.cpp
+++ b/src/core/qgsvectorlayercache.cpp
@@ -20,6 +20,7 @@
 #include "qgscachedfeatureiterator.h"
 #include "qgsvectorlayerjoininfo.h"
 #include "qgsvectorlayerjoinbuffer.h"
+#include "qgsvectorlayer.h"
 
 QgsVectorLayerCache::QgsVectorLayerCache( QgsVectorLayer *layer, int cacheSize, QObject *parent )
   : QObject( parent )

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -22,10 +22,14 @@
 #include "qgis_core.h"
 #include "qgis_sip.h"
 #include "qgis.h"
+#include "qgsfield.h"
+#include "qgsfeaturerequest.h"
+#include "qgsfeatureiterator.h"
+
 #include <QCache>
 
-#include "qgsvectorlayer.h"
-
+class QgsVectorLayer;
+class QgsFeature;
 class QgsCachedFeatureIterator;
 class QgsAbstractCacheIndex;
 

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -24,6 +24,7 @@
 #include "qgis.h"
 #include "qgswkbtypes.h"
 #include "qgsvectorlayerutils.h"
+#include "qgsvectorlayer.h"
 
 #include <limits>
 

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -19,8 +19,8 @@
 #include "qgis_core.h"
 #include "qgis.h"
 #include "qgsgeometry.h"
-#include "qgsvectorlayer.h"
 #include "qgsfeatureid.h"
+#include "qgsvectorlayer.h"
 
 class QgsCurve;
 

--- a/src/core/qgsvectorlayerfeaturecounter.cpp
+++ b/src/core/qgsvectorlayerfeaturecounter.cpp
@@ -12,7 +12,9 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+
 #include "qgsvectorlayerfeaturecounter.h"
+#include "qgsvectorlayer.h"
 
 QgsVectorLayerFeatureCounter::QgsVectorLayerFeatureCounter( QgsVectorLayer *layer, const QgsExpressionContext &context )
   : QgsTask( tr( "Counting features in %1" ).arg( layer->name() ), QgsTask::CanCancel )

--- a/src/core/qgsvectorlayerfeaturecounter.h
+++ b/src/core/qgsvectorlayerfeaturecounter.h
@@ -15,7 +15,6 @@
 #ifndef QGSVECTORLAYERFEATURECOUNTER_H
 #define QGSVECTORLAYERFEATURECOUNTER_H
 
-#include "qgsvectorlayer.h"
 #include "qgsvectorlayerfeatureiterator.h"
 #include "qgsrenderer.h"
 #include "qgstaskmanager.h"

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -21,6 +21,7 @@
 #include "qgis_core.h"
 #include "qgis.h"
 #include "qgsvectorlayerjoininfo.h"
+#include "qgsfeaturesink.h"
 
 #include <QHash>
 #include <QString>

--- a/src/core/qgsvectorlayerjoininfo.cpp
+++ b/src/core/qgsvectorlayerjoininfo.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsvectorlayerjoininfo.h"
+#include "qgsvectorlayer.h"
 
 QString QgsVectorLayerJoinInfo::prefixedFieldName( const QgsField &f ) const
 {

--- a/src/core/qgsvectorlayerref.h
+++ b/src/core/qgsvectorlayerref.h
@@ -16,7 +16,6 @@
 #define QGSVECTORLAYERREF_H
 
 #include "qgsmaplayerref.h"
-
 #include "qgsvectorlayer.h"
 
 typedef _LayerRef<QgsVectorLayer> QgsVectorLayerRef;

--- a/src/core/qgsvectorlayerundocommand.h
+++ b/src/core/qgsvectorlayerundocommand.h
@@ -29,7 +29,6 @@
 
 class QgsGeometry;
 
-#include "qgsvectorlayer.h"
 #include "qgsvectorlayereditbuffer.h"
 
 /**

--- a/src/core/qgsvectorlayerundopassthroughcommand.h
+++ b/src/core/qgsvectorlayerundopassthroughcommand.h
@@ -20,6 +20,8 @@
 
 #include "qgsvectorlayereditbuffer.h"
 
+class QgsTransaction;
+
 /**
  * \ingroup core
  * \class QgsVectorLayerUndoPassthroughCommand

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -23,6 +23,7 @@
 #include "qgsproject.h"
 #include "qgsrelationmanager.h"
 #include "qgsfeedback.h"
+#include "qgsvectorlayer.h"
 
 QgsFeatureIterator QgsVectorLayerUtils::getValuesIterator( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok, bool selectedOnly )
 {

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -17,7 +17,6 @@
 #define QGSVECTORLAYERUTILS_H
 
 #include "qgis_core.h"
-#include "qgsvectorlayer.h"
 #include "qgsgeometry.h"
 #include "qgsvectorlayerfeatureiterator.h"
 

--- a/src/core/qgsvirtuallayertask.cpp
+++ b/src/core/qgsvirtuallayertask.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsvirtuallayertask.h"
 #include "qgslogger.h"
+#include "qgsvectorlayer.h"
 
 QgsVirtualLayerTask::QgsVirtualLayerTask( const QgsVirtualLayerDefinition &definition )
   : mDefinition( definition )

--- a/src/core/qgsvirtuallayertask.h
+++ b/src/core/qgsvirtuallayertask.h
@@ -18,9 +18,9 @@
 #ifndef QGSVIRTUALLAYERTASK_H
 #define QGSVIRTUALLAYERTASK_H
 
-#include "qgsvectorlayer.h"
 #include "qgsvirtuallayerdefinition.h"
 #include "qgstaskmanager.h"
+#include "qgsvectorlayer.h"
 
 /**
  * \ingroup core

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -25,7 +25,6 @@
 #include <QQueue>
 #include <QMap>
 
-#include "qgsvectorlayer.h" // QgsAttributeList
 #include "qgsconditionalstyle.h"
 #include "qgsattributeeditorcontext.h"
 #include "qgsvectorlayercache.h"

--- a/src/gui/qgsattributeeditorcontext.h
+++ b/src/gui/qgsattributeeditorcontext.h
@@ -20,8 +20,8 @@
 #include <QWidget>
 
 #include "qgsdistancearea.h"
-#include "qgsvectorlayer.h"
 #include "qgsvectorlayertools.h"
+#include "qgsvectorlayer.h"
 #include "qgis_gui.h"
 #include "qgsproject.h"
 

--- a/src/gui/qgscurveeditorwidget.cpp
+++ b/src/gui/qgscurveeditorwidget.cpp
@@ -15,6 +15,7 @@
 
 
 #include "qgscurveeditorwidget.h"
+#include "qgsvectorlayer.h"
 
 #include <QPainter>
 #include <QVBoxLayout>

--- a/src/gui/qgsfieldvalueslineedit.cpp
+++ b/src/gui/qgsfieldvalueslineedit.cpp
@@ -133,6 +133,9 @@ void QgsFieldValuesLineEdit::updateCompleter( const QStringList &values )
 }
 
 
+// just internal guff - definitely not for exposing to public API!
+///@cond PRIVATE
+
 void QgsFieldValuesLineEditValuesGatherer::run()
 {
   mWasCanceled = false;
@@ -166,3 +169,5 @@ void QgsFieldValuesLineEditValuesGatherer::stop()
 
   mWasCanceled = true;
 }
+
+///@endcond

--- a/src/gui/qgsfieldvalueslineedit.cpp
+++ b/src/gui/qgsfieldvalueslineedit.cpp
@@ -16,6 +16,7 @@
 #include "qgsfieldvalueslineedit.h"
 #include "qgsvectorlayer.h"
 #include "qgsfloatingwidget.h"
+
 #include <QCompleter>
 #include <QStringListModel>
 #include <QTimer>
@@ -131,3 +132,37 @@ void QgsFieldValuesLineEdit::updateCompleter( const QStringList &values )
   completer()->complete();
 }
 
+
+void QgsFieldValuesLineEditValuesGatherer::run()
+{
+  mWasCanceled = false;
+  if ( mSubstring.isEmpty() )
+  {
+    emit collectedValues( QStringList() );
+    return;
+  }
+
+  // allow responsive cancelation
+  mFeedback = new QgsFeedback();
+  // just get 100 values... maybe less/more would be useful?
+  mValues = mLayer->uniqueStringsMatching( mAttributeIndex, mSubstring, 100, mFeedback );
+
+  // be overly cautious - it's *possible* stop() might be called between deleting mFeedback and nulling it
+  mFeedbackMutex.lock();
+  delete mFeedback;
+  mFeedback = nullptr;
+  mFeedbackMutex.unlock();
+
+  emit collectedValues( mValues );
+}
+
+void QgsFieldValuesLineEditValuesGatherer::stop()
+{
+  // be cautious, in case gatherer stops naturally just as we are canceling it and mFeedback gets deleted
+  mFeedbackMutex.lock();
+  if ( mFeedback )
+    mFeedback->cancel();
+  mFeedbackMutex.unlock();
+
+  mWasCanceled = true;
+}

--- a/src/gui/qgsfieldvalueslineedit.h
+++ b/src/gui/qgsfieldvalueslineedit.h
@@ -18,16 +18,19 @@
 #include "qgsfilterlineedit.h"
 #include "qgis.h"
 #include "qgsfeedback.h"
-#include "qgsvectorlayer.h"
+
 #include <QStringListModel>
 #include <QTreeView>
 #include <QFocusEvent>
 #include <QHeaderView>
 #include <QTimer>
 #include <QThread>
+#include <QMutex>
+
 #include "qgis_gui.h"
 
 class QgsFloatingWidget;
+class QgsVectorLayer;
 
 
 #ifndef SIP_RUN
@@ -55,40 +58,10 @@ class QgsFieldValuesLineEditValuesGatherer: public QThread
      */
     void setSubstring( const QString &string ) { mSubstring = string; }
 
-    void run() override
-    {
-      mWasCanceled = false;
-      if ( mSubstring.isEmpty() )
-      {
-        emit collectedValues( QStringList() );
-        return;
-      }
-
-      // allow responsive cancelation
-      mFeedback = new QgsFeedback();
-      // just get 100 values... maybe less/more would be useful?
-      mValues = mLayer->uniqueStringsMatching( mAttributeIndex, mSubstring, 100, mFeedback );
-
-      // be overly cautious - it's *possible* stop() might be called between deleting mFeedback and nulling it
-      mFeedbackMutex.lock();
-      delete mFeedback;
-      mFeedback = nullptr;
-      mFeedbackMutex.unlock();
-
-      emit collectedValues( mValues );
-    }
+    void run() override;
 
     //! Informs the gatherer to immediately stop collecting values
-    void stop()
-    {
-      // be cautious, in case gatherer stops naturally just as we are canceling it and mFeedback gets deleted
-      mFeedbackMutex.lock();
-      if ( mFeedback )
-        mFeedback->cancel();
-      mFeedbackMutex.unlock();
-
-      mWasCanceled = true;
-    }
+    void stop();
 
     //! Returns true if collection was canceled before completion
     bool wasCanceled() const { return mWasCanceled; }

--- a/src/gui/qgsnewauxiliaryfielddialog.h
+++ b/src/gui/qgsnewauxiliaryfielddialog.h
@@ -21,7 +21,6 @@
 #include "ui_qgsnewauxiliaryfielddialogbase.h"
 #include "qgsguiutils.h"
 #include "qgis_gui.h"
-#include "qgsvectorlayer.h"
 #include "qgsproperty.h"
 
 /**

--- a/src/gui/qgsnewauxiliarylayerdialog.h
+++ b/src/gui/qgsnewauxiliarylayerdialog.h
@@ -21,7 +21,8 @@
 #include "ui_qgsnewauxiliarylayerdialogbase.h"
 #include "qgsguiutils.h"
 #include "qgis_gui.h"
-#include "qgsvectorlayer.h"
+
+class QgsVectorLayer;
 
 /**
  * \ingroup gui

--- a/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.cpp
+++ b/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.cpp
@@ -35,6 +35,7 @@
 #include "qgspointxy.h"
 #include "qgsfields.h"
 #include "qgsrectangle.h"
+#include "qgsvectorlayer.h"
 
 #include <QMessageBox>
 #include <QTreeWidgetItem>

--- a/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.h
+++ b/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.h
@@ -34,7 +34,6 @@
 #include "qgsfeature.h"
 #include "qgsmapcanvas.h"
 #include "qgisinterface.h"
-#include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 
 #include "evisconfiguration.h"

--- a/src/plugins/geometry_checker/qgsgeometrycheckerfixsummarydialog.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckerfixsummarydialog.cpp
@@ -20,6 +20,7 @@
 #include "qgsfeaturepool.h"
 #include "qgisinterface.h"
 #include "qgsmapcanvas.h"
+#include "qgsvectorlayer.h"
 
 QgsGeometryCheckerFixSummaryDialog::QgsGeometryCheckerFixSummaryDialog( const Statistics &stats, QgsGeometryChecker *checker, QWidget *parent )
   : QDialog( parent )

--- a/src/plugins/globe/featuresource/qgsglobefeaturecursor.h
+++ b/src/plugins/globe/featuresource/qgsglobefeaturecursor.h
@@ -19,7 +19,6 @@
 #include <osgEarthFeatures/FeatureCursor>
 #include "qgsfeature.h"
 #include "qgsfeatureiterator.h"
-#include "qgsvectorlayer.h"
 
 #include "qgsglobefeatureutils.h"
 

--- a/src/plugins/globe/featuresource/qgsglobefeatureutils.h
+++ b/src/plugins/globe/featuresource/qgsglobefeatureutils.h
@@ -26,7 +26,6 @@
 #include "qgsmultipolygon.h"
 #include "qgspolygon.h"
 #include "qgslinestring.h"
-#include "qgsvectorlayer.h"
 
 class QgsGlobeFeatureUtils
 {

--- a/src/plugins/gps_importer/qgsgpsplugingui.cpp
+++ b/src/plugins/gps_importer/qgsgpsplugingui.cpp
@@ -16,6 +16,7 @@
 #include "qgslogger.h"
 #include "qgsgpsdetector.h"
 #include "qgssettings.h"
+#include "qgsvectorlayer.h"
 
 //qt includes
 #include <QFileDialog>

--- a/src/plugins/gps_importer/qgsgpsplugingui.h
+++ b/src/plugins/gps_importer/qgsgpsplugingui.h
@@ -17,7 +17,6 @@
 #ifndef QGSGPSPLUGINGUI_H
 #define QGSGPSPLUGINGUI_H
 
-#include "qgsvectorlayer.h"
 #include "ui_qgsgpspluginguibase.h"
 #include "qgsbabelformat.h"
 #include "qgsgpsdevice.h"
@@ -26,6 +25,8 @@
 #include <vector>
 
 #include <QString>
+
+class QgsVectorLayer;
 
 
 /**

--- a/src/plugins/grass/qgsgrassplugin.h
+++ b/src/plugins/grass/qgsgrassplugin.h
@@ -18,6 +18,7 @@
 #include "../qgisplugin.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransform.h"
+#include "qgseditformconfig.h"
 #include <QObject>
 
 class QgsGrassTools;
@@ -28,6 +29,7 @@ class QgsMapCanvas;
 class QgsMapLayer;
 class QgsMapTool;
 class QgsRubberBand;
+class QgsVectorLayer;
 
 class QAction;
 class QIcon;

--- a/src/plugins/grass/qgsgrassplugin.h
+++ b/src/plugins/grass/qgsgrassplugin.h
@@ -18,7 +18,6 @@
 #include "../qgisplugin.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgscoordinatetransform.h"
-#include "qgsvectorlayer.h"
 #include <QObject>
 
 class QgsGrassTools;

--- a/src/plugins/topology/checkDock.h
+++ b/src/plugins/topology/checkDock.h
@@ -20,7 +20,6 @@
 
 #include "qgsdockwidget.h"
 
-#include "qgsvectorlayer.h"
 #include "qgsgeometry.h"
 //#include "qgsvertexmarker.h"
 #include "qgsspatialindex.h"

--- a/src/plugins/topology/dockModel.cpp
+++ b/src/plugins/topology/dockModel.cpp
@@ -17,6 +17,7 @@
 
 #include "dockModel.h"
 #include "topolError.h"
+#include "qgsvectorlayer.h"
 
 DockModel::DockModel( ErrorList &errorList, QObject *parent = nullptr ) : mErrorlist( errorList )
 {

--- a/src/plugins/topology/rulesDialog.h
+++ b/src/plugins/topology/rulesDialog.h
@@ -20,7 +20,6 @@
 
 #include <QDialog>
 
-#include "qgsvectorlayer.h"
 
 #include "ui_rulesDialog.h"
 #include "topolTest.h"

--- a/src/plugins/topology/topolError.cpp
+++ b/src/plugins/topology/topolError.cpp
@@ -18,6 +18,7 @@
 #include "topolError.h"
 #include "qgsmessagelog.h"
 #include "qgsfeatureiterator.h"
+#include "qgsvectorlayer.h"
 
 //TODO: tell dock to parse errorlist when feature is deleted
 bool TopolError::fix( const QString &fixName )

--- a/src/plugins/topology/topolError.h
+++ b/src/plugins/topology/topolError.h
@@ -18,13 +18,14 @@
 #ifndef TOPOLERROR_H
 #define TOPOLERROR_H
 
-#include "qgsvectorlayer.h"
 #include "qgsgeometry.h"
 #include "qgsrectangle.h"
+#include "qgsfeature.h"
 
 class TopolError;
 typedef QList<TopolError *> ErrorList;
 typedef bool ( TopolError::*fixFunction )();
+
 
 class FeatureLayer
 {

--- a/src/plugins/topology/topolTest.h
+++ b/src/plugins/topology/topolTest.h
@@ -20,7 +20,6 @@
 
 #include <QObject>
 
-#include "qgsvectorlayer.h"
 #include "qgsgeometry.h"
 #include "qgsspatialindex.h"
 

--- a/src/providers/virtual/qgsvirtuallayerqueryparser.cpp
+++ b/src/providers/virtual/qgsvirtuallayerqueryparser.cpp
@@ -18,6 +18,8 @@ email                : hugo dot mercier at oslandia dot com
 #include "qgsvirtuallayersqlitehelper.h"
 #include "qgsvirtuallayerblob.h"
 
+#include "sqlite3.h"
+
 #include <QRegExp>
 #include <QtDebug>
 

--- a/src/providers/virtual/qgsvirtuallayerqueryparser.h
+++ b/src/providers/virtual/qgsvirtuallayerqueryparser.h
@@ -19,7 +19,8 @@ email                : hugo dot mercier at oslandia dot com
 
 #include "qgis.h"
 #include "qgswkbtypes.h"
-#include "qgsvectorlayer.h"
+
+struct sqlite3;
 
 namespace QgsVirtualLayerQueryParser
 {

--- a/src/quickgui/attributes/qgsquickattributemodel.h
+++ b/src/quickgui/attributes/qgsquickattributemodel.h
@@ -20,7 +20,6 @@
 #include <QVector>
 
 #include "qgsfeature.h"
-#include "qgsvectorlayer.h"
 
 #include "qgis_quick.h"
 #include "qgsquickfeaturelayerpair.h"

--- a/src/server/qgsserverinterfaceimpl.cpp
+++ b/src/server/qgsserverinterfaceimpl.cpp
@@ -95,6 +95,10 @@ void QgsServerInterfaceImpl::registerServerCache( QgsServerCacheFilter *serverCa
 #endif
 }
 
+QgsServerCacheManager *QgsServerInterfaceImpl::cacheManager() const
+{
+  return mCacheManager.get();
+}
 
 void QgsServerInterfaceImpl::removeConfigCacheEntry( const QString &path )
 {

--- a/src/server/qgsserverinterfaceimpl.h
+++ b/src/server/qgsserverinterfaceimpl.h
@@ -24,6 +24,7 @@
 
 #include "qgsserverinterface.h"
 #include "qgscapabilitiescache.h"
+#include "qgsservercachemanager.h"
 
 /**
  * \ingroup server
@@ -74,7 +75,7 @@ class QgsServerInterfaceImpl : public QgsServerInterface
      * \returns the server cache helper
      * \since QGIS 3.4
      */
-    QgsServerCacheManager *cacheManager() const override { return mCacheManager.get(); }
+    QgsServerCacheManager *cacheManager() const override;
 
     QString getEnv( const QString &name ) const override;
     QString configFilePath() override { return mConfigFilePath; }

--- a/src/server/qgsserverprojectutils.h
+++ b/src/server/qgsserverprojectutils.h
@@ -20,7 +20,6 @@
 
 #include "qgis_server.h"
 #include "qgsproject.h"
-#include "qgsvectorlayer.h"
 
 #ifdef SIP_RUN
 % ModuleHeaderCode

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.h
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.h
@@ -22,7 +22,6 @@
 #ifndef QGSWFSDESCRIBEFEATURETYPE_H
 #define QGSWFSDESCRIBEFEATURETYPE_H
 
-#include "qgsvectorlayer.h"
 
 #include <QDomDocument>
 #include <QDomElement>

--- a/src/server/services/wfs/qgswfsutils.cpp
+++ b/src/server/services/wfs/qgswfsutils.cpp
@@ -25,6 +25,7 @@
 #include "qgsconfigcache.h"
 #include "qgsserverprojectutils.h"
 #include "qgswfsparameters.h"
+#include "qgsvectorlayer.h"
 
 namespace QgsWfs
 {

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -39,6 +39,7 @@
 
 #include "qgsexception.h"
 #include "qgsexpressionnodeimpl.h"
+#include "qgsvectorlayer.h"
 
 
 namespace QgsWms

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -38,6 +38,7 @@
 #include "qgsreferencedgeometry.h"
 #include "qgssettings.h"
 #include "qgsmessagelog.h"
+#include "qgsvectorlayer.h"
 
 class DummyAlgorithm : public QgsProcessingAlgorithm
 {

--- a/tests/src/analysis/testqgsprocessingalgs.cpp
+++ b/tests/src/analysis/testqgsprocessingalgs.cpp
@@ -26,6 +26,7 @@
 #include "qgsalgorithmimportphotos.h"
 #include "qgsalgorithmtransform.h"
 #include "qgsalgorithmkmeansclustering.h"
+#include "qgsvectorlayer.h"
 
 class TestQgsProcessingAlgs: public QObject
 {

--- a/tests/src/app/testqgsmaptoolutils.h
+++ b/tests/src/app/testqgsmaptoolutils.h
@@ -20,7 +20,6 @@
 #include "qgisapp.h"
 #include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
-#include "qgsvectorlayer.h"
 
 /**
  * \ingroup UnitTests

--- a/tests/src/core/testqgslayoutitem.cpp
+++ b/tests/src/core/testqgslayoutitem.cpp
@@ -29,6 +29,8 @@
 #include "qgsfillsymbollayer.h"
 #include "qgslayoutpagecollection.h"
 #include "qgslayoutundostack.h"
+#include "qgsvectorlayer.h"
+
 #include <QObject>
 #include <QPainter>
 #include <QImage>

--- a/tests/src/core/testqgslayoututils.cpp
+++ b/tests/src/core/testqgslayoututils.cpp
@@ -22,6 +22,8 @@
 #include "qgslayoutitemmap.h"
 #include "qgsfontutils.h"
 #include "qgsrenderchecker.h"
+#include "qgsvectorlayer.h"
+
 #include <QStyleOptionGraphicsItem>
 
 class TestQgsLayoutUtils: public QObject

--- a/tests/src/core/testqgsvectorlayercache.cpp
+++ b/tests/src/core/testqgsvectorlayercache.cpp
@@ -20,11 +20,13 @@
 
 //qgis includes...
 #include "qgsfeatureiterator.h"
-#include <qgsvectorlayercache.h>
-#include <qgsvectordataprovider.h>
-#include <qgsapplication.h>
-#include <qgsvectorlayereditbuffer.h>
-#include <qgscacheindexfeatureid.h>
+#include "qgsvectorlayercache.h"
+#include "qgsvectordataprovider.h"
+#include "qgsapplication.h"
+#include "qgsvectorlayereditbuffer.h"
+#include "qgscacheindexfeatureid.h"
+#include "qgsvectorlayer.h"
+
 #include <QDebug>
 
 /**

--- a/tests/src/core/testqgsvectorlayerutils.cpp
+++ b/tests/src/core/testqgsvectorlayerutils.cpp
@@ -15,6 +15,7 @@
 #include "qgstest.h"
 
 #include "qgsvectorlayerutils.h"
+#include "qgsvectorlayer.h"
 
 /**
  * \ingroup UnitTests


### PR DESCRIPTION
This reduces the number of objects that depend on qgsvectorlayer.h and should help to get build times a bit down.