### PR TITLE
Fix an undeclarated variable in Voronoi Polygon Plugin

### DIFF
--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -404,7 +404,7 @@ class VoronoiPolygons(QgisAlgorithm):
                 if hasYMin:
                     bndpoints.append(QgsPointXY(width + extent.xMinimum(),
                                                 extent.yMinimum()))
-                elif HasYMax:
+                elif hasYMax:
                     bndpoints.append(QgsPointXY(width + extent.xMinimum(),
                                                 height + extent.yMinimum()))
         if pt_y == ymin:    # lowest point


### PR DESCRIPTION
## Description
`clip_voronoi` method in VoronoiPolygons class (`python/plugins/processing/algs/qgis/VoronoiPolygons.py`) has `hasYMax` variable, but at line 407, there is `HasYMax` variable. I fixed it.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
