### PR TITLE
[3d] Use layout item bg color as 3D scene bg color

### DIFF
--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -106,6 +106,12 @@ void QgsLayoutItem3DMap::draw( QgsLayoutItemRenderContext &context )
     return;
   }
 
+  if ( mSettings->backgroundColor() != backgroundColor() )
+  {
+    mSettings->setBackgroundColor( backgroundColor() );
+    mCapturedImage = QImage();
+  }
+
   if ( !mCapturedImage.isNull() )
   {
     painter->drawImage( r, mCapturedImage );

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -115,16 +115,23 @@ void QgsLayout3DMapWidget::updateCameraPoseWidgetsFromItem()
 void QgsLayout3DMapWidget::copy3DMapSettings()
 {
   Qgs3DMapCanvasDockWidget *dock = _dock3DViewFromSender( sender() );
+  if ( !dock )
+    return;
 
-  // if this is the first settings passed on, also copy camera details
+  Qgs3DMapSettings *settings = new Qgs3DMapSettings( *dock->mapCanvas3D()->map() );
+
+  // first setting passed on
   if ( !mMap3D->mapSettings() )
   {
+    // copy background color
+    mMap3D->setBackgroundColor( settings->backgroundColor() );
+
+    // copy camera position details
     mMap3D->setCameraPose( dock->mapCanvas3D()->cameraController()->cameraPose() );
     updateCameraPoseWidgetsFromItem();
   }
 
-  if ( dock )
-    mMap3D->setMapSettings( new Qgs3DMapSettings( *dock->mapCanvas3D()->map() ) );
+  mMap3D->setMapSettings( settings );
 }
 
 void QgsLayout3DMapWidget::copeCameraPose()

--- a/tests/src/3d/testqgslayout3dmap.cpp
+++ b/tests/src/3d/testqgslayout3dmap.cpp
@@ -114,6 +114,7 @@ void TestQgsLayout3DMap::testBasic()
   l.initializeDefaults();
 
   QgsLayoutItem3DMap *map3dItem = new QgsLayoutItem3DMap( &l );
+  map3dItem->setBackgroundColor( QColor( 0, 0, 0 ) );
   map3dItem->attemptSetSceneRect( QRectF( 0, 0, 297, 210 ) );
   map3dItem->setCameraPose( cam );
   map3dItem->setMapSettings( map );


### PR DESCRIPTION
## Description
@wonder-sk , that can be quite useful.

![peek 2018-09-05 17-12](https://user-images.githubusercontent.com/1728657/45087112-0af1d400-b12f-11e8-93de-3a6a26a91880.gif)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
