### PR TITLE
Support QGIS Server logs to stderr

### DIFF
--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -107,7 +107,7 @@ class QgsMessageLogConsole : QObject
 %Docstring
 Default implementation of message logging interface
 
-This class outputs log messages to the standard output. Therefore it might
+This class outputs log messages to the standard error. Therefore it might
 be the right choice for apps without GUI.
 %End
 

--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -136,7 +136,7 @@ Formats a log message. Used by child classes.
 
   public slots:
 
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    virtual void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 %Docstring
 Logs a message to stderr.
 

--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -117,6 +117,17 @@ be the right choice for apps without GUI.
   public:
     QgsMessageLogConsole();
 
+  protected:
+
+    QString formatLogMessage( const QString &message, const QString &tag, Qgis::MessageLevel level = Qgis::Info ) const;
+%Docstring
+Format a log message. Used by child classes.
+
+:param message: the message to format
+:param tag: the tag of the message
+:param level: the log level of the message
+%End
+
   public slots:
     void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 };

--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -108,7 +108,7 @@ class QgsMessageLogConsole : QObject
 Default implementation of message logging interface
 
 This class outputs log messages to the standard error. Therefore it might
-be the right choice for apps without GUI.
+be the right choice for applications without GUI.
 %End
 
 %TypeHeaderCode
@@ -125,18 +125,20 @@ Constructor for QgsMessageLogConsole.
 
     QString formatLogMessage( const QString &message, const QString &tag, Qgis::MessageLevel level = Qgis::Info ) const;
 %Docstring
-Format a log message. Used by child classes.
+Formats a log message. Used by child classes.
 
 :param message: the message to format
 :param tag: the tag of the message
 :param level: the log level of the message
+
+.. versionadded:: 3.4
 %End
 
   public slots:
 
     void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 %Docstring
-Log a message to stderr.
+Logs a message to stderr.
 
 :param message: the message to format
 :param tag: the tag of the message

--- a/python/core/auto_generated/qgsmessagelog.sip.in
+++ b/python/core/auto_generated/qgsmessagelog.sip.in
@@ -115,7 +115,11 @@ be the right choice for apps without GUI.
 #include "qgsmessagelog.h"
 %End
   public:
+
     QgsMessageLogConsole();
+%Docstring
+Constructor for QgsMessageLogConsole.
+%End
 
   protected:
 
@@ -129,7 +133,15 @@ Format a log message. Used by child classes.
 %End
 
   public slots:
+
     void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+%Docstring
+Log a message to stderr.
+
+:param message: the message to format
+:param tag: the tag of the message
+:param level: the log level of the message
+%End
 };
 
 /************************************************************************

--- a/python/server/auto_generated/qgsserverlogger.sip.in
+++ b/python/server/auto_generated/qgsserverlogger.sip.in
@@ -61,7 +61,8 @@ Activates logging to stderr.
 
   public slots:
 
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    virtual void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+
 %Docstring
 Log a message from the server context
 

--- a/python/server/auto_generated/qgsserverlogger.sip.in
+++ b/python/server/auto_generated/qgsserverlogger.sip.in
@@ -47,9 +47,16 @@ Set the current log level
 .. versionadded:: 3.0
 %End
 
-    void setLogFile( const QString &f );
+    void setLogFile( const QString &filename = QString() );
 %Docstring
 Set the current log file
+%End
+
+    void setLogStderr();
+%Docstring
+Activates logging to stderr.
+
+.. versionadded:: 3.4.
 %End
 
   public slots:

--- a/python/server/auto_generated/qgsserverlogger.sip.in
+++ b/python/server/auto_generated/qgsserverlogger.sip.in
@@ -1,0 +1,77 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/server/qgsserverlogger.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsServerLogger : QgsMessageLogConsole
+{
+%Docstring
+Writes message log into server logfile
+
+.. versionadded:: 2.8
+%End
+
+%TypeHeaderCode
+#include "qgsserverlogger.h"
+%End
+  public:
+
+    static QgsServerLogger *instance();
+%Docstring
+Gets the singleton instance
+%End
+
+    Qgis::MessageLevel logLevel() const;
+%Docstring
+Gets the current log level
+
+:return: the log level
+
+.. versionadded:: 3.0
+%End
+
+    void setLogLevel( Qgis::MessageLevel level );
+%Docstring
+Set the current log level
+
+:param level: the log level
+
+.. versionadded:: 3.0
+%End
+
+    void setLogFile( const QString &f );
+%Docstring
+Set the current log file
+%End
+
+  public slots:
+
+    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+%Docstring
+Log a message from the server context
+
+:param message: the message
+:param tag: tag of the message
+:param level: log level of the message
+%End
+
+  protected:
+    QgsServerLogger();
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/server/qgsserverlogger.h                                         *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/server/auto_generated/qgsserversettings.sip.in
+++ b/python/server/auto_generated/qgsserversettings.sip.in
@@ -96,6 +96,15 @@ Returns the log file.
 :return: the path of the log file or an empty string if none is defined.
 %End
 
+    bool logStderr() const;
+%Docstring
+Returns whether logging to stderr is activated.
+
+:return: true if logging to stderr is activated, false otherwise.
+
+.. versionadded:: 3.4
+%End
+
     qint64 cacheSize() const;
 %Docstring
 Returns the cache size.

--- a/python/server/server_auto.sip
+++ b/python/server/server_auto.sip
@@ -3,6 +3,7 @@
 %Include auto_generated/qgsmapserviceexception.sip
 %Include auto_generated/qgscapabilitiescache.sip
 %Include auto_generated/qgsconfigcache.sip
+%Include auto_generated/qgsserverlogger.sip
 %Include auto_generated/qgsserversettings.sip
 %Include auto_generated/qgsserverparameters.sip
 %Include auto_generated/qgsbufferserverrequest.sip

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -18,7 +18,9 @@
 #include "qgslogger.h"
 #include <QDateTime>
 #include <QMetaType>
+#include <QTextStream>
 #include <iostream>
+#include <stdio.h>
 
 class QgsMessageLogConsole;
 
@@ -47,12 +49,19 @@ QgsMessageLogConsole::QgsMessageLogConsole()
 
 void QgsMessageLogConsole::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level )
 {
-  std::cerr
-      << tag.toLocal8Bit().data() << "[" <<
-      ( level == Qgis::Info ? "INFO"
-        : level == Qgis::Warning ? "WARNING"
-        : "CRITICAL" )
-      << "]: " << message.toLocal8Bit().data() << std::endl;
+  QString formattedMessage = formatLogMessage( message, tag, level );
+  QTextStream cerr( stderr );
+  cerr << formattedMessage;
+}
+
+QString QgsMessageLogConsole::formatLogMessage( const QString &message, const QString &tag, Qgis::MessageLevel level ) const
+{
+  const QString time = QTime::currentTime().toString();
+  const QString levelStr = level == Qgis::Info ? QStringLiteral( "INFO" ) :
+                           level == Qgis::Warning ? QStringLiteral( "WARNING" ) :
+                           QStringLiteral( "CRITICAL" );
+  const QString pid = QString::number( QCoreApplication::applicationPid() );
+  return QStringLiteral( "%1 %2 %3[%4]: %5\n" ).arg( time, levelStr, tag, pid, message );
 }
 
 //

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -131,7 +131,7 @@ class CORE_EXPORT QgsMessageLogNotifyBlocker
  * \brief Default implementation of message logging interface
  *
  * This class outputs log messages to the standard error. Therefore it might
- * be the right choice for apps without GUI.
+ * be the right choice for applications without GUI.
  */
 class CORE_EXPORT QgsMessageLogConsole : public QObject
 {
@@ -147,18 +147,19 @@ class CORE_EXPORT QgsMessageLogConsole : public QObject
   protected:
 
     /**
-     * Format a log message. Used by child classes.
+     * Formats a log message. Used by child classes.
      *
      * \param message the message to format
      * \param tag the tag of the message
      * \param level the log level of the message
+     * \since QGIS 3.4
      */
     QString formatLogMessage( const QString &message, const QString &tag, Qgis::MessageLevel level = Qgis::Info ) const;
 
   public slots:
 
     /**
-     * Log a message to stderr.
+     * Logs a message to stderr.
      *
      * \param message the message to format
      * \param tag the tag of the message

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -128,11 +128,11 @@ class CORE_EXPORT QgsMessageLogNotifyBlocker
 
 /**
  * \ingroup core
-\brief Default implementation of message logging interface
-
-This class outputs log messages to the standard output. Therefore it might
-be the right choice for apps without GUI.
-*/
+ * \brief Default implementation of message logging interface
+ *
+ * This class outputs log messages to the standard output. Therefore it might
+ * be the right choice for apps without GUI.
+ */
 class CORE_EXPORT QgsMessageLogConsole : public QObject
 {
     Q_OBJECT

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -130,7 +130,7 @@ class CORE_EXPORT QgsMessageLogNotifyBlocker
  * \ingroup core
  * \brief Default implementation of message logging interface
  *
- * This class outputs log messages to the standard output. Therefore it might
+ * This class outputs log messages to the standard error. Therefore it might
  * be the right choice for apps without GUI.
  */
 class CORE_EXPORT QgsMessageLogConsole : public QObject

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -138,6 +138,10 @@ class CORE_EXPORT QgsMessageLogConsole : public QObject
     Q_OBJECT
 
   public:
+
+    /**
+     * Constructor for QgsMessageLogConsole.
+     */
     QgsMessageLogConsole();
 
   protected:
@@ -152,6 +156,14 @@ class CORE_EXPORT QgsMessageLogConsole : public QObject
     QString formatLogMessage( const QString &message, const QString &tag, Qgis::MessageLevel level = Qgis::Info ) const;
 
   public slots:
+
+    /**
+     * Log a message to stderr.
+     *
+     * \param message the message to format
+     * \param tag the tag of the message
+     * \param level the log level of the message
+     */
     void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 };
 

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -140,6 +140,17 @@ class CORE_EXPORT QgsMessageLogConsole : public QObject
   public:
     QgsMessageLogConsole();
 
+  protected:
+
+    /**
+     * Format a log message. Used by child classes.
+     *
+     * \param message the message to format
+     * \param tag the tag of the message
+     * \param level the log level of the message
+     */
+    QString formatLogMessage( const QString &message, const QString &tag, Qgis::MessageLevel level = Qgis::Info ) const;
+
   public slots:
     void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 };

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -165,7 +165,7 @@ class CORE_EXPORT QgsMessageLogConsole : public QObject
      * \param tag the tag of the message
      * \param level the log level of the message
      */
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    virtual void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
 };
 
 #endif

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -186,7 +186,14 @@ bool QgsServer::init()
   // init and configure logger
   QgsServerLogger::instance();
   QgsServerLogger::instance()->setLogLevel( sSettings.logLevel() );
-  QgsServerLogger::instance()->setLogFile( sSettings.logFile() );
+  if ( ! sSettings.logFile().isEmpty() )
+  {
+    QgsServerLogger::instance()->setLogFile( sSettings.logFile() );
+  }
+  else if ( sSettings.logStderr() )
+  {
+    QgsServerLogger::instance()->setLogStderr();
+  }
 
   // log settings currently used
   sSettings.logSummary();

--- a/src/server/qgsserverlogger.cpp
+++ b/src/server/qgsserverlogger.cpp
@@ -36,44 +36,44 @@ QgsServerLogger *QgsServerLogger::instance()
 }
 
 QgsServerLogger::QgsServerLogger()
-  : mLogFile( nullptr )
+  : QgsMessageLogConsole()
 {
-  connect( QgsApplication::messageLog(), static_cast<void ( QgsMessageLog::* )( const QString &, const QString &, Qgis::MessageLevel )>( &QgsMessageLog::messageReceived ), this,
-           &QgsServerLogger::logMessage );
 }
 
-void QgsServerLogger::setLogLevel( Qgis::MessageLevel level )
+void QgsServerLogger::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level )
+{
+  if ( mLogLevel > level )
+  {
+    return;
+  }
+  if ( mLogFile.isOpen() )
+  {
+    QString formattedMessage = formatLogMessage( message, tag, level );
+    mTextStream << formattedMessage;
+    mTextStream.flush();
+  }
+  else if ( QString::compare( mLogFile.fileName(), QStringLiteral( "stderr" ), Qt::CaseInsensitive ) == 0 )
+  {
+    QgsMessageLogConsole::logMessage( message, tag, level );
+  }
+}
+
+void QgsServerLogger::setLogLevel( const Qgis::MessageLevel level )
 {
   mLogLevel = level;
 }
 
 void QgsServerLogger::setLogFile( const QString &f )
 {
-  if ( ! f.isEmpty() )
-  {
-    if ( mLogFile.exists() )
-    {
-      mTextStream.flush();
-      mLogFile.close();
-    }
-
-    mLogFile.setFileName( f );
-    if ( mLogFile.open( QIODevice::Append ) )
-    {
-      mTextStream.setDevice( &mLogFile );
-    }
-  }
-}
-
-void QgsServerLogger::logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level )
-{
-  Q_UNUSED( tag );
-  if ( !mLogFile.isOpen() || mLogLevel > level )
-  {
-    return;
-  }
-
-  mTextStream << ( "[" + QString::number( qlonglong( QCoreApplication::applicationPid() ) ) + "]["
-                   + QTime::currentTime().toString() + "] " + message + "\n" );
   mTextStream.flush();
+  mLogFile.close();
+
+  mLogFile.setFileName( f );
+
+  if ( ( ! f.isEmpty() ) &&
+       QString::compare( f, QStringLiteral( "stderr" ), Qt::CaseInsensitive ) != 0 &&
+       mLogFile.open( QIODevice::Append ) )
+  {
+    mTextStream.setDevice( &mLogFile );
+  }
 }

--- a/src/server/qgsserverlogger.cpp
+++ b/src/server/qgsserverlogger.cpp
@@ -52,7 +52,7 @@ void QgsServerLogger::logMessage( const QString &message, const QString &tag, Qg
     mTextStream << formattedMessage;
     mTextStream.flush();
   }
-  else if ( QString::compare( mLogFile.fileName(), QStringLiteral( "stderr" ), Qt::CaseInsensitive ) == 0 )
+  else if ( mLogStderr )
   {
     QgsMessageLogConsole::logMessage( message, tag, level );
   }
@@ -63,17 +63,20 @@ void QgsServerLogger::setLogLevel( const Qgis::MessageLevel level )
   mLogLevel = level;
 }
 
-void QgsServerLogger::setLogFile( const QString &f )
+void QgsServerLogger::setLogFile( const QString &filename )
 {
   mTextStream.flush();
   mLogFile.close();
+  mLogFile.setFileName( filename );
 
-  mLogFile.setFileName( f );
-
-  if ( ( ! f.isEmpty() ) &&
-       QString::compare( f, QStringLiteral( "stderr" ), Qt::CaseInsensitive ) != 0 &&
-       mLogFile.open( QIODevice::Append ) )
+  if ( ( ! filename.isEmpty() ) && mLogFile.open( QIODevice::Append ) )
   {
     mTextStream.setDevice( &mLogFile );
   }
+}
+
+void QgsServerLogger::setLogStderr()
+{
+  setLogFile();
+  mLogStderr = true;
 }

--- a/src/server/qgsserverlogger.h
+++ b/src/server/qgsserverlogger.h
@@ -18,8 +18,6 @@
 #ifndef QGSSERVERLOGGER_H
 #define QGSSERVERLOGGER_H
 
-#define SIP_NO_FILE
-
 
 #include "qgsmessagelog.h"
 
@@ -27,13 +25,14 @@
 #include <QObject>
 #include <QString>
 #include <QTextStream>
+#include "qgis_server.h"
 
 /**
  * \ingroup server
  * \brief Writes message log into server logfile
  * \since QGIS 2.8
  */
-class QgsServerLogger: public QgsMessageLogConsole
+class SERVER_EXPORT QgsServerLogger : public QgsMessageLogConsole
 {
     Q_OBJECT
   public:

--- a/src/server/qgsserverlogger.h
+++ b/src/server/qgsserverlogger.h
@@ -59,7 +59,13 @@ class SERVER_EXPORT QgsServerLogger : public QgsMessageLogConsole
     /**
       * Set the current log file
       */
-    void setLogFile( const QString &f );
+    void setLogFile( const QString &filename = QString() );
+
+    /**
+     * Activates logging to stderr.
+     * \since QGIS 3.4.
+     */
+    void setLogStderr();
 
   public slots:
 
@@ -79,6 +85,7 @@ class SERVER_EXPORT QgsServerLogger : public QgsMessageLogConsole
     static QgsServerLogger *sInstance;
 
     QFile mLogFile;
+    bool mLogStderr = false;
     QTextStream mTextStream;
     Qgis::MessageLevel mLogLevel = Qgis::None;
 };

--- a/src/server/qgsserverlogger.h
+++ b/src/server/qgsserverlogger.h
@@ -33,7 +33,7 @@
  * \brief Writes message log into server logfile
  * \since QGIS 2.8
  */
-class QgsServerLogger: public QObject
+class QgsServerLogger: public QgsMessageLogConsole
 {
     Q_OBJECT
   public:

--- a/src/server/qgsserverlogger.h
+++ b/src/server/qgsserverlogger.h
@@ -76,7 +76,7 @@ class SERVER_EXPORT QgsServerLogger : public QgsMessageLogConsole
      * \param tag tag of the message
      * \param level log level of the message
      */
-    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level );
+    void logMessage( const QString &message, const QString &tag, Qgis::MessageLevel level ) override;
 
   protected:
     QgsServerLogger();

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -87,6 +87,17 @@ void QgsServerSettings::initSettings()
                            };
   mSettings[ sLogFile.envVar ] = sLogFile;
 
+  // log to stderr
+  const Setting sLogStderr = { QgsServerSettingsEnv::QGIS_SERVER_LOG_STDERR,
+                               QgsServerSettingsEnv::DEFAULT_VALUE,
+                               "Activate/Deactivate logging to stderr",
+                               "",
+                               QVariant::Bool,
+                               QVariant( false ),
+                               QVariant()
+                             };
+  mSettings[ sLogStderr.envVar ] = sLogStderr;
+
   // project file
   const Setting sProject = { QgsServerSettingsEnv::QGIS_PROJECT_FILE,
                              QgsServerSettingsEnv::DEFAULT_VALUE,
@@ -279,6 +290,11 @@ int QgsServerSettings::maxThreads() const
 QString QgsServerSettings::logFile() const
 {
   return value( QgsServerSettingsEnv::QGIS_SERVER_LOG_FILE ).toString();
+}
+
+bool QgsServerSettings::logStderr() const
+{
+  return value( QgsServerSettingsEnv::QGIS_SERVER_LOG_STDERR ).toBool();
 }
 
 Qgis::MessageLevel QgsServerSettings::logLevel() const

--- a/src/server/qgsserversettings.h
+++ b/src/server/qgsserversettings.h
@@ -56,6 +56,7 @@ class SERVER_EXPORT QgsServerSettingsEnv : public QObject
       QGIS_SERVER_MAX_THREADS,
       QGIS_SERVER_LOG_LEVEL,
       QGIS_SERVER_LOG_FILE,
+      QGIS_SERVER_LOG_STDERR,
       QGIS_PROJECT_FILE,
       MAX_CACHE_LAYERS,
       QGIS_SERVER_CACHE_DIRECTORY,
@@ -147,6 +148,13 @@ class SERVER_EXPORT QgsServerSettings
       * \returns the path of the log file or an empty string if none is defined.
       */
     QString logFile() const;
+
+    /**
+     * Returns whether logging to stderr is activated.
+     * \returns true if logging to stderr is activated, false otherwise.
+     * \since QGIS 3.4
+     */
+    bool logStderr() const;
 
     /**
      * Returns the cache size.

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -255,6 +255,7 @@ ENDIF (ENABLE_ORACLETEST)
 
 IF (WITH_SERVER)
   ADD_PYTHON_TEST(PyQgsServer test_qgsserver.py)
+  ADD_PYTHON_TEST(PyQgsServerLogger test_qgsserverlogger.py)
   ADD_PYTHON_TEST(PyQgsServerPlugins test_qgsserver_plugins.py)
   ADD_PYTHON_TEST(PyQgsServerWMS test_qgsserver_wms.py)
   ADD_PYTHON_TEST(PyQgsServerWMSGetMap test_qgsserver_wms_getmap.py)

--- a/tests/src/python/test_qgsserverlogger.py
+++ b/tests/src/python/test_qgsserverlogger.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for QgsServerLogger.
+"""
+__author__ = 'Eric Lemoine'
+__date__ = '11/09/2018'
+__copyright__ = 'Copyright 2018, The QGIS Project'
+__revision__ = '$Format:%H$'
+
+import os
+
+from qgis.testing import unittest
+from qgis.server import QgsServerLogger
+
+from utilities import unitTestDataPath
+
+
+class TestQgsServerLogger(unittest.TestCase):
+
+    log_file = os.path.join(unitTestDataPath('qgis_server'), 'qgis_server_test.log')
+
+    @staticmethod
+    def remove_file(filename):
+        try:
+            os.remove(filename)
+        except FileNotFoundError:
+            pass
+
+    def setUp(self):
+        self.logger = QgsServerLogger.instance()
+        self.logger.setLogLevel(0)
+        self.logger.setLogFile(self.log_file)
+        exists = os.access(self.log_file, os.R_OK)
+        self.assertTrue(exists)
+        self.remove_file(self.log_file)
+
+    def tearDown(self):
+        self.remove_file(self.log_file)
+
+    def test_logging_no_log_file(self):
+        self.logger.setLogFile('')
+        exists = os.access(self.log_file, os.R_OK)
+        self.assertFalse(exists)
+
+    def test_logging_log_file(self):
+        self.logger.setLogFile(self.log_file)
+        exists = os.access(self.log_file, os.R_OK)
+        self.assertTrue(exists)
+
+    def test_logging_stderr(self):
+        self.logger.setLogFile('stderr')
+        exists = os.access(self.log_file, os.R_OK)
+        self.assertFalse(exists)

--- a/tests/src/python/test_qgsserverlogger.py
+++ b/tests/src/python/test_qgsserverlogger.py
@@ -46,7 +46,12 @@ class TestQgsServerLogger(unittest.TestCase):
         exists = os.access(self.log_file, os.R_OK)
         self.assertTrue(exists)
 
-    def test_logging_stderr(self):
+    def test_logging_log_file_stderr(self):
         self.logger.setLogFile('stderr')
+        exists = os.access(self.log_file, os.R_OK)
+        self.assertFalse(exists)
+
+    def test_logging_stderr(self):
+        self.logger.setLogStderr()
         exists = os.access(self.log_file, os.R_OK)
         self.assertFalse(exists)


### PR DESCRIPTION
## Description

QGIS Server can be configured to write its logs to a file on the file system. This is done through the QGIS_SERVER_LOG_FILE environment variable.

But there is currently no way to make QGIS Server write its logs to stderr. And logging to stderr is desirable in some cases, when executing QGIS Server in a Docker container for example.

This PR adds that capability. With this PR, when QGIS_SERVER_LOG_FILE is set  to the special value "stderr",  QGIS Server will write its logs to stderr.

To avoid duplicating code the `QgsServerLogger` class now inherits from `QgsMessageLogConsole`, which already existed in the QGIS code base before this patch. In this way changes to `QgsMessageLogConsole` will directly benefit the server, with no other changes required to the server code.

Note: I have a [doc patch](https://github.com/qgis/QGIS-Documentation/compare/master...elemoine:ele_logging) ready if this one gets accepted.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
