### PR TITLE
Fix some crashes in style manager dialog

### DIFF
--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -213,15 +213,6 @@ Enables or disables the groupTree items for grouping mode
 sets the text of the item with bold font
 %End
 
-
-
-
-
-
-
-
-
-
 };
 
 /************************************************************************

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -199,7 +199,7 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     //! Menu for the "Add item" toolbutton when in colorramp mode
     QMenu *mMenuBtnAddItemColorRamp = nullptr;
 
-
+    bool mBlockGroupUpdates = false;
 
 };
 

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -169,6 +169,12 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     //! sets the text of the item with bold font
     void setBold( QStandardItem * );
 
+  private slots:
+
+    void tabItemType_currentChanged( int );
+
+  private:
+
     QgsStyle *mStyle = nullptr;
 
     QString mStyleFilename;
@@ -193,9 +199,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     //! Menu for the "Add item" toolbutton when in colorramp mode
     QMenu *mMenuBtnAddItemColorRamp = nullptr;
 
-  private slots:
 
-    void tabItemType_currentChanged( int );
+
 };
 
 #endif


### PR DESCRIPTION
Because the dialog group list is now repopulated whenever
the style emits group modified signal, the extra code relating
to updating the existing list is not required.
