### PR TITLE
[server] Activates rendering optimization

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1139,6 +1139,9 @@ namespace QgsWms
 
     // add labeling engine settings
     mapSettings.setLabelingEngineSettings( mProject->labelingEngineSettings() );
+
+    // enable rendering optimization
+    mapSettings.setFlag( QgsMapSettings::UseRenderingOptimization );
   }
 
   QDomDocument QgsRenderer::featureInfoDocument( QList<QgsMapLayer *> &layers, const QgsMapSettings &mapSettings,


### PR DESCRIPTION
## Description

Whatever the parameters in the `.ini` configuration file, rendering optimization is currently not used by the WMS renderer of the server.

This PR enables this optimization.

As a consequence, for a vector layer with 125 000 lines:
- without the optimization: about 6 000 000 points are effectively drawn in the underlying painter
- with the optimization: only 600 000 points are drawn

This way, the rendering time is much better compared to the 3.0/3.2 release:

![getmap_lines_dpi96_graph](https://user-images.githubusercontent.com/9266424/45212306-7ac9a100-b28c-11e8-9672-872425c5d0bb.png)

Note: thanks [Graffiti](https://github.com/pblottiere/graffiti) for the graph :)

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
