### PR TITLE
[BUGFIX][Server] Quickfix in QgsHttpTransaction to support HTTPS scheme

### DIFF
--- a/python/core/qgshttptransaction.sip
+++ b/python/core/qgshttptransaction.sip
@@ -79,6 +79,12 @@ class QgsHttpTransaction : QObject
 
     void networkTimedOut();
 
+    /**
+     * Handle SSL errors
+     * @since QGIS 2.18.24
+     */
+    void handleSslErrors( const QList<QSslError> &errors );
+
     /** Aborts the current transaction*/
     void abort();
 

--- a/src/core/qgshttptransaction.h
+++ b/src/core/qgshttptransaction.h
@@ -22,6 +22,7 @@
 #define QGSHTTPTRANSACTION_H
 
 #include <QHttp>
+#include <QSslError>
 #include <QNetworkProxy>
 #include <QString>
 
@@ -113,6 +114,12 @@ class CORE_EXPORT QgsHttpTransaction : public QObject
     void dataStateChanged( int state );
 
     void networkTimedOut();
+
+    /**
+     * Handle SSL errors
+     * @since QGIS 2.18.24
+     */
+    void handleSslErrors( const QList<QSslError> &errors );
 
     /** Aborts the current transaction*/
     void abort();


### PR DESCRIPTION
## Description

The class QgsHttpTransaction is only used in server for getting files provided by URL. This class does not support HTTPS.

This is a quickfix to enable requesting SLD files provided through HTTPS scheme

Fixes https://issues.qgis.org/issues/6898 QGIS mapserver forces http when requesting SLD=https
## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
