### PR TITLE
[processing] Fix exception in modeler when showing advanced params

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -812,12 +812,9 @@ class DistanceWidgetWrapper(WidgetWrapper):
 class RangeWidgetWrapper(WidgetWrapper):
 
     def createWidget(self):
-        if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
-            widget = RangePanel(self.parameterDefinition())
-            widget.hasChanged.connect(lambda: self.widgetValueHasChanged.emit(self))
-            return widget
-        #else:
-        #    return ModelerNumberInputPanel(self.param, self.dialog)
+        widget = RangePanel(self.parameterDefinition())
+        widget.hasChanged.connect(lambda: self.widgetValueHasChanged.emit(self))
+        return widget
 
     def setValue(self, value):
         if value is None or value == NULL:

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -231,8 +231,10 @@ class ModelerParametersDialog(QDialog):
             self.advancedButton.setText(self.tr('Show advanced parameters'))
         for param in self._alg.parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
-                self.wrappers[param.name()].widget.setVisible(self.showAdvanced)
-                self.wrappers[param.name()].label.setVisible(self.showAdvanced)
+                wrapper = self.wrappers[param.name()]
+                if issubclass(wrapper.__class__, QgsProcessingModelerParameterWidget):
+                    self.wrappers[param.name()].widget.setVisible(self.showAdvanced)
+                    self.wrappers[param.name()].label.setVisible(self.showAdvanced)
 
     def getAvailableValuesOfType(self, paramType, outTypes=[], dataTypes=[]):
         # upgrade paramType to list

--- a/python/plugins/processing/tests/GuiTest.py
+++ b/python/plugins/processing/tests/GuiTest.py
@@ -35,6 +35,7 @@ from qgis.core import (QgsApplication,
                        QgsProcessingParameterFolderDestination,
                        QgsProcessingParameterVectorDestination,
                        QgsProcessingParameterRasterDestination,
+                       QgsProcessingParameterRange,
                        QgsVectorLayer,
                        QgsProject)
 from qgis.analysis import QgsNativeAlgorithms
@@ -169,6 +170,66 @@ class WrappersTest(unittest.TestCase):
         wrapper.setValue('/home/my_layer.shp')
         value = wrapper.value()
         self.assertEqual(value, '/home/my_layer.shp')
+
+    def testRange(self):
+        # minimal test to check if wrapper generate GUI for each processign context
+        self.checkConstructWrapper(QgsProcessingParameterRange('test'), RangeWidgetWrapper)
+
+        alg = QgsApplication.processingRegistry().algorithmById('native:centroids')
+        dlg = AlgorithmDialog(alg)
+        param = QgsProcessingParameterRange(
+            name='test',
+            description='test',
+            type=QgsProcessingParameterNumber.Double,
+            defaultValue="0.0,100.0")
+
+        wrapper = RangeWidgetWrapper(param, dlg)
+        widget = wrapper.createWidget()
+
+        # range values check
+
+        # check intial value
+        self.assertEqual(widget.getValue(), '0.0,100.0')
+        # check set/get
+        widget.setValue("100.0,200.0")
+        self.assertEqual(widget.getValue(), '100.0,200.0')
+        # check that min/max are mutually adapted
+        widget.setValue("200.0,100.0")
+        self.assertEqual(widget.getValue(), '100.0,100.0')
+        widget.spnMax.setValue(50)
+        self.assertEqual(widget.getValue(), '50.0,50.0')
+        widget.spnMin.setValue(100)
+        self.assertEqual(widget.getValue(), '100.0,100.0')
+
+        # check for integers
+        param = QgsProcessingParameterRange(
+            name='test',
+            description='test',
+            type=QgsProcessingParameterNumber.Integer,
+            defaultValue="0.1,100.1")
+
+        wrapper = RangeWidgetWrapper(param, dlg)
+        widget = wrapper.createWidget()
+
+        # range values check
+
+        # check intial value
+        self.assertEqual(widget.getValue(), '0.0,100.0')
+        # check rounding
+        widget.setValue("100.1,200.1")
+        self.assertEqual(widget.getValue(), '100.0,200.0')
+        widget.setValue("100.6,200.6")
+        self.assertEqual(widget.getValue(), '101.0,201.0')
+        # check set/get
+        widget.setValue("100.1,200.1")
+        self.assertEqual(widget.getValue(), '100.0,200.0')
+        # check that min/max are mutually adapted
+        widget.setValue("200.1,100.1")
+        self.assertEqual(widget.getValue(), '100.0,100.0')
+        widget.spnMax.setValue(50.1)
+        self.assertEqual(widget.getValue(), '50.0,50.0')
+        widget.spnMin.setValue(100.1)
+        self.assertEqual(widget.getValue(), '100.0,100.0')
 
     def testMapLayer(self):
         self.checkConstructWrapper(QgsProcessingParameterMapLayer('test'), MapLayerWidgetWrapper)

--- a/python/plugins/processing/tests/GuiTest.py
+++ b/python/plugins/processing/tests/GuiTest.py
@@ -188,7 +188,7 @@ class WrappersTest(unittest.TestCase):
 
         # range values check
 
-        # check intial value
+        # check initial value
         self.assertEqual(widget.getValue(), '0.0,100.0')
         # check set/get
         widget.setValue("100.0,200.0")
@@ -213,7 +213,7 @@ class WrappersTest(unittest.TestCase):
 
         # range values check
 
-        # check intial value
+        # check initial value
         self.assertEqual(widget.getValue(), '0.0,100.0')
         # check rounding
         widget.setValue("100.1,200.1")


### PR DESCRIPTION
## Description
fix exception in modeler showing advanced params when wrapper is not a widget

fix promoted inside GeoMove [1] project for Cartolab [2] (A Coruña university)

[1] http://cartolab.udc.es/geomove/
[2] http://cartolab.udc.es

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
