### PR TITLE
Code completion for expression builder [FEATURE]

### DIFF
--- a/python/gui/auto_generated/qgscodeeditorexpression.sip.in
+++ b/python/gui/auto_generated/qgscodeeditorexpression.sip.in
@@ -1,0 +1,53 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscodeeditorexpression.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+class QgsCodeEditorExpression : QgsCodeEditor
+{
+%Docstring
+
+A QGIS expression editor based on QScintilla2. Adds syntax highlighting and
+code autocompletion.
+
+.. versionadded:: 3.4
+%End
+
+%TypeHeaderCode
+#include "qgscodeeditorexpression.h"
+%End
+  public:
+    QgsCodeEditorExpression( QWidget *parent /TransferThis/ = 0 );
+%Docstring
+Constructor for QgsCodeEditorExpression
+%End
+
+    void setExpressionContext( const QgsExpressionContext &context );
+%Docstring
+Variables and functions from this expression context will be added to
+the API.
+Will also reload all globally registered functions.
+%End
+
+    void setFields( const QgsFields &fields );
+%Docstring
+Field names will be added to the API.
+%End
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgscodeeditorexpression.h                                    *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -79,6 +79,9 @@
 %If ( HAVE_QSCI_SIP )
 %Include auto_generated/qgscodeeditorsql.sip
 %End
+%If ( HAVE_QSCI_SIP )
+%Include auto_generated/qgscodeeditorexpression.sip
+%End
 %Include auto_generated/qgscollapsiblegroupbox.sip
 %Include auto_generated/qgscolorbrewercolorrampdialog.sip
 %Include auto_generated/qgscolorbutton.sip

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -229,6 +229,7 @@ SET(QGIS_GUI_SRCS
   qgscodeeditorhtml.cpp
   qgscodeeditorpython.cpp
   qgscodeeditorsql.cpp
+  qgscodeeditorexpression.cpp
   qgscollapsiblegroupbox.cpp
   qgscolorbrewercolorrampdialog.cpp
   qgscolorbutton.cpp
@@ -406,6 +407,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgscodeeditorhtml.h
   qgscodeeditorpython.h
   qgscodeeditorsql.h
+  qgscodeeditorexpression.h
   qgscollapsiblegroupbox.h
   qgscolorbrewercolorrampdialog.h
   qgscolorbutton.h

--- a/src/gui/qgscodeeditorexpression.cpp
+++ b/src/gui/qgscodeeditorexpression.cpp
@@ -144,6 +144,7 @@ void QgsCodeEditorExpression::updateApis()
   mSqlLexer->setAPIs( mApis );
 }
 
+///@cond PRIVATE
 QgsCaseInsensitiveLexerExpression::QgsCaseInsensitiveLexerExpression( QObject *parent )
   : QsciLexerSQL( parent )
 {
@@ -158,3 +159,4 @@ const char *QgsCaseInsensitiveLexerExpression::wordCharacters() const
 {
   return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_@";
 }
+///@endcond

--- a/src/gui/qgscodeeditorexpression.cpp
+++ b/src/gui/qgscodeeditorexpression.cpp
@@ -118,7 +118,7 @@ void QgsCodeEditorExpression::initializeLexer()
 
 void QgsCodeEditorExpression::updateApis()
 {
-  mApis = new QsciAPIs( mSqlLexer );
+  mApis = new QgsSciApisExpression( mSqlLexer );
 
   for ( const QString &var : qgis::as_const( mVariables ) )
   {
@@ -163,5 +163,21 @@ bool QgsLexerExpression::caseSensitive() const
 const char *QgsLexerExpression::wordCharacters() const
 {
   return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_@";
+}
+
+QgsSciApisExpression::QgsSciApisExpression( QsciLexer *lexer )
+  : QsciAPIs( lexer )
+{
+
+}
+
+QStringList QgsSciApisExpression::callTips( const QStringList &context, int commas, QsciScintilla::CallTipsStyle style, QList<int> &shifts )
+{
+  const QStringList originalTips = QsciAPIs::callTips( context, commas, style, shifts );
+  QStringList lowercaseTips;
+  for ( const QString &tip : originalTips )
+    lowercaseTips << tip.toLower();
+
+  return lowercaseTips;
 }
 ///@endcond

--- a/src/gui/qgscodeeditorexpression.cpp
+++ b/src/gui/qgscodeeditorexpression.cpp
@@ -16,11 +16,9 @@
 #include "qgsapplication.h"
 #include "qgscodeeditorexpression.h"
 
-#include <QWidget>
 #include <QString>
 #include <QFont>
 #include <QLabel>
-
 
 QgsCodeEditorExpression::QgsCodeEditorExpression( QWidget *parent )
   : QgsCodeEditor( parent )
@@ -146,18 +144,22 @@ void QgsCodeEditorExpression::updateApis()
   mSqlLexer->setAPIs( mApis );
 }
 
+QgsCaseInsensitiveLexerExpression::QgsCaseInsensitiveLexerExpression( QObject *parent )
+  : QsciLexerSQL( parent )
+{
+}
+
 bool QgsCaseInsensitiveLexerExpression::caseSensitive() const
 {
   return false;
 }
-#if 0
+
 const char *QgsCaseInsensitiveLexerExpression::wordCharacters() const
 {
-  static QString wordChars;
-
-  wordChars = QsciLexerSQL::wordCharacters();
-  wordChars += '@';
-  return wordChars.toUtf8().constData();
+  return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_@";
 }
 
-#endif
+const char *QgsCaseInsensitiveLexerExpression::autoCompletionFillups() const
+{
+  return "(";
+}

--- a/src/gui/qgscodeeditorexpression.cpp
+++ b/src/gui/qgscodeeditorexpression.cpp
@@ -1,0 +1,163 @@
+/***************************************************************************
+    qgscodeeditorexpressoin.cpp - An expression editor based on QScintilla
+     --------------------------------------
+    Date                 : 8.9.2018
+    Copyright            : (C) 2018 by Matthias Kuhn
+    Email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsapplication.h"
+#include "qgscodeeditorexpression.h"
+
+#include <QWidget>
+#include <QString>
+#include <QFont>
+#include <QLabel>
+
+
+QgsCodeEditorExpression::QgsCodeEditorExpression( QWidget *parent )
+  : QgsCodeEditor( parent )
+{
+  if ( !parent )
+  {
+    setTitle( tr( "Expression Editor" ) );
+  }
+  setMarginVisible( false );
+  setFoldingVisible( true );
+  setAutoCompletionCaseSensitivity( false );
+  initializeLexer();
+}
+
+void QgsCodeEditorExpression::setExpressionContext( const QgsExpressionContext &context )
+{
+  mVariables.clear();
+
+  const QStringList variableNames = context.filteredVariableNames();
+  for ( const QString &var : variableNames )
+  {
+    mVariables << '@' + var;
+  }
+
+  mContextFunctions = context.functionNames();
+
+  mFunctions.clear();
+
+  const int count = QgsExpression::functionCount();
+  for ( int i = 0; i < count; i++ )
+  {
+    QgsExpressionFunction *func = QgsExpression::Functions()[i];
+    if ( func->isDeprecated() ) // don't show deprecated functions
+      continue;
+    if ( func->isContextual() )
+    {
+      //don't show contextual functions by default - it's up the the QgsExpressionContext
+      //object to provide them if supported
+      continue;
+    }
+
+    QString signature = func->name();
+    if ( !signature.startsWith( '$' ) )
+    {
+      signature += '(';
+
+      QStringList paramNames;
+      const auto &parameters = func->parameters();
+      for ( const auto &param : parameters )
+      {
+        paramNames << param.name();
+      }
+
+      // No named parameters but there should be parameteres? Show an ellipsis at least
+      if ( parameters.isEmpty() && func->params() )
+        signature += QChar( 0x2026 );
+
+      signature += paramNames.join( ", " );
+
+      signature += ')';
+    }
+    mFunctions << signature;
+  }
+
+  updateApis();
+}
+
+void QgsCodeEditorExpression::setFields( const QgsFields &fields )
+{
+  mFieldNames.clear();
+
+  for ( const QgsField &field : fields )
+  {
+    mFieldNames << field.name();
+  }
+
+  updateApis();
+}
+
+
+void QgsCodeEditorExpression::initializeLexer()
+{
+  QFont font = getMonospaceFont();
+#ifdef Q_OS_MAC
+  // The font size gotten from getMonospaceFont() is too small on Mac
+  font.setPointSize( QLabel().font().pointSize() );
+#endif
+  mSqlLexer = new QgsCaseInsensitiveLexerExpression( this );
+  mSqlLexer->setDefaultFont( font );
+  mSqlLexer->setFont( font, -1 );
+  font.setBold( true );
+  mSqlLexer->setFont( font, QsciLexerSQL::Keyword );
+  mSqlLexer->setColor( Qt::darkYellow, QsciLexerSQL::DoubleQuotedString ); // fields
+
+  setLexer( mSqlLexer );
+}
+
+void QgsCodeEditorExpression::updateApis()
+{
+  mApis = new QsciAPIs( mSqlLexer );
+
+  for ( const QString &var : qgis::as_const( mVariables ) )
+  {
+    mApis->add( var );
+  }
+
+  for ( const QString &function : qgis::as_const( mContextFunctions ) )
+  {
+    mApis->add( function );
+  }
+
+  for ( const QString &function : qgis::as_const( mFunctions ) )
+  {
+    mApis->add( function );
+  }
+
+  for ( const QString &fieldName : qgis::as_const( mFieldNames ) )
+  {
+    mApis->add( fieldName );
+  }
+
+  mApis->prepare();
+  mSqlLexer->setAPIs( mApis );
+}
+
+bool QgsCaseInsensitiveLexerExpression::caseSensitive() const
+{
+  return false;
+}
+#if 0
+const char *QgsCaseInsensitiveLexerExpression::wordCharacters() const
+{
+  static QString wordChars;
+
+  wordChars = QsciLexerSQL::wordCharacters();
+  wordChars += '@';
+  return wordChars.toUtf8().constData();
+}
+
+#endif

--- a/src/gui/qgscodeeditorexpression.cpp
+++ b/src/gui/qgscodeeditorexpression.cpp
@@ -158,8 +158,3 @@ const char *QgsCaseInsensitiveLexerExpression::wordCharacters() const
 {
   return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_@";
 }
-
-const char *QgsCaseInsensitiveLexerExpression::autoCompletionFillups() const
-{
-  return "(";
-}

--- a/src/gui/qgscodeeditorexpression.cpp
+++ b/src/gui/qgscodeeditorexpression.cpp
@@ -106,7 +106,7 @@ void QgsCodeEditorExpression::initializeLexer()
   // The font size gotten from getMonospaceFont() is too small on Mac
   font.setPointSize( QLabel().font().pointSize() );
 #endif
-  mSqlLexer = new QgsCaseInsensitiveLexerExpression( this );
+  mSqlLexer = new QgsLexerExpression( this );
   mSqlLexer->setDefaultFont( font );
   mSqlLexer->setFont( font, -1 );
   font.setBold( true );
@@ -145,17 +145,22 @@ void QgsCodeEditorExpression::updateApis()
 }
 
 ///@cond PRIVATE
-QgsCaseInsensitiveLexerExpression::QgsCaseInsensitiveLexerExpression( QObject *parent )
+QgsLexerExpression::QgsLexerExpression( QObject *parent )
   : QsciLexerSQL( parent )
 {
 }
 
-bool QgsCaseInsensitiveLexerExpression::caseSensitive() const
+const char *QgsLexerExpression::language() const
+{
+  return "QGIS Expression";
+}
+
+bool QgsLexerExpression::caseSensitive() const
 {
   return false;
 }
 
-const char *QgsCaseInsensitiveLexerExpression::wordCharacters() const
+const char *QgsLexerExpression::wordCharacters() const
 {
   return "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_@";
 }

--- a/src/gui/qgscodeeditorexpression.h
+++ b/src/gui/qgscodeeditorexpression.h
@@ -82,14 +82,14 @@ class QgsCaseInsensitiveLexerExpression : public QsciLexerSQL
     Q_OBJECT
 
   public:
-    //! constructor
-    explicit QgsCaseInsensitiveLexerExpression( QObject *parent = nullptr ) : QsciLexerSQL( parent ) {}
+    //! Constructor
+    explicit QgsCaseInsensitiveLexerExpression( QObject *parent = nullptr );
 
     bool caseSensitive() const override;
 
-#if 0
     const char *wordCharacters() const override;
-#endif
+
+    const char *autoCompletionFillups() const override;
 };
 ///@endcond
 #endif

--- a/src/gui/qgscodeeditorexpression.h
+++ b/src/gui/qgscodeeditorexpression.h
@@ -88,8 +88,6 @@ class QgsCaseInsensitiveLexerExpression : public QsciLexerSQL
     bool caseSensitive() const override;
 
     const char *wordCharacters() const override;
-
-    const char *autoCompletionFillups() const override;
 };
 ///@endcond
 #endif

--- a/src/gui/qgscodeeditorexpression.h
+++ b/src/gui/qgscodeeditorexpression.h
@@ -91,6 +91,14 @@ class QgsLexerExpression : public QsciLexerSQL
 
     const char *wordCharacters() const override;
 };
+
+class QgsSciApisExpression : public QsciAPIs
+{
+  public:
+    QgsSciApisExpression( QsciLexer *lexer );
+
+    QStringList callTips( const QStringList &context, int commas, QsciScintilla::CallTipsStyle style, QList<int> &shifts ) override;
+};
 ///@endcond
 #endif
 

--- a/src/gui/qgscodeeditorexpression.h
+++ b/src/gui/qgscodeeditorexpression.h
@@ -1,0 +1,97 @@
+/***************************************************************************
+    qgscodeeditorsql.h - A SQL editor based on QScintilla
+     --------------------------------------
+    Date                 : 06-Oct-2013
+    Copyright            : (C) 2013 by Salvatore Larosa
+    Email                : lrssvtml (at) gmail (dot) com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCODEEDITOREXPRESSION_H
+#define QGSCODEEDITOREXPRESSION_H
+
+#include "qgis_sip.h"
+#include "qgis_gui.h"
+#include "qgscodeeditor.h"
+#include "qgsexpressioncontext.h"
+
+#include <Qsci/qscilexersql.h>
+
+SIP_IF_MODULE( HAVE_QSCI_SIP )
+
+/**
+ * \ingroup gui
+ *
+ * A QGIS expression editor based on QScintilla2. Adds syntax highlighting and
+ * code autocompletion.
+ *
+ * \since QGIS 3.4
+ */
+class GUI_EXPORT QgsCodeEditorExpression : public QgsCodeEditor
+{
+    Q_OBJECT
+
+  public:
+    //! Constructor for QgsCodeEditorExpression
+    QgsCodeEditorExpression( QWidget *parent SIP_TRANSFERTHIS = nullptr );
+
+    /**
+     * Variables and functions from this expression context will be added to
+     * the API.
+     * Will also reload all globally registered functions.
+     */
+    void setExpressionContext( const QgsExpressionContext &context );
+
+    /**
+     * Field names will be added to the API.
+     */
+    void setFields( const QgsFields &fields );
+
+  private:
+    void initializeLexer();
+    void updateApis();
+    QsciAPIs *mApis;
+    QsciLexerSQL *mSqlLexer;
+
+    QStringList mVariables;
+    QStringList mContextFunctions;
+    QStringList mFunctions;
+    QStringList mFieldNames;
+};
+
+#ifndef SIP_RUN
+///@cond PRIVATE
+
+/**
+ * Internal use.
+
+   setAutoCompletionCaseSensitivity( false ) is not sufficient when installing
+   a lexer, since its caseSensitive() method is actually used, and defaults
+   to true.
+   \note not available in Python bindings
+   \ingroup gui
+*/
+class QgsCaseInsensitiveLexerExpression : public QsciLexerSQL
+{
+    Q_OBJECT
+
+  public:
+    //! constructor
+    explicit QgsCaseInsensitiveLexerExpression( QObject *parent = nullptr ) : QsciLexerSQL( parent ) {}
+
+    bool caseSensitive() const override;
+
+#if 0
+    const char *wordCharacters() const override;
+#endif
+};
+///@endcond
+#endif
+
+#endif

--- a/src/gui/qgscodeeditorexpression.h
+++ b/src/gui/qgscodeeditorexpression.h
@@ -56,7 +56,7 @@ class GUI_EXPORT QgsCodeEditorExpression : public QgsCodeEditor
   private:
     void initializeLexer();
     void updateApis();
-    QsciAPIs *mApis;
+    QsciAPIs *mApis = nullptr;
     QsciLexerSQL *mSqlLexer;
 
     QStringList mVariables;

--- a/src/gui/qgscodeeditorexpression.h
+++ b/src/gui/qgscodeeditorexpression.h
@@ -77,13 +77,15 @@ class GUI_EXPORT QgsCodeEditorExpression : public QgsCodeEditor
    \note not available in Python bindings
    \ingroup gui
 */
-class QgsCaseInsensitiveLexerExpression : public QsciLexerSQL
+class QgsLexerExpression : public QsciLexerSQL
 {
     Q_OBJECT
 
   public:
     //! Constructor
-    explicit QgsCaseInsensitiveLexerExpression( QObject *parent = nullptr );
+    explicit QgsLexerExpression( QObject *parent = nullptr );
+
+    const char *language() const override;
 
     bool caseSensitive() const override;
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -49,7 +49,7 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   connect( btnNewFile, &QToolButton::pressed, this, &QgsExpressionBuilderWidget::btnNewFile_pressed );
   connect( cmbFileNames, &QListWidget::currentItemChanged, this, &QgsExpressionBuilderWidget::cmbFileNames_currentItemChanged );
   connect( expressionTree, &QTreeView::doubleClicked, this, &QgsExpressionBuilderWidget::expressionTree_doubleClicked );
-  connect( txtExpressionString, &QgsCodeEditorSQL::textChanged, this, &QgsExpressionBuilderWidget::txtExpressionString_textChanged );
+  connect( txtExpressionString, &QgsCodeEditorExpression::textChanged, this, &QgsExpressionBuilderWidget::txtExpressionString_textChanged );
   connect( txtPython, &QgsCodeEditorPython::textChanged, this, &QgsExpressionBuilderWidget::txtPython_textChanged );
   connect( txtSearchEditValues, &QgsFilterLineEdit::textChanged, this, &QgsExpressionBuilderWidget::txtSearchEditValues_textChanged );
   connect( txtSearchEdit, &QgsFilterLineEdit::textChanged, this, &QgsExpressionBuilderWidget::txtSearchEdit_textChanged );
@@ -142,7 +142,10 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   txtExpressionString->setIndicatorHoverForegroundColor( QColor( Qt::blue ), FUNCTION_MARKER_ID );
   txtExpressionString->setIndicatorHoverStyle( QgsCodeEditor::DotsIndicator, FUNCTION_MARKER_ID );
 
-  connect( txtExpressionString, &QgsCodeEditorSQL::indicatorClicked, this, &QgsExpressionBuilderWidget::indicatorClicked );
+  connect( txtExpressionString, &QgsCodeEditorExpression::indicatorClicked, this, &QgsExpressionBuilderWidget::indicatorClicked );
+  txtExpressionString->setAutoCompletionCaseSensitivity( true );
+  txtExpressionString->setAutoCompletionSource( QsciScintilla::AcsAPIs );
+  txtExpressionString->setCallTipsVisible( 0 );
 
   setExpectedOutputFormat( QString() );
 }
@@ -340,6 +343,8 @@ void QgsExpressionBuilderWidget::loadFieldNames( const QgsFields &fields )
 {
   if ( fields.isEmpty() )
     return;
+
+  txtExpressionString->setFields( fields );
 
   QStringList fieldNames;
   //Q_FOREACH ( const QgsField& field, fields )
@@ -696,6 +701,7 @@ void QgsExpressionBuilderWidget::txtExpressionString_textChanged()
 
 void QgsExpressionBuilderWidget::loadExpressionContext()
 {
+  txtExpressionString->setExpressionContext( mExpressionContext );
   QStringList variableNames = mExpressionContext.filteredVariableNames();
   Q_FOREACH ( const QString &variable, variableNames )
   {

--- a/src/gui/qgsexpressionlineedit.cpp
+++ b/src/gui/qgsexpressionlineedit.cpp
@@ -55,7 +55,7 @@ void QgsExpressionLineEdit::setMultiLine( bool multiLine )
 
   if ( multiLine && !mCodeEditor )
   {
-    mCodeEditor = new QgsCodeEditorSQL();
+    mCodeEditor = new QgsCodeEditorExpression();
     mCodeEditor->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
     delete mLineEdit;
     mLineEdit = nullptr;

--- a/src/gui/qgsexpressionlineedit.h
+++ b/src/gui/qgsexpressionlineedit.h
@@ -27,7 +27,7 @@ class QgsFilterLineEdit;
 class QToolButton;
 class QgsDistanceArea;
 class QgsExpressionContextGenerator;
-class QgsCodeEditorSQL;
+class QgsCodeEditorExpression;
 
 /**
  * \ingroup gui
@@ -170,7 +170,7 @@ class GUI_EXPORT QgsExpressionLineEdit : public QWidget
 
   private:
     QgsFilterLineEdit *mLineEdit = nullptr;
-    QgsCodeEditorSQL *mCodeEditor = nullptr;
+    QgsCodeEditorExpression *mCodeEditor = nullptr;
     QToolButton *mButton = nullptr;
     QString mExpressionDialogTitle;
     std::unique_ptr<QgsDistanceArea> mDa;

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -273,7 +273,7 @@
                </widget>
               </item>
               <item>
-               <widget class="QgsCodeEditorSQL" name="txtExpressionString" native="true"/>
+               <widget class="QgsCodeEditorExpression" name="txtExpressionString" native="true"/>
               </item>
               <item>
                <layout class="QGridLayout" name="gridLayout">
@@ -768,9 +768,9 @@ Saved scripts are auto loaded on QGIS startup.</string>
    <header>qgsfilterlineedit.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsCodeEditorSQL</class>
+   <class>QgsCodeEditorExpression</class>
    <extends>QWidget</extends>
-   <header>qgscodeeditorsql.h</header>
+   <header>qgscodeeditorexpression.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>


### PR DESCRIPTION
Let the gif speak

![peek 2018-09-08 12-16](https://user-images.githubusercontent.com/588407/45253071-3bb94f80-b361-11e8-82e6-b1219bbe06bd.gif)

If someone else feels like jumping in and improve on this:

 * Add named parameters to more functions ;)
 * Implement context based things like `with_variable` or `@parent`
 * Think about function overloads
 * Convince QScintilla that on autocompletion of a function it should automatically open a bracket `(`
 * Quote field names on autocompletion