### PR TITLE
[processing] Fix DeleteColumn output hint

### DIFF
--- a/python/plugins/processing/algs/qgis/DeleteColumn.py
+++ b/python/plugins/processing/algs/qgis/DeleteColumn.py
@@ -66,7 +66,7 @@ class DeleteColumn(QgisFeatureBasedAlgorithm):
         return self.tr('Drop field(s)')
 
     def outputName(self):
-        return self.tr('Fields dropped')
+        return self.tr('Remaining fields')
 
     def prepareAlgorithm(self, parameters, context, feedback):
         self.fields_to_delete = self.parameterAsFields(parameters, self.COLUMNS, context)


### PR DESCRIPTION
The dropped fields are discarded, the remaining returned, as expected. The documentation has the right behaviour, while the output isn't named — nothing to do there.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
