### PR TITLE
Identify tool for 3D view

### DIFF
--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -112,18 +112,29 @@ void Qgs3DMapCanvas::saveAsImage( const QString fileName, const QString fileForm
 
 void Qgs3DMapCanvas::setMapTool( Qgs3DMapTool *tool )
 {
+  if ( tool == mMapTool )
+    return;
+
   if ( mMapTool && !tool )
   {
     mEngine->window()->removeEventFilter( this );
     mScene->cameraController()->setEnabled( true );
+    mEngine->window()->setCursor( Qt::OpenHandCursor );
   }
   else if ( !mMapTool && tool )
   {
     mEngine->window()->installEventFilter( this );
     mScene->cameraController()->setEnabled( false );
+    mEngine->window()->setCursor( Qt::CrossCursor );
   }
 
+  if ( mMapTool )
+    mMapTool->deactivate();
+
   mMapTool = tool;
+
+  if ( mMapTool )
+    mMapTool->activate();
 }
 
 bool Qgs3DMapCanvas::eventFilter( QObject *watched, QEvent *event )

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -22,6 +22,7 @@
 #include "qgscameracontroller.h"
 #include "qgs3dmapsettings.h"
 #include "qgs3dmapscene.h"
+#include "qgs3dmaptool.h"
 #include "qgswindow3dengine.h"
 
 
@@ -107,4 +108,43 @@ void Qgs3DMapCanvas::saveAsImage( const QString fileName, const QString fileForm
     mCaptureFileFormat = fileFormat;
     mEngine->requestCaptureImage();
   }
+}
+
+void Qgs3DMapCanvas::setMapTool( Qgs3DMapTool *tool )
+{
+  if ( mMapTool && !tool )
+  {
+    mEngine->window()->removeEventFilter( this );
+    mScene->cameraController()->setEnabled( true );
+  }
+  else if ( !mMapTool && tool )
+  {
+    mEngine->window()->installEventFilter( this );
+    mScene->cameraController()->setEnabled( false );
+  }
+
+  mMapTool = tool;
+}
+
+bool Qgs3DMapCanvas::eventFilter( QObject *watched, QEvent *event )
+{
+  if ( !mMapTool )
+    return false;
+
+  Q_UNUSED( watched );
+  switch ( event->type() )
+  {
+    case QEvent::MouseButtonPress:
+      mMapTool->mousePressEvent( static_cast<QMouseEvent *>( event ) );
+      break;
+    case QEvent::MouseButtonRelease:
+      mMapTool->mouseReleaseEvent( static_cast<QMouseEvent *>( event ) );
+      break;
+    case QEvent::MouseMove:
+      mMapTool->mouseMoveEvent( static_cast<QMouseEvent *>( event ) );
+      break;
+    default:
+      break;
+  }
+  return false;
 }

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -125,7 +125,7 @@ void Qgs3DMapCanvas::setMapTool( Qgs3DMapTool *tool )
   {
     mEngine->window()->installEventFilter( this );
     mScene->cameraController()->setEnabled( false );
-    mEngine->window()->setCursor( Qt::CrossCursor );
+    mEngine->window()->setCursor( tool->cursor() );
   }
 
   if ( mMapTool )

--- a/src/app/3d/qgs3dmapcanvas.h
+++ b/src/app/3d/qgs3dmapcanvas.h
@@ -26,6 +26,7 @@ namespace Qt3DExtras
 
 class Qgs3DMapSettings;
 class Qgs3DMapScene;
+class Qgs3DMapTool;
 class QgsWindow3DEngine;
 class QgsCameraController;
 class QgsPointXY;
@@ -59,12 +60,25 @@ class Qgs3DMapCanvas : public QWidget
     //! Saves the current scene as an image
     void saveAsImage( QString fileName, QString fileFormat );
 
+    /**
+     * Sets the active map tool that will receive events from the 3D canvas. Does not transfer ownership.
+     * If the tool is null, events will be used for camera manipulation.
+     */
+    void setMapTool( Qgs3DMapTool *tool );
+
+    /**
+     * Returns the active map tool that will receive events from the 3D canvas.
+     * If the tool is null, events will be used for camera manipulation.
+     */
+    Qgs3DMapTool *mapTool() const { return mMapTool; }
+
   signals:
     //! Emitted when the 3D map canvas was successfully saved as image
     void savedAsImage( QString fileName );
 
   protected:
     void resizeEvent( QResizeEvent *ev ) override;
+    bool eventFilter( QObject *watched, QEvent *event ) override;
 
   private:
     QgsWindow3DEngine *mEngine = nullptr;
@@ -78,6 +92,9 @@ class Qgs3DMapCanvas : public QWidget
     Qgs3DMapSettings *mMap = nullptr;
     //! Root entity of the 3D scene
     Qgs3DMapScene *mScene = nullptr;
+
+    //! Active map tool that receives events (if null then mouse/keyboard events are used for camera manipulation)
+    Qgs3DMapTool *mMapTool = nullptr;
 };
 
 #endif // QGS3DMAPCANVAS_H

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -25,6 +25,7 @@
 #include "qgs3danimationsettings.h"
 #include "qgs3danimationwidget.h"
 #include "qgs3dmapsettings.h"
+#include "qgs3dmaptoolidentify.h"
 #include "qgs3dutils.h"
 
 #include <QBoxLayout>
@@ -53,6 +54,10 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
                         tr( "Animations" ), this, &Qgs3DMapCanvasDockWidget::toggleAnimations );
   actionAnim->setCheckable( true );
 
+  QAction *actionIdentify = toolBar->addAction( QIcon( QgsApplication::iconPath( "mActionIdentify.svg" ) ),
+                            tr( "Identify" ), this, &Qgs3DMapCanvasDockWidget::identify );
+  actionIdentify->setCheckable( true );
+
   mCanvas = new Qgs3DMapCanvas( contentsWidget );
   mCanvas->setMinimumSize( QSize( 200, 200 ) );
   mCanvas->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
@@ -61,6 +66,8 @@ Qgs3DMapCanvasDockWidget::Qgs3DMapCanvasDockWidget( QWidget *parent )
   {
     QgisApp::instance()->messageBar()->pushSuccess( tr( "Save as Image" ), tr( "Successfully saved the 3D map to <a href=\"%1\">%2</a>" ).arg( QUrl::fromLocalFile( fileName ).toString(), QDir::toNativeSeparators( fileName ) ) );
   } );
+
+  mMapToolIdentify = new Qgs3DMapToolIdentify( mCanvas );
 
   mLabelPendingJobs = new QLabel( this );
   mProgressPendingJobs = new QProgressBar( this );
@@ -115,6 +122,15 @@ void Qgs3DMapCanvasDockWidget::toggleAnimations()
   {
     mAnimationWidget->setDefaultAnimation();
   }
+}
+
+void Qgs3DMapCanvasDockWidget::identify()
+{
+  QAction *action = qobject_cast<QAction *>( sender() );
+  if ( !action )
+    return;
+
+  mCanvas->setMapTool( action->isChecked() ? mMapToolIdentify : nullptr );
 }
 
 void Qgs3DMapCanvasDockWidget::setMapSettings( Qgs3DMapSettings *map )

--- a/src/app/3d/qgs3dmapcanvasdockwidget.h
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.h
@@ -24,6 +24,7 @@ class QProgressBar;
 class Qgs3DAnimationWidget;
 class Qgs3DMapCanvas;
 class Qgs3DMapSettings;
+class Qgs3DMapToolIdentify;
 class QgsMapCanvas;
 
 
@@ -46,6 +47,7 @@ class Qgs3DMapCanvasDockWidget : public QgsDockWidget
     void configure();
     void saveAsImage();
     void toggleAnimations();
+    void identify();
 
     void onMainCanvasLayersChanged();
     void onMainCanvasColorChanged();
@@ -57,6 +59,7 @@ class Qgs3DMapCanvasDockWidget : public QgsDockWidget
     QgsMapCanvas *mMainCanvas = nullptr;
     QProgressBar *mProgressPendingJobs = nullptr;
     QLabel *mLabelPendingJobs = nullptr;
+    Qgs3DMapToolIdentify *mMapToolIdentify = nullptr;
 };
 
 #endif // QGS3DMAPCANVASDOCKWIDGET_H

--- a/src/app/3d/qgs3dmaptool.cpp
+++ b/src/app/3d/qgs3dmaptool.cpp
@@ -45,3 +45,8 @@ void Qgs3DMapTool::activate()
 void Qgs3DMapTool::deactivate()
 {
 }
+
+QCursor Qgs3DMapTool::cursor() const
+{
+  return Qt::CrossCursor;
+}

--- a/src/app/3d/qgs3dmaptool.cpp
+++ b/src/app/3d/qgs3dmaptool.cpp
@@ -1,0 +1,36 @@
+/***************************************************************************
+  qgs3dmaptool.cpp
+  --------------------------------------
+  Date                 : Sep 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgs3dmaptool.h"
+
+Qgs3DMapTool::Qgs3DMapTool( Qgs3DMapCanvas *canvas )
+  : mCanvas( canvas )
+{
+}
+
+void Qgs3DMapTool::mousePressEvent( QMouseEvent *event )
+{
+  Q_UNUSED( event );
+}
+
+void Qgs3DMapTool::mouseReleaseEvent( QMouseEvent *event )
+{
+  Q_UNUSED( event );
+}
+
+void Qgs3DMapTool::mouseMoveEvent( QMouseEvent *event )
+{
+  Q_UNUSED( event );
+}

--- a/src/app/3d/qgs3dmaptool.h
+++ b/src/app/3d/qgs3dmaptool.h
@@ -41,6 +41,9 @@ class Qgs3DMapTool : public QObject
     //! Called when map tool is being deactivated
     virtual void deactivate();
 
+    //! Mouse cursor to be used when the tool is active
+    virtual QCursor cursor() const;
+
   protected:
     Qgs3DMapCanvas *mCanvas = nullptr;
 };

--- a/src/app/3d/qgs3dmaptool.h
+++ b/src/app/3d/qgs3dmaptool.h
@@ -35,6 +35,12 @@ class Qgs3DMapTool : public QObject
     virtual void mouseReleaseEvent( QMouseEvent *event );
     virtual void mouseMoveEvent( QMouseEvent *event );
 
+    //! Called when set as currently active map tool
+    virtual void activate();
+
+    //! Called when map tool is being deactivated
+    virtual void deactivate();
+
   protected:
     Qgs3DMapCanvas *mCanvas = nullptr;
 };

--- a/src/app/3d/qgs3dmaptool.h
+++ b/src/app/3d/qgs3dmaptool.h
@@ -1,0 +1,42 @@
+/***************************************************************************
+  qgs3dmaptool.h
+  --------------------------------------
+  Date                 : Sep 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGS3DMAPTOOL_H
+#define QGS3DMAPTOOL_H
+
+#include <QObject>
+
+class Qgs3DMapCanvas;
+class QMouseEvent;
+
+/**
+ * Base class for map tools operating on 3D map canvas.
+ */
+class Qgs3DMapTool : public QObject
+{
+    Q_OBJECT
+
+  public:
+    Qgs3DMapTool( Qgs3DMapCanvas *canvas );
+
+    virtual void mousePressEvent( QMouseEvent *event );
+    virtual void mouseReleaseEvent( QMouseEvent *event );
+    virtual void mouseMoveEvent( QMouseEvent *event );
+
+  protected:
+    Qgs3DMapCanvas *mCanvas = nullptr;
+};
+
+#endif // QGS3DMAPTOOL_H

--- a/src/app/3d/qgs3dmaptoolidentify.cpp
+++ b/src/app/3d/qgs3dmaptoolidentify.cpp
@@ -1,0 +1,72 @@
+/***************************************************************************
+  qgs3dmaptoolidentify.cpp
+  --------------------------------------
+  Date                 : Sep 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgs3dmaptoolidentify.h"
+
+#include "qgs3dmapcanvas.h"
+#include "qgs3dmapscene.h"
+#include "qgs3dutils.h"
+#include "qgsterrainentity_p.h"
+
+#include "qgisapp.h"
+#include "qgsmaptoolidentifyaction.h"
+
+#include <Qt3DRender/QObjectPicker>
+#include <Qt3DRender/QPickEvent>
+
+Qgs3DMapToolIdentify::Qgs3DMapToolIdentify( Qgs3DMapCanvas *canvas )
+  : Qgs3DMapTool( canvas )
+{
+  connect( mCanvas->scene(), &Qgs3DMapScene::terrainEntityChanged, this, &Qgs3DMapToolIdentify::onTerrainEntityChanged );
+}
+
+void Qgs3DMapToolIdentify::mousePressEvent( QMouseEvent *event )
+{
+  Q_UNUSED( event );
+
+  QgsMapToolIdentifyAction *identifyTool2D = QgisApp::instance()->identifyMapTool();
+  identifyTool2D->clearResults();
+}
+
+void Qgs3DMapToolIdentify::activate()
+{
+  Qt3DRender::QObjectPicker *picker = mCanvas->scene()->terrainEntity()->terrainPicker();
+  connect( picker, &Qt3DRender::QObjectPicker::pressed, this, &Qgs3DMapToolIdentify::onTerrainPicked );
+}
+
+void Qgs3DMapToolIdentify::deactivate()
+{
+  Qt3DRender::QObjectPicker *picker = mCanvas->scene()->terrainEntity()->terrainPicker();
+  disconnect( picker, &Qt3DRender::QObjectPicker::pressed, this, &Qgs3DMapToolIdentify::onTerrainPicked );
+}
+
+void Qgs3DMapToolIdentify::onTerrainPicked( Qt3DRender::QPickEvent *event )
+{
+  QgsVector3D mapCoords = Qgs3DUtils::worldToMapCoordinates( event->worldIntersection(), mCanvas->map()->origin() );
+
+  QgsGeometry geom = QgsGeometry::fromPointXY( QgsPointXY( mapCoords.x(), mapCoords.y() ) );
+
+  QgsMapToolIdentifyAction *identifyTool2D = QgisApp::instance()->identifyMapTool();
+
+  identifyTool2D->identifyAndShowResults( geom );
+}
+
+void Qgs3DMapToolIdentify::onTerrainEntityChanged()
+{
+  // no need to disconnect from the previous entity: it has been destroyed
+  // start listening to the new terrain entity
+  Qt3DRender::QObjectPicker *picker = mCanvas->scene()->terrainEntity()->terrainPicker();
+  connect( picker, &Qt3DRender::QObjectPicker::pressed, this, &Qgs3DMapToolIdentify::onTerrainPicked );
+}

--- a/src/app/3d/qgs3dmaptoolidentify.h
+++ b/src/app/3d/qgs3dmaptoolidentify.h
@@ -23,8 +23,6 @@ namespace Qt3DRender
   class QPickEvent;
 }
 
-//class QgsMapToolIdentifyAction;
-
 
 class Qgs3DMapToolIdentify : public Qgs3DMapTool
 {
@@ -45,7 +43,7 @@ class Qgs3DMapToolIdentify : public Qgs3DMapTool
     void onTerrainEntityChanged();
 
   private:
-    //QgsMapToolIdentifyAction *mIdentifyTool2D = nullptr;
+
 };
 
 #endif // QGS3DMAPTOOLIDENTIFY_H

--- a/src/app/3d/qgs3dmaptoolidentify.h
+++ b/src/app/3d/qgs3dmaptoolidentify.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-  qgs3dmaptool.cpp
+  qgs3dmaptoolidentify.h
   --------------------------------------
   Date                 : Sep 2018
   Copyright            : (C) 2018 by Martin Dobias
@@ -13,35 +13,39 @@
  *                                                                         *
  ***************************************************************************/
 
+#ifndef QGS3DMAPTOOLIDENTIFY_H
+#define QGS3DMAPTOOLIDENTIFY_H
+
 #include "qgs3dmaptool.h"
 
-#include "qgs3dmapcanvas.h"
-
-Qgs3DMapTool::Qgs3DMapTool( Qgs3DMapCanvas *canvas )
-  : QObject( canvas )
-  , mCanvas( canvas )
+namespace Qt3DRender
 {
+  class QPickEvent;
 }
 
-void Qgs3DMapTool::mousePressEvent( QMouseEvent *event )
-{
-  Q_UNUSED( event );
-}
+//class QgsMapToolIdentifyAction;
 
-void Qgs3DMapTool::mouseReleaseEvent( QMouseEvent *event )
-{
-  Q_UNUSED( event );
-}
 
-void Qgs3DMapTool::mouseMoveEvent( QMouseEvent *event )
+class Qgs3DMapToolIdentify : public Qgs3DMapTool
 {
-  Q_UNUSED( event );
-}
+    Q_OBJECT
 
-void Qgs3DMapTool::activate()
-{
-}
+  public:
+    Qgs3DMapToolIdentify( Qgs3DMapCanvas *canvas );
 
-void Qgs3DMapTool::deactivate()
-{
-}
+    void mousePressEvent( QMouseEvent *event ) override;
+    void mouseReleaseEvent( QMouseEvent *event ) override { Q_UNUSED( event );}
+    void mouseMoveEvent( QMouseEvent *event ) override {Q_UNUSED( event );}
+
+    void activate() override;
+    void deactivate() override;
+
+  private slots:
+    void onTerrainPicked( Qt3DRender::QPickEvent *event );
+    void onTerrainEntityChanged();
+
+  private:
+    //QgsMapToolIdentifyAction *mIdentifyTool2D = nullptr;
+};
+
+#endif // QGS3DMAPTOOLIDENTIFY_H

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -446,6 +446,7 @@ IF (WITH_3D)
     3d/qgs3dmapcanvasdockwidget.cpp
     3d/qgs3dmapconfigwidget.cpp
     3d/qgs3dmaptool.cpp
+    3d/qgs3dmaptoolidentify.cpp
     3d/qgsline3dsymbolwidget.cpp
     3d/qgspoint3dsymbolwidget.cpp
     3d/qgspolygon3dsymbolwidget.cpp
@@ -461,6 +462,7 @@ IF (WITH_3D)
     3d/qgs3dmapcanvasdockwidget.h
     3d/qgs3dmapconfigwidget.h
     3d/qgs3dmaptool.h
+    3d/qgs3dmaptoolidentify.h
     3d/qgsline3dsymbolwidget.h
     3d/qgspoint3dsymbolwidget.h
     3d/qgspolygon3dsymbolwidget.h

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -445,6 +445,7 @@ IF (WITH_3D)
     3d/qgs3dmapcanvas.cpp
     3d/qgs3dmapcanvasdockwidget.cpp
     3d/qgs3dmapconfigwidget.cpp
+    3d/qgs3dmaptool.cpp
     3d/qgsline3dsymbolwidget.cpp
     3d/qgspoint3dsymbolwidget.cpp
     3d/qgspolygon3dsymbolwidget.cpp
@@ -459,6 +460,7 @@ IF (WITH_3D)
     3d/qgs3dmapcanvas.h
     3d/qgs3dmapcanvasdockwidget.h
     3d/qgs3dmapconfigwidget.h
+    3d/qgs3dmaptool.h
     3d/qgsline3dsymbolwidget.h
     3d/qgspoint3dsymbolwidget.h
     3d/qgspolygon3dsymbolwidget.h

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -695,6 +695,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Zoom to a bookmark
     void zoomToBookmarkIndex( const QModelIndex & );
 
+    //! Returns pointer to the identify map tool - used by identify tool in 3D view
+    QgsMapToolIdentifyAction *identifyMapTool() const { return mMapTools.mIdentify; }
+
   public slots:
     //! save current vector layer
     void saveAsFile( QgsMapLayer *layer = nullptr, bool onlySelected = false );

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -212,6 +212,16 @@ void QgsMapToolIdentifyAction::deactivate()
   QgsMapToolIdentify::deactivate();
 }
 
+void QgsMapToolIdentifyAction::identifyAndShowResults( const QgsGeometry &geom )
+{
+  mSelectionHandler->setSelectedGeometry( geom );
+}
+
+void QgsMapToolIdentifyAction::clearResults()
+{
+  resultsDialog()->clear();
+}
+
 QgsUnitTypes::DistanceUnit QgsMapToolIdentifyAction::displayDistanceUnits() const
 {
   return QgsProject::instance()->distanceUnits();

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -61,6 +61,11 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
 
     void deactivate() override;
 
+    //! Triggers map identification of at the given location and outputs results in GUI
+    void identifyAndShowResults( const QgsGeometry &geom );
+    //! Clears any previous results from the GUI
+    void clearResults();
+
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );
     void handleChangedRasterResults( QList<QgsMapToolIdentify::IdentifyResult> &results );

--- a/src/app/qgsmaptoolselectionhandler.h
+++ b/src/app/qgsmaptoolselectionhandler.h
@@ -124,6 +124,8 @@ class QgsMapToolSelectionHandler : public QObject
     //! Handles escape press event - returns true if the even has been processed
     bool keyReleaseEvent( QKeyEvent *e );
 
+    void setSelectedGeometry( const QgsGeometry &geometry, Qt::KeyboardModifiers modifiers = Qt::NoModifier );
+
   signals:
     //! emitted when a new geometry has been picked (selectedGeometry())
     void geometryChanged( Qt::KeyboardModifiers modifiers = Qt::NoModifier );
@@ -164,8 +166,6 @@ class QgsMapToolSelectionHandler : public QObject
     void deleteDistanceWidget();
 
     void updateRadiusFromEdge( QgsPointXY &radiusEdge );
-
-    void setSelectedGeometry( const QgsGeometry &geometry, Qt::KeyboardModifiers modifiers = Qt::NoModifier );
 
   private:
 


### PR DESCRIPTION
Adds a map tool for identification of features within 3D map view. It reuses existing 2D map tool for identification, that means the results dock widget is shared among the 2D and 3D map.

Current limitations:
- ignores 3D entities created by map layers (i.e. only identifies features on the map on the terrain)
- does not show highlight in the 3D view
- assumes 3D view has the same CRS and search radius as 2D map canvas

These limitations will be removed in followup pull requests.

Financed by Department of Environment, Land and Infrastructure Engineering (DIATI) and Department of Architecture and Design (DAD) of Politecnico di Torino within ResCult project  (fund: European Commission, DG-ECHO Humanitarian Aid And Civil Protection)  in collaboration with Faunalia.