### PR TITLE
Rename "Array of translated features" output

### DIFF
--- a/src/analysis/processing/qgsalgorithmarrayfeatures.cpp
+++ b/src/analysis/processing/qgsalgorithmarrayfeatures.cpp
@@ -46,13 +46,13 @@ QString QgsArrayFeaturesAlgorithm::groupId() const
 
 QString QgsArrayFeaturesAlgorithm::outputName() const
 {
-  return QObject::tr( "Offsets" );
+  return QObject::tr( "Translated" );
 }
 
 QString QgsArrayFeaturesAlgorithm::shortHelpString() const
 {
   return QObject::tr( "This algorithm creates copies of features in a layer, by creating multiple translated versions of each feature. "
-                      "Each copy is displaced by a preset amount in the x/y/z/m axis." );
+                      "Each copy is incrementally displaced by a preset amount in the x/y/z/m axis." );
 }
 
 QString QgsArrayFeaturesAlgorithm::shortDescription() const


### PR DESCRIPTION
A left-out from #7687. The issue (not sure it's one given that it's not the first alg in this situation - but better mention it) is that it shares the same output name as the "translate" alg (_the culprit is English that does not allow pluralized form for these past participle_).