### PR TITLE
QgsCoordinateTransform::scaleFactor()

### DIFF
--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -358,11 +358,11 @@ been modified in order to ensure that outdated CRS transforms are not created.
 .. versionadded:: 3.0
 %End
 
-    double conversionFactor( const QgsRectangle &referenceExtent ) const;
+    double scaleFactor( const QgsRectangle &referenceExtent ) const;
 %Docstring
 Computes an *estimated* conversion factor between source and destination units:
 
-sourceUnits * conversionFactor = destinationUnits
+sourceUnits * scaleFactor = destinationUnits
 
 :param referenceExtent: A reference extent based on which to perform the computation
 

--- a/python/core/auto_generated/qgscoordinatetransform.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransform.sip.in
@@ -358,6 +358,17 @@ been modified in order to ensure that outdated CRS transforms are not created.
 .. versionadded:: 3.0
 %End
 
+    double conversionFactor( const QgsRectangle &referenceExtent ) const;
+%Docstring
+Computes an *estimated* conversion factor between source and destination units:
+
+sourceUnits * conversionFactor = destinationUnits
+
+:param referenceExtent: A reference extent based on which to perform the computation
+
+.. versionadded:: 3.4
+%End
+
 };
 
 

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -799,7 +799,7 @@ void QgsCoordinateTransform::invalidateCache()
   sCacheLock.unlock();
 }
 
-double QgsCoordinateTransform::conversionFactor( const QgsRectangle &ReferenceExtent ) const
+double QgsCoordinateTransform::scaleFactor( const QgsRectangle &ReferenceExtent ) const
 {
   QgsPointXY source1( ReferenceExtent.xMinimum(), ReferenceExtent.yMinimum() );
   QgsPointXY source2( ReferenceExtent.xMaximum(), ReferenceExtent.yMaximum() );

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -798,3 +798,14 @@ void QgsCoordinateTransform::invalidateCache()
   sTransforms.clear();
   sCacheLock.unlock();
 }
+
+double QgsCoordinateTransform::conversionFactor( const QgsRectangle &ReferenceExtent ) const
+{
+  QgsPointXY source1( ReferenceExtent.xMinimum(), ReferenceExtent.yMinimum() );
+  QgsPointXY source2( ReferenceExtent.xMaximum(), ReferenceExtent.yMaximum() );
+  double distSourceUnits = std::sqrt( source1.sqrDist( source2 ) );
+  QgsPointXY dest1 = transform( source1 );
+  QgsPointXY dest2 = transform( source2 );
+  double distDestUnits = std::sqrt( dest1.sqrDist( dest2 ) );
+  return distDestUnits / distSourceUnits;
+}

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -408,13 +408,13 @@ class CORE_EXPORT QgsCoordinateTransform
     /**
      * Computes an *estimated* conversion factor between source and destination units:
      *
-     *   sourceUnits * conversionFactor = destinationUnits
+     *   sourceUnits * scaleFactor = destinationUnits
      *
      * \param referenceExtent A reference extent based on which to perform the computation
      *
      * \since QGIS 3.4
      */
-    double conversionFactor( const QgsRectangle &referenceExtent ) const;
+    double scaleFactor( const QgsRectangle &referenceExtent ) const;
 
   private:
 

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -405,6 +405,17 @@ class CORE_EXPORT QgsCoordinateTransform
      */
     static void invalidateCache();
 
+    /**
+     * Computes an *estimated* conversion factor between source and destination units:
+     *
+     *   sourceUnits * conversionFactor = destinationUnits
+     *
+     * \param referenceExtent A reference extent based on which to perform the computation
+     *
+     * \since QGIS 3.4
+     */
+    double conversionFactor( const QgsRectangle &referenceExtent ) const;
+
   private:
 
     mutable QExplicitlySharedDataPointer<QgsCoordinateTransformPrivate> d;

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -396,14 +396,7 @@ QgsCoordinateTransform QgsMapSettings::layerTransform( const QgsMapLayer *layer 
 
 double QgsMapSettings::layerToMapUnits( const QgsMapLayer *layer, const QgsRectangle &referenceExtent ) const
 {
-  QgsRectangle extent = referenceExtent.isEmpty() ? layer->extent() : referenceExtent;
-  QgsPointXY l1( extent.xMinimum(), extent.yMinimum() );
-  QgsPointXY l2( extent.xMaximum(), extent.yMaximum() );
-  double distLayerUnits = std::sqrt( l1.sqrDist( l2 ) );
-  QgsPointXY m1 = layerToMapCoordinates( layer, l1 );
-  QgsPointXY m2 = layerToMapCoordinates( layer, l2 );
-  double distMapUnits = std::sqrt( m1.sqrDist( m2 ) );
-  return distMapUnits / distLayerUnits;
+  return layerTransform( layer ).conversionFactor( referenceExtent );
 }
 
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -396,7 +396,7 @@ QgsCoordinateTransform QgsMapSettings::layerTransform( const QgsMapLayer *layer 
 
 double QgsMapSettings::layerToMapUnits( const QgsMapLayer *layer, const QgsRectangle &referenceExtent ) const
 {
-  return layerTransform( layer ).conversionFactor( referenceExtent );
+  return layerTransform( layer ).scaleFactor( referenceExtent );
 }
 
 

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -36,6 +36,8 @@ class TestQgsCoordinateTransform: public QObject
     void isValid();
     void isShortCircuited();
     void contextShared();
+    void conversionFactor();
+    void conversionFactor_data();
 
   private:
 
@@ -213,6 +215,42 @@ void TestQgsCoordinateTransform::contextShared()
   QCOMPARE( copy2.sourceDestinationDatumTransforms(), expected );
 }
 
+void TestQgsCoordinateTransform::conversionFactor()
+{
+  QFETCH( QgsCoordinateReferenceSystem, sourceCrs );
+  QFETCH( QgsCoordinateReferenceSystem, destCrs );
+  QFETCH( QgsRectangle, rect );
+  QFETCH( double, factor );
+
+  QgsCoordinateTransform ct( sourceCrs, destCrs, QgsProject::instance() );
+
+  // qDebug() << QString::number(ct.conversionFactor( rect ), 'g', 17) ;
+  QVERIFY( qgsDoubleNear( ct.conversionFactor( rect ), factor ) );
+}
+
+void TestQgsCoordinateTransform::conversionFactor_data()
+{
+  QTest::addColumn<QgsCoordinateReferenceSystem>( "sourceCrs" );
+  QTest::addColumn<QgsCoordinateReferenceSystem>( "destCrs" );
+  QTest::addColumn<QgsRectangle>( "rect" );
+  QTest::addColumn<double>( "factor" );
+
+  QTest::newRow( "Different map units" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 2056 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 4326 )
+      << QgsRectangle( 2550000, 1200000, 2550100, 1200100 )
+      << 1.1223316038381985e-5;
+  QTest::newRow( "Same map units" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 2056 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 21781 )
+      << QgsRectangle( 2550000, 1200000, 2550100, 1200100 )
+      << 1.0000000000248837;
+  QTest::newRow( "Same CRS" )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 2056 )
+      << QgsCoordinateReferenceSystem::fromEpsgId( 2056 )
+      << QgsRectangle( 2550000, 1200000, 2550100, 1200100 )
+      << 1.0;
+}
 
 void TestQgsCoordinateTransform::transformBoundingBox()
 {

--- a/tests/src/core/testqgscoordinatetransform.cpp
+++ b/tests/src/core/testqgscoordinatetransform.cpp
@@ -36,8 +36,8 @@ class TestQgsCoordinateTransform: public QObject
     void isValid();
     void isShortCircuited();
     void contextShared();
-    void conversionFactor();
-    void conversionFactor_data();
+    void scaleFactor();
+    void scaleFactor_data();
 
   private:
 
@@ -215,7 +215,7 @@ void TestQgsCoordinateTransform::contextShared()
   QCOMPARE( copy2.sourceDestinationDatumTransforms(), expected );
 }
 
-void TestQgsCoordinateTransform::conversionFactor()
+void TestQgsCoordinateTransform::scaleFactor()
 {
   QFETCH( QgsCoordinateReferenceSystem, sourceCrs );
   QFETCH( QgsCoordinateReferenceSystem, destCrs );
@@ -224,11 +224,11 @@ void TestQgsCoordinateTransform::conversionFactor()
 
   QgsCoordinateTransform ct( sourceCrs, destCrs, QgsProject::instance() );
 
-  // qDebug() << QString::number(ct.conversionFactor( rect ), 'g', 17) ;
-  QVERIFY( qgsDoubleNear( ct.conversionFactor( rect ), factor ) );
+  // qDebug() << QString::number(ct.scaleFactor( rect ), 'g', 17) ;
+  QVERIFY( qgsDoubleNear( ct.scaleFactor( rect ), factor ) );
 }
 
-void TestQgsCoordinateTransform::conversionFactor_data()
+void TestQgsCoordinateTransform::scaleFactor_data()
 {
   QTest::addColumn<QgsCoordinateReferenceSystem>( "sourceCrs" );
   QTest::addColumn<QgsCoordinateReferenceSystem>( "destCrs" );


### PR DESCRIPTION
Add a method `QgsCoordinateTransform::scaleFactor()` to approximate a factor to convert between two CRS'. It's a direct port of `QgsMapSettings::layertoMapUnits`.