### PR TITLE
Fix querying virtual layers in DB manager

### DIFF
--- a/python/plugins/db_manager/db_plugins/vlayers/connector.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/connector.py
@@ -250,16 +250,14 @@ class VLayerConnector(DBConnector):
         return []
 
     def getTableRowCount(self, table):
-        t = table[1]
-        l = VLayerRegistry.instance().getLayer(t)
+        l = VLayerRegistry.instance().getLayer(table)
         if not l or not l.isValid():
             return None
         return l.featureCount()
 
     def getTableFields(self, table):
         """ return list of columns in table """
-        t = table[1]
-        l = VLayerRegistry.instance().getLayer(t)
+        l = VLayerRegistry.instance().getLayer(table)
         if not l or not l.isValid():
             return []
         # id, name, type, nonnull, default, pk


### PR DESCRIPTION
When trying to open the querytool in DB manageron a virtual layer DB manager throws an exception. 
To reproduce the problem try the following
![image](https://user-images.githubusercontent.com/233663/45311843-bc777780-b52a-11e8-8af0-3e1785a2f6f6.png)


`getTableFields` and `getTableRowCount` receive the table name and not the table. 

I did not change the argument name (although it would be good) to keep it in line with all the other methods


see:
https://github.com/qgis/QGIS/blob/master/python/plugins/db_manager/db_plugins/plugin.py#L742
https://github.com/qgis/QGIS/blob/master/python/plugins/db_manager/db_plugins/plugin.py#L879

## Description
Current

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
