### PR TITLE
Fix connection to GPS using serial port

### DIFF
--- a/src/core/gps/qgsgpsdetector.cpp
+++ b/src/core/gps/qgsgpsdetector.cpp
@@ -124,7 +124,7 @@ void QgsGpsDetector::advance()
       serial->setDataBits( QSerialPort::Data8 );
       serial->setStopBits( QSerialPort::OneStop );
 
-      if ( serial->open( QIODevice::ReadOnly | QIODevice::Unbuffered ) )
+      if ( serial->open( QIODevice::ReadOnly ) )
       {
         mConn = new QgsNmeaConnection( serial );
       }


### PR DESCRIPTION
It was impossible to start GPS live tracking when connecting via a serial port rather than gpsd.

QSerialPort in Qt5 does not support Unbuffered open mode and will just fail (around line 545):
https://github.com/qt/qtserialport/blob/5.11/src/serialport/qserialport.cpp

This was not a problem in QGIS 2.x / Qt4 where we used QextSerialPort which did not have such test.