### PR TITLE
Expression from OGC FE 2.0

### DIFF
--- a/python/core/auto_generated/qgsogcutils.sip.in
+++ b/python/core/auto_generated/qgsogcutils.sip.in
@@ -149,6 +149,8 @@ according to the OGC filter specs (=,!=,<,>,<=,>=,AND,OR,NOT)
       FILTER_FES_2_0
     };
 
+    static QgsExpression *expressionFromOgcFilter( const QDomElement &element, FilterVersion version, QgsVectorLayer *layer = 0 ) /Factory/;
+
 
     static QDomElement expressionToOgcExpression( const QgsExpression &exp, QDomDocument &doc, QString *errorMessage = 0 );
 %Docstring

--- a/python/core/auto_generated/qgsogcutils.sip.in
+++ b/python/core/auto_generated/qgsogcutils.sip.in
@@ -150,6 +150,15 @@ according to the OGC filter specs (=,!=,<,>,<=,>=,AND,OR,NOT)
     };
 
     static QgsExpression *expressionFromOgcFilter( const QDomElement &element, FilterVersion version, QgsVectorLayer *layer = 0 ) /Factory/;
+%Docstring
+Returns an expression from a WFS filter embedded in a document.
+
+:param element: The WFS Filter
+:param version: The WFS version
+:param layer: Layer to use to retrieve field values from literal filters
+
+.. versionadded:: 3.4
+%End
 
 
     static QDomElement expressionToOgcExpression( const QgsExpression &exp, QDomDocument &doc, QString *errorMessage = 0 );

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3287,11 +3287,11 @@ QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeSpatialOperatorF
     return nullptr;
   }
 
-  QgsExpressionNode::NodeList *opArgs = new QgsExpressionNode::NodeList();
+  std::unique_ptr<QgsExpressionNode::NodeList> opArgs( new QgsExpressionNode::NodeList() );
   opArgs->append( new QgsExpressionNodeFunction( QgsExpression::functionIndex( QStringLiteral( "$geometry" ) ), new QgsExpressionNode::NodeList() ) );
   opArgs->append( new QgsExpressionNodeFunction( QgsExpression::functionIndex( QStringLiteral( "geomFromGML" ) ), gml2Args.release() ) );
 
-  return new QgsExpressionNodeFunction( opIdx, opArgs );
+  return new QgsExpressionNodeFunction( opIdx, opArgs.release() );
 }
 
 QgsExpressionNodeColumnRef *QgsOgcUtilsExpressionFromFilter::nodeColumnRefFromOgcFilter( const QDomElement &element )

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3398,14 +3398,14 @@ QgsExpressionNodeUnaryOperator *QgsOgcUtilsExpressionFromFilter::nodeNotFromOgcF
     return nullptr;
 
   QDomElement operandElem = element.firstChildElement();
-  QgsExpressionNode *operand = nodeFromOgcFilter( operandElem );
+  std::unique_ptr<QgsExpressionNode> operand( nodeFromOgcFilter( operandElem ) );
   if ( !operand )
   {
     mErrorMessage = QObject::tr( "invalid operand for '%1' unary operator" ).arg( element.tagName() );
     return nullptr;
   }
 
-  return new QgsExpressionNodeUnaryOperator( QgsExpressionNodeUnaryOperator::uoNot, operand );
+  return new QgsExpressionNodeUnaryOperator( QgsExpressionNodeUnaryOperator::uoNot, operand.release() );
 }
 
 QgsExpressionNodeBinaryOperator *QgsOgcUtilsExpressionFromFilter::nodePropertyIsNullFromOgcFilter( const QDomElement &element )

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3440,23 +3440,22 @@ QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeFunctionFromOgcF
     if ( element.attribute( QStringLiteral( "name" ) ) != funcDef->name() )
       continue;
 
-    QgsExpressionNode::NodeList *args = new QgsExpressionNode::NodeList();
+    std::unique_ptr<QgsExpressionNode::NodeList> args( new QgsExpressionNode::NodeList() );
 
     QDomElement operandElem = element.firstChildElement();
     while ( !operandElem.isNull() )
     {
-      QgsExpressionNode *op = nodeFromOgcFilter( operandElem );
+      std::unique_ptr<QgsExpressionNode> op( nodeFromOgcFilter( operandElem ) );
       if ( !op )
       {
-        delete args;
         return nullptr;
       }
-      args->append( op );
+      args->append( op.release() );
 
       operandElem = operandElem.nextSiblingElement();
     }
 
-    return new QgsExpressionNodeFunction( i, args );
+    return new QgsExpressionNodeFunction( i, args.release() );
   }
 
   return nullptr;

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3093,7 +3093,7 @@ QDomElement QgsOgcUtilsSQLStatementToFilter::toOgcFilter( const QgsSQLStatement:
   return QDomElement();
 }
 
-QgsOgcUtilsExpressionFromFilter::QgsOgcUtilsExpressionFromFilter( const QgsOgcUtils::FilterVersion version, QgsVectorLayer *layer )
+QgsOgcUtilsExpressionFromFilter::QgsOgcUtilsExpressionFromFilter( const QgsOgcUtils::FilterVersion version, const QgsVectorLayer *layer )
   : mLayer( layer )
 {
   mPropertyName = QStringLiteral( "PropertyName" );
@@ -3263,7 +3263,7 @@ QgsExpressionNodeBinaryOperator *QgsOgcUtilsExpressionFromFilter::nodeBinaryOper
 QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeSpatialOperatorFromOgcFilter( const QDomElement &element )
 {
   // we are exploiting the fact that our function names are the same as the XML tag names
-  int opIdx = QgsExpression::functionIndex( element.tagName().toLower() );
+  const int opIdx = QgsExpression::functionIndex( element.tagName().toLower() );
 
   std::unique_ptr<QgsExpressionNode::NodeList> gml2Args( new QgsExpressionNode::NodeList() );
   QDomElement childElem = element.firstChildElement();
@@ -3324,7 +3324,7 @@ QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeLiteralFromOgcFilter( co
     if ( childNode.nodeType() == QDomNode::ElementNode )
     {
       // found a element node (e.g. PropertyName), convert it
-      QDomElement operandElem = childNode.toElement();
+      const QDomElement operandElem = childNode.toElement();
       operand.reset( nodeFromOgcFilter( operandElem ) );
       if ( !operand )
       {
@@ -3349,7 +3349,7 @@ QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeLiteralFromOgcFilter( co
         }
         if ( !propertyNameElement.isNull() || propertyNameElement.tagName() == mPropertyName )
         {
-          int fieldIndex = mLayer->fields().indexOf( propertyNameElement.firstChild().nodeValue() );
+          const int fieldIndex = mLayer->fields().indexOf( propertyNameElement.firstChild().nodeValue() );
           if ( fieldIndex != -1 )
           {
             QgsField field = mLayer->fields().field( propertyNameElement.firstChild().nodeValue() );
@@ -3363,7 +3363,7 @@ QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeLiteralFromOgcFilter( co
         // try to convert the node content to number if possible,
         // otherwise let's use it as string
         bool ok;
-        double d = value.toDouble( &ok );
+        const double d = value.toDouble( &ok );
         if ( ok )
           value = d;
       }
@@ -3397,7 +3397,7 @@ QgsExpressionNodeUnaryOperator *QgsOgcUtilsExpressionFromFilter::nodeNotFromOgcF
   if ( element.tagName() != QLatin1String( "Not" ) )
     return nullptr;
 
-  QDomElement operandElem = element.firstChildElement();
+  const QDomElement operandElem = element.firstChildElement();
   std::unique_ptr<QgsExpressionNode> operand( nodeFromOgcFilter( operandElem ) );
   if ( !operand )
   {
@@ -3416,7 +3416,7 @@ QgsExpressionNodeBinaryOperator *QgsOgcUtilsExpressionFromFilter::nodePropertyIs
     return nullptr;
   }
 
-  QDomElement operandElem = element.firstChildElement();
+  const QDomElement operandElem = element.firstChildElement();
   std::unique_ptr<QgsExpressionNode> opLeft( nodeFromOgcFilter( operandElem ) );
   if ( !opLeft )
     return nullptr;
@@ -3435,7 +3435,7 @@ QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeFunctionFromOgcF
 
   for ( int i = 0; i < QgsExpression::Functions().size(); i++ )
   {
-    QgsExpressionFunction *funcDef = QgsExpression::Functions()[i];
+    const QgsExpressionFunction *funcDef = QgsExpression::Functions()[i];
 
     if ( element.attribute( QStringLiteral( "name" ) ) != funcDef->name() )
       continue;

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3417,12 +3417,12 @@ QgsExpressionNodeBinaryOperator *QgsOgcUtilsExpressionFromFilter::nodePropertyIs
   }
 
   QDomElement operandElem = element.firstChildElement();
-  QgsExpressionNode *opLeft = nodeFromOgcFilter( operandElem );
+  std::unique_ptr<QgsExpressionNode> opLeft( nodeFromOgcFilter( operandElem ) );
   if ( !opLeft )
     return nullptr;
 
-  QgsExpressionNode *opRight = new QgsExpressionNodeLiteral( QVariant() );
-  return new QgsExpressionNodeBinaryOperator( QgsExpressionNodeBinaryOperator::boIs, opLeft, opRight );
+  std::unique_ptr<QgsExpressionNode> opRight( new QgsExpressionNodeLiteral( QVariant() ) );
+  return new QgsExpressionNodeBinaryOperator( QgsExpressionNodeBinaryOperator::boIs, opLeft.release(), opRight.release() );
 }
 
 QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeFunctionFromOgcFilter( const QDomElement &element )

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3094,8 +3094,7 @@ QDomElement QgsOgcUtilsSQLStatementToFilter::toOgcFilter( const QgsSQLStatement:
 }
 
 QgsOgcUtilsExpressionFromFilter::QgsOgcUtilsExpressionFromFilter( const QgsOgcUtils::FilterVersion version, QgsVectorLayer *layer )
-  : mVersion( version )
-  , mLayer( layer )
+  : mLayer( layer )
 {
   mPropertyName = QStringLiteral( "PropertyName" );
   mPrefix = QStringLiteral( "ogc" );

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3098,9 +3098,13 @@ QgsOgcUtilsExpressionFromFilter::QgsOgcUtilsExpressionFromFilter( const QgsOgcUt
   , mLayer( layer )
 {
   mPropertyName = QStringLiteral( "PropertyName" );
+  mPrefix = QStringLiteral( "ogc" );
 
   if ( version == QgsOgcUtils::FILTER_FES_2_0 )
+  {
     mPropertyName = QStringLiteral( "ValueReference" );
+    mPrefix = QStringLiteral( "fes" );
+  }
 }
 
 QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeFromOgcFilter( const QDomElement &element )
@@ -3300,7 +3304,7 @@ QgsExpressionNodeColumnRef *QgsOgcUtilsExpressionFromFilter::nodeColumnRefFromOg
 {
   if ( element.isNull() || element.tagName() != mPropertyName )
   {
-    mErrorMessage = QObject::tr( "ogc:PropertyName expected, got %1" ).arg( element.tagName() );
+    mErrorMessage = QObject::tr( "%1:PropertyName expected, got %2" ).arg( mPrefix, element.tagName() );
     return nullptr;
   }
 
@@ -3311,7 +3315,7 @@ QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeLiteralFromOgcFilter( co
 {
   if ( element.isNull() || element.tagName() != QLatin1String( "Literal" ) )
   {
-    mErrorMessage = QObject::tr( "ogc:Literal expected, got %1" ).arg( element.tagName() );
+    mErrorMessage = QObject::tr( "%1:Literal expected, got %2" ).arg( mPrefix, element.tagName() );
     return nullptr;
   }
 
@@ -3332,7 +3336,7 @@ QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeLiteralFromOgcFilter( co
       {
         delete root;
 
-        mErrorMessage = QObject::tr( "'%1' is an invalid or not supported content for ogc:Literal" ).arg( operandElem.tagName() );
+        mErrorMessage = QObject::tr( "'%1' is an invalid or not supported content for %2:Literal" ).arg( operandElem.tagName(), mPrefix );
         return nullptr;
       }
     }
@@ -3405,8 +3409,7 @@ QgsExpressionNodeUnaryOperator *QgsOgcUtilsExpressionFromFilter::nodeNotFromOgcF
   QgsExpressionNode *operand = nodeFromOgcFilter( operandElem );
   if ( !operand )
   {
-    if ( mErrorMessage.isEmpty() )
-      mErrorMessage = QObject::tr( "invalid operand for '%1' unary operator" ).arg( element.tagName() );
+    mErrorMessage = QObject::tr( "invalid operand for '%1' unary operator" ).arg( element.tagName() );
     return nullptr;
   }
 
@@ -3434,7 +3437,7 @@ QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeFunctionFromOgcF
 {
   if ( element.isNull() || element.tagName() != QLatin1String( "Function" ) )
   {
-    mErrorMessage = QObject::tr( "ogc:Function expected, got %1" ).arg( element.tagName() );
+    mErrorMessage = QObject::tr( "%1:Function expected, got %2" ).arg( mPrefix, element.tagName() );
     return nullptr;
   }
 
@@ -3507,7 +3510,7 @@ QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeIsBetweenFromOgcFilter( 
     delete lowerBound;
     delete upperBound;
 
-    mErrorMessage = QObject::tr( "missing some required sub-elements in ogc:PropertyIsBetween" );
+    mErrorMessage = QObject::tr( "missing some required sub-elements in %1:PropertyIsBetween" ).arg( mPrefix );
     return nullptr;
   }
 

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1619,7 +1619,7 @@ QgsExpression *QgsOgcUtils::expressionFromOgcFilter( const QDomElement &element,
     return expr;
   }
 
-  QgsOgcUtilsExprFromFilter utils( version, layer );
+  QgsOgcUtilsExpressionFromFilter utils( version, layer );
 
   // then check OGC DOM elements that contain OGC tags specifying
   // OGC operators.
@@ -1709,7 +1709,7 @@ static bool isSpatialOperator( const QString &tagName )
 
 QgsExpressionNode *QgsOgcUtils::nodeFromOgcFilter( QDomElement &element, QString &errorMessage, QgsVectorLayer *layer )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0, layer );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0, layer );
   QgsExpressionNode *node = utils.nodeFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -1717,7 +1717,7 @@ QgsExpressionNode *QgsOgcUtils::nodeFromOgcFilter( QDomElement &element, QString
 
 QgsExpressionNodeBinaryOperator *QgsOgcUtils::nodeBinaryOperatorFromOgcFilter( QDomElement &element, QString &errorMessage, QgsVectorLayer *layer )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0, layer );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0, layer );
   QgsExpressionNodeBinaryOperator *node = utils.nodeBinaryOperatorFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -1725,7 +1725,7 @@ QgsExpressionNodeBinaryOperator *QgsOgcUtils::nodeBinaryOperatorFromOgcFilter( Q
 
 QgsExpressionNodeFunction *QgsOgcUtils::nodeSpatialOperatorFromOgcFilter( QDomElement &element, QString &errorMessage )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
   QgsExpressionNodeFunction *node = utils.nodeSpatialOperatorFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -1733,7 +1733,7 @@ QgsExpressionNodeFunction *QgsOgcUtils::nodeSpatialOperatorFromOgcFilter( QDomEl
 
 QgsExpressionNodeUnaryOperator *QgsOgcUtils::nodeNotFromOgcFilter( QDomElement &element, QString &errorMessage )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
   QgsExpressionNodeUnaryOperator *node = utils.nodeNotFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -1741,7 +1741,7 @@ QgsExpressionNodeUnaryOperator *QgsOgcUtils::nodeNotFromOgcFilter( QDomElement &
 
 QgsExpressionNodeFunction *QgsOgcUtils::nodeFunctionFromOgcFilter( QDomElement &element, QString &errorMessage )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
   QgsExpressionNodeFunction *node = utils.nodeFunctionFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -1749,7 +1749,7 @@ QgsExpressionNodeFunction *QgsOgcUtils::nodeFunctionFromOgcFilter( QDomElement &
 
 QgsExpressionNode *QgsOgcUtils::nodeLiteralFromOgcFilter( QDomElement &element, QString &errorMessage, QgsVectorLayer *layer )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0, layer );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0, layer );
   QgsExpressionNode *node = utils.nodeLiteralFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -1757,7 +1757,7 @@ QgsExpressionNode *QgsOgcUtils::nodeLiteralFromOgcFilter( QDomElement &element, 
 
 QgsExpressionNodeColumnRef *QgsOgcUtils::nodeColumnRefFromOgcFilter( QDomElement &element, QString &errorMessage )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
   QgsExpressionNodeColumnRef *node = utils.nodeColumnRefFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -1765,7 +1765,7 @@ QgsExpressionNodeColumnRef *QgsOgcUtils::nodeColumnRefFromOgcFilter( QDomElement
 
 QgsExpressionNode *QgsOgcUtils::nodeIsBetweenFromOgcFilter( QDomElement &element, QString &errorMessage )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
   QgsExpressionNode *node = utils.nodeIsBetweenFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -1773,7 +1773,7 @@ QgsExpressionNode *QgsOgcUtils::nodeIsBetweenFromOgcFilter( QDomElement &element
 
 QgsExpressionNodeBinaryOperator *QgsOgcUtils::nodePropertyIsNullFromOgcFilter( QDomElement &element, QString &errorMessage )
 {
-  QgsOgcUtilsExprFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
+  QgsOgcUtilsExpressionFromFilter utils( QgsOgcUtils::FILTER_OGC_1_0 );
   QgsExpressionNodeBinaryOperator *node = utils.nodePropertyIsNullFromOgcFilter( element );
   errorMessage = utils.errorMessage();
   return node;
@@ -3093,7 +3093,7 @@ QDomElement QgsOgcUtilsSQLStatementToFilter::toOgcFilter( const QgsSQLStatement:
   return QDomElement();
 }
 
-QgsOgcUtilsExprFromFilter::QgsOgcUtilsExprFromFilter( const QgsOgcUtils::FilterVersion version, QgsVectorLayer *layer )
+QgsOgcUtilsExpressionFromFilter::QgsOgcUtilsExpressionFromFilter( const QgsOgcUtils::FilterVersion version, QgsVectorLayer *layer )
   : mVersion( version )
   , mLayer( layer )
 {
@@ -3103,7 +3103,7 @@ QgsOgcUtilsExprFromFilter::QgsOgcUtilsExprFromFilter( const QgsOgcUtils::FilterV
     mPropertyName = QStringLiteral( "ValueReference" );
 }
 
-QgsExpressionNode *QgsOgcUtilsExprFromFilter::nodeFromOgcFilter( const QDomElement &element )
+QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeFromOgcFilter( const QDomElement &element )
 {
   if ( element.isNull() )
     return nullptr;
@@ -3150,7 +3150,7 @@ QgsExpressionNode *QgsOgcUtilsExprFromFilter::nodeFromOgcFilter( const QDomEleme
   return nullptr;
 }
 
-QgsExpressionNodeBinaryOperator *QgsOgcUtilsExprFromFilter::nodeBinaryOperatorFromOgcFilter( const QDomElement &element )
+QgsExpressionNodeBinaryOperator *QgsOgcUtilsExpressionFromFilter::nodeBinaryOperatorFromOgcFilter( const QDomElement &element )
 {
   if ( element.isNull() )
     return nullptr;
@@ -3261,7 +3261,7 @@ QgsExpressionNodeBinaryOperator *QgsOgcUtilsExprFromFilter::nodeBinaryOperatorFr
 }
 
 
-QgsExpressionNodeFunction *QgsOgcUtilsExprFromFilter::nodeSpatialOperatorFromOgcFilter( const QDomElement &element )
+QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeSpatialOperatorFromOgcFilter( const QDomElement &element )
 {
   // we are exploiting the fact that our function names are the same as the XML tag names
   int opIdx = QgsExpression::functionIndex( element.tagName().toLower() );
@@ -3296,7 +3296,7 @@ QgsExpressionNodeFunction *QgsOgcUtilsExprFromFilter::nodeSpatialOperatorFromOgc
   return new QgsExpressionNodeFunction( opIdx, opArgs );
 }
 
-QgsExpressionNodeColumnRef *QgsOgcUtilsExprFromFilter::nodeColumnRefFromOgcFilter( const QDomElement &element )
+QgsExpressionNodeColumnRef *QgsOgcUtilsExpressionFromFilter::nodeColumnRefFromOgcFilter( const QDomElement &element )
 {
   if ( element.isNull() || element.tagName() != mPropertyName )
   {
@@ -3307,7 +3307,7 @@ QgsExpressionNodeColumnRef *QgsOgcUtilsExprFromFilter::nodeColumnRefFromOgcFilte
   return new QgsExpressionNodeColumnRef( element.firstChild().nodeValue() );
 }
 
-QgsExpressionNode *QgsOgcUtilsExprFromFilter::nodeLiteralFromOgcFilter( const QDomElement &element )
+QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeLiteralFromOgcFilter( const QDomElement &element )
 {
   if ( element.isNull() || element.tagName() != QLatin1String( "Literal" ) )
   {
@@ -3396,7 +3396,7 @@ QgsExpressionNode *QgsOgcUtilsExprFromFilter::nodeLiteralFromOgcFilter( const QD
   return nullptr;
 }
 
-QgsExpressionNodeUnaryOperator *QgsOgcUtilsExprFromFilter::nodeNotFromOgcFilter( const QDomElement &element )
+QgsExpressionNodeUnaryOperator *QgsOgcUtilsExpressionFromFilter::nodeNotFromOgcFilter( const QDomElement &element )
 {
   if ( element.tagName() != QLatin1String( "Not" ) )
     return nullptr;
@@ -3413,7 +3413,7 @@ QgsExpressionNodeUnaryOperator *QgsOgcUtilsExprFromFilter::nodeNotFromOgcFilter(
   return new QgsExpressionNodeUnaryOperator( QgsExpressionNodeUnaryOperator::uoNot, operand );
 }
 
-QgsExpressionNodeBinaryOperator *QgsOgcUtilsExprFromFilter::nodePropertyIsNullFromOgcFilter( const QDomElement &element )
+QgsExpressionNodeBinaryOperator *QgsOgcUtilsExpressionFromFilter::nodePropertyIsNullFromOgcFilter( const QDomElement &element )
 {
   // convert ogc:PropertyIsNull to IS operator with NULL right operand
   if ( element.tagName() != QLatin1String( "PropertyIsNull" ) )
@@ -3430,7 +3430,7 @@ QgsExpressionNodeBinaryOperator *QgsOgcUtilsExprFromFilter::nodePropertyIsNullFr
   return new QgsExpressionNodeBinaryOperator( QgsExpressionNodeBinaryOperator::boIs, opLeft, opRight );
 }
 
-QgsExpressionNodeFunction *QgsOgcUtilsExprFromFilter::nodeFunctionFromOgcFilter( const QDomElement &element )
+QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeFunctionFromOgcFilter( const QDomElement &element )
 {
   if ( element.isNull() || element.tagName() != QLatin1String( "Function" ) )
   {
@@ -3467,7 +3467,7 @@ QgsExpressionNodeFunction *QgsOgcUtilsExprFromFilter::nodeFunctionFromOgcFilter(
   return nullptr;
 }
 
-QgsExpressionNode *QgsOgcUtilsExprFromFilter::nodeIsBetweenFromOgcFilter( const QDomElement &element )
+QgsExpressionNode *QgsOgcUtilsExpressionFromFilter::nodeIsBetweenFromOgcFilter( const QDomElement &element )
 {
   // <ogc:PropertyIsBetween> encode a Range check
   QgsExpressionNode *operand = nullptr, *lowerBound = nullptr;
@@ -3516,7 +3516,7 @@ QgsExpressionNode *QgsOgcUtilsExprFromFilter::nodeIsBetweenFromOgcFilter( const 
   return new QgsExpressionNodeBinaryOperator( QgsExpressionNodeBinaryOperator::boAnd, geOperator, leOperator );
 }
 
-QString QgsOgcUtilsExprFromFilter::errorMessage() const
+QString QgsOgcUtilsExpressionFromFilter::errorMessage() const
 {
   return mErrorMessage;
 }

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3265,7 +3265,7 @@ QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeSpatialOperatorF
   // we are exploiting the fact that our function names are the same as the XML tag names
   int opIdx = QgsExpression::functionIndex( element.tagName().toLower() );
 
-  QgsExpressionNode::NodeList *gml2Args = new QgsExpressionNode::NodeList();
+  std::unique_ptr<QgsExpressionNode::NodeList> gml2Args( new QgsExpressionNode::NodeList() );
   QDomElement childElem = element.firstChildElement();
   QString gml2Str;
   while ( !childElem.isNull() && gml2Str.isEmpty() )
@@ -3284,13 +3284,12 @@ QgsExpressionNodeFunction *QgsOgcUtilsExpressionFromFilter::nodeSpatialOperatorF
   else
   {
     mErrorMessage = QObject::tr( "No OGC Geometry found" );
-    delete gml2Args;
     return nullptr;
   }
 
   QgsExpressionNode::NodeList *opArgs = new QgsExpressionNode::NodeList();
   opArgs->append( new QgsExpressionNodeFunction( QgsExpression::functionIndex( QStringLiteral( "$geometry" ) ), new QgsExpressionNode::NodeList() ) );
-  opArgs->append( new QgsExpressionNodeFunction( QgsExpression::functionIndex( QStringLiteral( "geomFromGML" ) ), gml2Args ) );
+  opArgs->append( new QgsExpressionNodeFunction( QgsExpression::functionIndex( QStringLiteral( "geomFromGML" ) ), gml2Args.release() ) );
 
   return new QgsExpressionNodeFunction( opIdx, opArgs );
 }

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -161,6 +161,8 @@ class CORE_EXPORT QgsOgcUtils
       FILTER_FES_2_0
     };
 
+    static QgsExpression *expressionFromOgcFilter( const QDomElement &element, FilterVersion version, QgsVectorLayer *layer = nullptr ) SIP_FACTORY;
+
     /**
      * Creates OGC filter XML element. Supports minimum standard filter
      * according to the OGC filter specs (=,!=,<,>,<=,>=,AND,OR,NOT)
@@ -365,6 +367,28 @@ class QgsOgcUtilsExprToFilter
     QDomElement expressionColumnRefToOgcFilter( const QgsExpressionNodeColumnRef *node, QgsExpression *expression, const QgsExpressionContext *context );
     QDomElement expressionInOperatorToOgcFilter( const QgsExpressionNodeInOperator *node, QgsExpression *expression, const QgsExpressionContext *context );
     QDomElement expressionFunctionToOgcFilter( const QgsExpressionNodeFunction *node, QgsExpression *expression, const QgsExpressionContext *context );
+};
+
+class QgsOgcUtilsExprFromFilter
+{
+  public:
+    QgsOgcUtilsExprFromFilter( QgsOgcUtils::FilterVersion version = QgsOgcUtils::FILTER_OGC_1_0,
+                               QgsVectorLayer *layer = nullptr );
+
+    QgsExpressionNode *nodeFromOgcFilter( const QDomElement &element );
+
+    QString errorMessage() const;
+
+    QgsExpressionNodeBinaryOperator *nodeBinaryOperatorFromOgcFilter( const QDomElement &element );
+    QgsExpressionNodeFunction *nodeSpatialOperatorFromOgcFilter( const QDomElement &element );
+    QgsExpressionNodeColumnRef *nodeColumnRefFromOgcFilter( const QDomElement &element );
+    QgsExpressionNode *nodeLiteralFromOgcFilter( const QDomElement &element );
+
+  private:
+    QgsOgcUtils::FilterVersion mVersion = QgsOgcUtils::FILTER_OGC_1_0;
+    QgsVectorLayer *mLayer = nullptr;
+    QString mErrorMessage;
+    QString mPropertyName;
 };
 
 /**

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -461,6 +461,7 @@ class QgsOgcUtilsExpressionFromFilter
     QgsVectorLayer *mLayer = nullptr;
     QString mErrorMessage;
     QString mPropertyName;
+    QString mPrefix;
 };
 
 /**

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -383,6 +383,10 @@ class QgsOgcUtilsExprFromFilter
     QgsExpressionNodeFunction *nodeSpatialOperatorFromOgcFilter( const QDomElement &element );
     QgsExpressionNodeColumnRef *nodeColumnRefFromOgcFilter( const QDomElement &element );
     QgsExpressionNode *nodeLiteralFromOgcFilter( const QDomElement &element );
+    QgsExpressionNodeUnaryOperator *nodeNotFromOgcFilter( const QDomElement &element );
+    QgsExpressionNodeBinaryOperator *nodePropertyIsNullFromOgcFilter( const QDomElement &element );
+    QgsExpressionNodeFunction *nodeFunctionFromOgcFilter( const QDomElement &element );
+    QgsExpressionNode *nodeIsBetweenFromOgcFilter( const QDomElement &element );
 
   private:
     QgsOgcUtils::FilterVersion mVersion = QgsOgcUtils::FILTER_OGC_1_0;

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -161,6 +161,13 @@ class CORE_EXPORT QgsOgcUtils
       FILTER_FES_2_0
     };
 
+    /**
+     * Returns an expression from a WFS filter embedded in a document.
+     * \param element The WFS Filter
+     * \param version The WFS version
+     * \param layer Layer to use to retrieve field values from literal filters
+     * \since QGIS 3.4
+     */
     static QgsExpression *expressionFromOgcFilter( const QDomElement &element, FilterVersion version, QgsVectorLayer *layer = nullptr ) SIP_FACTORY;
 
     /**
@@ -369,23 +376,84 @@ class QgsOgcUtilsExprToFilter
     QDomElement expressionFunctionToOgcFilter( const QgsExpressionNodeFunction *node, QgsExpression *expression, const QgsExpressionContext *context );
 };
 
+/**
+ * \ingroup core
+ * \brief Internal use by QgsOgcUtils
+ * \note not available in Python bindings
+ * \since QGIS 3.4
+ */
 class QgsOgcUtilsExprFromFilter
 {
   public:
+
+    /**
+     * Constructor for QgsOgcUtilsExprFromFilter.
+     * \param version WFS Version
+     * \param layer Layer to use to retrieve field values from literal filters
+     */
     QgsOgcUtilsExprFromFilter( QgsOgcUtils::FilterVersion version = QgsOgcUtils::FILTER_OGC_1_0,
                                QgsVectorLayer *layer = nullptr );
 
+    /**
+     * Returns an expression node from a WFS filter embedded in a document
+     * element. A null pointer is returned when an error happened.
+     * \param element The WFS filter
+     */
     QgsExpressionNode *nodeFromOgcFilter( const QDomElement &element );
 
+    /**
+     * Returns the underlying error message, or an empty string in case of no
+     * error.
+     */
     QString errorMessage() const;
 
+    /**
+     * Returns an expression node from a WFS filter embedded in a document with
+     * binary operators.
+     *
+     */
     QgsExpressionNodeBinaryOperator *nodeBinaryOperatorFromOgcFilter( const QDomElement &element );
+
+    /**
+     * Returns an expression node from a WFS filter embedded in a document with
+     * spatial operators.
+     */
     QgsExpressionNodeFunction *nodeSpatialOperatorFromOgcFilter( const QDomElement &element );
+
+    /**
+     * Returns an expression node from a WFS filter embedded in a document with
+     * column references.
+     */
     QgsExpressionNodeColumnRef *nodeColumnRefFromOgcFilter( const QDomElement &element );
+
+    /**
+     * Returns an expression node from a WFS filter embedded in a document with
+     * literal tag.
+     */
     QgsExpressionNode *nodeLiteralFromOgcFilter( const QDomElement &element );
+
+    /**
+     * Returns an expression node from a WFS filter embedded in a document with
+     * Not operator.
+     */
     QgsExpressionNodeUnaryOperator *nodeNotFromOgcFilter( const QDomElement &element );
+
+    /**
+     * Returns an expression node from a WFS filter embedded in a document with
+     * IsNull operator.
+     */
     QgsExpressionNodeBinaryOperator *nodePropertyIsNullFromOgcFilter( const QDomElement &element );
+
+    /**
+     * Returns an expression node from a WFS filter embedded in a document with
+     * functions.
+     */
     QgsExpressionNodeFunction *nodeFunctionFromOgcFilter( const QDomElement &element );
+
+    /**
+     * Returns an expression node from a WFS filter embedded in a document with
+     * boudnaries operator.
+     */
     QgsExpressionNode *nodeIsBetweenFromOgcFilter( const QDomElement &element );
 
   private:

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -392,7 +392,7 @@ class QgsOgcUtilsExpressionFromFilter
      * \param layer Layer to use to retrieve field values from literal filters
      */
     QgsOgcUtilsExpressionFromFilter( QgsOgcUtils::FilterVersion version = QgsOgcUtils::FILTER_OGC_1_0,
-                                     QgsVectorLayer *layer = nullptr );
+                                     const QgsVectorLayer *layer = nullptr );
 
     /**
      * Returns an expression node from a WFS filter embedded in a document
@@ -457,7 +457,7 @@ class QgsOgcUtilsExpressionFromFilter
     QgsExpressionNode *nodeIsBetweenFromOgcFilter( const QDomElement &element );
 
   private:
-    QgsVectorLayer *mLayer = nullptr;
+    const QgsVectorLayer *mLayer = nullptr;
     QString mErrorMessage;
     QString mPropertyName;
     QString mPrefix;

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -457,7 +457,6 @@ class QgsOgcUtilsExpressionFromFilter
     QgsExpressionNode *nodeIsBetweenFromOgcFilter( const QDomElement &element );
 
   private:
-    QgsOgcUtils::FilterVersion mVersion = QgsOgcUtils::FILTER_OGC_1_0;
     QgsVectorLayer *mLayer = nullptr;
     QString mErrorMessage;
     QString mPropertyName;

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -382,17 +382,17 @@ class QgsOgcUtilsExprToFilter
  * \note not available in Python bindings
  * \since QGIS 3.4
  */
-class QgsOgcUtilsExprFromFilter
+class QgsOgcUtilsExpressionFromFilter
 {
   public:
 
     /**
-     * Constructor for QgsOgcUtilsExprFromFilter.
+     * Constructor for QgsOgcUtilsExpressionFromFilter.
      * \param version WFS Version
      * \param layer Layer to use to retrieve field values from literal filters
      */
-    QgsOgcUtilsExprFromFilter( QgsOgcUtils::FilterVersion version = QgsOgcUtils::FILTER_OGC_1_0,
-                               QgsVectorLayer *layer = nullptr );
+    QgsOgcUtilsExpressionFromFilter( QgsOgcUtils::FilterVersion version = QgsOgcUtils::FILTER_OGC_1_0,
+                                     QgsVectorLayer *layer = nullptr );
 
     /**
      * Returns an expression node from a WFS filter embedded in a document


### PR DESCRIPTION
## Description

The aim of this PR is to add a basic support for building an expression from a OGC FE 2.0.

Basically, I just imitated the behavior of `QgsOgcUtilsExprToFilter` and `QgsOgcUtilsSQLStatementToFilter` to add a new class `QgsOgcUtilsExpressionFromFilter`. 

The core of parsing methods (`nodeIsBetweenFromOgcFilter`, `nodeNotFromOgcFilter`, ...) has practically not been updated, excepted for managing 2.0 specificities. 

Also, I would like to take this opportunity to improve the memory management with unique pointers.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
