### PR TITLE
Make QgsFeaturePool free of reprojection code and other improvements

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -81,6 +81,11 @@ QgsVectorLayer *QgsFeaturePool::layer() const
   return mLayer.data();
 }
 
+QPointer<QgsVectorLayer> QgsFeaturePool::layerPtr() const
+{
+  return mLayer;
+}
+
 void QgsFeaturePool::insertFeature( const QgsFeature &feature )
 {
   QgsReadWriteLocker locker( mCacheLock, QgsReadWriteLocker::Write );

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.cpp
@@ -26,13 +26,12 @@
 #include <QMutexLocker>
 
 
-QgsFeaturePool::QgsFeaturePool( QgsVectorLayer *layer, double layerToMapUnits, const QgsCoordinateTransform &layerToMapTransform )
+QgsFeaturePool::QgsFeaturePool( QgsVectorLayer *layer )
   : mFeatureCache( CACHE_SIZE )
   , mLayer( layer )
-  , mLayerToMapUnits( layerToMapUnits )
-  , mLayerToMapTransform( layerToMapTransform )
   , mLayerId( layer->id() )
   , mGeometryType( layer->geometryType() )
+  , mCrs( layer->crs() )
 {
 
 }
@@ -116,6 +115,11 @@ void QgsFeaturePool::removeFeature( const QgsFeatureId featureId )
 void QgsFeaturePool::setFeatureIds( const QgsFeatureIds &ids )
 {
   mFeatureIds = ids;
+}
+
+QgsCoordinateReferenceSystem QgsFeaturePool::crs() const
+{
+  return mCrs;
 }
 
 QgsWkbTypes::GeometryType QgsFeaturePool::geometryType() const

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -38,7 +38,7 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink
 {
 
   public:
-    QgsFeaturePool( QgsVectorLayer *layer, double layerToMapUnits, const QgsCoordinateTransform &layerToMapTransform );
+    QgsFeaturePool( QgsVectorLayer *layer );
     virtual ~QgsFeaturePool() = default;
 
     /**
@@ -73,18 +73,6 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink
     QgsFeatureIds getIntersects( const QgsRectangle &rect ) const;
 
     /**
-     * The factor of layer units to map units.
-     * TODO: should this be removed and determined on runtime by checks that need it?
-     */
-    double getLayerToMapUnits() const { return mLayerToMapUnits; }
-
-    /**
-     * A coordinate transform from layer to map CRS.
-     * TODO: should this be removed and determined on runtime by checks that need it?
-     */
-    const QgsCoordinateTransform &getLayerToMapTransform() const { return mLayerToMapTransform; }
-
-    /**
      * Get a pointer to the underlying layer.
      * May return a ``nullptr`` if the layer has been deleted.
      * This must only be called from the main thread.
@@ -100,6 +88,11 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink
      * The geometry type of this layer.
      */
     QgsWkbTypes::GeometryType geometryType() const;
+
+    /**
+     * The coordinate reference system of this layer.
+     */
+    QgsCoordinateReferenceSystem crs() const;
 
   protected:
 
@@ -135,10 +128,9 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink
     mutable QReadWriteLock mCacheLock;
     QgsFeatureIds mFeatureIds;
     QgsSpatialIndex mIndex;
-    double mLayerToMapUnits = 1.0;
-    QgsCoordinateTransform mLayerToMapTransform;
     QString mLayerId;
     QgsWkbTypes::GeometryType mGeometryType;
+    QgsCoordinateReferenceSystem mCrs;
 };
 
 #endif // QGS_FEATUREPOOL_H

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -79,6 +79,8 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink
      */
     QgsVectorLayer *layer() const;
 
+    QPointer<QgsVectorLayer> layerPtr() const;
+
     /**
      * The layer id of the layer.
      */

--- a/src/analysis/vector/geometry_checker/qgsfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsfeaturepool.h
@@ -79,6 +79,13 @@ class ANALYSIS_EXPORT QgsFeaturePool : public QgsFeatureSink
      */
     QgsVectorLayer *layer() const;
 
+    /**
+     * Get a QPointer to the underlying layer.
+     * Note that access to any methods of the object
+     * will need to be done on the main thread and
+     * the pointer will need to be checked for validity
+     * before usage.
+     */
     QPointer<QgsVectorLayer> layerPtr() const;
 
     /**

--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
@@ -20,7 +20,7 @@
 void QgsGeometryAngleCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, context() );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryanglecheck.cpp
@@ -23,7 +23,7 @@ void QgsGeometryAngleCheck::collectErrors( QList<QgsGeometryCheckError *> &error
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, context() );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )

--- a/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
@@ -21,11 +21,11 @@
 void QgsGeometryAreaCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    double layerToMapUnits = layerFeature.layerToMapUnits();
     const QgsAbstractGeometry *geom = layerFeature.geometry();
+    double layerToMapUnits = mContext->layerScaleFactor( layerFeature.layer() );
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       double value;
@@ -47,10 +47,12 @@ void QgsGeometryAreaCheck::fixError( QgsGeometryCheckError *error, int method, c
     error->setObsolete();
     return;
   }
-  double layerToMapUnits = featurePool->getLayerToMapUnits();
-  QgsGeometry g = feature.geometry();
+
+  const QgsGeometry g = feature.geometry();
   const QgsAbstractGeometry *geom = g.constGet();
   QgsVertexId vidx = error->vidx();
+
+  double layerToMapUnits = mContext->layerScaleFactor( featurePool->layer() );
 
   // Check if polygon still exists
   if ( !vidx.isValid( geom ) )

--- a/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryareacheck.cpp
@@ -24,7 +24,7 @@ void QgsGeometryAreaCheck::collectErrors( QList<QgsGeometryCheckError *> &errors
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     double layerToMapUnits = mContext->layerScaleFactor( layerFeature.layer() );
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
@@ -72,7 +72,7 @@ double QgsGeometryCheckerContext::layerScaleFactor( const QPointer<QgsVectorLaye
 }
 
 QgsGeometryCheckError::QgsGeometryCheckError( const QgsGeometryCheck *check, const QString &layerId,
-    QgsFeatureId featureId, QgsAbstractGeometry *geometry,
+    QgsFeatureId featureId, const QgsGeometry &geometry,
     const QgsPointXY &errorLocation,
     QgsVertexId vidx,
     const QVariant &value, ValueType valueType )
@@ -103,28 +103,28 @@ QgsGeometryCheckError::QgsGeometryCheckError( const QgsGeometryCheck *check,
 {
   if ( vidx.part != -1 )
   {
-    mGeometry.reset( QgsGeometryCheckerUtils::getGeomPart( layerFeature.geometry(), vidx.part )->clone() );
+    mGeometry = QgsGeometry( QgsGeometryCheckerUtils::getGeomPart( layerFeature.geometry().constGet(), vidx.part )->clone() );
   }
   else
   {
-    mGeometry.reset( layerFeature.geometry()->clone() );
+    mGeometry = layerFeature.geometry();
   }
   if ( !layerFeature.useMapCrs() )
   {
     const QgsCoordinateTransform &transform = check->context()->layerTransform( layerFeature.layer() );
-    mGeometry->transform( transform );
+    mGeometry.transform( transform );
     mErrorLocation = transform.transform( mErrorLocation );
   }
 }
 
 const QgsAbstractGeometry *QgsGeometryCheckError::geometry() const
 {
-  return mGeometry.get();
+  return mGeometry.constGet();
 }
 
 QgsRectangle QgsGeometryCheckError::affectedAreaBBox() const
 {
-  return mGeometry->boundingBox();
+  return mGeometry.boundingBox();
 }
 
 bool QgsGeometryCheckError::handleChanges( const QgsGeometryCheck::Changes &changes )

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -21,8 +21,11 @@
 #include <QApplication>
 #include <limits>
 #include <QStringList>
+#include <QPointer>
+
 #include "qgis_analysis.h"
 #include "qgsfeature.h"
+#include "qgsvectorlayer.h"
 #include "geometry/qgsgeometry.h"
 #include "qgsgeometrycheckerutils.h"
 
@@ -39,12 +42,13 @@ struct ANALYSIS_EXPORT QgsGeometryCheckerContext
     const QgsCoordinateReferenceSystem mapCrs;
     const QMap<QString, QgsFeaturePool *> featurePools;
     const QgsCoordinateTransformContext transformContext;
-    const QgsCoordinateTransform &layerTransform( QgsVectorLayer *layer );
-    double layerScaleFactor( QgsVectorLayer *layer );
+    const QgsCoordinateTransform &layerTransform( const QPointer<QgsVectorLayer> &layer );
+    double layerScaleFactor( const QPointer<QgsVectorLayer> &layer );
 
   private:
-    QMap<QgsVectorLayer *, QgsCoordinateTransform> mTransformCache;
-    QMap<QgsVectorLayer *, double> mScaleFactorCache;
+    QMap<QPointer<QgsVectorLayer>, QgsCoordinateTransform> mTransformCache;
+    QMap<QPointer<QgsVectorLayer>, double> mScaleFactorCache;
+    QReadWriteLock mCacheLock;
 };
 
 class ANALYSIS_EXPORT QgsGeometryCheck

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -33,11 +33,18 @@ class QgsFeaturePool;
 
 struct ANALYSIS_EXPORT QgsGeometryCheckerContext
 {
-  QgsGeometryCheckerContext( int _precision, const QgsCoordinateReferenceSystem &_mapCrs, const QMap<QString, QgsFeaturePool *> &_featurePools );
-  const double tolerance;
-  const double reducedTolerance;
-  const QgsCoordinateReferenceSystem mapCrs;
-  const QMap<QString, QgsFeaturePool *> featurePools;
+    QgsGeometryCheckerContext( int _precision, const QgsCoordinateReferenceSystem &_mapCrs, const QMap<QString, QgsFeaturePool *> &_featurePools, const QgsCoordinateTransformContext &transformContext );
+    const double tolerance;
+    const double reducedTolerance;
+    const QgsCoordinateReferenceSystem mapCrs;
+    const QMap<QString, QgsFeaturePool *> featurePools;
+    const QgsCoordinateTransformContext transformContext;
+    const QgsCoordinateTransform &layerTransform( QgsVectorLayer *layer );
+    double layerScaleFactor( QgsVectorLayer *layer );
+
+  private:
+    QMap<QgsVectorLayer *, QgsCoordinateTransform> mTransformCache;
+    QMap<QgsVectorLayer *, double> mScaleFactorCache;
 };
 
 class ANALYSIS_EXPORT QgsGeometryCheck

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -188,7 +188,7 @@ class ANALYSIS_EXPORT QgsGeometryCheckError
       mErrorLocation = other->mErrorLocation;
       mVidx = other->mVidx;
       mValue = other->mValue;
-      mGeometry.reset( other->mGeometry->clone() );
+      mGeometry = other->mGeometry;
     }
 
     virtual bool handleChanges( const QgsGeometryCheck::Changes &changes );
@@ -198,7 +198,7 @@ class ANALYSIS_EXPORT QgsGeometryCheckError
     QgsGeometryCheckError( const QgsGeometryCheck *check,
                            const QString &layerId,
                            QgsFeatureId featureId,
-                           QgsAbstractGeometry *geometry,
+                           const QgsGeometry &geometry,
                            const QgsPointXY &errorLocation,
                            QgsVertexId vidx = QgsVertexId(),
                            const QVariant &value = QVariant(),
@@ -207,7 +207,7 @@ class ANALYSIS_EXPORT QgsGeometryCheckError
     const QgsGeometryCheck *mCheck = nullptr;
     QString mLayerId;
     QgsFeatureId mFeatureId;
-    std::unique_ptr<QgsAbstractGeometry> mGeometry;
+    QgsGeometry mGeometry;
     QgsPointXY mErrorLocation;
     QgsVertexId mVidx;
     QVariant mValue;

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.cpp
@@ -291,3 +291,13 @@ void QgsGeometryChecker::runCheck( const QgsGeometryCheck *check )
     emit errorAdded( error );
   }
 }
+
+QgsGeometryChecker::RunCheckWrapper::RunCheckWrapper( QgsGeometryChecker *instance )
+  : mInstance( instance )
+{
+}
+
+void QgsGeometryChecker::RunCheckWrapper::operator()( const QgsGeometryCheck *check )
+{
+  mInstance->runCheck( check );
+}

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
@@ -23,6 +23,8 @@
 #include <QList>
 #include <QMutex>
 #include <QStringList>
+#include <memory>
+
 #include "qgis_analysis.h"
 #include "qgsfeatureid.h"
 
@@ -55,8 +57,12 @@ class ANALYSIS_EXPORT QgsGeometryChecker : public QObject
     class RunCheckWrapper
     {
       public:
-        explicit RunCheckWrapper( QgsGeometryChecker *instance ) : mInstance( instance ) {}
-        void operator()( const QgsGeometryCheck *check ) { mInstance->runCheck( check ); }
+
+        /**
+         * The caller needs to make sure that the context is not deleted before this thread ends.
+         */
+        explicit RunCheckWrapper( QgsGeometryChecker *instance );
+        void operator()( const QgsGeometryCheck *check );
       private:
         QgsGeometryChecker *mInstance = nullptr;
     };

--- a/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrychecker.h
@@ -23,11 +23,10 @@
 #include <QList>
 #include <QMutex>
 #include <QStringList>
-#include <memory>
-
 #include "qgis_analysis.h"
-#include "qgsfeatureid.h"
 
+typedef qint64 QgsFeatureId;
+typedef QSet<QgsFeatureId> QgsFeatureIds;
 struct QgsGeometryCheckerContext;
 class QgsGeometryCheck;
 class QgsGeometryCheckError;
@@ -57,10 +56,6 @@ class ANALYSIS_EXPORT QgsGeometryChecker : public QObject
     class RunCheckWrapper
     {
       public:
-
-        /**
-         * The caller needs to make sure that the context is not deleted before this thread ends.
-         */
         explicit RunCheckWrapper( QgsGeometryChecker *instance );
         void operator()( const QgsGeometryCheck *check );
       private:

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
@@ -35,7 +35,7 @@ namespace QgsGeometryCheckerUtils
     , mMapCrs( useMapCrs )
   {
     mGeometry = feature.geometry().constGet()->clone();
-    const QgsCoordinateTransform &transform = context->layerTransform( mFeaturePool->layer() );
+    const QgsCoordinateTransform &transform = context->layerTransform( mFeaturePool->layerPtr() );
     if ( useMapCrs && context->mapCrs.isValid() && !transform.isShortCircuited() )
     {
       mGeometry->transform( transform );
@@ -47,9 +47,14 @@ namespace QgsGeometryCheckerUtils
     delete mGeometry;
   }
 
-  QgsVectorLayer *LayerFeature::layer() const
+  QPointer<QgsVectorLayer> LayerFeature::layer() const
   {
-    return mFeaturePool->layer();
+    return mFeaturePool->layerPtr();
+  }
+
+  QString LayerFeature::layerId() const
+  {
+    return mFeaturePool->layerId();
   }
 
   QString LayerFeature::id() const

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
@@ -34,17 +34,12 @@ namespace QgsGeometryCheckerUtils
     , mFeature( feature )
     , mMapCrs( useMapCrs )
   {
-    mGeometry = feature.geometry().constGet()->clone();
+    mGeometry = feature.geometry();
     const QgsCoordinateTransform &transform = context->layerTransform( mFeaturePool->layerPtr() );
     if ( useMapCrs && context->mapCrs.isValid() && !transform.isShortCircuited() )
     {
-      mGeometry->transform( transform );
+      mGeometry.transform( transform );
     }
-  }
-
-  LayerFeature::~LayerFeature()
-  {
-    delete mGeometry;
   }
 
   QPointer<QgsVectorLayer> LayerFeature::layer() const
@@ -55,6 +50,12 @@ namespace QgsGeometryCheckerUtils
   QString LayerFeature::layerId() const
   {
     return mFeaturePool->layerId();
+  }
+
+  const QgsGeometry &LayerFeature::geometry() const
+  {
+    return mGeometry;
+
   }
 
   QString LayerFeature::id() const

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
@@ -23,22 +23,25 @@
 #include "qgsgeometrycollection.h"
 #include "qgssurface.h"
 #include "qgsvectorlayer.h"
+#include "qgsgeometrycheck.h"
 
 #include <qmath.h>
 
 namespace QgsGeometryCheckerUtils
 {
-  LayerFeature::LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, bool useMapCrs )
+  LayerFeature::LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, QgsGeometryCheckerContext *context, bool useMapCrs )
     : mFeaturePool( pool )
     , mFeature( feature )
     , mMapCrs( useMapCrs )
   {
     mGeometry = feature.geometry().constGet()->clone();
-    if ( useMapCrs && !mFeaturePool->getLayerToMapTransform().isShortCircuited() )
+    const QgsCoordinateTransform &transform = context->layerTransform( mFeaturePool->layer() );
+    if ( useMapCrs && context->mapCrs.isValid() && !transform.isShortCircuited() )
     {
-      mGeometry->transform( mFeaturePool->getLayerToMapTransform() );
+      mGeometry->transform( transform );
     }
   }
+
   LayerFeature::~LayerFeature()
   {
     delete mGeometry;
@@ -48,9 +51,6 @@ namespace QgsGeometryCheckerUtils
   {
     return mFeaturePool->layer();
   }
-
-  double LayerFeature::layerToMapUnits() const { return mFeaturePool->getLayerToMapUnits(); }
-  const QgsCoordinateTransform &LayerFeature::layerToMapTransform() const { return mFeaturePool->getLayerToMapTransform(); }
 
   QString LayerFeature::id() const
   {
@@ -75,6 +75,11 @@ namespace QgsGeometryCheckerUtils
     , mParent( parent )
   {
     nextLayerFeature( true );
+  }
+
+  bool LayerFeature::useMapCrs() const
+  {
+    return mMapCrs;
   }
   LayerFeatures::iterator::~iterator()
   {
@@ -149,7 +154,7 @@ namespace QgsGeometryCheckerUtils
       if ( featurePool->getFeature( *mFeatureIt, feature ) && feature.geometry() && feature.geometry().constGet() )
       {
         delete mCurrentFeature;
-        mCurrentFeature = new LayerFeature( mParent->mFeaturePools[*mLayerIt], feature, mParent->mUseMapCrs );
+        mCurrentFeature = new LayerFeature( mParent->mFeaturePools[*mLayerIt], feature, mParent->mContext, mParent->mUseMapCrs );
         return true;
       }
       ++mFeatureIt;
@@ -162,30 +167,35 @@ namespace QgsGeometryCheckerUtils
   LayerFeatures::LayerFeatures( const QMap<QString, QgsFeaturePool *> &featurePools,
                                 const QMap<QString, QgsFeatureIds> &featureIds,
                                 const QList<QgsWkbTypes::GeometryType> &geometryTypes,
-                                QAtomicInt *progressCounter, bool useMapCrs )
+                                QAtomicInt *progressCounter,
+                                QgsGeometryCheckerContext *context,
+                                bool useMapCrs )
     : mFeaturePools( featurePools )
     , mFeatureIds( featureIds )
     , mLayerIds( featurePools.keys() )
     , mGeometryTypes( geometryTypes )
     , mProgressCounter( progressCounter )
+    , mContext( context )
     , mUseMapCrs( useMapCrs )
   {}
 
   LayerFeatures::LayerFeatures( const QMap<QString, QgsFeaturePool *> &featurePools,
                                 const QList<QString> &layerIds, const QgsRectangle &extent,
-                                const QList<QgsWkbTypes::GeometryType> &geometryTypes )
+                                const QList<QgsWkbTypes::GeometryType> &geometryTypes,
+                                QgsGeometryCheckerContext *context )
     : mFeaturePools( featurePools )
     , mLayerIds( layerIds )
     , mExtent( extent )
     , mGeometryTypes( geometryTypes )
+    , mContext( context )
     , mUseMapCrs( true )
   {
     for ( const QString &layerId : layerIds )
     {
       const QgsFeaturePool *featurePool = featurePools[layerId];
-      if ( geometryTypes.contains( featurePool->layer()->geometryType() ) )
+      if ( geometryTypes.contains( featurePool->geometryType() ) )
       {
-        mFeatureIds.insert( layerId, featurePool->getIntersects( featurePool->getLayerToMapTransform().transform( extent, QgsCoordinateTransform::ReverseTransform ) ) );
+        mFeatureIds.insert( layerId, featurePool->getIntersects( context->layerTransform( featurePool->layer() ).transform( extent, QgsCoordinateTransform::ReverseTransform ) ) );
       }
       else
       {

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
@@ -42,6 +42,11 @@ namespace QgsGeometryCheckerUtils
     }
   }
 
+  const QgsFeature &LayerFeature::feature() const
+  {
+    return mFeature;
+  }
+
   QPointer<QgsVectorLayer> LayerFeature::layer() const
   {
     return mFeaturePool->layerPtr();
@@ -55,7 +60,6 @@ namespace QgsGeometryCheckerUtils
   const QgsGeometry &LayerFeature::geometry() const
   {
     return mGeometry;
-
   }
 
   QString LayerFeature::id() const

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
@@ -36,7 +36,8 @@ namespace QgsGeometryCheckerUtils
       LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, QgsGeometryCheckerContext *context, bool useMapCrs );
       ~LayerFeature();
       const QgsFeature &feature() const { return mFeature; }
-      QgsVectorLayer *layer() const;
+      QPointer<QgsVectorLayer> layer() const;
+      QString layerId() const;
       double layerToMapUnits() const;
       const QgsCoordinateTransform &layerToMapTransform() const;
       const QgsAbstractGeometry *geometry() const { return mGeometry; }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
@@ -26,13 +26,14 @@
 
 class QgsGeometryEngine;
 class QgsFeaturePool;
+struct QgsGeometryCheckerContext;
 
 namespace QgsGeometryCheckerUtils
 {
   class LayerFeature
   {
     public:
-      LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, bool useMapCrs );
+      LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, QgsGeometryCheckerContext *context, bool useMapCrs );
       ~LayerFeature();
       const QgsFeature &feature() const { return mFeature; }
       QgsVectorLayer *layer() const;
@@ -43,6 +44,8 @@ namespace QgsGeometryCheckerUtils
       QString id() const;
       bool operator==( const LayerFeature &other ) const;
       bool operator!=( const LayerFeature &other ) const;
+
+      bool useMapCrs() const;
 
     private:
       const QgsFeaturePool *mFeaturePool;
@@ -57,10 +60,14 @@ namespace QgsGeometryCheckerUtils
       LayerFeatures( const QMap<QString, QgsFeaturePool *> &featurePools,
                      const QMap<QString, QgsFeatureIds> &featureIds,
                      const QList<QgsWkbTypes::GeometryType> &geometryTypes,
-                     QAtomicInt *progressCounter, bool useMapCrs = false );
+                     QAtomicInt *progressCounter,
+                     QgsGeometryCheckerContext *context,
+                     bool useMapCrs = false );
+
       LayerFeatures( const QMap<QString, QgsFeaturePool *> &featurePools,
                      const QList<QString> &layerIds, const QgsRectangle &extent,
-                     const QList<QgsWkbTypes::GeometryType> &geometryTypes );
+                     const QList<QgsWkbTypes::GeometryType> &geometryTypes,
+                     QgsGeometryCheckerContext *context );
 
       class iterator
       {
@@ -91,7 +98,8 @@ namespace QgsGeometryCheckerUtils
       QgsRectangle mExtent;
       QList<QgsWkbTypes::GeometryType> mGeometryTypes;
       QAtomicInt *mProgressCounter = nullptr;
-      bool mUseMapCrs;
+      QgsGeometryCheckerContext *mContext = nullptr;
+      bool mUseMapCrs = true;
   };
 
   std::unique_ptr<QgsGeometryEngine> createGeomEngine( const QgsAbstractGeometry *geometry, double tolerance );

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
@@ -33,15 +33,44 @@ namespace QgsGeometryCheckerUtils
   class LayerFeature
   {
     public:
+
+      /**
+       * Create a new layer/feature combination.
+       * The layer is defined by \a pool, \a feature needs to be from this layer.
+       * If \a useMapCrs is True, geometries will be reprojected to the mapCrs defined
+       * in \a context.
+       */
       LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, QgsGeometryCheckerContext *context, bool useMapCrs );
-      const QgsFeature &feature() const { return mFeature; }
+
+      /**
+       * Returns the feature.
+       * The geometry will not be reprojected regardless of useMapCrs.
+       */
+      const QgsFeature &feature() const;
+
+      /**
+       * The layer.
+       */
       QPointer<QgsVectorLayer> layer() const;
+
+      /**
+       * The layer id.
+       */
       QString layerId() const;
+
+      /**
+       * Returns the geometry of this feature.
+       * If useMapCrs was specified, it will already be reprojected into the
+       * CRS specified in the context specified in the constructor.
+       */
       const QgsGeometry &geometry() const;
       QString id() const;
       bool operator==( const LayerFeature &other ) const;
       bool operator!=( const LayerFeature &other ) const;
 
+      /**
+       * Returns if the geometry is reprojected to the map CRS or not.
+       */
       bool useMapCrs() const;
 
     private:

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.h
@@ -34,14 +34,10 @@ namespace QgsGeometryCheckerUtils
   {
     public:
       LayerFeature( const QgsFeaturePool *pool, const QgsFeature &feature, QgsGeometryCheckerContext *context, bool useMapCrs );
-      ~LayerFeature();
       const QgsFeature &feature() const { return mFeature; }
       QPointer<QgsVectorLayer> layer() const;
       QString layerId() const;
-      double layerToMapUnits() const;
-      const QgsCoordinateTransform &layerToMapTransform() const;
-      const QgsAbstractGeometry *geometry() const { return mGeometry; }
-      QString geometryCrs() const { return mMapCrs ? layerToMapTransform().destinationCrs().authid() : layerToMapTransform().sourceCrs().authid(); }
+      const QgsGeometry &geometry() const;
       QString id() const;
       bool operator==( const LayerFeature &other ) const;
       bool operator!=( const LayerFeature &other ) const;
@@ -51,7 +47,7 @@ namespace QgsGeometryCheckerUtils
     private:
       const QgsFeaturePool *mFeaturePool;
       QgsFeature mFeature;
-      QgsAbstractGeometry *mGeometry = nullptr;
+      QgsGeometry mGeometry;
       bool mMapCrs;
   };
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.cpp
@@ -25,8 +25,8 @@ void QgsGeometryContainedCheck::collectErrors( QList<QgsGeometryCheckError *> &e
   QgsGeometryCheckerUtils::LayerFeatures layerFeaturesA( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureA : layerFeaturesA )
   {
-    QgsRectangle bboxA = layerFeatureA.geometry()->boundingBox();
-    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry(), mContext->tolerance );
+    QgsRectangle bboxA = layerFeatureA.geometry().boundingBox();
+    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry().constGet(), mContext->tolerance );
     if ( !geomEngineA->isValid() )
     {
       messages.append( tr( "Contained check failed for (%1): the geometry is invalid" ).arg( layerFeatureA.id() ) );
@@ -39,7 +39,7 @@ void QgsGeometryContainedCheck::collectErrors( QList<QgsGeometryCheckError *> &e
       {
         continue;
       }
-      std::unique_ptr< QgsGeometryEngine > geomEngineB = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureB.geometry(), mContext->tolerance );
+      std::unique_ptr< QgsGeometryEngine > geomEngineB = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureB.geometry().constGet(), mContext->tolerance );
       if ( !geomEngineB->isValid() )
       {
         messages.append( tr( "Contained check failed for (%1): the geometry is invalid" ).arg( layerFeatureB.id() ) );
@@ -47,9 +47,9 @@ void QgsGeometryContainedCheck::collectErrors( QList<QgsGeometryCheckError *> &e
       }
       QString errMsg;
       // If A contains B and B contains A, it would mean that the geometries are identical, which is covered by the duplicate check
-      if ( geomEngineA->contains( layerFeatureB.geometry(), &errMsg ) && !geomEngineB->contains( layerFeatureA.geometry(), &errMsg ) && errMsg.isEmpty() )
+      if ( geomEngineA->contains( layerFeatureB.geometry().constGet(), &errMsg ) && !geomEngineB->contains( layerFeatureA.geometry().constGet(), &errMsg ) && errMsg.isEmpty() )
       {
-        errors.append( new QgsGeometryContainedCheckError( this, layerFeatureB, layerFeatureB.geometry()->centroid(), layerFeatureA ) );
+        errors.append( new QgsGeometryContainedCheckError( this, layerFeatureB, layerFeatureB.geometry().constGet()->centroid(), layerFeatureA ) );
       }
       else if ( !errMsg.isEmpty() )
       {
@@ -78,10 +78,10 @@ void QgsGeometryContainedCheck::fixError( QgsGeometryCheckError *error, int meth
   QgsGeometryCheckerUtils::LayerFeature layerFeatureA( featurePoolA, featureA, mContext, true );
   QgsGeometryCheckerUtils::LayerFeature layerFeatureB( featurePoolB, featureB, mContext, true );
 
-  std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry(), mContext->tolerance );
-  std::unique_ptr< QgsGeometryEngine > geomEngineB = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureB.geometry(), mContext->tolerance );
+  std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry().constGet(), mContext->tolerance );
+  std::unique_ptr< QgsGeometryEngine > geomEngineB = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureB.geometry().constGet(), mContext->tolerance );
 
-  if ( !( geomEngineB->contains( layerFeatureA.geometry() ) && !geomEngineA->contains( layerFeatureB.geometry() ) ) )
+  if ( !( geomEngineB->contains( layerFeatureA.geometry().constGet() ) && !geomEngineA->contains( layerFeatureB.geometry().constGet() ) ) )
   {
     error->setObsolete();
     return;

--- a/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycontainedcheck.cpp
@@ -22,7 +22,7 @@
 void QgsGeometryContainedCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeaturesA( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, true );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeaturesA( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureA : layerFeaturesA )
   {
     QgsRectangle bboxA = layerFeatureA.geometry()->boundingBox();
@@ -32,7 +32,7 @@ void QgsGeometryContainedCheck::collectErrors( QList<QgsGeometryCheckError *> &e
       messages.append( tr( "Contained check failed for (%1): the geometry is invalid" ).arg( layerFeatureA.id() ) );
       continue;
     }
-    QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( mContext->featurePools, featureIds.keys(), bboxA, mCompatibleGeometryTypes );
+    QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( mContext->featurePools, featureIds.keys(), bboxA, mCompatibleGeometryTypes, mContext );
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureB : layerFeaturesB )
     {
       if ( layerFeatureA == layerFeatureB )
@@ -75,8 +75,8 @@ void QgsGeometryContainedCheck::fixError( QgsGeometryCheckError *error, int meth
   }
 
   // Check if error still applies
-  QgsGeometryCheckerUtils::LayerFeature layerFeatureA( featurePoolA, featureA, true );
-  QgsGeometryCheckerUtils::LayerFeature layerFeatureB( featurePoolB, featureB, true );
+  QgsGeometryCheckerUtils::LayerFeature layerFeatureA( featurePoolA, featureA, mContext, true );
+  QgsGeometryCheckerUtils::LayerFeature layerFeatureB( featurePoolB, featureB, mContext, true );
 
   std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry(), mContext->tolerance );
   std::unique_ptr< QgsGeometryEngine > geomEngineB = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureB.geometry(), mContext->tolerance );

--- a/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
@@ -20,7 +20,7 @@
 void QgsGeometryDangleCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();
@@ -47,7 +47,7 @@ void QgsGeometryDangleCheck::collectErrors( QList<QgsGeometryCheckError *> &erro
       }
 
       // Check whether endpoints line on another line in the layer
-      QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, QList<QString>() << layerFeature.layer()->id(), line->boundingBox(), {QgsWkbTypes::LineGeometry} );
+      QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, QList<QString>() << layerFeature.layer()->id(), line->boundingBox(), {QgsWkbTypes::LineGeometry}, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
         const QgsAbstractGeometry *testGeom = checkFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydanglecheck.cpp
@@ -23,7 +23,7 @@ void QgsGeometryDangleCheck::collectErrors( QList<QgsGeometryCheckError *> &erro
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       const QgsLineString *line = dynamic_cast<const QgsLineString *>( QgsGeometryCheckerUtils::getGeomPart( geom, iPart ) );
@@ -50,7 +50,7 @@ void QgsGeometryDangleCheck::collectErrors( QList<QgsGeometryCheckError *> &erro
       QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, QList<QString>() << layerFeature.layer()->id(), line->boundingBox(), {QgsWkbTypes::LineGeometry}, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
-        const QgsAbstractGeometry *testGeom = checkFeature.geometry();
+        const QgsAbstractGeometry *testGeom = checkFeature.geometry().constGet();
         for ( int jPart = 0, mParts = testGeom->partCount(); jPart < mParts; ++jPart )
         {
           if ( checkFeature.feature().id() == layerFeature.feature().id() && iPart == jPart )

--- a/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
@@ -22,7 +22,7 @@ void QgsGeometryDegeneratePolygonCheck::collectErrors( QList<QgsGeometryCheckErr
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )

--- a/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.cpp
@@ -19,7 +19,7 @@
 void QgsGeometryDegeneratePolygonCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatecheck.cpp
@@ -47,8 +47,8 @@ void QgsGeometryDuplicateCheck::collectErrors( QList<QgsGeometryCheckError *> &e
     // Ensure each pair of layers only gets compared once: remove the current layer from the layerIds, but add it to the layerList for layerFeaturesB
     layerIds.removeOne( layerFeatureA.layer()->id() );
 
-    QgsRectangle bboxA = layerFeatureA.geometry()->boundingBox();
-    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry(), mContext->tolerance );
+    QgsRectangle bboxA = layerFeatureA.geometry().boundingBox();
+    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry().constGet(), mContext->tolerance );
     if ( !geomEngineA->isValid() )
     {
       messages.append( tr( "Duplicate check failed for (%1): the geometry is invalid" ).arg( layerFeatureA.id() ) );
@@ -66,7 +66,7 @@ void QgsGeometryDuplicateCheck::collectErrors( QList<QgsGeometryCheckError *> &e
         continue;
       }
       QString errMsg;
-      QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( layerFeatureB.geometry(), &errMsg );
+      QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( layerFeatureB.geometry().constGet(), &errMsg );
       if ( errMsg.isEmpty() && diffGeom && diffGeom->isEmpty() )
       {
         duplicates[layerFeatureB.layer()->id()].append( layerFeatureB.feature().id() );
@@ -79,7 +79,7 @@ void QgsGeometryDuplicateCheck::collectErrors( QList<QgsGeometryCheckError *> &e
     }
     if ( !duplicates.isEmpty() )
     {
-      errors.append( new QgsGeometryDuplicateCheckError( this, layerFeatureA, layerFeatureA.geometry()->centroid(), duplicates ) );
+      errors.append( new QgsGeometryDuplicateCheckError( this, layerFeatureA, layerFeatureA.geometry().constGet()->centroid(), duplicates ) );
     }
   }
 }
@@ -101,7 +101,7 @@ void QgsGeometryDuplicateCheck::fixError( QgsGeometryCheckError *error, int meth
   else if ( method == RemoveDuplicates )
   {
     QgsGeometryCheckerUtils::LayerFeature layerFeatureA( featurePoolA, featureA, mContext, true );
-    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry(), mContext->tolerance );
+    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry().constGet(), mContext->tolerance );
 
     QgsGeometryDuplicateCheckError *duplicateError = static_cast<QgsGeometryDuplicateCheckError *>( error );
     for ( const QString &layerIdB : duplicateError->duplicates().keys() )
@@ -115,7 +115,7 @@ void QgsGeometryDuplicateCheck::fixError( QgsGeometryCheckError *error, int meth
           continue;
         }
         QgsGeometryCheckerUtils::LayerFeature layerFeatureB( featurePoolB, featureB, mContext, true );
-        QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( layerFeatureB.geometry() );
+        QgsAbstractGeometry *diffGeom = geomEngineA->symDifference( layerFeatureB.geometry().constGet() );
         if ( diffGeom && diffGeom->isEmpty() )
         {
           featurePoolB->deleteFeature( featureB.id() );

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
@@ -20,7 +20,7 @@
 void QgsGeometryDuplicateNodesCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryduplicatenodescheck.cpp
@@ -23,7 +23,7 @@ void QgsGeometryDuplicateNodesCheck::collectErrors( QList<QgsGeometryCheckError 
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )

--- a/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
@@ -46,7 +46,7 @@ void QgsGeometryFollowBoundariesCheck::collectErrors( QList<QgsGeometryCheckErro
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
 
     // The geometry to crs of the check layer
     QgsCoordinateTransform crst( layerFeature.layer()->crs(), mCheckLayer->crs(), QgsProject::instance() );

--- a/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryfollowboundariescheck.cpp
@@ -43,7 +43,7 @@ void QgsGeometryFollowBoundariesCheck::collectErrors( QList<QgsGeometryCheckErro
 
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
   featureIds.remove( mCheckLayer->id() ); // Don't check layer against itself
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -29,7 +29,7 @@ void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors,
   QVector<QgsAbstractGeometry *> geomList;
 
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, nullptr, true );
+  const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, nullptr, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     geomList.append( layerFeature.geometry()->clone() );
@@ -95,7 +95,7 @@ void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors,
 
     // Get neighboring polygons
     QMap<QString, QgsFeatureIds> neighboringIds;
-    const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds.keys(), gapAreaBBox, mCompatibleGeometryTypes );
+    const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds.keys(), gapAreaBBox, mCompatibleGeometryTypes, mContext );
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
     {
       if ( QgsGeometryCheckerUtils::sharedEdgeLength( gapGeom.get(), layerFeature.geometry(), mContext->reducedTolerance ) > 0 )
@@ -156,7 +156,7 @@ bool QgsGeometryGapCheck::mergeWithNeighbor( QgsGeometryGapCheckError *err, Chan
   {
     QgsFeaturePool *featurePool = mContext->featurePools.value( layerId );
     std::unique_ptr<QgsAbstractGeometry> errLayerGeom( errGeometry->clone() );
-    errLayerGeom->transform( featurePool->getLayerToMapTransform(), QgsCoordinateTransform::ReverseTransform );
+    errLayerGeom->transform( mContext->layerTransform( featurePool->layer() ), QgsCoordinateTransform::ReverseTransform );
 
     const auto featureIds = err->neighbors().value( layerId );
 
@@ -191,7 +191,7 @@ bool QgsGeometryGapCheck::mergeWithNeighbor( QgsGeometryGapCheckError *err, Chan
   // Merge geometries
   QgsFeaturePool *featurePool = mContext->featurePools[ mergeLayerId ];
   std::unique_ptr<QgsAbstractGeometry> errLayerGeom( errGeometry->clone() );
-  errLayerGeom->transform( featurePool->getLayerToMapTransform(), QgsCoordinateTransform::ReverseTransform );
+  errLayerGeom->transform( mContext->layerTransform( featurePool->layer() ), QgsCoordinateTransform::ReverseTransform );
   QgsGeometry mergeFeatureGeom = mergeFeature.geometry();
   const QgsAbstractGeometry *mergeGeom = mergeFeatureGeom.constGet();
   std::unique_ptr< QgsGeometryEngine > geomEngine = QgsGeometryCheckerUtils::createGeomEngine( errLayerGeom.get(), mContext->reducedTolerance );

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -32,7 +32,7 @@ void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors,
   const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, nullptr, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    geomList.append( layerFeature.geometry()->clone() );
+    geomList.append( layerFeature.geometry().constGet()->clone() );
   }
 
   if ( geomList.isEmpty() )
@@ -98,10 +98,10 @@ void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors,
     const QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds.keys(), gapAreaBBox, mCompatibleGeometryTypes, mContext );
     for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
     {
-      if ( QgsGeometryCheckerUtils::sharedEdgeLength( gapGeom.get(), layerFeature.geometry(), mContext->reducedTolerance ) > 0 )
+      if ( QgsGeometryCheckerUtils::sharedEdgeLength( gapGeom.get(), layerFeature.geometry().constGet(), mContext->reducedTolerance ) > 0 )
       {
         neighboringIds[layerFeature.layer()->id()].insert( layerFeature.feature().id() );
-        gapAreaBBox.combineExtentWith( layerFeature.geometry()->boundingBox() );
+        gapAreaBBox.combineExtentWith( layerFeature.geometry().constGet()->boundingBox() );
       }
     }
 
@@ -112,7 +112,7 @@ void QgsGeometryGapCheck::collectErrors( QList<QgsGeometryCheckError *> &errors,
 
     // Add error
     double area = gapGeom->area();
-    errors.append( new QgsGeometryGapCheckError( this, QString(), gapGeom.release(), neighboringIds, area, gapAreaBBox ) );
+    errors.append( new QgsGeometryGapCheckError( this, QString(), QgsGeometry( gapGeom.release() ), neighboringIds, area, gapAreaBBox ) );
 
   }
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.h
@@ -25,11 +25,11 @@ class ANALYSIS_EXPORT QgsGeometryGapCheckError : public QgsGeometryCheckError
   public:
     QgsGeometryGapCheckError( const QgsGeometryCheck *check,
                               const QString &layerId,
-                              QgsAbstractGeometry *geometry,
+                              const QgsGeometry &geometry,
                               const QMap<QString, QgsFeatureIds> &neighbors,
                               double area,
                               const QgsRectangle &gapAreaBBox )
-      : QgsGeometryCheckError( check, layerId, FEATUREID_NULL, geometry, geometry->centroid(), QgsVertexId(), area, ValueArea )
+      : QgsGeometryCheckError( check, layerId, FEATUREID_NULL, geometry, geometry.constGet()->centroid(), QgsVertexId(), area, ValueArea )
       , mNeighbors( neighbors )
       , mGapAreaBBox( gapAreaBBox )
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
@@ -21,7 +21,7 @@
 void QgsGeometryHoleCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryholecheck.cpp
@@ -24,7 +24,7 @@ void QgsGeometryHoleCheck::collectErrors( QList<QgsGeometryCheckError *> &errors
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       const QgsCurvePolygon *poly = dynamic_cast<const QgsCurvePolygon *>( QgsGeometryCheckerUtils::getGeomPart( geom, iPart ) );

--- a/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
@@ -27,7 +27,7 @@ void QgsGeometryLineIntersectionCheck::collectErrors( QList<QgsGeometryCheckErro
     // Ensure each pair of layers only gets compared once: remove the current layer from the layerIds, but add it to the layerList for layerFeaturesB
     layerIds.removeOne( layerFeatureA.layer()->id() );
 
-    const QgsAbstractGeometry *geom = layerFeatureA.geometry();
+    const QgsAbstractGeometry *geom = layerFeatureA.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       const QgsLineString *line = dynamic_cast<const QgsLineString *>( QgsGeometryCheckerUtils::getGeomPart( geom, iPart ) );
@@ -47,7 +47,7 @@ void QgsGeometryLineIntersectionCheck::collectErrors( QList<QgsGeometryCheckErro
           continue;
         }
 
-        const QgsAbstractGeometry *testGeom = layerFeatureB.geometry();
+        const QgsAbstractGeometry *testGeom = layerFeatureB.geometry().constGet();
         for ( int jPart = 0, mParts = testGeom->partCount(); jPart < mParts; ++jPart )
         {
           // Skip current feature part, only report intersections within same part once

--- a/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylineintersectioncheck.cpp
@@ -20,7 +20,7 @@
 void QgsGeometryLineIntersectionCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeaturesA( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, true );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeaturesA( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext, true );
   QList<QString> layerIds = featureIds.keys();
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureA : layerFeaturesA )
   {
@@ -38,7 +38,7 @@ void QgsGeometryLineIntersectionCheck::collectErrors( QList<QgsGeometryCheckErro
       }
 
       // Check whether the line intersects with any other lines
-      QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( mContext->featurePools, QList<QString>() << layerFeatureA.layer()->id() << layerIds, line->boundingBox(), {QgsWkbTypes::LineGeometry} );
+      QgsGeometryCheckerUtils::LayerFeatures layerFeaturesB( mContext->featurePools, QList<QString>() << layerFeatureA.layer()->id() << layerIds, line->boundingBox(), {QgsWkbTypes::LineGeometry}, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeatureB : layerFeaturesB )
       {
         // > : only report intersections within same layer once

--- a/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.cpp
@@ -25,7 +25,7 @@ void QgsGeometryLineLayerIntersectionCheck::collectErrors( QList<QgsGeometryChec
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       const QgsLineString *line = dynamic_cast<const QgsLineString *>( QgsGeometryCheckerUtils::getGeomPart( geom, iPart ) );
@@ -39,7 +39,7 @@ void QgsGeometryLineLayerIntersectionCheck::collectErrors( QList<QgsGeometryChec
       QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, QStringList() << mCheckLayer, line->boundingBox(), {QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry}, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
-        const QgsAbstractGeometry *testGeom = checkFeature.geometry();
+        const QgsAbstractGeometry *testGeom = checkFeature.geometry().constGet();
         for ( int jPart = 0, mParts = testGeom->partCount(); jPart < mParts; ++jPart )
         {
           const QgsAbstractGeometry *part = QgsGeometryCheckerUtils::getGeomPart( testGeom, jPart );

--- a/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrylinelayerintersectioncheck.cpp
@@ -22,7 +22,7 @@ void QgsGeometryLineLayerIntersectionCheck::collectErrors( QList<QgsGeometryChec
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
   featureIds.remove( mCheckLayer ); // Don't check layer against itself
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, true );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();
@@ -36,7 +36,7 @@ void QgsGeometryLineLayerIntersectionCheck::collectErrors( QList<QgsGeometryChec
       }
 
       // Check whether the line intersects with any other features of the specified layer
-      QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, QStringList() << mCheckLayer, line->boundingBox(), {QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry} );
+      QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, QStringList() << mCheckLayer, line->boundingBox(), {QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry}, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
         const QgsAbstractGeometry *testGeom = checkFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.cpp
@@ -22,7 +22,7 @@ void QgsGeometryMultipartCheck::collectErrors( QList<QgsGeometryCheckError *> &e
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     QgsWkbTypes::Type type = geom->wkbType();
     if ( geom->partCount() == 1 && QgsWkbTypes::isMultiType( type ) )
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.cpp
@@ -19,7 +19,7 @@
 void QgsGeometryMultipartCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.cpp
@@ -29,8 +29,8 @@ void QgsGeometryOverlapCheck::collectErrors( QList<QgsGeometryCheckError *> &err
     // Ensure each pair of layers only gets compared once: remove the current layer from the layerIds, but add it to the layerList for layerFeaturesB
     layerIds.removeOne( layerFeatureA.layer()->id() );
 
-    QgsRectangle bboxA = layerFeatureA.geometry()->boundingBox();
-    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry(), mContext->tolerance );
+    QgsRectangle bboxA = layerFeatureA.geometry().constGet()->boundingBox();
+    std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry().constGet(), mContext->tolerance );
     if ( !geomEngineA->isValid() )
     {
       messages.append( tr( "Overlap check failed for (%1): the geometry is invalid" ).arg( layerFeatureA.id() ) );
@@ -46,9 +46,9 @@ void QgsGeometryOverlapCheck::collectErrors( QList<QgsGeometryCheckError *> &err
         continue;
       }
       QString errMsg;
-      if ( geomEngineA->overlaps( layerFeatureB.geometry(), &errMsg ) )
+      if ( geomEngineA->overlaps( layerFeatureB.geometry().constGet(), &errMsg ) )
       {
-        QgsAbstractGeometry *interGeom = geomEngineA->intersection( layerFeatureB.geometry() );
+        QgsAbstractGeometry *interGeom = geomEngineA->intersection( layerFeatureB.geometry().constGet() );
         if ( interGeom && !interGeom->isEmpty() )
         {
           QgsGeometryCheckerUtils::filter1DTypes( interGeom );
@@ -58,7 +58,7 @@ void QgsGeometryOverlapCheck::collectErrors( QList<QgsGeometryCheckError *> &err
             double area = interPart->area();
             if ( area > mContext->reducedTolerance && area < overlapThreshold )
             {
-              errors.append( new QgsGeometryOverlapCheckError( this, layerFeatureA, interPart->clone(), interPart->centroid(), area, layerFeatureB ) );
+              errors.append( new QgsGeometryOverlapCheckError( this, layerFeatureA, QgsGeometry( interPart->clone() ), interPart->centroid(), area, layerFeatureB ) );
             }
           }
         }
@@ -91,14 +91,14 @@ void QgsGeometryOverlapCheck::fixError( QgsGeometryCheckError *error, int method
   // Check if error still applies
   QgsGeometryCheckerUtils::LayerFeature layerFeatureA( featurePoolA, featureA, mContext, true );
   QgsGeometryCheckerUtils::LayerFeature layerFeatureB( featurePoolB, featureB, mContext, true );
-  std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry(), mContext->reducedTolerance );
+  std::unique_ptr< QgsGeometryEngine > geomEngineA = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureA.geometry().constGet(), mContext->reducedTolerance );
 
-  if ( !geomEngineA->overlaps( layerFeatureB.geometry() ) )
+  if ( !geomEngineA->overlaps( layerFeatureB.geometry().constGet() ) )
   {
     error->setObsolete();
     return;
   }
-  std::unique_ptr< QgsAbstractGeometry > interGeom( geomEngineA->intersection( layerFeatureB.geometry(), &errMsg ) );
+  std::unique_ptr< QgsAbstractGeometry > interGeom( geomEngineA->intersection( layerFeatureB.geometry().constGet(), &errMsg ) );
   if ( !interGeom )
   {
     error->setFixFailed( tr( "Failed to compute intersection between overlapping features: %1" ).arg( errMsg ) );
@@ -139,7 +139,7 @@ void QgsGeometryOverlapCheck::fixError( QgsGeometryCheckError *error, int method
     {
       QgsGeometryCheckerUtils::filter1DTypes( diff1.get() );
     }
-    std::unique_ptr< QgsGeometryEngine > geomEngineB = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureB.geometry(), mContext->reducedTolerance );
+    std::unique_ptr< QgsGeometryEngine > geomEngineB = QgsGeometryCheckerUtils::createGeomEngine( layerFeatureB.geometry().constGet(), mContext->reducedTolerance );
     std::unique_ptr< QgsAbstractGeometry > diff2( geomEngineB->difference( interPart, &errMsg ) );
     if ( !diff2 || diff2->isEmpty() )
     {

--- a/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryoverlapcheck.h
@@ -26,7 +26,7 @@ class ANALYSIS_EXPORT QgsGeometryOverlapCheckError : public QgsGeometryCheckErro
   public:
     QgsGeometryOverlapCheckError( const QgsGeometryCheck *check,
                                   const QgsGeometryCheckerUtils::LayerFeature &layerFeature,
-                                  QgsAbstractGeometry *geometry,
+                                  const QgsGeometry &geometry,
                                   const QgsPointXY &errorLocation,
                                   const QVariant &value,
                                   const QgsGeometryCheckerUtils::LayerFeature &overlappedFeature )

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.cpp
@@ -23,7 +23,7 @@ void QgsGeometryPointCoveredByLineCheck::collectErrors( QList<QgsGeometryCheckEr
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       const QgsPoint *point = dynamic_cast<const QgsPoint *>( QgsGeometryCheckerUtils::getGeomPart( geom, iPart ) );
@@ -39,7 +39,7 @@ void QgsGeometryPointCoveredByLineCheck::collectErrors( QList<QgsGeometryCheckEr
       QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, featureIds.keys(), rect, {QgsWkbTypes::LineGeometry}, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
-        const QgsAbstractGeometry *testGeom = checkFeature.geometry();
+        const QgsAbstractGeometry *testGeom = checkFeature.geometry().constGet();
         for ( int jPart = 0, mParts = testGeom->partCount(); jPart < mParts; ++jPart )
         {
           const QgsLineString *testLine = dynamic_cast<const QgsLineString *>( QgsGeometryCheckerUtils::getGeomPart( testGeom, jPart ) );

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointcoveredbylinecheck.cpp
@@ -20,7 +20,7 @@
 void QgsGeometryPointCoveredByLineCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, true );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();
@@ -36,7 +36,7 @@ void QgsGeometryPointCoveredByLineCheck::collectErrors( QList<QgsGeometryCheckEr
       bool touches = false;
       QgsRectangle rect( point->x() - mContext->tolerance, point->y() - mContext->tolerance,
                          point->x() + mContext->tolerance, point->y() + mContext->tolerance );
-      QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, featureIds.keys(), rect, {QgsWkbTypes::LineGeometry} );
+      QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, featureIds.keys(), rect, {QgsWkbTypes::LineGeometry}, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
         const QgsAbstractGeometry *testGeom = checkFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.cpp
@@ -23,7 +23,7 @@ void QgsGeometryPointInPolygonCheck::collectErrors( QList<QgsGeometryCheckError 
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       const QgsPoint *point = dynamic_cast<const QgsPoint *>( QgsGeometryCheckerUtils::getGeomPart( geom, iPart ) );
@@ -42,7 +42,7 @@ void QgsGeometryPointInPolygonCheck::collectErrors( QList<QgsGeometryCheckError 
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
         ++nTested;
-        const QgsAbstractGeometry *testGeom = checkFeature.geometry();
+        const QgsAbstractGeometry *testGeom = checkFeature.geometry().constGet();
         std::unique_ptr< QgsGeometryEngine > testGeomEngine = QgsGeometryCheckerUtils::createGeomEngine( testGeom, mContext->reducedTolerance );
         if ( !testGeomEngine->isValid() )
         {

--- a/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrypointinpolygoncheck.cpp
@@ -20,7 +20,7 @@
 void QgsGeometryPointInPolygonCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, true );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext, true );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();
@@ -38,7 +38,7 @@ void QgsGeometryPointInPolygonCheck::collectErrors( QList<QgsGeometryCheckError 
       // Check whether point is contained by a fully contained by a polygon
       QgsRectangle rect( point->x() - mContext->tolerance, point->y() - mContext->tolerance,
                          point->x() + mContext->tolerance, point->y() + mContext->tolerance );
-      QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, featureIds.keys(), rect, {QgsWkbTypes::PolygonGeometry} );
+      QgsGeometryCheckerUtils::LayerFeatures checkFeatures( mContext->featurePools, featureIds.keys(), rect, {QgsWkbTypes::PolygonGeometry}, mContext );
       for ( const QgsGeometryCheckerUtils::LayerFeature &checkFeature : checkFeatures )
       {
         ++nTested;

--- a/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
@@ -20,10 +20,10 @@
 void QgsGeometrySegmentLengthCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    double layerToMapUnits = layerFeature.layerToMapUnits();
+    double layerToMapUnits = mContext->layerScaleFactor( layerFeature.layer() );
     double minLength = mMinLengthMapUnits / layerToMapUnits;
 
     const QgsAbstractGeometry *geom = layerFeature.geometry();
@@ -86,7 +86,7 @@ void QgsGeometrySegmentLengthCheck::fixError( QgsGeometryCheckError *error, int 
   QgsPoint pi = geom->vertexAt( error->vidx() );
   QgsPoint pj = geom->vertexAt( QgsVertexId( vidx.part, vidx.ring, ( vidx.vertex - 1 + nVerts ) % nVerts ) );
   double dist = pi.distance( pj );
-  double layerToMapUnits = featurePool->getLayerToMapUnits();
+  double layerToMapUnits = mContext->layerScaleFactor( featurePool->layer() );
   double minLength = mMinLengthMapUnits / layerToMapUnits;
   if ( dist >= minLength )
   {

--- a/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrysegmentlengthcheck.cpp
@@ -26,7 +26,7 @@ void QgsGeometrySegmentLengthCheck::collectErrors( QList<QgsGeometryCheckError *
     double layerToMapUnits = mContext->layerScaleFactor( layerFeature.layer() );
     double minLength = mMinLengthMapUnits / layerToMapUnits;
 
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
@@ -20,7 +20,7 @@
 void QgsGeometrySelfContactCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
@@ -23,7 +23,7 @@ void QgsGeometrySelfContactCheck::collectErrors( QList<QgsGeometryCheckError *> 
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
@@ -63,7 +63,7 @@ bool QgsGeometrySelfIntersectionCheckError::handleChanges( const QgsGeometryChec
 void QgsGeometrySelfIntersectionCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
@@ -66,7 +66,7 @@ void QgsGeometrySelfIntersectionCheck::collectErrors( QList<QgsGeometryCheckErro
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
     {
       for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )

--- a/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.cpp
@@ -26,7 +26,7 @@
 void QgsGeometryTypeCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
 {
   QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter );
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
     const QgsAbstractGeometry *geom = layerFeature.geometry();

--- a/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.cpp
@@ -29,7 +29,7 @@ void QgsGeometryTypeCheck::collectErrors( QList<QgsGeometryCheckError *> &errors
   QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
   for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry();
+    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
     QgsWkbTypes::Type type = QgsWkbTypes::flatType( geom->wkbType() );
     if ( ( mAllowedTypes & ( 1 << type ) ) == 0 )
     {

--- a/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
@@ -32,8 +32,8 @@ void runOnMainThread( const Func &func )
 #endif
 }
 
-QgsVectorDataProviderFeaturePool::QgsVectorDataProviderFeaturePool( QgsVectorLayer *layer, double layerToMapUnits, const QgsCoordinateTransform &layerToMapTransform, bool selectedOnly )
-  : QgsFeaturePool( layer, layerToMapUnits, layerToMapTransform )
+QgsVectorDataProviderFeaturePool::QgsVectorDataProviderFeaturePool( QgsVectorLayer *layer, bool selectedOnly )
+  : QgsFeaturePool( layer )
   , mSelectedOnly( selectedOnly )
 {
   // Build spatial index

--- a/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.h
+++ b/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.h
@@ -30,7 +30,7 @@ email                : matthias@opengis.ch
 class ANALYSIS_EXPORT QgsVectorDataProviderFeaturePool : public QgsFeaturePool
 {
   public:
-    QgsVectorDataProviderFeaturePool( QgsVectorLayer *layer, double layerToMapUnits, const QgsCoordinateTransform &layerToMapTransform, bool selectedOnly = false );
+    QgsVectorDataProviderFeaturePool( QgsVectorLayer *layer, bool selectedOnly = false );
 
     bool addFeature( QgsFeature &feature, QgsFeatureSink::Flags flags = nullptr ) override;
     bool addFeatures( QgsFeatureList &features, QgsFeatureSink::Flags flags = nullptr ) override;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -946,6 +946,7 @@ SET(QGIS_CORE_HDRS
   qgstextlabelfeature.h
   qgstextrenderer.h
   qgstextrenderer_p.h
+  qgsthreadingutils.h
   qgstracer.h
   qgstranslationcontext.h
 

--- a/src/core/qgsthreadingutils.h
+++ b/src/core/qgsthreadingutils.h
@@ -25,6 +25,8 @@
 /**
  * \ingroup core
  * Provides threading utilities for QGIS.
+ *
+ * \since QGIS 3.4
  */
 class CORE_EXPORT QgsThreadingUtils
 {

--- a/src/core/qgsthreadingutils.h
+++ b/src/core/qgsthreadingutils.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+               qgsthreadingutils.h
+                     --------------------------------------
+               Date                 : 11.9.2018
+               Copyright            : (C) 2018 by Matthias Kuhn
+               email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTHREADINGUTILS_H
+#define QGSTHREADINGUTILS_H
+
+#define SIP_NO_FILE
+
+#include "qgis_core.h"
+
+#include <QThread>
+
+/**
+ * \ingroup core
+ * Provides threading utilities for QGIS.
+ */
+class CORE_EXPORT QgsThreadingUtils
+{
+  public:
+
+    /**
+     * Guarantees that \a func is executed on the main thread. If this is called
+     * from another thread, the other thread will be blocked until the function
+     * has been executed.
+     * This is useful to quickly access information from objects that live on the
+     * main thread and copying this information into worker threads. Avoid running
+     * expensive code inside \a func.
+     *
+     * \note Only works with Qt >= 5.10, earlier versions will execute the code
+     *       in the worker thread.
+     *
+     * \since QGIS 3.4
+     */
+    template <typename Func>
+    static void runOnMainThread( const Func &func )
+    {
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
+      // Make sure we only deal with the vector layer on the main thread where it lives.
+      // Anything else risks a crash.
+      if ( QThread::currentThread() == qApp->thread() )
+        func();
+      else
+        QMetaObject::invokeMethod( qApp, func, Qt::BlockingQueuedConnection );
+#else
+      func();
+#endif
+    }
+
+};
+
+
+#endif

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -24,6 +24,7 @@
 #include "qgsrelationmanager.h"
 #include "qgsfeedback.h"
 #include "qgsvectorlayer.h"
+#include "qgsthreadingutils.h"
 
 QgsFeatureIterator QgsVectorLayerUtils::getValuesIterator( const QgsVectorLayer *layer, const QString &fieldOrExpression, bool &ok, bool selectedOnly )
 {
@@ -516,16 +517,7 @@ std::unique_ptr<QgsVectorLayerFeatureSource> QgsVectorLayerUtils::getFeatureSour
     }
   };
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 10, 0 )
-  // Make sure we only deal with the vector layer on the main thread where it lives.
-  // Anything else risks a crash.
-  if ( QThread::currentThread() == qApp->thread() )
-    getFeatureSource();
-  else
-    QMetaObject::invokeMethod( qApp, getFeatureSource, Qt::BlockingQueuedConnection );
-#else
-  getFeatureSource();
-#endif
+  QgsThreadingUtils::runOnMainThread( getFeatureSource );
 
   return featureSource;
 }

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -415,21 +415,17 @@ void QgsGeometryCheckerSetupTab::runChecks()
   QMap<QString, QgsFeaturePool *> featurePools;
   for ( QgsVectorLayer *layer : qgis::as_const( processLayers ) )
   {
-    double layerToMapUntis = mIface->mapCanvas()->mapSettings().layerToMapUnits( layer );
-    QgsCoordinateTransform layerToMapTransform( layer->crs(), QgsProject::instance()->crs(), QgsProject::instance() );
-    featurePools.insert( layer->id(), new QgsVectorDataProviderFeaturePool( layer, layerToMapUntis, layerToMapTransform, selectedOnly ) );
+    featurePools.insert( layer->id(), new QgsVectorDataProviderFeaturePool( layer, selectedOnly ) );
   }
   // LineLayerIntersection check is enabled, make sure there is also a feature pool for that layer
   if ( ui.checkLineLayerIntersection->isChecked() && !featurePools.keys().contains( ui.comboLineLayerIntersection->currentData().toString() ) )
   {
     QgsVectorLayer *layer = dynamic_cast<QgsVectorLayer *>( QgsProject::instance()->mapLayer( ui.comboLineLayerIntersection->currentData().toString() ) );
     Q_ASSERT( layer );
-    double layerToMapUntis = mIface->mapCanvas()->mapSettings().layerToMapUnits( layer );
-    QgsCoordinateTransform layerToMapTransform( layer->crs(), QgsProject::instance()->crs(), QgsProject::instance() );
-    featurePools.insert( layer->id(), new QgsVectorDataProviderFeaturePool( layer, layerToMapUntis, layerToMapTransform, selectedOnly ) );
+    featurePools.insert( layer->id(), new QgsVectorDataProviderFeaturePool( layer, selectedOnly ) );
   }
 
-  QgsGeometryCheckerContext *context = new QgsGeometryCheckerContext( ui.spinBoxTolerance->value(), QgsProject::instance()->crs(), featurePools );
+  QgsGeometryCheckerContext *context = new QgsGeometryCheckerContext( ui.spinBoxTolerance->value(), QgsProject::instance()->crs(), featurePools, QgsProject::instance()->transformContext() );
 
   QList<QgsGeometryCheck *> checks;
   for ( const QgsGeometryCheckFactory *factory : QgsGeometryCheckFactoryRegistry::getCheckFactories() )

--- a/tests/src/geometry_checker/testqgsgeometrychecks.cpp
+++ b/tests/src/geometry_checker/testqgsgeometrychecks.cpp
@@ -57,7 +57,7 @@ class TestQgsGeometryChecks: public QObject
       QgsVertexId vidx;
     };
     double layerToMapUnits( const QgsMapLayer *layer, const QgsCoordinateReferenceSystem &mapCrs ) const;
-    QgsFeaturePool *createFeaturePool( QgsVectorLayer *layer, const QgsCoordinateReferenceSystem &mapCrs, bool selectedOnly = false ) const;
+    QgsFeaturePool *createFeaturePool( QgsVectorLayer *layer, bool selectedOnly = false ) const;
     QgsGeometryCheckerContext *createTestContext( QTemporaryDir &tempDir, QMap<QString, QString> &layers, const QgsCoordinateReferenceSystem &mapCrs = QgsCoordinateReferenceSystem( "EPSG:4326" ), double prec = 8 ) const;
     void cleanupTestContext( QgsGeometryCheckerContext *ctx ) const;
     void listErrors( const QList<QgsGeometryCheckError *> &checkErrors, const QStringList &messages ) const;
@@ -972,11 +972,9 @@ double TestQgsGeometryChecks::layerToMapUnits( const QgsMapLayer *layer, const Q
   return distMapUnits / distLayerUnits;
 }
 
-QgsFeaturePool *TestQgsGeometryChecks::createFeaturePool( QgsVectorLayer *layer, const QgsCoordinateReferenceSystem &mapCrs, bool selectedOnly ) const
+QgsFeaturePool *TestQgsGeometryChecks::createFeaturePool( QgsVectorLayer *layer, bool selectedOnly ) const
 {
-  double layerToMapUntis = layerToMapUnits( layer, mapCrs );
-  QgsCoordinateTransform layerToMapTransform = QgsCoordinateTransform( layer->crs(), mapCrs, QgsProject::instance() );
-  return new QgsVectorDataProviderFeaturePool( layer, layerToMapUntis, layerToMapTransform, selectedOnly );
+  return new QgsVectorDataProviderFeaturePool( layer, selectedOnly );
 }
 
 QgsGeometryCheckerContext *TestQgsGeometryChecks::createTestContext( QTemporaryDir &tempDir, QMap<QString, QString> &layers, const QgsCoordinateReferenceSystem &mapCrs, double prec ) const
@@ -1000,9 +998,9 @@ QgsGeometryCheckerContext *TestQgsGeometryChecks::createTestContext( QTemporaryD
     Q_ASSERT( layer && layer->isValid() );
     layers[layerFile] = layer->id();
     layer->dataProvider()->enterUpdateMode();
-    featurePools.insert( layer->id(), createFeaturePool( layer, mapCrs ) );
+    featurePools.insert( layer->id(), createFeaturePool( layer ) );
   }
-  return new QgsGeometryCheckerContext( prec, mapCrs, featurePools );
+  return new QgsGeometryCheckerContext( prec, mapCrs, featurePools, QgsProject::instance()->transformContext() );
 }
 
 void TestQgsGeometryChecks::cleanupTestContext( QgsGeometryCheckerContext *ctx ) const


### PR DESCRIPTION
The feature pool does not store (and never did store) any reprojected geometries. Since this is all handled outside of the feature pool, it makes more sense to store reprojection information there.

This also introduces a couple of other fixes

 * `Q_ASSERT` to check that the raw feature pointer in the fature pool is only accessed from the main thread.
 * Several multi threading fixes to access layer properties
 * Some docstrings
 * A `QgsThreadingUtils::runOnMainThread` function to run any lambda on the main thread (@nyalldawson this is the single point to introduce pre-5.10 code for invokeMethod if you want to ;) )
 * Usage of implicitly shared `QgsGeometry` instead of raw `QgsAbstractGeometry` pointers where possible.