### PR TITLE
[FEATURE] Layer tree view indicator for non-removable (required) layers

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -709,6 +709,7 @@
         <file>themes/default/mDockify.svg</file>
         <file>themes/default/mActionReverseLine.svg</file>
         <file>themes/default/mActionAdd3DMap.svg</file>
+        <file>themes/default/mIndicatorNonRemovable.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mIndicatorNonRemovable.svg
+++ b/images/themes/default/mIndicatorNonRemovable.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="mIndicatorLocked.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3200"
+     inkscape:window-height="1633"
+     id="namedview10"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="17.357518"
+     inkscape:cy="6.7658225"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg8" />
+  <path
+     style="fill:none;stroke:#2c2c2c;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0.70588235"
+     inkscape:connector-curvature="0"
+     d="M 4.474418,7.9 C 4.592418,4.082 5.4064688,1.769 8.2774688,2.002 11.147468,2.234 11.657875,4.082 11.537875,7.9"
+     id="path2"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     d="m 4.3264688,9.451 0.116,-2.135 c 0.12,-3.818 0.95,-5.59 3.82,-5.358 C 11.132468,2.19 11.778468,4.081 11.659468,7.9 l -0.085,1.551"
+     id="path4" />
+  <rect
+     y="8.2999992"
+     x="2.5"
+     width="11"
+     ry="1"
+     rx="0.84600002"
+     height="7"
+     id="rect6"
+     style="fill:#ffffff;stroke:#2c2c2c;stroke-linecap:square;stroke-opacity:0.70588235;fill-opacity:1" />
+</svg>

--- a/python/core/auto_generated/qgsmaplayer.sip.in
+++ b/python/core/auto_generated/qgsmaplayer.sip.in
@@ -1380,6 +1380,17 @@ Emitted when the layer's metadata is changed.
 .. versionadded:: 3.0
 %End
 
+    void flagsChanged();
+%Docstring
+Emitted when layer's flags have been modified.
+
+.. seealso:: :py:func:`setFlags`
+
+.. seealso:: :py:func:`flags`
+
+.. versionadded:: 3.4
+%End
+
   protected:
 
     void clone( QgsMapLayer *layer ) const;

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(QGIS_APP_SRCS
   qgslayertreeviewembeddedindicator.cpp
   qgslayertreeviewfilterindicator.cpp
   qgslayertreeviewmemoryindicator.cpp
+  qgslayertreeviewnonremovableindicator.cpp
   qgsloadstylefromdbdialog.cpp
   qgsmapcanvasdockwidget.cpp
   qgsmaplayerstyleguiutils.cpp
@@ -281,6 +282,7 @@ SET (QGIS_APP_MOC_HDRS
   qgslayertreeviewembeddedindicator.h
   qgslayertreeviewmemoryindicator.h
   qgslayertreeviewfilterindicator.h
+  qgslayertreeviewnonremovableindicator.h
   qgsloadstylefromdbdialog.h
   qgsmapcanvasdockwidget.h
   qgsmaplayerstyleguiutils.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -204,6 +204,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayertreeviewembeddedindicator.h"
 #include "qgslayertreeviewfilterindicator.h"
 #include "qgslayertreeviewmemoryindicator.h"
+#include "qgslayertreeviewnonremovableindicator.h"
 #include "qgslayout.h"
 #include "qgslayoutatlas.h"
 #include "qgslayoutcustomdrophandler.h"
@@ -3873,6 +3874,7 @@ void QgisApp::initLayerTreeView()
   new QgsLayerTreeViewFilterIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewEmbeddedIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewMemoryIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
+  new QgsLayerTreeViewNonRemovableIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
 
   setupLayerTreeViewFromSettings();
 

--- a/src/app/qgslayertreeviewnonremovableindicator.cpp
+++ b/src/app/qgslayertreeviewnonremovableindicator.cpp
@@ -24,7 +24,7 @@ QgsLayerTreeViewNonRemovableIndicatorProvider::QgsLayerTreeViewNonRemovableIndic
   : QObject( view )
   , mLayerTreeView( view )
 {
-  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/lockedGray.svg" ) );
+  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorNonRemovable.svg" ) );
 
   QgsLayerTree *tree = mLayerTreeView->layerTreeModel()->rootGroup();
   onAddedChildren( tree, 0, tree->children().count() - 1 );

--- a/src/app/qgslayertreeviewnonremovableindicator.cpp
+++ b/src/app/qgslayertreeviewnonremovableindicator.cpp
@@ -1,0 +1,165 @@
+/***************************************************************************
+  qgslayertreeviewnonremovableindicator.cpp
+  --------------------------------------
+  Date                 : Sep 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayertreeviewnonremovableindicator.h"
+
+#include "qgslayertree.h"
+#include "qgslayertreemodel.h"
+#include "qgslayertreeview.h"
+
+
+QgsLayerTreeViewNonRemovableIndicatorProvider::QgsLayerTreeViewNonRemovableIndicatorProvider( QgsLayerTreeView *view )
+  : QObject( view )
+  , mLayerTreeView( view )
+{
+  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/lockedGray.svg" ) );
+
+  QgsLayerTree *tree = mLayerTreeView->layerTreeModel()->rootGroup();
+  onAddedChildren( tree, 0, tree->children().count() - 1 );
+
+  connect( tree, &QgsLayerTree::addedChildren, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onAddedChildren );
+  connect( tree, &QgsLayerTree::willRemoveChildren, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onWillRemoveChildren );
+}
+
+void QgsLayerTreeViewNonRemovableIndicatorProvider::onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+{
+  // recursively connect to providers' dataChanged() signal
+
+  QList<QgsLayerTreeNode *> children = node->children();
+  for ( int i = indexFrom; i <= indexTo; ++i )
+  {
+    QgsLayerTreeNode *childNode = children[i];
+
+    if ( QgsLayerTree::isGroup( childNode ) )
+    {
+      onAddedChildren( childNode, 0, childNode->children().count() - 1 );
+    }
+    else if ( QgsLayerTree::isLayer( childNode ) )
+    {
+      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
+      if ( QgsMapLayer *layer = childLayerNode->layer() )
+      {
+        connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
+        addOrRemoveIndicator( childLayerNode, layer );
+      }
+      else if ( !childLayerNode->layer() )
+      {
+        // wait for layer to be loaded (e.g. when loading project, first the tree is loaded, afterwards the references to layers are resolved)
+        connect( childLayerNode, &QgsLayerTreeLayer::layerLoaded, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onLayerLoaded );
+      }
+    }
+  }
+}
+
+
+void QgsLayerTreeViewNonRemovableIndicatorProvider::onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+{
+  // recursively disconnect from providers' dataChanged() signal
+
+  QList<QgsLayerTreeNode *> children = node->children();
+  for ( int i = indexFrom; i <= indexTo; ++i )
+  {
+    QgsLayerTreeNode *childNode = children[i];
+
+    if ( QgsLayerTree::isGroup( childNode ) )
+    {
+      onWillRemoveChildren( childNode, 0, childNode->children().count() - 1 );
+    }
+    else if ( QgsLayerTree::isLayer( childNode ) )
+    {
+      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
+      if ( childLayerNode->layer() )
+        disconnect( childLayerNode->layer(), &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
+    }
+  }
+}
+
+
+void QgsLayerTreeViewNonRemovableIndicatorProvider::onLayerLoaded()
+{
+  QgsLayerTreeLayer *nodeLayer = qobject_cast<QgsLayerTreeLayer *>( sender() );
+  if ( !nodeLayer )
+    return;
+
+  if ( QgsMapLayer *layer = nodeLayer->layer() )
+  {
+    connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
+    addOrRemoveIndicator( nodeLayer, layer );
+  }
+}
+
+void QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged()
+{
+  QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( sender() );
+  if ( !layer )
+    return;
+
+  // walk the tree and find layer node that needs to be updated
+  const QList<QgsLayerTreeLayer *> layerNodes = mLayerTreeView->layerTreeModel()->rootGroup()->findLayers();
+  for ( QgsLayerTreeLayer *node : layerNodes )
+  {
+    if ( node->layer() && node->layer() == layer )
+    {
+      addOrRemoveIndicator( node, layer );
+      break;
+    }
+  }
+}
+
+
+std::unique_ptr<QgsLayerTreeViewIndicator> QgsLayerTreeViewNonRemovableIndicatorProvider::newIndicator()
+{
+  std::unique_ptr< QgsLayerTreeViewIndicator > indicator = qgis::make_unique< QgsLayerTreeViewIndicator >( this );
+  indicator->setIcon( mIcon );
+  indicator->setToolTip( tr( "Layer required by the project" ) );
+  mIndicators.insert( indicator.get() );
+  return indicator;
+}
+
+void QgsLayerTreeViewNonRemovableIndicatorProvider::addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer )
+{
+  bool removable = layer->flags() & QgsMapLayer::Removable;
+  if ( !removable )
+  {
+    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
+
+    // maybe the indicator exists already
+    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
+    {
+      if ( mIndicators.contains( indicator ) )
+        return;
+    }
+
+    // it does not exist: need to create a new one
+    mLayerTreeView->addIndicator( node, newIndicator().release() );
+  }
+  else
+  {
+    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
+
+    // there may be existing indicator we need to get rid of
+    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
+    {
+      if ( mIndicators.contains( indicator ) )
+      {
+        mLayerTreeView->removeIndicator( node, indicator );
+        indicator->deleteLater();
+        return;
+      }
+    }
+
+    // no indicator was there before, nothing to do
+  }
+}

--- a/src/app/qgslayertreeviewnonremovableindicator.h
+++ b/src/app/qgslayertreeviewnonremovableindicator.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+  qgslayertreeviewnonremovableindicator.h
+  --------------------------------------
+  Date                 : Sep 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERTREEVIEWNONREMOVABLEINDICATOR_H
+#define QGSLAYERTREEVIEWNONREMOVABLEINDICATOR_H
+
+#include "qgslayertreeviewindicator.h"
+
+#include <QSet>
+#include <memory>
+
+class QgsLayerTreeNode;
+class QgsLayerTreeView;
+class QgsMapLayer;
+
+class QgsLayerTreeViewNonRemovableIndicatorProvider : public QObject
+{
+    Q_OBJECT
+  public:
+    explicit QgsLayerTreeViewNonRemovableIndicatorProvider( QgsLayerTreeView *view );
+
+  private slots:
+    //! Connects to signals of layers newly added to the tree
+    void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+    //! Disconnects from layers about to be removed from the tree
+    void onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+    //! Starts listening to layer provider's dataChanged signal
+    void onLayerLoaded();
+    void onFlagsChanged();
+
+  private:
+    std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator();
+    void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer );
+
+  private:
+    QgsLayerTreeView *mLayerTreeView = nullptr;
+    QIcon mIcon;
+    QSet<QgsLayerTreeViewIndicator *> mIndicators;
+};
+
+
+#endif // QGSLAYERTREEVIEWNONREMOVABLEINDICATOR_H

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -406,6 +406,7 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement,  QgsReadWriteCo
   // flags
   QDomElement flagsElem = layerElement.firstChildElement( QStringLiteral( "flags" ) );
   QMetaEnum metaEnum = QMetaEnum::fromType<QgsMapLayer::LayerFlag>();
+  LayerFlags flags = mFlags;
   for ( int idx = 0; idx < metaEnum.keyCount(); ++idx )
   {
     const char *enumKey = metaEnum.key( idx );
@@ -414,11 +415,12 @@ bool QgsMapLayer::readLayerXml( const QDomElement &layerElement,  QgsReadWriteCo
       continue;
     bool flagValue = flagNode.toElement().text() == "1" ? true : false;
     QgsMapLayer::LayerFlag enumValue = static_cast<QgsMapLayer::LayerFlag>( metaEnum.keyToValue( enumKey ) );
-    if ( mFlags.testFlag( enumValue ) && !flagValue )
-      mFlags &= ~enumValue;
-    else if ( !mFlags.testFlag( enumValue ) && flagValue )
-      mFlags |= enumValue;
+    if ( flags.testFlag( enumValue ) && !flagValue )
+      flags &= ~enumValue;
+    else if ( !flags.testFlag( enumValue ) && flagValue )
+      flags |= enumValue;
   }
+  setFlags( flags );
 
   return true;
 } // bool QgsMapLayer::readLayerXML

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -151,7 +151,11 @@ QgsMapLayer::LayerFlags QgsMapLayer::flags() const
 
 void QgsMapLayer::setFlags( QgsMapLayer::LayerFlags flags )
 {
+  if ( flags == mFlags )
+    return;
+
   mFlags = flags;
+  emit flagsChanged();
 }
 
 QString QgsMapLayer::id() const

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -1200,6 +1200,14 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void metadataChanged();
 
+    /**
+     * Emitted when layer's flags have been modified.
+     * \see setFlags()
+     * \see flags()
+     * \since QGIS 3.4
+     */
+    void flagsChanged();
+
   private slots:
 
     void onNotifiedTriggerRepaint( const QString &message );


### PR DESCRIPTION
It makes it easier for the user understand that the layers are marked as such in project properties.

![image](https://user-images.githubusercontent.com/193367/45356866-d9f91f80-b5c4-11e8-9cb9-b3eb820a5b27.png)

I am thinking of adding a parent class for layer-based indicators to lower the amount of duplicate code. Or maybe even merge all layer-based indicator providers into one? Not sure.

cc @ghtmtt 