### PR TITLE
fix #19825 where MultipleLayers python widget stays empty

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -639,11 +639,14 @@ class MultipleLayerWidgetWrapper(WidgetWrapper):
                 [QgsProcessingOutputRasterLayer,
                  QgsProcessingOutputMapLayer,
                  QgsProcessingOutputMultipleLayers])
-        elif self.parameterDefinition().layerType() == QgsProcessing.TypeVector:
-            options = self.dialog.getAvailableValuesOfType((QgsProcessingParameterFeatureSource,
+        elif self.parameterDefinition().layerType() == QgsProcessing.TypeMapLayer:
+            options = self.dialog.getAvailableValuesOfType((QgsProcessingParameterRasterLayer,
+                                                            QgsProcessingParameterFeatureSource,
                                                             QgsProcessingParameterVectorLayer,
                                                             QgsProcessingParameterMultipleLayers),
-                                                           [QgsProcessingOutputVectorLayer,
+                                                           [QgsProcessingOutputRasterLayer,
+                                                            QgsProcessingOutputVectorLayer,
+                                                            QgsProcessingOutputMapLayer,
                                                             QgsProcessingOutputMultipleLayers])
         else:
             options = self.dialog.getAvailableValuesOfType(QgsProcessingParameterFile, QgsProcessingOutputFile)


### PR DESCRIPTION
## Description
Fixes as small bug in the Processing modeler where MultipleLayerWidget doesn't show other layers from the model if type is TypeMapLayer.

Looks like a small mistake in the code as the condition `elif self.parameterDefinition().layerType() == QgsProcessing.TypeVector:` in `python/plugins/processing/gui/wrappers.py:642` is duplicated.

Please review carefully as I just started looking it that area of the code.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
