### PR TITLE
fix #19824 where modifications to project models were not saved

### DIFF
--- a/python/plugins/processing/tests/ProjectProvider.py
+++ b/python/plugins/processing/tests/ProjectProvider.py
@@ -100,6 +100,13 @@ class ProjectProviderTest(unittest.TestCase):
         self.assertEqual(len(provider.algorithms()), 1)
         self.assertEqual(provider.algorithms()[0].name(), 'test name2')
 
+        # overwrite model
+        alg2b = QgsProcessingModelAlgorithm('test name2', 'test group2')
+        alg2b.setHelpContent({'test': 'test'})
+        provider.add_model(alg2b)
+        self.assertEqual(len(provider.algorithms()), 1)
+        self.assertEqual(provider.algorithms()[0].helpContent(), {'test': 'test'})
+
         provider.remove_model(alg2)
         self.assertEqual(len(provider.algorithms()), 0)
 


### PR DESCRIPTION
## Description
Fix #19824 where modifications to project models were not saved.

The fix includes a small refactoring to use a dict instead of a list to store the algorithms in the project provider. This makes it easier to get a reference to the algorithm by name.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
