### PR TITLE
[Bugfix][Server][WFS] correctly define field type and encode values

### DIFF
--- a/src/server/qgswfsserver.h
+++ b/src/server/qgswfsserver.h
@@ -136,6 +136,9 @@ class QgsWFSServer: public QgsOWSServer
     QDomElement createFeatureGML3( QgsFeature* feat, QDomDocument& doc, int prec, QgsCoordinateReferenceSystem& crs, const QgsAttributeList& attrIndexes,
                                    const QgsAttributeList& pkAttributes = QgsAttributeList() ) /*const*/;
 
+    //methods to encode value to string for text node
+    QString encodeValueToText( const QVariant& value );
+
     void addTransactionResult( QDomDocument& responseDoc, QDomElement& responseElem, const QString& status, const QString& locator, const QString& message );
 };
 


### PR DESCRIPTION
## Description

In schema document (.xsd) provided by WFS DescribeFeatureType request:
* Replace `double` by `decimal`
* Use `int`, `unsignedInt`, `long` and `unsignedLong` for `QVariant::Int`, `QVariant::UInt`, `QVariant::LongLong` and `QVariant::ULongLong`
* Define double with 0 precision to `integer`

And define `encodeValueToText` method to correctly format field values to XML text node.
## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
