### PR TITLE
[BUGFIX][DbManager] SQL Layer: fix unique combo setting

### DIFF
--- a/python/plugins/db_manager/dlg_sql_layer_window.py
+++ b/python/plugins/db_manager/dlg_sql_layer_window.py
@@ -161,9 +161,8 @@ class DlgSqlLayerWindow(QWidget, Ui_Dialog):
                         item.setCheckState(Qt.Checked)
             else:
                 keyColumn = uri.keyColumn()
-                for item in self.uniqueModel.findItems("*", Qt.MatchWildcard):
-                    if item.data() == keyColumn:
-                        self.uniqueCombo.setCurrentIndex(self.uniqueModel.indexFromItem(item).row())
+                if self.uniqueModel.findItems(keyColumn):
+                    self.uniqueCombo.setEditText(keyColumn)
 
         # Finally layer name, filter and selectAtId
         self.layerNameEdit.setText(layer.name())


### PR DESCRIPTION
## Description

When opening *Update SQL layer*, the unique combobox is not well set specifically with oracle.

Funded by Ifremer

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
