### PR TITLE
Check layer pointer for validity

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12054,7 +12054,7 @@ void QgisApp::legendLayerSelectionChanged()
   bool removeEnabled = true;
   for ( QgsLayerTreeLayer *nodeLayer : selectedLayers )
   {
-    if ( !nodeLayer->layer()->flags().testFlag( QgsMapLayer::Removable ) )
+    if ( nodeLayer->layer() && !nodeLayer->layer()->flags().testFlag( QgsMapLayer::Removable ) )
     {
       removeEnabled = false;
       break;


### PR DESCRIPTION
Followup https://github.com/qgis/QGIS/pull/7815

Based on stacktrace here:
https://github.com/opengisch/quick_attribution/issues/5#issuecomment-420639624

There is an attempt to call a method on a layer pointer even though the pointer has not been resolved before. I assume this happens as soon as any QgsMapLayerComboBox is visible while loading a project.

On my test project here, removal is still disabled on the (one and only) layer in the project.