### PR TITLE
Add option to save QgsProject locally when saving to postgres failed

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14096,11 +14096,21 @@ void QgisApp::populateProjectStorageMenu( QMenu *menu, bool saving )
           }
           else
           {
-            QMessageBox::critical( this,
-                                   tr( "Unable to save project %1" ).arg( uri ),
-                                   QgsProject::instance()->error(),
-                                   QMessageBox::Ok,
-                                   Qt::NoButton );
+            QMessageBox msgbox;
+
+            msgbox.setWindowTitle( tr( "Unable to save project %1" ).arg( uri ) );
+            msgbox.setText( QgsProject::instance()->error() );
+            msgbox.setIcon( QMessageBox::Icon::Critical );
+            msgbox.addButton( QMessageBox::Cancel );
+            msgbox.addButton( QMessageBox::Save );
+            msgbox.setButtonText( QMessageBox::Save, tr( "Save as local file" ) );
+            msgbox.setDefaultButton( QMessageBox::Cancel );
+            msgbox.exec();
+
+            if ( msgbox.result() == QMessageBox::Save )
+            {
+              fileSaveAs();
+            }
           }
         }
       } );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -14098,12 +14098,12 @@ void QgisApp::populateProjectStorageMenu( QMenu *menu, bool saving )
           {
             QMessageBox msgbox;
 
-            msgbox.setWindowTitle( tr( "Unable to save project %1" ).arg( uri ) );
+            msgbox.setWindowTitle( tr( "Save Project" ) );
             msgbox.setText( QgsProject::instance()->error() );
             msgbox.setIcon( QMessageBox::Icon::Critical );
             msgbox.addButton( QMessageBox::Cancel );
             msgbox.addButton( QMessageBox::Save );
-            msgbox.setButtonText( QMessageBox::Save, tr( "Save as local file" ) );
+            msgbox.setButtonText( QMessageBox::Save, tr( "Save as Local File" ) );
             msgbox.setDefaultButton( QMessageBox::Cancel );
             msgbox.exec();
 

--- a/src/providers/postgres/qgspostgresprojectstorage.cpp
+++ b/src/providers/postgres/qgspostgresprojectstorage.cpp
@@ -161,7 +161,7 @@ bool QgsPostgresProjectStorage::writeProject( const QString &uri, QIODevice *dev
     QgsPostgresResult res( conn->PQexec( sql ) );
     if ( res.PQresultStatus() != PGRES_COMMAND_OK )
     {
-      QString errCause = QObject::tr( "Unable to save project. It's not possible to create the destination table on the database. Maybe this is due to database permissions (user=%1). Please contact your database admin" ).arg( projectUri.connInfo.username() );
+      QString errCause = QObject::tr( "Unable to save project. It's not possible to create the destination table on the database. Maybe this is due to database permissions (user=%1). Please contact your database admin." ).arg( projectUri.connInfo.username() );
       context.pushMessage( errCause, Qgis::Critical );
       QgsPostgresConnPool::instance()->releaseConnection( conn );
       return false;
@@ -189,7 +189,7 @@ bool QgsPostgresProjectStorage::writeProject( const QString &uri, QIODevice *dev
   QgsPostgresResult res( conn->PQexec( sql ) );
   if ( res.PQresultStatus() != PGRES_COMMAND_OK )
   {
-    QString errCause = QObject::tr( "Unable to insert or update project (project=%1) in the destination table on the database. Maybe this is due to table permissions (user=%2). Please contact your database admin" ).arg( projectUri.projectName, projectUri.connInfo.username() );
+    QString errCause = QObject::tr( "Unable to insert or update project (project=%1) in the destination table on the database. Maybe this is due to table permissions (user=%2). Please contact your database admin." ).arg( projectUri.projectName, projectUri.connInfo.username() );
     context.pushMessage( errCause, Qgis::Critical );
     QgsPostgresConnPool::instance()->releaseConnection( conn );
     return false;


### PR DESCRIPTION
Add option to save QgsProject locally when saving to postgres failed

![save_as_project](https://user-images.githubusercontent.com/804608/45435114-2705f000-b6b0-11e8-8567-5067e922fc3b.gif)
