### PR TITLE
Fix crash when adding feature to non-spatial layer

### DIFF
--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -83,7 +83,7 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
   }
 
   QgsVectorLayer *layer = currentVectorLayer();
-  if ( mSnapToLayerGridEnabled && layer )
+  if ( mSnapToGridCanvasItem && mSnapToLayerGridEnabled && layer )
   {
     e->snapToGrid( layer->geometryFixes()->geometryPrecision(), layer->crs() );
   }
@@ -108,7 +108,7 @@ void QgsMapToolAdvancedDigitizing::canvasMoveEvent( QgsMapMouseEvent *e )
   }
 
   QgsVectorLayer *layer = currentVectorLayer();
-  if ( mSnapToLayerGridEnabled && layer )
+  if ( mSnapToGridCanvasItem && mSnapToLayerGridEnabled && layer )
   {
     e->snapToGrid( layer->geometryFixes()->geometryPrecision(), layer->crs() );
     mSnapToGridCanvasItem->setPoint( e->mapPoint() );


### PR DESCRIPTION
I assumed that map tools will only receive events if `active()` was called before. The assumption has proven wrong.
CC @signedav 