### PR TITLE
Append raster layer to GeoPackage

### DIFF
--- a/python/gui/auto_generated/qgsrasterlayersaveasdialog.sip.in
+++ b/python/gui/auto_generated/qgsrasterlayersaveasdialog.sip.in
@@ -54,6 +54,7 @@ Constructor for QgsRasterLayerSaveAsDialog
     bool tileMode() const;
     bool addToCanvas() const;
     QString outputFileName() const;
+    QString outputLayerName() const;
     QString outputFormat() const;
     QgsCoordinateReferenceSystem outputCrs();
     QStringList createOptions() const;
@@ -71,6 +72,7 @@ Constructor for QgsRasterLayerSaveAsDialog
 
   public slots:
     virtual void accept();
+
 
 };
 

--- a/python/gui/auto_generated/qgsrasterlayersaveasdialog.sip.in
+++ b/python/gui/auto_generated/qgsrasterlayersaveasdialog.sip.in
@@ -54,7 +54,13 @@ Constructor for QgsRasterLayerSaveAsDialog
     bool tileMode() const;
     bool addToCanvas() const;
     QString outputFileName() const;
+
     QString outputLayerName() const;
+%Docstring
+Name of the output layer within GeoPackage file
+
+.. versionadded:: 3.4
+%End
     QString outputFormat() const;
     QgsCoordinateReferenceSystem outputCrs();
     QStringList createOptions() const;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7156,13 +7156,16 @@ void QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer )
   bool tileMode = d.tileMode();
   bool addToCanvas = d.addToCanvas();
   QPointer< QgsRasterLayer > rlWeakPointer( rasterLayer );
+  QString outputLayerName = d.outputLayerName();
+  QString outputFormat = d.outputFormat();
 
   QgsRasterFileWriterTask *writerTask = new QgsRasterFileWriterTask( fileWriter, pipe.release(), d.nColumns(), d.nRows(),
       d.outputRectangle(), d.outputCrs() );
 
   // when writer is successful:
 
-  connect( writerTask, &QgsRasterFileWriterTask::writeComplete, this, [this, tileMode, addToCanvas, rlWeakPointer ]( const QString & newFilename )
+  connect( writerTask, &QgsRasterFileWriterTask::writeComplete, this,
+           [this, tileMode, addToCanvas, rlWeakPointer, outputLayerName, outputFormat]( const QString & newFilename )
   {
     QString fileName = newFilename;
     if ( tileMode )
@@ -7173,7 +7176,14 @@ void QgisApp::saveAsRasterFile( QgsRasterLayer *rasterLayer )
 
     if ( addToCanvas )
     {
-      addRasterLayers( QStringList( fileName ) );
+      if ( outputFormat == QLatin1String( "GPKG" ) && !outputLayerName.isEmpty() )
+      {
+        addRasterLayers( QStringList( QStringLiteral( "GPKG:%1:%2" ).arg( fileName, outputLayerName ) ) );
+      }
+      else
+      {
+        addRasterLayers( QStringList( fileName ) );
+      }
     }
     if ( rlWeakPointer )
       emit layerSavedAs( rlWeakPointer, fileName );
@@ -12811,7 +12821,17 @@ bool QgisApp::addRasterLayers( QStringList const &fileNameQStringList, bool guiW
       QFileInfo myFileInfo( *myIterator );
 
       // try to create the layer
-      QgsRasterLayer *layer = addRasterLayerPrivate( *myIterator, myFileInfo.completeBaseName(),
+      // set the layer name to the file base name...
+      QString layerName = myFileInfo.completeBaseName();
+
+      // ...unless the layer uri matches "GPKG:filePath:layerName" and layerName differs from the file base name
+      QStringList layerUriSegments = myIterator->split( QLatin1String( ":" ) );
+      if ( layerUriSegments.count() == 3 && layerUriSegments[ 0 ] ==  QLatin1String( "GPKG" ) && layerUriSegments[ 2 ] != layerName )
+      {
+        layerName = QStringLiteral( "%1 %2" ).arg( layerName, layerUriSegments[ 2 ] );
+      }
+
+      QgsRasterLayer *layer = addRasterLayerPrivate( *myIterator, layerName,
                               QString(), guiWarning, true );
       if ( layer && layer->isValid() )
       {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12820,17 +12820,17 @@ bool QgisApp::addRasterLayers( QStringList const &fileNameQStringList, bool guiW
     {
       QFileInfo myFileInfo( *myIterator );
 
-      // try to create the layer
       // set the layer name to the file base name...
       QString layerName = myFileInfo.completeBaseName();
 
-      // ...unless the layer uri matches "GPKG:filePath:layerName" and layerName differs from the file base name
-      const QStringList layerUriSegments = myIterator->split( QLatin1String( ":" ) );
-      if ( layerUriSegments.count() == 3 && layerUriSegments[ 0 ] ==  QLatin1String( "GPKG" ) && layerUriSegments[ 2 ] != layerName )
+      // ...unless provided explicitly
+      const QVariantMap uriDetails = QgsProviderRegistry::instance()->decodeUri( QStringLiteral( "gdal" ), *myIterator );
+      if ( !uriDetails[ QStringLiteral( "layerName" ) ].toString().isEmpty() )
       {
-        layerName = QStringLiteral( "%1 %2" ).arg( layerName, layerUriSegments[ 2 ] );
+        layerName = uriDetails[ QStringLiteral( "layerName" ) ].toString();
       }
 
+      // try to create the layer
       QgsRasterLayer *layer = addRasterLayerPrivate( *myIterator, layerName,
                               QString(), guiWarning, true );
       if ( layer && layer->isValid() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -12825,7 +12825,7 @@ bool QgisApp::addRasterLayers( QStringList const &fileNameQStringList, bool guiW
       QString layerName = myFileInfo.completeBaseName();
 
       // ...unless the layer uri matches "GPKG:filePath:layerName" and layerName differs from the file base name
-      QStringList layerUriSegments = myIterator->split( QLatin1String( ":" ) );
+      const QStringList layerUriSegments = myIterator->split( QLatin1String( ":" ) );
       if ( layerUriSegments.count() == 3 && layerUriSegments[ 0 ] ==  QLatin1String( "GPKG" ) && layerUriSegments[ 2 ] != layerName )
       {
         layerName = QStringLiteral( "%1 %2" ).arg( layerName, layerUriSegments[ 2 ] );

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -441,7 +441,7 @@ QStringList QgsRasterLayerSaveAsDialog::createOptions() const
       indx = options.indexOf( QRegExp( "^APPEND_SUBDATASET=.*", Qt::CaseInsensitive ) );
       if ( indx > -1 )
       {
-        options.replace ( indx, QStringLiteral( "APPEND_SUBDATASET=YES" ) );
+        options.replace( indx, QStringLiteral( "APPEND_SUBDATASET=YES" ) );
       }
       else
       {

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -321,12 +321,15 @@ void QgsRasterLayerSaveAsDialog::mFormatComboBox_currentIndexChanged( const QStr
   }
   mFilename->setFilter( filter );
 
+  // Disable mTileModeCheckBox for GeoPackages
+  mTileModeCheckBox->setEnabled( outputFormat() != QStringLiteral( "GPKG" ) );
   mFilename->setConfirmOverwrite( outputFormat() != QStringLiteral( "GPKG" ) );
   mLayerName->setEnabled( outputFormat() == QStringLiteral( "GPKG" ) );
   if ( mLayerName->isEnabled() )
   {
     QString layerName = QFileInfo( mFilename->filePath() ).baseName();
     mLayerName->setText( layerName );
+    mTileModeCheckBox->setChecked( false );
   }
   else
   {

--- a/src/gui/qgsrasterlayersaveasdialog.h
+++ b/src/gui/qgsrasterlayersaveasdialog.h
@@ -71,6 +71,7 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     bool tileMode() const;
     bool addToCanvas() const;
     QString outputFileName() const;
+    QString outputLayerName() const;
     QString outputFormat() const;
     QgsCoordinateReferenceSystem outputCrs();
     QStringList createOptions() const;
@@ -87,7 +88,7 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     void hideOutput();
 
   public slots:
-    void accept() override { if ( validate() ) QDialog::accept(); }
+    void accept() override;
 
   private slots:
     void mRawModeRadioButton_toggled( bool );
@@ -138,6 +139,7 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     double noDataCellValue( int row, int column ) const;
     void adjustNoDataCellWidth( int row, int column );
     bool validate() const;
+    bool outputLayerExistsInGpkg() const;
 
     void insertAvailableOutputFormats();
 };

--- a/src/gui/qgsrasterlayersaveasdialog.h
+++ b/src/gui/qgsrasterlayersaveasdialog.h
@@ -71,6 +71,10 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     bool tileMode() const;
     bool addToCanvas() const;
     QString outputFileName() const;
+    /**
+     * Name of the output layer within GeoPackage file.
+     * \since QGIS 3.4
+     */
     QString outputLayerName() const;
     QString outputFormat() const;
     QgsCoordinateReferenceSystem outputCrs();
@@ -139,7 +143,7 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     double noDataCellValue( int row, int column ) const;
     void adjustNoDataCellWidth( int row, int column );
     bool validate() const;
-    // Returns true if the output layer already exists in a GeoPackage file.
+    // Returns true if the output layer already exists in the GeoPackage file.
     bool outputLayerExistsInGpkg() const;
 
     void insertAvailableOutputFormats();

--- a/src/gui/qgsrasterlayersaveasdialog.h
+++ b/src/gui/qgsrasterlayersaveasdialog.h
@@ -71,8 +71,9 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     bool tileMode() const;
     bool addToCanvas() const;
     QString outputFileName() const;
+
     /**
-     * Name of the output layer within GeoPackage file.
+     * Name of the output layer within GeoPackage file
      * \since QGIS 3.4
      */
     QString outputLayerName() const;
@@ -143,8 +144,8 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     double noDataCellValue( int row, int column ) const;
     void adjustNoDataCellWidth( int row, int column );
     bool validate() const;
-    // Returns true if the output layer already exists in the GeoPackage file.
-    bool outputLayerExistsInGpkg() const;
+    // Returns true if the output layer already exists.
+    bool outputLayerExists() const;
 
     void insertAvailableOutputFormats();
 };

--- a/src/gui/qgsrasterlayersaveasdialog.h
+++ b/src/gui/qgsrasterlayersaveasdialog.h
@@ -139,6 +139,7 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     double noDataCellValue( int row, int column ) const;
     void adjustNoDataCellWidth( int row, int column );
     bool validate() const;
+    // Returns true if the output layer already exists in a GeoPackage file.
     bool outputLayerExistsInGpkg() const;
 
     void insertAvailableOutputFormats();

--- a/src/ui/qgsrasterlayersaveasdialogbase.ui
+++ b/src/ui/qgsrasterlayersaveasdialogbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>575</width>
-    <height>580</height>
+    <height>610</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -86,7 +86,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
        <property name="focusPolicy">
         <enum>Qt::StrongFocus</enum>
@@ -118,7 +118,7 @@ datasets with maximum width and height specified below.</string>
        </item>
       </layout>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_2">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -147,7 +147,7 @@ datasets with maximum width and height specified below.</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0" colspan="2">
+     <item row="5" column="0" colspan="2">
       <widget class="QCheckBox" name="mAddToCanvas">
        <property name="text">
         <string>Add saved file to map</string>
@@ -156,6 +156,16 @@ datasets with maximum width and height specified below.</string>
         <bool>true</bool>
        </property>
       </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Layer name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLineEdit" name="mLayerName"/>
      </item>
     </layout>
    </item>
@@ -716,6 +726,7 @@ datasets with maximum width and height specified below.</string>
   <tabstop>mFormatComboBox</tabstop>
   <tabstop>mTileModeCheckBox</tabstop>
   <tabstop>mFilename</tabstop>
+  <tabstop>mLayerName</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mAddToCanvas</tabstop>
   <tabstop>mScrollArea</tabstop>


### PR DESCRIPTION
Currently, the *Save Raster Layer as* dialog tends to overwrite the whole GeoPackage file, and you need to tweak the creation options every time in order to append a new table to an existing file (see https://issues.qgis.org/issues/17926).   

This PR introduces a new field ``Layer name``, only enabled for GeoPackages and working exactly like the one for vector gpkg layers (it's set from the file widget by default, then you can edit the name):

![zrzut_20180912_225951](https://user-images.githubusercontent.com/1000043/45453053-f63daf00-b6df-11e8-9d54-8d6240ff6085.png)

Basically it sets the RASTER_TABLE and APPEND_SUBDATASET options (quietly, without enabling the options widget, and it overwrites these options if already set in the widget). 

Only new layers can be appended. If the target layer already exists, the present behaviour is used, so the whole file must be overwritten:

![zrzut_20180912_231055](https://user-images.githubusercontent.com/1000043/45453831-3b62e080-b6e2-11e8-9035-f691c40a2500.png)

I also disabled the ``Create VRT`` checkbox if the format is GeoPackage to avoid mess with the layer uri. I don't see any point in creating virtual rasters from GeoPackages anyway :)

This whole solution is a bit tricky and for sure it would be better to refactor all the involved classes, but it's all I managed to invent in reasonable time to free 3.4 from wiping out our beloved gpkg files. What do you think?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
