### PR TITLE
[FEATURE] 3D identify tool working on 3D entities

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolidentify.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolidentify.sip.in
@@ -158,6 +158,11 @@ Call the right method depending on layer type
     bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, QgsPointXY point, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
     bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point );
 
+    QMap< QString, QString > derivedAttributesForPoint( const QgsPoint &point );
+%Docstring
+Returns derived attributes map for a clicked point in map coordinates. May be 2D or 3D point.
+%End
+
 };
 
 QFlags<QgsMapToolIdentify::Type> operator|(QgsMapToolIdentify::Type f1, QFlags<QgsMapToolIdentify::Type> f2);

--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -56,6 +56,7 @@ SET(QGIS_3D_MOC_HDRS
   qgscameracontroller.h
   qgslayoutitem3dmap.h
   qgsoffscreen3dengine.h
+  qgstessellatedpolygongeometry.h
   qgswindow3dengine.h
 
   chunks/qgschunkedentity_p.h

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -24,6 +24,7 @@ namespace Qt3DRender
 {
   class QRenderSettings;
   class QCamera;
+  class QPickEvent;
 }
 
 namespace Qt3DLogic
@@ -39,6 +40,7 @@ namespace Qt3DExtras
 class QgsAbstract3DEngine;
 class QgsMapLayer;
 class QgsCameraController;
+class Qgs3DMapScenePickHandler;
 class Qgs3DMapSettings;
 class QgsTerrainEntity;
 class QgsChunkedEntity;
@@ -76,6 +78,11 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Returns the current state of the scene
     SceneState sceneState() const { return mSceneState; }
 
+    //! Registers an object that will get results of pick events on 3D entities. Does not take ownerhip of the pick handler. Adds object picker components to 3D entities.
+    void registerPickHandler( Qgs3DMapScenePickHandler *pickHandler );
+    //! Unregisters previously registered pick handler. Pick handler is not deleted. Also removes object picker components from 3D entities.
+    void unregisterPickHandler( Qgs3DMapScenePickHandler *pickHandler );
+
   signals:
     //! Emitted when the current terrain entity is replaced by a new one
     void terrainEntityChanged();
@@ -92,6 +99,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     void onLayersChanged();
     void createTerrainDeferred();
     void onBackgroundColorChanged();
+    void onLayerEntityPickEvent( Qt3DRender::QPickEvent *event );
 
   private:
     void addLayerEntity( QgsMapLayer *layer );
@@ -116,6 +124,8 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     QMap<QgsMapLayer *, Qt3DCore::QEntity *> mLayerEntities;
     bool mTerrainUpdateScheduled = false;
     SceneState mSceneState = Ready;
+    //! List of currently registered pick handlers (used by identify tool)
+    QList<Qgs3DMapScenePickHandler *> mPickHandlers;
 };
 
 #endif // QGS3DMAPSCENE_H

--- a/src/3d/qgs3dmapscene.h
+++ b/src/3d/qgs3dmapscene.h
@@ -78,7 +78,7 @@ class _3D_EXPORT Qgs3DMapScene : public Qt3DCore::QEntity
     //! Returns the current state of the scene
     SceneState sceneState() const { return mSceneState; }
 
-    //! Registers an object that will get results of pick events on 3D entities. Does not take ownerhip of the pick handler. Adds object picker components to 3D entities.
+    //! Registers an object that will get results of pick events on 3D entities. Does not take ownership of the pick handler. Adds object picker components to 3D entities.
     void registerPickHandler( Qgs3DMapScenePickHandler *pickHandler );
     //! Unregisters previously registered pick handler. Pick handler is not deleted. Also removes object picker components from 3D entities.
     void unregisterPickHandler( Qgs3DMapScenePickHandler *pickHandler );

--- a/src/3d/qgs3dmapscenepickhandler.h
+++ b/src/3d/qgs3dmapscenepickhandler.h
@@ -1,3 +1,18 @@
+/***************************************************************************
+  qgs3dmapscenepickhandler.h
+  --------------------------------------
+  Date                 : Sep 2018
+  Copyright            : (C) 2018 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #ifndef QGS3DMAPSCENEPICKHANDLER_H
 #define QGS3DMAPSCENEPICKHANDLER_H
 
@@ -19,7 +34,7 @@ class QgsVectorLayer;
 class Qgs3DMapScenePickHandler
 {
   public:
-    virtual ~Qgs3DMapScenePickHandler() {}
+    virtual ~Qgs3DMapScenePickHandler() = default;
 
     //! Called when user clicked a 3D entity belonging to a feature of a vector layer
     virtual void handlePickOnVectorLayer( QgsVectorLayer *vlayer, QgsFeatureId id, const QVector3D &worldIntersection ) = 0;

--- a/src/3d/qgs3dmapscenepickhandler.h
+++ b/src/3d/qgs3dmapscenepickhandler.h
@@ -1,0 +1,28 @@
+#ifndef QGS3DMAPSCENEPICKHANDLER_H
+#define QGS3DMAPSCENEPICKHANDLER_H
+
+#include "qgsfeatureid.h"
+
+class QVector3D;
+class QgsVectorLayer;
+
+/**
+ * \ingroup 3d
+ * Abstract base class for handlers that process pick events from a 3D map scene.
+ * 3D entities in map scene get QObjectPicker components assigned and mouse press events trigger virtual methods
+ * or pick handlers.
+ *
+ * This is used for identify tool to be able to identify entities coming from 3D renderers assigned to map layers.
+ *
+ * \since QGIS 3.4
+ */
+class Qgs3DMapScenePickHandler
+{
+  public:
+    virtual ~Qgs3DMapScenePickHandler() {}
+
+    //! Called when user clicked a 3D entity belonging to a feature of a vector layer
+    virtual void handlePickOnVectorLayer( QgsVectorLayer *vlayer, QgsFeatureId id, const QVector3D &worldIntersection ) = 0;
+};
+
+#endif // QGS3DMAPSCENEPICKHANDLER_H

--- a/src/3d/qgstessellatedpolygongeometry.cpp
+++ b/src/3d/qgstessellatedpolygongeometry.cpp
@@ -114,7 +114,7 @@ static int binary_search( uint v, const uint *data, int count )
 }
 
 
-QgsFeatureId QgsTessellatedPolygonGeometry::triangleIndexToFeatureId( uint triangleIndex )
+QgsFeatureId QgsTessellatedPolygonGeometry::triangleIndexToFeatureId( uint triangleIndex ) const
 {
   int i = binary_search( triangleIndex, mTriangleIndexStartingIndices.constData(), mTriangleIndexStartingIndices.count() );
   Q_ASSERT( i != -1 );

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -16,6 +16,7 @@
 #ifndef QGSTESSELLATEDPOLYGONGEOMETRY_H
 #define QGSTESSELLATEDPOLYGONGEOMETRY_H
 
+#include "qgsfeatureid.h"
 #include "qgspolygon.h"
 
 #include <Qt3DRender/QGeometry>
@@ -36,6 +37,7 @@ namespace Qt3DRender
  */
 class QgsTessellatedPolygonGeometry : public Qt3DRender::QGeometry
 {
+    Q_OBJECT
   public:
     //! Constructor
     QgsTessellatedPolygonGeometry( QNode *parent = nullptr );
@@ -58,13 +60,19 @@ class QgsTessellatedPolygonGeometry : public Qt3DRender::QGeometry
     void setAddBackFaces( bool add ) { mAddBackFaces = add; }
 
     //! Initializes vertex buffer from given polygons. Takes ownership of passed polygon geometries
-    void setPolygons( const QList<QgsPolygon *> &polygons, const QgsPointXY &origin, float extrusionHeight, const QList<float> &extrusionHeightPerPolygon = QList<float>() );
+    void setPolygons( const QList<QgsPolygon *> &polygons, const QList<QgsFeatureId> &featureIds, const QgsPointXY &origin, float extrusionHeight, const QList<float> &extrusionHeightPerPolygon = QList<float>() );
+
+    //! Returns ID of the feature to which given triangle index belongs (used for picking)
+    QgsFeatureId triangleIndexToFeatureId( uint triangleIndex );
 
   private:
 
     Qt3DRender::QAttribute *mPositionAttribute = nullptr;
     Qt3DRender::QAttribute *mNormalAttribute = nullptr;
     Qt3DRender::QBuffer *mVertexBuffer = nullptr;
+
+    QVector<QgsFeatureId> mTriangleIndexFids;
+    QVector<uint> mTriangleIndexStartingIndices;
 
     bool mWithNormals = true;
     bool mInvertNormals = false;

--- a/src/3d/qgstessellatedpolygongeometry.h
+++ b/src/3d/qgstessellatedpolygongeometry.h
@@ -63,7 +63,7 @@ class QgsTessellatedPolygonGeometry : public Qt3DRender::QGeometry
     void setPolygons( const QList<QgsPolygon *> &polygons, const QList<QgsFeatureId> &featureIds, const QgsPointXY &origin, float extrusionHeight, const QList<float> &extrusionHeightPerPolygon = QList<float>() );
 
     //! Returns ID of the feature to which given triangle index belongs (used for picking)
-    QgsFeatureId triangleIndexToFeatureId( uint triangleIndex );
+    QgsFeatureId triangleIndexToFeatureId( uint triangleIndex ) const;
 
   private:
 

--- a/src/app/3d/qgs3dmaptoolidentify.cpp
+++ b/src/app/3d/qgs3dmaptoolidentify.cpp
@@ -60,9 +60,8 @@ Qgs3DMapToolIdentify::Qgs3DMapToolIdentify( Qgs3DMapCanvas *canvas )
   mPickHandler.reset( new Qgs3DMapToolIdentifyPickHandler( this ) );
 }
 
-Qgs3DMapToolIdentify::~Qgs3DMapToolIdentify()
-{
-}
+Qgs3DMapToolIdentify::~Qgs3DMapToolIdentify() = default;
+
 
 void Qgs3DMapToolIdentify::mousePressEvent( QMouseEvent *event )
 {

--- a/src/app/3d/qgs3dmaptoolidentify.h
+++ b/src/app/3d/qgs3dmaptoolidentify.h
@@ -18,10 +18,14 @@
 
 #include "qgs3dmaptool.h"
 
+#include <memory>
+
 namespace Qt3DRender
 {
   class QPickEvent;
 }
+
+class Qgs3DMapToolIdentifyPickHandler;
 
 
 class Qgs3DMapToolIdentify : public Qgs3DMapTool
@@ -30,6 +34,7 @@ class Qgs3DMapToolIdentify : public Qgs3DMapTool
 
   public:
     Qgs3DMapToolIdentify( Qgs3DMapCanvas *canvas );
+    ~Qgs3DMapToolIdentify() override;
 
     void mousePressEvent( QMouseEvent *event ) override;
     void mouseReleaseEvent( QMouseEvent *event ) override { Q_UNUSED( event );}
@@ -43,7 +48,9 @@ class Qgs3DMapToolIdentify : public Qgs3DMapTool
     void onTerrainEntityChanged();
 
   private:
+    std::unique_ptr<Qgs3DMapToolIdentifyPickHandler> mPickHandler;
 
+    friend class Qgs3DMapToolIdentifyPickHandler;
 };
 
 #endif // QGS3DMAPTOOLIDENTIFY_H

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -222,6 +222,19 @@ void QgsMapToolIdentifyAction::clearResults()
   resultsDialog()->clear();
 }
 
+void QgsMapToolIdentifyAction::showResultsForFeature( QgsVectorLayer *vlayer, QgsFeatureId fid, const QgsPoint &pt )
+{
+  QgsFeature feature = vlayer->getFeature( fid );
+  QMap< QString, QString > derivedAttributes = derivedAttributesForPoint( pt );
+  // TODO: private in QgsMapToolIdentify
+  //derivedAttributes.unite( featureDerivedAttributes( feature, vlayer, QgsPointXY( pt ) ) );
+
+  resultsDialog()->addFeature( IdentifyResult( vlayer, feature, derivedAttributes ) );
+  resultsDialog()->show();
+  // update possible view modes
+  resultsDialog()->updateViewModes();
+}
+
 QgsUnitTypes::DistanceUnit QgsMapToolIdentifyAction::displayDistanceUnits() const
 {
   return QgsProject::instance()->distanceUnits();

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -65,6 +65,8 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
     void identifyAndShowResults( const QgsGeometry &geom );
     //! Clears any previous results from the GUI
     void clearResults();
+    //! Looks up feature by its ID and outputs the result in GUI
+    void showResultsForFeature( QgsVectorLayer *vlayer, QgsFeatureId fid, const QgsPoint &pt );
 
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );

--- a/src/core/qgstessellator.cpp
+++ b/src/core/qgstessellator.cpp
@@ -542,7 +542,7 @@ QgsPoint getPointFromData( QVector< float >::const_iterator &it )
 
 int QgsTessellator::dataVerticesCount() const
 {
-  return mData.size() / 3;
+  return mData.size() / ( mAddNormals ? 6 : 3 );
 }
 
 std::unique_ptr<QgsMultiPolygon> QgsTessellator::asMultiPolygon() const

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -215,6 +215,16 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
   return identifyVectorLayer( results, layer, QgsGeometry::fromPointXY( point ) );
 }
 
+QMap<QString, QString> QgsMapToolIdentify::derivedAttributesForPoint( const QgsPoint &point )
+{
+  QMap< QString, QString > derivedAttributes;
+  derivedAttributes.insert( tr( "(clicked coordinate X)" ), formatXCoordinate( point ) );
+  derivedAttributes.insert( tr( "(clicked coordinate Y)" ), formatYCoordinate( point ) );
+  if ( point.is3D() )
+    derivedAttributes.insert( tr( "(clicked coordinate Z)" ), QString::number( point.z(), 'f' ) );
+  return derivedAttributes;
+}
+
 bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsGeometry &geometry )
 {
   if ( !layer || !layer->isSpatial() )
@@ -239,8 +249,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<QgsMapToolIdentify::Identify
     isPointOrRectangle = true;
     point = selectionGeom.asPoint();
 
-    commonDerivedAttributes.insert( tr( "(clicked coordinate X)" ), formatXCoordinate( point ) );
-    commonDerivedAttributes.insert( tr( "(clicked coordinate Y)" ), formatYCoordinate( point ) );
+    commonDerivedAttributes = derivedAttributesForPoint( QgsPoint( point ) );
   }
   else
   {
@@ -649,8 +658,7 @@ bool QgsMapToolIdentify::identifyRasterLayer( QList<IdentifyResult> *results, Qg
     identifyResult = dprovider->identify( point, format, viewExtent, width, height );
   }
 
-  derivedAttributes.insert( tr( "(clicked coordinate X)" ), formatXCoordinate( pointInCanvasCrs ) );
-  derivedAttributes.insert( tr( "(clicked coordinate Y)" ), formatYCoordinate( pointInCanvasCrs ) );
+  derivedAttributes.unite( derivedAttributesForPoint( QgsPoint( pointInCanvasCrs ) ) );
 
   if ( identifyResult.isValid() )
   {

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -165,6 +165,9 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, QgsPointXY point, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
     bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point );
 
+    //! Returns derived attributes map for a clicked point in map coordinates. May be 2D or 3D point.
+    QMap< QString, QString > derivedAttributesForPoint( const QgsPoint &point );
+
   private:
 
     bool identifyLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMapLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType = AllLayers );


### PR DESCRIPTION
Until now the tool only considered terrain. This commit adds support
for 3D renderers created from vector layers, so it is possible to
correctly identify polygons and linestrings in 3D.

In other words, you can pick a building extruded from its footprint or some other piece of a 3D geometry of a vector layer and it will magically work :-)

Founded by Politecnico di Torino, Dipartimento di Ingegneria dell'Ambiente, del Territorio e delle Infrastrutture (DIATI) within RESCULT project in collaboration with Faunalia