### PR TITLE
[ux] Make tag combobox in symbol selector non-editable

### DIFF
--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -100,7 +100,7 @@
         </size>
        </property>
        <property name="editable">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
There doesn't seem to be any reason to support edits here -- entering any text which doesn't exist in the combobox results in an empty list

This PR refers to this combobox:

![image](https://user-images.githubusercontent.com/1829991/45460587-e48cf380-b741-11e8-9552-c427d7309db5.png)
