### PR TITLE
A couple of format-specific string to map expression functions

### DIFF
--- a/python/core/auto_generated/qgshstoreutils.sip.in
+++ b/python/core/auto_generated/qgshstoreutils.sip.in
@@ -1,0 +1,35 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgshstoreutils.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+%ModuleHeaderCode
+#include "qgshstoreutils.h"
+%End
+
+namespace QgsHstoreUtils
+{
+
+  QVariantMap parse( const QString &string );
+%Docstring
+Returns a QVariantMap object containing the key and values from a hstore-formatted string.
+
+:param string: The hstored-formatted string
+
+.. versionadded:: 3.4
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgshstoreutils.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -57,6 +57,7 @@
 %Include auto_generated/qgsgeometryfixes.sip
 %Include auto_generated/qgsgeometrysimplifier.sip
 %Include auto_generated/qgshistogram.sip
+%Include auto_generated/qgshstoreutils.sip
 %Include auto_generated/qgshtmlutils.sip
 %Include auto_generated/qgsinterval.sip
 %Include auto_generated/qgsjsonutils.sip

--- a/resources/function_help/json/hstore_to_map
+++ b/resources/function_help/json/hstore_to_map
@@ -1,0 +1,9 @@
+{
+  "name": "hstore_to_map",
+  "type": "function",
+  "description": "Creates a map from a hstore-formatted string.",
+  "arguments": [
+    {"arg":"string", "description":"the input string"}],
+  "examples": [ { "expression":"hstore_to_map('qgis=>rocks')", "returns":"{ \"qgis\" : \"rocks\" }"}
+  ]
+}

--- a/resources/function_help/json/json_to_map
+++ b/resources/function_help/json/json_to_map
@@ -1,0 +1,9 @@
+{
+  "name": "json_to_map",
+  "type": "function",
+  "description": "Creates a map from a json-formatted string.",
+  "arguments": [
+    {"arg":"string", "description":"the input string"}],
+  "examples": [ { "expression":"json_to_map('{\"qgis\":\"rocks\"}')", "returns":"{ \"qgis\" : \"rocks\" }"}
+  ]
+}

--- a/resources/function_help/json/map_to_hstore
+++ b/resources/function_help/json/map_to_hstore
@@ -1,0 +1,9 @@
+{
+  "name": "map_to_hstore",
+  "type": "function",
+  "description": "Merge map elements into a hstore-formatted string.",
+  "arguments": [
+    {"arg":"map", "description":"the input map"}],
+  "examples": [ { "expression":"map_to_hstore(map('qgis','rocks'))", "returns":"\"qgis\"=>\"rocks\"}"}
+  ]
+}

--- a/resources/function_help/json/map_to_json
+++ b/resources/function_help/json/map_to_json
@@ -1,0 +1,9 @@
+{
+  "name": "map_to_json",
+  "type": "function",
+  "description": "Merge map elements into a json-formatted string.",
+  "arguments": [
+    {"arg":"map", "description":"the input map"}],
+  "examples": [ { "expression":"map_to_json(map('qgis','rocks'))", "returns":"{\"qgis\":\"rocks\"}"}
+  ]
+}

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -208,6 +208,7 @@ SET(QGIS_CORE_SRCS
   qgsgml.cpp
   qgsgmlschema.cpp
   qgshistogram.cpp
+  qgshstoreutils.cpp
   qgshtmlutils.cpp
   qgsinterval.cpp
   qgsjsonutils.cpp
@@ -869,6 +870,7 @@ SET(QGIS_CORE_HDRS
   qgsgeometryfixes.h
   qgsgeometrysimplifier.h
   qgshistogram.h
+  qgshstoreutils.h
   qgshtmlutils.h
   qgsindexedfeature.h
   qgsinterval.h

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4349,6 +4349,24 @@ static QVariant fcnStringToArray( const QVariantList &values, const QgsExpressio
   return array;
 }
 
+static QVariant fcnJsonToMap( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
+  QJsonDocument document = QJsonDocument::fromJson( str.toUtf8() );
+  if ( document.isNull() || !document.isObject() )
+    return QVariantMap();
+
+  return document.object().toVariantMap();
+}
+
+static QVariant fcnMapToJson( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+{
+  QVariantMap map = QgsExpressionUtils::getMapValue( values.at( 0 ), parent );
+  QJsonObject object = QJsonObject::fromVariantMap( map );
+  QJsonDocument document( object );
+  return document.toJson( QJsonDocument::Compact );
+}
+
 static QVariant fcnMap( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QVariantMap result;
@@ -5014,6 +5032,8 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "generate_series" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "start" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "stop" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "step" ), true, 1.0 ), fcnGenerateSeries, QStringLiteral( "Arrays" ) )
 
         //functions for maps
+        << new QgsStaticExpressionFunction( QStringLiteral( "json_to_map" ), 1, fcnJsonToMap, QStringLiteral( "Maps" ) )
+        << new QgsStaticExpressionFunction( QStringLiteral( "map_to_json" ), 1, fcnMapToJson, QStringLiteral( "Maps" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "map" ), -1, fcnMap, QStringLiteral( "Maps" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "map_get" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "map" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "key" ) ), fcnMapGet, QStringLiteral( "Maps" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "map_exist" ), QgsExpressionFunction::ParameterList() << QgsExpressionFunction::Parameter( QStringLiteral( "map" ) ) << QgsExpressionFunction::Parameter( QStringLiteral( "key" ) ), fcnMapExist, QStringLiteral( "Maps" ) )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -21,6 +21,7 @@
 #include "qgsstringutils.h"
 #include "qgsmultipoint.h"
 #include "qgsgeometryutils.h"
+#include "qgshstoreutils.h"
 #include "qgsmultilinestring.h"
 #include "qgslinestring.h"
 #include "qgscurvepolygon.h"
@@ -4374,70 +4375,7 @@ static QVariant fcnHstoreToMap( const QVariantList &values, const QgsExpressionC
     return QVariantMap();
   str = str.trimmed();
 
-  QVariantMap map;
-  QList<QString> bits;
-  QList<QString> seps;
-  seps << "=>" << ",";
-  int i = 0;
-  while ( i < str.length() )
-  {
-    while ( i < str.length() && str.at( i ).isSpace() )
-      ++i;
-    QString current = str.mid( i );
-    QString sep = seps.at( bits.length() );
-    if ( current.startsWith( '"' ) )
-    {
-      QRegularExpression re( "^\"((?:\\\\.|[^\"\\\\])*)\".*" );
-      QRegularExpressionMatch match = re.match( current );
-      bits << QString();
-      if ( match.hasMatch() )
-      {
-        bits[bits.length() - 1] = match.captured( 1 ).replace( QLatin1String( "\\\"" ), QLatin1String( "\"" ) ).replace( QLatin1String( "\\\\" ), QLatin1String( "\\" ) );
-        i += match.captured( 1 ).length() + 2;
-        while ( i < str.length() && str.at( i ).isSpace() )
-          ++i;
-
-        if ( str.midRef( i ).startsWith( sep ) )
-        {
-          i += sep.length();
-        }
-        else if ( i < str.length() )
-        {
-          // hstore string format broken, end construction
-          i += current.length();
-        }
-      }
-      else
-      {
-        // hstore string format broken, end construction
-        i += current.length();
-        bits[bits.length() - 1] = current.trimmed();
-      }
-    }
-    else
-    {
-      int sepPos = current.indexOf( sep );
-      if ( sepPos < 0 )
-      {
-        i += current.length();
-        bits << current.trimmed();
-      }
-      else
-      {
-        i += sepPos + sep.length();
-        bits << current.left( sepPos ).trimmed();
-      }
-    }
-
-    if ( bits.length() == 2 )
-    {
-      if ( !bits.at( 0 ).isEmpty() && !bits.at( 1 ).isEmpty() )
-        map[ bits.at( 0 ) ] = bits.at( 1 );
-      bits.clear();
-    }
-  }
-
-  return map;
+  return QgsHstoreUtils::parse( str );
 }
 
 static QVariant fcnMapToHstore( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )

--- a/src/core/expression/qgsexpressionfunction.h
+++ b/src/core/expression/qgsexpressionfunction.h
@@ -21,6 +21,8 @@
 #include <QString>
 #include <QVariant>
 #include <QSet>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #include "qgis.h"
 #include "qgis_core.h"

--- a/src/core/qgshstoreutils.cpp
+++ b/src/core/qgshstoreutils.cpp
@@ -1,0 +1,86 @@
+/***************************************************************************
+                                  qgshstoreutils.h
+                              ---------------------
+    begin                : Sept 2018
+    copyright            : (C) 2018 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgshstoreutils.h"
+
+#include <QRegularExpression>
+
+QVariantMap QgsHstoreUtils::parse( const QString &string )
+{
+  QVariantMap map;
+  QList<QString> bits;
+  static const QList<QString > sSeps{ "=>", "," };
+
+  int i = 0;
+  while ( i < string.length() )
+  {
+    while ( i < string.length() && string.at( i ).isSpace() )
+      ++i;
+    QString current = string.mid( i );
+    QString sep = sSeps.at( bits.length() );
+    if ( current.startsWith( '"' ) )
+    {
+      QRegularExpression re( "^\"((?:\\\\.|[^\"\\\\])*)\".*" );
+      QRegularExpressionMatch match = re.match( current );
+      bits << QString();
+      if ( match.hasMatch() )
+      {
+        bits[bits.length() - 1] = match.captured( 1 ).replace( QLatin1String( "\\\"" ), QLatin1String( "\"" ) ).replace( QLatin1String( "\\\\" ), QLatin1String( "\\" ) );
+        i += match.captured( 1 ).length() + 2;
+        while ( i < string.length() && string.at( i ).isSpace() )
+          ++i;
+
+        if ( string.midRef( i ).startsWith( sep ) )
+        {
+          i += sep.length();
+        }
+        else if ( i < string.length() )
+        {
+          // hstore string format broken, end construction
+          i += current.length();
+        }
+      }
+      else
+      {
+        // hstore string format broken, end construction
+        i += current.length();
+        bits[bits.length() - 1] = current.trimmed();
+      }
+    }
+    else
+    {
+      int sepPos = current.indexOf( sep );
+      if ( sepPos < 0 )
+      {
+        i += current.length();
+        bits << current.trimmed();
+      }
+      else
+      {
+        i += sepPos + sep.length();
+        bits << current.left( sepPos ).trimmed();
+      }
+    }
+
+    if ( bits.length() == 2 )
+    {
+      if ( !bits.at( 0 ).isEmpty() && !bits.at( 1 ).isEmpty() )
+        map[ bits.at( 0 ) ] = bits.at( 1 );
+      bits.clear();
+    }
+  }
+
+  return map;
+}

--- a/src/core/qgshstoreutils.h
+++ b/src/core/qgshstoreutils.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+                                  qgshstoreutils.h
+                              ---------------------
+    begin                : Sept 2018
+    copyright            : (C) 2018 by Mathieu Pellerin
+    email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSHSTOREUTILS_H
+#define QGSHSTOREUTILS_H
+
+#include "qgis_core.h"
+#include "qgis.h"
+
+#ifdef SIP_RUN
+% ModuleHeaderCode
+#include "qgshstoreutils.h"
+% End
+#endif
+
+/**
+ * \ingroup core
+ * The QgsHstoreUtils namespace provides functions to handle hstore-formatted strings.
+ * \since QGIS 3.4
+ */
+namespace QgsHstoreUtils
+{
+
+  /**
+   * Returns a QVariantMap object containing the key and values from a hstore-formatted string.
+   * \param string The hstored-formatted string
+   * \since QGIS 3.4
+   */
+  CORE_EXPORT QVariantMap parse( const QString &string );
+
+};
+
+#endif //QGSHSTOREUTILS_H

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2897,6 +2897,11 @@ class TestQgsExpression: public QObject
       hstoreExpected[QStringLiteral( "test_mix" )] = "key with value in quotation marks";
       QCOMPARE( QgsExpression( "hstore_to_map('\"test_quotes\"=>\"test \\\\\"quote\\\\\" symbol\",\"test_slashes\"=>\"test \\\\slash symbol\",test_mix=>\"key with value in quotation marks\"')" ).evaluate( &context ), QVariant( hstoreExpected ) );
 
+      hstoreExpected.clear();
+      hstoreExpected[QStringLiteral( "1" )] = "one";
+      // if a key is missing its closing quote, the map construction process will stop and a partial map is returned
+      QCOMPARE( QgsExpression( "hstore_to_map('\"1\"=>\"one\",\"2=>\"two\"')" ).evaluate( &context ), QVariant( hstoreExpected ) );
+
       QStringList keysExpected;
       keysExpected << QStringLiteral( "1" ) << QStringLiteral( "2" );
       QCOMPARE( QgsExpression( "map_akeys(\"map\")" ).evaluate( &context ), QVariant( keysExpected ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2885,6 +2885,9 @@ class TestQgsExpression: public QObject
       concatExpected[QStringLiteral( "3" )] = "three";
       QCOMPARE( QgsExpression( "map_concat(map('1', 'one', '2', 'overridden by next map'), map('2', 'two', '3', 'three'))" ).evaluate( &context ), QVariant( concatExpected ) );
 
+      QCOMPARE( QgsExpression( "json_to_map('{\"1\":\"one\",\"2\":\"two\",\"3\":\"three\"}')" ).evaluate( &context ), QVariant( concatExpected ) );
+      QCOMPARE( QgsExpression( "map_to_json(map('1','one','2','two','3','three'))" ).evaluate( &context ), QVariant( "{\"1\":\"one\",\"2\":\"two\",\"3\":\"three\"}" ) );
+
       QStringList keysExpected;
       keysExpected << QStringLiteral( "1" ) << QStringLiteral( "2" );
       QCOMPARE( QgsExpression( "map_akeys(\"map\")" ).evaluate( &context ), QVariant( keysExpected ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -2888,6 +2888,15 @@ class TestQgsExpression: public QObject
       QCOMPARE( QgsExpression( "json_to_map('{\"1\":\"one\",\"2\":\"two\",\"3\":\"three\"}')" ).evaluate( &context ), QVariant( concatExpected ) );
       QCOMPARE( QgsExpression( "map_to_json(map('1','one','2','two','3','three'))" ).evaluate( &context ), QVariant( "{\"1\":\"one\",\"2\":\"two\",\"3\":\"three\"}" ) );
 
+      QCOMPARE( QgsExpression( "hstore_to_map('1=>one,2=>two,3=>three')" ).evaluate( &context ), QVariant( concatExpected ) );
+      QCOMPARE( QgsExpression( "map_to_hstore(map('1','one','2','two','3','three'))" ).evaluate( &context ), QVariant( "\"1\"=>\"one\",\"2\"=>\"two\",\"3\"=>\"three\"" ) );
+
+      QVariantMap hstoreExpected;
+      hstoreExpected[QStringLiteral( "test_quotes" )] = "test \"quote\" symbol";
+      hstoreExpected[QStringLiteral( "test_slashes" )] = "test \\slash symbol";
+      hstoreExpected[QStringLiteral( "test_mix" )] = "key with value in quotation marks";
+      QCOMPARE( QgsExpression( "hstore_to_map('\"test_quotes\"=>\"test \\\\\"quote\\\\\" symbol\",\"test_slashes\"=>\"test \\\\slash symbol\",test_mix=>\"key with value in quotation marks\"')" ).evaluate( &context ), QVariant( hstoreExpected ) );
+
       QStringList keysExpected;
       keysExpected << QStringLiteral( "1" ) << QStringLiteral( "2" );
       QCOMPARE( QgsExpression( "map_akeys(\"map\")" ).evaluate( &context ), QVariant( keysExpected ) );


### PR DESCRIPTION
## Description
Last contribution before freeze: a couple of format-specific string to map expression functions:
- json_to_map()
- map_to_json()
- hstore_to_map()
- map_to_hstore()

This can be useful to interact with datasets that include such format via a text field. For e.g., GDAL's OSM driver exports most tags in the "other_tags" field using hstore format. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
