### PR TITLE
Snap to grid to sub unit resolution

### DIFF
--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -53,9 +53,9 @@ void QgsSnapToGridCanvasItem::paint( QPainter *painter )
     const double gridYMin = std::ceil( layerExtent.yMinimum() / mPrecision ) * mPrecision;
     const double gridYMax = std::ceil( layerExtent.yMaximum() / mPrecision ) * mPrecision;
 
-    for ( int x = gridXMin ; x < gridXMax; x += mPrecision )
+    for ( double x = gridXMin ; x < gridXMax; x += mPrecision )
     {
-      for ( int y = gridYMin ; y < gridYMax; y += mPrecision )
+      for ( double y = gridYMin ; y < gridYMax; y += mPrecision )
       {
         const QgsPointXY pt = mTransform.transform( x, y );
         const QPointF canvasPt = toCanvasCoordinates( pt );


### PR DESCRIPTION
When the grid was smaller than 1 map unit, qgis would just freeze. ouch

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
