### PR TITLE
[Bugfix] Show child features in search mode again

### DIFF
--- a/src/gui/qgsattributeformrelationeditorwidget.cpp
+++ b/src/gui/qgsattributeformrelationeditorwidget.cpp
@@ -28,7 +28,7 @@ QgsAttributeFormRelationEditorWidget::QgsAttributeFormRelationEditorWidget( QgsR
 
 void QgsAttributeFormRelationEditorWidget::createSearchWidgetWrappers( const QgsAttributeEditorContext &context )
 {
-  if ( context.parentContext() )
+  if ( !context.parentContext() )
   {
     mSearchWidget = new QgsRelationAggregateSearchWidgetWrapper( layer(), mWrapper, form() );
     mSearchWidget->setContext( context );


### PR DESCRIPTION
It's just checking on creating the widgets of search page, if the widget current layer is parent (has no parentContext) instead of checking if it's child.

Fix:  #19821