### PR TITLE
[Bugfix] Do not store recursively

### DIFF
--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -47,15 +47,15 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
 
 void QgsRelationWidgetWrapper::aboutToSave()
 {
-  if ( !mRelation.isValid() || !widget() || !widget()->isVisible() || mRelation.referencingLayer()->name() ==  mRelation.referencedLayer()->name() )
+  if ( !mRelation.isValid() || !widget() || !widget()->isVisible() || mRelation.referencingLayer() ==  mRelation.referencedLayer() )
     return;
 
   // If the layer is already saved before, return
   const QgsAttributeEditorContext *ctx = &context();
   do
   {
-    if ( ctx->relation().isValid() && ( ctx->relation().referencedLayer()->name() == mRelation.referencingLayer()->name()
-                                        || ( mNmRelation.isValid() && ctx->relation().referencedLayer()->name() == mNmRelation.referencedLayer()->name() ) )
+    if ( ctx->relation().isValid() && ( ctx->relation().referencedLayer() == mRelation.referencingLayer()
+                                        || ( mNmRelation.isValid() && ctx->relation().referencedLayer() == mNmRelation.referencedLayer() ) )
        )
     {
       return;

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -48,6 +48,19 @@ void QgsRelationWidgetWrapper::setVisible( bool visible )
 
 void QgsRelationWidgetWrapper::aboutToSave()
 {
+  // If this widget is already embedded by the same relation return
+  const QgsAttributeEditorContext *ctx = &context();
+  do
+  {
+    if ( ( ctx->relation().name() == mRelation.name() && ctx->formMode() == QgsAttributeEditorContext::Embed )
+         || ( mNmRelation.isValid() && ctx->relation().name() == mNmRelation.name() ) )
+    {
+      return;
+    }
+    ctx = ctx->parentContext();
+  }
+  while ( ctx );
+
   if ( !mRelation.isValid() || !widget() || !widget()->isVisible() )
     return;
 

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -55,7 +55,7 @@ void QgsRelationWidgetWrapper::aboutToSave()
   do
   {
     if ( ctx->relation().isValid() && ( ctx->relation().referencedLayer()->name() == mRelation.referencingLayer()->name()
-                                        || ctx->relation().referencedLayer()->name() == mNmRelation.referencedLayer()->name() )
+                                        || ( mNmRelation.isValid() && ctx->relation().referencedLayer()->name() == mNmRelation.referencedLayer()->name() ) )
        )
     {
       return;

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.cpp
@@ -19,8 +19,6 @@
 #include "qgsattributeeditorcontext.h"
 #include "qgsproject.h"
 #include "qgsrelationmanager.h"
-#undef QGISDEBUG
-#include "qgslogger.h"
 #include <QWidget>
 
 QgsRelationWidgetWrapper::QgsRelationWidgetWrapper( QgsVectorLayer *vl, const QgsRelation &relation, QWidget *editor, QWidget *parent )
@@ -52,10 +50,7 @@ void QgsRelationWidgetWrapper::aboutToSave()
   if ( !mRelation.isValid() || !widget() || !widget()->isVisible() || mRelation.referencingLayer()->name() ==  mRelation.referencedLayer()->name() )
     return;
 
-
-  QgsDebugMsg( QString( "2. Rel Name: %1, ParentLayer: %2 ChildLayer: %3" ).arg( mRelation.name(), mRelation.referencedLayer()->name(), mRelation.referencingLayer()->name() ) );
-
-  // If this widget is already embedded by the same relation, reduce functionality
+  // If the layer is already saved before, return
   const QgsAttributeEditorContext *ctx = &context();
   do
   {
@@ -63,7 +58,6 @@ void QgsRelationWidgetWrapper::aboutToSave()
                                         || ctx->relation().referencedLayer()->name() == mNmRelation.referencedLayer()->name() )
        )
     {
-      QgsDebugMsg( QString( "- Layer %1 allready occured in the relation %2 as referenced layer" ).arg( mRelation.referencingLayer()->name(), ctx->relation().name() ) );
       return;
     }
     ctx = ctx->parentContext();


### PR DESCRIPTION
This avoids having an endless loop -> crash.

It's the same behavior like on loading the embedded widgets. Checking if there is one that is the same like the current.

There and here is still the issue, when the loop goes not back to the current layer but it loops to another child in between, that it could lead to the endless loop. This commit avoids the most cases. But it could be improved...

This has been the recursion:
notifyAboutToSave -> aboutToSave -> **_isModified_** -> QgsVectorLayer::beforeModifiedCheck -> QgsAttributeForm::save -> notifyAboutToSave