### PR TITLE
[feature] Identify/Select polygon from existing feature geometry (#19064)

### DIFF
--- a/python/gui/auto_generated/qgsidentifymenu.sip.in
+++ b/python/gui/auto_generated/qgsidentifymenu.sip.in
@@ -64,7 +64,7 @@ define if the menu executed can return multiple results (e.g. all results or all
 
     void setExecWithSingleResult( bool execWithSingleResult );
 %Docstring
-define if the menu will be shown with a single idetify result
+define if the menu will be shown with a single identify result
 %End
     bool execWithSingleResult();
 

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qgsmaptoolselect.cpp  -  map tool for selecting features by single click
+    qgsmaptoolselect.cpp  -  map tool for selecting features
     ----------------------
     begin                : January 2006
     copyright            : (C) 2006 by Martin Dobias

--- a/src/app/qgsmaptoolselect.h
+++ b/src/app/qgsmaptoolselect.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qgsmaptoolselect.h  -  map tool for selecting features by single click
+    qgsmaptoolselect.h  -  map tool for selecting features
     ---------------------
     begin                : May 2010
     copyright            : (C) 2010 by Jeremy Palmer

--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -109,7 +109,6 @@ QgsMapToolSelectionHandler::QgsMapToolSelectionHandler( QgsMapCanvas *canvas, Qg
 QgsMapToolSelectionHandler::~QgsMapToolSelectionHandler()
 {
   cancel();
-  delete mIdentifyMenu;
 }
 
 void QgsMapToolSelectionHandler::canvasReleaseEvent( QgsMapMouseEvent *e )
@@ -256,7 +255,8 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
     double x = mapPoint.x(), y = mapPoint.y();
     double sr = QgsMapTool::searchRadiusMU( mCanvas );
 
-    for ( auto layer : mCanvas->layers() )
+    const QList<QgsMapLayer*> layers = mCanvas->layers();
+    for ( auto layer : layers )
     {
       if ( layer->type() == QgsMapLayer::VectorLayer )
       {

--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -104,6 +104,7 @@ QgsMapToolSelectionHandler::QgsMapToolSelectionHandler( QgsMapCanvas *canvas, Qg
   , mIdentifyMenu( new QgsIdentifyMenu( mCanvas ) )
 {
   mIdentifyMenu->setAllowMultipleReturn( false );
+  mIdentifyMenu->setExecWithSingleResult( true );
 }
 
 QgsMapToolSelectionHandler::~QgsMapToolSelectionHandler()
@@ -255,7 +256,7 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
     double x = mapPoint.x(), y = mapPoint.y();
     double sr = QgsMapTool::searchRadiusMU( mCanvas );
 
-    const QList<QgsMapLayer*> layers = mCanvas->layers();
+    const QList<QgsMapLayer *> layers = mCanvas->layers();
     for ( auto layer : layers )
     {
       if ( layer->type() == QgsMapLayer::VectorLayer )

--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -25,7 +25,7 @@
 #include "qgsmapmouseevent.h"
 #include "qgsrubberband.h"
 #include "qgssnapindicator.h"
-
+#include "qgsidentifymenu.h"
 
 /// @cond private
 
@@ -101,12 +101,15 @@ QgsMapToolSelectionHandler::QgsMapToolSelectionHandler( QgsMapCanvas *canvas, Qg
   : mCanvas( canvas )
   , mSelectionMode( selectionMode )
   , mSnapIndicator( qgis::make_unique< QgsSnapIndicator >( canvas ) )
+  , mIdentifyMenu( new QgsIdentifyMenu( mCanvas ) )
 {
+  mIdentifyMenu->setAllowMultipleReturn( false );
 }
 
 QgsMapToolSelectionHandler::~QgsMapToolSelectionHandler()
 {
   cancel();
+  delete mIdentifyMenu;
 }
 
 void QgsMapToolSelectionHandler::canvasReleaseEvent( QgsMapMouseEvent *e )
@@ -243,6 +246,43 @@ void QgsMapToolSelectionHandler::selectPolygonMoveEvent( QgsMapMouseEvent *e )
 
 void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
 {
+  // Handle immediate right-click on feature to show context menu
+  if ( !mSelectionRubberBand && ( e->button() == Qt::RightButton ) )
+  {
+    QList<QgsMapToolIdentify::IdentifyResult> results;
+    QMap< QString, QString > derivedAttributes;
+
+    const QgsPointXY mapPoint = toMapCoordinates( e->pos() );
+    double x = mapPoint.x(), y = mapPoint.y();
+    double sr = QgsMapTool::searchRadiusMU( mCanvas );
+
+    for ( auto layer : mCanvas->layers() )
+    {
+      if ( layer->type() == QgsMapLayer::VectorLayer )
+      {
+        auto vectorLayer = static_cast<QgsVectorLayer *>( layer );
+        if ( vectorLayer->geometryType() == QgsWkbTypes::PolygonGeometry )
+        {
+          QgsRectangle r = mCanvas->mapSettings().mapToLayerCoordinates( layer, QgsRectangle( x - sr, y - sr, x + sr, y + sr ) );
+          QgsFeatureIterator fit = vectorLayer->getFeatures( QgsFeatureRequest().setFilterRect( r ).setFlags( QgsFeatureRequest::ExactIntersect ) );
+          QgsFeature f;
+          while ( fit.nextFeature( f ) )
+          {
+            results << QgsMapToolIdentify::IdentifyResult( vectorLayer, f, derivedAttributes );
+          }
+        }
+      }
+    }
+
+    QPoint globalPos = mCanvas->mapToGlobal( QPoint( e->pos().x() + 5, e->pos().y() + 5 ) );
+    const QList<QgsMapToolIdentify::IdentifyResult> selectedFeatures = mIdentifyMenu->exec( results, globalPos );
+    if ( !selectedFeatures.empty() && selectedFeatures[0].mFeature.hasGeometry() )
+      setSelectedGeometry( selectedFeatures[0].mFeature.geometry(), e->modifiers() );
+
+    return;
+  }
+
+  // Handle definition of polygon by clicking points on cancas
   if ( !mSelectionRubberBand )
     initRubberBand();
 

--- a/src/app/qgsmaptoolselectionhandler.h
+++ b/src/app/qgsmaptoolselectionhandler.h
@@ -29,6 +29,7 @@ class QgsMapCanvas;
 class QgsMapMouseEvent;
 class QgsRubberBand;
 class QgsSnapIndicator;
+class QgsIdentifyMenu;
 
 /// @cond private
 
@@ -88,7 +89,7 @@ class QgsMapToolSelectionHandler : public QObject
     {
       //! SelectSimple - single click or drawing a rectangle, default option
       SelectSimple,
-      //! SelectPolygon - drawing a polygon
+      //! SelectPolygon - drawing a polygon or right-click on existing polygon feature
       SelectPolygon,
       //! SelectFreehand - free hand selection
       SelectFreehand,
@@ -119,7 +120,7 @@ class QgsMapToolSelectionHandler : public QObject
     void canvasMoveEvent( QgsMapMouseEvent *e );
     //! Handles mouse press event from map tool
     void canvasPressEvent( QgsMapMouseEvent *e );
-    //! Handles mouse releasae event from map tool
+    //! Handles mouse release event from map tool
     void canvasReleaseEvent( QgsMapMouseEvent *e );
     //! Handles escape press event - returns true if the even has been processed
     bool keyReleaseEvent( QKeyEvent *e );
@@ -196,6 +197,9 @@ class QgsMapToolSelectionHandler : public QObject
 
     QColor mFillColor = QColor( 254, 178, 76, 63 );
     QColor mStrokeColor = QColor( 254, 58, 29, 100 );
+
+    //! Shows features to select polygon from existing features
+    QgsIdentifyMenu *mIdentifyMenu = nullptr;
 };
 
 #endif

--- a/src/app/qgsmaptoolselectionhandler.h
+++ b/src/app/qgsmaptoolselectionhandler.h
@@ -199,7 +199,7 @@ class QgsMapToolSelectionHandler : public QObject
     QColor mStrokeColor = QColor( 254, 58, 29, 100 );
 
     //! Shows features to select polygon from existing features
-    QgsIdentifyMenu *mIdentifyMenu = nullptr;
+    QgsIdentifyMenu *mIdentifyMenu = nullptr; // owned by canvas
 };
 
 #endif

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -26,6 +26,7 @@
 #include "qgssettings.h"
 #include "qgsgui.h"
 
+//TODO 4.0 add explicitely qobject parent to constructor
 QgsIdentifyMenu::QgsIdentifyMenu( QgsMapCanvas *canvas )
   : QMenu( canvas )
   , mCanvas( canvas )

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -26,7 +26,7 @@
 #include "qgssettings.h"
 #include "qgsgui.h"
 
-//TODO 4.0 add explicitely qobject parent to constructor
+//TODO 4.0 add explicitly qobject parent to constructor
 QgsIdentifyMenu::QgsIdentifyMenu( QgsMapCanvas *canvas )
   : QMenu( canvas )
   , mCanvas( canvas )

--- a/src/gui/qgsidentifymenu.h
+++ b/src/gui/qgsidentifymenu.h
@@ -99,7 +99,7 @@ class GUI_EXPORT QgsIdentifyMenu : public QMenu
     void setAllowMultipleReturn( bool multipleReturn ) { mAllowMultipleReturn = multipleReturn;}
     bool allowMultipleReturn() { return mAllowMultipleReturn;}
 
-    //! define if the menu will be shown with a single idetify result
+    //! define if the menu will be shown with a single identify result
     void setExecWithSingleResult( bool execWithSingleResult ) { mExecWithSingleResult = execWithSingleResult;}
     bool execWithSingleResult() { return mExecWithSingleResult;}
 


### PR DESCRIPTION
fixes https://issues.qgis.org/issues/19064

When "Identify features by polygon" mode in Identify map tool is active, user can now also right-click on the canvas instead of defining polygon by hand. When right-click happens, the polygon geometry is taken from a polygon feature from active layers.

Same thing works also for "Select features by polygon" map tool 

