### PR TITLE
Replace a Qt5 macro in RPM spec

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -279,7 +279,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %{_libdir}/lib%{name}_gui.so.*
 %{_libdir}/lib%{name}_3d.so.*
 %{_libdir}/%{name}/
-%{_qt5_prefix}/plugins/sqldrivers/libqsqlspatialite.so
+%{?_qt5_plugindir}/sqldrivers/libqsqlspatialite.so
 %{_bindir}/%{name}
 %{_mandir}/man1/%{name}.1*
 %dir %{_datadir}/%{name}/


### PR DESCRIPTION
## Description

Replace a Qt5 macro in RPM spec which was deprecated and does not work anymore after Fedora 28 moved to Qt 5.11 (which happened a couple of days ago). The change it's backward compatible with F27 since the updated macro was already used here https://github.com/qgis/QGIS/blob/638339f1462f0dfc27e3147bce80b99417b3e625/rpm/qgis.spec.template#L305.

You can see the error here: https://copr-be.cloud.fedoraproject.org/results/dani/qgis/fedora-28-x86_64/00797859-qgis/build.log.gz
New build with patch applied: https://copr.fedorainfracloud.org/coprs/dani/qgis/build/797899/

/cc @m-kuhn 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
