### PR TITLE
Make style filter model search by word, not phrase

### DIFF
--- a/tests/src/python/test_qgsstylemodel.py
+++ b/tests/src/python/test_qgsstylemodel.py
@@ -548,6 +548,12 @@ class TestQgsStyleModel(unittest.TestCase):
         self.assertEqual(model.rowCount(), 2)
         self.assertEqual(model.data(model.index(0, 0)), 'a')
         self.assertEqual(model.data(model.index(1, 0)), 'ramp a')
+        model.setFilterString('ram b')
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), 'ramp BB')
+        model.setFilterString('ta ram') # match ta -> "tag 1", ram -> "ramp a"
+        self.assertEqual(model.rowCount(), 1)
+        self.assertEqual(model.data(model.index(0, 0)), 'ramp a')
         model.setFilterString('')
         self.assertEqual(model.rowCount(), 8)
 


### PR DESCRIPTION
This allows matching of a filter string "hash line" to the symbol "hashed red lines"
