### PR TITLE
New class QgsWindowManagerInterface

### DIFF
--- a/python/gui/auto_generated/qgsgui.sip.in
+++ b/python/gui/auto_generated/qgsgui.sip.in
@@ -82,6 +82,24 @@ Register the widget to allow its position to be automatically saved and restored
 Use this to avoid needing to call saveGeometry() and restoreGeometry() on your widget.
 %End
 
+    static QgsWindowManagerInterface *windowManager();
+%Docstring
+Returns the global window manager, if set.
+
+.. seealso:: :py:func:`setWindowManager`
+
+.. versionadded:: 3.4
+%End
+
+    static void setWindowManager( QgsWindowManagerInterface *manager /Transfer/ );
+%Docstring
+Sets the global window ``manager``. Ownership is transferred to the QgsGui instance.
+
+.. seealso:: :py:func:`windowManager`
+
+.. versionadded:: 3.4
+%End
+
     ~QgsGui();
 
   private:

--- a/python/gui/auto_generated/qgswindowmanagerinterface.sip.in
+++ b/python/gui/auto_generated/qgswindowmanagerinterface.sip.in
@@ -1,0 +1,58 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgswindowmanagerinterface.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsWindowManagerInterface
+{
+%Docstring
+Interface for window manager.
+
+An implementation of the window manager interface is usually retrieved from
+the QgsGui instance, via :py:func:`QgsGui.windowManager()`
+
+.. note::
+
+   This is not considered stable API and may change in future QGIS versions.
+
+.. versionadded:: 3.4
+%End
+
+%TypeHeaderCode
+#include "qgswindowmanagerinterface.h"
+%End
+  public:
+
+    enum StandardDialog
+    {
+      DialogStyleManager,
+    };
+
+    virtual ~QgsWindowManagerInterface();
+
+    virtual QWidget *openStandardDialog( StandardDialog dialog ) = 0;
+%Docstring
+Opens an instance of a standard QGIS dialog. Depending on the window manager
+implementation, this may either open a new instance of the dialog or bring an
+existing instance to the foreground.
+
+Returns the dialog if shown, or None if the dialog either could not be
+created or is not supported by the window manager implementation.
+%End
+
+};
+
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgswindowmanagerinterface.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -22,6 +22,7 @@
 %Include auto_generated/qgsabstractdatasourcewidget.sip
 %Include auto_generated/qgssourceselectprovider.sip
 %Include auto_generated/qgssourceselectproviderregistry.sip
+%Include auto_generated/qgswindowmanagerinterface.sip
 %Include auto_generated/attributetable/qgsfeaturemodel.sip
 %Include auto_generated/auth/qgsauthauthoritieseditor.sip
 %Include auto_generated/auth/qgsauthcertificateinfo.sip

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(QGIS_APP_SRCS
   qgsalignrasterdialog.cpp
   qgsappbrowserproviders.cpp
   qgsapplayertreeviewmenuprovider.cpp
+  qgsappwindowmanager.cpp
   qgsaddattrdialog.cpp
   qgsaddtaborgroup.cpp
   qgsjoindialog.cpp

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -210,7 +210,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayoutcustomdrophandler.h"
 #include "qgslayoutdesignerdialog.h"
 #include "qgslayoutmanager.h"
-#include "qgslayoutmanagerdialog.h"
 #include "qgslayoutqptdrophandler.h"
 #include "qgslayoutapputils.h"
 #include "qgslocatorwidget.h"
@@ -10577,13 +10576,7 @@ void QgisApp::reloadConnections()
 
 void QgisApp::showLayoutManager()
 {
-  if ( !mLayoutManagerDialog )
-  {
-    mLayoutManagerDialog = new QgsLayoutManagerDialog( this, Qt::Window );
-    mLayoutManagerDialog->setAttribute( Qt::WA_DeleteOnClose );
-  }
-  mLayoutManagerDialog->show();
-  mLayoutManagerDialog->activate();
+  static_cast< QgsAppWindowManager * >( QgsGui::windowManager() )->openApplicationDialog( QgsAppWindowManager::DialogLayoutManager );
 }
 
 QgsVectorLayer *QgisApp::addVectorLayer( const QString &vectorLayerPath, const QString &name, const QString &providerKey )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -319,7 +319,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsnewnamedialog.h"
 #include "qgsgui.h"
 #include "qgsdatasourcemanagerdialog.h"
-#include "qgsstylemanagerdialog.h"
+#include "qgsappwindowmanager.h"
 
 #include "qgsuserprofilemanager.h"
 #include "qgsuserprofile.h"
@@ -1263,6 +1263,8 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   qApp->processEvents();
   endProfile();
 
+  QgsGui::setWindowManager( new QgsAppWindowManager() );
+
   mMapCanvas->freeze( false );
   mMapCanvas->clearExtentHistory(); // reset zoomnext/zoomlast
 
@@ -1517,8 +1519,8 @@ QgisApp::~QgisApp()
   delete mVectorLayerTools;
   delete mWelcomePage;
 
-  if ( mStyleManagerDialog )
-    delete mStyleManagerDialog;
+  // Gracefully delete window manager now
+  QgsGui::setWindowManager( nullptr );
 
   deleteLayoutDesigners();
   removeAnnotationItems();
@@ -2269,18 +2271,9 @@ void QgisApp::createActions()
 
 }
 
-#include "qgsstyle.h"
-#include "qgsstylemanagerdialog.h"
-
 void QgisApp::showStyleManager()
 {
-  if ( !mStyleManagerDialog )
-  {
-    mStyleManagerDialog = new QgsStyleManagerDialog( QgsStyle::defaultStyle(), this, Qt::Window );
-    mStyleManagerDialog->setAttribute( Qt::WA_DeleteOnClose );
-  }
-  mStyleManagerDialog->show();
-  mStyleManagerDialog->activate();
+  QgsGui::windowManager()->openStandardDialog( QgsWindowManagerInterface::DialogStyleManager );
 }
 
 void QgisApp::showPythonDialog()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -64,7 +64,6 @@ class QgsMasterLayoutInterface;
 class QgsLayoutCustomDropHandler;
 class QgsLayoutDesignerDialog;
 class QgsLayoutDesignerInterface;
-class QgsLayoutManagerDialog;
 class QgsMapCanvas;
 class QgsMapCanvasDockWidget;
 class QgsMapLayer;
@@ -2201,8 +2200,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsUserProfileManager *mUserProfileManager = nullptr;
     QgsDockWidget *mMapStylingDock = nullptr;
     QgsLayerStylingWidget *mMapStyleWidget = nullptr;
-
-    QPointer< QgsLayoutManagerDialog > mLayoutManagerDialog;
 
     //! Persistent tile scale slider
     QgsTileScaleWidget *mpTileScaleWidget = nullptr;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -65,7 +65,6 @@ class QgsLayoutCustomDropHandler;
 class QgsLayoutDesignerDialog;
 class QgsLayoutDesignerInterface;
 class QgsLayoutManagerDialog;
-class QgsStyleManagerDialog;
 class QgsMapCanvas;
 class QgsMapCanvasDockWidget;
 class QgsMapLayer;
@@ -2204,7 +2203,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsLayerStylingWidget *mMapStyleWidget = nullptr;
 
     QPointer< QgsLayoutManagerDialog > mLayoutManagerDialog;
-    QPointer< QgsStyleManagerDialog > mStyleManagerDialog;
 
     //! Persistent tile scale slider
     QgsTileScaleWidget *mpTileScaleWidget = nullptr;

--- a/src/app/qgsappwindowmanager.cpp
+++ b/src/app/qgsappwindowmanager.cpp
@@ -1,0 +1,45 @@
+/***************************************************************************
+                             qgswindowmanagerinterface.cpp
+                             -----------------------------
+    Date                 : September 2018
+    Copyright            : (C) 2018 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsappwindowmanager.h"
+#include "qgsstylemanagerdialog.h"
+#include "qgsstyle.h"
+#include "qgisapp.h"
+
+
+QgsAppWindowManager::~QgsAppWindowManager()
+{
+  if ( mStyleManagerDialog )
+    delete mStyleManagerDialog;
+}
+
+QWidget *QgsAppWindowManager::openStandardDialog( QgsWindowManagerInterface::StandardDialog dialog )
+{
+  switch ( dialog )
+  {
+    case QgsWindowManagerInterface::DialogStyleManager:
+    {
+      if ( !mStyleManagerDialog )
+      {
+        mStyleManagerDialog = new QgsStyleManagerDialog( QgsStyle::defaultStyle(), QgisApp::instance(), Qt::Window );
+        mStyleManagerDialog->setAttribute( Qt::WA_DeleteOnClose );
+      }
+      mStyleManagerDialog->show();
+      mStyleManagerDialog->activate();
+      return mStyleManagerDialog;
+    }
+  }
+  return nullptr;
+}

--- a/src/app/qgsappwindowmanager.cpp
+++ b/src/app/qgsappwindowmanager.cpp
@@ -17,12 +17,14 @@
 #include "qgsstylemanagerdialog.h"
 #include "qgsstyle.h"
 #include "qgisapp.h"
-
+#include "qgslayoutmanagerdialog.h"
 
 QgsAppWindowManager::~QgsAppWindowManager()
 {
   if ( mStyleManagerDialog )
     delete mStyleManagerDialog;
+  if ( mLayoutManagerDialog )
+    delete mLayoutManagerDialog;
 }
 
 QWidget *QgsAppWindowManager::openStandardDialog( QgsWindowManagerInterface::StandardDialog dialog )
@@ -40,6 +42,25 @@ QWidget *QgsAppWindowManager::openStandardDialog( QgsWindowManagerInterface::Sta
       mStyleManagerDialog->activate();
       return mStyleManagerDialog;
     }
+  }
+  return nullptr;
+}
+
+QWidget *QgsAppWindowManager::openApplicationDialog( QgsAppWindowManager::ApplicationDialog dialog )
+{
+  switch ( dialog )
+  {
+    case DialogLayoutManager:
+    {
+      if ( !mLayoutManagerDialog )
+      {
+        mLayoutManagerDialog = new QgsLayoutManagerDialog( QgisApp::instance(), Qt::Window );
+        mLayoutManagerDialog->setAttribute( Qt::WA_DeleteOnClose );
+      }
+      mLayoutManagerDialog->show();
+      mLayoutManagerDialog->activate();
+    }
+    return nullptr;
   }
   return nullptr;
 }

--- a/src/app/qgsappwindowmanager.cpp
+++ b/src/app/qgsappwindowmanager.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
-                             qgswindowmanagerinterface.cpp
-                             -----------------------------
+                             qgsappwindowmanager.cpp
+                             -----------------------
     Date                 : September 2018
     Copyright            : (C) 2018 Nyall Dawson
     Email                : nyall dot dawson at gmail dot com
@@ -59,8 +59,8 @@ QWidget *QgsAppWindowManager::openApplicationDialog( QgsAppWindowManager::Applic
       }
       mLayoutManagerDialog->show();
       mLayoutManagerDialog->activate();
+      return mLayoutManagerDialog;
     }
-    return nullptr;
   }
   return nullptr;
 }

--- a/src/app/qgsappwindowmanager.h
+++ b/src/app/qgsappwindowmanager.h
@@ -1,6 +1,6 @@
 /***************************************************************************
-                             qgswindowmanagerinterface.h
-                             ---------------------------
+                             qgsappwindowmanager.h
+                             ---------------------
     Date                 : September 2018
     Copyright            : (C) 2018 Nyall Dawson
     Email                : nyall dot dawson at gmail dot com

--- a/src/app/qgsappwindowmanager.h
+++ b/src/app/qgsappwindowmanager.h
@@ -1,0 +1,43 @@
+/***************************************************************************
+                             qgswindowmanagerinterface.h
+                             ---------------------------
+    Date                 : September 2018
+    Copyright            : (C) 2018 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSAPPWINDOWMANAGER_H
+#define QGSAPPWINDOWMANAGER_H
+
+#include "qgis.h"
+#include "qgswindowmanagerinterface.h"
+#include <QPointer>
+
+class QgsStyleManagerDialog;
+
+/**
+ * \ingroup gui
+ * \brief Implementation of QgsWindowManagerInterface for the QGIS application.
+ */
+class QgsAppWindowManager : public QgsWindowManagerInterface
+{
+  public:
+
+    QgsAppWindowManager() = default;
+    ~QgsAppWindowManager();
+
+    QWidget *openStandardDialog( QgsWindowManagerInterface::StandardDialog dialog ) override;
+
+  private:
+    QPointer< QgsStyleManagerDialog > mStyleManagerDialog;
+};
+
+
+#endif // QGSAPPWINDOWMANAGER_H

--- a/src/app/qgsappwindowmanager.h
+++ b/src/app/qgsappwindowmanager.h
@@ -21,6 +21,7 @@
 #include <QPointer>
 
 class QgsStyleManagerDialog;
+class QgsLayoutManagerDialog;
 
 /**
  * \ingroup gui
@@ -30,13 +31,31 @@ class QgsAppWindowManager : public QgsWindowManagerInterface
 {
   public:
 
+    //! Application-only QGIS dialogs
+    enum ApplicationDialog
+    {
+      DialogLayoutManager = 0, //!< Layout manager dialog
+    };
+
     QgsAppWindowManager() = default;
     ~QgsAppWindowManager();
 
     QWidget *openStandardDialog( QgsWindowManagerInterface::StandardDialog dialog ) override;
 
+    /**
+     * Opens an instance of a application QGIS dialog. Depending on the dialog,
+     * this may either open a new instance of the dialog or bring an
+     * existing instance to the foreground.
+     *
+     * Returns the dialog if shown, or nullptr if the dialog either could not be
+     * created.
+     */
+    QWidget *openApplicationDialog( ApplicationDialog dialog );
+
   private:
     QPointer< QgsStyleManagerDialog > mStyleManagerDialog;
+    QPointer< QgsLayoutManagerDialog > mLayoutManagerDialog;
+
 };
 
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -780,6 +780,7 @@ SET(QGIS_GUI_HDRS
   qgswidgetstatehelper_p.h
   qgssourceselectprovider.h
   qgssourceselectproviderregistry.h
+  qgswindowmanagerinterface.h
 
   ogr/qgsogrhelperfunctions.h
   ogr/qgsnewogrconnection.h

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -37,6 +37,7 @@
 #include "qgswidgetstatehelper_p.h"
 #include "qgslogger.h"
 #include "qgsprocessingrecentalgorithmlog.h"
+#include "qgswindowmanagerinterface.h"
 
 QgsGui *QgsGui::instance()
 {
@@ -93,9 +94,19 @@ void QgsGui::enableAutoGeometryRestore( QWidget *widget, const QString &key )
 {
   if ( widget->objectName().isEmpty() )
   {
-    QgsDebugMsg( "WARNING: No object name set. Best for it to be set objectName when using QgsGui::enableAutoGeometryRestore" );
+    QgsDebugMsg( QStringLiteral( "WARNING: No object name set. Best for it to be set objectName when using QgsGui::enableAutoGeometryRestore" ) );
   }
   instance()->mWidgetStateHelper->registerWidget( widget, key );
+}
+
+QgsWindowManagerInterface *QgsGui::windowManager()
+{
+  return instance()->mWindowManager.get();
+}
+
+void QgsGui::setWindowManager( QgsWindowManagerInterface *manager )
+{
+  instance()->mWindowManager.reset( manager );
 }
 
 QgsGui::~QgsGui()

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -21,6 +21,7 @@
 #include "qgis_gui.h"
 #include "qgis_sip.h"
 #include <QWidget>
+#include <memory>
 
 class QgsEditorWidgetRegistry;
 class QgsShortcutsManager;
@@ -32,6 +33,7 @@ class QgsLayoutItemGuiRegistry;
 class QgsWidgetStateHelper;
 class QgsProcessingGuiRegistry;
 class QgsProcessingRecentAlgorithmLog;
+class QgsWindowManagerInterface;
 
 /**
  * \ingroup gui
@@ -109,6 +111,20 @@ class GUI_EXPORT QgsGui
      */
     static void enableAutoGeometryRestore( QWidget *widget, const QString &key = QString() );
 
+    /**
+     * Returns the global window manager, if set.
+     * \see setWindowManager()
+     * \since QGIS 3.4
+     */
+    static QgsWindowManagerInterface *windowManager();
+
+    /**
+     * Sets the global window \a manager. Ownership is transferred to the QgsGui instance.
+     * \see windowManager()
+     * \since QGIS 3.4
+     */
+    static void setWindowManager( QgsWindowManagerInterface *manager SIP_TRANSFER );
+
     ~QgsGui();
 
   private:
@@ -125,6 +141,7 @@ class GUI_EXPORT QgsGui
     QgsLayoutItemGuiRegistry *mLayoutItemGuiRegistry = nullptr;
     QgsProcessingGuiRegistry *mProcessingGuiRegistry = nullptr;
     QgsProcessingRecentAlgorithmLog *mProcessingRecentAlgorithmLog = nullptr;
+    std::unique_ptr< QgsWindowManagerInterface > mWindowManager;
 
 #ifdef SIP_RUN
     QgsGui( const QgsGui &other );

--- a/src/gui/qgswindowmanagerinterface.h
+++ b/src/gui/qgswindowmanagerinterface.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+                             qgswindowmanagerinterface.h
+                             ---------------------------
+    Date                 : September 2018
+    Copyright            : (C) 2018 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSWINDOWMANAGERINTERFACE_H
+#define QGSWINDOWMANAGERINTERFACE_H
+
+#include "qgis.h"
+#include "qgis_gui.h"
+
+///@cond NOT_STABLE
+
+/**
+ * \ingroup gui
+ * \brief Interface for window manager.
+ *
+ * An implementation of the window manager interface is usually retrieved from
+ * the QgsGui instance, via QgsGui::windowManager().
+ *
+ * \note This is not considered stable API and may change in future QGIS versions.
+ * \since QGIS 3.4
+ */
+class GUI_EXPORT QgsWindowManagerInterface
+{
+  public:
+
+    //! Standard QGIS dialogs
+    enum StandardDialog
+    {
+      DialogStyleManager = 0, //!< Style manager dialog
+    };
+
+    virtual ~QgsWindowManagerInterface() = default;
+
+    /**
+     * Opens an instance of a standard QGIS dialog. Depending on the window manager
+     * implementation, this may either open a new instance of the dialog or bring an
+     * existing instance to the foreground.
+     *
+     * Returns the dialog if shown, or nullptr if the dialog either could not be
+     * created or is not supported by the window manager implementation.
+     */
+    virtual QWidget *openStandardDialog( StandardDialog dialog ) = 0;
+
+};
+
+///@endcond
+
+#endif // QGSWINDOWMANAGERINTERFACE_H

--- a/src/gui/symbology/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology/qgssymbolslistwidget.cpp
@@ -397,8 +397,14 @@ void QgsSymbolsListWidget::updateModelFilters()
 void QgsSymbolsListWidget::openStyleManager()
 {
   // prefer to use global window manager to open the style manager, if possible!
-  // this allows reuse of an existing non-modal window instead of opening a new modal window
-  if ( !QgsGui::windowManager() || !QgsGui::windowManager()->openStandardDialog( QgsWindowManagerInterface::DialogStyleManager ) )
+  // this allows reuse of an existing non-modal window instead of opening a new modal window.
+  // Note that we only use the non-modal dialog if we're open in the panel -- if we're already
+  // open as part of a modal dialog, then we MUST use another modal dialog or the result will
+  // not be focusable!
+  QgsPanelWidget *panel = QgsPanelWidget::findParentPanel( this );
+  if ( !panel || !panel->dockMode()
+       || !QgsGui::windowManager()
+       || !QgsGui::windowManager()->openStandardDialog( QgsWindowManagerInterface::DialogStyleManager ) )
   {
     // fallback to modal dialog
     QgsStyleManagerDialog dlg( mStyle, this );

--- a/src/gui/symbology/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology/qgssymbolslistwidget.cpp
@@ -30,6 +30,8 @@
 #include "qgsnewauxiliarylayerdialog.h"
 #include "qgsauxiliarystorage.h"
 #include "qgsstylemodel.h"
+#include "qgsgui.h"
+#include "qgswindowmanagerinterface.h"
 
 #include <QAction>
 #include <QString>
@@ -134,7 +136,7 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbol *symbol, QgsStyle *style, 
 
   connect( mStyle, &QgsStyle::groupsModified, this, &QgsSymbolsListWidget::populateGroups );
 
-  connect( openStyleManagerButton, &QPushButton::pressed, this, &QgsSymbolsListWidget::openStyleManager );
+  connect( openStyleManagerButton, &QToolButton::clicked, this, &QgsSymbolsListWidget::openStyleManager );
 
   lblSymbolName->clear();
 
@@ -394,10 +396,16 @@ void QgsSymbolsListWidget::updateModelFilters()
 
 void QgsSymbolsListWidget::openStyleManager()
 {
-  QgsStyleManagerDialog dlg( mStyle, this );
-  dlg.exec();
+  // prefer to use global window manager to open the style manager, if possible!
+  // this allows reuse of an existing non-modal window instead of opening a new modal window
+  if ( !QgsGui::windowManager() || !QgsGui::windowManager()->openStandardDialog( QgsWindowManagerInterface::DialogStyleManager ) )
+  {
+    // fallback to modal dialog
+    QgsStyleManagerDialog dlg( mStyle, this );
+    dlg.exec();
 
-  updateModelFilters(); // probably not needed -- the model should automatically update if any changes were made
+    updateModelFilters(); // probably not needed -- the model should automatically update if any changes were made
+  }
 }
 
 void QgsSymbolsListWidget::clipFeaturesToggled( bool checked )


### PR DESCRIPTION
With an implementation in app. This allows GUI library classes to re-use standard dialogs which are created in app. The initial use-case is to allow the GUI library symbol list widget to focus/open an existing Style Manager dialog (created in app), instead of opening a new modal style manager dialog.

Side benefit - moves some code out of the monolithic qgisapp.cpp file. We should possibly move all the handling of application dialogs to QgsAppWindowManager just to clear some clutter out of the monolithic qgisapp.cpp file. (i.e. custom projections dialog, shortcuts, customize interface, options, project properties, etc).