### PR TITLE
[ux] Hide frame when collapsible group box is collapsed

### DIFF
--- a/python/gui/auto_generated/qgscollapsiblegroupbox.sip.in
+++ b/python/gui/auto_generated/qgscollapsiblegroupbox.sip.in
@@ -118,6 +118,7 @@ Visual fixes for when group box is collapsed/expanded
     void clearModifiers();
 
 
+
 };
 
 

--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -382,7 +382,8 @@ void QgsCollapsibleGroupBoxBasic::updateStyle()
     ss += QLatin1String( "  background-color: rgba(0,0,0,0)" );
   }
   ss += '}';
-  setStyleSheet( styleSheet() + ss );
+  mStyleSheet = styleSheet() + ss;
+  setStyleSheet( mStyleSheet );
 
   // clear toolbutton default background and border and apply offset
   QString ssd;
@@ -445,6 +446,7 @@ void QgsCollapsibleGroupBoxBasic::collapseExpandFixes()
 
   if ( mCollapsed )
   {
+    setStyleSheet( mStyleSheet + " QgsCollapsibleGroupBoxBasic { border: none; }" );
     Q_FOREACH ( QObject *child, children() )
     {
       QWidget *w = qobject_cast<QWidget *>( child );
@@ -457,6 +459,7 @@ void QgsCollapsibleGroupBoxBasic::collapseExpandFixes()
   }
   else // on expand
   {
+    setStyleSheet( mStyleSheet );
     Q_FOREACH ( QObject *child, children() )
     {
       QWidget *w = qobject_cast<QWidget *>( child );

--- a/src/gui/qgscollapsiblegroupbox.h
+++ b/src/gui/qgscollapsiblegroupbox.h
@@ -166,6 +166,8 @@ class GUI_EXPORT QgsCollapsibleGroupBoxBasic : public QGroupBox
 
     QIcon mCollapseIcon;
     QIcon mExpandIcon;
+
+    QString mStyleSheet;
 };
 
 /**


### PR DESCRIPTION
Prevents an ugly cropped frame from showing in collapsed group boxes

Fixes this:
![image](https://user-images.githubusercontent.com/1829991/45531135-96571d80-b831-11e8-8e9d-5e3b44c8890d.png)

