### PR TITLE
Fix geometry comparison between null geometries

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1188,7 +1188,13 @@ bool QgsGeometry::disjoint( const QgsGeometry &geometry ) const
 
 bool QgsGeometry::equals( const QgsGeometry &geometry ) const
 {
-  if ( !d->geometry || geometry.isNull() )
+
+  if ( isNull() && geometry.isNull() )
+  {
+    return true;
+  }
+
+  if ( isNull() )
   {
     return false;
   }

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -439,7 +439,7 @@ void TestQgsGeometry::operatorBool()
 void TestQgsGeometry::equality()
 {
   // null geometries
-  QVERIFY( !QgsGeometry().equals( QgsGeometry() ) );
+  QVERIFY( QgsGeometry().equals( QgsGeometry() ) );
 
   // compare to null
   QgsGeometry g1( qgis::make_unique< QgsPoint >( 1.0, 2.0 ) );


### PR DESCRIPTION
I understand that SQL does this:

```
postgres=# SELECT CASE WHEN (NULL = NULL) THEN 'true' ELSE 'false' END;
 case
-------
 false
(1 row)
```

but I believe that the context here is different and when comparing
geometries two null geometries should be considered equal.

For instance, when we want to compare two features, we want to
return equality in case the attributes are the same and the
geometry is equal, if both features have null geometries and
same attributes they should also be considered equal.

No hurry: this is not necessarily meant for 3.4