### PR TITLE
[Bugfix][Server][WFS] Server wfs format field

### DIFF
--- a/src/server/services/wfs/CMakeLists.txt
+++ b/src/server/services/wfs/CMakeLists.txt
@@ -45,6 +45,7 @@ INCLUDE_DIRECTORIES(
   ../../../core/raster
   ../../../core/symbology
   ../../../core/layertree
+  ../../../core/fieldformatter
   ../..
   ..
   .

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -251,8 +251,8 @@ namespace QgsWfs
       const QSet<QString> &layerExcludedAttributes = layer->excludeAttributesWfs();
       for ( int idx = 0; idx < fields.count(); ++idx )
       {
-
-        QString attributeName = fields.at( idx ).name();
+        const QgsField field = fields.at( idx );
+        QString attributeName = field.name();
         //skip attribute if excluded from WFS publication
         if ( layerExcludedAttributes.contains( attributeName ) )
         {
@@ -262,27 +262,54 @@ namespace QgsWfs
         //xsd:element
         QDomElement attElem = doc.createElement( QStringLiteral( "element" )/*xsd:element*/ );
         attElem.setAttribute( QStringLiteral( "name" ), attributeName.replace( ' ', '_' ).replace( cleanTagNameRegExp, QString() ) );
-        QVariant::Type attributeType = fields.at( idx ).type();
+        QVariant::Type attributeType = field.type();
         if ( attributeType == QVariant::Int )
-          attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "integer" ) );
+        {
+          attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "int" ) );
+        }
+        else if ( attributeType == QVariant::UInt )
+        {
+          attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "unsignedInt" ) );
+        }
         else if ( attributeType == QVariant::LongLong )
+        {
           attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "long" ) );
+        }
+        else if ( attributeType == QVariant::ULongLong )
+        {
+          attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "unsignedLong" ) );
+        }
         else if ( attributeType == QVariant::Double )
-          attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "double" ) );
+        {
+          if ( field.length() != 0 && field.precision() == 0 )
+            attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "integer" ) );
+          else
+            attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "decimal" ) );
+        }
         else if ( attributeType == QVariant::Bool )
+        {
           attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "boolean" ) );
+        }
         else if ( attributeType == QVariant::Date )
+        {
           attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "date" ) );
+        }
         else if ( attributeType == QVariant::Time )
+        {
           attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "time" ) );
+        }
         else if ( attributeType == QVariant::DateTime )
+        {
           attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "dateTime" ) );
+        }
         else
+        {
           attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "string" ) );
+        }
 
         sequenceElem.appendChild( attElem );
 
-        QString alias = fields.at( idx ).alias();
+        QString alias = field.alias();
         if ( !alias.isEmpty() )
         {
           attElem.setAttribute( QStringLiteral( "alias" ), alias );

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -323,6 +323,24 @@ namespace QgsWfs
           else
             attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "dateTime" ) );
         }
+        else if ( setup.type() ==  QStringLiteral( "Range" ) )
+        {
+          const QVariantMap config = setup.config();
+          if ( config.contains( QStringLiteral( "Precision" ) ) )
+          {
+            // if precision in range config is not the same as the attributePrec
+            // we need to update type
+            bool ok;
+            int configPrec( config[ QStringLiteral( "Precision" ) ].toInt( &ok ) );
+            if ( ok && configPrec != field.precision() )
+            {
+              if ( configPrec == 0 )
+                attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "integer" ) );
+              else
+                attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "decimal" ) );
+            }
+          }
+        }
 
         sequenceElem.appendChild( attElem );
 

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -30,6 +30,9 @@
 #include "qgsvectordataprovider.h"
 #include "qgsmapserviceexception.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsfieldformatterregistry.h"
+#include "qgsfieldformatter.h"
+#include "qgsdatetimefieldformatter.h"
 
 #include <QStringList>
 
@@ -305,6 +308,20 @@ namespace QgsWfs
         else
         {
           attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "string" ) );
+        }
+
+        const QgsEditorWidgetSetup setup = field.editorWidgetSetup();
+        if ( setup.type() ==  QStringLiteral( "DateTime" ) )
+        {
+          QgsDateTimeFieldFormatter fieldFormatter;
+          const QVariantMap config = setup.config();
+          const QString fieldFormat = config.value( QStringLiteral( "field_format" ), fieldFormatter.defaultFormat( field.type() ) ).toString();
+          if ( fieldFormat == QStringLiteral( "yyyy-MM-dd" ) )
+            attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "date" ) );
+          else if ( fieldFormat == QStringLiteral( "HH:mm:ss" ) )
+            attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "time" ) );
+          else
+            attElem.setAttribute( QStringLiteral( "type" ), QStringLiteral( "dateTime" ) );
         }
 
         sequenceElem.appendChild( attElem );

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1467,6 +1467,18 @@ namespace QgsWfs
           return date.toString( fieldFormat );
         }
       }
+      else if ( setup.type() ==  QStringLiteral( "Range" ) )
+      {
+        const QVariantMap config = setup.config();
+        if ( config.contains( QStringLiteral( "Precision" ) ) )
+        {
+          // if precision is defined, use it
+          bool ok;
+          int precision( config[ QStringLiteral( "Precision" ) ].toInt( &ok ) );
+          if ( ok )
+            return QString::number( value.toDouble(), 'f', precision );
+        }
+      }
 
       switch ( value.type() )
       {


### PR DESCRIPTION
## Description

In schema document (.xsd) provided by WFS DescribeFeatureType request:
* Replace `double` by `decimal`
* Use `int`, `unsignedInt`, `long` and `unsignedLong` for `QVariant::Int`, `QVariant::UInt`, `QVariant::LongLong` and `QVariant::ULongLong`
* Define double with 0 precision to `integer`

Define `encodeValueToText` method to correctly format field values to XML text node.

Use editor widget setup for `DateTime` and `Range` fields.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
