### PR TITLE
Fix a build error on Fedora 29+

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -46,6 +46,10 @@ Source5:        %{name}-mime.xml
 # https://github.com/qgis/QGIS/commit/718581ffb12b723f9a3c0ae01b7ec2d8aed9d4bb.patch
 Patch0:         %{name}-lib64.patch
 
+# Fix build error "PyCapsule_GetPointer called with incorrect name" on >=F29
+# https://issues.qgis.org/issues/19476
+Patch1:         %{name}-fix-sip-name.patch
+
 # Compiling stuff
 BuildRequires: bison
 BuildRequires: clang
@@ -184,6 +188,9 @@ Please refer to %{name}-server-README.fedora for details!
 %prep
 %setup -q
 %patch0 -p0 -b .lib64
+%if 0%{?fedora} >= 29
+%patch1 -p1
+%endif
 
 # Remove executable permissions from source code files
 find . \( -name "*.cpp" -o -name "*.h" \) -type f -perm /111 -execdir chmod -x {} \+

--- a/rpm/sources/qgis-fix-sip-name.patch
+++ b/rpm/sources/qgis-fix-sip-name.patch
@@ -1,0 +1,62 @@
+--- qgis-3.2.1/python/CMakeLists.txt.orig	2018-07-28 21:05:44.650275372 +0100
++++ qgis-3.2.1/python/CMakeLists.txt	2018-07-28 21:06:31.702276533 +0100
+@@ -174,7 +174,7 @@ FILE(GLOB_RECURSE sip_files_core core/*.
+ SET(SIP_EXTRA_FILES_DEPEND ${sip_files_core})
+ SET(SIP_EXTRA_OPTIONS ${PYQT_SIP_FLAGS} -g -o -a ${CMAKE_BINARY_DIR}/python/qgis.core.api)
+ IF((${SIP_VERSION_STR} VERSION_EQUAL 4.19.11) OR (${SIP_VERSION_STR} VERSION_GREATER 4.19.11))
+-  SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -n sip)
++  SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -n PyQt5.sip)
+ ENDIF((${SIP_VERSION_STR} VERSION_EQUAL 4.19.11) OR (${SIP_VERSION_STR} VERSION_GREATER 4.19.11))
+ IF((${SIP_VERSION_STR} VERSION_EQUAL 4.18) OR (${SIP_VERSION_STR} VERSION_GREATER 4.18))
+   SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -y ${QGIS_PYTHON_OUTPUT_DIRECTORY}/_core.pyi)
+@@ -198,7 +198,7 @@ IF (WITH_GUI)
+   SET(SIP_EXTRA_FILES_DEPEND ${sip_files_core} ${sip_files_gui})
+   SET(SIP_EXTRA_OPTIONS ${PYQT_SIP_FLAGS} -g -o -a ${CMAKE_BINARY_DIR}/python/qgis.gui.api)
+   IF((${SIP_VERSION_STR} VERSION_EQUAL 4.19.11) OR (${SIP_VERSION_STR} VERSION_GREATER 4.19.11))
+-    SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -n sip)
++    SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -n PyQt5.sip)
+   ENDIF((${SIP_VERSION_STR} VERSION_EQUAL 4.19.11) OR (${SIP_VERSION_STR} VERSION_GREATER 4.19.11))
+   IF((${SIP_VERSION_STR} VERSION_EQUAL 4.18) OR (${SIP_VERSION_STR} VERSION_GREATER 4.18))
+     SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -y ${QGIS_PYTHON_OUTPUT_DIRECTORY}/_gui.pyi)
+@@ -227,7 +227,7 @@ IF (WITH_SERVER AND WITH_SERVER_PLUGINS)
+   SET(SIP_EXTRA_FILES_DEPEND ${sip_files_core} ${sip_files_server})
+   SET(SIP_EXTRA_OPTIONS ${PYQT_SIP_FLAGS} -g -o -a ${CMAKE_BINARY_DIR}/python/qgis.server.api)
+   IF((${SIP_VERSION_STR} VERSION_EQUAL 4.19.11) OR (${SIP_VERSION_STR} VERSION_GREATER 4.19.11))
+-    SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -n sip)
++    SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -n PyQt5.sip)
+   ENDIF((${SIP_VERSION_STR} VERSION_EQUAL 4.19.11) OR (${SIP_VERSION_STR} VERSION_GREATER 4.19.11))
+   IF((${SIP_VERSION_STR} VERSION_EQUAL 4.18) OR (${SIP_VERSION_STR} VERSION_GREATER 4.18))
+     SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -y ${QGIS_PYTHON_OUTPUT_DIRECTORY}/_server.pyi)
+@@ -257,7 +257,7 @@ FILE(GLOB_RECURSE sip_files_analysis ana
+ SET(SIP_EXTRA_FILES_DEPEND ${sip_files_core} ${sip_files_analysis})
+ SET(SIP_EXTRA_OPTIONS ${PYQT_SIP_FLAGS} -g -o -a ${CMAKE_BINARY_DIR}/python/qgis.analysis.api)
+ IF((${SIP_VERSION_STR} VERSION_EQUAL 4.19.11) OR (${SIP_VERSION_STR} VERSION_GREATER 4.19.11))
+-  SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -n sip)
++  SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -n PyQt5.sip)
+ ENDIF((${SIP_VERSION_STR} VERSION_EQUAL 4.19.11) OR (${SIP_VERSION_STR} VERSION_GREATER 4.19.11))
+ IF((${SIP_VERSION_STR} VERSION_EQUAL 4.18) OR (${SIP_VERSION_STR} VERSION_GREATER 4.18))
+   SET(SIP_EXTRA_OPTIONS ${SIP_EXTRA_OPTIONS} -y ${QGIS_PYTHON_OUTPUT_DIRECTORY}/_analysis.pyi)
+diff -rup qgis-3.2.1.orig/python/plugins/processing/gui/NumberInputPanel.py qgis-3.2.1/python/plugins/processing/gui/NumberInputPanel.py
+--- qgis-3.2.1.orig/python/plugins/processing/gui/NumberInputPanel.py	2018-07-20 13:00:05.000000000 +0100
++++ qgis-3.2.1/python/plugins/processing/gui/NumberInputPanel.py	2018-07-29 06:01:51.016024892 +0100
+@@ -27,7 +27,7 @@ __revision__ = '1edf372fb80f2a35c77b128d
+ 
+ import os
+ import math
+-import sip
++import PyQt5.sip as sip
+ import warnings
+ 
+ from qgis.PyQt import uic
+diff -rup qgis-3.2.1.orig/src/python/qgspythonutilsimpl.cpp qgis-3.2.1/src/python/qgspythonutilsimpl.cpp
+--- qgis-3.2.1.orig/src/python/qgspythonutilsimpl.cpp	2018-07-20 13:00:05.000000000 +0100
++++ qgis-3.2.1/src/python/qgspythonutilsimpl.cpp	2018-07-29 06:03:57.048028001 +0100
+@@ -104,7 +104,7 @@ bool QgsPythonUtilsImpl::checkSystemImpo
+   runString( "sys.path = [" + newpaths.join( QStringLiteral( "," ) ) + "] + sys.path" );
+ 
+   // import SIP
+-  if ( !runString( QStringLiteral( "import sip" ),
++  if ( !runString( QStringLiteral( "import PyQt5.sip as sip" ),
+                    QObject::tr( "Couldn't load SIP module." ) + '\n' + QObject::tr( "Python support will be disabled." ) ) )
+   {
+     return false;


### PR DESCRIPTION
## Description
Builds fail on Fedora 29 due to `PyCapsule_GetPointer called with incorrect name` error.

The reason is that

> Latest PyQt5 versions include and use a private copy of sip module, named PyQt5.sip now.

(from https://bugzilla.redhat.com/show_bug.cgi?id=1601917#c11)

Patch is taken from: https://issues.qgis.org/issues/19476
build with patch applied: https://ci.services.vigano.me/#/builders/2/builds/61

I guess that soon or later also future releases of Debian and Ubuntu will be affected.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
