### PR TITLE
[FEATURE][Processing] add ability to set an m-value with PointToPath algorithm

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -319,6 +319,8 @@ qgis:pointstopath:
 
   Points can be grouped by a field to output individual line features per group.
 
+  An M-value can optionnaly be added to the vertices to represent additional information.
+
 qgis:polarplot: >
   This algorithm generates a polar plot based on the value of an input vector layer.
 


### PR DESCRIPTION
## Description

This adds a new feature to the `Point to Path` algorithm. It now allows to set an m-value using an expression on the input points layers to the output line.

This works especially well in conjunction with the `Variable width buffer (using m-value)` algorithm.


## Checklist

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
