### PR TITLE
[bugfix] Fixes float input in advanced digitizing ...

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -310,7 +310,7 @@ QgsAdvancedDigitizingDockWidget::CadConstraint *QgsAdvancedDigitizingDockWidget:
 double QgsAdvancedDigitizingDockWidget::parseUserInput( const QString &inputValue, bool &ok ) const
 {
   ok = false;
-  double value = inputValue.toDouble( &ok );
+  double value = qgsPermissiveToDouble( inputValue, ok );
   if ( ok )
   {
     return value;
@@ -1092,7 +1092,7 @@ void QgsAdvancedDigitizingDockWidget::CadConstraint::setValue( double value, boo
 {
   mValue = value;
   if ( updateWidget )
-    mLineEdit->setText( QString::number( value, 'f' ) );
+    mLineEdit->setText( QLocale().toString( value, 'f', 6 ) );
 }
 
 void QgsAdvancedDigitizingDockWidget::CadConstraint::toggleLocked()


### PR DESCRIPTION
... with not-dot locales

Fixes #18102 - Can only input integer value in the vertex editor

Precision is hardcoded to 6 decimal places, we can either increase it
or make it configurable.
