### PR TITLE
Add QgsSingleGeometryCheck

### DIFF
--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -139,6 +139,7 @@ SET(QGIS_ANALYSIS_SRCS
   vector/geometry_checker/qgsgeometryanglecheck.cpp
   vector/geometry_checker/qgsgeometryareacheck.cpp
   vector/geometry_checker/qgsgeometrycheck.cpp
+  vector/geometry_checker/qgssinglegeometrycheck.cpp
   vector/geometry_checker/qgsgeometrychecker.cpp
   vector/geometry_checker/qgsgeometrycheckerutils.cpp
   vector/geometry_checker/qgsgeometrycontainedcheck.cpp
@@ -268,6 +269,7 @@ SET(QGIS_ANALYSIS_HDRS
   vector/geometry_checker/qgsgeometryareacheck.h
   vector/geometry_checker/qgsgeometrychecker.h
   vector/geometry_checker/qgsgeometrycheck.h
+  vector/geometry_checker/qgssinglegeometrycheck.h
   vector/geometry_checker/qgsgeometrycontainedcheck.h
   vector/geometry_checker/qgsgeometrydanglecheck.h
   vector/geometry_checker/qgsgeometrydegeneratepolygoncheck.h

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.cpp
@@ -127,6 +127,32 @@ QgsRectangle QgsGeometryCheckError::affectedAreaBBox() const
   return mGeometry.boundingBox();
 }
 
+void QgsGeometryCheckError::setFixed( int method )
+{
+  mStatus = StatusFixed;
+  const QStringList methods = mCheck->resolutionMethods();
+  mResolutionMessage = methods[method];
+}
+
+void QgsGeometryCheckError::setFixFailed( const QString &reason )
+{
+  mStatus = StatusFixFailed;
+  mResolutionMessage = reason;
+}
+
+bool QgsGeometryCheckError::isEqual( QgsGeometryCheckError *other ) const
+{
+  return other->check() == check() &&
+         other->layerId() == layerId() &&
+         other->featureId() == featureId() &&
+         other->vidx() == vidx();
+}
+
+bool QgsGeometryCheckError::closeMatch( QgsGeometryCheckError * ) const
+{
+  return false;
+}
+
 bool QgsGeometryCheckError::handleChanges( const QgsGeometryCheck::Changes &changes )
 {
   if ( status() == StatusObsolete )
@@ -276,4 +302,15 @@ void QgsGeometryCheck::deleteFeatureGeometryRing( const QString &layerId, QgsFea
   {
     deleteFeatureGeometryPart( layerId, feature, partIdx, changes );
   }
+}
+
+void QgsGeometryCheckError::update( const QgsGeometryCheckError *other )
+{
+  Q_ASSERT( mCheck == other->mCheck );
+  Q_ASSERT( mLayerId == other->mLayerId );
+  Q_ASSERT( mFeatureId == other->mFeatureId );
+  mErrorLocation = other->mErrorLocation;
+  mVidx = other->mVidx;
+  mValue = other->mValue;
+  mGeometry = other->mGeometry;
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -160,10 +160,29 @@ class ANALYSIS_EXPORT QgsGeometryCheckError
     void setFixed( int method );
     void setFixFailed( const QString &reason );
     void setObsolete() { mStatus = StatusObsolete; }
+
+    /**
+     * Check if this error is equal to \a other.
+     * Is reimplemented by subclasses with additional information, comparison
+     * of base information is done in parent class.
+     */
     virtual bool isEqual( QgsGeometryCheckError *other ) const;
+
+    /**
+     * Check if this error is almost equal to \a other.
+     * If this returns true, it can be used to update existing errors after re-checking.
+     */
     virtual bool closeMatch( QgsGeometryCheckError * /*other*/ ) const;
+
+    /**
+     * Update this error with the information from \other.
+     * Will be used to update existing errors whenever they are re-checked.
+     */
     virtual void update( const QgsGeometryCheckError *other );
 
+    /**
+     * Apply a list of \a changes.
+     */
     virtual bool handleChanges( const QgsGeometryCheck::Changes &changes );
 
   protected:

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheck.h
@@ -157,39 +157,12 @@ class ANALYSIS_EXPORT QgsGeometryCheckError
     const QgsVertexId &vidx() const { return mVidx; }
     Status status() const { return mStatus; }
     QString resolutionMessage() const { return mResolutionMessage; }
-    void setFixed( int method )
-    {
-      mStatus = StatusFixed;
-      const QStringList methods = mCheck->resolutionMethods();
-      mResolutionMessage = methods[method];
-    }
-    void setFixFailed( const QString &reason )
-    {
-      mStatus = StatusFixFailed;
-      mResolutionMessage = reason;
-    }
+    void setFixed( int method );
+    void setFixFailed( const QString &reason );
     void setObsolete() { mStatus = StatusObsolete; }
-    virtual bool isEqual( QgsGeometryCheckError *other ) const
-    {
-      return other->check() == check() &&
-             other->layerId() == layerId() &&
-             other->featureId() == featureId() &&
-             other->vidx() == vidx();
-    }
-    virtual bool closeMatch( QgsGeometryCheckError * /*other*/ ) const
-    {
-      return false;
-    }
-    virtual void update( const QgsGeometryCheckError *other )
-    {
-      Q_ASSERT( mCheck == other->mCheck );
-      Q_ASSERT( mLayerId == other->mLayerId );
-      Q_ASSERT( mFeatureId == other->mFeatureId );
-      mErrorLocation = other->mErrorLocation;
-      mVidx = other->mVidx;
-      mValue = other->mValue;
-      mGeometry = other->mGeometry;
-    }
+    virtual bool isEqual( QgsGeometryCheckError *other ) const;
+    virtual bool closeMatch( QgsGeometryCheckError * /*other*/ ) const;
+    virtual void update( const QgsGeometryCheckError *other );
 
     virtual bool handleChanges( const QgsGeometryCheck::Changes &changes );
 

--- a/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.cpp
@@ -25,7 +25,7 @@ QList<QgsSingleGeometryCheckError *> QgsGeometryMultipartCheck::processGeometry(
   QgsWkbTypes::Type type = geom->wkbType();
   if ( geom->partCount() == 1 && QgsWkbTypes::isMultiType( type ) )
   {
-    errors.append( new QgsSingleGeometryCheckError( this, geometry, geom->centroid() ) );
+    errors.append( new QgsSingleGeometryCheckError( this, geometry, geometry ) );
   }
   return errors;
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymultipartcheck.h
@@ -18,14 +18,14 @@
 #ifndef QGS_GEOMETRY_MULTIPART_CHECK_H
 #define QGS_GEOMETRY_MULTIPART_CHECK_H
 
-#include "qgsgeometrycheck.h"
+#include "qgssinglegeometrycheck.h"
 
-class ANALYSIS_EXPORT QgsGeometryMultipartCheck : public QgsGeometryCheck
+class ANALYSIS_EXPORT QgsGeometryMultipartCheck : public QgsSingleGeometryCheck
 {
   public:
     explicit QgsGeometryMultipartCheck( QgsGeometryCheckerContext *context )
-      : QgsGeometryCheck( FeatureCheck, {QgsWkbTypes::PointGeometry, QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry}, context ) {}
-    void collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter = nullptr, const QMap<QString, QgsFeatureIds> &ids = QMap<QString, QgsFeatureIds>() ) const override;
+      : QgsSingleGeometryCheck( FeatureCheck, {QgsWkbTypes::PointGeometry, QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry}, context ) {}
+    QList<QgsSingleGeometryCheckError *> processGeometry( const QgsGeometry &geometry, const QVariantMap &configuration ) const override;
     void fixError( QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     QStringList resolutionMethods() const override;
     QString errorDescription() const override { return tr( "Multipart object with only one feature" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
@@ -19,6 +19,7 @@
 
 QList<QgsSingleGeometryCheckError *> QgsGeometrySelfContactCheck::processGeometry( const QgsGeometry &geometry, const QVariantMap &configuration ) const
 {
+  Q_UNUSED( configuration )
   QList<QgsSingleGeometryCheckError *> errors;
   const QgsAbstractGeometry *geom = geometry.constGet();
   for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
@@ -71,7 +71,7 @@ QList<QgsSingleGeometryCheckError *> QgsGeometrySelfContactCheck::processGeometr
           QgsPoint q = QgsGeometryUtils::projectPointOnSegment( p, si, sj );
           if ( QgsGeometryUtils::sqrDistance2D( p, q ) < mContext->tolerance * mContext->tolerance )
           {
-            errors.append( new QgsSingleGeometryCheckError( this, geometry, p, QgsVertexId( iPart, iRing, vtxMap[iVert] ) ) );
+            errors.append( new QgsSingleGeometryCheckError( this, geometry, QgsGeometry( p.clone() ), QgsVertexId( iPart, iRing, vtxMap[iVert] ) ) );
             break; // No need to report same contact on different segments multiple times
           }
         }

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.cpp
@@ -17,70 +17,67 @@
 #include "qgsgeometryutils.h"
 #include "qgsfeaturepool.h"
 
-void QgsGeometrySelfContactCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
+QList<QgsSingleGeometryCheckError *> QgsGeometrySelfContactCheck::processGeometry( const QgsGeometry &geometry, const QVariantMap &configuration ) const
 {
-  QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
-  for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
+  QList<QgsSingleGeometryCheckError *> errors;
+  const QgsAbstractGeometry *geom = geometry.constGet();
+  for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
   {
-    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
-    for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
+    for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )
     {
-      for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )
+      // Test for self-contacts
+      int n = geom->vertexCount( iPart, iRing );
+      bool isClosed = geom->vertexAt( QgsVertexId( iPart, iRing, 0 ) ) == geom->vertexAt( QgsVertexId( iPart, iRing, n - 1 ) );
+
+      // Geometry ring without duplicate nodes
+      QVector<int> vtxMap;
+      QVector<QgsPoint> ring;
+      vtxMap.append( 0 );
+      ring.append( geom->vertexAt( QgsVertexId( iPart, iRing, 0 ) ) );
+      for ( int i = 1; i < n; ++i )
       {
-        // Test for self-contacts
-        int n = geom->vertexCount( iPart, iRing );
-        bool isClosed = geom->vertexAt( QgsVertexId( iPart, iRing, 0 ) ) == geom->vertexAt( QgsVertexId( iPart, iRing, n - 1 ) );
-
-        // Geometry ring without duplicate nodes
-        QVector<int> vtxMap;
-        QVector<QgsPoint> ring;
-        vtxMap.append( 0 );
-        ring.append( geom->vertexAt( QgsVertexId( iPart, iRing, 0 ) ) );
-        for ( int i = 1; i < n; ++i )
+        QgsPoint p = geom->vertexAt( QgsVertexId( iPart, iRing, i ) );
+        if ( QgsGeometryUtils::sqrDistance2D( p, ring.last() ) > mContext->tolerance * mContext->tolerance )
         {
-          QgsPoint p = geom->vertexAt( QgsVertexId( iPart, iRing, i ) );
-          if ( QgsGeometryUtils::sqrDistance2D( p, ring.last() ) > mContext->tolerance * mContext->tolerance )
+          vtxMap.append( i );
+          ring.append( p );
+        }
+      }
+      while ( QgsGeometryUtils::sqrDistance2D( ring.front(), ring.back() ) < mContext->tolerance * mContext->tolerance )
+      {
+        vtxMap.pop_back();
+        ring.pop_back();
+      }
+      if ( isClosed )
+      {
+        vtxMap.append( n - 1 );
+        ring.append( ring.front() );
+      }
+      n = ring.size();
+
+      // For each vertex, check whether it lies on a segment
+      for ( int iVert = 0, nVerts = n - isClosed; iVert < nVerts; ++iVert )
+      {
+        const QgsPoint &p = ring[iVert];
+        for ( int i = 0, j = 1; j < n; i = j++ )
+        {
+          if ( iVert == i || iVert == j || ( isClosed && iVert == 0 && j == n - 1 ) )
           {
-            vtxMap.append( i );
-            ring.append( p );
+            continue;
           }
-        }
-        while ( QgsGeometryUtils::sqrDistance2D( ring.front(), ring.back() ) < mContext->tolerance * mContext->tolerance )
-        {
-          vtxMap.pop_back();
-          ring.pop_back();
-        }
-        if ( isClosed )
-        {
-          vtxMap.append( n - 1 );
-          ring.append( ring.front() );
-        }
-        n = ring.size();
-
-        // For each vertex, check whether it lies on a segment
-        for ( int iVert = 0, nVerts = n - isClosed; iVert < nVerts; ++iVert )
-        {
-          const QgsPoint &p = ring[iVert];
-          for ( int i = 0, j = 1; j < n; i = j++ )
+          const QgsPoint &si = ring[i];
+          const QgsPoint &sj = ring[j];
+          QgsPoint q = QgsGeometryUtils::projectPointOnSegment( p, si, sj );
+          if ( QgsGeometryUtils::sqrDistance2D( p, q ) < mContext->tolerance * mContext->tolerance )
           {
-            if ( iVert == i || iVert == j || ( isClosed && iVert == 0 && j == n - 1 ) )
-            {
-              continue;
-            }
-            const QgsPoint &si = ring[i];
-            const QgsPoint &sj = ring[j];
-            QgsPoint q = QgsGeometryUtils::projectPointOnSegment( p, si, sj );
-            if ( QgsGeometryUtils::sqrDistance2D( p, q ) < mContext->tolerance * mContext->tolerance )
-            {
-              errors.append( new QgsGeometryCheckError( this, layerFeature, p, QgsVertexId( iPart, iRing, vtxMap[iVert] ) ) );
-              break; // No need to report same contact on different segments multiple times
-            }
+            errors.append( new QgsSingleGeometryCheckError( this, geometry, p, QgsVertexId( iPart, iRing, vtxMap[iVert] ) ) );
+            break; // No need to report same contact on different segments multiple times
           }
         }
       }
     }
   }
+  return errors;
 }
 
 void QgsGeometrySelfContactCheck::fixError( QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes & /*changes*/ ) const

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfcontactcheck.h
@@ -18,14 +18,14 @@
 #ifndef QGS_GEOMETRY_SELFCONTACT_CHECK_H
 #define QGS_GEOMETRY_SELFCONTACT_CHECK_H
 
-#include "qgsgeometrycheck.h"
+#include "qgssinglegeometrycheck.h"
 
-class ANALYSIS_EXPORT QgsGeometrySelfContactCheck : public QgsGeometryCheck
+class ANALYSIS_EXPORT QgsGeometrySelfContactCheck : public QgsSingleGeometryCheck
 {
   public:
     QgsGeometrySelfContactCheck( QgsGeometryCheckerContext *context )
-      : QgsGeometryCheck( FeatureNodeCheck, {QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry}, context ) {}
-    void collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter = nullptr, const QMap<QString, QgsFeatureIds> &ids = QMap<QString, QgsFeatureIds>() ) const override;
+      : QgsSingleGeometryCheck( FeatureNodeCheck, {QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry}, context ) {}
+    QList<QgsSingleGeometryCheckError *> processGeometry( const QgsGeometry &geometry, const QVariantMap &configuration ) const override;
     void fixError( QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes & ) const override;
     QStringList resolutionMethods() const override;
     QString errorDescription() const override { return tr( "Self contact" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
@@ -327,7 +327,7 @@ QList<QgsSingleGeometryCheckError *> QgsGeometrySelfIntersectionCheck::processGe
     {
       for ( const QgsGeometryUtils::SelfIntersection &inter : QgsGeometryUtils::selfIntersections( geom, iPart, iRing, mContext->tolerance ) )
       {
-        errors.append( new QgsGeometrySelfIntersectionCheckError( this, geometry, inter.point, QgsVertexId( iPart, iRing ), inter ) );
+        errors.append( new QgsGeometrySelfIntersectionCheckError( this, geometry, QgsGeometry( inter.point.clone() ), QgsVertexId( iPart, iRing ), inter ) );
       }
     }
   }

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.cpp
@@ -22,62 +22,48 @@
 #include "qgsgeometryutils.h"
 #include "qgsfeaturepool.h"
 
-bool QgsGeometrySelfIntersectionCheckError::isEqual( QgsGeometryCheckError *other ) const
+bool QgsGeometrySelfIntersectionCheckError::isEqual( const QgsSingleGeometryCheckError *other ) const
 {
-  return QgsGeometryCheckError::isEqual( other ) &&
-         static_cast<QgsGeometrySelfIntersectionCheckError *>( other )->intersection().segment1 == intersection().segment1 &&
-         static_cast<QgsGeometrySelfIntersectionCheckError *>( other )->intersection().segment2 == intersection().segment2;
+  return QgsSingleGeometryCheckError::isEqual( other ) &&
+         static_cast<const QgsGeometrySelfIntersectionCheckError *>( other )->intersection().segment1 == intersection().segment1 &&
+         static_cast<const QgsGeometrySelfIntersectionCheckError *>( other )->intersection().segment2 == intersection().segment2;
 }
 
-bool QgsGeometrySelfIntersectionCheckError::handleChanges( const QgsGeometryCheck::Changes &changes )
+bool QgsGeometrySelfIntersectionCheckError::handleChanges( const QList<QgsGeometryCheck::Change> &changes )
 {
-  if ( !QgsGeometryCheckError::handleChanges( changes ) )
-  {
+  if ( !QgsSingleGeometryCheckError::handleChanges( changes ) )
     return false;
-  }
-  for ( const QgsGeometryCheck::Change &change : changes[layerId()].value( featureId() ) )
+
+  for ( const QgsGeometryCheck::Change &change : changes )
   {
-    if ( change.vidx.vertex == mInter.segment1 ||
-         change.vidx.vertex == mInter.segment1 + 1 ||
-         change.vidx.vertex == mInter.segment2 ||
-         change.vidx.vertex == mInter.segment2 + 1 )
+    if ( change.vidx.vertex == mIntersection.segment1 ||
+         change.vidx.vertex == mIntersection.segment1 + 1 ||
+         change.vidx.vertex == mIntersection.segment2 ||
+         change.vidx.vertex == mIntersection.segment2 + 1 )
     {
       return false;
     }
     else if ( change.vidx.vertex >= 0 )
     {
-      if ( change.vidx.vertex < mInter.segment1 )
+      if ( change.vidx.vertex < mIntersection.segment1 )
       {
-        mInter.segment1 += change.type == QgsGeometryCheck::ChangeAdded ? 1 : -1;
+        mIntersection.segment1 += change.type == QgsGeometryCheck::ChangeAdded ? 1 : -1;
       }
-      if ( change.vidx.vertex < mInter.segment2 )
+      if ( change.vidx.vertex < mIntersection.segment2 )
       {
-        mInter.segment2 += change.type == QgsGeometryCheck::ChangeAdded ? 1 : -1;
+        mIntersection.segment2 += change.type == QgsGeometryCheck::ChangeAdded ? 1 : -1;
       }
     }
   }
   return true;
 }
 
-
-void QgsGeometrySelfIntersectionCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &/*messages*/, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
+void QgsGeometrySelfIntersectionCheckError::update( const QgsSingleGeometryCheckError *other )
 {
-  QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
-  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
-  for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
-  {
-    const QgsAbstractGeometry *geom = layerFeature.geometry().constGet();
-    for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
-    {
-      for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )
-      {
-        for ( const QgsGeometryUtils::SelfIntersection &inter : QgsGeometryUtils::selfIntersections( geom, iPart, iRing, mContext->tolerance ) )
-        {
-          errors.append( new QgsGeometrySelfIntersectionCheckError( this, layerFeature, inter.point, QgsVertexId( iPart, iRing ), inter ) );
-        }
-      }
-    }
-  }
+  QgsSingleGeometryCheckError::update( other );
+  // Static cast since this should only get called if isEqual == true
+  const QgsGeometrySelfIntersectionCheckError *err = static_cast<const QgsGeometrySelfIntersectionCheckError *>( other );
+  mIntersection.point = err->mIntersection.point;
 }
 
 void QgsGeometrySelfIntersectionCheck::fixError( QgsGeometryCheckError *error, int method, const QMap<QString, int> & /*mergeAttributeIndices*/, Changes &changes ) const
@@ -89,9 +75,11 @@ void QgsGeometrySelfIntersectionCheck::fixError( QgsGeometryCheckError *error, i
     error->setObsolete();
     return;
   }
+
   QgsGeometry featureGeom = feature.geometry();
   QgsAbstractGeometry *geom = featureGeom.get();
-  QgsVertexId vidx = error->vidx();
+
+  const QgsVertexId vidx = error->vidx();
 
   // Check if ring still exists
   if ( !vidx.isValid( geom ) )
@@ -100,7 +88,8 @@ void QgsGeometrySelfIntersectionCheck::fixError( QgsGeometryCheckError *error, i
     return;
   }
 
-  const QgsGeometryUtils::SelfIntersection &inter = static_cast<QgsGeometrySelfIntersectionCheckError *>( error )->intersection();
+  const QgsGeometryCheckErrorSingle *singleError = static_cast<const QgsGeometryCheckErrorSingle *>( error );
+  const QgsGeometryUtils::SelfIntersection &inter = static_cast<const QgsGeometrySelfIntersectionCheckError *>( singleError->singleError() )->intersection();
   // Check if error still applies
   bool ringIsClosed = false;
   int nVerts = QgsGeometryCheckerUtils::polyLineSize( geom, vidx.part, vidx.ring, &ringIsClosed );
@@ -324,4 +313,23 @@ QStringList QgsGeometrySelfIntersectionCheck::resolutionMethods() const
                                << tr( "Split feature into multiple single-object features" )
                                << tr( "No action" );
   return methods;
+}
+
+QList<QgsSingleGeometryCheckError *> QgsGeometrySelfIntersectionCheck::processGeometry( const QgsGeometry &geometry, const QVariantMap &configuration ) const
+{
+  Q_UNUSED( configuration )
+
+  QList<QgsSingleGeometryCheckError *> errors;
+  const QgsAbstractGeometry *geom = geometry.constGet();
+  for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
+  {
+    for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )
+    {
+      for ( const QgsGeometryUtils::SelfIntersection &inter : QgsGeometryUtils::selfIntersections( geom, iPart, iRing, mContext->tolerance ) )
+      {
+        errors.append( new QgsGeometrySelfIntersectionCheckError( this, geometry, inter.point, QgsVertexId( iPart, iRing ), inter ) );
+      }
+    }
+  }
+  return errors;
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometryselfintersectioncheck.h
@@ -26,7 +26,7 @@ class ANALYSIS_EXPORT QgsGeometrySelfIntersectionCheckError : public QgsSingleGe
   public:
     QgsGeometrySelfIntersectionCheckError( const QgsSingleGeometryCheck *check,
                                            const QgsGeometry &geometry,
-                                           const QgsPoint &errorLocation,
+                                           const QgsGeometry &errorLocation,
                                            QgsVertexId vertexId,
                                            const QgsGeometryUtils::SelfIntersection &intersection )
       : QgsSingleGeometryCheckError( check, geometry, errorLocation, vertexId )

--- a/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.cpp
@@ -31,7 +31,7 @@ QList<QgsSingleGeometryCheckError *> QgsGeometryTypeCheck::processGeometry( cons
   QgsWkbTypes::Type type = QgsWkbTypes::flatType( geom->wkbType() );
   if ( ( mAllowedTypes & ( 1 << type ) ) == 0 )
   {
-    errors.append( new QgsGeometryTypeCheckError( this, geometry, geom->centroid(), type ) );
+    errors.append( new QgsGeometryTypeCheckError( this, geometry, geometry, type ) );
   }
   return errors;
 }

--- a/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.cpp
@@ -25,6 +25,7 @@
 
 QList<QgsSingleGeometryCheckError *> QgsGeometryTypeCheck::processGeometry( const QgsGeometry &geometry, const QVariantMap &configuration ) const
 {
+  Q_UNUSED( configuration )
   QList<QgsSingleGeometryCheckError *> errors;
   const QgsAbstractGeometry *geom = geometry.constGet();
   QgsWkbTypes::Type type = QgsWkbTypes::flatType( geom->wkbType() );

--- a/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.h
@@ -18,40 +18,36 @@
 #ifndef QGS_GEOMETRY_TYPE_CHECK_H
 #define QGS_GEOMETRY_TYPE_CHECK_H
 
-#include "qgsgeometrycheck.h"
+#include "qgssinglegeometrycheck.h"
 
-class ANALYSIS_EXPORT QgsGeometryTypeCheckError : public QgsGeometryCheckError
+class ANALYSIS_EXPORT QgsGeometryTypeCheckError : public QgsSingleGeometryCheckError
 {
   public:
-    QgsGeometryTypeCheckError( const QgsGeometryCheck *check,
-                               const QgsGeometryCheckerUtils::LayerFeature &layerFeature,
-                               const QgsPointXY &errorLocation,
+    QgsGeometryTypeCheckError( const QgsSingleGeometryCheck *check,
+                               const QgsGeometry &geometry,
+                               const QgsPoint &errorLocation,
                                QgsWkbTypes::Type flatType )
-      : QgsGeometryCheckError( check, layerFeature, errorLocation )
+      : QgsSingleGeometryCheckError( check, geometry, errorLocation )
+      , mFlatType( flatType )
     {
-      mTypeName = QgsWkbTypes::displayString( flatType );
     }
 
-    bool isEqual( QgsGeometryCheckError *other ) const override
-    {
-      return QgsGeometryCheckError::isEqual( other ) &&
-             mTypeName == static_cast<QgsGeometryTypeCheckError *>( other )->mTypeName;
-    }
+    bool isEqual( const QgsSingleGeometryCheckError *other ) const override;
 
-    QString description() const override { return QStringLiteral( "%1 (%2)" ).arg( mCheck->errorDescription(), mTypeName ); }
+    QString description() const override;
 
   private:
-    QString mTypeName;
+    QgsWkbTypes::Type mFlatType;
 };
 
-class ANALYSIS_EXPORT QgsGeometryTypeCheck : public QgsGeometryCheck
+class ANALYSIS_EXPORT QgsGeometryTypeCheck : public QgsSingleGeometryCheck
 {
   public:
     QgsGeometryTypeCheck( QgsGeometryCheckerContext *context, int allowedTypes )
-      : QgsGeometryCheck( FeatureCheck, {QgsWkbTypes::PointGeometry, QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry}, context )
+      : QgsSingleGeometryCheck( FeatureCheck, {QgsWkbTypes::PointGeometry, QgsWkbTypes::LineGeometry, QgsWkbTypes::PolygonGeometry}, context )
     , mAllowedTypes( allowedTypes )
     {}
-    void collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter = nullptr, const QMap<QString, QgsFeatureIds> &ids = QMap<QString, QgsFeatureIds>() ) const override;
+    QList<QgsSingleGeometryCheckError *> processGeometry( const QgsGeometry &geometry, const QVariantMap &configuration ) const override;
     void fixError( QgsGeometryCheckError *error, int method, const QMap<QString, int> &mergeAttributeIndices, Changes &changes ) const override;
     QStringList resolutionMethods() const override;
     QString errorDescription() const override { return tr( "Geometry type" ); }

--- a/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrytypecheck.h
@@ -25,7 +25,7 @@ class ANALYSIS_EXPORT QgsGeometryTypeCheckError : public QgsSingleGeometryCheckE
   public:
     QgsGeometryTypeCheckError( const QgsSingleGeometryCheck *check,
                                const QgsGeometry &geometry,
-                               const QgsPoint &errorLocation,
+                               const QgsGeometry &errorLocation,
                                QgsWkbTypes::Type flatType )
       : QgsSingleGeometryCheckError( check, geometry, errorLocation )
       , mFlatType( flatType )

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
@@ -1,0 +1,103 @@
+/***************************************************************************
+                      qgssinglegeometrycheck.cpp
+                     --------------------------------------
+Date                 : 6.9.2018
+Copyright            : (C) 2018 by Matthias Kuhn
+email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssinglegeometrycheck.h"
+#include "qgspoint.h"
+
+QgsSingleGeometryCheck::QgsSingleGeometryCheck( CheckType checkType, const QList<QgsWkbTypes::GeometryType> &compatibleGeometryTypes, QgsGeometryCheckerContext *context )
+  : QgsGeometryCheck( checkType, compatibleGeometryTypes, context )
+{
+
+}
+
+void QgsSingleGeometryCheck::collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter, const QMap<QString, QgsFeatureIds> &ids ) const
+{
+  Q_UNUSED( messages )
+  QMap<QString, QgsFeatureIds> featureIds = ids.isEmpty() ? allLayerFeatureIds() : ids;
+  QgsGeometryCheckerUtils::LayerFeatures layerFeatures( mContext->featurePools, featureIds, mCompatibleGeometryTypes, progressCounter, mContext );
+  for ( const QgsGeometryCheckerUtils::LayerFeature &layerFeature : layerFeatures )
+  {
+    const auto singleErrors = processGeometry( layerFeature.geometry(), QVariantMap() );
+    for ( const auto error : singleErrors )
+      errors.append( convertToGeometryCheckError( error, layerFeature ) );
+  }
+}
+
+QgsGeometryCheckErrorSingle *QgsSingleGeometryCheck::convertToGeometryCheckError( QgsSingleGeometryCheckError *singleGeometryCheckError, const QgsGeometryCheckerUtils::LayerFeature &layerFeature ) const
+{
+  return new QgsGeometryCheckErrorSingle( singleGeometryCheckError, layerFeature );
+}
+
+void QgsSingleGeometryCheckError::update( const QgsSingleGeometryCheckError *other )
+{
+  Q_ASSERT( mCheck == other->mCheck );
+  mErrorLocation = other->mErrorLocation;
+  mVertexId = other->mVertexId;
+  mGeometry = other->mGeometry;
+}
+
+bool QgsSingleGeometryCheckError::isEqual( const QgsSingleGeometryCheckError *other ) const
+{
+  return mGeometry == other->mGeometry
+         && mCheck == other->mCheck
+         && mErrorLocation == other->mErrorLocation
+         && mVertexId == other->mVertexId;
+}
+
+bool QgsSingleGeometryCheckError::handleChanges( const QList<QgsGeometryCheck::Change> &changes )
+{
+  Q_UNUSED( changes )
+  return true;
+}
+
+QString QgsSingleGeometryCheckError::description() const
+{
+  return mCheck->errorDescription();
+}
+
+const QgsSingleGeometryCheck *QgsSingleGeometryCheckError::check() const
+{
+  return mCheck;
+}
+
+QgsPoint QgsSingleGeometryCheckError::errorLocation() const
+{
+  return mErrorLocation;
+}
+
+QgsVertexId QgsSingleGeometryCheckError::vertexId() const
+{
+  return mVertexId;
+}
+
+QgsGeometryCheckErrorSingle::QgsGeometryCheckErrorSingle( QgsSingleGeometryCheckError *error, const QgsGeometryCheckerUtils::LayerFeature &layerFeature )
+  : QgsGeometryCheckError( error->check(), layerFeature, QgsPointXY( error->errorLocation() ), error->vertexId() )
+  , mError( error )
+{
+
+}
+
+QgsSingleGeometryCheckError *QgsGeometryCheckErrorSingle::singleError() const
+{
+  return mError;
+}
+
+bool QgsGeometryCheckErrorSingle::handleChanges( const QgsGeometryCheck::Changes &changes )
+{
+  if ( !QgsGeometryCheckError::handleChanges( changes ) )
+    return false;
+
+  return mError->handleChanges( changes.value( layerId() ).value( featureId() ) );
+}

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
@@ -72,7 +72,7 @@ const QgsSingleGeometryCheck *QgsSingleGeometryCheckError::check() const
   return mCheck;
 }
 
-QgsPoint QgsSingleGeometryCheckError::errorLocation() const
+QgsGeometry QgsSingleGeometryCheckError::errorLocation() const
 {
   return mErrorLocation;
 }
@@ -83,7 +83,7 @@ QgsVertexId QgsSingleGeometryCheckError::vertexId() const
 }
 
 QgsGeometryCheckErrorSingle::QgsGeometryCheckErrorSingle( QgsSingleGeometryCheckError *error, const QgsGeometryCheckerUtils::LayerFeature &layerFeature )
-  : QgsGeometryCheckError( error->check(), layerFeature, QgsPointXY( error->errorLocation() ), error->vertexId() )
+  : QgsGeometryCheckError( error->check(), layerFeature, QgsPointXY( error->errorLocation().constGet()->centroid() ), error->vertexId() ) // TODO: should send geometry to QgsGeometryCheckError
   , mError( error )
 {
 

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
@@ -1,0 +1,143 @@
+/***************************************************************************
+                      qgssinglegeometrycheck.h
+                     --------------------------------------
+Date                 : 6.9.2018
+Copyright            : (C) 2018 by Matthias Kuhn
+email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSINGLEGEOMETRYCHECK_H
+#define QGSSINGLEGEOMETRYCHECK_H
+
+#define SIP_NO_FILE
+
+#include <QList>
+#include <QCoreApplication>
+
+#include "qgsgeometry.h"
+#include "qgsgeometrycheck.h"
+
+#include "qgis_analysis.h"
+
+class QgsFeature;
+class QgsSingleGeometryCheck;
+
+/**
+ * An error from a QgsSingleGeometryCheck.
+ *
+ */
+class ANALYSIS_EXPORT QgsSingleGeometryCheckError
+{
+  public:
+    QgsSingleGeometryCheckError( const QgsSingleGeometryCheck *check, const QgsGeometry &geometry, const QgsPoint &errorLocation, const QgsVertexId &vertexId = QgsVertexId() )
+      : mCheck( check )
+      , mGeometry( geometry )
+      , mErrorLocation( errorLocation )
+      , mVertexId( vertexId )
+    {}
+
+    virtual ~QgsSingleGeometryCheckError() = default;
+
+    virtual void update( const QgsSingleGeometryCheckError *other );
+    virtual bool isEqual( const QgsSingleGeometryCheckError *other ) const;
+    virtual bool handleChanges( const QList<QgsGeometryCheck::Change> &changes );
+    virtual QString description() const;
+
+    /**
+     * The check that created this error.
+     *
+     * \since QGIS 3.4
+     */
+    const QgsSingleGeometryCheck *check() const;
+
+    /**
+     * The exact location of the error.
+     *
+     * \since QGIS 3.4
+     */
+    QgsPoint errorLocation() const;
+
+    /**
+     * The vertex id of the error. May be invalid depending on the check.
+     *
+     * \since QGIS 3.4
+     */
+    QgsVertexId vertexId() const;
+
+  protected:
+    const QgsSingleGeometryCheck *mCheck;
+    QgsGeometry mGeometry;
+    QgsPoint mErrorLocation;
+    QgsVertexId mVertexId;
+};
+
+/**
+ * \ingroup analysis
+ *
+ * Wraps a QgsSingleGeometryError into a standard QgsGeometryCheckError.
+ * The single error can be obtained via singleError.
+ *
+ * \since QGIS 3.4
+ */
+class ANALYSIS_EXPORT QgsGeometryCheckErrorSingle : public QgsGeometryCheckError
+{
+  public:
+    QgsGeometryCheckErrorSingle( QgsSingleGeometryCheckError *singleError, const QgsGeometryCheckerUtils::LayerFeature &layerFeature );
+
+    /**
+     * The underlying single error.
+     */
+    QgsSingleGeometryCheckError *singleError() const;
+
+    bool handleChanges( const QgsGeometryCheck::Changes &changes ) override;
+
+  private:
+    QgsSingleGeometryCheckError *mError;
+};
+
+/**
+ * \ingroup analysis
+ *
+ * Base class for geometry checks for a single geometry without any context of the layer or other layers in the project.
+ * Classic examples are validity checks like self-intersection.
+ *
+ * Subclasses need to implement the processGeometry method.
+ *
+ * \since QGIS 3.4
+ */
+class ANALYSIS_EXPORT QgsSingleGeometryCheck : public QgsGeometryCheck
+{
+  public:
+    QgsSingleGeometryCheck( CheckType checkType, const QList<QgsWkbTypes::GeometryType> &compatibleGeometryTypes, QgsGeometryCheckerContext *context );
+
+    void collectErrors( QList<QgsGeometryCheckError *> &errors, QStringList &messages, QAtomicInt *progressCounter = nullptr, const QMap<QString, QgsFeatureIds> &ids = QMap<QString, QgsFeatureIds>() ) const final;
+
+    /**
+     * Check the \a geometry for errors. It may make use of \a configuration options.
+     *
+     * Returns a list of QgsSingleGeometryCheckErrors, ownership is transferred to the caller.
+     * An empty list is returned for geometries without errors.
+     *
+     * \since QGIS 3.4
+     */
+    virtual QList<QgsSingleGeometryCheckError *> processGeometry( const QgsGeometry &geometry, const QVariantMap &configuration ) const = 0;
+
+  private:
+
+    /**
+     * Converts a QgsSingleGeometryCheckError to a QgsGeometryCheckErrorSingle.
+     *
+     * \since QGIS 3.4
+     */
+    QgsGeometryCheckErrorSingle *convertToGeometryCheckError( QgsSingleGeometryCheckError *singleGeometryCheckError, const QgsGeometryCheckerUtils::LayerFeature &layerFeature ) const;
+
+};
+
+#endif // QGSSINGLEGEOMETRYCHECK_H

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
@@ -39,7 +39,7 @@ class QgsSingleGeometryCheck;
 class ANALYSIS_EXPORT QgsSingleGeometryCheckError
 {
   public:
-    QgsSingleGeometryCheckError( const QgsSingleGeometryCheck *check, const QgsGeometry &geometry, const QgsPoint &errorLocation, const QgsVertexId &vertexId = QgsVertexId() )
+    QgsSingleGeometryCheckError( const QgsSingleGeometryCheck *check, const QgsGeometry &geometry, const QgsGeometry &errorLocation, const QgsVertexId &vertexId = QgsVertexId() )
       : mCheck( check )
       , mGeometry( geometry )
       , mErrorLocation( errorLocation )
@@ -83,7 +83,7 @@ class ANALYSIS_EXPORT QgsSingleGeometryCheckError
      *
      * \since QGIS 3.4
      */
-    QgsPoint errorLocation() const;
+    QgsGeometry errorLocation() const;
 
     /**
      * The vertex id of the error. May be invalid depending on the check.
@@ -95,7 +95,7 @@ class ANALYSIS_EXPORT QgsSingleGeometryCheckError
   protected:
     const QgsSingleGeometryCheck *mCheck = nullptr;
     QgsGeometry mGeometry;
-    QgsPoint mErrorLocation;
+    QgsGeometry mErrorLocation;
     QgsVertexId mVertexId;
 };
 

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
@@ -30,8 +30,11 @@ class QgsFeature;
 class QgsSingleGeometryCheck;
 
 /**
+ * \ingroup analysis
+ *
  * An error from a QgsSingleGeometryCheck.
  *
+ * \since QGIS 3.4
  */
 class ANALYSIS_EXPORT QgsSingleGeometryCheckError
 {
@@ -45,9 +48,27 @@ class ANALYSIS_EXPORT QgsSingleGeometryCheckError
 
     virtual ~QgsSingleGeometryCheckError() = default;
 
+    /**
+     * Update this error with the information from \other.
+     * Will be used to update existing errors whenever they are re-checked.
+     */
     virtual void update( const QgsSingleGeometryCheckError *other );
+
+    /**
+     * Check if this error is equal to \a other.
+     * Is reimplemented by subclasses with additional information, comparison
+     * of base information is done in parent class.
+     */
     virtual bool isEqual( const QgsSingleGeometryCheckError *other ) const;
+
+    /**
+     * Apply a list of \a changes.
+     */
     virtual bool handleChanges( const QList<QgsGeometryCheck::Change> &changes );
+
+    /**
+     * A human readable description of this error.
+     */
     virtual QString description() const;
 
     /**

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.h
@@ -72,7 +72,7 @@ class ANALYSIS_EXPORT QgsSingleGeometryCheckError
     QgsVertexId vertexId() const;
 
   protected:
-    const QgsSingleGeometryCheck *mCheck;
+    const QgsSingleGeometryCheck *mCheck = nullptr;
     QgsGeometry mGeometry;
     QgsPoint mErrorLocation;
     QgsVertexId mVertexId;
@@ -99,7 +99,7 @@ class ANALYSIS_EXPORT QgsGeometryCheckErrorSingle : public QgsGeometryCheckError
     bool handleChanges( const QgsGeometryCheck::Changes &changes ) override;
 
   private:
-    QgsSingleGeometryCheckError *mError;
+    QgsSingleGeometryCheckError *mError = nullptr;
 };
 
 /**

--- a/tests/src/geometry_checker/testqgsgeometrychecks.cpp
+++ b/tests/src/geometry_checker/testqgsgeometrychecks.cpp
@@ -916,14 +916,14 @@ void TestQgsGeometryChecks::testSelfIntersectionCheck()
   QCOMPARE( f.geometry().constGet()->vertexCount( 1, 1 ), 5 );
 
   // Test change tracking
-  QgsGeometrySelfIntersectionCheckError *err = static_cast<QgsGeometrySelfIntersectionCheckError *>( errs4[0] );
-  QgsGeometryUtils::SelfIntersection  oldInter = err->intersection();
-  QVERIFY( err->handleChanges( change2changes( {err->layerId(), err->featureId(), QgsGeometryCheck::ChangeNode, QgsGeometryCheck::ChangeRemoved, QgsVertexId( errs4[0]->vidx().part, errs4[0]->vidx().ring, 0 )} ) ) );
-  QgsGeometryUtils::SelfIntersection  newInter = err->intersection();
+  QgsGeometryCheckErrorSingle *err = static_cast<QgsGeometryCheckErrorSingle *>( errs4[0] );
+  QgsGeometryUtils::SelfIntersection oldInter = static_cast<QgsGeometrySelfIntersectionCheckError *>( err->singleError() )->intersection();
+  QVERIFY( err->handleChanges( change2changes( {err->layerId(), err->featureId(), QgsGeometryCheck::ChangeNode, QgsGeometryCheck::ChangeRemoved, QgsVertexId( err->vidx().part, errs4[0]->vidx().ring, 0 )} ) ) );
+  QgsGeometryUtils::SelfIntersection  newInter = static_cast<QgsGeometrySelfIntersectionCheckError *>( err->singleError() )->intersection();
   QVERIFY( oldInter.segment1 == newInter.segment1 + 1 );
   QVERIFY( oldInter.segment2 == newInter.segment2 + 1 );
-  QVERIFY( err->handleChanges( change2changes( {err->layerId(), err->featureId(), QgsGeometryCheck::ChangeNode, QgsGeometryCheck::ChangeAdded, QgsVertexId( errs4[0]->vidx().part, errs4[0]->vidx().ring, 0 )} ) ) );
-  newInter = err->intersection();
+  QVERIFY( err->handleChanges( change2changes( {err->layerId(), errs4[0]->featureId(), QgsGeometryCheck::ChangeNode, QgsGeometryCheck::ChangeAdded, QgsVertexId( err->vidx().part, errs4[0]->vidx().ring, 0 )} ) ) );
+  newInter = static_cast<QgsGeometrySelfIntersectionCheckError *>( err->singleError() )->intersection();
   QVERIFY( oldInter.segment1 == newInter.segment1 );
   QVERIFY( oldInter.segment2 == newInter.segment2 );
 


### PR DESCRIPTION
This class is a new subclass of QgsGeometryCheck that implements an interface that works on isolated geometries.
It has no dependency on a context, apart from a configuration that can be passed in. This makes it suitable
for checks that only work on in-memory information like self-intersection and other isValid checks.

For reference the classes QgsGeometrySelfIntersectionCheck, QgsGeometryMultipartCheck, QgsGeometryTypeCheck
and QgsGeometrySelfContactCheck have been ported to this interface.
