### PR TITLE
 [processing] Show a message bar success message after running in-place, parameterless alg

### DIFF
--- a/python/plugins/processing/gui/AlgorithmExecutor.py
+++ b/python/plugins/processing/gui/AlgorithmExecutor.py
@@ -208,7 +208,7 @@ def execute_in_place_run(alg, active_layer, parameters, context=None, feedback=N
     try:
         new_feature_ids = []
 
-        active_layer.beginEditCommand(alg.name())
+        active_layer.beginEditCommand(alg.displayName())
 
         req = QgsFeatureRequest(QgsExpression(r"$id < 0"))
         req.setFlags(QgsFeatureRequest.NoGeometry)

--- a/python/plugins/processing/gui/MessageBarProgress.py
+++ b/python/plugins/processing/gui/MessageBarProgress.py
@@ -45,8 +45,8 @@ class MessageBarProgress(QgsProcessingFeedback):
         self.progress.setMaximum(100)
         self.progress.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         self.progressMessageBar.layout().addWidget(self.progress)
-        iface.messageBar().pushWidget(self.progressMessageBar,
-                                      Qgis.Info)
+        self.message_bar_item = iface.messageBar().pushWidget(self.progressMessageBar,
+                                                              Qgis.Info)
 
     def reportError(self, msg, fatalError=False):
         self.msg.append(msg)
@@ -57,7 +57,7 @@ class MessageBarProgress(QgsProcessingFeedback):
             dlg.setTitle(QCoreApplication.translate('MessageBarProgress', 'Problem executing algorithm'))
             dlg.setMessage("<br>".join(self.msg))
             dlg.exec_()
-        iface.messageBar().clearWidgets()
+        iface.messageBar().popWidget(self.message_bar_item)
 
     def tr(self, string, context=''):
         if context == '':

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -231,7 +231,12 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
 
             if self.in_place_mode and not [d for d in alg.parameterDefinitions() if d.name() not in ('INPUT', 'OUTPUT')]:
                 parameters = {}
-                execute_in_place(alg, parameters)
+                feedback = MessageBarProgress(algname=alg.displayName())
+                ok, results = execute_in_place(alg, parameters, feedback=feedback)
+                if ok:
+                    iface.messageBar().pushSuccess('', self.tr('{} complete').format(alg.displayName()))
+                feedback.close()
+                # MessageBarProgress handles errors
                 return
 
             if alg.countVisibleParameters() > 0:
@@ -250,7 +255,7 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
                         pass
                     canvas.setMapTool(prevMapTool)
             else:
-                feedback = MessageBarProgress()
+                feedback = MessageBarProgress(algname=alg.displayName())
                 context = dataobjects.createContext(feedback)
                 parameters = {}
                 ret, results = execute(alg, parameters, context, feedback)


### PR DESCRIPTION
Allows users to know that the algorithm has actually run in case there's no visible changes