### PR TITLE
[browser] Correctly show drives inserted (or removed!) after QGIS launch

### DIFF
--- a/python/core/auto_generated/qgsbrowsermodel.sip.in
+++ b/python/core/auto_generated/qgsbrowsermodel.sip.in
@@ -129,6 +129,15 @@ notify the provider dialogs of a changed connection
 %Docstring
 Reload the whole model
 %End
+
+    void refreshDrives();
+%Docstring
+Refreshes the list of drive items, removing any corresponding to removed
+drives and adding newly added drives.
+
+.. versionadded:: 3.4
+%End
+
     void beginInsertItems( QgsDataItem *parent, int first, int last );
     void endInsertItems();
     void beginRemoveItems( QgsDataItem *parent, int first, int last );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1322,10 +1322,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
       QgsApplication::applicationName(),
       QgsApplication::organizationName(),
       Qgis::QGIS_VERSION );
-  connect( QgsGui::instance()->nativePlatformInterface(), &QgsNative::usbStorageNotification, this, [ = ]( const QString & path, bool inserted )
-  {
-    QgsDebugMsg( QStringLiteral( "USB STORAGE NOTIFICATION! %1 %2" ).arg( path ).arg( inserted ? QStringLiteral( "inserted" ) : QStringLiteral( "removed" ) ) );
-  } );
+  connect( QgsGui::instance()->nativePlatformInterface(), &QgsNative::usbStorageNotification, mBrowserModel, &QgsBrowserModel::refreshDrives );
 
   // setup application progress reports from task manager
   connect( QgsApplication::taskManager(), &QgsTaskManager::taskAdded, this, []

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1321,8 +1321,11 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   QgsGui::instance()->nativePlatformInterface()->initializeMainWindow( windowHandle(),
       QgsApplication::applicationName(),
       QgsApplication::organizationName(),
-      Qgis::QGIS_VERSION
-                                                                     );
+      Qgis::QGIS_VERSION );
+  connect( QgsGui::instance()->nativePlatformInterface(), &QgsNative::usbStorageNotification, this, [ = ]( const QString & path, bool inserted )
+  {
+    QgsDebugMsg( QStringLiteral( "USB STORAGE NOTIFICATION! %1 %2" ).arg( path ).arg( inserted ? QStringLiteral( "inserted" ) : QStringLiteral( "removed" ) ) );
+  } );
 
   // setup application progress reports from task manager
   connect( QgsApplication::taskManager(), &QgsTaskManager::taskAdded, this, []

--- a/src/core/qgsbrowsermodel.h
+++ b/src/core/qgsbrowsermodel.h
@@ -145,6 +145,15 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
   public slots:
     //! Reload the whole model
     void reload();
+
+    /**
+     * Refreshes the list of drive items, removing any corresponding to removed
+     * drives and adding newly added drives.
+     *
+     * \since QGIS 3.4
+     */
+    void refreshDrives();
+
     void beginInsertItems( QgsDataItem *parent, int first, int last );
     void endInsertItems();
     void beginRemoveItems( QgsDataItem *parent, int first, int last );
@@ -192,6 +201,9 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
 
   private:
     bool mInitialized = false;
+    QMap< QString, QgsDataItem * > mDriveItems;
+
+    void removeRootItem( QgsDataItem *item );
 };
 
 #endif // QGSBROWSERMODEL_H

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -36,6 +36,10 @@ SET(QGIS_NATIVE_SRCS
   qgsnative.cpp
 )
 
+SET (QGIS_NATIVE_MOC_HDRS
+  qgsnative.h
+)
+
 IF(APPLE)
   SET(QGIS_APP_OBJC_SRCS
     mac/cocoainitializer.mm
@@ -54,6 +58,10 @@ IF(WIN32)
     ../../external/wintoast/src/wintoastlib.cpp
     win/qgswinnative.cpp
   )
+  SET (QGIS_NATIVE_MOC_HDRS
+    ${QGIS_NATIVE_MOC_HDRS}
+    win/qgswinnative.h
+  )
   SET(QGIS_NATIVE_SRCS ${QGIS_NATIVE_SRCS}
     ${QGIS_APP_WIN32_SRCS}
   )
@@ -71,6 +79,8 @@ ENDIF(UNIX AND NOT APPLE AND NOT ANDROID)
 SET(QGIS_NATIVE_HDRS
   qgsnative.h
 )
+
+QT5_WRAP_CPP(QGIS_NATIVE_MOC_SRCS ${QGIS_NATIVE_MOC_HDRS})
 
 # install headers
 
@@ -107,7 +117,7 @@ ENDIF(WIN32)
 #############################################################
 # qgis_native library
 
-ADD_LIBRARY(qgis_native SHARED ${QGIS_NATIVE_SRCS} ${QGIS_NATIVE_HDRS})
+ADD_LIBRARY(qgis_native SHARED ${QGIS_NATIVE_SRCS} ${QGIS_NATIVE_MOC_SRCS} ${QGIS_NATIVE_HDRS} ${QGIS_NATIVE_MOC_HDRS})
 SET_PROPERTY(TARGET qgis_native PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 GENERATE_EXPORT_HEADER(

--- a/src/native/mac/cocoainitializer.mm
+++ b/src/native/mac/cocoainitializer.mm
@@ -41,10 +41,10 @@
 #include <AppKit/AppKit.h>
 #include <Cocoa/Cocoa.h>
 
-class CocoaInitializer::Private 
+class CocoaInitializer::Private
 {
   public:
-    NSAutoreleasePool* autoReleasePool_;
+    NSAutoreleasePool *autoReleasePool_;
 };
 
 CocoaInitializer::CocoaInitializer()

--- a/src/native/qgsnative.h
+++ b/src/native/qgsnative.h
@@ -22,6 +22,7 @@
 #include <QImage>
 #include <QVariant>
 #include <vector>
+#include <QObject>
 
 class QString;
 class QWindow;
@@ -33,8 +34,10 @@ class QWindow;
  * are implemented in subclasses to provide platform abstraction.
  * \since QGIS 3.0
  */
-class NATIVE_EXPORT QgsNative
+class NATIVE_EXPORT QgsNative : public QObject
 {
+    Q_OBJECT
+
   public:
 
     //! Native interface capabilities
@@ -215,6 +218,21 @@ class NATIVE_EXPORT QgsNative
      * \since QGIS 3.4
      */
     virtual void onRecentProjectsChanged( const std::vector< RecentProjectProperties > &recentProjects );
+
+  signals:
+
+    /**
+     * Emitted whenever a USB storage device has been inserted or removed.
+     *
+     * The \a path argument gives the file path to the device (if available).
+     *
+     * If \a inserted is true then the device was inserted. If \a inserted is false then
+     * the device was removed.
+     *
+     * \since QGIS 3.4
+     */
+    void usbStorageNotification( const QString &path, bool inserted );
+
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsNative::Capabilities )

--- a/src/native/win/qgswinnative.h
+++ b/src/native/win/qgswinnative.h
@@ -19,13 +19,29 @@
 #define QGSMACNATIVE_H
 
 #include "qgsnative.h"
-#include <windows.h>
-#include <shlobj.h>
+#include <QAbstractNativeEventFilter>
+
+#include <Windows.h>
+#include <ShlObj.h>
 #pragma comment(lib,"Shell32.lib")
 
 class QWinTaskbarButton;
 class QWinTaskbarProgress;
 class QWindow;
+
+
+class QgsWinNativeEventFilter : public QObject, public QAbstractNativeEventFilter
+{
+    Q_OBJECT
+  public:
+
+    bool nativeEventFilter( const QByteArray &eventType, void *message, long * ) override;
+
+  signals:
+
+    void usbStorageNotification( const QString &path, bool inserted );
+};
+
 
 class NATIVE_EXPORT QgsWinNative : public QgsNative
 {
@@ -49,6 +65,8 @@ class NATIVE_EXPORT QgsWinNative : public QgsNative
     bool mWinToastInitialized = false;
     QWinTaskbarButton *mTaskButton = nullptr;
     QWinTaskbarProgress *mTaskProgress = nullptr;
+    QgsWinNativeEventFilter *mNativeEventFilter = nullptr;
+
 };
 
 #endif // QGSMACNATIVE_H


### PR DESCRIPTION
Adds a native platform interface for usb storage events, allowing native interfaces to send a signal when a USB storage device is inserted/removed. Implemented for Windows only.

Make the browser hook into this to correctly add/remove drive items as USB drives are added/removed. 

Fixes #14481, #9843