### PR TITLE
Fix outline width in simple marker sld import

### DIFF
--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -1251,6 +1251,7 @@ QgsSymbolLayerV2* QgsSimpleMarkerSymbolLayerV2::createFromSld( QDomElement &elem
   m->setAngle( angle );
   m->setOffset( offset );
   m->setOutlineStyle( borderStyle );
+  m->setOutlineWidth( borderWidth );
   return m;
 }
 


### PR DESCRIPTION
Simple marker outline width is currently ignored in simple marker sld import. This PR provides a fix