### PR TITLE
[server] Fixes Operations in WFS GetCapabilities document

### DIFF
--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -436,9 +436,6 @@ namespace QgsWfs
     operationElement.appendChild( queryText );
     operationsElement.appendChild( operationElement );
 
-    // QDomElement queryElement = doc.createElement( QStringLiteral( "Query" )/*wfs:Query*/ );
-    // operationsElement.appendChild( queryElement );
-
     const QStringList wfsLayerIds = QgsServerProjectUtils::wfsLayerIds( *project );
     const QStringList wfstUpdateLayersId = QgsServerProjectUtils::wfstUpdateLayerIds( *project );
     const QStringList wfstInsertLayersId = QgsServerProjectUtils::wfstInsertLayerIds( *project );
@@ -528,8 +525,6 @@ namespace QgsWfs
       //wfs:Operations element
       QDomElement operationsElement = doc.createElement( QStringLiteral( "Operations" )/*wfs:Operations*/ );
       //wfs:Query element
-      // QDomElement queryElement = doc.createElement( QStringLiteral( "Query" )/*wfs:Query*/ );
-      // operationsElement.appendChild( queryElement );
       QDomElement operationElement = doc.createElement( QStringLiteral( "Operation" ) );
       QDomText queryText = doc.createTextNode( QStringLiteral( "Query" ) );
       operationElement.appendChild( queryText );

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -431,8 +431,13 @@ namespace QgsWfs
     QDomElement operationsElement = doc.createElement( QStringLiteral( "Operations" )/*wfs:Operations*/ );
     featureTypeListElement.appendChild( operationsElement );
     //wfs:Query element
-    QDomElement queryElement = doc.createElement( QStringLiteral( "Query" )/*wfs:Query*/ );
-    operationsElement.appendChild( queryElement );
+    QDomElement operationElement = doc.createElement( QStringLiteral( "Operation" ) );
+    QDomText queryText = doc.createTextNode( "Query" );
+    operationElement.appendChild( queryText );
+    operationsElement.appendChild( operationElement );
+
+    // QDomElement queryElement = doc.createElement( QStringLiteral( "Query" )/*wfs:Query*/ );
+    // operationsElement.appendChild( queryElement );
 
     const QStringList wfsLayerIds = QgsServerProjectUtils::wfsLayerIds( *project );
     const QStringList wfstUpdateLayersId = QgsServerProjectUtils::wfstUpdateLayerIds( *project );
@@ -575,8 +580,12 @@ namespace QgsWfs
       //wfs:Operations element
       QDomElement operationsElement = doc.createElement( QStringLiteral( "Operations" )/*wfs:Operations*/ );
       //wfs:Query element
-      QDomElement queryElement = doc.createElement( QStringLiteral( "Query" )/*wfs:Query*/ );
-      operationsElement.appendChild( queryElement );
+      // QDomElement queryElement = doc.createElement( QStringLiteral( "Query" )/*wfs:Query*/ );
+      // operationsElement.appendChild( queryElement );
+      QDomElement operationElement = doc.createElement( QStringLiteral( "Operation" ) );
+      QDomText queryText = doc.createTextNode( "Query" );
+      operationElement.appendChild( queryText );
+      operationsElement.appendChild( operationElement );
       if ( wfstUpdateLayersId.contains( layer->id() ) ||
            wfstInsertLayersId.contains( layer->id() ) ||
            wfstDeleteLayersId.contains( layer->id() ) )

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -525,58 +525,6 @@ namespace QgsWfs
         layerElem.appendChild( otherSrsElem );
       }
 
-      //create OutputFormats element
-      QDomElement outputFormatsElem = doc.createElement( QStringLiteral( "OutputFormats" ) );
-      QDomElement outputFormatElem = doc.createElement( QStringLiteral( "Format" ) );
-      QDomText outputFormatText = doc.createTextNode( QStringLiteral( "text/xml; subtype=gml/3.1.1" ) );
-      outputFormatElem.appendChild( outputFormatText );
-      outputFormatsElem.appendChild( outputFormatElem );
-      layerElem.appendChild( outputFormatsElem );
-
-      //create WGS84BoundingBox
-      QgsRectangle layerExtent = layer->extent();
-      //transform the layers native CRS into WGS84
-      QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( GEO_EPSG_CRS_AUTHID );
-      QgsRectangle wgs84BoundingRect;
-      if ( !layerExtent.isNull() )
-      {
-        QgsCoordinateTransform exGeoTransform( layer->crs(), wgs84, project );
-        try
-        {
-          wgs84BoundingRect = exGeoTransform.transformBoundingBox( layerExtent );
-        }
-        catch ( const QgsCsException & )
-        {
-          wgs84BoundingRect = QgsRectangle();
-        }
-      }
-      //create WGS84BoundingBox element
-      QDomElement bBoxElement = doc.createElement( QStringLiteral( "ows:WGS84BoundingBox" ) );
-      bBoxElement.setAttribute( QStringLiteral( "dimensions" ), QStringLiteral( "2" ) );
-      QDomElement lCornerElement = doc.createElement( QStringLiteral( "ows:LowerCorner" ) );
-      QDomText lCornerText = doc.createTextNode( QString::number( wgs84BoundingRect.xMinimum() ) + " " + QString::number( wgs84BoundingRect.yMinimum() ) );
-      lCornerElement.appendChild( lCornerText );
-      bBoxElement.appendChild( lCornerElement );
-      QDomElement uCornerElement = doc.createElement( QStringLiteral( "ows:UpperCorner" ) );
-      QDomText uCornerText = doc.createTextNode( QString::number( wgs84BoundingRect.xMaximum() ) + " " + QString::number( wgs84BoundingRect.yMaximum() ) );
-      uCornerElement.appendChild( uCornerText );
-      bBoxElement.appendChild( uCornerElement );
-      layerElem.appendChild( bBoxElement );
-
-      // layer metadata URL
-      QString metadataUrl = layer->metadataUrl();
-      if ( !metadataUrl.isEmpty() )
-      {
-        QDomElement metaUrlElem = doc.createElement( QStringLiteral( "MetadataURL" ) );
-        QString metadataUrlType = layer->metadataUrlType();
-        metaUrlElem.setAttribute( QStringLiteral( "type" ), metadataUrlType );
-        QString metadataUrlFormat = layer->metadataUrlFormat();
-        metaUrlElem.setAttribute( QStringLiteral( "format" ), metadataUrlFormat );
-        QDomText metaUrlText = doc.createTextNode( metadataUrl );
-        metaUrlElem.appendChild( metaUrlText );
-        layerElem.appendChild( metaUrlElem );
-      }
-
       //wfs:Operations element
       QDomElement operationsElement = doc.createElement( QStringLiteral( "Operations" )/*wfs:Operations*/ );
       //wfs:Query element
@@ -615,6 +563,59 @@ namespace QgsWfs
       }
 
       layerElem.appendChild( operationsElement );
+
+      //create OutputFormats element
+      QDomElement outputFormatsElem = doc.createElement( QStringLiteral( "OutputFormats" ) );
+      QDomElement outputFormatElem = doc.createElement( QStringLiteral( "Format" ) );
+      QDomText outputFormatText = doc.createTextNode( QStringLiteral( "text/xml; subtype=gml/3.1.1" ) );
+      outputFormatElem.appendChild( outputFormatText );
+      outputFormatsElem.appendChild( outputFormatElem );
+      layerElem.appendChild( outputFormatsElem );
+
+      //create WGS84BoundingBox
+      QgsRectangle layerExtent = layer->extent();
+      //transform the layers native CRS into WGS84
+      QgsCoordinateReferenceSystem wgs84 = QgsCoordinateReferenceSystem::fromOgcWmsCrs( GEO_EPSG_CRS_AUTHID );
+      QgsRectangle wgs84BoundingRect;
+      if ( !layerExtent.isNull() )
+      {
+        QgsCoordinateTransform exGeoTransform( layer->crs(), wgs84, project );
+        try
+        {
+          wgs84BoundingRect = exGeoTransform.transformBoundingBox( layerExtent );
+        }
+        catch ( const QgsCsException & )
+        {
+          wgs84BoundingRect = QgsRectangle();
+        }
+      }
+
+      //create WGS84BoundingBox element
+      QDomElement bBoxElement = doc.createElement( QStringLiteral( "ows:WGS84BoundingBox" ) );
+      bBoxElement.setAttribute( QStringLiteral( "dimensions" ), QStringLiteral( "2" ) );
+      QDomElement lCornerElement = doc.createElement( QStringLiteral( "ows:LowerCorner" ) );
+      QDomText lCornerText = doc.createTextNode( QString::number( wgs84BoundingRect.xMinimum() ) + " " + QString::number( wgs84BoundingRect.yMinimum() ) );
+      lCornerElement.appendChild( lCornerText );
+      bBoxElement.appendChild( lCornerElement );
+      QDomElement uCornerElement = doc.createElement( QStringLiteral( "ows:UpperCorner" ) );
+      QDomText uCornerText = doc.createTextNode( QString::number( wgs84BoundingRect.xMaximum() ) + " " + QString::number( wgs84BoundingRect.yMaximum() ) );
+      uCornerElement.appendChild( uCornerText );
+      bBoxElement.appendChild( uCornerElement );
+      layerElem.appendChild( bBoxElement );
+
+      // layer metadata URL
+      QString metadataUrl = layer->metadataUrl();
+      if ( !metadataUrl.isEmpty() )
+      {
+        QDomElement metaUrlElem = doc.createElement( QStringLiteral( "MetadataURL" ) );
+        QString metadataUrlType = layer->metadataUrlType();
+        metaUrlElem.setAttribute( QStringLiteral( "type" ), metadataUrlType );
+        QString metadataUrlFormat = layer->metadataUrlFormat();
+        metaUrlElem.setAttribute( QStringLiteral( "format" ), metadataUrlFormat );
+        QDomText metaUrlText = doc.createTextNode( metadataUrl );
+        metaUrlElem.appendChild( metaUrlText );
+        layerElem.appendChild( metaUrlElem );
+      }
 
       featureTypeListElement.appendChild( layerElem );
     }

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -531,9 +531,10 @@ namespace QgsWfs
       // QDomElement queryElement = doc.createElement( QStringLiteral( "Query" )/*wfs:Query*/ );
       // operationsElement.appendChild( queryElement );
       QDomElement operationElement = doc.createElement( QStringLiteral( "Operation" ) );
-      QDomText queryText = doc.createTextNode( "Query" );
+      QDomText queryText = doc.createTextNode( QStringLiteral( "Query" ) );
       operationElement.appendChild( queryText );
       operationsElement.appendChild( operationElement );
+
       if ( wfstUpdateLayersId.contains( layer->id() ) ||
            wfstInsertLayersId.contains( layer->id() ) ||
            wfstDeleteLayersId.contains( layer->id() ) )
@@ -543,22 +544,30 @@ namespace QgsWfs
         if ( ( provider->capabilities() & QgsVectorDataProvider::AddFeatures ) && wfstInsertLayersId.contains( layer->id() ) )
         {
           //wfs:Insert element
-          QDomElement insertElement = doc.createElement( QStringLiteral( "Insert" )/*wfs:Insert*/ );
-          operationsElement.appendChild( insertElement );
+          QDomElement operationElement = doc.createElement( QStringLiteral( "Operation" ) );
+          QDomText insertText = doc.createTextNode( QStringLiteral( "Insert" )/*wfs:Insert*/ );
+          operationElement.appendChild( insertText );
+          operationsElement.appendChild( operationElement );
         }
+
         if ( ( provider->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) &&
              ( provider->capabilities() & QgsVectorDataProvider::ChangeGeometries ) &&
              wfstUpdateLayersId.contains( layer->id() ) )
         {
           //wfs:Update element
-          QDomElement updateElement = doc.createElement( QStringLiteral( "Update" )/*wfs:Update*/ );
-          operationsElement.appendChild( updateElement );
+          QDomElement operationElement = doc.createElement( QStringLiteral( "Operation" ) );
+          QDomText updateText = doc.createTextNode( QStringLiteral( "Update" )/*wfs:Update*/ );
+          operationElement.appendChild( updateText );
+          operationsElement.appendChild( operationElement );
         }
+
         if ( ( provider->capabilities() & QgsVectorDataProvider::DeleteFeatures ) && wfstDeleteLayersId.contains( layer->id() ) )
         {
           //wfs:Delete element
-          QDomElement deleteElement = doc.createElement( QStringLiteral( "Delete" )/*wfs:Delete*/ );
-          operationsElement.appendChild( deleteElement );
+          QDomElement operationElement = doc.createElement( QStringLiteral( "Operation" ) );
+          QDomText deleteText = doc.createTextNode( QStringLiteral( "Delete" )/*wfs:Delete*/ );
+          operationElement.appendChild( deleteText );
+          operationsElement.appendChild( operationElement );
         }
       }
 

--- a/tests/testdata/qgis_server/wfs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wfs_getcapabilities.txt
@@ -82,7 +82,7 @@ Content-Type: text/xml; charset=utf-8
  </ows:OperationsMetadata>
  <FeatureTypeList>
   <Operations>
-   <Query/>
+   <Operation>Query</Operation>
   </Operations>
   <FeatureType>
    <Name>testlayer</Name>
@@ -90,6 +90,12 @@ Content-Type: text/xml; charset=utf-8
    <Abstract>A test vector layer with unicode òà</Abstract>
    <DefaultSRS>EPSG:4326</DefaultSRS>
    <OtherSRS>EPSG:3857</OtherSRS>
+   <Operations>
+    <Operation>Query</Operation>
+    <Operation>Insert</Operation>
+    <Operation>Update</Operation>
+    <Operation>Delete</Operation>
+   </Operations>
    <OutputFormats>
     <Format>text/xml; subtype=gml/3.1.1</Format>
    </OutputFormats>
@@ -97,12 +103,6 @@ Content-Type: text/xml; charset=utf-8
     <ows:LowerCorner>8.20346 44.9014</ows:LowerCorner>
     <ows:UpperCorner>8.20355 44.9015</ows:UpperCorner>
    </ows:WGS84BoundingBox>
-   <Operations>
-    <Query/>
-    <Insert/>
-    <Update/>
-    <Delete/>
-   </Operations>
   </FeatureType>
  </FeatureTypeList>
  <ogc:Filter_Capabilities>


### PR DESCRIPTION
## Description

This PR fixes the next failures in OGC tests for WFS 1.1.0:

```
       Validation error:
  cvc-complex-type.2.4.a: Invalid content was found starting with element 'Query'. One of '{"http://www.opengis.net/wfs":Operation}' is expected.
Validation error:
  cvc-complex-type.4: Attribute 'typeName' must appear on element 'Query'.
Validation error:
  cvc-complex-type.2.4.a: Invalid content was found starting with element 'Operations'. One of '{"http://www.opengis.net/ows":WGS84BoundingBox, "http://www.opengis.net/wfs":MetadataURL}' is expected.
Validation error:
  cvc-complex-type.2.4.a: Invalid content was found starting with element 'Query'. One of '{"http://www.opengis.net/wfs":Operation}' is expected.
Validation error:
  cvc-complex-type.4: Attribute 'typeName' must appear on element 'Query'.
```

See [online reports](http://test.qgis.org/ogc_cite/wfs_110/2018_09_18_06_00/report.html#s0001/d68e38807_1/d68e636_1/d68e28810_1/d68e1095_1).

Unit tests have been updated accordingly.

## Checklist


- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
