### PR TITLE
[server] Fixes Filter_Capabilities element in WFS GetCapabilities document

### DIFF
--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -153,6 +153,11 @@ namespace QgsWfs
     }
     scalarCapabilitiesElement.appendChild( comparisonOperatorsElem );
 
+    QDomElement idCapabilitiesElement = doc.createElement( QStringLiteral( "ogc:Id_Capabilities" ) );
+    QDomElement fidElem = doc.createElement( QStringLiteral( "ogc:FID" ) );
+    idCapabilitiesElement.appendChild( fidElem );
+    filterCapabilitiesElement.appendChild( idCapabilitiesElement );
+
     return doc;
 
   }

--- a/tests/testdata/qgis_server/wfs_getcapabilities.txt
+++ b/tests/testdata/qgis_server/wfs_getcapabilities.txt
@@ -139,5 +139,8 @@ Content-Type: text/xml; charset=utf-8
     <ogc:ComparisonOperator>Between</ogc:ComparisonOperator>
    </ogc:ComparisonOperators>
   </ogc:Scalar_Capabilities>
+  <ogc:Id_Capabilities>
+   <ogc:FID/>
+  </ogc:Id_Capabilities>
  </ogc:Filter_Capabilities>
 </WFS_Capabilities>


### PR DESCRIPTION
## Description

This PR fixes the next failures in OGC tests for WFS 1.1.0:

```
Validation error:
  cvc-complex-type.2.4.b: The content of element 'ogc:Filter_Capabilities' is not complete. One of '{"http://www.opengis.net/ogc":Id_Capabilities}' is expected.
6 validation errors detected.
```

See [online reports](http://test.qgis.org/ogc_cite/wfs_110/2018_09_18_06_00/report.html#s0001/d68e38807_1/d68e636_1/d68e28810_1/d68e1095_1).

Unit tests have been updated accordingly.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
