### PR TITLE
Bugfix 19802 dbmanager saved queries

### DIFF
--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -24,6 +24,7 @@ The content of this file is based on
 from builtins import zip
 from builtins import next
 from builtins import str
+from hashlib import md5
 
 from qgis.PyQt.QtCore import Qt, pyqtSignal
 from qgis.PyQt.QtWidgets import QDialog, QWidget, QAction, QApplication, QInputDialog, QStyledItemDelegate, QTableWidgetItem
@@ -197,6 +198,9 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
 
         self.populateQueryHistory()
 
+    def getQueryHash(self, name):
+        return 'q%s' % md5(name.encode('utf8')).hexdigest()
+
     def updatePresetsCombobox(self):
         self.presetCombo.clear()
 
@@ -214,9 +218,9 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         query = self._getSqlQuery()
         if query == "":
             return
-        name = self.presetName.text()
-        QgsProject.instance().writeEntry('DBManager', 'savedQueries/q' + str(name.__hash__()) + '/name', name)
-        QgsProject.instance().writeEntry('DBManager', 'savedQueries/q' + str(name.__hash__()) + '/query', query)
+        name = str(self.presetName.text())
+        QgsProject.instance().writeEntry('DBManager', 'savedQueries/' + self.getQueryHash(name) + '/name', name)
+        QgsProject.instance().writeEntry('DBManager', 'savedQueries/' + self.getQueryHash(name) + '/query', query)
         index = self.presetCombo.findText(name)
         if index == -1:
             self.presetCombo.addItem(name)
@@ -226,13 +230,13 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
 
     def deletePreset(self):
         name = self.presetCombo.currentText()
-        QgsProject.instance().removeEntry('DBManager', 'savedQueries/q' + str(name.__hash__()))
+        QgsProject.instance().removeEntry('DBManager', 'savedQueries/' + self.getQueryHash(name))
         self.presetCombo.removeItem(self.presetCombo.findText(name))
         self.presetCombo.setCurrentIndex(-1)
 
     def loadPreset(self, name):
-        query = QgsProject.instance().readEntry('DBManager', 'savedQueries/q' + str(name.__hash__()) + '/query')[0]
-        name = QgsProject.instance().readEntry('DBManager', 'savedQueries/q' + str(name.__hash__()) + '/name')[0]
+        query = QgsProject.instance().readEntry('DBManager', 'savedQueries/' + self.getQueryHash(name) + '/query')[0]
+        name = QgsProject.instance().readEntry('DBManager', 'savedQueries/' + self.getQueryHash(name) + '/name')[0]
         self.editSql.setText(query)
 
     def loadAsLayerToggled(self, checked):

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -32,7 +32,7 @@ from qgis.gui import (QgsLayerTreeMapCanvasBridge,
                       QgsMapCanvas)
 
 from qgis.PyQt.QtTest import QSignalSpy
-from qgis.PyQt.QtCore import QT_VERSION_STR, QTemporaryFile, QTemporaryDir
+from qgis.PyQt.QtCore import QT_VERSION_STR, QTemporaryDir
 import sip
 
 from qgis.testing import start_app, unittest
@@ -1104,6 +1104,22 @@ class TestQgsProject(unittest.TestCase):
 
         self.assertEqual(p0.baseName(), '2.18.21')
         self.assertEqual(p1.baseName(), 'qgis-3.2.0')
+
+    def testWriteEntry(self):
+
+        tmpDir = QTemporaryDir()
+        tmpFile = "{}/project.qgs".format(tmpDir.path())
+
+        # zip with existing file
+        project = QgsProject()
+        query = 'select * from "sample DH" where "sample DH"."Elev" > 130 and "sample DH"."Elev" < 140'
+        self.assertTrue(project.writeEntry('myscope', 'myentry', query))
+        self.assertTrue(project.write(tmpFile))
+
+        self.assertTrue(project.read(tmpFile))
+        q, ok = project.readEntry('myscope', 'myentry')
+        self.assertTrue(ok)
+        self.assertEqual(q, query)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Looks like `__hash__()` returns different values in different sessions, let's use `md5` for proper hashing instead of relying on a private function (that can vary at any time)

