### PR TITLE
Add WITH_INTERNAL_QT3DEXTRAS_HEADERS cmake option to ease building process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,14 @@ IF(WITH_CORE)
     # (Qt 3D was introduced in 5.7 but it is not stable enough in that branch)
     # Qt 5.8 is missing some classes, https://github.com/qgis/QGIS/pull/5203#discussion_r142319862
     SET(QT_MIN_VERSION 5.9.0)
+    # on recent Debian and Ubuntu the headers from Qt3DExtras library have been removed
+    # so we ship them ourselves as a workaround
+    SET (WITH_INTERNAL_QT3DEXTRAS_HEADERS FALSE CACHE BOOL "Determines whether to use our copy of Qt3DExtras headers (needed for Debian/Ubuntu)")
+    IF (WITH_INTERNAL_QT3DEXTRAS_HEADERS)
+      SET(CMAKE_PREFIX_PATH "${CMAKE_SOURCE_DIR}/external/qt3dextra-headers/cmake")
+      SET(QT5_3DEXTRA_INCLUDE_DIR "${CMAKE_SOURCE_DIR}/external/qt3dextra-headers")
+      SET(QT5_3DEXTRA_LIBRARY "/usr/lib/x86_64-linux-gnu/libQt53DExtras.so")
+    ENDIF ()
   ELSE ()
     SET(QT_MIN_VERSION 5.4.0)
   ENDIF()


### PR DESCRIPTION
## Description
This PR adds a WITH_INTERNAL_QT3DEXTRAS_HEADERS cmake parameter to ease building against debian/ubuntu. The patch was originally written by @wonder-sk.

Ideally, this line `SET(QT5_3DEXTRA_LIBRARY "/usr/lib/x86_64-linux-gnu/libQt53DExtras.so")` needs to be modified to generalize the /usr/lib/x86_64-linux-gnu/ path. 

@jef-n , any idea?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
