### PR TITLE
[bugfix] Fix Dissolve GDAL algorithm

### DIFF
--- a/python/plugins/processing/algs/gdal/Dissolve.py
+++ b/python/plugins/processing/algs/gdal/Dissolve.py
@@ -85,7 +85,7 @@ class Dissolve(GdalAlgorithm):
                                                   self.tr('Numeric attribute to calculate statistics on'),
                                                   None,
                                                   self.INPUT,
-                                                  QgsProcessingParameterField.Any,
+                                                  QgsProcessingParameterField.Numeric,
                                                   optional=True))
         params.append(QgsProcessingParameterString(self.OPTIONS,
                                                    self.tr('Additional creation options'),
@@ -154,7 +154,7 @@ class Dissolve(GdalAlgorithm):
         if self.parameterAsBool(parameters, self.COMPUTE_AREA, context):
             tokens.append("SUM(ST_Area({0})) AS area, ST_Perimeter(ST_Union({0})) AS perimeter".format(geometry))
 
-        statsField = self.parameterAsString(parameters, self.FIELD, context)
+        statsField = self.parameterAsString(parameters, self.STATISTICS_ATTRIBUTE, context)
         if statsField and self.parameterAsBool(parameters, self.COMPUTE_STATISTICS, context):
             tokens.append("SUM({0}) AS sum, MIN({0}) AS min, MAX({0}) AS max, AVG({0}) AS avg".format(statsField))
 

--- a/python/plugins/processing/algs/gdal/Dissolve.py
+++ b/python/plugins/processing/algs/gdal/Dissolve.py
@@ -161,14 +161,14 @@ class Dissolve(GdalAlgorithm):
         params = ','.join(tokens)
         if params:
             if self.parameterAsBool(parameters, self.KEEP_ATTRIBUTES, context):
-                sql = "SELECT ST_Union({}) AS {}{}, {} FROM {} GROUP BY {}".format(geometry, geometry, other_fields, params, layerName, fieldName)
+                sql = "SELECT ST_Union({}) AS {}{}, {} FROM '{}' GROUP BY {}".format(geometry, geometry, other_fields, params, layerName, fieldName)
             else:
-                sql = "SELECT ST_Union({}) AS {}, {}, {} FROM {} GROUP BY {}".format(geometry, geometry, fieldName, params, layerName, fieldName)
+                sql = "SELECT ST_Union({}) AS {}, {}, {} FROM '{}' GROUP BY {}".format(geometry, geometry, fieldName, params, layerName, fieldName)
         else:
             if self.parameterAsBool(parameters, self.KEEP_ATTRIBUTES, context):
-                sql = "SELECT ST_Union({}) AS {}{} FROM {} GROUP BY {}".format(geometry, geometry, other_fields, layerName, fieldName)
+                sql = "SELECT ST_Union({}) AS {}{} FROM '{}' GROUP BY {}".format(geometry, geometry, other_fields, layerName, fieldName)
             else:
-                sql = "SELECT ST_Union({}) AS {}, {} FROM {} GROUP BY {}".format(geometry, geometry, fieldName, layerName, fieldName)
+                sql = "SELECT ST_Union({}) AS {}, {} FROM '{}' GROUP BY {}".format(geometry, geometry, fieldName, layerName, fieldName)
 
         arguments.append(sql)
 

--- a/python/plugins/processing/tests/testdata/custom/dissolve_polys_2.gfs
+++ b/python/plugins/processing/tests/testdata/custom/dissolve_polys_2.gfs
@@ -1,0 +1,32 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>dissolve_polys_2</Name>
+    <ElementPath>dissolve_polys_2</ElementPath>
+    <!--POLYGON-->
+    <GeometryType>3</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>8</FeatureCount>
+      <ExtentXMin>-1.00000</ExtentXMin>
+      <ExtentXMax>9.16296</ExtentXMax>
+      <ExtentYMin>-3.00000</ExtentYMin>
+      <ExtentYMax>6.08868</ExtentYMax>
+    </DatasetSpecificInfo>
+    <PropertyDefn>
+      <Name>name</Name>
+      <ElementPath>name</ElementPath>
+      <Type>String</Type>
+      <Width>2</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>intval</Name>
+      <ElementPath>intval</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>floatval</Name>
+      <ElementPath>floatval</ElementPath>
+      <Type>Real</Type>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/custom/dissolve_polys_2.gml
+++ b/python/plugins/processing/tests/testdata/custom/dissolve_polys_2.gml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ dissolve_polys_2.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>9.162955854126682</gml:X><gml:Y>6.088675623800385</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                        
+  <gml:featureMember>
+    <ogr:dissolve_polys_2 fid="polys.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>-1,-1 -1,3 3,3 3,2 2,2 2,-1 -1,-1</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aa</ogr:name>
+      <ogr:intval>1</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+    </ogr:dissolve_polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:dissolve_polys_2 fid="polys.1">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6.24145873320538,-0.054510556621882 7.24145873320538,-1.05451055662188 5.24145873320538,-1.05451055662188 6.24145873320538,-0.054510556621882</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>dd</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0</ogr:floatval>
+    </ogr:dissolve_polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:dissolve_polys_2 fid="polys.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2,5 2,6 3,6 3,5 2,5</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bb</ogr:name>
+      <ogr:intval>1</ogr:intval>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:dissolve_polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:dissolve_polys_2 fid="polys.4">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,2 6,1 6,-3 2,-1 2,2 3,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aa</ogr:name>
+      <ogr:intval>1</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+    </ogr:dissolve_polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:dissolve_polys_2 fid="polys.5">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2.44337811900192,4.42360844529751 2.44337811900192,5.42360844529751 3.44337811900192,5.42360844529751 3.44337811900192,4.42360844529751 2.44337811900192,4.42360844529751</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bb</ogr:name>
+      <ogr:intval>1</ogr:intval>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:dissolve_polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:dissolve_polys_2 fid="polys.6">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4.17255278310941,4.82264875239923 4.17255278310941,5.82264875239923 5.17255278310941,5.82264875239923 5.17255278310941,4.82264875239923 4.17255278310941,4.82264875239923</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bb</ogr:name>
+      <ogr:intval>1</ogr:intval>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:dissolve_polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:dissolve_polys_2 fid="polys.7">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>8.16295585412668,2.73877159309021 8.16295585412668,3.73877159309021 9.16295585412668,3.73877159309021 9.16295585412668,2.73877159309021 8.16295585412668,2.73877159309021</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>cc</ogr:name>
+      <ogr:intval xsi:nil="true"/>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:dissolve_polys_2>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:dissolve_polys_2 fid="polys.8">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2.62072936660269,5.08867562380038 2.62072936660269,6.08867562380038 3.62072936660269,6.08867562380038 3.62072936660269,5.08867562380038 2.62072936660269,5.08867562380038</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>bb</ogr:name>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:dissolve_polys_2>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/gdal/dissolve_polys_2_dissolved.gml
+++ b/python/plugins/processing/tests/testdata/expected/gdal/dissolve_polys_2_dissolved.gml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ dissolve_polys_2_dissolved.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>9.162955854126681</gml:X><gml:Y>6.08867562380038</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                         
+  <gml:featureMember>
+    <ogr:SELECT fid="SELECT.0">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>3,2 6,1 6,-3 2,-1 -1,-1 -1,3 3,3 3,2</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>aa</ogr:name>
+      <ogr:count>2</ogr:count>
+      <ogr:sum>47.453456</ogr:sum>
+      <ogr:min>3.33</ogr:min>
+      <ogr:max>44.123456</ogr:max>
+      <ogr:avg>23.726728</ogr:avg>
+    </ogr:SELECT>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:SELECT fid="SELECT.1">
+      <ogr:geometryProperty><gml:MultiPolygon srsName="EPSG:4326"><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>4.17255278310941,4.82264875239923 4.17255278310941,5.82264875239923 5.17255278310941,5.82264875239923 5.17255278310941,4.82264875239923 4.17255278310941,4.82264875239923</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember><gml:polygonMember><gml:Polygon><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>2.44337811900192,4.42360844529751 2.44337811900192,5.0 2,5 2,6 2.62072936660269,6.0 2.62072936660269,6.08867562380038 3.62072936660269,6.08867562380038 3.62072936660269,5.08867562380038 3.44337811900192,5.08867562380038 3.44337811900192,4.42360844529751 2.44337811900192,4.42360844529751</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></gml:polygonMember></gml:MultiPolygon></ogr:geometryProperty>
+      <ogr:name>bb</ogr:name>
+      <ogr:count>4</ogr:count>
+      <ogr:sum>0.492</ogr:sum>
+      <ogr:min>0.123</ogr:min>
+      <ogr:max>0.123</ogr:max>
+      <ogr:avg>0.123</ogr:avg>
+    </ogr:SELECT>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:SELECT fid="SELECT.2">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>8.16295585412668,2.73877159309021 8.16295585412668,3.73877159309021 9.16295585412668,3.73877159309021 9.16295585412668,2.73877159309021 8.16295585412668,2.73877159309021</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>cc</ogr:name>
+      <ogr:count>1</ogr:count>
+      <ogr:sum>0.123</ogr:sum>
+      <ogr:min>0.123</ogr:min>
+      <ogr:max>0.123</ogr:max>
+      <ogr:avg>0.123</ogr:avg>
+    </ogr:SELECT>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:SELECT fid="SELECT.3">
+      <ogr:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6.24145873320538,-0.054510556621882 7.24145873320538,-1.05451055662188 5.24145873320538,-1.05451055662188 6.24145873320538,-0.054510556621882</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></ogr:geometryProperty>
+      <ogr:name>dd</ogr:name>
+      <ogr:count>1</ogr:count>
+      <ogr:sum>0</ogr:sum>
+      <ogr:min>0</ogr:min>
+      <ogr:max>0</ogr:max>
+      <ogr:avg>0</ogr:avg>
+    </ogr:SELECT>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/gdal/dissolve_polys_2_dissolved.xsd
+++ b/python/plugins/processing/tests/testdata/expected/gdal/dissolve_polys_2_dissolved.xsd
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="SELECT" type="ogr:SELECT_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="SELECT_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:GeometryPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="name" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:string">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="count" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="16"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="sum" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="min" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="max" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="avg" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -733,3 +733,23 @@ tests:
       OUTPUT:
         name: expected/gdal/points_along_lines.gml
         type: vector
+
+  - algorithm: gdal:dissolve
+    name: Dissolve with statistics
+    params:
+      COMPUTE_AREA: false
+      COMPUTE_STATISTICS: true
+      COUNT_FEATURES: true
+      EXPLODE_COLLECTIONS: false
+      FIELD: name
+      GEOMETRY: geometry
+      INPUT:
+        name: custom/dissolve_polys_2.gml
+        type: vector
+      KEEP_ATTRIBUTES: false
+      OPTIONS: ''
+      STATISTICS_ATTRIBUTE: floatval
+    results:
+      OUTPUT:
+        name: expected/gdal/dissolve_polys_2_dissolved.gml
+        type: vector


### PR DESCRIPTION
## Description
Fixes [#19900](https://issues.qgis.org/issues/19900)

Statistics were erroneously computed on the dissolve field, rather than on the statistic attribute field as it should be.

Fixes [#19307](https://issues.qgis.org/issues/19307)

In order to properly handle filenames with white spaces (in the same way as Buffer, OffsetCurve, OneSideBuffer, PintsAlongLines algs).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
