### PR TITLE
[processing] Port numeric widget wrapper to c++, correctly expose complete expression context within modeler gui

### DIFF
--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -424,13 +424,13 @@ contained by the context.
 
     bool isHighlightedVariable( const QString &name ) const;
 %Docstring
-Returns true if the specified variable name is intended to be highlighted to the
+Returns true if the specified variable ``name`` is intended to be highlighted to the
 user. This is used by the expression builder to more prominently display the
 variable.
 
-:param name: variable name
-
 .. seealso:: :py:func:`setHighlightedVariables`
+
+.. seealso:: :py:func:`isHighlightedFunction`
 %End
 
     void setHighlightedVariables( const QStringList &variableNames );
@@ -441,6 +441,36 @@ is used by the expression builder to more prominently display these variables.
 :param variableNames: variable names to highlight
 
 .. seealso:: :py:func:`isHighlightedVariable`
+
+.. seealso:: :py:func:`setHighlightedFunctions`
+%End
+
+    bool isHighlightedFunction( const QString &name ) const;
+%Docstring
+Returns true if the specified function ``name`` is intended to be highlighted to the
+user. This is used by the expression builder to more prominently display the
+function.
+
+.. seealso:: :py:func:`setHighlightedFunctions`
+
+.. seealso:: :py:func:`isHighlightedVariable`
+
+.. versionadded:: 3.4
+%End
+
+    void setHighlightedFunctions( const QStringList &names );
+%Docstring
+Sets the list of function ``names`` intended to be highlighted to the user. This
+is used by the expression builder to more prominently display these functions.
+
+Note that these function names may include standard functions which are not functions
+specific to this context, and these standard functions will also be highlighted to users.
+
+.. seealso:: :py:func:`isHighlightedFunction`
+
+.. seealso:: :py:func:`setHighlightedVariables`
+
+.. versionadded:: 3.4
 %End
 
     QgsExpressionContextScope *activeScopeForVariable( const QString &name );

--- a/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
@@ -57,6 +57,15 @@ last for the lifetime of the widget.
 
     ~QgsProcessingModelerParameterWidget();
 
+    void setWidgetContext( const QgsProcessingParameterWidgetContext &context );
+%Docstring
+Sets the ``context`` in which the modeler parameter widget is shown, e.g., the
+parent model algorithm and other relevant information which allows the widget
+to fine-tune its behavior.
+
+.. seealso:: :py:func:`widgetContext`
+%End
+
     void populateSources( const QStringList &compatibleParameterTypes,
                           const QStringList &compatibleOutputTypes,
                           const QList< int > &compatibleDataTypes );

--- a/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
@@ -66,6 +66,12 @@ to fine-tune its behavior.
 .. seealso:: :py:func:`widgetContext`
 %End
 
+    void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
+%Docstring
+Register a Processing context ``generator`` class that will be used to retrieve
+a Processing context for the widget when required.
+%End
+
     void populateSources( const QStringList &compatibleParameterTypes,
                           const QStringList &compatibleOutputTypes,
                           const QList< int > &compatibleDataTypes );

--- a/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
@@ -62,8 +62,6 @@ last for the lifetime of the widget.
 Sets the ``context`` in which the modeler parameter widget is shown, e.g., the
 parent model algorithm and other relevant information which allows the widget
 to fine-tune its behavior.
-
-.. seealso:: :py:func:`widgetContext`
 %End
 
     void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );

--- a/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
@@ -66,7 +66,7 @@ to fine-tune its behavior.
 
     void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
 %Docstring
-Register a Processing context ``generator`` class that will be used to retrieve
+Registers a Processing context ``generator`` class that will be used to retrieve
 a Processing context for the widget when required.
 %End
 

--- a/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingmodelerparameterwidget.sip.in
@@ -12,7 +12,7 @@
 
 
 
-class QgsProcessingModelerParameterWidget : QWidget
+class QgsProcessingModelerParameterWidget : QWidget, QgsExpressionContextGenerator
 {
 %Docstring
 
@@ -116,6 +116,9 @@ Returns the current value of the parameter.
 
 .. seealso:: :py:func:`setWidgetValue`
 %End
+
+    virtual QgsExpressionContext createExpressionContext() const;
+
 
 };
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -197,6 +197,9 @@ Returns the current value of the parameter.
 .. seealso:: :py:func:`setWidgetValue`
 %End
 
+  protected:
+
+
 };
 
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -109,7 +109,7 @@ Sets the child algorithm ``id`` within the model which the parameter widget is a
 
 };
 
-class QgsAbstractProcessingParameterWidgetWrapper : QObject
+class QgsAbstractProcessingParameterWidgetWrapper : QObject, QgsExpressionContextGenerator
 {
 %Docstring
 
@@ -232,7 +232,7 @@ Returns the current value of the parameter.
 
     void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
 %Docstring
-Register a Processing context generator class that will be used to retrieve
+Register a Processing context ``generator`` class that will be used to retrieve
 a Processing context for the wrapper when required.
 %End
 
@@ -241,6 +241,9 @@ a Processing context for the wrapper when required.
 Called after all wrappers have been created within a particular dialog or context,
 allowing the wrapper to connect to the wrappers of other, related parameters.
 %End
+
+    virtual QgsExpressionContext createExpressionContext() const;
+
 
   signals:
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -232,7 +232,7 @@ Returns the current value of the parameter.
 
     void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
 %Docstring
-Register a Processing context ``generator`` class that will be used to retrieve
+Registers a Processing context ``generator`` class that will be used to retrieve
 a Processing context for the wrapper when required.
 %End
 

--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -36,6 +36,79 @@ return a pointer to a context which they have already created and own.
     virtual ~QgsProcessingContextGenerator();
 };
 
+class QgsProcessingParameterWidgetContext
+{
+%Docstring
+Contains settings which reflect the context in which a Processing parameter widget is shown, e.g., the
+parent model algorithm, a linked map canvas, and other relevant information which allows the widget
+to fine-tune its behavior.
+
+.. versionadded:: 3.4
+%End
+
+%TypeHeaderCode
+#include "qgsprocessingwidgetwrapper.h"
+%End
+  public:
+
+    QgsProcessingParameterWidgetContext();
+%Docstring
+Constructor for QgsProcessingParameterWidgetContext.
+%End
+
+    void setMapCanvas( QgsMapCanvas *canvas );
+%Docstring
+Sets the map ``canvas`` associated with the widget. This allows the widget to retrieve the current
+map scale and other properties from the canvas.
+
+.. seealso:: :py:func:`mapCanvas`
+%End
+
+    QgsMapCanvas *mapCanvas() const;
+%Docstring
+Returns the map canvas associated with the widget.
+
+.. seealso:: :py:func:`setMapCanvas`
+%End
+
+    QgsProcessingModelAlgorithm *model() const;
+%Docstring
+Returns the model which the parameter widget is associated with.
+
+.. seealso:: :py:func:`setModel`
+
+.. seealso:: :py:func:`modelChildAlgorithmId`
+%End
+
+    void setModel( QgsProcessingModelAlgorithm *model );
+%Docstring
+Sets the ``model`` which the parameter widget is associated with.
+
+.. seealso:: :py:func:`model`
+
+.. seealso:: :py:func:`setModelChildAlgorithmId`
+%End
+
+    QString modelChildAlgorithmId() const;
+%Docstring
+Returns the child algorithm ID within the model which the parameter widget is associated with.
+
+.. seealso:: :py:func:`setModelChildAlgorithmId`
+
+.. seealso:: :py:func:`model`
+%End
+
+    void setModelChildAlgorithmId( const QString &id );
+%Docstring
+Sets the child algorithm ``id`` within the model which the parameter widget is associated with.
+
+.. seealso:: :py:func:`modelChildAlgorithmId`
+
+.. seealso:: :py:func:`setModel`
+%End
+
+};
+
 class QgsAbstractProcessingParameterWidgetWrapper : QObject
 {
 %Docstring
@@ -71,6 +144,26 @@ Constructor for QgsAbstractProcessingParameterWidgetWrapper, for the specified
     QgsProcessingGui::WidgetType type() const;
 %Docstring
 Returns the dialog type for which widgets and labels will be created by this wrapper.
+%End
+
+    virtual void setWidgetContext( const QgsProcessingParameterWidgetContext &context );
+%Docstring
+Sets the ``context`` in which the Processing parameter widget is shown, e.g., the
+parent model algorithm, a linked map canvas, and other relevant information which allows the widget
+to fine-tune its behavior.
+
+Subclasses should take care to call the base class method when reimplementing this method.
+
+.. seealso:: :py:func:`widgetContext`
+%End
+
+    const QgsProcessingParameterWidgetContext &widgetContext() const;
+%Docstring
+Returns the context in which the Processing parameter widget is shown, e.g., the
+parent model algorithm, a linked map canvas, and other relevant information which allows the widget
+to fine-tune its behavior.
+
+.. seealso:: :py:func:`setWidgetContext`
 %End
 
     QWidget *createWrappedWidget( QgsProcessingContext &context ) /Factory/;

--- a/python/plugins/processing/algs/grass7/description/v.decimate.txt
+++ b/python/plugins/processing/algs/grass7/description/v.decimate.txt
@@ -2,7 +2,7 @@ v.decimate
 Decimates a point cloud
 Vector (v.*)
 QgsProcessingParameterFeatureSource|input|Input vector|1|None|False
-QgsProcessingParameterRange|zrange|Filter range for z data (min,max)|QgsProcessingParameterNumber.Integer|None|True
+QgsProcessingParameterRange|zrange|Filter range for z data (min,max)|QgsProcessingParameterNumber.Double|None|True
 QgsProcessingParameterString|cats|Category values|None|False|True
 QgsProcessingParameterNumber|skip|Throw away every n-th point|QgsProcessingParameterNumber.Integer|None|True|0|None
 QgsProcessingParameterNumber|preserve|Preserve only every n-th point|QgsProcessingParameterNumber.Integer|None|True|0|None

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -256,7 +256,8 @@ class BatchPanel(BASE, WIDGET):
         is_cpp_wrapper = not issubclass(wrapper.__class__, WidgetWrapper)
         if is_cpp_wrapper:
             widget_context = QgsProcessingParameterWidgetContext()
-            widget_context.setMapCanvas(iface.mapCanvas())
+            if iface is not None:
+                widget_context.setMapCanvas(iface.mapCanvas())
             wrapper.setWidgetContext(widget_context)
             widget = wrapper.createWrappedWidget(context)
         else:

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -36,6 +36,8 @@ from qgis.core import (Qgis,
                        QgsApplication,
                        QgsSettings,
                        QgsProcessingParameterDefinition)
+from qgis.gui import QgsProcessingParameterWidgetContext
+from qgis.utils import iface
 
 from processing.gui.wrappers import WidgetWrapperFactory, WidgetWrapper
 from processing.gui.BatchOutputSelectionPanel import BatchOutputSelectionPanel
@@ -253,6 +255,9 @@ class BatchPanel(BASE, WIDGET):
         # TODO QGIS 4.0 - remove
         is_cpp_wrapper = not issubclass(wrapper.__class__, WidgetWrapper)
         if is_cpp_wrapper:
+            widget_context = QgsProcessingParameterWidgetContext()
+            widget_context.setMapCanvas(iface.mapCanvas())
+            wrapper.setWidgetContext(widget_context)
             widget = wrapper.createWrappedWidget(context)
         else:
             widget = wrapper.widget

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -126,7 +126,8 @@ class ParametersPanel(BASE, WIDGET):
                 break
 
         widget_context = QgsProcessingParameterWidgetContext()
-        widget_context.setMapCanvas(iface.mapCanvas())
+        if iface is not None:
+            widget_context.setMapCanvas(iface.mapCanvas())
 
         # Create widgets and put them in layouts
         for param in self.alg.parameterDefinitions():

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -42,7 +42,9 @@ from qgis.core import (QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSink,
                        QgsProcessingParameterVectorDestination,
                        QgsProject)
-from qgis.gui import QgsProcessingContextGenerator
+from qgis.gui import (QgsProcessingContextGenerator,
+                      QgsProcessingParameterWidgetContext)
+from qgis.utils import iface
 
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import QCoreApplication, Qt
@@ -122,6 +124,10 @@ class ParametersPanel(BASE, WIDGET):
             if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
                 self.grpAdvanced.show()
                 break
+
+        widget_context = QgsProcessingParameterWidgetContext()
+        widget_context.setMapCanvas(iface.mapCanvas())
+
         # Create widgets and put them in layouts
         for param in self.alg.parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagHidden:
@@ -142,6 +148,7 @@ class ParametersPanel(BASE, WIDGET):
                 # TODO QGIS 4.0 - remove
                 is_python_wrapper = issubclass(wrapper.__class__, WidgetWrapper)
                 if not is_python_wrapper:
+                    wrapper.setWidgetContext(widget_context)
                     widget = wrapper.createWrappedWidget(self.processing_context)
                     wrapper.registerProcessingContextGenerator(self.context_generator)
                 else:

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -58,7 +58,9 @@ from qgis.gui import (QgsGui,
                       QgsScrollArea,
                       QgsFilterLineEdit,
                       QgsHelp,
-                      QgsProcessingModelerParameterWidget)
+                      QgsProcessingModelerParameterWidget,
+                      QgsProcessingParameterWidgetContext)
+from qgis.utils import iface
 
 from processing.gui.wrappers import WidgetWrapperFactory
 from processing.gui.wrappers import InvalidParameterValue
@@ -131,6 +133,9 @@ class ModelerParametersDialog(QDialog):
             self.algorithmItem.setConfiguration(self.configuration)
         self.verticalLayout.addWidget(self.algorithmItem)
 
+        widget_context = QgsProcessingParameterWidgetContext()
+        widget_context.setMapCanvas(iface.mapCanvas())
+
         for param in self._alg.parameterDefinitions():
             if param.flags() & QgsProcessingParameterDefinition.FlagAdvanced:
                 self.advancedButton = QPushButton()
@@ -150,6 +155,7 @@ class ModelerParametersDialog(QDialog):
             self.wrappers[param.name()] = wrapper
 
             if issubclass(wrapper.__class__, QgsProcessingModelerParameterWidget):
+                wrapper.setWidgetContext(widget_context)
                 widget = wrapper
             else:
                 widget = wrapper.widget

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -146,7 +146,8 @@ class ModelerParametersDialog(QDialog):
         self.verticalLayout.addWidget(self.algorithmItem)
 
         widget_context = QgsProcessingParameterWidgetContext()
-        widget_context.setMapCanvas(iface.mapCanvas())
+        if iface is not None:
+            widget_context.setMapCanvas(iface.mapCanvas())
         widget_context.setModel(self.model)
         widget_context.setModelChildAlgorithmId(self.childId)
 

--- a/src/app/layout/qgslayoutmapgridwidget.cpp
+++ b/src/app/layout/qgslayoutmapgridwidget.cpp
@@ -1004,6 +1004,7 @@ void QgsLayoutMapGridWidget::mAnnotationFormatButton_clicked()
   }
 
   QgsExpressionContext expressionContext = mMapGrid->createExpressionContext();
+  expressionContext.setHighlightedFunctions( QStringList() << QStringLiteral( "to_dms" ) << QStringLiteral( "to_dm" ) );
 
   QgsExpressionBuilderDialog exprDlg( nullptr, mMapGrid->annotationExpression(), this, QStringLiteral( "generic" ), expressionContext );
   exprDlg.setWindowTitle( tr( "Expression Based Annotation" ) );

--- a/src/app/layout/qgslayoutmapgridwidget.cpp
+++ b/src/app/layout/qgslayoutmapgridwidget.cpp
@@ -747,22 +747,22 @@ void QgsLayoutMapGridWidget::mCheckGridBottomSide_toggled( bool checked )
 
 void QgsLayoutMapGridWidget::mFrameDivisionsLeftComboBox_currentIndexChanged( int index )
 {
-  handleChangedFrameDisplay( QgsLayoutItemMapGrid::Left, ( QgsLayoutItemMapGrid::DisplayMode ) mFrameDivisionsLeftComboBox->itemData( index ).toInt() );
+  handleChangedFrameDisplay( QgsLayoutItemMapGrid::Left, static_cast< QgsLayoutItemMapGrid::DisplayMode >( mFrameDivisionsLeftComboBox->itemData( index ).toInt() ) );
 }
 
 void QgsLayoutMapGridWidget::mFrameDivisionsRightComboBox_currentIndexChanged( int index )
 {
-  handleChangedFrameDisplay( QgsLayoutItemMapGrid::Right, ( QgsLayoutItemMapGrid::DisplayMode ) mFrameDivisionsRightComboBox->itemData( index ).toInt() );
+  handleChangedFrameDisplay( QgsLayoutItemMapGrid::Right, static_cast< QgsLayoutItemMapGrid::DisplayMode >( mFrameDivisionsRightComboBox->itemData( index ).toInt() ) );
 }
 
 void QgsLayoutMapGridWidget::mFrameDivisionsTopComboBox_currentIndexChanged( int index )
 {
-  handleChangedFrameDisplay( QgsLayoutItemMapGrid::Top, ( QgsLayoutItemMapGrid::DisplayMode ) mFrameDivisionsTopComboBox->itemData( index ).toInt() );
+  handleChangedFrameDisplay( QgsLayoutItemMapGrid::Top, static_cast< QgsLayoutItemMapGrid::DisplayMode >( mFrameDivisionsTopComboBox->itemData( index ).toInt() ) );
 }
 
 void QgsLayoutMapGridWidget::mFrameDivisionsBottomComboBox_currentIndexChanged( int index )
 {
-  handleChangedFrameDisplay( QgsLayoutItemMapGrid::Bottom, ( QgsLayoutItemMapGrid::DisplayMode ) mFrameDivisionsBottomComboBox->itemData( index ).toInt() );
+  handleChangedFrameDisplay( QgsLayoutItemMapGrid::Bottom, static_cast< QgsLayoutItemMapGrid::DisplayMode >( mFrameDivisionsBottomComboBox->itemData( index ).toInt() ) );
 }
 
 void QgsLayoutMapGridWidget::mGridFramePenSizeSpinBox_valueChanged( double d )
@@ -1061,22 +1061,22 @@ void QgsLayoutMapGridWidget::mAnnotationPositionBottomComboBox_currentIndexChang
 
 void QgsLayoutMapGridWidget::mAnnotationDirectionComboBoxLeft_currentIndexChanged( int index )
 {
-  handleChangedAnnotationDirection( QgsLayoutItemMapGrid::Left, ( QgsLayoutItemMapGrid::AnnotationDirection ) mAnnotationDirectionComboBoxLeft->itemData( index ).toInt() );
+  handleChangedAnnotationDirection( QgsLayoutItemMapGrid::Left, static_cast< QgsLayoutItemMapGrid::AnnotationDirection >( mAnnotationDirectionComboBoxLeft->itemData( index ).toInt() ) );
 }
 
 void QgsLayoutMapGridWidget::mAnnotationDirectionComboBoxRight_currentIndexChanged( int index )
 {
-  handleChangedAnnotationDirection( QgsLayoutItemMapGrid::Right, ( QgsLayoutItemMapGrid::AnnotationDirection ) mAnnotationDirectionComboBoxRight->itemData( index ).toInt() );
+  handleChangedAnnotationDirection( QgsLayoutItemMapGrid::Right, static_cast< QgsLayoutItemMapGrid::AnnotationDirection >( mAnnotationDirectionComboBoxRight->itemData( index ).toInt() ) );
 }
 
 void QgsLayoutMapGridWidget::mAnnotationDirectionComboBoxTop_currentIndexChanged( int index )
 {
-  handleChangedAnnotationDirection( QgsLayoutItemMapGrid::Top, ( QgsLayoutItemMapGrid::AnnotationDirection ) mAnnotationDirectionComboBoxTop->itemData( index ).toInt() );
+  handleChangedAnnotationDirection( QgsLayoutItemMapGrid::Top, static_cast< QgsLayoutItemMapGrid::AnnotationDirection >( mAnnotationDirectionComboBoxTop->itemData( index ).toInt() ) );
 }
 
 void QgsLayoutMapGridWidget::mAnnotationDirectionComboBoxBottom_currentIndexChanged( int index )
 {
-  handleChangedAnnotationDirection( QgsLayoutItemMapGrid::Bottom, ( QgsLayoutItemMapGrid::AnnotationDirection ) mAnnotationDirectionComboBoxBottom->itemData( index ).toInt() );
+  handleChangedAnnotationDirection( QgsLayoutItemMapGrid::Bottom, static_cast< QgsLayoutItemMapGrid::AnnotationDirection >( mAnnotationDirectionComboBoxBottom->itemData( index ).toInt() ) );
 }
 
 void QgsLayoutMapGridWidget::mDistanceToMapFrameSpinBox_valueChanged( double d )
@@ -1155,7 +1155,7 @@ void QgsLayoutMapGridWidget::mAnnotationFormatComboBox_currentIndexChanged( int 
 
   mMap->beginCommand( tr( "Change Annotation Format" ) );
 
-  mMapGrid->setAnnotationFormat( ( QgsLayoutItemMapGrid::AnnotationFormat )mAnnotationFormatComboBox->itemData( index ).toInt() );
+  mMapGrid->setAnnotationFormat( static_cast< QgsLayoutItemMapGrid::AnnotationFormat >( mAnnotationFormatComboBox->itemData( index ).toInt() ) );
   mAnnotationFormatButton->setEnabled( mMapGrid->annotationFormat() == QgsLayoutItemMapGrid::CustomFormat );
 
   mMap->updateBoundingRect();

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -784,6 +784,10 @@ void QgsExpression::initVariableHelp()
 
   //processing variables
   sVariableHelpTexts.insert( QStringLiteral( "algorithm_id" ), QCoreApplication::translate( "algorithm_id", "Unique ID for algorithm." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "fullextent_minx" ), QCoreApplication::translate( "fullextent_minx", "Minimum x-value from full canvas extent (including all layers)." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "fullextent_miny" ), QCoreApplication::translate( "fullextent_miny", "Minimum y-value from full canvas extent (including all layers)." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "fullextent_maxx" ), QCoreApplication::translate( "fullextent_maxx", "Maximum x-value from full canvas extent (including all layers)." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "fullextent_maxy" ), QCoreApplication::translate( "fullextent_maxy", "Maximum y-value from full canvas extent (including all layers)." ) );
 
   //provider notification
   sVariableHelpTexts.insert( QStringLiteral( "notification_message" ), QCoreApplication::translate( "notification_message", "Content of the notification message sent by the provider (available only for actions triggered by provider notifications)." ) );

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -1297,13 +1297,13 @@ QgsExpressionContextScope *QgsExpressionContextUtils::processingAlgorithmScope( 
   Q_UNUSED( context );
 
   std::unique_ptr< QgsExpressionContextScope > scope( new QgsExpressionContextScope( QObject::tr( "Algorithm" ) ) );
+  scope->addFunction( QStringLiteral( "parameter" ), new GetProcessingParameterValue( parameters ) );
+
   if ( !algorithm )
     return scope.release();
 
   //add standard algorithm variables
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "algorithm_id" ), algorithm->id(), true ) );
-
-  scope->addFunction( QStringLiteral( "parameter" ), new GetProcessingParameterValue( parameters ) );
 
   return scope.release();
 }

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -237,6 +237,7 @@ QgsExpressionContext::QgsExpressionContext( const QgsExpressionContext &other )
     mStack << new QgsExpressionContextScope( *scope );
   }
   mHighlightedVariables = other.mHighlightedVariables;
+  mHighlightedFunctions = other.mHighlightedFunctions;
   mCachedValues = other.mCachedValues;
 }
 
@@ -250,6 +251,7 @@ QgsExpressionContext &QgsExpressionContext::operator=( QgsExpressionContext &&ot
     other.mStack.clear();
 
     mHighlightedVariables = other.mHighlightedVariables;
+    mHighlightedFunctions = other.mHighlightedFunctions;
     mCachedValues = other.mCachedValues;
   }
   return *this;
@@ -264,6 +266,7 @@ QgsExpressionContext &QgsExpressionContext::operator=( const QgsExpressionContex
     mStack << new QgsExpressionContextScope( *scope );
   }
   mHighlightedVariables = other.mHighlightedVariables;
+  mHighlightedFunctions = other.mHighlightedFunctions;
   mCachedValues = other.mCachedValues;
   return *this;
 }
@@ -309,6 +312,16 @@ bool QgsExpressionContext::isHighlightedVariable( const QString &name ) const
 void QgsExpressionContext::setHighlightedVariables( const QStringList &variableNames )
 {
   mHighlightedVariables = variableNames;
+}
+
+bool QgsExpressionContext::isHighlightedFunction( const QString &name ) const
+{
+  return mHighlightedFunctions.contains( name );
+}
+
+void QgsExpressionContext::setHighlightedFunctions( const QStringList &names )
+{
+  mHighlightedFunctions = names;
 }
 
 const QgsExpressionContextScope *QgsExpressionContext::activeScopeForVariable( const QString &name ) const

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -425,11 +425,11 @@ class CORE_EXPORT QgsExpressionContext
     QVariantMap variablesToMap() const;
 
     /**
-     * Returns true if the specified variable name is intended to be highlighted to the
+     * Returns true if the specified variable \a name is intended to be highlighted to the
      * user. This is used by the expression builder to more prominently display the
      * variable.
-     * \param name variable name
      * \see setHighlightedVariables()
+     * \see isHighlightedFunction()
      */
     bool isHighlightedVariable( const QString &name ) const;
 
@@ -438,8 +438,32 @@ class CORE_EXPORT QgsExpressionContext
      * is used by the expression builder to more prominently display these variables.
      * \param variableNames variable names to highlight
      * \see isHighlightedVariable()
+     * \see setHighlightedFunctions()
      */
     void setHighlightedVariables( const QStringList &variableNames );
+
+    /**
+     * Returns true if the specified function \a name is intended to be highlighted to the
+     * user. This is used by the expression builder to more prominently display the
+     * function.
+     * \see setHighlightedFunctions()
+     * \see isHighlightedVariable()
+     * \since QGIS 3.4
+     */
+    bool isHighlightedFunction( const QString &name ) const;
+
+    /**
+     * Sets the list of function \a names intended to be highlighted to the user. This
+     * is used by the expression builder to more prominently display these functions.
+     *
+     * Note that these function names may include standard functions which are not functions
+     * specific to this context, and these standard functions will also be highlighted to users.
+     *
+     * \see isHighlightedFunction()
+     * \see setHighlightedVariables()
+     * \since QGIS 3.4
+     */
+    void setHighlightedFunctions( const QStringList &names );
 
     /**
      * Returns the currently active scope from the context for a specified variable name.
@@ -714,6 +738,7 @@ class CORE_EXPORT QgsExpressionContext
 
     QList< QgsExpressionContextScope * > mStack;
     QStringList mHighlightedVariables;
+    QStringList mHighlightedFunctions;
 
     // Cache is mutable because we want to be able to add cached values to const contexts
     mutable QMap< QString, QVariant > mCachedValues;

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -31,6 +31,7 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingCrsWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingStringWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingNumericWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingDistanceWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -30,6 +30,7 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingBooleanWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingCrsWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingStringWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingNumericWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -32,6 +32,7 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingStringWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingNumericWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingDistanceWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingRangeWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -113,6 +113,12 @@ QgsProcessingModelerParameterWidget::QgsProcessingModelerParameterWidget( QgsPro
 
 QgsProcessingModelerParameterWidget::~QgsProcessingModelerParameterWidget() = default;
 
+void QgsProcessingModelerParameterWidget::setWidgetContext( const QgsProcessingParameterWidgetContext &context )
+{
+  if ( mStaticWidgetWrapper )
+    mStaticWidgetWrapper->setWidgetContext( context );
+}
+
 const QgsProcessingParameterDefinition *QgsProcessingModelerParameterWidget::parameterDefinition() const
 {
   return mParameterDefinition;

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -81,6 +81,7 @@ QgsProcessingModelerParameterWidget::QgsProcessingModelerParameterWidget( QgsPro
   }
 
   mExpressionWidget = new QgsExpressionLineEdit();
+  mExpressionWidget->registerExpressionContextGenerator( this );
   mStackedWidget->addWidget( mExpressionWidget );
 
   mModelInputCombo = new QComboBox();
@@ -167,6 +168,11 @@ QgsProcessingModelChildParameterSource QgsProcessingModelerParameterWidget::valu
   }
 
   return QgsProcessingModelChildParameterSource();
+}
+
+QgsExpressionContext QgsProcessingModelerParameterWidget::createExpressionContext() const
+{
+  return QgsExpressionContext();
 }
 
 void QgsProcessingModelerParameterWidget::sourceMenuAboutToShow()

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -22,6 +22,7 @@
 #include "qgsprocessingguiregistry.h"
 #include "models/qgsprocessingmodelalgorithm.h"
 #include "qgsgui.h"
+#include "qgsexpressioncontext.h"
 #include <QHBoxLayout>
 #include <QToolButton>
 #include <QStackedWidget>
@@ -172,7 +173,23 @@ QgsProcessingModelChildParameterSource QgsProcessingModelerParameterWidget::valu
 
 QgsExpressionContext QgsProcessingModelerParameterWidget::createExpressionContext() const
 {
-  return QgsExpressionContext();
+  QgsExpressionContext c = mContext.expressionContext();
+  if ( mModel )
+  {
+    QgsExpressionContextScope *algorithmScope = QgsExpressionContextUtils::processingAlgorithmScope( mModel->childAlgorithm( mChildId ).algorithm(), QVariantMap(), mContext );
+    c << algorithmScope;
+    QgsExpressionContextScope *childScope = mModel->createExpressionContextScopeForChildAlgorithm( mChildId, mContext, QVariantMap(), QVariantMap() );
+    c << childScope;
+
+    QStringList highlightedVariables = childScope->variableNames();
+    QStringList highlightedFunctions = childScope->functionNames();
+    highlightedVariables += algorithmScope->variableNames();
+    highlightedFunctions += algorithmScope->functionNames();
+    c.setHighlightedVariables( highlightedVariables );
+    c.setHighlightedFunctions( highlightedFunctions );
+  }
+
+  return c;
 }
 
 void QgsProcessingModelerParameterWidget::sourceMenuAboutToShow()

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -88,8 +88,6 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
      * Sets the \a context in which the modeler parameter widget is shown, e.g., the
      * parent model algorithm and other relevant information which allows the widget
      * to fine-tune its behavior.
-     *
-     * \see widgetContext()
      */
     void setWidgetContext( const QgsProcessingParameterWidgetContext &context );
 

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -92,7 +92,7 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
     void setWidgetContext( const QgsProcessingParameterWidgetContext &context );
 
     /**
-     * Register a Processing context \a generator class that will be used to retrieve
+     * Registers a Processing context \a generator class that will be used to retrieve
      * a Processing context for the widget when required.
      */
     void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -56,7 +56,7 @@ class QComboBox;
  * \ingroup gui
  * \since QGIS 3.4
  */
-class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget
+class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -30,6 +30,7 @@ class QgsProcessingParameterDefinition;
 class QgsAbstractProcessingParameterWidgetWrapper;
 class QgsExpressionLineEdit;
 class QgsProcessingModelAlgorithm;
+class QgsProcessingParameterWidgetContext;
 
 class QLabel;
 class QToolButton;
@@ -81,6 +82,15 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget
                                          QWidget *parent SIP_TRANSFERTHIS = nullptr );
 
     ~QgsProcessingModelerParameterWidget() override;
+
+    /**
+     * Sets the \a context in which the modeler parameter widget is shown, e.g., the
+     * parent model algorithm and other relevant information which allows the widget
+     * to fine-tune its behavior.
+     *
+     * \see widgetContext()
+     */
+    void setWidgetContext( const QgsProcessingParameterWidgetContext &context );
 
     /**
      * Populates the widget with available sources for the parameter's value, e.g.

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -143,6 +143,8 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
      */
     virtual QgsProcessingModelChildParameterSource value() const;
 
+    QgsExpressionContext createExpressionContext() const override;
+
   private slots:
 
     void sourceMenuAboutToShow();

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.h
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.h
@@ -31,6 +31,7 @@ class QgsAbstractProcessingParameterWidgetWrapper;
 class QgsExpressionLineEdit;
 class QgsProcessingModelAlgorithm;
 class QgsProcessingParameterWidgetContext;
+class QgsProcessingContextGenerator;
 
 class QLabel;
 class QToolButton;
@@ -91,6 +92,12 @@ class GUI_EXPORT QgsProcessingModelerParameterWidget : public QWidget, public Qg
      * \see widgetContext()
      */
     void setWidgetContext( const QgsProcessingParameterWidgetContext &context );
+
+    /**
+     * Register a Processing context \a generator class that will be used to retrieve
+     * a Processing context for the widget when required.
+     */
+    void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
 
     /**
      * Populates the widget with available sources for the parameter's value, e.g.

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -23,6 +23,45 @@
 #include <QLabel>
 #include <QHBoxLayout>
 
+//
+// QgsProcessingParameterWidgetContext
+//
+
+void QgsProcessingParameterWidgetContext::setMapCanvas( QgsMapCanvas *canvas )
+{
+  mMapCanvas = canvas;
+}
+
+QgsMapCanvas *QgsProcessingParameterWidgetContext::mapCanvas() const
+{
+  return mMapCanvas;
+}
+
+QString QgsProcessingParameterWidgetContext::modelChildAlgorithmId() const
+{
+  return mModelChildAlgorithmId;
+}
+
+void QgsProcessingParameterWidgetContext::setModelChildAlgorithmId( const QString &modelChildAlgorithmId )
+{
+  mModelChildAlgorithmId = modelChildAlgorithmId;
+}
+
+QgsProcessingModelAlgorithm *QgsProcessingParameterWidgetContext::model() const
+{
+  return mModel;
+}
+
+void QgsProcessingParameterWidgetContext::setModel( QgsProcessingModelAlgorithm *model )
+{
+  mModel = model;
+}
+
+
+//
+// QgsAbstractProcessingParameterWidgetWrapper
+//
+
 QgsAbstractProcessingParameterWidgetWrapper::QgsAbstractProcessingParameterWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QObject *parent )
   : QObject( parent )
   , mType( type )
@@ -33,6 +72,16 @@ QgsAbstractProcessingParameterWidgetWrapper::QgsAbstractProcessingParameterWidge
 QgsProcessingGui::WidgetType QgsAbstractProcessingParameterWidgetWrapper::type() const
 {
   return mType;
+}
+
+void QgsAbstractProcessingParameterWidgetWrapper::setWidgetContext( const QgsProcessingParameterWidgetContext &context )
+{
+  mWidgetContext = context;
+}
+
+const QgsProcessingParameterWidgetContext &QgsAbstractProcessingParameterWidgetWrapper::widgetContext() const
+{
+  return mWidgetContext;
 }
 
 QWidget *QgsAbstractProcessingParameterWidgetWrapper::createWrappedWidget( QgsProcessingContext &context )
@@ -222,3 +271,4 @@ QString QgsProcessingParameterWidgetFactoryInterface::modelerExpressionFormatStr
 {
   return QString();
 }
+

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -153,7 +153,7 @@ class GUI_EXPORT QgsProcessingParameterWidgetContext
  * \ingroup gui
  * \since QGIS 3.4
  */
-class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject
+class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 
@@ -257,7 +257,7 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject
     QVariant parameterValue() const;
 
     /**
-     * Register a Processing context generator class that will be used to retrieve
+     * Register a Processing context \a generator class that will be used to retrieve
      * a Processing context for the wrapper when required.
      */
     void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );
@@ -267,6 +267,8 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject
      * allowing the wrapper to connect to the wrappers of other, related parameters.
      */
     virtual void postInitialize( const QList< QgsAbstractProcessingParameterWidgetWrapper * > &wrappers );
+
+    QgsExpressionContext createExpressionContext() const override;
 
   signals:
 

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -34,6 +34,8 @@ class QgsProcessingModelAlgorithm;
 class QLabel;
 class QgsPropertyOverrideButton;
 class QgsVectorLayer;
+class QgsProcessingModelAlgorithm;
+class QgsMapCanvas;
 
 /**
  * \class QgsProcessingContextGenerator
@@ -57,6 +59,79 @@ class GUI_EXPORT QgsProcessingContextGenerator
     virtual QgsProcessingContext *processingContext() = 0;
 
     virtual ~QgsProcessingContextGenerator() = default;
+};
+
+/**
+ * \ingroup gui
+ * \class QgsProcessingParameterWidgetContext
+ * Contains settings which reflect the context in which a Processing parameter widget is shown, e.g., the
+ * parent model algorithm, a linked map canvas, and other relevant information which allows the widget
+ * to fine-tune its behavior.
+ *
+ * \since QGIS 3.4
+ */
+class GUI_EXPORT QgsProcessingParameterWidgetContext
+{
+  public:
+
+    /**
+     * Constructor for QgsProcessingParameterWidgetContext.
+     */
+    QgsProcessingParameterWidgetContext() = default;
+
+    /**
+     * Sets the map \a canvas associated with the widget. This allows the widget to retrieve the current
+     * map scale and other properties from the canvas.
+     * \see mapCanvas()
+     */
+    void setMapCanvas( QgsMapCanvas *canvas );
+
+    /**
+     * Returns the map canvas associated with the widget.
+     * \see setMapCanvas()
+     */
+    QgsMapCanvas *mapCanvas() const;
+
+    /**
+     * Returns the model which the parameter widget is associated with.
+     *
+     * \see setModel()
+     * \see modelChildAlgorithmId()
+     */
+    QgsProcessingModelAlgorithm *model() const;
+
+    /**
+     * Sets the \a model which the parameter widget is associated with.
+     *
+     * \see model()
+     * \see setModelChildAlgorithmId()
+     */
+    void setModel( QgsProcessingModelAlgorithm *model );
+
+    /**
+     * Returns the child algorithm ID within the model which the parameter widget is associated with.
+     *
+     * \see setModelChildAlgorithmId()
+     * \see model()
+     */
+    QString modelChildAlgorithmId() const;
+
+    /**
+     * Sets the child algorithm \a id within the model which the parameter widget is associated with.
+     *
+     * \see modelChildAlgorithmId()
+     * \see setModel()
+     */
+    void setModelChildAlgorithmId( const QString &id );
+
+  private:
+
+    QgsProcessingModelAlgorithm *mModel = nullptr;
+
+    QString mModelChildAlgorithmId;
+
+    QgsMapCanvas *mMapCanvas = nullptr;
+
 };
 
 /**
@@ -95,6 +170,26 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject
      * Returns the dialog type for which widgets and labels will be created by this wrapper.
      */
     QgsProcessingGui::WidgetType type() const;
+
+    /**
+     * Sets the \a context in which the Processing parameter widget is shown, e.g., the
+     * parent model algorithm, a linked map canvas, and other relevant information which allows the widget
+     * to fine-tune its behavior.
+     *
+     * Subclasses should take care to call the base class method when reimplementing this method.
+     *
+     * \see widgetContext()
+     */
+    virtual void setWidgetContext( const QgsProcessingParameterWidgetContext &context );
+
+    /**
+     * Returns the context in which the Processing parameter widget is shown, e.g., the
+     * parent model algorithm, a linked map canvas, and other relevant information which allows the widget
+     * to fine-tune its behavior.
+     *
+     * \see setWidgetContext()
+     */
+    const QgsProcessingParameterWidgetContext &widgetContext() const;
 
     /**
      * Creates and return a new wrapped widget which allows customization of the parameter's value.
@@ -226,6 +321,7 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject
   protected:
 
     QgsProcessingContextGenerator *mProcessingContextGenerator = nullptr;
+    QgsProcessingParameterWidgetContext mWidgetContext;
 
   private slots:
 

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -223,6 +223,10 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject
      */
     virtual QVariant widgetValue() const = 0;
 
+  protected:
+
+    QgsProcessingContextGenerator *mProcessingContextGenerator = nullptr;
+
   private slots:
 
     void parentLayerChanged( QgsAbstractProcessingParameterWidgetWrapper *wrapper );
@@ -231,7 +235,6 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject
 
     QgsProcessingGui::WidgetType mType = QgsProcessingGui::Standard;
     const QgsProcessingParameterDefinition *mParameterDefinition = nullptr;
-    QgsProcessingContextGenerator *mProcessingContextGenerator = nullptr;
 
     void setDynamicParentLayerParameter( const QVariant &value );
 

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -257,7 +257,7 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject, p
     QVariant parameterValue() const;
 
     /**
-     * Register a Processing context \a generator class that will be used to retrieve
+     * Registers a Processing context \a generator class that will be used to retrieve
      * a Processing context for the wrapper when required.
      */
     void registerProcessingContextGenerator( QgsProcessingContextGenerator *generator );

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -19,6 +19,8 @@
 #include "qgsprocessingparameters.h"
 #include "qgsprocessingoutputs.h"
 #include "qgsprojectionselectionwidget.h"
+#include "qgsspinbox.h"
+#include "qgsdoublespinbox.h"
 #include <QLabel>
 #include <QHBoxLayout>
 #include <QCheckBox>
@@ -400,6 +402,235 @@ QString QgsProcessingStringWidgetWrapper::parameterType() const
 QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingStringWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
 {
   return new QgsProcessingStringWidgetWrapper( parameter, type );
+}
+
+
+
+//
+// QgsProcessingNumericWidgetWrapper
+//
+
+QgsProcessingNumericWidgetWrapper::QgsProcessingNumericWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+  : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
+{
+
+}
+
+QWidget *QgsProcessingNumericWidgetWrapper::createWidget()
+{
+  const QgsProcessingParameterNumber *numberDef = static_cast< const QgsProcessingParameterNumber * >( parameterDefinition() );
+  switch ( type() )
+  {
+    case QgsProcessingGui::Standard:
+    case QgsProcessingGui::Modeler:
+    case QgsProcessingGui::Batch:
+    {
+      // lots of duplicate code here -- but there's no common interface between QSpinBox/QDoubleSpinBox which would allow us to avoid this
+      QAbstractSpinBox *spinBox = nullptr;
+      switch ( numberDef->dataType() )
+      {
+        case QgsProcessingParameterNumber::Double:
+          mDoubleSpinBox = new QgsDoubleSpinBox();
+          mDoubleSpinBox->setExpressionsEnabled( true );
+          mDoubleSpinBox->setDecimals( 6 );
+
+          // guess reasonable step value for double spin boxes
+          if ( !qgsDoubleNear( numberDef->maximum(), std::numeric_limits<double>::max() ) &&
+               !qgsDoubleNear( numberDef->minimum(), std::numeric_limits<double>::lowest() + 1 ) )
+          {
+            const double singleStep = calculateStep( numberDef->minimum(), numberDef->maximum() );
+            mDoubleSpinBox->setSingleStep( singleStep );
+          }
+
+          spinBox = mDoubleSpinBox;
+          break;
+
+        case QgsProcessingParameterNumber::Integer:
+          mSpinBox = new QgsSpinBox();
+          mSpinBox->setExpressionsEnabled( true );
+          spinBox = mSpinBox;
+          break;
+      }
+      spinBox->setToolTip( parameterDefinition()->toolTip() );
+
+      double max = 999999999;
+      if ( !qgsDoubleNear( numberDef->maximum(), std::numeric_limits<double>::max() ) )
+      {
+        max = numberDef->maximum();
+      }
+      double min = -999999999;
+      if ( !qgsDoubleNear( numberDef->minimum(), std::numeric_limits<double>::lowest() ) )
+      {
+        min = numberDef->minimum();
+      }
+      if ( mDoubleSpinBox )
+      {
+        mDoubleSpinBox->setMinimum( min );
+        mDoubleSpinBox->setMaximum( max );
+      }
+      else
+      {
+        mSpinBox->setMinimum( static_cast< int >( min ) );
+        mSpinBox->setMaximum( static_cast< int >( max ) );
+      }
+
+      if ( numberDef->flags() & QgsProcessingParameterDefinition::FlagOptional )
+      {
+        mAllowingNull = true;
+        if ( mDoubleSpinBox )
+        {
+          mDoubleSpinBox->setShowClearButton( true );
+          const double min = mDoubleSpinBox->minimum() - 1;
+          mDoubleSpinBox->setMinimum( min );
+          mDoubleSpinBox->setValue( min );
+        }
+        else
+        {
+          mSpinBox->setShowClearButton( true );
+          const int min = mSpinBox->minimum() - 1;
+          mSpinBox->setMinimum( min );
+          mSpinBox->setValue( min );
+        }
+        spinBox->setSpecialValueText( tr( "Not set" ) );
+      }
+
+      if ( numberDef->defaultValue().isValid() )
+      {
+        // if default value for parameter, we clear to that
+        bool ok = false;
+        if ( mDoubleSpinBox )
+        {
+          double defaultVal = numberDef->defaultValue().toDouble( &ok );
+          if ( ok )
+            mDoubleSpinBox->setClearValue( defaultVal );
+        }
+        else
+        {
+          int intVal = numberDef->defaultValue().toInt( &ok );
+          if ( ok )
+            mSpinBox->setClearValue( intVal );
+        }
+      }
+      else if ( !qgsDoubleNear( numberDef->minimum(), std::numeric_limits<double>::lowest() ) && !mAllowingNull )
+      {
+        // otherwise we clear to the minimum, if it's set
+        if ( mDoubleSpinBox )
+          mDoubleSpinBox->setClearValue( numberDef->minimum() );
+        else
+          mSpinBox->setClearValue( static_cast< int >( numberDef->minimum() ) );
+      }
+      else if ( !mAllowingNull )
+      {
+        // last resort, we clear to 0
+        if ( mDoubleSpinBox )
+        {
+          mDoubleSpinBox->setValue( 0 );
+          mDoubleSpinBox->setClearValue( 0 );
+        }
+        else
+        {
+          mSpinBox->setValue( 0 );
+          mSpinBox->setClearValue( 0 );
+        }
+      }
+
+      if ( mDoubleSpinBox )
+        connect( mDoubleSpinBox, qgis::overload<double>::of( &QgsDoubleSpinBox::valueChanged ), this, [ = ] { emit widgetValueHasChanged( this ); } );
+      else if ( mSpinBox )
+        connect( mSpinBox, qgis::overload<int>::of( &QgsSpinBox::valueChanged ), this, [ = ] { emit widgetValueHasChanged( this ); } );
+
+      return spinBox;
+    };
+  }
+  return nullptr;
+}
+
+void QgsProcessingNumericWidgetWrapper::setWidgetValue( const QVariant &value, QgsProcessingContext &context )
+{
+  if ( mDoubleSpinBox )
+  {
+    if ( mAllowingNull && !value.isValid() )
+      mDoubleSpinBox->clear();
+    else
+    {
+      const double v = QgsProcessingParameters::parameterAsDouble( parameterDefinition(), value, context );
+      mDoubleSpinBox->setValue( v );
+    }
+  }
+  else if ( mSpinBox )
+  {
+    if ( mAllowingNull && !value.isValid() )
+      mSpinBox->clear();
+    else
+    {
+      const int v = QgsProcessingParameters::parameterAsInt( parameterDefinition(), value, context );
+      mSpinBox->setValue( v );
+    }
+  }
+}
+
+QVariant QgsProcessingNumericWidgetWrapper::widgetValue() const
+{
+  if ( mDoubleSpinBox )
+  {
+    if ( mAllowingNull && qgsDoubleNear( mDoubleSpinBox->value(), mDoubleSpinBox->minimum() ) )
+      return QVariant();
+    else
+      return mDoubleSpinBox->value();
+  }
+  else if ( mSpinBox )
+  {
+    if ( mAllowingNull && mSpinBox->value() == mSpinBox->minimum() )
+      return QVariant();
+    else
+      return mSpinBox->value();
+  }
+  else
+    return QVariant();
+}
+
+QStringList QgsProcessingNumericWidgetWrapper::compatibleParameterTypes() const
+{
+  return QStringList()
+         << QgsProcessingParameterString::typeName()
+         << QgsProcessingParameterNumber::typeName()
+         << QgsProcessingParameterDistance::typeName();
+}
+
+QStringList QgsProcessingNumericWidgetWrapper::compatibleOutputTypes() const
+{
+  return QStringList() << QgsProcessingOutputNumber::typeName()
+         << QgsProcessingOutputString::typeName();
+}
+
+QList<int> QgsProcessingNumericWidgetWrapper::compatibleDataTypes() const
+{
+  return QList< int >();
+}
+
+double QgsProcessingNumericWidgetWrapper::calculateStep( const double minimum, const double maximum )
+{
+  const double valueRange = maximum - minimum;
+  if ( valueRange <= 1.0 )
+  {
+    const double step = valueRange / 10.0;
+    // round to 1 significant figure
+    return qgsRound( step, std::floor( std::log( step ) ) );
+  }
+  else
+  {
+    return 1.0;
+  }
+}
+
+QString QgsProcessingNumericWidgetWrapper::parameterType() const
+{
+  return QgsProcessingParameterNumber::typeName();
+}
+
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingNumericWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+{
+  return new QgsProcessingNumericWidgetWrapper( parameter, type );
 }
 
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -493,44 +493,46 @@ QWidget *QgsProcessingNumericWidgetWrapper::createWidget()
         }
         spinBox->setSpecialValueText( tr( "Not set" ) );
       }
-
-      if ( numberDef->defaultValue().isValid() )
+      else
       {
-        // if default value for parameter, we clear to that
-        bool ok = false;
-        if ( mDoubleSpinBox )
+        if ( numberDef->defaultValue().isValid() )
         {
-          double defaultVal = numberDef->defaultValue().toDouble( &ok );
-          if ( ok )
-            mDoubleSpinBox->setClearValue( defaultVal );
+          // if default value for parameter, we clear to that
+          bool ok = false;
+          if ( mDoubleSpinBox )
+          {
+            double defaultVal = numberDef->defaultValue().toDouble( &ok );
+            if ( ok )
+              mDoubleSpinBox->setClearValue( defaultVal );
+          }
+          else
+          {
+            int intVal = numberDef->defaultValue().toInt( &ok );
+            if ( ok )
+              mSpinBox->setClearValue( intVal );
+          }
+        }
+        else if ( !qgsDoubleNear( numberDef->minimum(), std::numeric_limits<double>::lowest() ) )
+        {
+          // otherwise we clear to the minimum, if it's set
+          if ( mDoubleSpinBox )
+            mDoubleSpinBox->setClearValue( numberDef->minimum() );
+          else
+            mSpinBox->setClearValue( static_cast< int >( numberDef->minimum() ) );
         }
         else
         {
-          int intVal = numberDef->defaultValue().toInt( &ok );
-          if ( ok )
-            mSpinBox->setClearValue( intVal );
-        }
-      }
-      else if ( !qgsDoubleNear( numberDef->minimum(), std::numeric_limits<double>::lowest() ) && !mAllowingNull )
-      {
-        // otherwise we clear to the minimum, if it's set
-        if ( mDoubleSpinBox )
-          mDoubleSpinBox->setClearValue( numberDef->minimum() );
-        else
-          mSpinBox->setClearValue( static_cast< int >( numberDef->minimum() ) );
-      }
-      else if ( !mAllowingNull )
-      {
-        // last resort, we clear to 0
-        if ( mDoubleSpinBox )
-        {
-          mDoubleSpinBox->setValue( 0 );
-          mDoubleSpinBox->setClearValue( 0 );
-        }
-        else
-        {
-          mSpinBox->setValue( 0 );
-          mSpinBox->setClearValue( 0 );
+          // last resort, we clear to 0
+          if ( mDoubleSpinBox )
+          {
+            mDoubleSpinBox->setValue( 0 );
+            mDoubleSpinBox->setClearValue( 0 );
+          }
+          else
+          {
+            mSpinBox->setValue( 0 );
+            mSpinBox->setClearValue( 0 );
+          }
         }
       }
 
@@ -615,7 +617,7 @@ double QgsProcessingNumericWidgetWrapper::calculateStep( const double minimum, c
   {
     const double step = valueRange / 10.0;
     // round to 1 significant figure
-    return qgsRound( step, std::floor( std::log( step ) ) );
+    return qgsRound( step, -std::floor( std::log( step ) ) );
   }
   else
   {

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -209,7 +209,7 @@ class GUI_EXPORT QgsProcessingDistanceWidgetWrapper : public QgsProcessingNumeri
 
     QgsUnitTypes::DistanceUnit mBaseUnit = QgsUnitTypes::DistanceUnknownUnit;
     QLabel *mLabel = nullptr;
-    QLabel *mWarningLabel = nullptr;
+    QWidget *mWarningLabel = nullptr;
     QComboBox *mUnitsCombo = nullptr;
 
     friend class TestProcessingGui;

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -165,21 +165,55 @@ class GUI_EXPORT QgsProcessingNumericWidgetWrapper : public QgsAbstractProcessin
 
     QList< int > compatibleDataTypes() const override;
 
-  private:
-
-    static double calculateStep( double minimum, double maximum );
+  protected:
 
     QgsSpinBox *mSpinBox = nullptr;
     QgsDoubleSpinBox *mDoubleSpinBox = nullptr;
 
-    QLineEdit *mLineEdit = nullptr;
-    QPlainTextEdit *mPlainTextEdit = nullptr;
+  private:
+
+    static double calculateStep( double minimum, double maximum );
 
     bool mAllowingNull = false;
 
     friend class TestProcessingGui;
 };
 
+
+class GUI_EXPORT QgsProcessingDistanceWidgetWrapper : public QgsProcessingNumericWidgetWrapper
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingDistanceWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                        QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+    // QgsProcessingParameterWidgetWrapper interface
+    QWidget *createWidget() override SIP_FACTORY;
+    void postInitialize( const QList< QgsAbstractProcessingParameterWidgetWrapper * > &wrappers ) override;
+
+  public slots:
+    void setUnitParameterValue( const QVariant &value );
+    void setUnits( QgsUnitTypes::DistanceUnit unit );
+
+  protected:
+
+    QVariant widgetValue() const override;
+
+  private:
+
+    QgsUnitTypes::DistanceUnit mBaseUnit = QgsUnitTypes::DistanceUnknownUnit;
+    QLabel *mLabel = nullptr;
+    QLabel *mWarningLabel = nullptr;
+    QComboBox *mUnitsCombo = nullptr;
+
+    friend class TestProcessingGui;
+};
 
 ///@endcond PRIVATE
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -215,6 +215,44 @@ class GUI_EXPORT QgsProcessingDistanceWidgetWrapper : public QgsProcessingNumeri
     friend class TestProcessingGui;
 };
 
+
+class GUI_EXPORT QgsProcessingRangeWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingRangeWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                     QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+    // QgsProcessingParameterWidgetWrapper interface
+    QWidget *createWidget() override SIP_FACTORY;
+
+  protected:
+
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
+    QVariant widgetValue() const override;
+    QStringList compatibleParameterTypes() const override;
+    QStringList compatibleOutputTypes() const override;
+    QList< int > compatibleDataTypes() const override;
+    QString modelerExpressionFormatString() const override;
+
+  protected:
+
+    QgsDoubleSpinBox *mMinSpinBox = nullptr;
+    QgsDoubleSpinBox *mMaxSpinBox = nullptr;
+
+  private:
+
+    int mBlockChangedSignal = 0;
+
+    friend class TestProcessingGui;
+};
+
 ///@endcond PRIVATE
 
 #endif // QGSPROCESSINGWIDGETWRAPPERIMPL_H

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -27,6 +27,9 @@ class QComboBox;
 class QLineEdit;
 class QPlainTextEdit;
 class QgsProjectionSelectionWidget;
+class QgsSpinBox;
+class QgsDoubleSpinBox;
+
 
 ///@cond PRIVATE
 
@@ -131,6 +134,48 @@ class GUI_EXPORT QgsProcessingStringWidgetWrapper : public QgsAbstractProcessing
 
     QLineEdit *mLineEdit = nullptr;
     QPlainTextEdit *mPlainTextEdit = nullptr;
+
+    friend class TestProcessingGui;
+};
+
+class GUI_EXPORT QgsProcessingNumericWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingNumericWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                       QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+    // QgsProcessingParameterWidgetWrapper interface
+    QWidget *createWidget() override SIP_FACTORY;
+
+  protected:
+
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
+    QVariant widgetValue() const override;
+
+    QStringList compatibleParameterTypes() const override;
+
+    QStringList compatibleOutputTypes() const override;
+
+    QList< int > compatibleDataTypes() const override;
+
+  private:
+
+    static double calculateStep( double minimum, double maximum );
+
+    QgsSpinBox *mSpinBox = nullptr;
+    QgsDoubleSpinBox *mDoubleSpinBox = nullptr;
+
+    QLineEdit *mLineEdit = nullptr;
+    QPlainTextEdit *mPlainTextEdit = nullptr;
+
+    bool mAllowingNull = false;
 
     friend class TestProcessingGui;
 };

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -577,7 +577,7 @@ void QgsExpressionBuilderWidget::updateFunctionTree()
       name += '(';
     else if ( !name.startsWith( '$' ) )
       name += QLatin1String( "()" );
-    registerItemForAllGroups( func->groups(), func->name(), ' ' + name + ' ', func->helpText() );
+    registerItemForAllGroups( func->groups(), func->name(), ' ' + name + ' ', func->helpText(), QgsExpressionItem::ExpressionNode, mExpressionContext.isHighlightedFunction( func->name() ) );
   }
 
   // load relation names
@@ -721,7 +721,7 @@ void QgsExpressionBuilderWidget::loadExpressionContext()
       continue;
     if ( func->params() != 0 )
       name += '(';
-    registerItemForAllGroups( func->groups(), func->name(), ' ' + name + ' ', func->helpText() );
+    registerItemForAllGroups( func->groups(), func->name(), ' ' + name + ' ', func->helpText(), QgsExpressionItem::ExpressionNode, mExpressionContext.isHighlightedFunction( func->name() ) );
   }
 }
 

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -44,6 +44,7 @@ class TestQgsExpressionContext : public QObject
     void setFeature();
     void setFields();
     void takeScopes();
+    void highlighted();
 
     void globalScope();
     void projectScope();
@@ -540,6 +541,27 @@ void TestQgsExpressionContext::takeScopes()
 
   QVERIFY( !context.variable( "test_global" ).isValid() );
   QVERIFY( !context.variable( "test_project" ).isValid() );
+}
+
+void TestQgsExpressionContext::highlighted()
+{
+  QgsExpressionContext context;
+  QVERIFY( !context.isHighlightedFunction( QStringLiteral( "x" ) ) );
+  QVERIFY( !context.isHighlightedVariable( QStringLiteral( "x" ) ) );
+  context.setHighlightedFunctions( QStringList() << QStringLiteral( "x" ) << QStringLiteral( "y" ) );
+  QVERIFY( context.isHighlightedFunction( QStringLiteral( "x" ) ) );
+  QVERIFY( context.isHighlightedFunction( QStringLiteral( "y" ) ) );
+  QVERIFY( !context.isHighlightedFunction( QStringLiteral( "z" ) ) );
+  QVERIFY( !context.isHighlightedVariable( QStringLiteral( "x" ) ) );
+  context.setHighlightedVariables( QStringList() << QStringLiteral( "a" ) << QStringLiteral( "b" ) );
+  QVERIFY( context.isHighlightedVariable( QStringLiteral( "a" ) ) );
+  QVERIFY( context.isHighlightedVariable( QStringLiteral( "b" ) ) );
+  QVERIFY( !context.isHighlightedVariable( QStringLiteral( "c" ) ) );
+  QVERIFY( !context.isHighlightedFunction( QStringLiteral( "a" ) ) );
+  context.setHighlightedFunctions( QStringList() );
+  context.setHighlightedVariables( QStringList() );
+  QVERIFY( !context.isHighlightedFunction( QStringLiteral( "x" ) ) );
+  QVERIFY( !context.isHighlightedVariable( QStringLiteral( "a" ) ) );
 }
 
 void TestQgsExpressionContext::globalScope()

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -873,8 +873,8 @@ void TestProcessingGui::testNumericWrapperDouble()
     QVERIFY( static_cast< QgsDoubleSpinBox * >( wrapper.wrappedWidget() )->expressionsEnabled() );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapper.wrappedWidget() )->decimals(), 6 ); // you can change this, if it's an intentional change!
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapper.wrappedWidget() )->singleStep(), 1.0 );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapper.wrappedWidget() )->minimum(), -999999999 );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapper.wrappedWidget() )->maximum(), 999999999 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapper.wrappedWidget() )->minimum(), -999999999.0 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapper.wrappedWidget() )->maximum(), 999999999.0 );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapper.wrappedWidget() )->clearValue(), 0.0 );
 
     QSignalSpy spy( &wrapper, &QgsProcessingNumericWidgetWrapper::widgetValueHasChanged );
@@ -922,9 +922,9 @@ void TestProcessingGui::testNumericWrapperDouble()
 
     w = wrapperMin.createWrappedWidget( context );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->singleStep(), 1.0 );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->minimum(), -5 );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->maximum(), 999999999 );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->clearValue(), -5 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->minimum(), -5.0 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->maximum(), 999999999.0 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->clearValue(), -5.0 );
     QCOMPARE( wrapperMin.parameterValue(), 0.0 );
     delete w;
 
@@ -936,9 +936,9 @@ void TestProcessingGui::testNumericWrapperDouble()
 
     w = wrapperMax.createWrappedWidget( context );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->singleStep(), 1.0 );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->minimum(), -999999999 );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->maximum(), 5 );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->clearValue(), 0 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->minimum(), -999999999.0 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->maximum(), 5.0 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->clearValue(), 0.0 );
     QCOMPARE( wrapperMax.parameterValue(), 0.0 );
     delete w;
 
@@ -974,7 +974,7 @@ void TestProcessingGui::testNumericWrapperDouble()
     QgsProcessingNumericWidgetWrapper wrapperOptional( &paramOptional, type );
 
     w = wrapperOptional.createWrappedWidget( context );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptional.wrappedWidget() )->clearValue(), -1000000000 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptional.wrappedWidget() )->clearValue(), -1000000000.0 );
     QVERIFY( !wrapperOptional.parameterValue().isValid() );
     wrapperOptional.setParameterValue( 5, context );
     QCOMPARE( wrapperOptional.parameterValue(), 5.0 );
@@ -989,12 +989,12 @@ void TestProcessingGui::testNumericWrapperDouble()
     QgsProcessingNumericWidgetWrapper wrapperOptionalDefault( &paramOptional, type );
 
     w = wrapperOptionalDefault.createWrappedWidget( context );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->clearValue(), -1000000000 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->clearValue(), -1000000000.0 );
     QCOMPARE( wrapperOptionalDefault.parameterValue(), 3.0 );
     wrapperOptionalDefault.setParameterValue( 5, context );
     QCOMPARE( wrapperOptionalDefault.parameterValue(), 5.0 );
     wrapperOptionalDefault.setParameterValue( QVariant(), context );
-    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->value(), -1000000000 );
+    QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->value(), -1000000000.0 );
     QVERIFY( !wrapperOptionalDefault.parameterValue().isValid() );
     wrapperOptionalDefault.setParameterValue( 5, context );
     QCOMPARE( wrapperOptionalDefault.parameterValue(), 5.0 );

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -40,6 +40,8 @@
 #include "qgsprojectionselectionwidget.h"
 #include "qgsdoublespinbox.h"
 #include "qgsspinbox.h"
+#include "qgsmapcanvas.h"
+#include "models/qgsprocessingmodelalgorithm.h"
 
 class TestParamType : public QgsProcessingParameterDefinition
 {
@@ -306,6 +308,21 @@ void TestProcessingGui::testWrapperGeneral()
   w = falseDefault.createWrappedWidget( context );
   QVERIFY( !falseDefault.widgetValue().toBool() );
   delete w;
+
+  std::unique_ptr< QgsMapCanvas > mc = qgis::make_unique< QgsMapCanvas >();
+  QgsProcessingParameterWidgetContext widgetContext;
+  widgetContext.setMapCanvas( mc.get() );
+  QCOMPARE( widgetContext.mapCanvas(), mc.get() );
+  std::unique_ptr< QgsProcessingModelAlgorithm > model = qgis::make_unique< QgsProcessingModelAlgorithm >();
+  widgetContext.setModel( model.get() );
+  QCOMPARE( widgetContext.model(), model.get() );
+  widgetContext.setModelChildAlgorithmId( QStringLiteral( "xx" ) );
+  QCOMPARE( widgetContext.modelChildAlgorithmId(), QStringLiteral( "xx" ) );
+
+  wrapper.setWidgetContext( widgetContext );
+  QCOMPARE( wrapper.widgetContext().mapCanvas(), mc.get() );
+  QCOMPARE( wrapper.widgetContext().model(), model.get() );
+  QCOMPARE( wrapper.widgetContext().modelChildAlgorithmId(), QStringLiteral( "xx" ) );
 }
 
 class TestProcessingContextGenerator : public QgsProcessingContextGenerator

--- a/tests/src/gui/testprocessinggui.cpp
+++ b/tests/src/gui/testprocessinggui.cpp
@@ -925,7 +925,7 @@ void TestProcessingGui::testNumericWrapperDouble()
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->minimum(), -5.0 );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->maximum(), 999999999.0 );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMin.wrappedWidget() )->clearValue(), -5.0 );
-    QCOMPARE( wrapperMin.parameterValue(), 0.0 );
+    QCOMPARE( wrapperMin.parameterValue().toDouble(), 0.0 );
     delete w;
 
     // with max value
@@ -939,7 +939,7 @@ void TestProcessingGui::testNumericWrapperDouble()
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->minimum(), -999999999.0 );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->maximum(), 5.0 );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMax.wrappedWidget() )->clearValue(), 0.0 );
-    QCOMPARE( wrapperMax.parameterValue(), 0.0 );
+    QCOMPARE( wrapperMax.parameterValue().toDouble(), 0.0 );
     delete w;
 
     // with min and max value
@@ -954,7 +954,7 @@ void TestProcessingGui::testNumericWrapperDouble()
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMinMax.wrappedWidget() )->minimum(), -.1 );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMinMax.wrappedWidget() )->maximum(), .1 );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperMinMax.wrappedWidget() )->clearValue(), -.1 );
-    QCOMPARE( wrapperMinMax.parameterValue(), 0.0 );
+    QCOMPARE( wrapperMinMax.parameterValue().toDouble(), 0.0 );
     delete w;
 
     // with default value
@@ -965,7 +965,7 @@ void TestProcessingGui::testNumericWrapperDouble()
 
     w = wrapperDefault.createWrappedWidget( context );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperDefault.wrappedWidget() )->clearValue(), 55.0 );
-    QCOMPARE( wrapperDefault.parameterValue(), 55.0 );
+    QCOMPARE( wrapperDefault.parameterValue().toDouble(), 55.0 );
     delete w;
 
     // optional, no default
@@ -977,7 +977,7 @@ void TestProcessingGui::testNumericWrapperDouble()
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptional.wrappedWidget() )->clearValue(), -1000000000.0 );
     QVERIFY( !wrapperOptional.parameterValue().isValid() );
     wrapperOptional.setParameterValue( 5, context );
-    QCOMPARE( wrapperOptional.parameterValue(), 5.0 );
+    QCOMPARE( wrapperOptional.parameterValue().toDouble(), 5.0 );
     wrapperOptional.setParameterValue( QVariant(), context );
     QVERIFY( !wrapperOptional.parameterValue().isValid() );
     wrapperOptional.setParameterValue( 5, context );
@@ -990,18 +990,18 @@ void TestProcessingGui::testNumericWrapperDouble()
 
     w = wrapperOptionalDefault.createWrappedWidget( context );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->clearValue(), -1000000000.0 );
-    QCOMPARE( wrapperOptionalDefault.parameterValue(), 3.0 );
+    QCOMPARE( wrapperOptionalDefault.parameterValue().toDouble(), 3.0 );
     wrapperOptionalDefault.setParameterValue( 5, context );
-    QCOMPARE( wrapperOptionalDefault.parameterValue(), 5.0 );
+    QCOMPARE( wrapperOptionalDefault.parameterValue().toDouble(), 5.0 );
     wrapperOptionalDefault.setParameterValue( QVariant(), context );
     QCOMPARE( static_cast< QgsDoubleSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->value(), -1000000000.0 );
     QVERIFY( !wrapperOptionalDefault.parameterValue().isValid() );
     wrapperOptionalDefault.setParameterValue( 5, context );
-    QCOMPARE( wrapperOptionalDefault.parameterValue(), 5.0 );
+    QCOMPARE( wrapperOptionalDefault.parameterValue().toDouble(), 5.0 );
     static_cast< QgsDoubleSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->clear();
     QVERIFY( !wrapperOptionalDefault.parameterValue().isValid() );
     wrapperOptionalDefault.setParameterValue( 5, context );
-    QCOMPARE( wrapperOptionalDefault.parameterValue(), 5.0 );
+    QCOMPARE( wrapperOptionalDefault.parameterValue().toDouble(), 5.0 );
 
     delete w;
   };
@@ -1078,7 +1078,7 @@ void TestProcessingGui::testNumericWrapperInt()
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMin.wrappedWidget() )->minimum(), -5 );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMin.wrappedWidget() )->maximum(), 999999999 );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMin.wrappedWidget() )->clearValue(), -5 );
-    QCOMPARE( wrapperMin.parameterValue(), 0 );
+    QCOMPARE( wrapperMin.parameterValue().toInt(), 0 );
     delete w;
 
     // with max value
@@ -1091,7 +1091,7 @@ void TestProcessingGui::testNumericWrapperInt()
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMax.wrappedWidget() )->minimum(), -999999999 );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMax.wrappedWidget() )->maximum(), 5 );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMax.wrappedWidget() )->clearValue(), 0 );
-    QCOMPARE( wrapperMax.parameterValue(), 0 );
+    QCOMPARE( wrapperMax.parameterValue().toInt(), 0 );
     delete w;
 
     // with min and max value
@@ -1105,7 +1105,7 @@ void TestProcessingGui::testNumericWrapperInt()
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMinMax.wrappedWidget() )->minimum(), -1 );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMinMax.wrappedWidget() )->maximum(), 1 );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperMinMax.wrappedWidget() )->clearValue(), -1 );
-    QCOMPARE( wrapperMinMax.parameterValue(), 0 );
+    QCOMPARE( wrapperMinMax.parameterValue().toInt(), 0 );
     delete w;
 
     // with default value
@@ -1116,7 +1116,7 @@ void TestProcessingGui::testNumericWrapperInt()
 
     w = wrapperDefault.createWrappedWidget( context );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperDefault.wrappedWidget() )->clearValue(), 55 );
-    QCOMPARE( wrapperDefault.parameterValue(), 55 );
+    QCOMPARE( wrapperDefault.parameterValue().toInt(), 55 );
     delete w;
 
     // optional, no default
@@ -1128,7 +1128,7 @@ void TestProcessingGui::testNumericWrapperInt()
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperOptional.wrappedWidget() )->clearValue(), -1000000000 );
     QVERIFY( !wrapperOptional.parameterValue().isValid() );
     wrapperOptional.setParameterValue( 5, context );
-    QCOMPARE( wrapperOptional.parameterValue(), 5 );
+    QCOMPARE( wrapperOptional.parameterValue().toInt(), 5 );
     wrapperOptional.setParameterValue( QVariant(), context );
     QVERIFY( !wrapperOptional.parameterValue().isValid() );
     wrapperOptional.setParameterValue( 5, context );
@@ -1141,18 +1141,18 @@ void TestProcessingGui::testNumericWrapperInt()
 
     w = wrapperOptionalDefault.createWrappedWidget( context );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->clearValue(), -1000000000 );
-    QCOMPARE( wrapperOptionalDefault.parameterValue(), 3 );
+    QCOMPARE( wrapperOptionalDefault.parameterValue().toInt(), 3 );
     wrapperOptionalDefault.setParameterValue( 5, context );
-    QCOMPARE( wrapperOptionalDefault.parameterValue(), 5 );
+    QCOMPARE( wrapperOptionalDefault.parameterValue().toInt(), 5 );
     wrapperOptionalDefault.setParameterValue( QVariant(), context );
     QCOMPARE( static_cast< QgsSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->value(), -1000000000 );
     QVERIFY( !wrapperOptionalDefault.parameterValue().isValid() );
     wrapperOptionalDefault.setParameterValue( 5, context );
-    QCOMPARE( wrapperOptionalDefault.parameterValue(), 5 );
+    QCOMPARE( wrapperOptionalDefault.parameterValue().toInt(), 5 );
     static_cast< QgsSpinBox * >( wrapperOptionalDefault.wrappedWidget() )->clear();
     QVERIFY( !wrapperOptionalDefault.parameterValue().isValid() );
     wrapperOptionalDefault.setParameterValue( 5, context );
-    QCOMPARE( wrapperOptionalDefault.parameterValue(), 5 );
+    QCOMPARE( wrapperOptionalDefault.parameterValue().toInt(), 5 );
 
     delete w;
   };
@@ -1273,7 +1273,7 @@ void TestProcessingGui::testDistanceWrapper()
   QCOMPARE( wrapper.parameterValue().toDouble(), 2000.0 );
 
   wrapper.setUnitParameterValue( id );
-  QCOMPARE( wrapper.parameterValue().toDouble(), 2 );
+  QCOMPARE( wrapper.parameterValue().toDouble(), 2.0 );
   wrapper.setParameterValue( 5, context );
   QCOMPARE( wrapper.parameterValue().toDouble(), 5.0 );
 
@@ -1307,13 +1307,13 @@ void TestProcessingGui::testDistanceWrapper()
   w = wrapperM.createWrappedWidget( context );
   QSignalSpy spy3( &wrapperM, &QgsProcessingDistanceWidgetWrapper::widgetValueHasChanged );
   wrapperM.setWidgetValue( 29, context );
-  QCOMPARE( wrapperM.widgetValue().toDouble(), 29 );
+  QCOMPARE( wrapperM.widgetValue().toDouble(), 29.0 );
   QCOMPARE( spy3.count(), 1 );
-  QCOMPARE( wrapperM.mDoubleSpinBox->value(), 29 );
+  QCOMPARE( wrapperM.mDoubleSpinBox->value(), 29.0 );
   wrapperM.setWidgetValue( -29, context );
-  QCOMPARE( wrapperM.widgetValue().toDouble(), -29 );
+  QCOMPARE( wrapperM.widgetValue().toDouble(), -29.0 );
   QCOMPARE( spy3.count(), 2 );
-  QCOMPARE( wrapperM.mDoubleSpinBox->value(), -29 );
+  QCOMPARE( wrapperM.mDoubleSpinBox->value(), -29.0 );
 
   // check signal
   wrapperM.mDoubleSpinBox->setValue( 33 );


### PR DESCRIPTION
This ended up being a mega-PR, sorry!

Contained within we have such delicious goodness as:

- Porting the Processing numeric (and distance) parameter widgets to the new c++ API. While I was originally going to do this for 3.6, there's a few bugs present in the older Python wrapper which are fixed by doing this (specifically relating to handling of nulled optional number values). 
- By porting numeric/distance wrappers to the new API, we fix confusing UI issues in the modeler parameter dialog with numeric parameters. Specifically, there's a lot of confusion about what the values exposed in the current expression builder represent, and how they are calculated/used. See e.g. https://issues.qgis.org/issues/19858. The UI exposed by the new API should avoid these issues/confusion (side benefit is that it correctly expose the data defined option for use in models too, so child algorithms can utilise data defined parameters to vary parameter values by feature).
- Adds a ton of new unit tests for the ported numeric and distance parameter widgets.
- Adds a "widget context" for processing parameter widgets. Currently used to expose the map canvas and associated model (if part of a model) to the parameter. (Note that map canvas isn't actually used anywhere yet in master, but it's just making this available for 3rd party widgets for 3.4)
- Allows expression contexts to also set lists of highlighted functions. Previously contexts could only highlight variables, yet in some places it makes sense to also highlight select functions. E.g. here I've highlighted the "to_dms" and "to_dm" functions in the layout map grid custom annotation format expression builder, since these functions are very useful for that context.

... and the big one..

- Exposes the complete expression context which is available to modeler child algorithm parameters in the UI. Previously the context was generated for the parameter in core when running the model, but never actually shown anywhere in the GUI! So users had no clue that all these yummy variables and functions were available for use within their models (unless they browsed the c++ source). This is done for both the "pre-calculated" parameter value expression builder AND the data defined parameter expression builder*.

Just to stress -- none of this is NEW functionality, it's just correctly exposing in the GUI existing functionality (from 3.0).


* What this means is that users are now aware that they can use expressions like ` @stats_for_speed_field_MAX / "speed" ` to calculate (per-feature) the value of the feature's speed field vs the max speed value calculated by a basic stats algorithm, and use this as the value for a parameter for that feature (e.g. variable buffer size). Wooo!



