### PR TITLE
[browser] GPKG VACUUM menu item

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -438,16 +438,6 @@ bool QgsGeoPackageCollectionItem::deleteGeoPackageRasterLayer( const QString &ur
           );
           sqlite3_free( sql );
         }
-        // Vacuum
-        {
-          ( void )sqlite3_exec(
-            database.get(),                      /* An open database */
-            "VACUUM",                            /* SQL to be evaluated */
-            nullptr,                             /* Callback function */
-            nullptr,                             /* 1st argument to callback */
-            nullptr                              /* Error msg written here */
-          );
-        }
 
         if ( status == SQLITE_OK )
         {

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -88,10 +88,17 @@ class QgsGeoPackageCollectionItem : public QgsDataCollectionItem
     //! Returns the layer type from \a geometryType
     static QgsLayerItem::LayerType layerTypeFromDb( const QString &geometryType );
 
-    //! Deletes a geopackage layer
+    //! Deletes a geopackage raster layer
     static bool deleteGeoPackageRasterLayer( const QString &uri, QString &errCause );
 
-
+    /**
+     * Compacts (VACUUM) a geopackage database
+     * \param path DB path
+     * \param name DB name
+     * \param errCause contains the error message
+     * \return true on success
+     */
+    static bool vacuumGeoPackageDb( const QString &path, const QString &name, QString &errCause );
 
   public slots:
 #ifdef HAVE_GUI
@@ -99,7 +106,7 @@ class QgsGeoPackageCollectionItem : public QgsDataCollectionItem
     void addConnection();
     void deleteConnection();
     //! Compacts (VACUUM) a geopackage database
-    void vacuumGeoPackageDb();
+    void vacuumGeoPackageDbAction();
 #endif
 
   protected:

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -88,14 +88,18 @@ class QgsGeoPackageCollectionItem : public QgsDataCollectionItem
     //! Returns the layer type from \a geometryType
     static QgsLayerItem::LayerType layerTypeFromDb( const QString &geometryType );
 
-    //! Delete a geopackage layer
+    //! Deletes a geopackage layer
     static bool deleteGeoPackageRasterLayer( const QString &uri, QString &errCause );
+
+
 
   public slots:
 #ifdef HAVE_GUI
     void addTable();
     void addConnection();
     void deleteConnection();
+    //! Compacts (VACUUM) a geopackage database
+    void vacuumGeoPackageDb();
 #endif
 
   protected:


### PR DESCRIPTION
Fixes #19895 - Garbage-collection is not performed after deletion of vector layer from geopackage

![geopackage-vacuum](https://user-images.githubusercontent.com/142164/45870585-84beca00-bd8b-11e8-8f03-186063de9bef.gif)


By design, VACUUM (being a potentially time-consuming operation)
was automatically performed only after deleting a raster
while when deleting a vector layer it was not executed.

This PR adds a menu item in the browser that allows
the user to perform this operation on the DB.

A possible UX improvement would be to add
a button to the success dialog that
offers the user the option to run VACUUM
after a successful layer deletion.
