### PR TITLE
fixes #16587

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3884,7 +3884,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
 
     QString contentType = reply->header( QNetworkRequest::ContentTypeHeader ).toString();
     QgsDebugMsg( "contentType: " + contentType );
-    if ( !contentType.startsWith( QLatin1String( "image/" ), Qt::CaseInsensitive ) &&
+    if ( !contentType.isEmpty() && !contentType.startsWith( QLatin1String( "image/" ), Qt::CaseInsensitive ) &&
          contentType.compare( QLatin1String( "application/octet-stream" ), Qt::CaseInsensitive ) != 0 )
     {
       QByteArray text = reply->readAll();


### PR DESCRIPTION
This will allow to load XYZ tiles from local directory. Thanks to @nyalldawson suggestion here:
https://lists.osgeo.org/pipermail/qgis-user/2018-September/041118.html

Tested on a folder created by QTiles and adding the path as:
`file:////path/to/folder/{z}/{x}/{y}.png`
allows you to load the tiles az XYZ tile layer.