### PR TITLE
Fix layer styling dock has tiny icons on hidpi

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -46,6 +46,7 @@
 #include "qgsmaplayerstylemanagerwidget.h"
 #include "qgsruntimeprofiler.h"
 #include "qgsrasterminmaxwidget.h"
+#include "qgisapp.h"
 
 #ifdef HAVE_3D
 #include "qgsvectorlayer3drendererwidget.h"
@@ -61,6 +62,9 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, const QList<
   , mPageFactories( pages )
 {
   setupUi( this );
+
+  mOptionsListWidget->setIconSize( QgisApp::instance()->iconSize( false ) );
+  mOptionsListWidget->setMaximumWidth( static_cast< int >( mOptionsListWidget->iconSize().width() * 1.18 ) );
 
   connect( QgsProject::instance(), static_cast < void ( QgsProject::* )( QgsMapLayer * ) > ( &QgsProject::layerWillBeRemoved ), this, &QgsLayerStylingWidget::layerAboutToBeRemoved );
 

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -232,6 +232,9 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
   setupUi( this );
   this->layout()->setContentsMargins( 0, 0, 0, 0 );
 
+  layersTree->setMaximumHeight( static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().height() * 7 ) );
+  layersTree->setMinimumHeight( layersTree->maximumHeight() );
+
   // setup icons
   btnAddLayer->setIcon( QIcon( QgsApplication::iconPath( "symbologyAdd.svg" ) ) );
   btnRemoveLayer->setIcon( QIcon( QgsApplication::iconPath( "symbologyRemove.svg" ) ) );

--- a/src/ui/qgsmapstylingwidgetbase.ui
+++ b/src/ui/qgsmapstylingwidgetbase.ui
@@ -197,12 +197,6 @@
               <height>0</height>
              </size>
             </property>
-            <property name="maximumSize">
-             <size>
-              <width>38</width>
-              <height>16777215</height>
-             </size>
-            </property>
             <property name="frameShape">
              <enum>QFrame::NoFrame</enum>
             </property>
@@ -211,12 +205,6 @@
             </property>
             <property name="editTriggers">
              <set>QAbstractItemView::NoEditTriggers</set>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>32</width>
-              <height>32</height>
-             </size>
             </property>
             <property name="textElideMode">
              <enum>Qt::ElideNone</enum>


### PR DESCRIPTION
Fixes some hidpi issues:

Before:

![image](https://user-images.githubusercontent.com/1829991/45933893-fb9cd280-bfd8-11e8-82d4-ae3c150c3b19.png)

After:

![image](https://user-images.githubusercontent.com/1829991/45933959-6ef31400-bfda-11e8-9db3-56f0424d741f.png)


The tiny cramped symbol layer list in particular made symbol editing on hidpi very frustrating. 