### PR TITLE
Add an option to cartesian measurement / Fix 19902 [FEATURE]

### DIFF
--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -69,8 +69,17 @@ QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool *tool, Qt::WindowFlags f )
   connect( mUnitsCombo, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsMeasureDialog::unitsChanged );
   connect( buttonBox, &QDialogButtonBox::rejected, this, &QgsMeasureDialog::reject );
   connect( mCanvas, &QgsMapCanvas::destinationCrsChanged, this, &QgsMeasureDialog::crsChanged );
+  connect( mCartesian, &QRadioButton::toggled, this, &QgsMeasureDialog::projChanged );
 
   groupBox->setCollapsed( true );
+}
+
+void QgsMeasureDialog::projChanged()
+{
+  if ( mCartesian->isChecked() )
+    mDa.setEllipsoid( GEO_NONE );
+  else
+    mDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
 }
 
 void QgsMeasureDialog::openConfigTab()
@@ -105,7 +114,7 @@ void QgsMeasureDialog::updateSettings()
   mDistanceUnits = QgsProject::instance()->distanceUnits();
   mAreaUnits = QgsProject::instance()->areaUnits();
   mDa.setSourceCrs( mCanvas->mapSettings().destinationCrs(), QgsProject::instance()->transformContext() );
-  mDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  projChanged();
 
   mTable->clear();
   mTotal = 0;

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -80,6 +80,9 @@ void QgsMeasureDialog::projChanged()
     mDa.setEllipsoid( GEO_NONE );
   else
     mDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+  mTable->clear();
+  mTotal = 0.;
+  updateUi();
 }
 
 void QgsMeasureDialog::openConfigTab()

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -72,6 +72,8 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 
     void crsChanged();
 
+    void projChanged();
+
   private:
 
     //! formats distance to most appropriate units

--- a/src/ui/qgsmeasurebase.ui
+++ b/src/ui/qgsmeasurebase.ui
@@ -21,8 +21,7 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff/>
-   </iconset>
+    <normaloff>.</normaloff>.</iconset>
   </property>
   <layout class="QGridLayout">
    <property name="leftMargin">
@@ -101,19 +100,19 @@
        <string>Segments</string>
       </property>
       <property name="textAlignment">
-       <set>AlignRight|AlignVCenter</set>
+       <set>AlignTrailing|AlignVCenter</set>
       </property>
      </column>
     </widget>
    </item>
-   <item row="6" column="0" colspan="4">
+   <item row="7" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="4">
+   <item row="6" column="0" colspan="4">
     <widget class="QgsCollapsibleGroupBox" name="groupBox">
      <property name="title">
       <string>Info</string>
@@ -130,6 +129,26 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QRadioButton" name="mCartesian">
+     <property name="text">
+      <string>Cartesian</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QRadioButton" name="mProjected">
+     <property name="text">
+      <string>Projected</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/ui/qgsmeasurebase.ui
+++ b/src/ui/qgsmeasurebase.ui
@@ -142,9 +142,9 @@
     </widget>
    </item>
    <item row="5" column="2">
-    <widget class="QRadioButton" name="mProjected">
+    <widget class="QRadioButton" name="mEllipsoidal">
      <property name="text">
-      <string>Projected</string>
+      <string>Ellipsoidal</string>
      </property>
      <property name="checked">
       <bool>false</bool>

--- a/tests/src/app/testqgsmeasuretool.cpp
+++ b/tests/src/app/testqgsmeasuretool.cpp
@@ -166,7 +166,7 @@ void TestQgsMeasureTool::testLengthCalculationProjected()
   // run length calculation
   std::unique_ptr< QgsMeasureTool > tool( new QgsMeasureTool( mCanvas, false ) );
   std::unique_ptr< QgsMeasureDialog > dlg( new QgsMeasureDialog( tool.get() ) );
-  dlg->mProjected->setChecked( true );
+  dlg->mEllipsoidal->setChecked( true );
 
   tool->restart();
   tool->addPoint( QgsPointXY( 2484588, 2425722 ) );
@@ -184,7 +184,7 @@ void TestQgsMeasureTool::testLengthCalculationProjected()
   QgsProject::instance()->setDistanceUnits( QgsUnitTypes::DistanceFeet );
   std::unique_ptr< QgsMeasureTool > tool2( new QgsMeasureTool( mCanvas, false ) );
   std::unique_ptr< QgsMeasureDialog > dlg2( new QgsMeasureDialog( tool2.get() ) );
-  dlg2->mProjected->setChecked( true );
+  dlg2->mEllipsoidal->setChecked( true );
 
   tool2->restart();
   tool2->addPoint( QgsPointXY( 2484588, 2425722 ) );
@@ -316,7 +316,7 @@ void TestQgsMeasureTool::testAreaCalculationProjected()
   std::unique_ptr< QgsMeasureTool > tool( new QgsMeasureTool( mCanvas, true ) );
   std::unique_ptr< QgsMeasureDialog > dlg( new QgsMeasureDialog( tool.get() ) );
 
-  dlg->mProjected->setChecked( true );
+  dlg->mEllipsoidal->setChecked( true );
 
   tool->restart();
   tool->addPoint( QgsPointXY( 2484588, 2425722 ) );
@@ -337,7 +337,7 @@ void TestQgsMeasureTool::testAreaCalculationProjected()
   std::unique_ptr< QgsMeasureTool > tool2( new QgsMeasureTool( mCanvas, true ) );
   std::unique_ptr< QgsMeasureDialog > dlg2( new QgsMeasureDialog( tool2.get() ) );
 
-  dlg2->mProjected->setChecked( true );
+  dlg2->mEllipsoidal->setChecked( true );
 
   tool2->restart();
   tool2->addPoint( QgsPointXY( 2484588, 2425722 ) );


### PR DESCRIPTION
## Description
Fixes #19902
Both a fix and an addition. It is sometimes interesting to compare the two measurement methods, a bit like in the identification tool.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
