### PR TITLE
Micro-optimisation: don't call geos for checking point geometry validity

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2366,7 +2366,7 @@ bool QgsGeometry::isGeosValid() const
   }
 
   // avoid calling geos for trivial point geometries
-  if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == QgsWkbTypes::Point )
+  if ( QgsWkbTypes::geometryType( d->geometry->wkbType() ) == QgsWkbTypes::PointGeometry )
   {
     return true;
   }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -2365,6 +2365,12 @@ bool QgsGeometry::isGeosValid() const
     return false;
   }
 
+  // avoid calling geos for trivial point geometries
+  if ( QgsWkbTypes::flatType( d->geometry->wkbType() ) == QgsWkbTypes::Point )
+  {
+    return true;
+  }
+
   QgsGeos geos( d->geometry.get() );
   mLastError.clear();
   return geos.isValid( &mLastError );


### PR DESCRIPTION
Since a single-point will always be valid
