### PR TITLE
[processing] Never run feature validity check for point layers

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -727,7 +727,9 @@ QgsFields QgsProcessingUtils::indicesToFields( const QList<int> &indices, const 
 QgsProcessingFeatureSource::QgsProcessingFeatureSource( QgsFeatureSource *originalSource, const QgsProcessingContext &context, bool ownsOriginalSource )
   : mSource( originalSource )
   , mOwnsSource( ownsOriginalSource )
-  , mInvalidGeometryCheck( context.invalidGeometryCheck() )
+  , mInvalidGeometryCheck( QgsWkbTypes::geometryType( mSource->wkbType() ) == QgsWkbTypes::PointGeometry
+                           ? QgsFeatureRequest::GeometryNoCheck // never run geometry validity checks for point layers!
+                           : context.invalidGeometryCheck() )
   , mInvalidGeometryCallback( context.invalidGeometryCallback() )
   , mTransformErrorCallback( context.transformErrorCallback() )
 {}


### PR DESCRIPTION
Saves a few cycles. The feature validity checks have no meaning
for point layers.

Refs #19919
