### PR TITLE
[processing] Fix crash when an algorithm dialog is left open and processing options are changed

### DIFF
--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -201,7 +201,7 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
             popupmenu.exec_(self.algorithmTree.mapToGlobal(point))
 
     def editRenderingStyles(self):
-        alg = self.algorithmTree.selectedAlgorithm()
+        alg = self.algorithmTree.selectedAlgorithm().create() if self.algorithmTree.selectedAlgorithm() is not None else None
         if alg is not None:
             dlg = EditRenderingStylesDialog(alg)
             dlg.exec_()
@@ -210,14 +210,14 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
         self.executeAlgorithm()
 
     def executeAlgorithmAsBatchProcess(self):
-        alg = self.algorithmTree.selectedAlgorithm()
+        alg = self.algorithmTree.selectedAlgorithm().create() if self.algorithmTree.selectedAlgorithm() is not None else None
         if alg is not None:
             dlg = BatchAlgorithmDialog(alg)
             dlg.show()
             dlg.exec_()
 
     def executeAlgorithm(self):
-        alg = self.algorithmTree.selectedAlgorithm()
+        alg = self.algorithmTree.selectedAlgorithm().create() if self.algorithmTree.selectedAlgorithm() is not None else None
         if alg is not None:
             ok, message = alg.canExecute()
             if not ok:

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -127,7 +127,7 @@ def createAlgorithmDialog(algOrName, parameters={}):
     and delete this dialog.
     """
     if isinstance(algOrName, QgsProcessingAlgorithm):
-        alg = algOrName
+        alg = algOrName.create()
     else:
         alg = QgsApplication.processingRegistry().createAlgorithmById(algOrName)
 


### PR DESCRIPTION
Make sure the algorithm dialogs use their own copy of algorithms,
instead of the copies owned by the processing registry. Opening
processing options triggers a full reload of providers, deleting
all existing algorithm instances from the registry first.
