### PR TITLE
[browser] Allow GPKG VACUUM from file browser

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -193,6 +193,12 @@ QList<QAction *> QgsGeoPackageCollectionItem::actions( QWidget *parent )
   connect( actionAddTable, &QAction::triggered, this, &QgsGeoPackageCollectionItem::addTable );
   lst.append( actionAddTable );
 
+  // Run VACUUM
+  QAction *actionVacuumDb = new QAction( tr( "Compact database (VACUUM)" ), parent );
+  connect( actionVacuumDb, &QAction::triggered, this, &QgsGeoPackageConnectionItem::vacuumGeoPackageDbAction );
+  lst.append( actionVacuumDb );
+
+
   return lst;
 }
 
@@ -374,7 +380,6 @@ QList<QAction *> QgsGeoPackageConnectionItem::actions( QWidget *parent )
   QAction *actionVacuumDb = new QAction( tr( "Compact database (VACUUM)" ), parent );
   connect( actionVacuumDb, &QAction::triggered, this, &QgsGeoPackageConnectionItem::vacuumGeoPackageDbAction );
   lst.append( actionVacuumDb );
-
 
   return lst;
 }

--- a/src/providers/ogr/qgsgeopackagedataitems.h
+++ b/src/providers/ogr/qgsgeopackagedataitems.h
@@ -37,7 +37,7 @@ class QgsGeoPackageAbstractLayerItem : public QgsLayerItem
      */
     virtual bool executeDeleteLayer( QString &errCause );
 #ifdef HAVE_GUI
-    QList<QAction *> actions( QWidget *parent ) override;
+    QList<QAction *> actions( QWidget *menu ) override;
   public slots:
     virtual void deleteLayer();
 #endif


### PR DESCRIPTION
Add the VACUUM action to the file file browser too (the same action that is already implemented for stored GPKG connections)