### PR TITLE
Make sure that also groups with "required" layers cannot be removed

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
@@ -97,6 +97,14 @@ Insert a QgsMapLayer just below another one
 
 :return: the new tree layer
 %End
+
+    static QSet<QgsMapLayer *> collectMapLayersRecursive( const QList<QgsLayerTreeNode *> &nodes );
+%Docstring
+Returns map layers from the given list of layer tree nodes. Also recursively visits
+child nodes of groups.
+
+.. versionadded:: 3.4
+%End
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeview.sip.in
@@ -111,6 +111,15 @@ Returns list of selected nodes filtered to just layer nodes
 Gets list of selected layers
 %End
 
+    QList<QgsMapLayer *> selectedLayersRecursive() const;
+%Docstring
+Gets list of selected layers, including those that are not directly selected, but their
+ancestor groups is selected. If we have a group with two layers L1, L2 and just the group
+node is selected, this method returns L1 and L2, while selectedLayers() returns an empty list.
+
+.. versionadded:: 3.4
+%End
+
     void addIndicator( QgsLayerTreeNode *node, QgsLayerTreeViewIndicator *indicator );
 %Docstring
 Adds an indicator to the given layer tree node. Indicators are icons shown next to layer/group names

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9559,7 +9559,21 @@ void QgisApp::removeLayer()
     return;
   }
 
-  const QList<QgsMapLayer *> selectedLayers = mLayerTreeView->selectedLayers();
+  // look for layers recursively so we catch also those that are within selected groups
+  const QList<QgsMapLayer *> selectedLayers = mLayerTreeView->selectedLayersRecursive();
+
+  QStringList nonRemovableLayerNames;
+  for ( QgsMapLayer *layer : selectedLayers )
+  {
+    if ( !layer->flags().testFlag( QgsMapLayer::Removable ) )
+      nonRemovableLayerNames << layer->name();
+  }
+  if ( !nonRemovableLayerNames.isEmpty() )
+  {
+    QMessageBox::warning( this, tr( "Required Layers" ),
+                          tr( "The following layers are marked as required by the project:\n\n%1\n\nPlease deselect them (or unmark as required) and retry." ).arg( nonRemovableLayerNames.join( QStringLiteral( "\n" ) ) ) );
+    return;
+  }
 
   for ( QgsMapLayer *layer : selectedLayers )
   {
@@ -9579,15 +9593,6 @@ void QgisApp::removeLayer()
         activeTaskDescriptions << tr( " • %1" ).arg( task->description() );
       }
     }
-  }
-
-  // extra check for required layers
-  // In theory it should not be needed because the remove action should be disabled
-  // if there are required layers in the selection...
-  for ( QgsMapLayer *layer : selectedLayers )
-  {
-    if ( !layer->flags().testFlag( QgsMapLayer::Removable ) )
-      return;
   }
 
   if ( !activeTaskDescriptions.isEmpty() )

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -413,3 +413,27 @@ QgsLayerTreeLayer *QgsLayerTreeUtils::insertLayerBelow( QgsLayerTreeGroup *group
   QgsLayerTreeGroup *parent = static_cast<QgsLayerTreeGroup *>( inTree->parent() ) ? static_cast<QgsLayerTreeGroup *>( inTree->parent() ) : group;
   return parent->insertLayer( idx, layerToInsert );
 }
+
+static void _collectMapLayers( const QList<QgsLayerTreeNode *> &nodes, QSet<QgsMapLayer *> &layersSet )
+{
+  for ( QgsLayerTreeNode *node : nodes )
+  {
+    if ( QgsLayerTree::isLayer( node ) )
+    {
+      QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
+      if ( nodeLayer->layer() )
+        layersSet << nodeLayer->layer();
+    }
+    else if ( QgsLayerTree::isGroup( node ) )
+    {
+      _collectMapLayers( QgsLayerTree::toGroup( node )->children(), layersSet );
+    }
+  }
+}
+
+QSet<QgsMapLayer *> QgsLayerTreeUtils::collectMapLayersRecursive( const QList<QgsLayerTreeNode *> &nodes )
+{
+  QSet<QgsMapLayer *> layersSet;
+  _collectMapLayers( nodes, layersSet );
+  return layersSet;
+}

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -87,6 +87,13 @@ class CORE_EXPORT QgsLayerTreeUtils
      * \returns the new tree layer
      */
     static QgsLayerTreeLayer *insertLayerBelow( QgsLayerTreeGroup *group, const QgsMapLayer *refLayer, QgsMapLayer *layerToInsert );
+
+    /**
+     * Returns map layers from the given list of layer tree nodes. Also recursively visits
+     * child nodes of groups.
+     * \since QGIS 3.4
+     */
+    static QSet<QgsMapLayer *> collectMapLayersRecursive( const QList<QgsLayerTreeNode *> &nodes );
 };
 
 #endif // QGSLAYERTREEUTILS_H

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -356,6 +356,31 @@ QList<QgsMapLayer *> QgsLayerTreeView::selectedLayers() const
   return list;
 }
 
+static void _collectMapLayers( const QList<QgsLayerTreeNode *> &nodes, QSet<QgsMapLayer *> &layersSet )
+{
+  for ( QgsLayerTreeNode *node : nodes )
+  {
+    if ( QgsLayerTree::isLayer( node ) )
+    {
+      QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
+      if ( nodeLayer->layer() )
+        layersSet << nodeLayer->layer();
+    }
+    else if ( QgsLayerTree::isGroup( node ) )
+    {
+      _collectMapLayers( QgsLayerTree::toGroup( node )->children(), layersSet );
+    }
+  }
+}
+
+QList<QgsMapLayer *> QgsLayerTreeView::selectedLayersRecursive() const
+{
+  QSet<QgsMapLayer *> layersSet;
+  const QList<QgsLayerTreeNode *> nodes = layerTreeModel()->indexes2nodes( selectionModel()->selectedIndexes(), false );
+  _collectMapLayers( nodes, layersSet );
+  return layersSet.toList();
+}
+
 void QgsLayerTreeView::addIndicator( QgsLayerTreeNode *node, QgsLayerTreeViewIndicator *indicator )
 {
   if ( !mIndicators[node].contains( indicator ) )

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -19,6 +19,7 @@
 #include "qgslayertreeembeddedwidgetregistry.h"
 #include "qgslayertreemodel.h"
 #include "qgslayertreemodellegendnode.h"
+#include "qgslayertreeutils.h"
 #include "qgslayertreeviewdefaultactions.h"
 #include "qgsmaplayer.h"
 #include "qgsgui.h"
@@ -356,28 +357,10 @@ QList<QgsMapLayer *> QgsLayerTreeView::selectedLayers() const
   return list;
 }
 
-static void _collectMapLayers( const QList<QgsLayerTreeNode *> &nodes, QSet<QgsMapLayer *> &layersSet )
-{
-  for ( QgsLayerTreeNode *node : nodes )
-  {
-    if ( QgsLayerTree::isLayer( node ) )
-    {
-      QgsLayerTreeLayer *nodeLayer = QgsLayerTree::toLayer( node );
-      if ( nodeLayer->layer() )
-        layersSet << nodeLayer->layer();
-    }
-    else if ( QgsLayerTree::isGroup( node ) )
-    {
-      _collectMapLayers( QgsLayerTree::toGroup( node )->children(), layersSet );
-    }
-  }
-}
-
 QList<QgsMapLayer *> QgsLayerTreeView::selectedLayersRecursive() const
 {
-  QSet<QgsMapLayer *> layersSet;
   const QList<QgsLayerTreeNode *> nodes = layerTreeModel()->indexes2nodes( selectionModel()->selectedIndexes(), false );
-  _collectMapLayers( nodes, layersSet );
+  QSet<QgsMapLayer *> layersSet = QgsLayerTreeUtils::collectMapLayersRecursive( nodes );
   return layersSet.toList();
 }
 

--- a/src/gui/layertree/qgslayertreeview.h
+++ b/src/gui/layertree/qgslayertreeview.h
@@ -108,6 +108,14 @@ class GUI_EXPORT QgsLayerTreeView : public QTreeView
     QList<QgsMapLayer *> selectedLayers() const;
 
     /**
+     * Gets list of selected layers, including those that are not directly selected, but their
+     * ancestor groups is selected. If we have a group with two layers L1, L2 and just the group
+     * node is selected, this method returns L1 and L2, while selectedLayers() returns an empty list.
+     * \since QGIS 3.4
+     */
+    QList<QgsMapLayer *> selectedLayersRecursive() const;
+
+    /**
      * Adds an indicator to the given layer tree node. Indicators are icons shown next to layer/group names
      * in the layer tree view. They can be used to show extra information with tree nodes and they allow
      * user interaction.


### PR DESCRIPTION
Fixes an unreported bug where it was possible to select a layer tree group and remove even when it contained required layers.

When removing layers/groups, the following checks will now also recursively test layers and not just directly selected layers:
- test for layers with unsaved changes
- test for layers with active tasks running in background
