### PR TITLE
make QgsWkbTypes a Q_GADGET and declare GeometryType as Q_ENUM

### DIFF
--- a/python/core/auto_additions/qgswkbtypes.py
+++ b/python/core/auto_additions/qgswkbtypes.py
@@ -1,0 +1,2 @@
+# The following has been generated automatically from src/core/geometry/qgswkbtypes.h
+QgsWkbTypes.GeometryType.baseClass = QgsWkbTypes

--- a/python/core/auto_generated/geometry/qgswkbtypes.sip.in
+++ b/python/core/auto_generated/geometry/qgswkbtypes.sip.in
@@ -24,6 +24,9 @@ Handles storage of information regarding WKB types and their properties.
 #include "qgswkbtypes.h"
 %End
   public:
+    static const QMetaObject staticMetaObject;
+
+  public:
 
     enum Type
     {

--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -11,7 +11,6 @@
 
 
 
-
 class QgsDataItem : QObject
 {
 %Docstring

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -295,7 +295,6 @@
 %Include auto_generated/geometry/qgstriangle.sip
 %Include auto_generated/geometry/qgssurface.sip
 %Include auto_generated/geometry/qgswkbptr.sip
-%Include auto_generated/geometry/qgswkbtypes.sip
 %Include auto_generated/./3d/qgs3drendererregistry.sip
 %Include auto_generated/./3d/qgsabstract3drenderer.sip
 %Include auto_generated/fieldformatter/qgsrangefieldformatter.sip
@@ -396,6 +395,7 @@
 %Include auto_generated/geometry/qgsabstractgeometry.sip
 %Include auto_generated/geometry/qgsgeometry.sip
 %Include auto_generated/geometry/qgspoint.sip
+%Include auto_generated/geometry/qgswkbtypes.sip
 %Include auto_generated/geocms/geonode/qgsgeonoderequest.sip
 %Include auto_generated/gps/qgsgpsconnection.sip
 %Include auto_generated/gps/qgsgpsdetector.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -700,6 +700,7 @@ SET(QGIS_CORE_MOC_HDRS
   geometry/qgsabstractgeometry.h
   geometry/qgsgeometry.h
   geometry/qgspoint.h
+  geometry/qgswkbtypes.h
 
   geocms/geonode/qgsgeonoderequest.h
 
@@ -1160,7 +1161,6 @@ SET(QGIS_CORE_HDRS
   geometry/qgstriangle.h
   geometry/qgssurface.h
   geometry/qgswkbptr.h
-  geometry/qgswkbtypes.h
 
   3d/qgs3drendererregistry.h
   3d/qgsabstract3drenderer.h

--- a/src/core/geometry/qgswkbtypes.h
+++ b/src/core/geometry/qgswkbtypes.h
@@ -39,6 +39,7 @@
 
 class CORE_EXPORT QgsWkbTypes
 {
+    Q_GADGET
   public:
 
     /**
@@ -142,6 +143,7 @@ class CORE_EXPORT QgsWkbTypes
       UnknownGeometry,
       NullGeometry
     };
+    Q_ENUM( GeometryType )
 
     /**
      * Returns the single type for a WKB type. For example, for MultiPolygon WKB types the single type would be Polygon.

--- a/src/core/geometry/qgswkbtypes.h
+++ b/src/core/geometry/qgswkbtypes.h
@@ -18,6 +18,7 @@
 #ifndef QGSWKBTYPES_H
 #define QGSWKBTYPES_H
 
+#include <QObject>
 #include <QMap>
 #include <QString>
 

--- a/src/core/geometry/qgswkbtypes.h
+++ b/src/core/geometry/qgswkbtypes.h
@@ -23,7 +23,6 @@
 #include <QString>
 
 #include "qgis_core.h"
-#include "qgis.h"
 
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -33,7 +33,7 @@
 #include "qgsmaplayer.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsmimedatautils.h"
-
+#include "qgswkbtypes.h"
 
 class QgsDataProvider;
 class QgsDataItem;

--- a/src/providers/arcgisrest/qgsafsdataitems.h
+++ b/src/providers/arcgisrest/qgsafsdataitems.h
@@ -17,7 +17,7 @@
 
 #include "qgsdataitem.h"
 #include "qgsdatasourceuri.h"
-
+#include "qgswkbtypes.h"
 
 class QgsAfsRootItem : public QgsDataCollectionItem
 {

--- a/src/providers/arcgisrest/qgsamsdataitems.h
+++ b/src/providers/arcgisrest/qgsamsdataitems.h
@@ -19,6 +19,7 @@
 
 #include "qgsdataitem.h"
 #include "qgsdatasourceuri.h"
+#include "qgswkbtypes.h"
 
 
 class QgsAmsRootItem : public QgsDataCollectionItem

--- a/src/providers/ows/qgsowsdataitems.h
+++ b/src/providers/ows/qgsowsdataitems.h
@@ -17,6 +17,8 @@
 
 #include "qgsdataitem.h"
 #include "qgsdatasourceuri.h"
+#include "qgswkbtypes.h"
+
 class QgsOWSConnectionItem : public QgsDataCollectionItem
 {
     Q_OBJECT

--- a/src/providers/postgres/qgspostgresdataitems.h
+++ b/src/providers/postgres/qgspostgresdataitems.h
@@ -22,6 +22,7 @@
 #include "qgspostgresconn.h"
 #include "qgsmimedatautils.h"
 #include "qgsvectorlayerexporter.h"
+#include "qgswkbtypes.h"
 
 class QgsPGRootItem;
 class QgsPGConnectionItem;


### PR DESCRIPTION
followup of #8007 
this will allow saving GeometryType as text instead of int in XML and prepare the change of enum values for flags.
such as QgsMapLayer::exportNamedStyle