### PR TITLE
Fixes  #19555 DWG import overwrites existing Geopackage without warning

### DIFF
--- a/src/app/dwg/qgsdwgimportdialog.h
+++ b/src/app/dwg/qgsdwgimportdialog.h
@@ -33,13 +33,12 @@ class QgsDwgImportDialog : public QDialog, private Ui::QgsDwgImportBase
 
   private slots:
     void buttonBox_accepted();
-    void pbBrowseDatabase_clicked();
     void pbBrowseDrawing_clicked();
     void pbImportDrawing_clicked();
     void pbLoadDatabase_clicked();
     void pbSelectAll_clicked();
     void pbDeselectAll_clicked();
-    void leDatabase_textChanged( const QString &text );
+    void mDatabaseFileWidget_textChanged( const QString &filename );
     void leLayerGroup_textChanged( const QString &text );
     void showHelp();
 

--- a/src/ui/qgsdwgimportbase.ui
+++ b/src/ui/qgsdwgimportbase.ui
@@ -114,7 +114,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="1" column="1">
-       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
         </property>
@@ -160,9 +160,6 @@
         <property name="text">
          <string>Target package</string>
         </property>
-        <property name="buddy">
-         <cstring>leDatabase</cstring>
-        </property>
        </widget>
       </item>
       <item row="1" column="0">
@@ -178,16 +175,12 @@
       <item row="0" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLineEdit" name="leDatabase">
-          <property name="readOnly">
-           <bool>true</bool>
+         <widget class="QgsFileWidget" name="mDatabaseFileWidget">
+          <property name="dialogTitle">
+           <string>Select GeoPackage Database</string>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pbBrowseDatabase">
-          <property name="text">
-           <string>…</string>
+          <property name="filter">
+           <string notr="true">*.gpkg;;*.GPKG</string>
           </property>
          </widget>
         </item>
@@ -232,6 +225,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
@@ -239,8 +237,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>leDatabase</tabstop>
-  <tabstop>pbBrowseDatabase</tabstop>
   <tabstop>pbLoadDatabase</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>leDrawing</tabstop>


### PR DESCRIPTION
## Description
Fixes  #19555

Adds a QMessageBox if file exists
Remove lastDatabase setting to lastDirDatabase. It's dangerous to reuse
the last database.
Adds a .gpkg extension to filename if not presents.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
