### PR TITLE
Fix missing indicators after they are moved to a different group

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
@@ -105,6 +105,21 @@ child nodes of groups.
 
 .. versionadded:: 3.4
 %End
+
+    static int countMapLayerInTree( QgsLayerTreeNode *tree, QgsMapLayer *layer );
+%Docstring
+Returns how many occurences of a map layer are there in a layer tree.
+In normal situations there is at most one occurence, but sometimes there
+may be temporarily more: for example, during drag&drop, upon drop a new layer
+node is created while the original dragged node is still in the tree, resulting
+in two occurences.
+
+This is useful when deciding whether to start or stop listening to a signal
+of a map layer within a layer tree and only connecting/disconnecting when
+there is only one occurence of that layer.
+
+.. versionadded:: 3.4
+%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreeutils.sip.in
@@ -108,15 +108,15 @@ child nodes of groups.
 
     static int countMapLayerInTree( QgsLayerTreeNode *tree, QgsMapLayer *layer );
 %Docstring
-Returns how many occurences of a map layer are there in a layer tree.
-In normal situations there is at most one occurence, but sometimes there
+Returns how many occurrences of a map layer are there in a layer tree.
+In normal situations there is at most one occurrence, but sometimes there
 may be temporarily more: for example, during drag&drop, upon drop a new layer
 node is created while the original dragged node is still in the tree, resulting
-in two occurences.
+in two occurrences.
 
 This is useful when deciding whether to start or stop listening to a signal
 of a map layer within a layer tree and only connecting/disconnecting when
-there is only one occurence of that layer.
+there is only one occurrence of that layer.
 
 .. versionadded:: 3.4
 %End

--- a/src/app/qgslayertreeviewfilterindicator.cpp
+++ b/src/app/qgslayertreeviewfilterindicator.cpp
@@ -17,6 +17,7 @@
 
 #include "qgslayertree.h"
 #include "qgslayertreemodel.h"
+#include "qgslayertreeutils.h"
 #include "qgslayertreeview.h"
 #include "qgsquerybuilder.h"
 #include "qgsvectorlayer.h"
@@ -54,12 +55,10 @@ void QgsLayerTreeViewFilterIndicatorProvider::onAddedChildren( QgsLayerTreeNode 
       QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
       if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( childLayerNode->layer() ) )
       {
-        if ( vlayer )
-        {
+        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), vlayer ) == 1 )
           connect( vlayer, &QgsVectorLayer::subsetStringChanged, this, &QgsLayerTreeViewFilterIndicatorProvider::onSubsetStringChanged );
 
-          addOrRemoveIndicator( childLayerNode, vlayer );
-        }
+        addOrRemoveIndicator( childLayerNode, vlayer );
       }
       else if ( !childLayerNode->layer() )
       {
@@ -89,7 +88,7 @@ void QgsLayerTreeViewFilterIndicatorProvider::onWillRemoveChildren( QgsLayerTree
       QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
       if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( childLayerNode->layer() ) )
       {
-        if ( vlayer )
+        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), vlayer ) == 1 )
           disconnect( vlayer, &QgsVectorLayer::subsetStringChanged, this, &QgsLayerTreeViewFilterIndicatorProvider::onSubsetStringChanged );
       }
     }

--- a/src/app/qgslayertreeviewmemoryindicator.cpp
+++ b/src/app/qgslayertreeviewmemoryindicator.cpp
@@ -16,6 +16,7 @@
 #include "qgslayertreeviewmemoryindicator.h"
 #include "qgslayertree.h"
 #include "qgslayertreemodel.h"
+#include "qgslayertreeutils.h"
 #include "qgslayertreeview.h"
 #include "qgsvectorlayer.h"
 #include "qgisapp.h"
@@ -51,7 +52,8 @@ void QgsLayerTreeViewMemoryIndicatorProvider::onAddedChildren( QgsLayerTreeNode 
       {
         if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layerNode->layer() ) )
         {
-          connect( vlayer, &QgsVectorLayer::dataSourceChanged, this, &QgsLayerTreeViewMemoryIndicatorProvider::onDataSourceChanged );
+          if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), vlayer ) == 1 )
+            connect( vlayer, &QgsVectorLayer::dataSourceChanged, this, &QgsLayerTreeViewMemoryIndicatorProvider::onDataSourceChanged );
           addOrRemoveIndicator( childNode, vlayer );
         }
         else if ( !layerNode->layer() )
@@ -82,7 +84,7 @@ void QgsLayerTreeViewMemoryIndicatorProvider::onWillRemoveChildren( QgsLayerTree
       QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
       if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( childLayerNode->layer() ) )
       {
-        if ( vlayer )
+        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), childLayerNode->layer() ) == 1 )
           disconnect( vlayer, &QgsVectorLayer::dataSourceChanged, this, &QgsLayerTreeViewMemoryIndicatorProvider::onDataSourceChanged );
       }
     }

--- a/src/app/qgslayertreeviewnonremovableindicator.cpp
+++ b/src/app/qgslayertreeviewnonremovableindicator.cpp
@@ -17,6 +17,7 @@
 
 #include "qgslayertree.h"
 #include "qgslayertreemodel.h"
+#include "qgslayertreeutils.h"
 #include "qgslayertreeview.h"
 
 
@@ -51,7 +52,8 @@ void QgsLayerTreeViewNonRemovableIndicatorProvider::onAddedChildren( QgsLayerTre
       QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
       if ( QgsMapLayer *layer = childLayerNode->layer() )
       {
-        connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
+        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), layer ) == 1 )
+          connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
         addOrRemoveIndicator( childLayerNode, layer );
       }
       else if ( !childLayerNode->layer() )
@@ -81,7 +83,10 @@ void QgsLayerTreeViewNonRemovableIndicatorProvider::onWillRemoveChildren( QgsLay
     {
       QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
       if ( childLayerNode->layer() )
-        disconnect( childLayerNode->layer(), &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
+      {
+        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), childLayerNode->layer() ) == 1 )
+          disconnect( childLayerNode->layer(), &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
+      }
     }
   }
 }

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -437,3 +437,19 @@ QSet<QgsMapLayer *> QgsLayerTreeUtils::collectMapLayersRecursive( const QList<Qg
   _collectMapLayers( nodes, layersSet );
   return layersSet;
 }
+
+int QgsLayerTreeUtils::countMapLayerInTree( QgsLayerTreeNode *tree, QgsMapLayer *layer )
+{
+  if ( QgsLayerTree::isLayer( tree ) )
+  {
+    if ( QgsLayerTree::toLayer( tree )->layer() == layer )
+      return 1;
+    return 0;
+  }
+
+  int cnt = 0;
+  const QList<QgsLayerTreeNode *> children = tree->children();
+  for ( QgsLayerTreeNode *child : children )
+    cnt += countMapLayerInTree( child, layer );
+  return cnt;
+}

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -96,15 +96,15 @@ class CORE_EXPORT QgsLayerTreeUtils
     static QSet<QgsMapLayer *> collectMapLayersRecursive( const QList<QgsLayerTreeNode *> &nodes );
 
     /**
-     * Returns how many occurences of a map layer are there in a layer tree.
-     * In normal situations there is at most one occurence, but sometimes there
+     * Returns how many occurrences of a map layer are there in a layer tree.
+     * In normal situations there is at most one occurrence, but sometimes there
      * may be temporarily more: for example, during drag&drop, upon drop a new layer
      * node is created while the original dragged node is still in the tree, resulting
-     * in two occurences.
+     * in two occurrences.
      *
      * This is useful when deciding whether to start or stop listening to a signal
      * of a map layer within a layer tree and only connecting/disconnecting when
-     * there is only one occurence of that layer.
+     * there is only one occurrence of that layer.
      * \since QGIS 3.4
      */
     static int countMapLayerInTree( QgsLayerTreeNode *tree, QgsMapLayer *layer );

--- a/src/core/layertree/qgslayertreeutils.h
+++ b/src/core/layertree/qgslayertreeutils.h
@@ -94,6 +94,20 @@ class CORE_EXPORT QgsLayerTreeUtils
      * \since QGIS 3.4
      */
     static QSet<QgsMapLayer *> collectMapLayersRecursive( const QList<QgsLayerTreeNode *> &nodes );
+
+    /**
+     * Returns how many occurences of a map layer are there in a layer tree.
+     * In normal situations there is at most one occurence, but sometimes there
+     * may be temporarily more: for example, during drag&drop, upon drop a new layer
+     * node is created while the original dragged node is still in the tree, resulting
+     * in two occurences.
+     *
+     * This is useful when deciding whether to start or stop listening to a signal
+     * of a map layer within a layer tree and only connecting/disconnecting when
+     * there is only one occurence of that layer.
+     * \since QGIS 3.4
+     */
+    static int countMapLayerInTree( QgsLayerTreeNode *tree, QgsMapLayer *layer );
 };
 
 #endif // QGSLAYERTREEUTILS_H

--- a/tests/src/core/testqgslayertree.cpp
+++ b/tests/src/core/testqgslayertree.cpp
@@ -52,6 +52,7 @@ class TestQgsLayerTree : public QObject
     void testLayerDeleted();
     void testFindGroups();
     void testUtilsCollectMapLayers();
+    void testUtilsCountMapLayers();
 
   private:
 
@@ -685,6 +686,25 @@ void TestQgsLayerTree::testUtilsCollectMapLayers()
   QCOMPARE( set1, QSet<QgsMapLayer *>() << vl1 << vl2 );
   QCOMPARE( set2, QSet<QgsMapLayer *>() << vl1 );
   QCOMPARE( set3, QSet<QgsMapLayer *>() << vl2 );
+}
+
+void TestQgsLayerTree::testUtilsCountMapLayers()
+{
+  QgsVectorLayer *vl = new QgsVectorLayer( QStringLiteral( "Point?field=col1:integer" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) );
+
+  QgsProject project;
+  project.addMapLayer( vl );
+
+  QgsLayerTree root;
+  QgsLayerTreeGroup *nodeGrp = root.addGroup( "grp" );
+
+  QCOMPARE( QgsLayerTreeUtils::countMapLayerInTree( &root, vl ), 0 );
+
+  root.addLayer( vl );
+  QCOMPARE( QgsLayerTreeUtils::countMapLayerInTree( &root, vl ), 1 );
+
+  nodeGrp->addLayer( vl );
+  QCOMPARE( QgsLayerTreeUtils::countMapLayerInTree( &root, vl ), 2 );
 }
 
 


### PR DESCRIPTION
The issue was that during drag&drop, we first connect to layer's signal for the second time, but then the disconnect() call on removal of the original layer node would disconnect all connections (not just one). For that reason now we only connect/disconnect when the layer is in the tree only once.
