### PR TITLE
 Fix save style dialog expansion and UI cleanup

### DIFF
--- a/src/app/qgsvectorlayersavestyledialog.cpp
+++ b/src/app/qgsvectorlayersavestyledialog.cpp
@@ -62,7 +62,7 @@ QgsVectorLayerSaveStyleDialog::QgsVectorLayerSaveStyleDialog( QgsVectorLayer *la
   mDbStyleUIFileWidget->setDefaultRoot( myLastUsedDir );
   mDbStyleUIFileWidget->setFilter( tr( "Qt Designer UI file (*.ui)" ) );
   connect( mDbStyleUIFileWidget, &QgsFileWidget::fileChanged, this, &QgsVectorLayerSaveStyleDialog::readUiFileContent );
-  connect( mHelpButton, &QPushButton::clicked, this, &QgsVectorLayerSaveStyleDialog::showDbHelp );
+  connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsVectorLayerSaveStyleDialog::showHelp );
 
   // save to file setup
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, &QgsVectorLayerSaveStyleDialog::updateSaveButtonState );
@@ -154,7 +154,7 @@ void QgsVectorLayerSaveStyleDialog::readUiFileContent( const QString &filePath )
   }
 }
 
-void QgsVectorLayerSaveStyleDialog::showDbHelp()
+void QgsVectorLayerSaveStyleDialog::showHelp()
 {
   QgsHelp::openHelp( QStringLiteral( "introduction/general_tools.html#save-and-share-layer-properties" ) );
 }

--- a/src/app/qgsvectorlayersavestyledialog.h
+++ b/src/app/qgsvectorlayersavestyledialog.h
@@ -53,7 +53,7 @@ class QgsVectorLayerSaveStyleDialog : public QDialog, private Ui::QgsVectorLayer
 
   private slots:
     void updateSaveButtonState();
-    void showDbHelp();
+    void showHelp();
     void readUiFileContent( const QString &filePath );
 
   private:

--- a/src/ui/qgsvectorlayersavestyledialog.ui
+++ b/src/ui/qgsvectorlayersavestyledialog.ui
@@ -14,88 +14,31 @@
    <string>Save layer style</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0" colspan="2">
-    <widget class="QWidget" name="mSaveToDbWidget" native="true">
-     <layout class="QGridLayout" name="gridLayout_3">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="nameLabel">
-        <property name="text">
-         <string>Style name</string>
-        </property>
-        <property name="buddy">
-         <cstring>mDbStyleNameEdit</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="mDbStyleNameEdit"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="descriptionLabel">
-        <property name="text">
-         <string>Description</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPlainTextEdit" name="mDbStyleDescriptionEdit"/>
-      </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Optionally pick an input form for attribute editing (QT Designer UI format), it will be stored in the database</string>
-        </property>
-        <property name="textFormat">
-         <enum>Qt::PlainText</enum>
-        </property>
-        <property name="scaledContents">
-         <bool>false</bool>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="mUILabel">
-        <property name="text">
-         <string>UI</string>
-        </property>
-        <property name="buddy">
-         <cstring>mDbStyleNameEdit</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget" native="true"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QPushButton" name="mHelpButton">
-        <property name="text">
-         <string>Help</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QCheckBox" name="mDbStyleUseAsDefault">
-        <property name="text">
-         <string>Use as default style for this layer</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="mStyleTypeComboBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mModeLabel">
+     <property name="text">
+      <string>Save style</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
@@ -139,7 +82,7 @@
       <item row="1" column="1">
        <widget class="QListView" name="mStyleCategoriesListView">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -149,45 +92,70 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="mStyleTypeComboBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+   <item row="2" column="0" colspan="2">
+    <widget class="QWidget" name="mSaveToDbWidget" native="true">
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="nameLabel">
+        <property name="text">
+         <string>Style name</string>
+        </property>
+        <property name="buddy">
+         <cstring>mDbStyleNameEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="mDbStyleNameEdit"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="descriptionLabel">
+        <property name="text">
+         <string>Description</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPlainTextEdit" name="mDbStyleDescriptionEdit"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="mUILabel">
+        <property name="text">
+         <string>UI</string>
+        </property>
+        <property name="buddy">
+         <cstring>mDbStyleNameEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QCheckBox" name="mDbStyleUseAsDefault">
+        <property name="text">
+         <string>Use as default style for this layer</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsFileWidget" name="mDbStyleUIFileWidget" native="true">
+        <property name="toolTip">
+         <string>Optionally pick an input form for attribute editing (QT Designer UI format), it will be stored in the database</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mModeLabel">
-     <property name="text">
-      <string>Save style</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
@@ -199,6 +167,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>mStyleTypeComboBox</tabstop>
+  <tabstop>mStyleCategoriesListView</tabstop>
+  <tabstop>mDbStyleNameEdit</tabstop>
+  <tabstop>mDbStyleDescriptionEdit</tabstop>
+  <tabstop>mDbStyleUseAsDefault</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Currently, save as style dialog shows either
* this (note the help button placement) ![dbsavestyle](https://user-images.githubusercontent.com/7983394/46069997-1019d000-c17d-11e8-9f4e-42855586cd7a.png)
* or this (see all the lost spacing)
![qmlsavestyle](https://user-images.githubusercontent.com/7983394/46070045-2cb60800-c17d-11e8-9ad9-1084e04fd2bf.png)

The PR proposes this (sorry- no way to build) 

* removes the vertical spacer
* uses a help buttonBox
* moves the UI descriptive text as tooltip for the UI file selector widget
![image](https://user-images.githubusercontent.com/7983394/46070161-6424b480-c17d-11e8-8da0-1e8afef3eacb.png)

I also wonder if  `UI` label should not instead read `UI (optional)` to make it more obvious now the text is in tooltip