### PR TITLE
Fixes #19911 - Updating the vertexEditor after moving vertices or edges

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1579,6 +1579,9 @@ void QgsVertexTool::moveVertex( const QgsPointXY &mapPoint, const QgsPointLocato
     }
   }
 
+  if ( mVertexEditor )
+    mVertexEditor->updateEditor( dragLayer, mSelectedFeature.get() );
+
   setHighlightedVertices( mSelectedVertices );  // update positions of existing highlighted vertices
   setHighlightedVerticesVisible( true );  // time to show highlighted vertices again
 }
@@ -1631,9 +1634,22 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
     layer->beginEditCommand( tr( "Moved vertex" ) );
     QHash<QgsFeatureId, QgsGeometry>::iterator it2 = layerEdits.begin();
     for ( ; it2 != layerEdits.end(); ++it2 )
+    {
       layer->changeGeometry( it2.key(), it2.value() );
+      for ( int i = 0; i < mSelectedVertices.length(); ++i )
+      {
+        if ( mSelectedVertices.at( i ).layer == layer && mSelectedVertices.at( i ).fid == it2.value() )
+        {
+          mSelectedFeature->selectVertex( mSelectedVertices.at( i ).vertexId );
+        }
+      }
+    }
     layer->endEditCommand();
     layer->triggerRepaint();
+
+
+    if ( mVertexEditor )
+      mVertexEditor->updateEditor( layer, mSelectedFeature.get() );
   }
 }
 


### PR DESCRIPTION
## Description
(Should) Fixes #19911

![output](https://user-images.githubusercontent.com/7521540/46072920-e1ebbe80-c183-11e8-9d18-7a1ae047e1e5.gif)

@wonder-sk Do you think this is the right approach?
@haubourg can you try it?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
