### PR TITLE
Add QgsVectorLayer::allowCommit property

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2354,6 +2354,16 @@ Is emitted, when editing on this layer has started
 Is emitted, when edited changes successfully have been written to the data provider
 %End
 
+    void canCommitChanges( bool &canCommit );
+%Docstring
+Emitted when a layer wants to commit changes to the data provider.
+Can be used to prevent the layer from being saved by setting ``canCommit`` to false.
+
+It is the developers responsibility to inform the user about this in a suitable manner.
+
+.. versionadded:: 3.4
+%End
+
     void beforeCommitChanges();
 %Docstring
 Is emitted, before changes are committed to the data provider

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2399,16 +2399,6 @@ Is emitted, when editing on this layer has started
 Is emitted, when edited changes successfully have been written to the data provider
 %End
 
-    void canCommitChanges( bool *canCommit );
-%Docstring
-Emitted when a layer wants to commit changes to the data provider.
-Can be used to prevent the layer from being saved by setting ``canCommit`` to false.
-
-It is the developers responsibility to inform the user about this in a suitable manner.
-
-.. versionadded:: 3.4
-%End
-
     void beforeCommitChanges();
 %Docstring
 Is emitted, before changes are committed to the data provider

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2239,7 +2239,7 @@ Configuration and logic to apply automatically on any edit happening on this lay
 .. versionadded:: 3.4
 %End
 
-    bool allowCommit()() const;
+    bool allowCommit() const;
 %Docstring
 Controls, if the layer is allowed to commit changes. If this is set to false
 it will not be possible to commit changes on this layer. This can be used to
@@ -2258,7 +2258,7 @@ When calling :py:func:`commitChanges`, this flag is checked just after the
 .. versionadded:: 3.4
 %End
 
-    void setAllowCommit()( bool allowCommit() );
+    void setAllowCommit( bool allowCommit );
 %Docstring
 Controls, if the layer is allowed to commit changes. If this is set to false
 it will not be possible to commit changes on this layer. This can be used to

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2239,43 +2239,7 @@ Configuration and logic to apply automatically on any edit happening on this lay
 .. versionadded:: 3.4
 %End
 
-    bool allowCommit() const;
-%Docstring
-Controls, if the layer is allowed to commit changes. If this is set to false
-it will not be possible to commit changes on this layer. This can be used to
-define checks on a layer that need to be pass before the layer can be saved.
-If you use this API, make sure that:
 
-- the user is visibly informed that his changes were not saved and what he needs
-to do in order to be able to save the changes.
-
-- to set the property back to true, once the user has fixed his data.
-
-When calling :py:func:`commitChanges`, this flag is checked just after the
-
-.. seealso:: :py:func:`beforeCommitChanges`
-
-.. versionadded:: 3.4
-%End
-
-    void setAllowCommit( bool allowCommit );
-%Docstring
-Controls, if the layer is allowed to commit changes. If this is set to false
-it will not be possible to commit changes on this layer. This can be used to
-define checks on a layer that need to be pass before the layer can be saved.
-If you use this API, make sure that:
-
-- the user is visibly informed that his changes were not saved and what he needs
-to do in order to be able to save the changes.
-
-- to set the property back to true, once the user has fixed his data.
-
-When calling :py:func:`commitChanges`, this flag is checked just after the
-
-.. seealso:: :py:func:`beforeCommitChanges`
-
-.. versionadded:: 3.4
-%End
 
   public slots:
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2354,7 +2354,7 @@ Is emitted, when editing on this layer has started
 Is emitted, when edited changes successfully have been written to the data provider
 %End
 
-    void canCommitChanges( bool &canCommit );
+    void canCommitChanges( bool *canCommit );
 %Docstring
 Emitted when a layer wants to commit changes to the data provider.
 Can be used to prevent the layer from being saved by setting ``canCommit`` to false.

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2239,6 +2239,44 @@ Configuration and logic to apply automatically on any edit happening on this lay
 .. versionadded:: 3.4
 %End
 
+    bool allowCommit()() const;
+%Docstring
+Controls, if the layer is allowed to commit changes. If this is set to false
+it will not be possible to commit changes on this layer. This can be used to
+define checks on a layer that need to be pass before the layer can be saved.
+If you use this API, make sure that:
+
+- the user is visibly informed that his changes were not saved and what he needs
+to do in order to be able to save the changes.
+
+- to set the property back to true, once the user has fixed his data.
+
+When calling :py:func:`commitChanges`, this flag is checked just after the
+
+.. seealso:: :py:func:`beforeCommitChanges`
+
+.. versionadded:: 3.4
+%End
+
+    void setAllowCommit()( bool allowCommit() );
+%Docstring
+Controls, if the layer is allowed to commit changes. If this is set to false
+it will not be possible to commit changes on this layer. This can be used to
+define checks on a layer that need to be pass before the layer can be saved.
+If you use this API, make sure that:
+
+- the user is visibly informed that his changes were not saved and what he needs
+to do in order to be able to save the changes.
+
+- to set the property back to true, once the user has fixed his data.
+
+When calling :py:func:`commitChanges`, this flag is checked just after the
+
+.. seealso:: :py:func:`beforeCommitChanges`
+
+.. versionadded:: 3.4
+%End
+
   public slots:
 
     void select( QgsFeatureId featureId );
@@ -2332,6 +2370,13 @@ This signal is emitted when selection was changed
     void layerModified();
 %Docstring
 This signal is emitted when modifications has been done on layer
+%End
+
+    void allowCommitChanged();
+%Docstring
+Emitted whenever the allowCommitChanged() property of this layer changes.
+
+.. versionadded:: 3.4
 %End
 
     void beforeModifiedCheck() const;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2926,7 +2926,7 @@ bool QgsVectorLayer::commitChanges()
 
   bool canCommit = true;
 
-  emit canCommitChanges( canCommit );
+  emit canCommitChanges( &canCommit );
 
   if ( !canCommit )
     return false;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2924,6 +2924,13 @@ bool QgsVectorLayer::commitChanges()
     return false;
   }
 
+  bool canCommit = true;
+
+  emit canCommitChanges( canCommit );
+
+  if ( !canCommit )
+    return false;
+
   emit beforeCommitChanges();
 
   bool success = mEditBuffer->commitChanges( mCommitErrors );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2924,14 +2924,10 @@ bool QgsVectorLayer::commitChanges()
     return false;
   }
 
-  bool canCommit = true;
-
-  emit canCommitChanges( &canCommit );
-
-  if ( !canCommit )
-    return false;
-
   emit beforeCommitChanges();
+
+  if ( !mAllowCommit )
+    return false;
 
   bool success = mEditBuffer->commitChanges( mCommitErrors );
 
@@ -4851,6 +4847,20 @@ QgsAbstractVectorLayerLabeling *QgsVectorLayer::readLabelingFromCustomProperties
   }
 
   return labeling;
+}
+
+bool QgsVectorLayer::allowCommit() const
+{
+  return mAllowCommit;
+}
+
+void QgsVectorLayer::setAllowCommit( bool allowCommit )
+{
+  if ( mAllowCommit == allowCommit )
+    return;
+
+  mAllowCommit = allowCommit;
+  emit allowCommitChanged();
 }
 
 QgsGeometryOptions *QgsVectorLayer::geometryOptions() const

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2010,6 +2010,42 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     QgsGeometryOptions *geometryOptions() const;
 
+    /**
+     * Controls, if the layer is allowed to commit changes. If this is set to false
+     * it will not be possible to commit changes on this layer. This can be used to
+     * define checks on a layer that need to be pass before the layer can be saved.
+     * If you use this API, make sure that:
+     *
+     *  - the user is visibly informed that his changes were not saved and what he needs
+     *    to do in order to be able to save the changes.
+     *
+     *  - to set the property back to true, once the user has fixed his data.
+     *
+     * When calling \see commitChanges(), this flag is checked just after the
+     * \see beforeCommitChanges() signal is emitted, so it's possible to adjust it from there.
+     *
+     * \since QGIS 3.4
+     */
+    bool allowCommit()() const;
+
+    /**
+     * Controls, if the layer is allowed to commit changes. If this is set to false
+     * it will not be possible to commit changes on this layer. This can be used to
+     * define checks on a layer that need to be pass before the layer can be saved.
+     * If you use this API, make sure that:
+     *
+     *  - the user is visibly informed that his changes were not saved and what he needs
+     *    to do in order to be able to save the changes.
+     *
+     *  - to set the property back to true, once the user has fixed his data.
+     *
+     * When calling \see commitChanges(), this flag is checked just after the
+     * \see beforeCommitChanges() signal is emitted, so it's possible to adjust it from there.
+     *
+     * \since QGIS 3.4
+     */
+    void setAllowCommit()( bool allowCommit() );
+
   public slots:
 
     /**
@@ -2101,6 +2137,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
 
     //! This signal is emitted when modifications has been done on layer
     void layerModified();
+
+    /**
+     * Emitted whenever the allowCommitChanged() property of this layer changes.
+     *
+     * \since QGIS 3.4
+     */
+    void allowCommitChanged();
 
     //! Is emitted, when layer is checked for modifications. Use for last-minute additions
     void beforeModifiedCheck() const;
@@ -2511,6 +2554,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     QgsVectorLayerFeatureCounter *mFeatureCounter = nullptr;
 
     std::unique_ptr<QgsGeometryOptions> mGeometryOptions;
+
+    bool mAllowCommit = true;
 
     friend class QgsVectorLayerFeatureSource;
 };

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2122,7 +2122,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \since QGIS 3.4
      */
-    void canCommitChanges( bool &canCommit );
+    void canCommitChanges( bool *canCommit );
 
     //! Is emitted, before changes are committed to the data provider
     void beforeCommitChanges();

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2026,7 +2026,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \since QGIS 3.4
      */
-    bool allowCommit()() const;
+    bool allowCommit() const;
 
     /**
      * Controls, if the layer is allowed to commit changes. If this is set to false
@@ -2044,7 +2044,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      *
      * \since QGIS 3.4
      */
-    void setAllowCommit()( bool allowCommit() );
+    void setAllowCommit( bool allowCommit );
 
   public slots:
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2114,6 +2114,16 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Is emitted, when edited changes successfully have been written to the data provider
     void editingStopped();
 
+    /**
+     * Emitted when a layer wants to commit changes to the data provider.
+     * Can be used to prevent the layer from being saved by setting \a canCommit to false.
+     *
+     * It is the developers responsibility to inform the user about this in a suitable manner.
+     *
+     * \since QGIS 3.4
+     */
+    void canCommitChanges( bool &canCommit );
+
     //! Is emitted, before changes are committed to the data provider
     void beforeCommitChanges();
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2157,16 +2157,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     //! Is emitted, when edited changes successfully have been written to the data provider
     void editingStopped();
 
-    /**
-     * Emitted when a layer wants to commit changes to the data provider.
-     * Can be used to prevent the layer from being saved by setting \a canCommit to false.
-     *
-     * It is the developers responsibility to inform the user about this in a suitable manner.
-     *
-     * \since QGIS 3.4
-     */
-    void canCommitChanges( bool *canCommit );
-
     //! Is emitted, before changes are committed to the data provider
     void beforeCommitChanges();
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2024,9 +2024,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * When calling \see commitChanges(), this flag is checked just after the
      * \see beforeCommitChanges() signal is emitted, so it's possible to adjust it from there.
      *
+     * \note Not available in Python bindings
+     *
      * \since QGIS 3.4
      */
-    bool allowCommit() const;
+    bool allowCommit() const SIP_SKIP;
 
     /**
      * Controls, if the layer is allowed to commit changes. If this is set to false
@@ -2042,9 +2044,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      * When calling \see commitChanges(), this flag is checked just after the
      * \see beforeCommitChanges() signal is emitted, so it's possible to adjust it from there.
      *
+     * \note Not available in Python bindings
+     *
      * \since QGIS 3.4
      */
-    void setAllowCommit( bool allowCommit );
+    void setAllowCommit( bool allowCommit ) SIP_SKIP;
 
   public slots:
 


### PR DESCRIPTION
to control if changes can be saved or not. ~]This signal is emitted before a layer is being saved and if a connected slot marks the canCommit variable as False, the layer will not be saved~~

Usecase: when a user tries to save, check if the layer is "good to save", if yes continue, if not stop and leave in edit mode.
The requirement is to have the prevent a user from saving an edit session until he cleaned up his current edit buffer.

Another approach would be to have a `bool savable` property on the layer and trigger the re-check from the `beforeCommitChanges()` signal.

**Update** this other approach is the status quo, because python bindings are possible and first feedback from @elpaso is he prefers it.

Opinions?