### PR TITLE
[BUG FIX][Split Tool] Bug fix for split features tool

### DIFF
--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -380,11 +380,12 @@ QgsFeature QgsVectorLayerUtils::createFeature( const QgsVectorLayer *layer, cons
     bool checkUnique = true;
 
     // in order of priority:
-    // 1. passed attribute value
+    // 1. passed attribute value and if field does not have a unique constraint like primary key
     if ( attributes.contains( idx )
          && !( fields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique ) )
     {
       v = attributes.value( idx );
+      checkUnique = false;
     }
 
     // 2. client side default expression

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -418,7 +418,7 @@ QgsFeature QgsVectorLayerUtils::createFeature( const QgsVectorLayer *layer, cons
 
     // 4. passed attribute value
     // note - deliberately not using else if!
-    if ( !v.isValid() && attributes.contains( idx ) )
+    if ( v.isValid() && attributes.contains( idx ) && !layer->primaryKeyAttributes().contains(idx) )
     {
       v = attributes.value( idx );
     }

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -382,7 +382,6 @@ QgsFeature QgsVectorLayerUtils::createFeature( const QgsVectorLayer *layer, cons
     // in order of priority:
     // 1. passed attribute value
     if ( attributes.contains( idx )
-         && !layer->primaryKeyAttributes().contains( idx )
          && !( fields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique ) )
     {
       v = attributes.value( idx );
@@ -390,7 +389,7 @@ QgsFeature QgsVectorLayerUtils::createFeature( const QgsVectorLayer *layer, cons
 
     // 2. client side default expression
     // note - deliberately not using else if!
-    if ( layer->defaultValueDefinition( idx ).isValid() )
+    if ( !v.isValid() && layer->defaultValueDefinition( idx ).isValid() )
     {
       // client side default expression set - takes precedence over all. Why? Well, this is the only default
       // which QGIS users have control over, so we assume that they're deliberately overriding any

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -381,10 +381,17 @@ QgsFeature QgsVectorLayerUtils::createFeature( const QgsVectorLayer *layer, cons
 
     // in order of priority:
     // 1. passed attribute value and if field does not have a unique constraint like primary key
-    if ( attributes.contains( idx )
-         && !( fields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique ) )
+    if ( attributes.contains( idx ) )
     {
       v = attributes.value( idx );
+      if ( fields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique
+           && QgsVectorLayerUtils::valueExists( layer, idx, v ) )
+      {
+        // unique constraint violated
+        QVariant uniqueValue = QgsVectorLayerUtils::createUniqueValue( layer, idx, v );
+        if ( uniqueValue.isValid() )
+          v = uniqueValue;
+      }
       checkUnique = false;
     }
 

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -418,7 +418,7 @@ QgsFeature QgsVectorLayerUtils::createFeature( const QgsVectorLayer *layer, cons
 
     // 4. passed attribute value
     // note - deliberately not using else if!
-    if ( attributes.contains( idx ) && !layer->primaryKeyAttributes().contains(idx) )
+    if ( attributes.contains( idx ) && !layer->primaryKeyAttributes().contains( idx ) )
     {
       v = attributes.value( idx );
     }

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -418,7 +418,7 @@ QgsFeature QgsVectorLayerUtils::createFeature( const QgsVectorLayer *layer, cons
 
     // 4. passed attribute value
     // note - deliberately not using else if!
-    if ( v.isValid() && attributes.contains( idx ) && !layer->primaryKeyAttributes().contains(idx) )
+    if ( attributes.contains( idx ) && !layer->primaryKeyAttributes().contains(idx) )
     {
       v = attributes.value( idx );
     }

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -808,12 +808,15 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         default_clause = 'nextval(\'qgis_test."someData_pk_seq"\'::regclass)'
         self.assertEqual(vl.dataProvider().defaultValueClause(0), default_clause)
 
-        # !!!this check was originally designed to change input attributes with the provider's default
+        # !!!this check was originally designed to change input attributes 
+        # with the provider's default
         # original comment:
         # check that provider default clause takes precedence over passed attribute values
-        # this also checks that the inbuilt unique constraint handling is bypassed in the case of a provider default clause
+        # this also checks that the inbuilt unique constraint handling is
+        #  bypassed in the case of a provider default clause
         #
-        # the new behaviour that was implemented is to respect the user's choice. See https://issues.qgis.org/issues/19936
+        # the new behaviour that was implemented is to respect the user's choice. 
+        # See https://issues.qgis.org/issues/19936
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 5, 3: 'map'})
         #changed so that createFeature respects user choice
         self.assertEqual(f.attributes(), [default_clause, 5, "'qgis'::text", 'map', None, None])

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -813,12 +813,16 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # User's choice will not be respected if the value violates unique constraints.
         # See https://issues.qgis.org/issues/19936
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 5, 3: 'map'})
-        #changed so that createFeature respects user choice
+        # changed so that createFeature respects user choice
         self.assertEqual(f.attributes(), [default_clause, 5, "'qgis'::text", 'map', None, None])
 
-        # test take vector layer default value expression overrides postgres provider default clause
         vl.setDefaultValueDefinition(3, QgsDefaultValue("'mappy'"))
+        # test ignore vector layer default value expression overrides postgres provider default clause,
+        # due to user's choice
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 5, 3: 'map'})
+        self.assertEqual(f.attributes(), [default_clause, 5, "'qgis'::text", 'map', None, None])
+        # Since user did not enter a default for field 3, test must return the default value chosen
+        f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 5})
         self.assertEqual(f.attributes(), [default_clause, 5, "'qgis'::text", 'mappy', None, None])
 
     # See https://issues.qgis.org/issues/15188

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -808,10 +808,15 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         default_clause = 'nextval(\'qgis_test."someData_pk_seq"\'::regclass)'
         self.assertEqual(vl.dataProvider().defaultValueClause(0), default_clause)
 
+        # !!!this check was originally designed to change input attributes with the provider's default
+        # original comment:
         # check that provider default clause takes precedence over passed attribute values
         # this also checks that the inbuilt unique constraint handling is bypassed in the case of a provider default clause
+        #
+        # the new behaviour that was implemented is to respect the user's choice. See https://issues.qgis.org/issues/19936
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 5, 3: 'map'})
-        self.assertEqual(f.attributes(), [default_clause, 5, "'qgis'::text", "'qgis'::text", None, None])
+        #changed so that createFeature respects user choice
+        self.assertEqual(f.attributes(), [default_clause, 5, "'qgis'::text", 'map', None, None])
 
         # test take vector layer default value expression overrides postgres provider default clause
         vl.setDefaultValueDefinition(3, QgsDefaultValue("'mappy'"))

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -808,14 +808,9 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         default_clause = 'nextval(\'qgis_test."someData_pk_seq"\'::regclass)'
         self.assertEqual(vl.dataProvider().defaultValueClause(0), default_clause)
 
-        # !!!this check was originally designed to change input attributes 
-        # with the provider's default
-        # original comment:
-        # check that provider default clause takes precedence over passed attribute values
-        # this also checks that the inbuilt unique constraint handling is
-        #  bypassed in the case of a provider default clause
-        #
-        # the new behaviour that was implemented is to respect the user's choice. 
+        # If an attribute map is provided, QgsVectorLayerUtils.createFeature must
+        # respect it, otherwise default values from provider are checked.
+        # User's choice will not be respected if the value violates unique constraints.
         # See https://issues.qgis.org/issues/19936
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 5, 3: 'map'})
         #changed so that createFeature respects user choice

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -190,7 +190,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         btn.click()
         # magically the above code selects the feature here...
 
-        link_feature = list(next(self.vl_link.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0])))))
+        link_feature = list(next(self.vl_link.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0])))))[0]
         self.assertIsNotNone(link_feature[0])
 
         self.assertEqual(self.table_view.model().rowCount(), 1)

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -190,7 +190,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         btn.click()
         # magically the above code selects the feature here...
 
-        link_feature = list(next(self.vl_link.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0])))))[0]
+        link_feature = next(self.vl_link.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0])))))
         self.assertIsNotNone(link_feature[0])
 
         self.assertEqual(self.table_view.model().rowCount(), 1)
@@ -199,19 +199,19 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         """
         Check if a linked feature can be unlinked
         """
-        wrapper = self.createWrapper(self.vl_b)   # NOQA
+        wrapper=self.createWrapper(self.vl_b)   # NOQA
 
         # All authors are listed
         self.assertEqual(self.table_view.model().rowCount(), 4)
 
-        it = self.vl_a.getFeatures(
+        it=self.vl_a.getFeatures(
             QgsFeatureRequest().setFilterExpression('"name" IN (\'Richard Helm\', \'Ralph Johnson\')'))
 
         self.widget.featureSelectionManager().select([f.id() for f in it])
 
         self.assertEqual(2, self.widget.featureSelectionManager().selectedFeatureCount())
 
-        btn = self.widget.findChild(QToolButton, 'mUnlinkFeatureButton')
+        btn=self.widget.findChild(QToolButton, 'mUnlinkFeatureButton')
         btn.click()
 
         # This is actually more checking that the database on delete action is properly set on the relation
@@ -223,18 +223,18 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         """
         Test the automatic discovery of relations
         """
-        relations = self.relMgr.discoverRelations([], [self.vl_a, self.vl_b, self.vl_link])
-        relations = {r.name(): r for r in relations}
+        relations=self.relMgr.discoverRelations([], [self.vl_a, self.vl_b, self.vl_link])
+        relations={r.name(): r for r in relations}
         self.assertEqual({'books_authors_fk_book_fkey', 'books_authors_fk_author_fkey'}, set(relations.keys()))
 
-        ba2b = relations['books_authors_fk_book_fkey']
+        ba2b=relations['books_authors_fk_book_fkey']
         self.assertTrue(ba2b.isValid())
         self.assertEqual('books_authors', ba2b.referencingLayer().name())
         self.assertEqual('books', ba2b.referencedLayer().name())
         self.assertEqual([0], ba2b.referencingFields())
         self.assertEqual([0], ba2b.referencedFields())
 
-        ba2a = relations['books_authors_fk_author_fkey']
+        ba2a=relations['books_authors_fk_author_fkey']
         self.assertTrue(ba2a.isValid())
         self.assertEqual('books_authors', ba2a.referencingLayer().name())
         self.assertEqual('authors', ba2a.referencedLayer().name())
@@ -250,9 +250,9 @@ class TestQgsRelationEditWidget(unittest.TestCase):
 
         :return: None
         """
-        lyrs = [self.vl_a, self.vl_b, self.vl_link]
+        lyrs=[self.vl_a, self.vl_b, self.vl_link]
 
-        self.transaction = QgsTransaction.create(lyrs)
+        self.transaction=QgsTransaction.create(lyrs)
         self.transaction.begin()
         for l in lyrs:
             l.startEditing()
@@ -265,12 +265,12 @@ class TestQgsRelationEditWidget(unittest.TestCase):
 
         :return: None
         """
-        lyrs = [self.vl_a, self.vl_b, self.vl_link]
+        lyrs=[self.vl_a, self.vl_b, self.vl_link]
         for l in lyrs:
             l.commitChanges()
         self.transaction.rollback()
 
-    def createWrapper(self, layer, filter=None):
+    def createWrapper(self, layer, filter = None):
         """
         Basic setup of a relation widget wrapper.
         Will create a new wrapper and set its feature to the one and only book
@@ -283,28 +283,28 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         :return: The created wrapper
         """
         if layer == self.vl_b:
-            relation = self.rel_b
-            nmrel = self.rel_a
+            relation=self.rel_b
+            nmrel=self.rel_a
         else:
-            relation = self.rel_a
-            nmrel = self.rel_b
+            relation=self.rel_a
+            nmrel=self.rel_b
 
-        self.wrapper = QgsRelationWidgetWrapper(layer, relation)
+        self.wrapper=QgsRelationWidgetWrapper(layer, relation)
         self.wrapper.setConfig({'nm-rel': nmrel.id()})
-        context = QgsAttributeEditorContext()
+        context=QgsAttributeEditorContext()
         context.setVectorLayerTools(self.vltools)
         self.wrapper.setContext(context)
 
-        self.widget = self.wrapper.widget()
+        self.widget=self.wrapper.widget()
         self.widget.show()
 
-        request = QgsFeatureRequest()
+        request=QgsFeatureRequest()
         if filter:
             request.setFilterExpression(filter)
-        book = next(layer.getFeatures(request))
+        book=next(layer.getFeatures(request))
         self.wrapper.setFeature(book)
 
-        self.table_view = self.widget.findChild(QTableView)
+        self.table_view=self.widget.findChild(QTableView)
         return self.wrapper
 
 
@@ -321,7 +321,7 @@ class VlTools(QgsVectorLayerTools):
         :param values: An array of values that shall be used for the next inserted record
         :return: None
         """
-        self.values = values
+        self.values=values
 
     def addFeature(self, layer, defaultValues, defaultGeometry):
         """
@@ -331,16 +331,16 @@ class VlTools(QgsVectorLayerTools):
         :param defaultGeometry: a default geometry that may be provided by QGIS
         :return: tuple(ok, f) where ok is if the layer added the feature and f is the added feature
         """
-        values = list()
+        values=list()
         for i, v in enumerate(self.values):
             if v:
                 values.append(v)
             else:
                 values.append(layer.dataProvider().defaultValueClause(i))
-        f = QgsFeature(layer.fields())
+        f=QgsFeature(layer.fields())
         f.setAttributes(self.values)
         f.setGeometry(defaultGeometry)
-        ok = layer.addFeature(f)
+        ok=layer.addFeature(f)
 
         return ok, f
 

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -190,7 +190,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         btn.click()
         # magically the above code selects the feature here...
 
-        link_feature = next(self.vl_link.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0]))))
+        link_feature = list(next(self.vl_link.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0])))))
         self.assertIsNotNone(link_feature[0])
 
         self.assertEqual(self.table_view.model().rowCount(), 1)

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -190,7 +190,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         btn.click()
         # magically the above code selects the feature here...
 
-        link_feature = next(self.vl_link.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0])))))
+        link_feature = next(self.vl_link.getFeatures(QgsFeatureRequest().setFilterExpression('"fk_book"={}'.format(f[0]))))
         self.assertIsNotNone(link_feature[0])
 
         self.assertEqual(self.table_view.model().rowCount(), 1)
@@ -199,19 +199,19 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         """
         Check if a linked feature can be unlinked
         """
-        wrapper=self.createWrapper(self.vl_b)   # NOQA
+        wrapper = self.createWrapper(self.vl_b)   # NOQA
 
         # All authors are listed
         self.assertEqual(self.table_view.model().rowCount(), 4)
 
-        it=self.vl_a.getFeatures(
+        it = self.vl_a.getFeatures(
             QgsFeatureRequest().setFilterExpression('"name" IN (\'Richard Helm\', \'Ralph Johnson\')'))
 
         self.widget.featureSelectionManager().select([f.id() for f in it])
 
         self.assertEqual(2, self.widget.featureSelectionManager().selectedFeatureCount())
 
-        btn=self.widget.findChild(QToolButton, 'mUnlinkFeatureButton')
+        btn = self.widget.findChild(QToolButton, 'mUnlinkFeatureButton')
         btn.click()
 
         # This is actually more checking that the database on delete action is properly set on the relation
@@ -223,18 +223,18 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         """
         Test the automatic discovery of relations
         """
-        relations=self.relMgr.discoverRelations([], [self.vl_a, self.vl_b, self.vl_link])
-        relations={r.name(): r for r in relations}
+        relations = self.relMgr.discoverRelations([], [self.vl_a, self.vl_b, self.vl_link])
+        relations = {r.name(): r for r in relations}
         self.assertEqual({'books_authors_fk_book_fkey', 'books_authors_fk_author_fkey'}, set(relations.keys()))
 
-        ba2b=relations['books_authors_fk_book_fkey']
+        ba2b = relations['books_authors_fk_book_fkey']
         self.assertTrue(ba2b.isValid())
         self.assertEqual('books_authors', ba2b.referencingLayer().name())
         self.assertEqual('books', ba2b.referencedLayer().name())
         self.assertEqual([0], ba2b.referencingFields())
         self.assertEqual([0], ba2b.referencedFields())
 
-        ba2a=relations['books_authors_fk_author_fkey']
+        ba2a = relations['books_authors_fk_author_fkey']
         self.assertTrue(ba2a.isValid())
         self.assertEqual('books_authors', ba2a.referencingLayer().name())
         self.assertEqual('authors', ba2a.referencedLayer().name())
@@ -250,9 +250,9 @@ class TestQgsRelationEditWidget(unittest.TestCase):
 
         :return: None
         """
-        lyrs=[self.vl_a, self.vl_b, self.vl_link]
+        lyrs = [self.vl_a, self.vl_b, self.vl_link]
 
-        self.transaction=QgsTransaction.create(lyrs)
+        self.transaction = QgsTransaction.create(lyrs)
         self.transaction.begin()
         for l in lyrs:
             l.startEditing()
@@ -265,12 +265,12 @@ class TestQgsRelationEditWidget(unittest.TestCase):
 
         :return: None
         """
-        lyrs=[self.vl_a, self.vl_b, self.vl_link]
+        lyrs = [self.vl_a, self.vl_b, self.vl_link]
         for l in lyrs:
             l.commitChanges()
         self.transaction.rollback()
 
-    def createWrapper(self, layer, filter = None):
+    def createWrapper(self, layer, filter=None):
         """
         Basic setup of a relation widget wrapper.
         Will create a new wrapper and set its feature to the one and only book
@@ -283,28 +283,28 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         :return: The created wrapper
         """
         if layer == self.vl_b:
-            relation=self.rel_b
-            nmrel=self.rel_a
+            relation = self.rel_b
+            nmrel = self.rel_a
         else:
-            relation=self.rel_a
-            nmrel=self.rel_b
+            relation = self.rel_a
+            nmrel = self.rel_b
 
-        self.wrapper=QgsRelationWidgetWrapper(layer, relation)
+        self.wrapper = QgsRelationWidgetWrapper(layer, relation)
         self.wrapper.setConfig({'nm-rel': nmrel.id()})
-        context=QgsAttributeEditorContext()
+        context = QgsAttributeEditorContext()
         context.setVectorLayerTools(self.vltools)
         self.wrapper.setContext(context)
 
-        self.widget=self.wrapper.widget()
+        self.widget = self.wrapper.widget()
         self.widget.show()
 
-        request=QgsFeatureRequest()
+        request = QgsFeatureRequest()
         if filter:
             request.setFilterExpression(filter)
-        book=next(layer.getFeatures(request))
+        book = next(layer.getFeatures(request))
         self.wrapper.setFeature(book)
 
-        self.table_view=self.widget.findChild(QTableView)
+        self.table_view = self.widget.findChild(QTableView)
         return self.wrapper
 
 
@@ -321,7 +321,7 @@ class VlTools(QgsVectorLayerTools):
         :param values: An array of values that shall be used for the next inserted record
         :return: None
         """
-        self.values=values
+        self.values = values
 
     def addFeature(self, layer, defaultValues, defaultGeometry):
         """
@@ -331,16 +331,16 @@ class VlTools(QgsVectorLayerTools):
         :param defaultGeometry: a default geometry that may be provided by QGIS
         :return: tuple(ok, f) where ok is if the layer added the feature and f is the added feature
         """
-        values=list()
+        values = list()
         for i, v in enumerate(self.values):
             if v:
                 values.append(v)
             else:
                 values.append(layer.dataProvider().defaultValueClause(i))
-        f=QgsFeature(layer.fields())
+        f = QgsFeature(layer.fields())
         f.setAttributes(self.values)
         f.setGeometry(defaultGeometry)
-        ok=layer.addFeature(f)
+        ok = layer.addFeature(f)
 
         return ok, f
 

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -265,7 +265,8 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         # layer with default value expression based on geometry
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*$x'))
         f = QgsVectorLayerUtils.createFeature(layer, g)
-        self.assertEqual(f.attributes(), ['a', NULL, 12.0]) #adjusted so that input value and output feature are the same
+        #adjusted so that input value and output feature are the same
+        self.assertEqual(f.attributes(), ['a', NULL, 6.0])
         layer.setDefaultValueDefinition(2, QgsDefaultValue(None))
 
         # test with violated unique constraints

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -259,7 +259,8 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*4'))
         f = QgsVectorLayerUtils.createFeature(layer)
         self.assertEqual(f.attributes(), ['a', NULL, 6.0])
-        # we do not expect the default value expression to take precedence over the attribute map
+        # we do not expect the default value expression to 
+        # take precedence over the attribute map
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'a', 2: 6.0})
         self.assertEqual(f.attributes(), ['a', NULL, 6.0])
         # layer with default value expression based on geometry

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -258,10 +258,10 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         # layer with default value expression
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*4'))
         f = QgsVectorLayerUtils.createFeature(layer)
-        self.assertEqual(f.attributes(), [NULL, NULL, 12.0])
+        self.assertEqual(f.attributes(), ['a', NULL, 6.0])
         # we do not expect the default value expression to take precedence over the attribute map
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'a', 2: 6.0})
-        self.assertEqual(f.attributes(), ['a', NULL, 12.0])
+        self.assertEqual(f.attributes(), ['a', NULL, 6.0])
         # layer with default value expression based on geometry
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*$x'))
         f = QgsVectorLayerUtils.createFeature(layer, g)

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -272,12 +272,12 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         # test with violated unique constraints
         layer.setFieldConstraint(1, QgsFieldConstraints.ConstraintUnique)
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'test_1', 1: 123})
-        # since field 1 has Unique Constraint, it ignores value 123 that already has been set
-        self.assertEqual(f.attributes(), ['test_1', NULL, NULL])
+        # since field 1 has Unique Constraint, it ignores value 123 that already has been set and sets to 128
+        self.assertEqual(f.attributes(), ['test_1', 128, NULL])
         layer.setFieldConstraint(0, QgsFieldConstraints.ConstraintUnique)
-        # since field 0 and 1 already have values test_1 and 123, the output must be NULL
+        # since field 0 and 1 already have values test_1 and 123, the output must be a new unique value
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'test_1', 1: 123})
-        self.assertEqual(f.attributes(), [NULL, NULL, NULL])
+        self.assertEqual(f.attributes(), ['test_4', 128, NULL])
 
     def testDuplicateFeature(self):
         """ test duplicating a feature """

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -259,13 +259,13 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*4'))
         f = QgsVectorLayerUtils.createFeature(layer)
         self.assertEqual(f.attributes(), [NULL, NULL, 12.0])
-        # we expect the default value expression to take precedence over the attribute map
+        # we do not expect the default value expression to take precedence over the attribute map
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'a', 2: 6.0})
         self.assertEqual(f.attributes(), ['a', NULL, 12.0])
         # layer with default value expression based on geometry
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*$x'))
         f = QgsVectorLayerUtils.createFeature(layer, g)
-        self.assertEqual(f.attributes(), [NULL, NULL, 300.0])
+        self.assertEqual(f.attributes(), ['a', NULL, 12.0]) #adjusted so that input value and output feature are the same
         layer.setDefaultValueDefinition(2, QgsDefaultValue(None))
 
         # test with violated unique constraints

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -258,25 +258,26 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         # layer with default value expression
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*4'))
         f = QgsVectorLayerUtils.createFeature(layer)
-        self.assertEqual(f.attributes(), ['a', NULL, 6.0])
-        # we do not expect the default value expression to 
-        # take precedence over the attribute map
+        self.assertEqual(f.attributes(), [NULL, NULL, 12])
+        # we do not expect the default value expression to take precedence over the attribute map
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'a', 2: 6.0})
         self.assertEqual(f.attributes(), ['a', NULL, 6.0])
         # layer with default value expression based on geometry
         layer.setDefaultValueDefinition(2, QgsDefaultValue('3*$x'))
         f = QgsVectorLayerUtils.createFeature(layer, g)
         #adjusted so that input value and output feature are the same
-        self.assertEqual(f.attributes(), ['a', NULL, 6.0])
+        self.assertEqual(f.attributes(), [NULL, NULL, 300.0])
         layer.setDefaultValueDefinition(2, QgsDefaultValue(None))
 
         # test with violated unique constraints
         layer.setFieldConstraint(1, QgsFieldConstraints.ConstraintUnique)
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'test_1', 1: 123})
-        self.assertEqual(f.attributes(), ['test_1', 128, NULL])
+        # since field 1 has Unique Constraint, it ignores value 123 that already has been set
+        self.assertEqual(f.attributes(), ['test_1', NULL, NULL])
         layer.setFieldConstraint(0, QgsFieldConstraints.ConstraintUnique)
+        # since field 0 and 1 already have values test_1 and 123, the output must be NULL
         f = QgsVectorLayerUtils.createFeature(layer, attributes={0: 'test_1', 1: 123})
-        self.assertEqual(f.attributes(), ['test_4', 128, NULL])
+        self.assertEqual(f.attributes(), [NULL, NULL, NULL])
 
     def testDuplicateFeature(self):
         """ test duplicating a feature """


### PR DESCRIPTION
## Description
Split feature was resetting attributes of new features with PostGIS providers that have default values. 

For example, if a layer has a field called field1 and it has a default value of 1, if a user used the split tool in a feature that has field1=2, the new part instead of getting the old value of 2 gets the provider value of 1.

A small change on createFeature from QgsVectorLayerUtils was made.

This bugfix is a suggestion for Bug report #19936 from redmine.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
