### PR TITLE
Remove background from scalable icon

### DIFF
--- a/editors/QtCreator/templates/wizards/qgis/qgis_icon.svg
+++ b/editors/QtCreator/templates/wizards/qgis/qgis_icon.svg
@@ -1,25 +1,113 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="256" height="256" viewBox="0, 0, 256, 256">
-  <g id="Background">
-    <rect x="0" y="0" width="256" height="256" fill="#FFFFFF"/>
-  </g>
-  <defs>
-    <linearGradient id="Gradient_1" gradientUnits="userSpaceOnUse" x1="200.788" y1="249.007" x2="197.17" y2="11.232">
-      <stop offset="0" stop-color="#589632"/>
-      <stop offset="1" stop-color="#93B023"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0"
+   y="0"
+   width="256"
+   height="256"
+   viewBox="0, 0, 256, 256"
+   id="svg25"
+   sodipodi:docname="qgis_icon.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1332"
+     inkscape:window-height="785"
+     id="namedview27"
+     showgrid="false"
+     inkscape:zoom="0.921875"
+     inkscape:cx="128"
+     inkscape:cy="128"
+     inkscape:window-x="64"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Background" />
+  <g
+     id="Background" />
+  <defs
+     id="defs15">
+    <linearGradient
+       id="Gradient_1"
+       gradientUnits="userSpaceOnUse"
+       x1="200.788"
+       y1="249.007"
+       x2="197.17"
+       y2="11.232">
+      <stop
+         offset="0"
+         stop-color="#589632"
+         id="stop5" />
+      <stop
+         offset="1"
+         stop-color="#93B023"
+         id="stop7" />
     </linearGradient>
-    <linearGradient id="Gradient_2" gradientUnits="userSpaceOnUse" x1="129.939" y1="252.718" x2="126.351" y2="16.928">
-      <stop offset="0" stop-color="#589632"/>
-      <stop offset="1" stop-color="#93B023"/>
+    <linearGradient
+       id="Gradient_2"
+       gradientUnits="userSpaceOnUse"
+       x1="129.939"
+       y1="252.718"
+       x2="126.351"
+       y2="16.928">
+      <stop
+         offset="0"
+         stop-color="#589632"
+         id="stop10" />
+      <stop
+         offset="1"
+         stop-color="#93B023"
+         id="stop12" />
     </linearGradient>
   </defs>
-  <g id="Background"/>
-  <g id="Layer_1">
-    <path d="M137.607,136.899 L172.044,136.899 L142.898,108.083 L107.19,108.083 L107.19,142.392 L137.607,172.708 z" fill="#EE7913" id="polygon3"/>
-    <path d="M248.061,212.048 L186.618,151.306 L152.01,151.306 L152.01,187.067 L210.891,245.749 L248.061,245.749 z" fill="url(#Gradient_1)" id="polygon10"/>
-    <path d="M152.01,151.306 L186.618,151.306 L172.044,136.899 L137.607,136.899 L137.607,172.708 L152.01,187.067 z" fill="#F0E64A" id="polygon12"/>
-    <path d="M144.826,199.3 C139.606,200.502 134.183,201.154 128.588,201.154 C88.561,201.154 54.516,168.24 54.516,125.564 C54.516,82.887 88.182,50.695 128.588,50.695 C168.989,50.695 201.158,82.882 201.158,125.564 C201.158,132.501 200.295,139.183 198.697,145.509 L235.744,182.551 C245.296,165.815 250.64,146.354 250.64,125.277 C250.64,59.499 198.147,10.251 127.839,10.251 C57.849,10.251 5.36,59.178 5.36,125.277 C5.36,191.698 57.849,241.598 127.839,241.598 C145.905,241.598 162.791,238.275 177.916,232.227 L144.826,199.3 z" fill="url(#Gradient_2)" id="path19"/>
-    <path d="M107.19,108.083 L248.061,245.749 L248.061,212.048 L186.618,151.306 L172.044,136.898 L142.898,108.083 z" fill="#FFFFFF" fill-opacity="0.172" id="polygon4153"/>
+  <g
+     id="g17" />
+  <g
+     id="Layer_1">
+    <path
+       d="M137.607,136.899 L172.044,136.899 L142.898,108.083 L107.19,108.083 L107.19,142.392 L137.607,172.708 z"
+       fill="#EE7913"
+       id="polygon3" />
+    <path
+       d="M248.061,212.048 L186.618,151.306 L152.01,151.306 L152.01,187.067 L210.891,245.749 L248.061,245.749 z"
+       fill="url(#Gradient_1)"
+       id="polygon10" />
+    <path
+       d="M152.01,151.306 L186.618,151.306 L172.044,136.899 L137.607,136.899 L137.607,172.708 L152.01,187.067 z"
+       fill="#F0E64A"
+       id="polygon12" />
+    <path
+       d="M144.826,199.3 C139.606,200.502 134.183,201.154 128.588,201.154 C88.561,201.154 54.516,168.24 54.516,125.564 C54.516,82.887 88.182,50.695 128.588,50.695 C168.989,50.695 201.158,82.882 201.158,125.564 C201.158,132.501 200.295,139.183 198.697,145.509 L235.744,182.551 C245.296,165.815 250.64,146.354 250.64,125.277 C250.64,59.499 198.147,10.251 127.839,10.251 C57.849,10.251 5.36,59.178 5.36,125.277 C5.36,191.698 57.849,241.598 127.839,241.598 C145.905,241.598 162.791,238.275 177.916,232.227 L144.826,199.3 z"
+       fill="url(#Gradient_2)"
+       id="path19" />
+    <path
+       d="M107.19,108.083 L248.061,245.749 L248.061,212.048 L186.618,151.306 L172.044,136.898 L142.898,108.083 z"
+       fill="#FFFFFF"
+       fill-opacity="0.172"
+       id="polygon4153" />
   </g>
 </svg>

--- a/images/icons/qgis_icon.svg
+++ b/images/icons/qgis_icon.svg
@@ -1,25 +1,111 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="256" height="256" viewBox="0, 0, 256, 256">
-  <g id="Background">
-    <rect x="0" y="0" width="256" height="256" fill="#FFFFFF"/>
-  </g>
-  <defs>
-    <linearGradient id="Gradient_1" gradientUnits="userSpaceOnUse" x1="200.788" y1="249.007" x2="197.17" y2="11.232">
-      <stop offset="0" stop-color="#589632"/>
-      <stop offset="1" stop-color="#93B023"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0"
+   y="0"
+   width="256"
+   height="256"
+   viewBox="0, 0, 256, 256"
+   id="svg25"
+   sodipodi:docname="qgis_icon.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata29">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1856"
+     inkscape:window-height="1051"
+     id="namedview27"
+     showgrid="false"
+     inkscape:zoom="0.921875"
+     inkscape:cx="128"
+     inkscape:cy="128"
+     inkscape:window-x="64"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg25" />
+  <defs
+     id="defs15">
+    <linearGradient
+       id="Gradient_1"
+       gradientUnits="userSpaceOnUse"
+       x1="200.788"
+       y1="249.007"
+       x2="197.17"
+       y2="11.232">
+      <stop
+         offset="0"
+         stop-color="#589632"
+         id="stop5" />
+      <stop
+         offset="1"
+         stop-color="#93B023"
+         id="stop7" />
     </linearGradient>
-    <linearGradient id="Gradient_2" gradientUnits="userSpaceOnUse" x1="129.939" y1="252.718" x2="126.351" y2="16.928">
-      <stop offset="0" stop-color="#589632"/>
-      <stop offset="1" stop-color="#93B023"/>
+    <linearGradient
+       id="Gradient_2"
+       gradientUnits="userSpaceOnUse"
+       x1="129.939"
+       y1="252.718"
+       x2="126.351"
+       y2="16.928">
+      <stop
+         offset="0"
+         stop-color="#589632"
+         id="stop10" />
+      <stop
+         offset="1"
+         stop-color="#93B023"
+         id="stop12" />
     </linearGradient>
   </defs>
-  <g id="Background"/>
-  <g id="Layer_1">
-    <path d="M137.607,136.899 L172.044,136.899 L142.898,108.083 L107.19,108.083 L107.19,142.392 L137.607,172.708 z" fill="#EE7913" id="polygon3"/>
-    <path d="M248.061,212.048 L186.618,151.306 L152.01,151.306 L152.01,187.067 L210.891,245.749 L248.061,245.749 z" fill="url(#Gradient_1)" id="polygon10"/>
-    <path d="M152.01,151.306 L186.618,151.306 L172.044,136.899 L137.607,136.899 L137.607,172.708 L152.01,187.067 z" fill="#F0E64A" id="polygon12"/>
-    <path d="M144.826,199.3 C139.606,200.502 134.183,201.154 128.588,201.154 C88.561,201.154 54.516,168.24 54.516,125.564 C54.516,82.887 88.182,50.695 128.588,50.695 C168.989,50.695 201.158,82.882 201.158,125.564 C201.158,132.501 200.295,139.183 198.697,145.509 L235.744,182.551 C245.296,165.815 250.64,146.354 250.64,125.277 C250.64,59.499 198.147,10.251 127.839,10.251 C57.849,10.251 5.36,59.178 5.36,125.277 C5.36,191.698 57.849,241.598 127.839,241.598 C145.905,241.598 162.791,238.275 177.916,232.227 L144.826,199.3 z" fill="url(#Gradient_2)" id="path19"/>
-    <path d="M107.19,108.083 L248.061,245.749 L248.061,212.048 L186.618,151.306 L172.044,136.898 L142.898,108.083 z" fill="#FFFFFF" fill-opacity="0.172" id="polygon4153"/>
+  <g
+     id="g17" />
+  <g
+     id="Layer_1">
+    <path
+       d="M137.607,136.899 L172.044,136.899 L142.898,108.083 L107.19,108.083 L107.19,142.392 L137.607,172.708 z"
+       fill="#EE7913"
+       id="polygon3" />
+    <path
+       d="M248.061,212.048 L186.618,151.306 L152.01,151.306 L152.01,187.067 L210.891,245.749 L248.061,245.749 z"
+       fill="url(#Gradient_1)"
+       id="polygon10" />
+    <path
+       d="M152.01,151.306 L186.618,151.306 L172.044,136.899 L137.607,136.899 L137.607,172.708 L152.01,187.067 z"
+       fill="#F0E64A"
+       id="polygon12" />
+    <path
+       d="M144.826,199.3 C139.606,200.502 134.183,201.154 128.588,201.154 C88.561,201.154 54.516,168.24 54.516,125.564 C54.516,82.887 88.182,50.695 128.588,50.695 C168.989,50.695 201.158,82.882 201.158,125.564 C201.158,132.501 200.295,139.183 198.697,145.509 L235.744,182.551 C245.296,165.815 250.64,146.354 250.64,125.277 C250.64,59.499 198.147,10.251 127.839,10.251 C57.849,10.251 5.36,59.178 5.36,125.277 C5.36,191.698 57.849,241.598 127.839,241.598 C145.905,241.598 162.791,238.275 177.916,232.227 L144.826,199.3 z"
+       fill="url(#Gradient_2)"
+       id="path19" />
+    <path
+       d="M107.19,108.083 L248.061,245.749 L248.061,212.048 L186.618,151.306 L172.044,136.898 L142.898,108.083 z"
+       fill="#FFFFFF"
+       fill-opacity="0.172"
+       id="polygon4153" />
   </g>
 </svg>


### PR DESCRIPTION
Remove the white background the svg file has.

Fixes flathub/org.qgis.qgis#9

## Description
Some Desktop Environments will prefer the svg icon. It will look odd, as seen as in the bug report.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
