### PR TITLE
[3D] Allow usual camera controls while the identify tool is active

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -188,7 +188,7 @@ void Qgs3DMapScene::registerPickHandler( Qgs3DMapScenePickHandler *pickHandler )
     {
       Qt3DRender::QObjectPicker *picker = new Qt3DRender::QObjectPicker( entity );
       entity->addComponent( picker );
-      connect( picker, &Qt3DRender::QObjectPicker::pressed, this, &Qgs3DMapScene::onLayerEntityPickEvent );
+      connect( picker, &Qt3DRender::QObjectPicker::clicked, this, &Qgs3DMapScene::onLayerEntityPickEvent );
     }
   }
 

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -124,7 +124,7 @@ void Qgs3DMapCanvas::setMapTool( Qgs3DMapTool *tool )
   else if ( !mMapTool && tool )
   {
     mEngine->window()->installEventFilter( this );
-    mScene->cameraController()->setEnabled( false );
+    mScene->cameraController()->setEnabled( tool->allowsCameraControls() );
     mEngine->window()->setCursor( tool->cursor() );
   }
 

--- a/src/app/3d/qgs3dmaptool.h
+++ b/src/app/3d/qgs3dmaptool.h
@@ -44,6 +44,14 @@ class Qgs3DMapTool : public QObject
     //! Mouse cursor to be used when the tool is active
     virtual QCursor cursor() const;
 
+    /**
+     * Whether the default mouse controls to zoom/pan/rotate camera can stay enabled
+     * while the tool is active. This may be useful for some basic tools using just
+     * mouse clicks (e.g. identify, measure), but it could be creating conflicts when used
+     * with more advanced tools. Default implementation returns true.
+     */
+    virtual bool allowsCameraControls() const { return true; }
+
   protected:
     Qgs3DMapCanvas *mCanvas = nullptr;
 };

--- a/src/app/3d/qgs3dmaptoolidentify.cpp
+++ b/src/app/3d/qgs3dmaptoolidentify.cpp
@@ -75,7 +75,7 @@ void Qgs3DMapToolIdentify::mousePressEvent( QMouseEvent *event )
 void Qgs3DMapToolIdentify::activate()
 {
   Qt3DRender::QObjectPicker *picker = mCanvas->scene()->terrainEntity()->terrainPicker();
-  connect( picker, &Qt3DRender::QObjectPicker::pressed, this, &Qgs3DMapToolIdentify::onTerrainPicked );
+  connect( picker, &Qt3DRender::QObjectPicker::clicked, this, &Qgs3DMapToolIdentify::onTerrainPicked );
 
   mCanvas->scene()->registerPickHandler( mPickHandler.get() );
 }
@@ -83,7 +83,7 @@ void Qgs3DMapToolIdentify::activate()
 void Qgs3DMapToolIdentify::deactivate()
 {
   Qt3DRender::QObjectPicker *picker = mCanvas->scene()->terrainEntity()->terrainPicker();
-  disconnect( picker, &Qt3DRender::QObjectPicker::pressed, this, &Qgs3DMapToolIdentify::onTerrainPicked );
+  disconnect( picker, &Qt3DRender::QObjectPicker::clicked, this, &Qgs3DMapToolIdentify::onTerrainPicked );
 
   mCanvas->scene()->unregisterPickHandler( mPickHandler.get() );
 }
@@ -132,5 +132,5 @@ void Qgs3DMapToolIdentify::onTerrainEntityChanged()
   // no need to disconnect from the previous entity: it has been destroyed
   // start listening to the new terrain entity
   Qt3DRender::QObjectPicker *picker = mCanvas->scene()->terrainEntity()->terrainPicker();
-  connect( picker, &Qt3DRender::QObjectPicker::pressed, this, &Qgs3DMapToolIdentify::onTerrainPicked );
+  connect( picker, &Qt3DRender::QObjectPicker::clicked, this, &Qgs3DMapToolIdentify::onTerrainPicked );
 }


### PR DESCRIPTION
A small usability improvement... until now one would need to disable identify tool before being able to move/zoom/rotate the camera in 3D view and then enable identify tool again. Now camera can be controlled while the tool is active and the tool is easier to use.
