### PR TITLE
Respect selection sort order and fields in attribute table copy

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 typedef QVector< QgsPoint > QgsPointSequence;
 typedef QVector< QVector< QgsPoint > > QgsRingSequence;
 typedef QVector< QVector< QVector< QgsPoint > > > QgsCoordinateSequence;

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -13,6 +13,7 @@
 
 
 
+
 typedef QVector<QgsPointXY> QgsPolylineXY;
 
 typedef QVector<QgsPoint> QgsPolyline;

--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -60,6 +60,15 @@ the appearance of the attribute table.
 .. versionadded:: 2.16
 %End
 
+    QList<QgsFeatureId> selectedFeaturesIds() const;
+%Docstring
+Returns the selected features in the attribute table in table sorted order.
+
+:return: The selected features in the attribute table in the order sorted by the table.
+
+.. versionadded:: 3.4
+%End
+
   protected:
 
     virtual void mousePressEvent( QMouseEvent *event );

--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -167,6 +167,13 @@ Set the expression used for sorting the table and feature list.
 Gets the expression used for sorting the table and feature list.
 %End
 
+    QgsAttributeTableConfig attributeTableConfig() const;
+%Docstring
+The config used for the attribute table.
+
+:return: The config used for the attribute table.
+%End
+
   public slots:
 
     void setCurrentEditSelection( const QgsFeatureIds &fids );

--- a/python/gui/auto_generated/attributetable/qgsorganizetablecolumnsdialog.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsorganizetablecolumnsdialog.sip.in
@@ -24,6 +24,16 @@ Dialog for organising (hiding and reordering) columns in the attributes table.
 %End
   public:
 
+    QgsOrganizeTableColumnsDialog( const QgsVectorLayer *vl, QgsAttributeTableConfig config, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = Qt::Window );
+%Docstring
+Constructor
+
+:param vl: The concerned vector layer
+:param parent: parent object
+:param config: attribute table config to use.
+:param flags: window flags
+%End
+
     QgsOrganizeTableColumnsDialog( const QgsVectorLayer *vl, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = Qt::Window );
 %Docstring
 Constructor
@@ -32,8 +42,6 @@ Constructor
 :param parent: parent object
 :param flags: window flags
 %End
-
-    ~QgsOrganizeTableColumnsDialog();
 
     QgsAttributeTableConfig config() const;
 %Docstring

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -115,7 +115,6 @@ QString QgsClipboard::generateClipboardText() const
           }
         }
 
-        // QgsDebugMsg("about to traverse fields.");
         for ( int idx = 0; idx < attributes.count(); ++idx )
         {
           // QgsDebugMsg(QString("inspecting field '%1'.").arg(it2->toString()));

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -104,6 +104,30 @@ void QgsAttributeTableView::setAttributeTableConfig( const QgsAttributeTableConf
     }
     i++;
   }
+  mConfig = config;
+}
+
+QList<QgsFeatureId> QgsAttributeTableView::selectedFeaturesIds() const
+{
+  // In order to get the ids in the right sorted order based on the view we have to get the feature ids first
+  // from the selection manager which is in the order the user selected them when clicking
+  // then get the model index, sort that, and finally return the new sorted features ids.
+  const QgsFeatureIds featureIds = mFeatureSelectionManager->selectedFeatureIds();
+  QModelIndexList indexList;
+  for ( const QgsFeatureId &id : featureIds )
+  {
+    QModelIndex index = mFilterModel->fidToIndex( id );
+    indexList << index;
+  }
+
+  std::sort( indexList.begin(), indexList.end() );
+  QList<QgsFeatureId> ids;
+  for ( const QModelIndex &index : indexList )
+  {
+    QgsFeatureId id = mFilterModel->data( index, QgsAttributeTableModel::FeatureIdRole ).toLongLong();
+    ids.append( id );
+  }
+  return ids;
 }
 
 void QgsAttributeTableView::setModel( QgsAttributeTableFilterModel *filterModel )
@@ -153,7 +177,7 @@ void QgsAttributeTableView::setFeatureSelectionManager( QgsIFeatureSelectionMana
 
 QWidget *QgsAttributeTableView::createActionWidget( QgsFeatureId fid )
 {
-  QgsAttributeTableConfig attributeTableConfig = mFilterModel->layer()->attributeTableConfig();
+  QgsAttributeTableConfig attributeTableConfig = mConfig;
 
   QToolButton *toolButton = nullptr;
   QWidget *container = nullptr;

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -22,6 +22,7 @@
 #include "qgsfeatureid.h"
 
 #include "qgis_gui.h"
+#include "qgsattributetableconfig.h"
 
 class QgsAttributeTableDelegate;
 class QgsAttributeTableFilterModel;
@@ -34,6 +35,7 @@ class QgsVectorLayerCache;
 class QMenu;
 class QProgressDialog;
 class QgsAttributeTableConfig;
+class QgsFeature;
 
 /**
  * \ingroup gui
@@ -79,6 +81,13 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
      * \since QGIS 2.16
      */
     void setAttributeTableConfig( const QgsAttributeTableConfig &config );
+
+    /**
+     * Returns the selected features in the attribute table in table sorted order.
+     * \returns The selected features in the attribute table in the order sorted by the table.
+     * \since QGIS 3.4
+     */
+    QList<QgsFeatureId> selectedFeaturesIds() const;
 
   protected:
 
@@ -179,6 +188,7 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
     int mRowSectionAnchor = 0;
     QItemSelectionModel::SelectionFlag mCtrlDragSelectionFlag = QItemSelectionModel::Select;
     QMap< QModelIndex, QWidget * > mActionWidgets;
+    QgsAttributeTableConfig mConfig;
 };
 
 #endif

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -654,7 +654,7 @@ void QgsDualView::organizeColumns()
     return;
   }
 
-  QgsOrganizeTableColumnsDialog dialog( mLayer, this );
+  QgsOrganizeTableColumnsDialog dialog( mLayer, attributeTableConfig(), this );
   if ( dialog.exec() == QDialog::Accepted )
   {
     QgsAttributeTableConfig config = dialog.config();
@@ -838,7 +838,7 @@ void QgsDualView::previewExpressionChanged( const QString &expression )
 
 void QgsDualView::onSortColumnChanged()
 {
-  QgsAttributeTableConfig cfg = mLayer->attributeTableConfig();
+  QgsAttributeTableConfig cfg = attributeTableConfig();
   if ( cfg.sortExpression() != mFilterModel->sortExpression() ||
        cfg.sortOrder() != mFilterModel->sortOrder() )
   {
@@ -916,7 +916,6 @@ void QgsDualView::setAttributeTableConfig( const QgsAttributeTableConfig &config
 {
   mConfig = config;
   mConfig.update( mLayer->fields() );
-  mLayer->setAttributeTableConfig( mConfig );
   mFilterModel->setAttributeTableConfig( mConfig );
   mTableView->setAttributeTableConfig( mConfig );
 }
@@ -936,6 +935,11 @@ void QgsDualView::setSortExpression( const QString &sortExpression, Qt::SortOrde
 QString QgsDualView::sortExpression() const
 {
   return mFilterModel->sortExpression();
+}
+
+QgsAttributeTableConfig QgsDualView::attributeTableConfig() const
+{
+  return mConfig;
 }
 
 void QgsDualView::progress( int i, bool &cancel )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -198,6 +198,12 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      */
     QString sortExpression() const;
 
+    /**
+     * The config used for the attribute table.
+     * \returns The config used for the attribute table.
+     */
+    QgsAttributeTableConfig attributeTableConfig() const;
+
   public slots:
 
     /**

--- a/src/gui/attributetable/qgsorganizetablecolumnsdialog.cpp
+++ b/src/gui/attributetable/qgsorganizetablecolumnsdialog.cpp
@@ -39,18 +39,21 @@
 #include "qgsfields.h"
 #include "qgseditorwidgetregistry.h"
 
+#include "qgsgui.h"
 
-QgsOrganizeTableColumnsDialog::QgsOrganizeTableColumnsDialog( const QgsVectorLayer *vl, QWidget *parent, Qt::WindowFlags flags )
+
+QgsOrganizeTableColumnsDialog::QgsOrganizeTableColumnsDialog( const QgsVectorLayer *vl, QgsAttributeTableConfig config, QWidget *parent, Qt::WindowFlags flags )
   : QDialog( parent, flags )
 {
   setupUi( this );
+  QgsGui::instance()->enableAutoGeometryRestore( this );
 
   connect( mShowAllButton, &QAbstractButton::clicked, this, &QgsOrganizeTableColumnsDialog::showAll );
   connect( mHideAllButton, &QAbstractButton::clicked, this, &QgsOrganizeTableColumnsDialog::hideAll );
 
   if ( vl )
   {
-    mConfig = vl->attributeTableConfig();
+    mConfig = config;
     mConfig.update( vl->fields() );
 
     mFieldsList->clear();
@@ -94,15 +97,11 @@ QgsOrganizeTableColumnsDialog::QgsOrganizeTableColumnsDialog( const QgsVectorLay
     mShowAllButton->hide();
     mHideAllButton->hide();
   }
-
-  QgsSettings settings;
-  restoreGeometry( settings.value( QStringLiteral( "Windows/QgsOrganizeTableColumnsDialog/geometry" ) ).toByteArray() );
 }
 
-QgsOrganizeTableColumnsDialog::~QgsOrganizeTableColumnsDialog()
+QgsOrganizeTableColumnsDialog::QgsOrganizeTableColumnsDialog( const QgsVectorLayer *vl, QWidget *parent, Qt::WindowFlags flags )
+  : QgsOrganizeTableColumnsDialog( vl, vl->attributeTableConfig(), parent, flags )
 {
-  QgsSettings settings;
-  settings.setValue( QStringLiteral( "Windows/QgsOrganizeTableColumnsDialog/geometry" ), saveGeometry() );
 }
 
 QgsAttributeTableConfig QgsOrganizeTableColumnsDialog::config() const

--- a/src/gui/attributetable/qgsorganizetablecolumnsdialog.h
+++ b/src/gui/attributetable/qgsorganizetablecolumnsdialog.h
@@ -42,11 +42,18 @@ class GUI_EXPORT QgsOrganizeTableColumnsDialog : public QDialog, private Ui::Qgs
      * Constructor
      * \param vl The concerned vector layer
      * \param parent parent object
+     * \param config attribute table config to use.
+     * \param flags window flags
+     */
+    QgsOrganizeTableColumnsDialog( const QgsVectorLayer *vl, QgsAttributeTableConfig config, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = Qt::Window );
+
+    /**
+     * Constructor
+     * \param vl The concerned vector layer
+     * \param parent parent object
      * \param flags window flags
      */
     QgsOrganizeTableColumnsDialog( const QgsVectorLayer *vl, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = Qt::Window );
-
-    ~QgsOrganizeTableColumnsDialog() override;
 
     /**
      * Gets the updated configuration


### PR DESCRIPTION
PR to allow maintaining the order of the selection as well as the fields that have been selected for that view.

Before this PR the attribute table would use the selection order that is in the layer selection list, which may or may not follow the order in the table itself.  Best to respect the sort here I think in order to give the user back what they see in the UI.

Limiting the fields also better control over the data that you copy to the clipboard.  

![image](https://user-images.githubusercontent.com/381660/46188628-c5fa3100-c2d9-11e8-8cc6-1518dc9d889a.png)

![image](https://user-images.githubusercontent.com/381660/46188717-56d10c80-c2da-11e8-9599-2cd73df27f48.png)

WIth some more testing I would like to get this into 3.4 as it's improves the UX quite a lot for the attribute table.

