### PR TITLE
[browser] Fix tiny folder icons on hidpi screens

### DIFF
--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -501,6 +501,15 @@ A Collection: logical collection of layers or subcollections, e.g. GRASS locatio
 
     static QIcon iconDir(); // shared icon: open/closed directory
     static QIcon iconDataCollection(); // default icon for data collection
+
+  protected:
+
+    static QIcon openDirIcon();
+%Docstring
+Shared open directory icon.
+
+.. versionadded:: 3.4
+%End
 };
 
 class QgsDirectoryItem : QgsDataCollectionItem

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -89,6 +89,20 @@ QIcon QgsDataCollectionItem::iconDataCollection()
   return QgsApplication::getThemeIcon( QStringLiteral( "/mIconDbSchema.svg" ) );
 }
 
+QIcon QgsDataCollectionItem::openDirIcon()
+{
+  static QIcon sIcon;
+
+  if ( sIcon.isNull() )
+  {
+    // initialize shared icons
+    QStyle *style = QApplication::style();
+    sIcon = QIcon( style->standardIcon( QStyle::SP_DirOpenIcon ) );
+  }
+
+  return sIcon;
+}
+
 QIcon QgsDataCollectionItem::iconDir()
 {
   static QIcon sIcon;
@@ -97,7 +111,7 @@ QIcon QgsDataCollectionItem::iconDir()
   {
     // initialize shared icons
     QStyle *style = QApplication::style();
-    sIcon = QIcon( style->standardPixmap( QStyle::SP_DirClosedIcon ) );
+    sIcon = QIcon( style->standardIcon( QStyle::SP_DirClosedIcon ) );
     sIcon.addPixmap( style->standardPixmap( QStyle::SP_DirOpenIcon ),
                      QIcon::Normal, QIcon::On );
   }
@@ -737,8 +751,15 @@ void QgsDirectoryItem::init()
 
 QIcon QgsDirectoryItem::icon()
 {
+  // still loading? show the spinner
   if ( state() == Populating )
     return QgsDataItem::icon();
+
+  // loaded? show the open dir icon
+  if ( state() == Populated )
+    return openDirIcon();
+
+  // show the closed dir icon
   return iconDir();
 }
 
@@ -1555,6 +1576,8 @@ QgsProjectHomeItem::QgsProjectHomeItem( QgsDataItem *parent, const QString &name
 
 QIcon QgsProjectHomeItem::icon()
 {
+  if ( state() == Populating )
+    return QgsDirectoryItem::icon();
   return QgsApplication::getThemeIcon( QStringLiteral( "mIconQgsProjectFile.svg" ) );
 }
 

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -522,6 +522,14 @@ class CORE_EXPORT QgsDataCollectionItem : public QgsDataItem
 
     static QIcon iconDir(); // shared icon: open/closed directory
     static QIcon iconDataCollection(); // default icon for data collection
+
+  protected:
+
+    /**
+     * Shared open directory icon.
+     * \since QGIS 3.4
+     */
+    static QIcon openDirIcon();
 };
 
 /**


### PR DESCRIPTION
QStyle::standardPixmap is deprecated and not hi-dpi friendly.
Unfortunately, there's no equivalent of QIcon::addPixmap
for QIcons themselves -- so it's **impossible** in current Qt
API to handle the ON/OFF icon states.

Believe me... there's NOOOOOOO way. I've looked. I've tried.
It's not possible.

This means we have to change the logic for showing open/closed
folders in browser. This commit revises the logic to show the
open icon for any *populated* folders, regardless of whether
they are opened or not.
