### PR TITLE
[mesh] add fundamental support for time format

### DIFF
--- a/src/app/mesh/qgsmeshrendereractivedatasetwidget.h
+++ b/src/app/mesh/qgsmeshrendereractivedatasetwidget.h
@@ -82,12 +82,18 @@ class APP_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui
     void onActiveScalarGroupChanged( int groupIndex );
     void onActiveVectorGroupChanged( int groupIndex );
     void onActiveDatasetChanged( int value );
-    void updateMetadata( );
+    void onFirstTimeClicked();
+    void onPreviousTimeClicked();
+    void onNextTimeClicked();
+    void onLastTimeClicked();
+
     QString metadata( QgsMeshDatasetIndex datasetIndex );
 
   private:
     //! Loop through all dataset groups and find the maximum number of datasets
-    void setSliderRange();
+    void setTimeRange();
+    void updateMetadata();
+    QString timeToString( double val );
 
     QgsMeshLayer *mMeshLayer = nullptr; // not owned
     int mActiveScalarDatasetGroup = -1;

--- a/src/ui/mesh/qgsmeshrendereractivedatasetwidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrendereractivedatasetwidgetbase.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>319</width>
-    <height>317</height>
+    <width>286</width>
+    <height>337</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -35,17 +35,71 @@
     </widget>
    </item>
    <item>
-    <widget class="QSlider" name="mDatasetSlider">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="tickPosition">
-      <enum>QSlider::TicksBelow</enum>
-     </property>
-     <property name="tickInterval">
-      <number>1</number>
-     </property>
-    </widget>
+    <layout class="QGridLayout" name="mTimeLayout">
+     <item row="0" column="0" colspan="6">
+      <widget class="QSlider" name="mDatasetSlider">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="tickPosition">
+        <enum>QSlider::TicksBelow</enum>
+       </property>
+       <property name="tickInterval">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="QToolButton" name="mLastDatasetButton">
+       <property name="text">
+        <string>&gt;|</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="QToolButton" name="mNextDatasetButton">
+       <property name="text">
+        <string>&gt;</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QToolButton" name="mPreviousDatasetButton">
+       <property name="text">
+        <string>&lt;</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QToolButton" name="mFirstDatasetButton">
+       <property name="text">
+        <string>|&lt;</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QComboBox" name="mTimeComboBox">
+       <property name="editable">
+        <bool>true</bool>
+       </property>
+       <property name="insertPolicy">
+        <enum>QComboBox::NoInsert</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QgsCollapsibleGroupBox" name="mActiveDatasetMetadataGroup">
@@ -70,15 +124,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsMeshDatasetGroupTreeView</class>
-   <extends>QTreeView</extends>
-   <header>mesh/qgsmeshdatasetgrouptreeview.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMeshDatasetGroupTreeView</class>
+   <extends>QTreeView</extends>
+   <header>mesh/qgsmeshdatasetgrouptreeview.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
Time that comes from MDAL is in (double) hours. Added simple combobox (similar to Crayfish 2.x) to show the current (rendered) time. 

Time formatting with reference time and all those advanced options present in Crayfish 2.x were not ported and will be added in QGIS 3.6

<img width="908" alt="screen shot 2018-09-28 at 16 20 14" src="https://user-images.githubusercontent.com/804608/46214236-f920dc80-c33a-11e8-939e-b0cc404da168.png">
