### PR TITLE
use float precision for screen coordinates

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -24,7 +24,7 @@ QGIS 3.4        {#qgis_api_break_3_4}
 QgsMapToPixel       {#qgis_api_break_3_4_qgsmaptopixel}
 -------------
 
-- toMapCoordinatesF have been renamed to toMapCoodinates (as a double overload) for C++ only (Python keeps toMapCoordinatesF).
+- toMapCoordinatesF have been renamed to toMapCoordinates (as a double overload) for C++ only (Python keeps toMapCoordinatesF).
 - toMapPoint has been deprecated in favor of toMapCoordinates.
 
 

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -18,6 +18,17 @@ This page tries to maintain a list with incompatible changes that happened in pr
 
 
 
+QGIS 3.4        {#qgis_api_break_3_4}
+========
+
+QgsMapToPixel       {#qgis_api_break_3_4_qgsmaptopixel}
+-------------
+
+- toMapCoordinatesF have been renamed to toMapCoodinates (as a double overload) for C++ only (Python keeps toMapCoordinatesF).
+- toMapPoint has been deprecated in favor of toMapCoordinates.
+
+
+
 QGIS 3.0        {#qgis_api_break_3_0}
 ========
 

--- a/python/core/auto_generated/qgsmaptopixel.sip.in
+++ b/python/core/auto_generated/qgsmaptopixel.sip.in
@@ -95,8 +95,11 @@ transform.
 
 
     QgsPointXY toMapCoordinates( int x, int y ) const;
+%Docstring
+Transform device coordinates to map (world) coordinates
+%End
 
-    QgsPointXY toMapCoordinatesF( double x, double y ) const;
+    QgsPointXY toMapCoordinates( double x, double y ) const /PyName=toMapCoordinatesF/;
 %Docstring
 Transform device coordinates to map (world) coordinates
 %End
@@ -110,7 +113,12 @@ Transform device coordinates to map (world) coordinates
 :return: QgsPointXY in map coorndiates
 %End
 
-    QgsPointXY toMapPoint( double x, double y ) const;
+ QgsPointXY toMapPoint( double x, double y ) const;
+%Docstring
+Transform device coordinates to map (world) coordinates
+
+.. deprecated:: since QGIS 3.4 use toMapCoordinates instead
+%End
 
     void setMapUnitsPerPixel( double mapUnitsPerPixel );
 %Docstring

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -82,8 +82,8 @@ QgsRectangle QgsMapToolSelectUtils::expandSelectRectangle( QgsPointXY mapPoint, 
 
   const QgsMapToPixel *transform = canvas->getCoordinateTransform();
   QgsPointXY point = transform->transform( mapPoint );
-  QgsPointXY ll = transform->toMapCoordinates( point.x() - boxSize, point.y() + boxSize );
-  QgsPointXY ur = transform->toMapCoordinates( point.x() + boxSize, point.y() - boxSize );
+  QgsPointXY ll = transform->toMapCoordinates( static_cast<int>( point.x() - boxSize ), static_cast<int>( point.y() + boxSize ) );
+  QgsPointXY ur = transform->toMapCoordinates( static_cast<int>( point.x() + boxSize ), static_cast<int>( point.y() - boxSize ) );
   return QgsRectangle( ll, ur );
 }
 

--- a/src/app/qgspointmarkeritem.cpp
+++ b/src/app/qgspointmarkeritem.cpp
@@ -108,8 +108,10 @@ void QgsPointMarkerItem::updateSize()
   mMarkerSymbol->startRender( rc, mFeature.fields() );
   QRectF bounds = mMarkerSymbol->bounds( mLocation, rc, mFeature );
   mMarkerSymbol->stopRender( rc );
-  QgsRectangle r( mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( bounds.x(), bounds.y() ),
-                  mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( bounds.x() + bounds.width() * 2, bounds.y() + bounds.height() * 2 ) );
+  QgsRectangle r( mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( static_cast<int>( bounds.x() ),
+                  static_cast<int>( bounds.y() ) ),
+                  mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( static_cast<int>( bounds.x() + bounds.width() * 2 ),
+                      static_cast<int>( bounds.y() + bounds.height() * 2 ) ) );
   setRect( r );
 }
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -350,10 +350,10 @@ QPolygonF QgsMapSettings::visiblePolygon() const
   const QSize &sz = outputSize();
   const QgsMapToPixel &m2p = mapToPixel();
 
-  poly << m2p.toMapCoordinatesF( 0,          0 ).toQPointF();
-  poly << m2p.toMapCoordinatesF( sz.width(), 0 ).toQPointF();
-  poly << m2p.toMapCoordinatesF( sz.width(), sz.height() ).toQPointF();
-  poly << m2p.toMapCoordinatesF( 0,          sz.height() ).toQPointF();
+  poly << m2p.toMapCoordinates( 0.0,                             0.0 ).toQPointF();
+  poly << m2p.toMapCoordinates( static_cast<double>( sz.width() ), 0.0 ).toQPointF();
+  poly << m2p.toMapCoordinates( static_cast<double>( sz.width() ), static_cast<double>( sz.height() ) ).toQPointF();
+  poly << m2p.toMapCoordinates( 0.0,                             static_cast<double>( sz.height() ) ).toQPointF();
 
   return poly;
 }

--- a/src/core/qgsmaptopixel.cpp
+++ b/src/core/qgsmaptopixel.cpp
@@ -88,7 +88,7 @@ bool QgsMapToPixel::updateMatrix()
   return true;
 }
 
-QgsPointXY QgsMapToPixel::toMapPoint( double x, double y ) const
+QgsPointXY QgsMapToPixel::toMapCoordinates( double x, double y ) const
 {
   bool invertible;
   QTransform matrix = mMatrix.inverted( &invertible );
@@ -96,24 +96,23 @@ QgsPointXY QgsMapToPixel::toMapPoint( double x, double y ) const
   qreal mx, my;
   qreal x_qreal = x, y_qreal = y;
   matrix.map( x_qreal, y_qreal, &mx, &my );
-  //QgsDebugMsg(QString("XXX toMapPoint x:%1 y:%2 -> x:%3 y:%4").arg(x).arg(y).arg(mx).arg(my));
   return QgsPointXY( mx, my );
 }
 
 QgsPointXY QgsMapToPixel::toMapCoordinates( QPoint p ) const
 {
-  QgsPointXY mapPt = toMapPoint( p.x(), p.y() );
+  QgsPointXY mapPt = toMapCoordinates( static_cast<double>( p.x() ), static_cast<double>( p.y() ) );
   return QgsPointXY( mapPt );
 }
 
 QgsPointXY QgsMapToPixel::toMapCoordinates( int x, int y ) const
 {
-  return toMapPoint( x, y );
+  return toMapCoordinates( static_cast<double>( x ), static_cast<double>( y ) );
 }
 
-QgsPointXY QgsMapToPixel::toMapCoordinatesF( double x, double y ) const
+QgsPointXY QgsMapToPixel::toMapPoint( double x, double y ) const
 {
-  return toMapPoint( x, y );
+  return toMapCoordinates( x, y );
 }
 
 void QgsMapToPixel::setMapUnitsPerPixel( double mapUnitsPerPixel )

--- a/src/core/qgsmaptopixel.h
+++ b/src/core/qgsmaptopixel.h
@@ -117,10 +117,11 @@ class CORE_EXPORT QgsMapToPixel
     }
 #endif
 
+    //! Transform device coordinates to map (world) coordinates
     QgsPointXY toMapCoordinates( int x, int y ) const;
 
     //! Transform device coordinates to map (world) coordinates
-    QgsPointXY toMapCoordinatesF( double x, double y ) const;
+    QgsPointXY toMapCoordinates( double x, double y ) const SIP_PYNAME( toMapCoordinatesF );
 
     /**
      * Transform device coordinates to map (world) coordinates
@@ -129,7 +130,11 @@ class CORE_EXPORT QgsMapToPixel
      */
     QgsPointXY toMapCoordinates( QPoint p ) const;
 
-    QgsPointXY toMapPoint( double x, double y ) const;
+    /**
+     * Transform device coordinates to map (world) coordinates
+     * \deprecated since QGIS 3.4 use toMapCoordinates instead
+     */
+    Q_DECL_DEPRECATED QgsPointXY toMapPoint( double x, double y ) const;
 
     /**
      * Set map units per pixel

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -319,7 +319,8 @@ QgsGeometry QgsVectorLayerLabelProvider::getPointObstacleGeometry( QgsFeature &f
     //TODO - remove when labeling is refactored to use screen units
     for ( int i = 0; i < boundLineString->numPoints(); ++i )
     {
-      QgsPointXY point = context.mapToPixel().toMapCoordinates( boundLineString->xAt( i ), boundLineString->yAt( i ) );
+      QgsPointXY point = context.mapToPixel().toMapCoordinates( static_cast<int>( boundLineString->xAt( i ) ),
+                         static_cast<int>( boundLineString->yAt( i ) ) );
       boundLineString->setXAt( i, point.x() );
       boundLineString->setYAt( i, point.y() );
     }

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -188,10 +188,10 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   mRasterViewPort->mBottomRightPoint.setY( std::ceil( mRasterViewPort->mBottomRightPoint.y() ) );
   // recalc myRasterExtent to aligned values
   myRasterExtent.set(
-    mapToPixel.toMapCoordinatesF( mRasterViewPort->mTopLeftPoint.x(),
-                                  mRasterViewPort->mBottomRightPoint.y() ),
-    mapToPixel.toMapCoordinatesF( mRasterViewPort->mBottomRightPoint.x(),
-                                  mRasterViewPort->mTopLeftPoint.y() )
+    mapToPixel.toMapCoordinates( mRasterViewPort->mTopLeftPoint.x(),
+                                 mRasterViewPort->mBottomRightPoint.y() ),
+    mapToPixel.toMapCoordinates( mRasterViewPort->mBottomRightPoint.x(),
+                                 mRasterViewPort->mTopLeftPoint.y() )
   );
 
   //raster viewport top left / bottom right are already rounded to int

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -79,8 +79,8 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
     // TODO: provide a method of QgsMapToPixel to fetch map center
     //       in geographical units
     QgsPointXY center = mapToPixel.toMapCoordinates(
-                          mapToPixel.mapWidth() / 2.0,
-                          mapToPixel.mapHeight() / 2.0
+                          static_cast<int>( mapToPixel.mapWidth() / 2.0 ),
+                          static_cast<int>( mapToPixel.mapHeight() / 2.0 )
                         );
     mapToPixel.setMapRotation( 0, center.x(), center.y() );
   }

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -407,7 +407,7 @@ void QgsHighlight::updateRect()
     // This is an hack to pass QgsMapCanvasItem::setRect what it
     // expects (encoding of position and size of the item)
     const QgsMapToPixel &m2p = mMapCanvas->mapSettings().mapToPixel();
-    QgsPointXY topLeft = m2p.toMapPoint( 0, 0 );
+    QgsPointXY topLeft = m2p.toMapCoordinates( 0, 0 );
     double res = m2p.mapUnitsPerPixel();
     QSizeF imageSize = mMapCanvas->mapSettings().outputSize();
     QgsRectangle rect( topLeft.x(), topLeft.y(), topLeft.x() + imageSize.width()*res, topLeft.y() - imageSize.height()*res );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -681,7 +681,7 @@ QgsRectangle QgsMapCanvas::imageRect( const QImage &img, const QgsMapSettings &m
   // This is a hack to pass QgsMapCanvasItem::setRect what it
   // expects (encoding of position and size of the item)
   const QgsMapToPixel &m2p = mapSettings.mapToPixel();
-  QgsPointXY topLeft = m2p.toMapPoint( 0, 0 );
+  QgsPointXY topLeft = m2p.toMapCoordinates( 0, 0 );
   double res = m2p.mapUnitsPerPixel();
   QgsRectangle rect( topLeft.x(), topLeft.y(), topLeft.x() + img.width()*res, topLeft.y() - img.height()*res );
   return rect;
@@ -1558,7 +1558,7 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
 
   // zoom map to mouse cursor by scaling
   QgsPointXY oldCenter = center();
-  QgsPointXY mousePos( getCoordinateTransform()->toMapPoint( e->x(), e->y() ) );
+  QgsPointXY mousePos( getCoordinateTransform()->toMapCoordinates( e->x(), e->y() ) );
   QgsPointXY newCenter( mousePos.x() + ( ( oldCenter.x() - mousePos.x() ) * signedWheelFactor ),
                         mousePos.y() + ( ( oldCenter.y() - mousePos.y() ) * signedWheelFactor ) );
 
@@ -1599,7 +1599,7 @@ void QgsMapCanvas::zoomWithCenter( int x, int y, bool zoomIn )
   else
   {
     // transform the mouse pos to map coordinates
-    QgsPointXY center  = getCoordinateTransform()->toMapPoint( x, y );
+    QgsPointXY center  = getCoordinateTransform()->toMapCoordinates( x, y );
     QgsRectangle r = mapSettings().visibleExtent();
     r.scale( scaleFactor, &center );
     setExtent( r, true );

--- a/src/gui/qgsmaptoolpan.cpp
+++ b/src/gui/qgsmaptoolpan.cpp
@@ -81,7 +81,7 @@ void QgsMapToolPan::canvasReleaseEvent( QgsMapMouseEvent *e )
       else // add pan to mouse cursor
       {
         // transform the mouse pos to map coordinates
-        QgsPointXY center = mCanvas->getCoordinateTransform()->toMapPoint( e->x(), e->y() );
+        QgsPointXY center = mCanvas->getCoordinateTransform()->toMapCoordinates( e->x(), e->y() );
         mCanvas->setCenter( center );
         mCanvas->refresh();
       }
@@ -127,7 +127,7 @@ void QgsMapToolPan::pinchTriggered( QPinchGesture *gesture )
       QPoint pos = gesture->centerPoint().toPoint();
       pos = mCanvas->mapFromGlobal( pos );
       // transform the mouse pos to map coordinates
-      QgsPointXY center  = mCanvas->getCoordinateTransform()->toMapPoint( pos.x(), pos.y() );
+      QgsPointXY center  = mCanvas->getCoordinateTransform()->toMapCoordinates( pos.x(), pos.y() );
       QgsRectangle r = mCanvas->extent();
       r.scale( 1 / gesture->totalScaleFactor(), &center );
       mCanvas->setExtent( r );

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -524,7 +524,7 @@ void QgsRubberBand::updateRect()
   // This is an hack to pass QgsMapCanvasItem::setRect what it
   // expects (encoding of position and size of the item)
   qreal res = m2p.mapUnitsPerPixel();
-  QgsPointXY topLeft = m2p.toMapPoint( r.xMinimum(), r.yMinimum() );
+  QgsPointXY topLeft = m2p.toMapCoordinates( r.xMinimum(), r.yMinimum() );
   QgsRectangle rect( topLeft.x(), topLeft.y(), topLeft.x() + r.width()*res, topLeft.y() - r.height()*res );
 
   setRect( rect );

--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -148,8 +148,10 @@ void QgsSnapToGridCanvasItem::updateZoomFactor()
     const QgsPointXY centerPoint = mMapCanvas->extent().center();
     const QPointF canvasCenter = toCanvasCoordinates( centerPoint );
 
-    const QgsPointXY pt1 = mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( canvasCenter.x() - threshold, canvasCenter.y() - threshold );
-    const QgsPointXY pt2 = mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( canvasCenter.x() + threshold, canvasCenter.y() + threshold );
+    const QgsPointXY pt1 = mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( static_cast<int>( canvasCenter.x() - threshold ),
+                           static_cast<int>( canvasCenter.y() - threshold ) );
+    const QgsPointXY pt2 = mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( static_cast<int>( canvasCenter.x() + threshold ),
+                           static_cast<int>( canvasCenter.y() + threshold ) );
 
     const QgsPointXY layerPt1 = mTransform.transform( pt1, QgsCoordinateTransform::ReverseTransform );
     const QgsPointXY layerPt2 = mTransform.transform( pt2, QgsCoordinateTransform::ReverseTransform );

--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -118,7 +118,10 @@ QPointF QgsQuickMapSettings::coordinateToScreen( const QgsPoint &point ) const
 
 QgsPoint QgsQuickMapSettings::screenToCoordinate( const QPointF &point ) const
 {
-  const QgsPointXY pp = mMapSettings.mapToPixel().toMapCoordinates( point.toPoint() );
+  // use floating point precision with mapToCoordinatesF
+  // this is to avoid rounding errors with an odd screen width or height
+  // and the point being set to the exact center of it
+  const QgsPointXY pp = mMapSettings.mapToPixel().toMapCoordinatesF( point.x(), point.y() );
   return QgsPoint( pp );
 }
 

--- a/src/quickgui/qgsquickmapsettings.cpp
+++ b/src/quickgui/qgsquickmapsettings.cpp
@@ -118,10 +118,10 @@ QPointF QgsQuickMapSettings::coordinateToScreen( const QgsPoint &point ) const
 
 QgsPoint QgsQuickMapSettings::screenToCoordinate( const QPointF &point ) const
 {
-  // use floating point precision with mapToCoordinatesF
+  // use floating point precision with mapToCoordinates (i.e. do not use QPointF::toPoint)
   // this is to avoid rounding errors with an odd screen width or height
   // and the point being set to the exact center of it
-  const QgsPointXY pp = mMapSettings.mapToPixel().toMapCoordinatesF( point.x(), point.y() );
+  const QgsPointXY pp = mMapSettings.mapToPixel().toMapCoordinates( point.x(), point.y() );
   return QgsPoint( pp );
 }
 

--- a/tests/src/core/testqgsmaptopixel.cpp
+++ b/tests/src/core/testqgsmaptopixel.cpp
@@ -28,7 +28,7 @@ class TestQgsMapToPixel: public QObject
     void rotation();
     void getters();
     void fromScale();
-    void toMapPoint();
+    void toMapCoordinates();
 };
 
 void TestQgsMapToPixel::rotation()
@@ -40,7 +40,7 @@ void TestQgsMapToPixel::rotation()
   QCOMPARE( d.x(), 5.0 ); // center doesn't move
   QCOMPARE( d.y(), 5.0 );
 
-  QgsPointXY b = m2p.toMapCoordinatesF( d.x(), d.y() ); // transform back
+  QgsPointXY b = m2p.toMapCoordinates( d.x(), d.y() ); // transform back
   QCOMPARE( p, b );
 
   m2p.transform( &p ); // in place transform
@@ -106,16 +106,16 @@ void TestQgsMapToPixel::fromScale()
   QGSCOMPARENEAR( m2p.mapUnitsPerPixel(), 0.000265, 0.000001 );
 }
 
-void TestQgsMapToPixel::toMapPoint()
+void TestQgsMapToPixel::toMapCoordinates()
 {
   QgsMapToPixel m2p( 1, 5, 5, 10, 10, 90 );
-  QgsPointXY p = m2p.toMapPoint( 5, 5 );
+  QgsPointXY p = m2p.toMapCoordinates( 5, 5 );
   QCOMPARE( p, QgsPointXY( 5, 5 ) );
 
-  p = m2p.toMapPoint( 10, 10 );
+  p = m2p.toMapCoordinates( 10, 10 );
   QCOMPARE( p, QgsPointXY( 10, 10 ) );
 
-  p = m2p.toMapPoint( 20, 20 );
+  p = m2p.toMapCoordinates( 20, 20 );
   QCOMPARE( p, QgsPointXY( 20, 20 ) );
 }
 


### PR DESCRIPTION
this should fix rounding error when the map canvas has an odd pixel size

successfully tested in QField