### PR TITLE
remove useless invokable methods

### DIFF
--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -267,7 +267,7 @@ class CORE_EXPORT QgsUnitTypes
      * \param unit unit to convert to string
      * \see stringToAreaUnit()
      */
-    Q_INVOKABLE static QString toString( QgsUnitTypes::AreaUnit unit );
+    static QString toString( QgsUnitTypes::AreaUnit unit );
 
     /**
      * Returns a translated abbreviation representing an areal unit.
@@ -276,7 +276,7 @@ class CORE_EXPORT QgsUnitTypes
      *
      * \since QGIS 3.0
      */
-    Q_INVOKABLE static QString toAbbreviatedString( QgsUnitTypes::AreaUnit unit );
+    static QString toAbbreviatedString( QgsUnitTypes::AreaUnit unit );
 
     /**
      * Converts a translated string to an areal unit.
@@ -324,7 +324,7 @@ class CORE_EXPORT QgsUnitTypes
      * Returns a translated string representing an angular unit.
      * \param unit unit to convert to string
      */
-    Q_INVOKABLE static QString toString( QgsUnitTypes::AngleUnit unit );
+    static QString toString( QgsUnitTypes::AngleUnit unit );
 
     /**
      * Returns the conversion factor between the specified angular units.
@@ -415,7 +415,7 @@ class CORE_EXPORT QgsUnitTypes
      * Returns a translated string representing a render \a unit.
      * \since QGIS 3.0
      */
-    Q_INVOKABLE static QString toString( QgsUnitTypes::RenderUnit unit );
+    static QString toString( QgsUnitTypes::RenderUnit unit );
 
 
     // LAYOUT UNITS
@@ -451,14 +451,14 @@ class CORE_EXPORT QgsUnitTypes
      *
      * \since QGIS 3.0
      */
-    Q_INVOKABLE static QString toAbbreviatedString( QgsUnitTypes::LayoutUnit unit );
+    static QString toAbbreviatedString( QgsUnitTypes::LayoutUnit unit );
 
     /**
      * Returns a translated string representing a layout \a unit.
      *
      * \since QGIS 3.0
      */
-    Q_INVOKABLE static QString toString( QgsUnitTypes::LayoutUnit unit );
+    static QString toString( QgsUnitTypes::LayoutUnit unit );
 
 };
 


### PR DESCRIPTION
having invokable on overloaded methods taking enum as parameter is pretty useless as it is seen as an integer
the last one declared was used: e.g. the one with LayoutUnit for toAbbreviatedSring
this commit only keeps the ones for DistanceUnit which is the most likely to be used

