### PR TITLE
Make values in attribute form better readable

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -137,7 +137,6 @@ void QgsTextEditWrapper::initWidget( QWidget *editor )
 
     mWritablePalette = mLineEdit->palette();
     mReadOnlyPalette = mLineEdit->palette();
-    mReadOnlyPalette.setColor( QPalette::Text, mWritablePalette.color( QPalette::Disabled, QPalette::Text ) );
   }
 }
 
@@ -195,7 +194,13 @@ void QgsTextEditWrapper::setEnabled( bool enabled )
     if ( enabled )
       mLineEdit->setPalette( mWritablePalette );
     else
+    {
       mLineEdit->setPalette( mReadOnlyPalette );
+      // removing frame + setting transparent background to distinguish the readonly lineEdit from a normal one
+      // did not get this working via the Palette:
+      mLineEdit->setStyleSheet( QStringLiteral( "background-color: rgba(255, 255, 255, 75%);" ) );
+    }
+    mLineEdit->setFrame( enabled );
   }
 }
 


### PR DESCRIPTION
## Description

Currently in readonly modus of a form, the line-edits get
a 'disabled'-palette (to distinguish from writable mode). But because text is then so light, readability
is bad in my opinion:

![image](https://user-images.githubusercontent.com/731673/46244461-67b77600-c3df-11e8-8659-9da745164f87.png)

Removing this 'diabled'-palette make the lineedits look like they are writable
input fields. See below: top is without the 'Disable-palette' in readonly modus,
Bottom is in writable modus.

![defaultpalette](https://user-images.githubusercontent.com/731673/46244475-8b7abc00-c3df-11e8-9dee-31c6b4fc579f.png)

So to distinguish them from input field more, I opt to remove the frame
and set the background (of the lineEdit) set to almost
transparent. Below is the result of current PR:

![white75percent](https://user-images.githubusercontent.com/731673/46244490-cbda3a00-c3df-11e8-9d68-1d21ca62bbb2.png)

I think 75% transparent is better then make the background fully transparent:

![white0percent](https://user-images.githubusercontent.com/731673/46244532-82d6b580-c3e0-11e8-8657-6cf6ddc7503f.png)

Started as a question on the dev list: https://lists.osgeo.org/pipermail/qgis-developer/2018-September/054676.html

I only am able to build on Linux/Gnome, so please check if this works on Windows/Mac too.

Or discuss here ...

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ X ] Commit messages are descriptive and explain the rationale for changes
- [ - ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ - ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ - ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ X ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ X ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
