### PR TITLE
embedded widget registry now uses providers supportsLayer() method (fixes #19960)

### DIFF
--- a/src/gui/layertree/qgslayertreeembeddedconfigwidget.cpp
+++ b/src/gui/layertree/qgslayertreeembeddedconfigwidget.cpp
@@ -42,10 +42,13 @@ void QgsLayerTreeEmbeddedConfigWidget::setLayer( QgsMapLayer *layer )
   Q_FOREACH ( const QString &providerId, QgsGui::layerTreeEmbeddedWidgetRegistry()->providers() )
   {
     QgsLayerTreeEmbeddedWidgetProvider *provider = QgsGui::layerTreeEmbeddedWidgetRegistry()->provider( providerId );
-    QStandardItem *item = new QStandardItem( provider->name() );
-    item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-    item->setData( provider->id(), Qt::UserRole + 1 );
-    modelAvailable->appendRow( item );
+    if ( provider->supportsLayer( mLayer ) )
+    {
+      QStandardItem *item = new QStandardItem( provider->name() );
+      item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
+      item->setData( provider->id(), Qt::UserRole + 1 );
+      modelAvailable->appendRow( item );
+    }
   }
   mListAvailable->setModel( modelAvailable );
 


### PR DESCRIPTION

## Description
This is a fix for [#19960](https://issues.qgis.org/issues/19960).

The `qgsLayerTreeEmbeddedWidgetProvider.supportsLayer()` method was not being called anywhere, which resulted in embedded widgets always being available for all layers. The proposed implementation just adds an `if()` clause to check if each provider's `supportsLayer()` returns `True` before adding it to the available providers list.