### PR TITLE
Use a custom folder icon instead of O/S folder icon

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -714,6 +714,8 @@
         <file>themes/default/mActionReverseLine.svg</file>
         <file>themes/default/mActionAdd3DMap.svg</file>
         <file>themes/default/mIndicatorNonRemovable.svg</file>
+        <file>themes/default/mIconFolder.svg</file>
+        <file>themes/default/mIconFolderOpen.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mIconFolder.svg
+++ b/images/themes/default/mIconFolder.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path d="M1 2v11s0 1 1 1h12s1 0 1-1V4c0-1-1-1-1-1H9L7 1H2S1 1 1 2z" fill="#5c616c"/></svg>

--- a/images/themes/default/mIconFolderOpen.svg
+++ b/images/themes/default/mIconFolderOpen.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path class="ColorScheme-Text" d="M2 1S1 1 1 2v3c0-1 1-1 1-1h5l2 2h5s1 0 1 1V4c0-1-1-1-1-1H9L7 1H2z"  fill="#5c616c" opacity=".3"/><path class="ColorScheme-Text" d="M2 5S1 5 1 6v7s0 1 1 1h12s1 0 1-1V8c0-1-1-1-1-1H9L7 5H2z" fill="#5c616c"/></svg>

--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -111,11 +111,7 @@ class ConfigDialog(BASE, WIDGET):
         super(ConfigDialog, self).__init__(None)
         self.setupUi(self)
 
-        self.groupIcon = QIcon()
-        self.groupIcon.addPixmap(self.style().standardPixmap(
-            QStyle.SP_DirClosedIcon, None), QIcon.Normal, QIcon.Off)
-        self.groupIcon.addPixmap(self.style().standardPixmap(
-            QStyle.SP_DirOpenIcon, None), QIcon.Normal, QIcon.On)
+        self.groupIcon = QgsApplication.getThemeIcon('mIconFolder.svg')
 
         self.model = QStandardItemModel()
         self.tree.setModel(self.model)

--- a/python/plugins/processing/gui/HistoryDialog.py
+++ b/python/plugins/processing/gui/HistoryDialog.py
@@ -28,6 +28,7 @@ __revision__ = '$Format:%H$'
 import os
 import warnings
 
+from qgis.core import QgsApplication
 from qgis.gui import QgsGui
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import Qt, QCoreApplication
@@ -52,8 +53,7 @@ class HistoryDialog(BASE, WIDGET):
 
         QgsGui.instance().enableAutoGeometryRestore(self)
 
-        self.groupIcon = self.style().standardIcon(
-            QStyle.SP_DirClosedIcon)
+        self.groupIcon = QgsApplication.getThemeIcon('mIconFolder.svg')
 
         self.keyIcon = self.style().standardIcon(QStyle.SP_FileIcon)
 

--- a/src/app/qgssettingstree.cpp
+++ b/src/app/qgssettingstree.cpp
@@ -45,6 +45,7 @@
 #include "qgsvariantdelegate.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgsapplication.h"
 
 QgsSettingsTree::QgsSettingsTree( QWidget *parent )
   : QTreeWidget( parent )
@@ -62,10 +63,7 @@ QgsSettingsTree::QgsSettingsTree( QWidget *parent )
 
   mRefreshTimer.setInterval( 2000 );
 
-  mGroupIcon.addPixmap( style()->standardPixmap( QStyle::SP_DirClosedIcon ),
-                        QIcon::Normal, QIcon::Off );
-  mGroupIcon.addPixmap( style()->standardPixmap( QStyle::SP_DirOpenIcon ),
-                        QIcon::Normal, QIcon::On );
+  mGroupIcon = QgsApplication::getThemeIcon( QStringLiteral( "mIconFolderOpen.svg" ) );
   mKeyIcon = style()->standardIcon( QStyle::SP_FileIcon );
 
   setEditTriggers( QAbstractItemView::AllEditTriggers );

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -91,32 +91,12 @@ QIcon QgsDataCollectionItem::iconDataCollection()
 
 QIcon QgsDataCollectionItem::openDirIcon()
 {
-  static QIcon sIcon;
-
-  if ( sIcon.isNull() )
-  {
-    // initialize shared icons
-    QStyle *style = QApplication::style();
-    sIcon = QIcon( style->standardIcon( QStyle::SP_DirOpenIcon ) );
-  }
-
-  return sIcon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFolderOpen.svg" ) );
 }
 
 QIcon QgsDataCollectionItem::iconDir()
 {
-  static QIcon sIcon;
-
-  if ( sIcon.isNull() )
-  {
-    // initialize shared icons
-    QStyle *style = QApplication::style();
-    sIcon = QIcon( style->standardIcon( QStyle::SP_DirClosedIcon ) );
-    sIcon.addPixmap( style->standardPixmap( QStyle::SP_DirOpenIcon ),
-                     QIcon::Normal, QIcon::On );
-  }
-
-  return sIcon;
+  return QgsApplication::getThemeIcon( QStringLiteral( "/mIconFolder.svg" ) );
 }
 
 QIcon QgsFavoritesItem::iconFavorites()
@@ -981,7 +961,7 @@ QgsDirectoryParamWidget::QgsDirectoryParamWidget( const QString &path, QWidget *
   setHeaderLabels( labels );
 
   QStyle *style = QApplication::style();
-  QIcon iconDirectory = QIcon( style->standardIcon( QStyle::SP_DirClosedIcon ) );
+  QIcon iconDirectory = QgsApplication::getThemeIcon( QStringLiteral( "mIconFolderOpen.svg" ) );
   QIcon iconFile = QIcon( style->standardIcon( QStyle::SP_FileIcon ) );
   QIcon iconDirLink = QIcon( style->standardIcon( QStyle::SP_DirLinkIcon ) );
   QIcon iconFileLink = QIcon( style->standardIcon( QStyle::SP_FileLinkIcon ) );


### PR DESCRIPTION
...because using O/S folder icon can causes crashes.

Fixes #18260

As discussed with @nirvn, using the default style icon for folders is fragile and causes crashes on startup on some environments. At @nirvns suggestion, we now use our own custom folder icon for ALL platforms. The icon is based off the Papyrus theme icon.

Screenie:

![image](https://user-images.githubusercontent.com/1829991/46270886-1947da00-c58d-11e8-9a9a-fac9d6a07a34.png)
