### PR TITLE
Add more explicit error message when auxiliary storage is saved

### DIFF
--- a/python/core/auto_generated/qgsauxiliarystorage.sip.in
+++ b/python/core/auto_generated/qgsauxiliarystorage.sip.in
@@ -288,14 +288,21 @@ Returns the path of the current database used. It may be different from
 the target filename if the auxiliary storage is opened in copy mode.
 %End
 
-    bool saveAs( const QString &filename ) const;
+    QString errorString() const;
+%Docstring
+Returns the underlying error string when something went wrong.
+
+.. versionadded:: 3.4
+%End
+
+    bool saveAs( const QString &filename );
 %Docstring
 Saves the current database to a new path.
 
 :return: true if everything is saved, false otherwise
 %End
 
-    bool saveAs( const QgsProject &project ) const;
+    bool saveAs( const QgsProject &project );
 %Docstring
 Saves the current database to a new path for a specific project.
 Actually, the current filename of the project is used to deduce the

--- a/python/core/auto_generated/qgsauxiliarystorage.sip.in
+++ b/python/core/auto_generated/qgsauxiliarystorage.sip.in
@@ -290,7 +290,8 @@ the target filename if the auxiliary storage is opened in copy mode.
 
     QString errorString() const;
 %Docstring
-Returns the underlying error string when something went wrong.
+Returns the underlying error string describing potential errors
+hapenning in saveAs(). Empty by default.
 
 .. versionadded:: 3.4
 %End

--- a/src/core/qgsauxiliarystorage.cpp
+++ b/src/core/qgsauxiliarystorage.cpp
@@ -626,15 +626,33 @@ bool QgsAuxiliaryStorage::duplicateTable( const QgsDataSourceUri &ogrUri, const 
   return rc;
 }
 
-bool QgsAuxiliaryStorage::saveAs( const QString &filename ) const
+QString QgsAuxiliaryStorage::errorString() const
 {
-  if ( QFile::exists( filename ) )
-    QFile::remove( filename );
-
-  return  QFile::copy( currentFileName(), filename );
+  return mErrorString;
 }
 
-bool QgsAuxiliaryStorage::saveAs( const QgsProject &project ) const
+bool QgsAuxiliaryStorage::saveAs( const QString &filename )
+{
+  mErrorString.clear();
+
+  QFile dest( filename );
+  if ( dest.exists() && !dest.remove() )
+  {
+    mErrorString = dest.errorString();
+    return false;
+  }
+
+  QFile origin( currentFileName() );
+  if ( !origin.copy( filename ) )
+  {
+    mErrorString = origin.errorString();
+    return false;
+  }
+
+  return true;
+}
+
+bool QgsAuxiliaryStorage::saveAs( const QgsProject &project )
 {
   return saveAs( filenameForProject( project ) );
 }

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -319,12 +319,14 @@ class CORE_EXPORT QgsAuxiliaryStorage
      */
     QString currentFileName() const;
 
+    QString errorString() const;
+
     /**
      * Saves the current database to a new path.
      *
      * \returns true if everything is saved, false otherwise
      */
-    bool saveAs( const QString &filename ) const;
+    bool saveAs( const QString &filename );
 
     /**
      * Saves the current database to a new path for a specific project.
@@ -333,7 +335,7 @@ class CORE_EXPORT QgsAuxiliaryStorage
      *
      * \returns true if everything is saved, false otherwise
      */
-    bool saveAs( const QgsProject &project ) const;
+    bool saveAs( const QgsProject &project );
 
     /**
      * Saves the current database.
@@ -408,6 +410,7 @@ class CORE_EXPORT QgsAuxiliaryStorage
     QString mFileName; // original filename
     QString mTmpFileName; // temporary filename used in copy mode
     bool mCopy = false;
+    QString mErrorString;
 };
 
 #endif

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -320,7 +320,8 @@ class CORE_EXPORT QgsAuxiliaryStorage
     QString currentFileName() const;
 
     /**
-     * Returns the underlying error string when something went wrong.
+     * Returns the underlying error string describing potential errors
+     * hapenning in saveAs(). Empty by default.
      *
      * \since QGIS 3.4
      */

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -319,6 +319,11 @@ class CORE_EXPORT QgsAuxiliaryStorage
      */
     QString currentFileName() const;
 
+    /**
+     * Returns the underlying error string when something went wrong.
+     *
+     * \since QGIS 3.4
+     */
     QString errorString() const;
 
     /**

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1649,7 +1649,10 @@ bool QgsProject::write()
 
     // errors raised during writing project file are more important
     if ( !asOk && writeOk )
-      setError( tr( "Unable to save auxiliary storage" ) );
+    {
+      const QString err = mAuxiliaryStorage->errorString();
+      setError( tr( "Unable to save auxiliary storage ('%1')" ).arg( err ) );
+    }
 
     return asOk && writeOk;
   }
@@ -2614,7 +2617,8 @@ bool QgsProject::zip( const QString &filename )
 
   if ( ! saveAuxiliaryStorage( asFileName ) )
   {
-    setError( tr( "Unable to save auxiliary storage" ) );
+    const QString err = mAuxiliaryStorage->errorString();
+    setError( tr( "Unable to save auxiliary storage ('%1')" ).arg( err ) );
     return false;
   }
 


### PR DESCRIPTION
## Description

This PR follows the next issue: https://issues.qgis.org/issues/18477.

Actually, sometimes, auxiliary storage is not correctly saved, but I did not succeed in reproducing the error. 

Considering that `QFile::remove()` and `QFile::copy()` methods seems to be implicated, I propose to add a more explicit error message.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
