### PR TITLE
Misc GUI fixes for mesh layers

### DIFF
--- a/src/app/mesh/qgsmeshdatasetgrouptreeview.h
+++ b/src/app/mesh/qgsmeshdatasetgrouptreeview.h
@@ -191,9 +191,6 @@ class APP_EXPORT QgsMeshDatasetGroupTreeView : public QTreeView
     //! Selected dataset group for vectors changed. -1 for invalid group
     void activeVectorGroupChanged( int groupIndex );
 
-  private slots:
-    // void onSelectionChanged( const QItemSelection &selected, const QItemSelection &deselected );
-
   private:
     void setActiveGroupFromActiveDataset();
 

--- a/src/app/mesh/qgsmeshrendereractivedatasetwidget.h
+++ b/src/app/mesh/qgsmeshrendereractivedatasetwidget.h
@@ -63,12 +63,6 @@ class APP_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui
 
   signals:
 
-    //! Emitted when active scalar dataset changed
-    void activeScalarDatasetChanged( QgsMeshDatasetIndex index );
-
-    //! Emitted when active vector dataset changed
-    void activeVectorDatasetChanged( QgsMeshDatasetIndex index );
-
     //! Emitted when the current scalar group gets changed
     void activeScalarGroupChanged( int groupIndex );
 
@@ -81,7 +75,7 @@ class APP_EXPORT QgsMeshRendererActiveDatasetWidget : public QWidget, private Ui
   private slots:
     void onActiveScalarGroupChanged( int groupIndex );
     void onActiveVectorGroupChanged( int groupIndex );
-    void onActiveDatasetChanged( int value );
+    void onActiveTimeChanged( int value );
     void onFirstTimeClicked();
     void onPreviousTimeClicked();
     void onNextTimeClicked();

--- a/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
+++ b/src/ui/mesh/qgsmeshrenderervectorsettingswidgetbase.ui
@@ -111,7 +111,7 @@
         <item row="1" column="1">
          <widget class="QSpinBox" name="mYSpacingSpinBox">
           <property name="suffix">
-           <string>px</string>
+           <string> px</string>
           </property>
           <property name="minimum">
            <number>1</number>


### PR DESCRIPTION
- correct rounding of time
- correct display of time (was off by an hour)
- fixed time combo box when not time-varying dataset group is loaded
- fixed switching of active dataset groups
- bonus: added missing space for arrows on grid ("10 px" not "10px")
