### PR TITLE
Fix truncated symbol name text in style manager dialog

### DIFF
--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -255,7 +255,6 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
 
   double iconSize = Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 10;
   listItems->setIconSize( QSize( static_cast< int >( iconSize ), static_cast< int >( iconSize * 0.9 ) ) );  // ~100, 90 on low dpi
-  listItems->setGridSize( QSize( static_cast< int >( iconSize * 1.2 ), static_cast< int >( iconSize * 1.1 ) ) ); // ~120,110 on low dpi
 
   populateList();
 }
@@ -287,6 +286,9 @@ void QgsStyleManagerDialog::populateSymbols( const QStringList &symbolNames, boo
       QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( symbol.get(), listItems->iconSize(), static_cast< int >( listItems->iconSize().width() * 0.16 ) );
       item->setIcon( icon );
       item->setData( name ); // used to find out original name when user edited the name
+      QFont f = item->data( Qt::FontRole ).value< QFont >();
+      f.setPointSize( 9 );
+      item->setData( f, Qt::FontRole );
       item->setCheckable( check );
       item->setToolTip( QStringLiteral( "<b>%1</b><br><i>%2</i>" ).arg( name, tags.count() > 0 ? tags.join( QStringLiteral( ", " ) ) : tr( "Not tagged" ) ) );
       // add to model

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -237,9 +237,12 @@
          </property>
          <property name="iconSize">
           <size>
-           <width>0</width>
-           <height>0</height>
+           <width>77</width>
+           <height>70</height>
           </size>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::ElideNone</enum>
          </property>
          <property name="movement">
           <enum>QListView::Static</enum>
@@ -249,12 +252,6 @@
          </property>
          <property name="spacing">
           <number>5</number>
-         </property>
-         <property name="gridSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
          </property>
          <property name="viewMode">
           <enum>QListView::IconMode</enum>


### PR DESCRIPTION
Probably the biggest ux issue in this dialog is that the symbol names are almost totally unreadable most of the time ;)