### PR TITLE
[ux] Show large swatch preview in color/symbol tooltips

### DIFF
--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -74,15 +74,16 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
 
           if ( role == Qt::ToolTipRole )
           {
-            QString tooltip = QStringLiteral( "<b>%1</b><br><i>%2</i>" ).arg( name,
+            QString tooltip = QStringLiteral( "<h3>%1</h3><p><i>%2</i>" ).arg( name,
                               tags.count() > 0 ? tags.join( QStringLiteral( ", " ) ) : tr( "Not tagged" ) );
 
             // create very large preview image
             std::unique_ptr< QgsSymbol > symbol( mStyle->symbol( name ) );
             if ( symbol )
             {
-              int size = static_cast< int >( Qgis::UI_SCALE_FACTOR * QFontMetrics( data( index, Qt::FontRole ).value< QFont >() ).width( 'X' ) * 20 );
-              QPixmap pm = QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), QSize( size, size ), size / 20 );
+              int width = static_cast< int >( Qgis::UI_SCALE_FACTOR * QFontMetrics( data( index, Qt::FontRole ).value< QFont >() ).width( 'X' ) * 23 );
+              int height = static_cast< int >( width / 1.61803398875 ); // golden ratio
+              QPixmap pm = QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), QSize( width, height ), height / 20 );
               QByteArray data;
               QBuffer buffer( &data );
               pm.save( &buffer, "PNG", 100 );

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -163,9 +163,11 @@ bool QgsColorButton::event( QEvent *e )
     int saturation = mColor.saturation();
 
     // create very large preview swatch
-    int size = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 15 );
-    int margin = static_cast< int >( size * 0.1 );
-    QImage icon = QImage( size + 2 * margin, size + 2 * margin, QImage::Format_ARGB32 );
+    int width = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 23 );
+    int height = static_cast< int >( width / 1.61803398875 ); // golden ratio
+
+    int margin = static_cast< int >( height * 0.1 );
+    QImage icon = QImage( width + 2 * margin, height + 2 * margin, QImage::Format_ARGB32 );
     icon.fill( Qt::transparent );
 
     QPainter p;
@@ -175,14 +177,14 @@ bool QgsColorButton::event( QEvent *e )
     QBrush checkBrush = QBrush( transparentBackground() );
     p.setPen( Qt::NoPen );
     p.setBrush( checkBrush );
-    p.drawRect( margin, margin, size, size );
+    p.drawRect( margin, margin, width, height );
 
     //draw color over pattern
     p.setBrush( QBrush( mColor ) );
 
     //draw border
     p.setPen( QColor( 197, 197, 197 ) );
-    p.drawRect( margin, margin, size, size );
+    p.drawRect( margin, margin, width, height );
     p.end();
 
     QByteArray data;

--- a/src/gui/qgscolorswatchgrid.cpp
+++ b/src/gui/qgscolorswatchgrid.cpp
@@ -123,9 +123,10 @@ void QgsColorSwatchGrid::updateTooltip( const int colorIdx )
     QString colorName = mColors.at( colorIdx ).second;
 
     // create very large preview swatch, because the grid itself has only tiny preview icons
-    int size = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 15 );
-    int margin = static_cast< int >( size * 0.1 );
-    QImage icon = QImage( size + 2 * margin, size + 2 * margin, QImage::Format_ARGB32 );
+    int width = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 23 );
+    int height = static_cast< int >( width / 1.61803398875 ); // golden ratio
+    int margin = static_cast< int >( height * 0.1 );
+    QImage icon = QImage( width + 2 * margin, height + 2 * margin, QImage::Format_ARGB32 );
     icon.fill( Qt::transparent );
 
     QPainter p;
@@ -135,14 +136,14 @@ void QgsColorSwatchGrid::updateTooltip( const int colorIdx )
     QBrush checkBrush = QBrush( transparentBackground() );
     p.setPen( Qt::NoPen );
     p.setBrush( checkBrush );
-    p.drawRect( margin, margin, size, size );
+    p.drawRect( margin, margin, width, height );
 
     //draw color over pattern
     p.setBrush( QBrush( mColors.at( colorIdx ).first ) );
 
     //draw border
     p.setPen( QColor( 197, 197, 197 ) );
-    p.drawRect( margin, margin, size, size );
+    p.drawRect( margin, margin, width, height );
     p.end();
 
     QByteArray data;

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -45,7 +45,7 @@ QgsSymbolButton::QgsSymbolButton( QWidget *parent, const QString &dialogTitle )
 
   //make sure height of button looks good under different platforms
   QSize size = QToolButton::minimumSizeHint();
-  int fontHeight = Qgis::UI_SCALE_FACTOR * fontMetrics().height() * 1.4;
+  int fontHeight = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().height() * 1.4 );
   mSizeHint = QSize( size.width(), std::max( size.height(), fontHeight ) );
 }
 
@@ -473,8 +473,10 @@ void QgsSymbolButton::updatePreview( const QColor &color, QgsSymbol *tempSymbol 
 
   // set tooltip
   // create very large preview image
-  int size = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 20 );
-  QPixmap pm = QgsSymbolLayerUtils::symbolPreviewPixmap( previewSymbol.get(), QSize( size, size ), size / 20 );
+  int width = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 23 );
+  int height = static_cast< int >( width / 1.61803398875 ); // golden ratio
+
+  QPixmap pm = QgsSymbolLayerUtils::symbolPreviewPixmap( previewSymbol.get(), QSize( width, height ), height / 20 );
   QByteArray data;
   QBuffer buffer( &data );
   pm.save( &buffer, "PNG", 100 );

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -470,6 +470,15 @@ void QgsSymbolButton::updatePreview( const QColor &color, QgsSymbol *tempSymbol 
   QIcon icon = QgsSymbolLayerUtils::symbolPreviewIcon( previewSymbol.get(), currentIconSize );
   setIconSize( currentIconSize );
   setIcon( icon );
+
+  // set tooltip
+  // create very large preview image
+  int size = static_cast< int >( Qgis::UI_SCALE_FACTOR * fontMetrics().width( 'X' ) * 20 );
+  QPixmap pm = QgsSymbolLayerUtils::symbolPreviewPixmap( previewSymbol.get(), QSize( size, size ), size / 20 );
+  QByteArray data;
+  QBuffer buffer( &data );
+  pm.save( &buffer, "PNG", 100 );
+  setToolTip( QStringLiteral( "<img src='data:image/png;base64, %3'>" ).arg( QString( data.toBase64() ) ) );
 }
 
 bool QgsSymbolButton::colorFromMimeData( const QMimeData *mimeData, QColor &resultColor, bool &hasAlpha )


### PR DESCRIPTION
Fixes an annoying usability issue, where color button/menu swatches/symbol list icons are too small to give a good indication of the color/symbol, by showing large swatches in the tooltips:

![image](https://user-images.githubusercontent.com/1829991/46324941-6da89380-c639-11e8-9f21-9e8ee2153ef3.png)

![image](https://user-images.githubusercontent.com/1829991/46324980-9cbf0500-c639-11e8-9696-d229ef29a03f.png)

![image](https://user-images.githubusercontent.com/1829991/46325013-be1ff100-c639-11e8-9891-420c592118d7.png)
