### PR TITLE
Load default QGIS metadata for layers in browser layer metadata panel

### DIFF
--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -150,6 +150,8 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
     {
       if ( layer->isValid() )
       {
+        bool ok = false;
+        layer->loadDefaultMetadata( ok );
         layerCrs = layer->crs();
         layerMetadata = layer->htmlMetadata();
       }
@@ -163,6 +165,8 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
     {
       if ( layer->isValid() )
       {
+        bool ok = false;
+        layer->loadDefaultMetadata( ok );
         layerCrs = layer->crs();
         layerMetadata = layer->htmlMetadata();
       }
@@ -176,6 +180,8 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
     {
       if ( layer->isValid() )
       {
+        bool ok = false;
+        layer->loadDefaultMetadata( ok );
         layerCrs = layer->crs();
         layerMetadata = layer->htmlMetadata();
       }

--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -117,7 +117,6 @@ QgsBrowserLayerProperties::QgsBrowserLayerProperties( QWidget *parent )
   mHeaderGridLayout->addItem( new QWidgetItem( mUriLabel ), 1, 1 );
 }
 
-///@cond PRIVATE
 class ProjectionSettingRestorer
 {
   public:
@@ -137,7 +136,6 @@ class ProjectionSettingRestorer
 
     QString previousSetting;
 };
-///@endcond PRIVATE
 
 void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
 {


### PR DESCRIPTION
Currently QGIS metadata is not shown in the browser dock panel, even if it's set to be the default metadata for a layer.