### PR TITLE
[mesh] make layer blend mode option visible in UI

### DIFF
--- a/src/app/mesh/qgsrenderermeshpropertieswidget.cpp
+++ b/src/app/mesh/qgsrenderermeshpropertieswidget.cpp
@@ -44,6 +44,10 @@ QgsRendererMeshPropertiesWidget::QgsRendererMeshPropertiesWidget( QgsMeshLayer *
   mMeshRendererVectorSettingsWidget->setLayer( mMeshLayer );
   syncToLayer();
 
+  //blend mode
+  mBlendModeComboBox->setBlendMode( mMeshLayer->blendMode() );
+  connect( mBlendModeComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsPanelWidget::widgetChanged );
+
   connect( mMeshRendererActiveDatasetWidget, &QgsMeshRendererActiveDatasetWidget::activeScalarGroupChanged,
            this, &QgsRendererMeshPropertiesWidget::onActiveScalarGroupChanged );
   connect( mMeshRendererActiveDatasetWidget, &QgsMeshRendererActiveDatasetWidget::activeVectorGroupChanged,
@@ -53,7 +57,6 @@ QgsRendererMeshPropertiesWidget::QgsRendererMeshPropertiesWidget( QgsMeshLayer *
   connect( mTriangularMeshGroup, &QGroupBox::toggled, this, &QgsPanelWidget::widgetChanged );
   connect( mContoursGroupBox, &QGroupBox::toggled, this, &QgsPanelWidget::widgetChanged );
   connect( mVectorsGroupBox, &QGroupBox::toggled, this, &QgsPanelWidget::widgetChanged );
-
   connect( mMeshRendererActiveDatasetWidget, &QgsMeshRendererActiveDatasetWidget::widgetChanged, this, &QgsPanelWidget::widgetChanged );
   connect( mMeshRendererScalarSettingsWidget, &QgsMeshRendererScalarSettingsWidget::widgetChanged, this, &QgsPanelWidget::widgetChanged );
   connect( mMeshRendererVectorSettingsWidget, &QgsMeshRendererVectorSettingsWidget::widgetChanged, this, &QgsPanelWidget::widgetChanged );
@@ -99,6 +102,9 @@ void QgsRendererMeshPropertiesWidget::apply()
   settings.setActiveVectorDataset( activeVectorDatasetIndex );
   if ( activeVectorDatasetIndex.isValid() )
     settings.setVectorSettings( activeVectorDatasetIndex.group(), mMeshRendererVectorSettingsWidget->settings() );
+
+  //set the blend mode for the layer
+  mMeshLayer->setBlendMode( mBlendModeComboBox->blendMode() );
 
   mMeshLayer->setRendererSettings( settings );
   mMeshLayer->triggerRepaint();

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -27,6 +27,7 @@
 #include "qgsmeshlayer.h"
 #include "qgsmeshlayerrenderer.h"
 #include "qgsmeshlayerutils.h"
+#include "qgspainting.h"
 #include "qgsproviderregistry.h"
 #include "qgsreadwritecontext.h"
 #include "qgsstyle.h"
@@ -271,6 +272,14 @@ bool QgsMeshLayer::readSymbology( const QDomNode &node, QString &errorMessage,
   if ( !elemRendererSettings.isNull() )
     mRendererSettings.readXml( elemRendererSettings );
 
+  // get and set the blend mode if it exists
+  QDomNode blendModeNode = node.namedItem( QStringLiteral( "blendMode" ) );
+  if ( !blendModeNode.isNull() )
+  {
+    QDomElement e = blendModeNode.toElement();
+    setBlendMode( QgsPainting::getCompositionMode( static_cast< QgsPainting::BlendMode >( e.text().toInt() ) ) );
+  }
+
   return true;
 }
 
@@ -286,6 +295,12 @@ bool QgsMeshLayer::writeSymbology( QDomNode &node, QDomDocument &doc, QString &e
 
   QDomElement elemRendererSettings = mRendererSettings.writeXml( doc );
   elem.appendChild( elemRendererSettings );
+
+  // add blend mode node
+  QDomElement blendModeElement  = doc.createElement( QStringLiteral( "blendMode" ) );
+  QDomText blendModeText = doc.createTextNode( QString::number( QgsPainting::getBlendModeEnum( blendMode() ) ) );
+  blendModeElement.appendChild( blendModeText );
+  node.appendChild( blendModeElement );
 
   return true;
 }

--- a/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
+++ b/src/ui/mesh/qgsrenderermeshpropswidgetbase.ui
@@ -68,6 +68,32 @@
          </property>
         </widget>
        </item>
+      <item>
+       <widget class="QgsCollapsibleGroupBox" name="mActiveDatasetBlendingMode">
+        <property name="title">
+         <string>Layer Rendering</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="">
+           <property name="text">
+            <string>Blending mode</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
        <item>
         <spacer name="verticalSpacer_3">
          <property name="orientation">
@@ -297,6 +323,17 @@
    <class>QgsMeshRendererVectorSettingsWidget</class>
    <extends>QWidget</extends>
    <header>mesh/qgsmeshrenderervectorsettingswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
## Description
@PeterPetrik , @wonder-sk , blending mode is a layer-level setting, which is there for the mesh layer to make use of, but not exposed through the UI. This PR fixes this, and in doing so unlocks the door for nice cartographic possibilities.

Simple example:
![screenshot from 2018-10-03 16-21-51](https://user-images.githubusercontent.com/1728657/46402091-01a55880-c729-11e8-93ef-967e76be3aa2.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
