### PR TITLE
fix the GRASS7 r_contour tool removing the mandatory flag of one of the parameters

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.contour.txt
+++ b/python/plugins/processing/algs/grass7/description/r.contour.txt
@@ -3,7 +3,7 @@ Produces a vector map of specified contours from a raster map.
 Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Input raster|None|False
 QgsProcessingParameterNumber|step|Increment between contour levels|QgsProcessingParameterNumber.Double|None|True|None|None
-QgsProcessingParameterString|levels|List of contour levels|None|False
+QgsProcessingParameterString|levels|List of contour levels|None|False|True
 QgsProcessingParameterNumber|minlevel|Minimum contour level|QgsProcessingParameterNumber.Double|None|True|None|None
 QgsProcessingParameterNumber|maxlevel|Maximum contour level|QgsProcessingParameterNumber.Double|None|True|None|None
 QgsProcessingParameterNumber|cut|Minimum number of points for a contour line (0 -> no limit)|QgsProcessingParameterNumber.Integer|0|True|0|None


### PR DESCRIPTION
## Description
fix the GRASS7 r_contour tool removing the mandatory flag of one of the parameters

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
