### PR TITLE
Add qt PATH_SUFFIXES to find QScintilla2 includes; match conda-forge qt

### DIFF
--- a/cmake/FindQScintilla.cmake
+++ b/cmake/FindQScintilla.cmake
@@ -56,6 +56,7 @@ ELSE(EXISTS QSCINTILLA_VERSION_STR)
       "${QT_INCLUDE_DIR}"
       /usr/local/include
       /usr/include
+    PATH_SUFFIXES qt
     )
 
   IF(QSCINTILLA_LIBRARY AND QSCINTILLA_INCLUDE_DIR)


### PR DESCRIPTION
## Description
For builds using dependencies from [conda-forge](https://conda-forge.org/), also search in `qt` recipe's include path at `<prefix>/include/qt`

See also:
**qt-feedstock**
https://github.com/conda-forge/qt-feedstock/blob/master/recipe/build.sh#L25
**qscintilla2-feedstock**
https://github.com/conda-forge/qscintilla2-feedstock/blob/master/recipe/build.sh#L35

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
