### PR TITLE
 [labeling] Fix substitutions don't play well with wrapped labels

### DIFF
--- a/python/core/auto_generated/qgspallabeling.sip.in
+++ b/python/core/auto_generated/qgspallabeling.sip.in
@@ -159,6 +159,7 @@ class QgsPalLayerSettings
 
       // text formatting
       MultiLineWrapChar,
+      AutoWrapLength,
       MultiLineHeight,
       MultiLineAlignment,
       DirSymbDraw,
@@ -282,6 +283,10 @@ Returns the QgsExpression for this label settings. May be None if isExpression i
 
 
     QString wrapChar;
+
+    int autoWrapLength;
+
+    bool useMaxLineLengthForAutoWrap;
 
     MultiLineAlign multilineAlign;
 
@@ -559,15 +564,16 @@ Checks whether a geometry requires preparation before registration with PAL
 .. versionadded:: 2.9
 %End
 
-    static QStringList splitToLines( const QString &text, const QString &wrapCharacter );
+    static QStringList splitToLines( const QString &text, const QString &wrapCharacter, int autoWrapLength = 0, bool useMaxLineLengthWhenAutoWrapping = true );
 %Docstring
-Splits a text string to a list of separate lines, using a specified wrap character.
+Splits a ``text`` string to a list of separate lines, using a specified wrap character (``wrapCharacter``).
 The text string will be split on either newline characters or the wrap character.
 
-:param text: text string to split
-:param wrapCharacter: additional character to wrap on
-
-:return: list of text split to lines
+Since QGIS 3.4 the ``autoWrapLength`` argument can be used to specify an ideal length of line to automatically
+wrap text to (automatic wrapping is disabled if ``autoWrapLength`` is 0). This automatic wrapping is performed
+after processing wrapping using ``wrapCharacter``. When auto wrapping is enabled, the ``useMaxLineLengthWhenAutoWrapping``
+argument controls whether the lines should be wrapped to an ideal maximum of ``autoWrapLength`` characters, or
+if false then the lines are wrapped to an ideal minimum length of ``autoWrapLength`` characters.
 
 .. versionadded:: 2.9
 %End

--- a/python/core/auto_generated/qgsstringutils.sip.in
+++ b/python/core/auto_generated/qgsstringutils.sip.in
@@ -261,6 +261,20 @@ links.
 
 .. versionadded:: 3.0
 %End
+
+    static QString wordWrap( const QString &string, int length, bool useMaxLineLength = true, const QString &customDelimiter = QString() );
+%Docstring
+Automatically wraps a \string by inserting new line characters at appropriate locations in the string.
+
+The ``length`` argument specifies either the minimum or maximum length of lines desired, depending
+on whether ``useMaxLineLength`` is true. If ``useMaxLineLength`` is true, then the string will be wrapped
+so that each line ideally will not exceed ``length`` of characters. If ``useMaxLineLength`` is false, then
+the string will be wrapped so that each line will ideally exceed ``length`` of characters.
+
+A custom delimiter can be specified to use instead of space characters.
+
+.. versionadded:: 3.4
+%End
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsstringutils.sip.in
+++ b/python/core/auto_generated/qgsstringutils.sip.in
@@ -264,7 +264,7 @@ links.
 
     static QString wordWrap( const QString &string, int length, bool useMaxLineLength = true, const QString &customDelimiter = QString() );
 %Docstring
-Automatically wraps a \string by inserting new line characters at appropriate locations in the string.
+Automatically wraps a ``string`` by inserting new line characters at appropriate locations in the string.
 
 The ``length`` argument specifies either the minimum or maximum length of lines desired, depending
 on whether ``useMaxLineLength`` is true. If ``useMaxLineLength`` is true, then the string will be wrapped

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -247,6 +247,8 @@ void QgsLabelingGui::setLayer( QgsMapLayer *mapLayer )
   mMaxCharAngleOutDSpinBox->setValue( std::fabs( lyr.maxCurvedCharAngleOut ) );
 
   wrapCharacterEdit->setText( lyr.wrapChar );
+  mAutoWrapLengthSpinBox->setValue( lyr.autoWrapLength );
+  mAutoWrapTypeComboBox->setCurrentIndex( lyr.useMaxLineLengthForAutoWrap ? 0 : 1 );
   mFontMultiLineAlignComboBox->setCurrentIndex( ( unsigned int ) lyr.multilineAlign );
   chkPreserveRotation->setChecked( lyr.preserveRotation );
 
@@ -435,6 +437,8 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
   lyr.fontMinPixelSize = mFontMinPixelSpinBox->value();
   lyr.fontMaxPixelSize = mFontMaxPixelSpinBox->value();
   lyr.wrapChar = wrapCharacterEdit->text();
+  lyr.autoWrapLength = mAutoWrapLengthSpinBox->value();
+  lyr.useMaxLineLengthForAutoWrap = mAutoWrapTypeComboBox->currentIndex() == 0;
   lyr.multilineAlign = ( QgsPalLayerSettings::MultiLineAlign ) mFontMultiLineAlignComboBox->currentIndex();
   lyr.preserveRotation = chkPreserveRotation->isChecked();
 
@@ -465,6 +469,7 @@ void QgsLabelingGui::populateDataDefinedButtons()
 
   // text formatting
   registerDataDefinedButton( mWrapCharDDBtn, QgsPalLayerSettings::MultiLineWrapChar );
+  registerDataDefinedButton( mAutoWrapLengthDDBtn, QgsPalLayerSettings::AutoWrapLength );
   registerDataDefinedButton( mFontLineHeightDDBtn, QgsPalLayerSettings::MultiLineHeight );
   registerDataDefinedButton( mFontMultiLineAlignDDBtn, QgsPalLayerSettings::MultiLineAlignment );
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1014,73 +1014,9 @@ static QVariant fcnWordwrap( const QVariantList &values, const QgsExpressionCont
     QString str = QgsExpressionUtils::getStringValue( values.at( 0 ), parent );
     qlonglong wrap = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
 
-    if ( !str.isEmpty() && wrap != 0 )
-    {
-      QString newstr;
-      QRegExp rx;
-      QString customdelimiter = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
-      int delimiterlength;
+    QString customdelimiter = QgsExpressionUtils::getStringValue( values.at( 2 ), parent );
 
-      if ( customdelimiter.length() > 0 )
-      {
-        rx.setPatternSyntax( QRegExp::FixedString );
-        rx.setPattern( customdelimiter );
-        delimiterlength = customdelimiter.length();
-      }
-      else
-      {
-        // \x200B is a ZERO-WIDTH SPACE, needed for worwrap to support a number of complex scripts (Indic, Arabic, etc.)
-        rx.setPattern( QStringLiteral( "[\\s\\x200B]" ) );
-        delimiterlength = 1;
-      }
-
-
-      QStringList lines = str.split( '\n' );
-      int strlength, strcurrent, strhit, lasthit;
-
-      for ( int i = 0; i < lines.size(); i++ )
-      {
-        strlength = lines[i].length();
-        strcurrent = 0;
-        strhit = 0;
-        lasthit = 0;
-
-        while ( strcurrent < strlength )
-        {
-          // positive wrap value = desired maximum line width to wrap
-          // negative wrap value = desired minimum line width before wrap
-          if ( wrap > 0 )
-          {
-            //first try to locate delimiter backwards
-            strhit = lines[i].lastIndexOf( rx, strcurrent + wrap );
-            if ( strhit == lasthit || strhit == -1 )
-            {
-              //if no new backward delimiter found, try to locate forward
-              strhit = lines[i].indexOf( rx, strcurrent + std::labs( wrap ) );
-            }
-            lasthit = strhit;
-          }
-          else
-          {
-            strhit = lines[i].indexOf( rx, strcurrent + std::labs( wrap ) );
-          }
-          if ( strhit > -1 )
-          {
-            newstr.append( lines[i].midRef( strcurrent, strhit - strcurrent ) );
-            newstr.append( '\n' );
-            strcurrent = strhit + delimiterlength;
-          }
-          else
-          {
-            newstr.append( lines[i].midRef( strcurrent ) );
-            strcurrent = strlength;
-          }
-        }
-        if ( i < lines.size() - 1 ) newstr.append( '\n' );
-      }
-
-      return QVariant( newstr );
-    }
+    return QgsStringUtils::wordWrap( str, static_cast< int >( wrap ), wrap > 0, customdelimiter );
   }
 
   return QVariant();

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -269,6 +269,7 @@ class CORE_EXPORT QgsPalLayerSettings
 
       // text formatting
       MultiLineWrapChar = 31,
+      AutoWrapLength = 101,
       MultiLineHeight = 32,
       MultiLineAlignment = 33,
       DirSymbDraw = 34,
@@ -416,6 +417,27 @@ class CORE_EXPORT QgsPalLayerSettings
      * label text will be replaced with new line characters.
      */
     QString wrapChar;
+
+    /**
+     * If non-zero, indicates that label text should be automatically wrapped to (ideally) the specified
+     * number of characters. If zero, auto wrapping is disabled.
+     *
+     * \see useMaxLineLengthForAutoWrap
+     * \since QGIS 3.4
+     */
+    int autoWrapLength = 0;
+
+    /**
+     * If true, indicates that when auto wrapping label text the autoWrapLength length indicates the maximum
+     * ideal length of text lines. If false, then autoWrapLength indicates the ideal minimum length of text
+     * lines.
+     *
+     * If autoWrapLength is 0 then this value has no effect.
+     *
+     * \see autoWrapLength
+     * \since QGIS 3.4
+     */
+    bool useMaxLineLengthForAutoWrap = true;
 
     //! Horizontal alignment of multi-line labels.
     MultiLineAlign multilineAlign;
@@ -986,14 +1008,18 @@ class CORE_EXPORT QgsPalLabeling
     static bool geometryRequiresPreparation( const QgsGeometry &geometry, QgsRenderContext &context, const QgsCoordinateTransform &ct, const QgsGeometry &clipGeometry = QgsGeometry() );
 
     /**
-     * Splits a text string to a list of separate lines, using a specified wrap character.
+     * Splits a \a text string to a list of separate lines, using a specified wrap character (\a wrapCharacter).
      * The text string will be split on either newline characters or the wrap character.
-     * \param text text string to split
-     * \param wrapCharacter additional character to wrap on
-     * \returns list of text split to lines
+     *
+     * Since QGIS 3.4 the \a autoWrapLength argument can be used to specify an ideal length of line to automatically
+     * wrap text to (automatic wrapping is disabled if \a autoWrapLength is 0). This automatic wrapping is performed
+     * after processing wrapping using \a wrapCharacter. When auto wrapping is enabled, the \a useMaxLineLengthWhenAutoWrapping
+     * argument controls whether the lines should be wrapped to an ideal maximum of \a autoWrapLength characters, or
+     * if false then the lines are wrapped to an ideal minimum length of \a autoWrapLength characters.
+     *
      * \since QGIS 2.9
      */
-    static QStringList splitToLines( const QString &text, const QString &wrapCharacter );
+    static QStringList splitToLines( const QString &text, const QString &wrapCharacter, int autoWrapLength = 0, bool useMaxLineLengthWhenAutoWrapping = true );
 
     /**
      * Splits a text string to a list of graphemes, which are the smallest allowable character

--- a/src/core/qgsstringutils.h
+++ b/src/core/qgsstringutils.h
@@ -262,7 +262,7 @@ class CORE_EXPORT QgsStringUtils
     static QString insertLinks( const QString &string, bool *foundLinks = nullptr );
 
     /**
-     * Automatically wraps a \string by inserting new line characters at appropriate locations in the string.
+     * Automatically wraps a \a string by inserting new line characters at appropriate locations in the string.
      *
      * The \a length argument specifies either the minimum or maximum length of lines desired, depending
      * on whether \a useMaxLineLength is true. If \a useMaxLineLength is true, then the string will be wrapped

--- a/src/core/qgsstringutils.h
+++ b/src/core/qgsstringutils.h
@@ -260,6 +260,20 @@ class CORE_EXPORT QgsStringUtils
      * \since QGIS 3.0
      */
     static QString insertLinks( const QString &string, bool *foundLinks = nullptr );
+
+    /**
+     * Automatically wraps a \string by inserting new line characters at appropriate locations in the string.
+     *
+     * The \a length argument specifies either the minimum or maximum length of lines desired, depending
+     * on whether \a useMaxLineLength is true. If \a useMaxLineLength is true, then the string will be wrapped
+     * so that each line ideally will not exceed \a length of characters. If \a useMaxLineLength is false, then
+     * the string will be wrapped so that each line will ideally exceed \a length of characters.
+     *
+     * A custom delimiter can be specified to use instead of space characters.
+     *
+     * \since QGIS 3.4
+     */
+    static QString wordWrap( const QString &string, int length, bool useMaxLineLength = true, const QString &customDelimiter = QString() );
 };
 
 #endif //QGSSTRINGUTILS_H

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -612,7 +612,7 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, Q
     }
 
     //QgsDebugMsgLevel( "drawLabel " + txt, 4 );
-    QStringList multiLineList = QgsPalLabeling::splitToLines( txt, tmpLyr.wrapChar );
+    QStringList multiLineList = QgsPalLabeling::splitToLines( txt, tmpLyr.wrapChar, tmpLyr.autoWrapLength, tmpLyr.useMaxLineLengthForAutoWrap );
 
     QgsTextRenderer::HAlignment hAlign = QgsTextRenderer::AlignLeft;
     if ( tmpLyr.multilineAlign == QgsPalLayerSettings::MultiCenter )

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -456,10 +456,13 @@ void QgsTextFormatWidget::initWidget()
           << mShapeTypeDDBtn
           << mShowLabelDDBtn
           << mWrapCharDDBtn
+          << mAutoWrapLengthDDBtn
           << mZIndexDDBtn
           << mZIndexSpinBox
           << spinBufferSize
           << wrapCharacterEdit
+          << mAutoWrapLengthSpinBox
+          << mAutoWrapTypeComboBox
           << mCentroidRadioVisible
           << mCentroidRadioWhole
           << mDirectSymbRadioBtnAbove

--- a/src/ui/qgstextformatwidgetbase.ui
+++ b/src/ui/qgstextformatwidgetbase.ui
@@ -172,7 +172,7 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>482</width>
+               <width>486</width>
                <height>300</height>
               </rect>
              </property>
@@ -651,7 +651,7 @@
               <item>
                <widget class="QStackedWidget" name="mLabelStackedWidget">
                 <property name="currentIndex">
-                 <number>6</number>
+                 <number>1</number>
                 </property>
                 <widget class="QWidget" name="mLabelPage_Text">
                  <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -680,8 +680,8 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>448</width>
-                       <height>444</height>
+                       <width>375</width>
+                       <height>470</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -1460,8 +1460,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>448</width>
-                       <height>389</height>
+                       <width>452</width>
+                       <height>479</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -1507,27 +1507,10 @@ font-style: italic;</string>
                            <property name="bottomMargin">
                             <number>0</number>
                            </property>
-                           <item row="0" column="2">
-                            <widget class="QgsPropertyOverrideButton" name="mWrapCharDDBtn">
+                           <item row="1" column="0">
+                            <widget class="QLabel" name="label_44">
                              <property name="text">
-                              <string>…</string>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="0" column="1">
-                            <widget class="QLineEdit" name="wrapCharacterEdit">
-                             <property name="minimumSize">
-                              <size>
-                               <width>0</width>
-                               <height>0</height>
-                              </size>
-                             </property>
-                            </widget>
-                           </item>
-                           <item row="1" column="2">
-                            <widget class="QgsPropertyOverrideButton" name="mFontLineHeightDDBtn">
-                             <property name="text">
-                              <string>…</string>
+                              <string>Wrap lines to</string>
                              </property>
                             </widget>
                            </item>
@@ -1544,7 +1527,7 @@ font-style: italic;</string>
                              </property>
                             </widget>
                            </item>
-                           <item row="1" column="0">
+                           <item row="3" column="0">
                             <widget class="QLabel" name="mFontLineHeightLabel">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -1557,7 +1540,98 @@ font-style: italic;</string>
                              </property>
                             </widget>
                            </item>
+                           <item row="1" column="2">
+                            <widget class="QgsPropertyOverrideButton" name="mAutoWrapLengthDDBtn">
+                             <property name="text">
+                              <string>…</string>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="4" column="1">
+                            <widget class="QComboBox" name="mFontMultiLineAlignComboBox">
+                             <property name="enabled">
+                              <bool>true</bool>
+                             </property>
+                             <property name="toolTip">
+                              <string>Paragraph style alignment of multi-line text</string>
+                             </property>
+                             <property name="layoutDirection">
+                              <enum>Qt::LeftToRight</enum>
+                             </property>
+                             <item>
+                              <property name="text">
+                               <string>Left</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>Center</string>
+                              </property>
+                             </item>
+                             <item>
+                              <property name="text">
+                               <string>Right</string>
+                              </property>
+                             </item>
+                            </widget>
+                           </item>
+                           <item row="4" column="2">
+                            <widget class="QgsPropertyOverrideButton" name="mFontMultiLineAlignDDBtn">
+                             <property name="text">
+                              <string>…</string>
+                             </property>
+                            </widget>
+                           </item>
                            <item row="1" column="1">
+                            <widget class="QgsSpinBox" name="mAutoWrapLengthSpinBox">
+                             <property name="enabled">
+                              <bool>true</bool>
+                             </property>
+                             <property name="toolTip">
+                              <string>If set, label text will automatically be wrapped to match the specified number of characters per line (if possible)</string>
+                             </property>
+                             <property name="specialValueText">
+                              <string>No automatic wrapping</string>
+                             </property>
+                             <property name="suffix">
+                              <string> characters</string>
+                             </property>
+                             <property name="maximum">
+                              <number>999</number>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="0" column="1">
+                            <widget class="QLineEdit" name="wrapCharacterEdit">
+                             <property name="minimumSize">
+                              <size>
+                               <width>0</width>
+                               <height>0</height>
+                              </size>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="4" column="0">
+                            <widget class="QLabel" name="mFontMultiLineLabel">
+                             <property name="sizePolicy">
+                              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                               <horstretch>0</horstretch>
+                               <verstretch>0</verstretch>
+                              </sizepolicy>
+                             </property>
+                             <property name="text">
+                              <string>Alignment</string>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="3" column="2">
+                            <widget class="QgsPropertyOverrideButton" name="mFontLineHeightDDBtn">
+                             <property name="text">
+                              <string>…</string>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="3" column="1">
                             <widget class="QgsDoubleSpinBox" name="mFontLineHeightSpinBox">
                              <property name="enabled">
                               <bool>true</bool>
@@ -1588,52 +1662,28 @@ font-style: italic;</string>
                              </property>
                             </widget>
                            </item>
-                           <item row="2" column="0">
-                            <widget class="QLabel" name="mFontMultiLineLabel">
-                             <property name="sizePolicy">
-                              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                               <horstretch>0</horstretch>
-                               <verstretch>0</verstretch>
-                              </sizepolicy>
-                             </property>
+                           <item row="0" column="2">
+                            <widget class="QgsPropertyOverrideButton" name="mWrapCharDDBtn">
                              <property name="text">
-                              <string>Alignment</string>
+                              <string>…</string>
                              </property>
                             </widget>
                            </item>
                            <item row="2" column="1">
-                            <widget class="QComboBox" name="mFontMultiLineAlignComboBox">
-                             <property name="enabled">
-                              <bool>true</bool>
-                             </property>
+                            <widget class="QComboBox" name="mAutoWrapTypeComboBox">
                              <property name="toolTip">
-                              <string>Paragraph style alignment of multi-line text</string>
-                             </property>
-                             <property name="layoutDirection">
-                              <enum>Qt::LeftToRight</enum>
+                              <string>Controls whether lines are automatically wrapped using the maximum number of characters in a line, or the minimum</string>
                              </property>
                              <item>
                               <property name="text">
-                               <string>Left</string>
+                               <string>Maximum line length</string>
                               </property>
                              </item>
                              <item>
                               <property name="text">
-                               <string>Center</string>
+                               <string>Minimum line length</string>
                               </property>
                              </item>
-                             <item>
-                              <property name="text">
-                               <string>Right</string>
-                              </property>
-                             </item>
-                            </widget>
-                           </item>
-                           <item row="2" column="2">
-                            <widget class="QgsPropertyOverrideButton" name="mFontMultiLineAlignDDBtn">
-                             <property name="text">
-                              <string>…</string>
-                             </property>
                             </widget>
                            </item>
                           </layout>
@@ -2095,8 +2145,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>464</width>
-                       <height>366</height>
+                       <width>466</width>
+                       <height>365</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2441,8 +2491,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>462</width>
-                       <height>738</height>
+                       <width>464</width>
+                       <height>776</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3214,8 +3264,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>448</width>
-                       <height>441</height>
+                       <width>452</width>
+                       <height>470</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -3675,8 +3725,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>448</width>
-                       <height>917</height>
+                       <width>452</width>
+                       <height>977</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -5309,8 +5359,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>448</width>
-                       <height>795</height>
+                       <width>452</width>
+                       <height>877</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -6188,6 +6238,34 @@ font-style: italic;</string>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgsdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsPropertyOverrideButton</class>
+   <extends>QToolButton</extends>
+   <header>qgspropertyoverridebutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsOpacityWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsopacitywidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsScrollArea</class>
    <extends>QScrollArea</extends>
    <header>qgsscrollarea.h</header>
@@ -6208,28 +6286,6 @@ font-style: italic;</string>
    <class>QgsScaleWidget</class>
    <extends>QWidget</extends>
    <header>qgsscalewidget.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsUnitSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsunitselectionwidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsPropertyOverrideButton</class>
-   <extends>QToolButton</extends>
-   <header>qgspropertyoverridebutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsBlendModeComboBox</class>
@@ -6256,12 +6312,6 @@ font-style: italic;</string>
    <class>QgsEffectStackCompactWidget</class>
    <extends>QWidget</extends>
    <header>effects/qgseffectstackpropertieswidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QgsOpacityWidget</class>
-   <extends>QWidget</extends>
-   <header>qgsopacitywidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -6307,6 +6357,9 @@ font-style: italic;</string>
   <tabstop>scrollArea_5</tabstop>
   <tabstop>wrapCharacterEdit</tabstop>
   <tabstop>mWrapCharDDBtn</tabstop>
+  <tabstop>mAutoWrapLengthSpinBox</tabstop>
+  <tabstop>mAutoWrapLengthDDBtn</tabstop>
+  <tabstop>mAutoWrapTypeComboBox</tabstop>
   <tabstop>mFontLineHeightSpinBox</tabstop>
   <tabstop>mFontLineHeightDDBtn</tabstop>
   <tabstop>mFontMultiLineAlignComboBox</tabstop>
@@ -6511,6 +6564,12 @@ font-style: italic;</string>
   <tabstop>scrollArea_mPreview</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>

--- a/tests/src/core/testqgspallabeling.cpp
+++ b/tests/src/core/testqgspallabeling.cpp
@@ -61,6 +61,14 @@ void TestQgsPalLabeling::wrapChar()
   QCOMPARE( QgsPalLabeling::splitToLines( "mixed new line\nand char", QString( " " ) ), QStringList() << "mixed" << "new" << "line" << "and" << "char" );
   QCOMPARE( QgsPalLabeling::splitToLines( "no matching chars", QString( "#" ) ), QStringList() << "no matching chars" );
   QCOMPARE( QgsPalLabeling::splitToLines( "no\nmatching\nchars", QString( "#" ) ), QStringList() << "no" << "matching" << "chars" );
+
+  // with auto wrap
+  QCOMPARE( QgsPalLabeling::splitToLines( "with auto wrap", QString(), 12, true ), QStringList() << "with auto" << "wrap" );
+  QCOMPARE( QgsPalLabeling::splitToLines( "with auto wrap", QString(), 6, false ), QStringList() << "with auto" << "wrap" );
+
+  // manual wrap character should take precedence
+  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 12, true ), QStringList() << "with auto" << "wrap and" << "manual" << "wrap" );
+  QCOMPARE( QgsPalLabeling::splitToLines( QStringLiteral( "with auto-wrap and manual-wrap" ), QStringLiteral( "-" ), 6, false ), QStringList() << "with auto" << "wrap and" << "manual" << "wrap" );
 }
 
 void TestQgsPalLabeling::graphemes()

--- a/tests/src/core/testqgsstringutils.cpp
+++ b/tests/src/core/testqgsstringutils.cpp
@@ -38,6 +38,8 @@ class TestQgsStringUtils : public QObject
     void titleCase();
     void ampersandEncode_data();
     void ampersandEncode();
+    void wordWrap_data();
+    void wordWrap();
 
 };
 
@@ -204,6 +206,35 @@ void TestQgsStringUtils::ampersandEncode()
   QFETCH( QString, expected );
   QCOMPARE( QgsStringUtils::ampersandEncode( input ), expected );
 
+}
+
+void TestQgsStringUtils::wordWrap_data()
+{
+  QTest::addColumn<QString>( "input" );
+  QTest::addColumn<int>( "length" );
+  QTest::addColumn<bool>( "isMax" );
+  QTest::addColumn<QString>( "delimiter" );
+  QTest::addColumn<QString>( "expected" );
+
+  QTest::newRow( "wordwrap" ) << "university of qgis" << 13 << true << QString() << "university of\nqgis";
+  QTest::newRow( "optional parameters unspecified" ) << "test string" << 5 << true << QString() << "test\nstring";
+  QTest::newRow( "wordwrap with delim" ) << "university of qgis" << 13 << true << QStringLiteral( " " ) << "university of\nqgis";
+  QTest::newRow( "wordwrap min" ) << "university of qgis" << 3 << false << QStringLiteral( " " ) << "university\nof qgis";
+  QTest::newRow( "wordwrap min with delim" ) << "university of qgis" << 3 << false << QStringLiteral( " " ) << "university\nof qgis";
+  QTest::newRow( "wordwrap on multi line" ) << "university of qgis\nsupports many multiline" << 5 << false << QStringLiteral( " " ) << "university\nof qgis\nsupports\nmany multiline";
+  QTest::newRow( "wordwrap on zero-space width" ) << QStringLiteral( "test%1zero-width space" ).arg( QChar( 8203 ) ) << 4 << false << QString() << "test\nzero-width\nspace";
+  QTest::newRow( "optional parameters specified" ) << "testxstring" << 5 << true << "x" << "test\nstring";
+}
+
+void TestQgsStringUtils::wordWrap()
+{
+  QFETCH( QString, input );
+  QFETCH( int, length );
+  QFETCH( bool, isMax );
+  QFETCH( QString, delimiter );
+  QFETCH( QString, expected );
+
+  QCOMPARE( QgsStringUtils::wordWrap( input, length, isMax, delimiter ), expected );
 }
 
 


### PR DESCRIPTION
Fixes an issue identified in the upcoming QGIS Map Design 2nd ed
(spoiler alert!) where it's impossible to utilise label text
substitutions if you also want to use word wrapping.

This isn't possible to directly fix, because we need to evaluate
the full label expression (including the word wrapping component)
in order to actually HAVE text to substitute into.

So, a new setting has been added to the label formatting tab
allowing users to directly set an auto-wrapping line ideal
line size. This is applied AFTER label text evaluation, substitutions,
and the 'wrap text on' character, so it can play correctly well with
all these other settings. This also has the nice side-effect
of making auto label text wrapping more accessible to new
users/those unfamiliar with the wordwrap expression function.

Fixes #20007, and cleans up a chapter of QMD 2ed ;)