### PR TITLE
[#19980] Fix cannot paste style when geometry doesn't match

### DIFF
--- a/python/core/auto_generated/qgsxmlutils.sip.in
+++ b/python/core/auto_generated/qgsxmlutils.sip.in
@@ -9,6 +9,9 @@
 
 
 
+
+
+
 class QgsXmlUtils
 {
 %Docstring
@@ -67,6 +70,7 @@ Supported types are
 %Docstring
 Read a QVariant from a QDomElement.
 %End
+
 };
 
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8884,6 +8884,7 @@ void QgisApp::copyStyle( QgsMapLayer *sourceLayer, QgsMapLayer::StyleCategories 
     }
     // Copies data in text form as well, so the XML can be pasted into a text editor
     clipboard()->setData( QGSCLIPBOARD_STYLE_MIME, doc.toByteArray(), doc.toString() );
+
     // Enables the paste menu element
     mActionPasteStyle->setEnabled( true );
   }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1059,9 +1059,10 @@ bool QgsMapLayer::importNamedStyle( QDomDocument &myDocument, QString &myErrorMe
   {
     QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( this );
     QgsWkbTypes::GeometryType importLayerGeometryType = static_cast<QgsWkbTypes::GeometryType>( myRoot.firstChildElement( QStringLiteral( "layerGeometryType" ) ).text().toInt() );
-    if ( vl->geometryType() != importLayerGeometryType )
+    if ( vl->geometryType() != importLayerGeometryType &&
+         ( categories.testFlag( QgsMapLayer::Symbology ) || categories.testFlag( QgsMapLayer::Symbology3D ) ) )
     {
-      myErrorMessage = tr( "Cannot apply style to layer with a different geometry type" );
+      myErrorMessage = tr( "Cannot apply style with symbology to layer with a different geometry type" );
       return false;
     }
   }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -551,6 +551,11 @@ bool QgsMapLayer::writeLayerXml( QDomElement &layerElement, QDomDocument &docume
 void QgsMapLayer::writeCommonStyle( QDomElement &layerElement, QDomDocument &document,
                                     const QgsReadWriteContext &context, QgsMapLayer::StyleCategories categories ) const
 {
+  // save categories
+  QMetaEnum metaEnum = QMetaEnum::fromType<QgsMapLayer::StyleCategories>();
+  QString categoriesKeys( metaEnum.valueToKeys( static_cast<int>( categories ) ) );
+  layerElement.setAttribute( QStringLiteral( "style_categories" ), categoriesKeys );
+
   if ( categories.testFlag( Rendering ) )
   {
     // use scale dependent visibility flag

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -554,7 +554,7 @@ void QgsMapLayer::writeCommonStyle( QDomElement &layerElement, QDomDocument &doc
   // save categories
   QMetaEnum metaEnum = QMetaEnum::fromType<QgsMapLayer::StyleCategories>();
   QString categoriesKeys( metaEnum.valueToKeys( static_cast<int>( categories ) ) );
-  layerElement.setAttribute( QStringLiteral( "style_categories" ), categoriesKeys );
+  layerElement.setAttribute( QStringLiteral( "styleCategories" ), categoriesKeys );
 
   if ( categories.testFlag( Rendering ) )
   {
@@ -1060,17 +1060,7 @@ bool QgsMapLayer::importNamedStyle( QDomDocument &myDocument, QString &myErrorMe
   }
 
   // Get source categories
-  QgsMapLayer::StyleCategories sourceCategories = QgsMapLayer::AllStyleCategories;
-  QMetaEnum metaEnum = QMetaEnum::fromType<QgsMapLayer::StyleCategories>();
-  QString sourceCategoriesStr( myRoot.attribute( "style_categories", metaEnum.valueToKeys( static_cast<int>( QgsMapLayer::AllStyleCategories ) ) ) );
-  if ( metaEnum.isValid() )
-  {
-    bool ok = false;
-    const char *vs = sourceCategoriesStr.toUtf8().data();
-    int newValue = metaEnum.keysToValue( vs, &ok );
-    if ( ok )
-      sourceCategories = static_cast<QgsMapLayer::StyleCategories>( newValue );
-  }
+  QgsMapLayer::StyleCategories sourceCategories = QgsXmlUtils::readFlagAttribute( myRoot, QStringLiteral( "styleCategories" ), QgsMapLayer::AllStyleCategories );
 
   //Test for matching geometry type on vector layers when applying, if geometry type is given in the style
   if ( ( sourceCategories.testFlag( QgsMapLayer::Symbology ) || sourceCategories.testFlag( QgsMapLayer::Symbology3D ) ) &&

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1059,16 +1059,32 @@ bool QgsMapLayer::importNamedStyle( QDomDocument &myDocument, QString &myErrorMe
     styleFile.updateRevision( thisVersion );
   }
 
-  //Test for matching geometry type on vector layers when applying, if geometry type is given in the style
-  if ( type() == QgsMapLayer::VectorLayer && !myRoot.firstChildElement( QStringLiteral( "layerGeometryType" ) ).isNull() )
+  // Get source categories
+  QgsMapLayer::StyleCategories sourceCategories = QgsMapLayer::AllStyleCategories;
+  QMetaEnum metaEnum = QMetaEnum::fromType<QgsMapLayer::StyleCategories>();
+  QString sourceCategoriesStr( myRoot.attribute( "style_categories", metaEnum.valueToKeys( static_cast<int>( QgsMapLayer::AllStyleCategories ) ) ) );
+  if ( metaEnum.isValid() )
   {
-    QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( this );
-    QgsWkbTypes::GeometryType importLayerGeometryType = static_cast<QgsWkbTypes::GeometryType>( myRoot.firstChildElement( QStringLiteral( "layerGeometryType" ) ).text().toInt() );
-    if ( vl->geometryType() != importLayerGeometryType &&
-         ( categories.testFlag( QgsMapLayer::Symbology ) || categories.testFlag( QgsMapLayer::Symbology3D ) ) )
+    bool ok = false;
+    const char *vs = sourceCategoriesStr.toUtf8().data();
+    int newValue = metaEnum.keysToValue( vs, &ok );
+    if ( ok )
+      sourceCategories = static_cast<QgsMapLayer::StyleCategories>( newValue );
+  }
+
+  //Test for matching geometry type on vector layers when applying, if geometry type is given in the style
+  if ( ( sourceCategories.testFlag( QgsMapLayer::Symbology ) || sourceCategories.testFlag( QgsMapLayer::Symbology3D ) ) &&
+       ( categories.testFlag( QgsMapLayer::Symbology ) || categories.testFlag( QgsMapLayer::Symbology3D ) ) )
+  {
+    if ( type() == QgsMapLayer::VectorLayer && !myRoot.firstChildElement( QStringLiteral( "layerGeometryType" ) ).isNull() )
     {
-      myErrorMessage = tr( "Cannot apply style with symbology to layer with a different geometry type" );
-      return false;
+      QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( this );
+      QgsWkbTypes::GeometryType importLayerGeometryType = static_cast<QgsWkbTypes::GeometryType>( myRoot.firstChildElement( QStringLiteral( "layerGeometryType" ) ).text().toInt() );
+      if ( vl->geometryType() != importLayerGeometryType )
+      {
+        myErrorMessage = tr( "Cannot apply style with symbology to layer with a different geometry type" );
+        return false;
+      }
     }
   }
 

--- a/src/core/qgsxmlutils.h
+++ b/src/core/qgsxmlutils.h
@@ -16,13 +16,16 @@
 #define QGSXMLUTILS_H
 
 class QDomDocument;
-class QDomElement;
 
 class QgsRectangle;
+
+#include <QDomElement>
 
 #include "qgis_core.h"
 #include "qgis.h"
 #include "qgsunittypes.h"
+
+
 
 /**
  * \ingroup core
@@ -75,6 +78,23 @@ class CORE_EXPORT QgsXmlUtils
      * Read a QVariant from a QDomElement.
      */
     static QVariant readVariant( const QDomElement &element );
+
+    template<class T> static T readFlagAttribute( const QDomElement &element, const QString &attributeName, T defaultValue ) SIP_SKIP
+    {
+      T value = defaultValue;
+      // Get source categories
+      QMetaEnum metaEnum = QMetaEnum::fromType<T>();
+      QString sourceCategoriesStr( element.attribute( attributeName, metaEnum.valueToKeys( static_cast<int>( defaultValue ) ) ) );
+      if ( metaEnum.isValid() )
+      {
+        bool ok = false;
+        const char *vs = sourceCategoriesStr.toUtf8().data();
+        int newValue = metaEnum.keysToValue( vs, &ok );
+        if ( ok )
+          value = static_cast<T>( newValue );
+      }
+      return value;
+    }
 };
 
 

--- a/src/core/qgsxmlutils.h
+++ b/src/core/qgsxmlutils.h
@@ -79,6 +79,15 @@ class CORE_EXPORT QgsXmlUtils
      */
     static QVariant readVariant( const QDomElement &element );
 
+    /**
+     * Read a flag value from an attribute of the element.
+     * \param element the element to read the attribute from
+     * \param attributeName the attribute name
+     * \param defaultValue the default value as a flag
+     * \note The flag value is a text as returned by \see QMetaEnum::valueToKeys.
+     *       The flag must have been declared with Q_ENUM macro.
+     * \since QGIS 3.4
+     */
     template<class T> static T readFlagAttribute( const QDomElement &element, const QString &attributeName, T defaultValue ) SIP_SKIP
     {
       T value = defaultValue;


### PR DESCRIPTION
this brings it a bit further.
The StyleCategories are now saved in the XML as an attribute.
So pasting only fails if the source AND the destination categories have Symbology or Symbology3D.
And...bonus: the categories are disabled in the paste style menu if they are not in the source:

![image](https://user-images.githubusercontent.com/127259/46475574-e29fd880-c7b3-11e8-86ec-3ed83e51f9c9.png)

