### PR TITLE
fixes the ogr2ogr based geoprocessing tools

### DIFF
--- a/python/plugins/processing/algs/gdal/Buffer.py
+++ b/python/plugins/processing/algs/gdal/Buffer.py
@@ -125,7 +125,7 @@ class Buffer(GdalAlgorithm):
             other_fields.append(f.name())
 
         if other_fields:
-            other_fields = ', {}'.format(','.join(other_fields))
+            other_fields = ',*'
         else:
             other_fields = ''
 

--- a/python/plugins/processing/algs/gdal/Dissolve.py
+++ b/python/plugins/processing/algs/gdal/Dissolve.py
@@ -135,7 +135,7 @@ class Dissolve(GdalAlgorithm):
             other_fields.append(f.name())
 
         if other_fields:
-            other_fields = ', {}'.format(','.join(other_fields))
+            other_fields = ',*'
         else:
             other_fields = ''
 

--- a/python/plugins/processing/algs/gdal/OffsetCurve.py
+++ b/python/plugins/processing/algs/gdal/OffsetCurve.py
@@ -107,7 +107,7 @@ class OffsetCurve(GdalAlgorithm):
             other_fields.append(f.name())
 
         if other_fields:
-            other_fields = ', {}'.format(','.join(other_fields))
+            other_fields = ',*'
         else:
             other_fields = ''
 

--- a/python/plugins/processing/algs/gdal/OneSideBuffer.py
+++ b/python/plugins/processing/algs/gdal/OneSideBuffer.py
@@ -136,7 +136,7 @@ class OneSideBuffer(GdalAlgorithm):
             other_fields.append(f.name())
 
         if other_fields:
-            other_fields = ', {}'.format(','.join(other_fields))
+            other_fields = ',*'
         else:
             other_fields = ''
 

--- a/python/plugins/processing/algs/gdal/PointsAlongLines.py
+++ b/python/plugins/processing/algs/gdal/PointsAlongLines.py
@@ -111,7 +111,7 @@ class PointsAlongLines(GdalAlgorithm):
             other_fields.append(f.name())
 
         if other_fields:
-            other_fields = ', {}'.format(','.join(other_fields))
+            other_fields = ',*'
         else:
             other_fields = ''
 


### PR DESCRIPTION
## Description
In ogr2ogr based geoprocessing tools we build the SQL statements using the flag "-dialect SQLITE". When using it then in the SELECT of the query is not possible to pass the full list of attributes (generated on the fly by QGIS) because the attribute recognized by ogr as "FID Column" in the datasource is not selectable (not sure why, but confirmed by Evan). So instead of the full list of attributes we use * as we did on 2.*

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
