### PR TITLE
[processing] Fix random selection count parameter

### DIFF
--- a/python/plugins/processing/algs/qgis/Aspect.py
+++ b/python/plugins/processing/algs/qgis/Aspect.py
@@ -62,7 +62,7 @@ class Aspect(QgisAlgorithm):
                                                             self.tr('Elevation layer')))
         self.addParameter(QgsProcessingParameterNumber(self.Z_FACTOR,
                                                        self.tr('Z factor'), QgsProcessingParameterNumber.Double,
-                                                       1, False, 0.00, 999999.99))
+                                                       1, False, 0.00))
         self.addParameter(QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr('Aspect')))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/CreateConstantRaster.py
+++ b/python/plugins/processing/algs/qgis/CreateConstantRaster.py
@@ -66,7 +66,7 @@ class CreateConstantRaster(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.PIXEL_SIZE,
                                                        self.tr('Pixel size'),
                                                        QgsProcessingParameterNumber.Double,
-                                                       0.1, False, 0.01, 999))
+                                                       0.1, False, 0.01))
         self.addParameter(QgsProcessingParameterNumber(self.NUMBER,
                                                        self.tr('Constant value'),
                                                        QgsProcessingParameterNumber.Double,

--- a/python/plugins/processing/algs/qgis/Heatmap.py
+++ b/python/plugins/processing/algs/qgis/Heatmap.py
@@ -99,7 +99,7 @@ class Heatmap(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterDistance(self.RADIUS,
                                                          self.tr('Radius'),
-                                                         100.0, self.INPUT, False, 0.0, 9999999999.99))
+                                                         100.0, self.INPUT, False, 0.0))
 
         radius_field_param = QgsProcessingParameterField(self.RADIUS_FIELD,
                                                          self.tr('Radius from field'),
@@ -113,9 +113,9 @@ class Heatmap(QgisAlgorithm):
 
         class ParameterHeatmapPixelSize(QgsProcessingParameterNumber):
 
-            def __init__(self, name='', description='', parent_layer=None, radius_param=None, radius_field_param=None, minValue=None, maxValue=None,
+            def __init__(self, name='', description='', parent_layer=None, radius_param=None, radius_field_param=None, minValue=None,
                          default=None, optional=False):
-                QgsProcessingParameterNumber.__init__(self, name, description, QgsProcessingParameterNumber.Double, default, optional, minValue, maxValue)
+                QgsProcessingParameterNumber.__init__(self, name, description, QgsProcessingParameterNumber.Double, default, optional, minValue)
                 self.parent_layer = parent_layer
                 self.radius_param = radius_param
                 self.radius_field_param = radius_field_param
@@ -130,7 +130,6 @@ class Heatmap(QgisAlgorithm):
                                                      radius_param=self.RADIUS,
                                                      radius_field_param=self.RADIUS_FIELD,
                                                      minValue=0.0,
-                                                     maxValue=9999999999,
                                                      default=0.1)
         pixel_size_param.setMetadata({
             'widget_wrapper': {

--- a/python/plugins/processing/algs/qgis/Hillshade.py
+++ b/python/plugins/processing/algs/qgis/Hillshade.py
@@ -64,7 +64,7 @@ class Hillshade(QgisAlgorithm):
                                                             self.tr('Elevation layer')))
         self.addParameter(QgsProcessingParameterNumber(self.Z_FACTOR,
                                                        self.tr('Z factor'), QgsProcessingParameterNumber.Double,
-                                                       1, False, 0.00, 999999.99))
+                                                       1, False, 0.00))
         self.addParameter(QgsProcessingParameterNumber(self.AZIMUTH,
                                                        self.tr('Azimuth (horizontal angle)'), QgsProcessingParameterNumber.Double,
                                                        300, False, 0, 360))

--- a/python/plugins/processing/algs/qgis/HypsometricCurves.py
+++ b/python/plugins/processing/algs/qgis/HypsometricCurves.py
@@ -69,7 +69,7 @@ class HypsometricCurves(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterFeatureSource(self.BOUNDARY_LAYER,
                                                               self.tr('Boundary layer'), [QgsProcessing.TypeVectorPolygon]))
         self.addParameter(QgsProcessingParameterNumber(self.STEP,
-                                                       self.tr('Step'), type=QgsProcessingParameterNumber.Double, minValue=0.0, maxValue=999999999.999999, defaultValue=100.0))
+                                                       self.tr('Step'), type=QgsProcessingParameterNumber.Double, minValue=0.0, defaultValue=100.0))
         self.addParameter(QgsProcessingParameterBoolean(self.USE_PERCENTAGE,
                                                         self.tr('Use % of area instead of absolute value'), defaultValue=False))
 

--- a/python/plugins/processing/algs/qgis/PointDistance.py
+++ b/python/plugins/processing/algs/qgis/PointDistance.py
@@ -101,7 +101,7 @@ class PointDistance(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterEnum(self.MATRIX_TYPE,
                                                      self.tr('Output matrix type'), options=self.mat_types, defaultValue=0))
         self.addParameter(QgsProcessingParameterNumber(self.NEAREST_POINTS,
-                                                       self.tr('Use only the nearest (k) target points'), type=QgsProcessingParameterNumber.Integer, minValue=0, maxValue=9999, defaultValue=0))
+                                                       self.tr('Use only the nearest (k) target points'), type=QgsProcessingParameterNumber.Integer, minValue=0, defaultValue=0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Distance matrix'), QgsProcessing.TypeVectorPoint))
 

--- a/python/plugins/processing/algs/qgis/RandomExtract.py
+++ b/python/plugins/processing/algs/qgis/RandomExtract.py
@@ -66,7 +66,7 @@ class RandomExtract(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterNumber(self.NUMBER,
                                                        self.tr('Number/percentage of selected features'), QgsProcessingParameterNumber.Integer,
-                                                       10, False, 0.0, 999999999999.0))
+                                                       10, False, 0.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Extracted (random)')))
 

--- a/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomExtractWithinSubsets.py
@@ -72,7 +72,7 @@ class RandomExtractWithinSubsets(QgisAlgorithm):
 
         self.addParameter(QgsProcessingParameterNumber(self.NUMBER,
                                                        self.tr('Number/percentage of selected features'), QgsProcessingParameterNumber.Integer,
-                                                       10, False, 0.0, 999999999999.0))
+                                                       10, False, 0.0))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT, self.tr('Extracted (random stratified)')))
 

--- a/python/plugins/processing/algs/qgis/RandomSelection.py
+++ b/python/plugins/processing/algs/qgis/RandomSelection.py
@@ -80,7 +80,7 @@ class RandomSelection(QgisAlgorithm):
                                                      self.tr('Method'), self.methods, False, 0))
         self.addParameter(QgsProcessingParameterNumber(self.NUMBER,
                                                        self.tr('Number/percentage of selected features'), QgsProcessingParameterNumber.Integer,
-                                                       10, False, 0.0, 999999999999.0))
+                                                       10, False, 0.0))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Selected (random)')))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
+++ b/python/plugins/processing/algs/qgis/RandomSelectionWithinSubsets.py
@@ -86,7 +86,7 @@ class RandomSelectionWithinSubsets(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.NUMBER,
                                                        self.tr('Number/percentage of selected features'),
                                                        QgsProcessingParameterNumber.Integer,
-                                                       10, False, 0.0, 999999999999.0))
+                                                       10, False, 0.0))
         self.addOutput(QgsProcessingOutputVectorLayer(self.OUTPUT, self.tr('Selected (stratified random)')))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsFixed.py
+++ b/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsFixed.py
@@ -71,15 +71,14 @@ class RectanglesOvalsDiamondsFixed(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterEnum(self.SHAPE,
                                                      self.tr('Buffer shape'), options=self.shapes))
         self.addParameter(QgsProcessingParameterDistance(self.WIDTH, self.tr('Width'), parentParameterName=self.INPUT,
-                                                         minValue=0.0000001, maxValue=999999999.0, defaultValue=1.0))
+                                                         minValue=0.0000001, defaultValue=1.0))
         self.addParameter(QgsProcessingParameterDistance(self.HEIGHT, self.tr('Height'), parentParameterName=self.INPUT,
-                                                         minValue=0.0000001, maxValue=999999999.0, defaultValue=1.0))
+                                                         minValue=0.0000001, defaultValue=1.0))
         self.addParameter(QgsProcessingParameterNumber(self.ROTATION, self.tr('Rotation'), type=QgsProcessingParameterNumber.Double,
                                                        minValue=0.0, maxValue=360.0, optional=True))
         self.addParameter(QgsProcessingParameterNumber(self.SEGMENTS,
                                                        self.tr('Number of segments'),
                                                        minValue=1,
-                                                       maxValue=999999999,
                                                        defaultValue=36))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT,

--- a/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsVariable.py
+++ b/python/plugins/processing/algs/qgis/RectanglesOvalsDiamondsVariable.py
@@ -90,7 +90,6 @@ class RectanglesOvalsDiamondsVariable(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.SEGMENTS,
                                                        self.tr('Number of segments'),
                                                        minValue=1,
-                                                       maxValue=999999999,
                                                        defaultValue=36))
 
         self.addParameter(QgsProcessingParameterFeatureSink(self.OUTPUT,

--- a/python/plugins/processing/algs/qgis/RegularPoints.py
+++ b/python/plugins/processing/algs/qgis/RegularPoints.py
@@ -81,9 +81,9 @@ class RegularPoints(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterExtent(self.EXTENT,
                                                        self.tr('Input extent'), optional=False))
         self.addParameter(QgsProcessingParameterDistance(self.SPACING,
-                                                         self.tr('Point spacing/count'), 100, self.CRS, False, 0.000001, 999999999.999999999))
+                                                         self.tr('Point spacing/count'), 100, self.CRS, False, 0.000001))
         self.addParameter(QgsProcessingParameterDistance(self.INSET,
-                                                         self.tr('Initial inset from corner (LH side)'), 0.0, self.CRS, False, 0.0, 9999.9999))
+                                                         self.tr('Initial inset from corner (LH side)'), 0.0, self.CRS, False, 0.0))
         self.addParameter(QgsProcessingParameterBoolean(self.RANDOMIZE,
                                                         self.tr('Apply random offset to point spacing'), False))
         self.addParameter(QgsProcessingParameterBoolean(self.IS_SPACING,

--- a/python/plugins/processing/algs/qgis/Relief.py
+++ b/python/plugins/processing/algs/qgis/Relief.py
@@ -108,7 +108,7 @@ class Relief(QgisAlgorithm):
                                                             self.tr('Elevation layer')))
         self.addParameter(QgsProcessingParameterNumber(self.Z_FACTOR,
                                                        self.tr('Z factor'), type=QgsProcessingParameterNumber.Double,
-                                                       minValue=0.00, maxValue=999999.99, defaultValue=1.0))
+                                                       minValue=0.00, defaultValue=1.0))
         self.addParameter(QgsProcessingParameterBoolean(self.AUTO_COLORS,
                                                         self.tr('Generate relief classes automatically'),
                                                         defaultValue=False))

--- a/python/plugins/processing/algs/qgis/Ruggedness.py
+++ b/python/plugins/processing/algs/qgis/Ruggedness.py
@@ -62,7 +62,7 @@ class Ruggedness(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.Z_FACTOR,
                                                        self.tr('Z factor'),
                                                        QgsProcessingParameterNumber.Double,
-                                                       1, False, 0.00, 999999.99))
+                                                       1, False, 0.00))
         self.addParameter(QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr('Ruggedness')))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/ServiceAreaFromLayer.py
+++ b/python/plugins/processing/algs/qgis/ServiceAreaFromLayer.py
@@ -118,7 +118,7 @@ class ServiceAreaFromLayer(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.TRAVEL_COST,
                                                        self.tr('Travel cost (distance for "Shortest", time for "Fastest")'),
                                                        QgsProcessingParameterNumber.Double,
-                                                       0.0, False, 0, 99999999.99))
+                                                       0.0, False, 0))
 
         params = []
         params.append(QgsProcessingParameterField(self.DIRECTION_FIELD,
@@ -147,10 +147,10 @@ class ServiceAreaFromLayer(QgisAlgorithm):
         params.append(QgsProcessingParameterNumber(self.DEFAULT_SPEED,
                                                    self.tr('Default speed (km/h)'),
                                                    QgsProcessingParameterNumber.Double,
-                                                   5.0, False, 0, 99999999.99))
+                                                   5.0, False, 0))
         params.append(QgsProcessingParameterDistance(self.TOLERANCE,
                                                      self.tr('Topology tolerance'),
-                                                     0.0, self.INPUT, False, 0, 99999999.99))
+                                                     0.0, self.INPUT, False, 0))
         params.append(QgsProcessingParameterBoolean(self.INCLUDE_BOUNDS,
                                                     self.tr('Include upper/lower bound points'),
                                                     defaultValue=False))

--- a/python/plugins/processing/algs/qgis/ServiceAreaFromPoint.py
+++ b/python/plugins/processing/algs/qgis/ServiceAreaFromPoint.py
@@ -115,7 +115,7 @@ class ServiceAreaFromPoint(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterNumber(self.TRAVEL_COST,
                                                        self.tr('Travel cost (distance for "Shortest", time for "Fastest")'),
                                                        QgsProcessingParameterNumber.Double,
-                                                       0.0, False, 0, 99999999.99))
+                                                       0.0, False, 0))
 
         params = []
         params.append(QgsProcessingParameterField(self.DIRECTION_FIELD,
@@ -144,10 +144,10 @@ class ServiceAreaFromPoint(QgisAlgorithm):
         params.append(QgsProcessingParameterNumber(self.DEFAULT_SPEED,
                                                    self.tr('Default speed (km/h)'),
                                                    QgsProcessingParameterNumber.Double,
-                                                   5.0, False, 0, 99999999.99))
+                                                   5.0, False, 0))
         params.append(QgsProcessingParameterDistance(self.TOLERANCE,
                                                      self.tr('Topology tolerance'),
-                                                     0.0, self.INPUT, False, 0, 99999999.99))
+                                                     0.0, self.INPUT, False, 0))
         params.append(QgsProcessingParameterBoolean(self.INCLUDE_BOUNDS,
                                                     self.tr('Include upper/lower bound points'),
                                                     defaultValue=False))

--- a/python/plugins/processing/algs/qgis/Slope.py
+++ b/python/plugins/processing/algs/qgis/Slope.py
@@ -62,7 +62,7 @@ class Slope(QgisAlgorithm):
                                                             self.tr('Elevation layer')))
         self.addParameter(QgsProcessingParameterNumber(self.Z_FACTOR,
                                                        self.tr('Z factor'), QgsProcessingParameterNumber.Double,
-                                                       1, False, 0.00, 999999.99))
+                                                       1, False, 0.00))
         self.addParameter(QgsProcessingParameterRasterDestination(self.OUTPUT, self.tr('Slope')))
 
     def name(self):

--- a/python/plugins/processing/algs/qgis/SnapGeometries.py
+++ b/python/plugins/processing/algs/qgis/SnapGeometries.py
@@ -64,7 +64,7 @@ class SnapGeometriesToLayer(QgisAlgorithm):
                                                                QgsProcessing.TypeVectorPolygon]))
 
         self.addParameter(QgsProcessingParameterDistance(self.TOLERANCE, self.tr('Tolerance'), parentParameterName=self.INPUT,
-                                                         minValue=0.00000001, maxValue=9999999999, defaultValue=10.0))
+                                                         minValue=0.00000001, defaultValue=10.0))
 
         self.modes = [self.tr('Prefer aligning nodes, insert extra vertices where required'),
                       self.tr('Prefer closest point, insert extra vertices where required'),

--- a/python/plugins/processing/algs/qgis/TopoColors.py
+++ b/python/plugins/processing/algs/qgis/TopoColors.py
@@ -82,7 +82,7 @@ class TopoColor(QgisAlgorithm):
         self.addParameter(QgsProcessingParameterDistance(self.MIN_DISTANCE,
                                                          self.tr('Minimum distance between features'),
                                                          parentParameterName=self.INPUT, minValue=0.0,
-                                                         maxValue=999999999.0, defaultValue=0.0))
+                                                         defaultValue=0.0))
         balance_by = [self.tr('By feature count'),
                       self.tr('By assigned area'),
                       self.tr('By distance between colors')]

--- a/python/plugins/processing/algs/qgis/VoronoiPolygons.py
+++ b/python/plugins/processing/algs/qgis/VoronoiPolygons.py
@@ -78,7 +78,7 @@ class VoronoiPolygons(QgisAlgorithm):
         self.addParameter(
             QgsProcessingParameterNumber(
                 self.BUFFER, self.tr('Buffer region (% of extent)'),
-                minValue=0.0, maxValue=9999999999, defaultValue=0.0))
+                minValue=0.0, defaultValue=0.0))
         self.addParameter(
             QgsProcessingParameterFeatureSink(
                 self.OUTPUT, self.tr('Voronoi polygons'),


### PR DESCRIPTION
Remove a bunch of manual "max" values for numeric parameters
where the maximum just represents a 'large number' and not a real
constraint, and let the default parameter max value handling kick in instead.

In the case of random selection the max value exceeded the possible
range for integers in spin boxes and broke the widget.

Fixes #20015
