### PR TITLE
[Bugfix][Server] WMS: The SLD content loaded from URL is not percent encoded

### DIFF
--- a/src/server/qgshttprequesthandler.cpp
+++ b/src/server/qgshttprequesthandler.cpp
@@ -602,7 +602,7 @@ void QgsHttpRequestHandler::requestStringToParameterMap( const QString& request,
       {
         continue; //only http and ftp supported at the moment
       }
-      value = QUrl::fromPercentEncoding( fileContents );
+      value = QString( fileContents );
 #else
       QgsMessageLog::logMessage( "http and ftp methods not supported with Qt5." );
       continue;


### PR DESCRIPTION
## Description
QGIS Server parses key/value pairs, decodes them from percent and converts them to UTF8.

In the case of SLD parameter, the value is an URL. The content was loaded and decoded from percent. The decoding has not to be done.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
