### PR TITLE
Force legend update when raster properties changes

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -55,6 +55,7 @@
 #include "qgshuesaturationfilter.h"
 #include "qgshillshaderendererwidget.h"
 #include "qgssettings.h"
+#include "qgsmaplayerlegend.h"
 
 #include <QDesktopServices>
 #include <QTableWidgetItem>
@@ -1052,8 +1053,12 @@ void QgsRasterLayerProperties::apply()
   mRasterLayer->setCustomProperty( "WMSPublishDataSourceUrl", mPublishDataSourceUrlCheckBox->isChecked() );
   mRasterLayer->setCustomProperty( "WMSBackgroundLayer", mBackgroundLayerCheckBox->isChecked() );
 
-  // update symbology
+
+  // update symbology (this is now disconnected)
   emit refreshLegend( mRasterLayer->id(), false );
+
+  // Force a redraw of the legend
+  mRasterLayer->setLegend( QgsMapLayerLegend::defaultRasterLegend( mRasterLayer ) );
 
   //make sure the layer is redrawn
   mRasterLayer->triggerRepaint();

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1054,8 +1054,10 @@ void QgsRasterLayerProperties::apply()
   mRasterLayer->setCustomProperty( "WMSBackgroundLayer", mBackgroundLayerCheckBox->isChecked() );
 
 
-  // update symbology (this is now disconnected)
+  // update symbology (this is now deprecated and disconnected)
+  Q_NOWARN_DEPRECATED_PUSH
   emit refreshLegend( mRasterLayer->id(), false );
+  Q_NOWARN_DEPRECATED_POP
 
   // Force a redraw of the legend
   mRasterLayer->setLegend( QgsMapLayerLegend::defaultRasterLegend( mRasterLayer ) );

--- a/src/app/qgsrasterlayerproperties.h
+++ b/src/app/qgsrasterlayerproperties.h
@@ -141,7 +141,7 @@ class APP_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
 
   signals:
     //! Emitted when changes to layer were saved to update legend
-    void refreshLegend( const QString &layerID, bool expandItem );
+    Q_DECL_DEPRECATED void refreshLegend( const QString &layerID, bool expandItem ) SIP_DEPRECATED;
 
   private:
     QPushButton *mBtnStyle = nullptr;

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -754,8 +754,10 @@ void QgsVectorLayerProperties::apply()
   mLayer->geometryOptions()->setRemoveDuplicateNodes( mRemoveDuplicateNodesCheckbox->isChecked() );
   mLayer->geometryOptions()->setGeometryPrecision( mGeometryPrecisionSpinBox->value() );
 
-  // update symbology
+  // update symbology (this is now deprecated and disconnected)
+  Q_NOWARN_DEPRECATED_PUSH
   emit refreshLegend( mLayer->id() );
+  Q_NOWARN_DEPRECATED_POP
 
   mLayer->triggerRepaint();
   // notify the project we've made a change

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -133,8 +133,8 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
   signals:
 
     //! Emitted when changes to layer were saved to update legend
-    void refreshLegend( const QString &layerID, bool expandItem );
-    void refreshLegend( const QString &layerID );
+    Q_DECL_DEPRECATED void refreshLegend( const QString &layerID, bool expandItem ) SIP_DEPRECATED;
+    Q_DECL_DEPRECATED void refreshLegend( const QString &layerID ) SIP_DEPRECATED;
 
     void toggleEditing( QgsMapLayer * );
 


### PR DESCRIPTION
Fixes #18608 - Layer tree embedded widgets do not show up unless you move layer

There is still an issue because "Opacity" is the opposite of "Transparency"  ... but that's another bug.