### PR TITLE
Replace toUtf8().data() by toUtf8().constData()

### DIFF
--- a/python/core/auto_generated/expression/qgsexpression.sip.in
+++ b/python/core/auto_generated/expression/qgsexpression.sip.in
@@ -590,7 +590,7 @@ value. The value may be null.
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsExpression: '%1'>" ).arg( sipCpp->expression() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
 };

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -256,7 +256,7 @@ Returns true if the circle contains the ``point``.
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsCircle: %1>" ).arg( sipCpp->toString() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 };
 

--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -169,7 +169,7 @@ Sets the circular string's points
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsCircularString: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -173,7 +173,7 @@ Appends first point if not already closed.
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsCompoundCurve: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -219,7 +219,7 @@ Returns approximate rotation angle for a vertex. Usually average angle between a
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsCurvePolygon: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgsellipse.sip.in
+++ b/python/core/auto_generated/geometry/qgsellipse.sip.in
@@ -251,7 +251,7 @@ Members will be truncated to the specified precision.
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsEllipse: %1>" ).arg( sipCpp->toString() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1297,7 +1297,7 @@ Exports the geometry to WKT
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsGeometry: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
     QString asJson( int precision = 17 ) const;

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -330,7 +330,7 @@ of the curve.
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsLineString: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgsmulticurve.sip.in
+++ b/python/core/auto_generated/geometry/qgsmulticurve.sip.in
@@ -59,7 +59,7 @@ Returns a copy of the multi curve, where each component curve has had its line d
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsMultiCurve: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
 };

--- a/python/core/auto_generated/geometry/qgsmultilinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultilinestring.sip.in
@@ -56,7 +56,7 @@ Returns the geometry converted to the more generic curve type :py:class:`QgsMult
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsMultiLineString: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgsmultipoint.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipoint.sip.in
@@ -58,7 +58,7 @@ Multi point geometry collection.
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsMultiPoint: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgsmultipolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipolygon.sip.in
@@ -57,7 +57,7 @@ Returns the geometry converted to the more generic curve type :py:class:`QgsMult
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsMultiPolygon: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgspoint.sip.in
+++ b/python/core/auto_generated/geometry/qgspoint.sip.in
@@ -429,7 +429,7 @@ Angle undefined. Always returns 0.0
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsPoint: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgspolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgspolygon.sip.in
@@ -68,7 +68,7 @@ negative if the point lies outside the polygon.
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsPolygon: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
   protected:

--- a/python/core/auto_generated/geometry/qgsrectangle.sip.in
+++ b/python/core/auto_generated/geometry/qgsrectangle.sip.in
@@ -325,7 +325,7 @@ Converts the rectangle to a 3D box, with the specified
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsRectangle: %1>" ).arg( sipCpp->asWktCoordinates() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
 };

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -333,7 +333,7 @@ by manual field configuration.
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsField: %1 (%2)>" ).arg( sipCpp->name() ).arg( sipCpp->typeName() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
 }; // class QgsField

--- a/python/core/auto_generated/qgspointxy.sip.in
+++ b/python/core/auto_generated/qgspointxy.sip.in
@@ -231,7 +231,7 @@ Multiply x and y by the given value
     SIP_PYOBJECT __repr__();
 %MethodCode
     QString str = QStringLiteral( "<QgsPointXY: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
     int __len__();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10534,7 +10534,7 @@ void QgisApp::openURL( QString url, bool useQgisDocDirectory )
    * commandline application rather than a bundled application.
    */
   CFURLRef urlRef = CFURLCreateWithBytes( kCFAllocatorDefault,
-                                          reinterpret_cast<const UInt8 *>( url.toUtf8().data() ), url.length(),
+                                          reinterpret_cast<const UInt8 *>( url.toUtf8().constData() ), url.length(),
                                           kCFStringEncodingUTF8, nullptr );
   OSStatus status = LSOpenCFURLRef( urlRef, nullptr );
   status = 0; //avoid compiler warning

--- a/src/core/expression/qgsexpression.h
+++ b/src/core/expression/qgsexpression.h
@@ -614,7 +614,7 @@ class CORE_EXPORT QgsExpression
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsExpression: '%1'>" ).arg( sipCpp->expression() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgscircle.h
+++ b/src/core/geometry/qgscircle.h
@@ -251,7 +251,7 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsCircle: %1>" ).arg( sipCpp->toString() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 };

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -153,7 +153,7 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsCircularString: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -153,7 +153,7 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsCompoundCurve: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -209,7 +209,7 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsCurvePolygon: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgsellipse.h
+++ b/src/core/geometry/qgsellipse.h
@@ -244,7 +244,7 @@ class CORE_EXPORT QgsEllipse
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsEllipse: %1>" ).arg( sipCpp->toString() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1256,7 +1256,7 @@ class CORE_EXPORT QgsGeometry
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsGeometry: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -360,7 +360,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsLineString: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgsmulticurve.h
+++ b/src/core/geometry/qgsmulticurve.h
@@ -77,7 +77,7 @@ class CORE_EXPORT QgsMultiCurve: public QgsGeometryCollection
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsMultiCurve: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgsmultilinestring.h
+++ b/src/core/geometry/qgsmultilinestring.h
@@ -69,7 +69,7 @@ class CORE_EXPORT QgsMultiLineString: public QgsMultiCurve
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsMultiLineString: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsMultiPoint: public QgsGeometryCollection
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsMultiPoint: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgsmultipolygon.h
+++ b/src/core/geometry/qgsmultipolygon.h
@@ -69,7 +69,7 @@ class CORE_EXPORT QgsMultiPolygon: public QgsMultiSurface
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsMultiPolygon: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -500,7 +500,7 @@ class CORE_EXPORT QgsPoint: public QgsAbstractGeometry
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsPoint: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -88,7 +88,7 @@ class CORE_EXPORT QgsPolygon: public QgsCurvePolygon
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsPolygon: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -545,7 +545,7 @@ class CORE_EXPORT QgsRectangle
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsRectangle: %1>" ).arg( sipCpp->asWktCoordinates() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -666,11 +666,11 @@ QString QgsApplication::resolvePkgPath()
       ABISYM( mBuildSourcePath ) = f.readLine().trimmed();
       ABISYM( mBuildOutputPath ) = f.readLine().trimmed();
       QgsDebugMsgLevel( QStringLiteral( "Running from build directory!" ), 4 );
-      QgsDebugMsgLevel( QStringLiteral( "- source directory: %1" ).arg( ABISYM( mBuildSourcePath ).toUtf8().data() ), 4 );
-      QgsDebugMsgLevel( QStringLiteral( "- output directory of the build: %1" ).arg( ABISYM( mBuildOutputPath ).toUtf8().data() ), 4 );
+      QgsDebugMsgLevel( QStringLiteral( "- source directory: %1" ).arg( ABISYM( mBuildSourcePath ).toUtf8().constData() ), 4 );
+      QgsDebugMsgLevel( QStringLiteral( "- output directory of the build: %1" ).arg( ABISYM( mBuildOutputPath ).toUtf8().constData() ), 4 );
 #if defined(_MSC_VER) && !defined(USING_NMAKE) && !defined(USING_NINJA)
       ABISYM( mCfgIntDir ) = appPath.split( '/', QString::SkipEmptyParts ).last();
-      qDebug( "- cfg: %s", ABISYM( mCfgIntDir ).toUtf8().data() );
+      qDebug( "- cfg: %s", ABISYM( mCfgIntDir ).toUtf8().constData() );
 #endif
     }
   }

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -339,7 +339,7 @@ class CORE_EXPORT QgsField
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsField: %1 (%2)>" ).arg( sipCpp->name() ).arg( sipCpp->typeName() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif
 

--- a/src/core/qgspointxy.h
+++ b/src/core/qgspointxy.h
@@ -298,7 +298,7 @@ class CORE_EXPORT QgsPointXY
     SIP_PYOBJECT __repr__();
     % MethodCode
     QString str = QStringLiteral( "<QgsPointXY: %1>" ).arg( sipCpp->asWkt() );
-    sipRes = PyUnicode_FromString( str.toUtf8().data() );
+    sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 
     int __len__();

--- a/src/core/qgsxmlutils.h
+++ b/src/core/qgsxmlutils.h
@@ -97,7 +97,7 @@ class CORE_EXPORT QgsXmlUtils
       if ( metaEnum.isValid() )
       {
         bool ok = false;
-        int newValue = metaEnum.keysToValue( sourceCategoriesStr.toUtf8().data(), &ok );
+        int newValue = metaEnum.keysToValue( sourceCategoriesStr.toUtf8().constData(), &ok );
         if ( ok )
           value = static_cast<T>( newValue );
       }

--- a/src/crashhandler/main.cpp
+++ b/src/crashhandler/main.cpp
@@ -42,7 +42,7 @@ int main( int argc, char *argv[] )
   QCoreApplication::setApplicationName( "QGIS3" );
 
   QString extraInfoFile = QString( argv[1] );
-  std::cout << "Extra Info File: " << extraInfoFile.toUtf8().data() << std::endl;
+  std::cout << "Extra Info File: " << extraInfoFile.toUtf8().constData() << std::endl;
 
   QFile file( extraInfoFile );
   QString processIdString;
@@ -75,7 +75,7 @@ int main( int argc, char *argv[] )
   std::cout << "Process ID: " << processIdString.toLocal8Bit().constData() << std::endl;
   std::cout << "Thread ID:" << threadIdString.toLocal8Bit().constData() << std::endl;
   std::cout << "Exception Pointer: " << exceptionPointersString.toLocal8Bit().constData() << std::endl;
-  std::cout << "Symbol Path :" << symbolPaths.toUtf8().data() << std::endl;
+  std::cout << "Symbol Path :" << symbolPaths.toUtf8().constData() << std::endl;
 
   std::unique_ptr<QgsStackTrace> stackTrace( QgsStackTrace::trace( processId, threadId, exception, symbolPaths ) );
 

--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -368,7 +368,7 @@ QString QgsProjectionSelectionTreeWidget::selectedProj4String()
   QgsDebugMsgLevel( "db = " + databaseFileName, 4 );
 
   sqlite3 *database = nullptr;
-  int rc = sqlite3_open_v2( databaseFileName.toUtf8().data(), &database, SQLITE_OPEN_READONLY, nullptr );
+  int rc = sqlite3_open_v2( databaseFileName.toUtf8().constData(), &database, SQLITE_OPEN_READONLY, nullptr );
   if ( rc )
   {
     showDBMissingWarning( databaseFileName );
@@ -437,7 +437,7 @@ QString QgsProjectionSelectionTreeWidget::getSelectedExpression( const QString &
   // assuming that it will never be used anywhere else. Given the low overhead,
   // opening it each time seems to be a reasonable approach at this time.
   sqlite3 *database = nullptr;
-  int rc = sqlite3_open_v2( databaseFileName.toUtf8().data(), &database, SQLITE_OPEN_READONLY, nullptr );
+  int rc = sqlite3_open_v2( databaseFileName.toUtf8().constData(), &database, SQLITE_OPEN_READONLY, nullptr );
   if ( rc )
   {
     QgsMessageLog::logMessage( tr( "Resource Location Error" ), tr( "Error reading database file from: \n %1\n"
@@ -652,7 +652,7 @@ void QgsProjectionSelectionTreeWidget::loadCrsList( QSet<QString> *crsFilter )
 
   // open the database containing the spatial reference data
   sqlite3 *database = nullptr;
-  int rc = sqlite3_open_v2( mSrsDatabaseFileName.toUtf8().data(), &database, SQLITE_OPEN_READONLY, nullptr );
+  int rc = sqlite3_open_v2( mSrsDatabaseFileName.toUtf8().constData(), &database, SQLITE_OPEN_READONLY, nullptr );
   if ( rc )
   {
     // XXX This will likely never happen since on open, sqlite creates the
@@ -935,7 +935,7 @@ long QgsProjectionSelectionTreeWidget::getLargestCrsIdMatch( const QString &sql 
   QString databaseFileName = QgsApplication::qgisUserDatabaseFilePath();
   if ( QFileInfo::exists( databaseFileName ) ) //only bother trying to open if the file exists
   {
-    result = sqlite3_open_v2( databaseFileName.toUtf8().data(), &database, SQLITE_OPEN_READONLY, nullptr );
+    result = sqlite3_open_v2( databaseFileName.toUtf8().constData(), &database, SQLITE_OPEN_READONLY, nullptr );
     if ( result )
     {
       // XXX This will likely never happen since on open, sqlite creates the
@@ -961,7 +961,7 @@ long QgsProjectionSelectionTreeWidget::getLargestCrsIdMatch( const QString &sql 
   else
   {
     //only bother looking in srs.db if it wasn't found above
-    result = sqlite3_open_v2( mSrsDatabaseFileName.toUtf8().data(), &database, SQLITE_OPEN_READONLY, nullptr );
+    result = sqlite3_open_v2( mSrsDatabaseFileName.toUtf8().constData(), &database, SQLITE_OPEN_READONLY, nullptr );
     if ( result )
     {
       QgsDebugMsg( QString( "Can't open * user * database: %1" ).arg( sqlite3_errmsg( database ) ) );
@@ -1041,7 +1041,7 @@ QStringList QgsProjectionSelectionTreeWidget::authorities()
   const char   *tail = nullptr;
   sqlite3_stmt *stmt = nullptr;
 
-  int result = sqlite3_open_v2( mSrsDatabaseFileName.toUtf8().data(), &database, SQLITE_OPEN_READONLY, nullptr );
+  int result = sqlite3_open_v2( mSrsDatabaseFileName.toUtf8().constData(), &database, SQLITE_OPEN_READONLY, nullptr );
   if ( result )
   {
     QgsDebugMsg( QString( "Can't open * user * database: %1" ).arg( sqlite3_errmsg( database ) ) );

--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -76,7 +76,7 @@ void QgsMacNative::currentAppActivateIgnoringOtherApps()
 
 void QgsMacNative::openFileExplorerAndSelectFile( const QString &path )
 {
-  NSString *pathStr = [[NSString alloc] initWithUTF8String:path.toUtf8().data()];
+  NSString *pathStr = [[NSString alloc] initWithUTF8String:path.toUtf8().constData()];
   NSArray *fileURLs = [NSArray arrayWithObjects:[NSURL fileURLWithPath:pathStr], nil];
   [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:fileURLs];
 }

--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -1258,7 +1258,7 @@ void QgsGrassNewMapset::createMapset()
     QString error;
     G_TRY
     {
-      ret = G_make_location( location.toUtf8().data(), &mCellHead, mProjInfo, mProjUnits );
+      ret = G_make_location( location.toUtf8().constData(), &mCellHead, mProjInfo, mProjUnits );
     }
     G_CATCH( QgsGrass::Exception & e )
     {

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -579,7 +579,7 @@ void QgsGrassPlugin::newVector()
   G_TRY
   {
     Map = QgsGrass::vectNewMapStruct();
-    Vect_open_new( Map, name.toUtf8().data(), 0 );
+    Vect_open_new( Map, name.toUtf8().constData(), 0 );
 
     Vect_build( Map );
     Vect_set_release_support( Map );

--- a/src/plugins/grass/qtermwidget/Session.cpp
+++ b/src/plugins/grass/qtermwidget/Session.cpp
@@ -486,7 +486,7 @@ void Session::activityStateSet(int state)
 {
     if (state==NOTIFYBELL) {
         QString s;
-        s.sprintf("Bell in session '%s'",_nameTitle.toUtf8().data());
+        s.sprintf("Bell in session '%s'",_nameTitle.toUtf8().constData());
 
         emit bellRequest( s );
     } else if (state==NOTIFYACTIVITY) {
@@ -632,16 +632,16 @@ void Session::done(int exitStatus)
 
         if (_shellProcess->exitStatus() == QProcess::NormalExit) {
             message.sprintf("Session '%s' exited with status %d.",
-                          _nameTitle.toUtf8().data(), exitStatus);
+                          _nameTitle.toUtf8().constData(), exitStatus);
         } else {
             message.sprintf("Session '%s' crashed.",
-                          _nameTitle.toUtf8().data());
+                          _nameTitle.toUtf8().constData());
         }
     }
 
     if ( !_wantedClose && _shellProcess->exitStatus() != QProcess::NormalExit )
         message.sprintf("Session '%s' exited unexpectedly.",
-                        _nameTitle.toUtf8().data());
+                        _nameTitle.toUtf8().constData());
     else
         emit finished();
 

--- a/src/providers/grass/qgis.r.in.cpp
+++ b/src/providers/grass/qgis.r.in.cpp
@@ -98,7 +98,7 @@ int main( int argc, char **argv )
   QString err = QgsGrass::setRegion( &window, extent, rows, cols );
   if ( !err.isEmpty() )
   {
-    G_fatal_error( "Cannot set region: %s", err.toUtf8().data() );
+    G_fatal_error( "Cannot set region: %s", err.toUtf8().constData() );
   }
   window.proj = ( int ) proj;
   window.zone = ( int ) zone;

--- a/src/providers/grass/qgis.v.in.cpp
+++ b/src/providers/grass/qgis.v.in.cpp
@@ -73,12 +73,12 @@ void closeMaps()
   if ( tmpMap )
   {
     Vect_close( tmpMap );
-    Vect_delete( sTmpName.toUtf8().data() );
+    Vect_delete( sTmpName.toUtf8().constData() );
   }
   if ( finalMap )
   {
     Vect_close( finalMap );
-    Vect_delete( sFinalName.toUtf8().data() );
+    Vect_delete( sFinalName.toUtf8().constData() );
   }
   if ( driver )
   {
@@ -161,7 +161,7 @@ int main( int argc, char **argv )
   {
     tmpMap = QgsGrass::vectNewMapStruct();
     // TODO: use Vect_open_tmp_new with GRASS 7
-    Vect_open_new( tmpMap, sTmpName.toUtf8().data(), 0 );
+    Vect_open_new( tmpMap, sTmpName.toUtf8().constData(), 0 );
     map = tmpMap;
   }
 
@@ -440,7 +440,7 @@ int main( int argc, char **argv )
     G_message( "Copying lines from temporary map" );
     Vect_copy_map_lines( tmpMap, finalMap );
     Vect_close( tmpMap );
-    Vect_delete( sTmpName.toUtf8().data() );
+    Vect_delete( sTmpName.toUtf8().constData() );
 
     int centroidsCount = centroids.size();
     count = 0;

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -582,12 +582,12 @@ void QgsGrass::setMapset( const QString &gisdbase, const QString &location, cons
 
   // Set principal GRASS variables (in memory)
 #ifdef Q_OS_WIN
-  G_setenv_nogisrc( "GISDBASE", shortPath( gisdbase ).toUtf8().data() );
+  G_setenv_nogisrc( "GISDBASE", shortPath( gisdbase ).toUtf8().constData() );
 #else
-  G_setenv_nogisrc( "GISDBASE", gisdbase.toUtf8().data() );
+  G_setenv_nogisrc( "GISDBASE", gisdbase.toUtf8().constData() );
 #endif
-  G_setenv_nogisrc( "LOCATION_NAME", location.toUtf8().data() );
-  G_setenv_nogisrc( "MAPSET", mapset.toUtf8().data() );
+  G_setenv_nogisrc( "LOCATION_NAME", location.toUtf8().constData() );
+  G_setenv_nogisrc( "MAPSET", mapset.toUtf8().constData() );
 
   // Add all available mapsets to search path
   // Why? Other mapsets should not be necessary.
@@ -994,11 +994,11 @@ QString QgsGrass::openMapset( const QString &gisdbase,
   putEnv( QStringLiteral( "GISRC" ), sGisrc );
 
   // Reinitialize GRASS
-  G_setenv_nogisrc( "GISRC", sGisrc.toUtf8().data() );
+  G_setenv_nogisrc( "GISRC", sGisrc.toUtf8().constData() );
 #ifdef Q_OS_WIN
   G_setenv_nogisrc( "GISDBASE", shortPath( gisdbase ).toLocal8Bit().data() );
 #else
-  G_setenv_nogisrc( "GISDBASE", gisdbase.toUtf8().data() );
+  G_setenv_nogisrc( "GISDBASE", gisdbase.toUtf8().constData() );
 #endif
   G_setenv_nogisrc( "LOCATION_NAME", location.toLocal8Bit().data() );
   G_setenv_nogisrc( "MAPSET", mapset.toLocal8Bit().data() );
@@ -1614,7 +1614,7 @@ void QgsGrass::region( const QString &gisdbase,
   QgsGrass::setLocation( gisdbase, location );
 
   // In GRASS 7 G__get_window does not return error code and calls G_fatal_error on error
-  G_FATAL_THROW( G_get_element_window( window, ( char * ) "", ( char * ) "WIND", mapset.toUtf8().data() ) );
+  G_FATAL_THROW( G_get_element_window( window, ( char * ) "", ( char * ) "WIND", mapset.toUtf8().constData() ) );
 }
 
 void QgsGrass::region( struct Cell_head *window )
@@ -1780,7 +1780,7 @@ bool QgsGrass::mapRegion( QgsGrassObject::Type type, const QString &gisdbase,
     QString error = tr( "Cannot read raster map region (%1/%2/%3)" ).arg( gisdbase, location, mapset );
     G_TRY
     {
-      Rast_get_cellhd( map.toUtf8().data(), mapset.toUtf8().data(), window );
+      Rast_get_cellhd( map.toUtf8().constData(), mapset.toUtf8().constData(), window );
     }
     G_CATCH( QgsGrass::Exception & e )
     {
@@ -1807,7 +1807,7 @@ bool QgsGrass::mapRegion( QgsGrassObject::Type type, const QString &gisdbase,
     {
       Map = vectNewMapStruct();
       Vect_set_open_level( 2 );
-      level = Vect_open_old_head( Map, map.toUtf8().data(), mapset.toUtf8().data() );
+      level = Vect_open_old_head( Map, map.toUtf8().constData(), mapset.toUtf8().constData() );
     }
     G_CATCH( QgsGrass::Exception & e )
     {
@@ -1865,7 +1865,7 @@ bool QgsGrass::mapRegion( QgsGrassObject::Type type, const QString &gisdbase,
     // G__get_window does not return error code in GRASS 7 and calls G_fatal_error on error
     G_TRY
     {
-      G_get_element_window( window, ( char * ) "windows", map.toUtf8().data(), mapset.toUtf8().data() );
+      G_get_element_window( window, ( char * ) "windows", map.toUtf8().constData(), mapset.toUtf8().constData() );
     }
     G_CATCH( QgsGrass::Exception & e )
     {
@@ -2227,7 +2227,7 @@ QList<QgsGrass::Color> QgsGrass::colors( const QString &gisdbase, const QString 
       QgsGrass::Color c;
       if ( list[i].isEmpty() )
         continue;
-      if ( sscanf( list[i].toUtf8().data(), "%lf %lf %d %d %d %d %d %d", &( c.value1 ), &( c.value2 ), &( c.red1 ), &( c.green1 ), &( c.blue1 ), &( c.red2 ), &( c.green2 ), &( c.blue2 ) ) != 8 )
+      if ( sscanf( list[i].toUtf8().constData(), "%lf %lf %d %d %d %d %d %d", &( c.value1 ), &( c.value2 ), &( c.red1 ), &( c.green1 ), &( c.blue1 ), &( c.red2 ), &( c.green2 ), &( c.blue2 ) ) != 8 )
       {
         throw QgsGrass::Exception( "Cannot parse GRASS colors" + list[i] + " (" + str + " ) " );
       }
@@ -2346,7 +2346,7 @@ void QgsGrass::createVectorMap( const QgsGrassObject &object, QString &error )
   G_TRY
   {
     Map = vectNewMapStruct();
-    Vect_open_new( Map, object.name().toUtf8().data(), 0 );
+    Vect_open_new( Map, object.name().toUtf8().constData(), 0 );
     Vect_build( Map );
     Vect_set_release_support( Map );
     Vect_close( Map );
@@ -2491,7 +2491,7 @@ bool QgsGrass::isExternal( const QgsGrassObject &object )
   {
     QgsGrass::setLocation( object.gisdbase(), object.location() );
     struct GDAL_link *gdal;
-    gdal = Rast_get_gdal_link( object.name().toUtf8().data(), object.mapset().toUtf8().data() );
+    gdal = Rast_get_gdal_link( object.name().toUtf8().constData(), object.mapset().toUtf8().constData() );
     if ( gdal )
     {
       isExternal = true;

--- a/src/providers/grass/qgsgrassimport.cpp
+++ b/src/providers/grass/qgsgrassimport.cpp
@@ -471,14 +471,14 @@ bool QgsGrassRasterImport::import()
     {
       QgsGrass::setMapset( mGrassObject.gisdbase(), mGrassObject.location(), mGrassObject.mapset() );
       struct Ref ref;
-      I_get_group_ref( name.toUtf8().data(), &ref );
+      I_get_group_ref( name.toUtf8().constData(), &ref );
       QString redName = name + QStringLiteral( ".%1" ).arg( redBand );
       QString greenName = name + QStringLiteral( ".%1" ).arg( greenBand );
       QString blueName = name + QStringLiteral( ".%1" ).arg( blueBand );
-      I_add_file_to_group_ref( redName.toUtf8().data(), mGrassObject.mapset().toUtf8().data(), &ref );
-      I_add_file_to_group_ref( greenName.toUtf8().data(), mGrassObject.mapset().toUtf8().data(), &ref );
-      I_add_file_to_group_ref( blueName.toUtf8().data(), mGrassObject.mapset().toUtf8().data(), &ref );
-      I_put_group_ref( name.toUtf8().data(), &ref );
+      I_add_file_to_group_ref( redName.toUtf8().constData(), mGrassObject.mapset().toUtf8().constData(), &ref );
+      I_add_file_to_group_ref( greenName.toUtf8().constData(), mGrassObject.mapset().toUtf8().constData(), &ref );
+      I_add_file_to_group_ref( blueName.toUtf8().constData(), mGrassObject.mapset().toUtf8().constData(), &ref );
+      I_put_group_ref( name.toUtf8().constData(), &ref );
     }
     G_CATCH( QgsGrass::Exception & e )
     {

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -548,7 +548,7 @@ bool QgsGrassProvider::isGrassEditable( void )
     return false;
 
   /* Check if current user is owner of mapset */
-  if ( G_mapset_permissions2( mGrassObject.gisdbase().toUtf8().data(), mGrassObject.location().toUtf8().data(), mGrassObject.mapset().toUtf8().data() ) != 1 )
+  if ( G_mapset_permissions2( mGrassObject.gisdbase().toUtf8().constData(), mGrassObject.location().toUtf8().constData(), mGrassObject.mapset().toUtf8().constData() ) != 1 )
     return false;
 
   // TODO: check format? (cannot edit OGR layers)
@@ -952,7 +952,7 @@ QgsAttributeMap *QgsGrassProvider::attributes( int field, int cat )
   db_init_string( &dbstr );
   QString query;
   query.sprintf( "select * from %s where %s = %d", fi->table, fi->key, cat );
-  db_set_string( &dbstr, query.toUtf8().data() );
+  db_set_string( &dbstr, query.toUtf8().constData() );
 
   QgsDebugMsg( QString( "SQL: %1" ).arg( db_get_string( &dbstr ) ) );
 

--- a/src/providers/grass/qgsgrassvector.cpp
+++ b/src/providers/grass/qgsgrassvector.cpp
@@ -118,7 +118,7 @@ QgsFields QgsGrassVectorLayer::fields()
     QgsDebugMsg( "open database " + mDatabase + " by driver " + mDriver );
     QgsGrass::lock();
     QgsGrass::setMapset( mGrassObject.gisdbase(), mGrassObject.location(),  mGrassObject.mapset() );
-    dbDriver *driver = db_start_driver_open_database( mDriver.toUtf8().data(), mDatabase.toUtf8().data() );
+    dbDriver *driver = db_start_driver_open_database( mDriver.toUtf8().constData(), mDatabase.toUtf8().constData() );
 
     if ( !driver )
     {
@@ -131,7 +131,7 @@ QgsFields QgsGrassVectorLayer::fields()
 
       dbString tableName;
       db_init_string( &tableName );
-      db_set_string( &tableName, mTable.toUtf8().data() );
+      db_set_string( &tableName, mTable.toUtf8().constData() );
 
       dbTable *table = nullptr;
       if ( db_describe_table( driver, &tableName, &table ) != DB_OK )
@@ -229,7 +229,7 @@ bool QgsGrassVector::openHead()
   G_TRY
   {
     map = QgsGrass::vectNewMapStruct();
-    level = Vect_open_old_head( map, ( char * ) mGrassObject.name().toUtf8().data(), ( char * ) mGrassObject.mapset().toUtf8().data() );
+    level = Vect_open_old_head( map, ( char * ) mGrassObject.name().toUtf8().constData(), ( char * ) mGrassObject.mapset().toUtf8().constData() );
   }
   G_CATCH( QgsGrass::Exception & e )
   {

--- a/src/providers/grass/qgsgrassvectormap.cpp
+++ b/src/providers/grass/qgsgrassvectormap.cpp
@@ -112,7 +112,7 @@ bool QgsGrassVectorMap::openMap()
   QgsGrass::setLocation( mGrassObject.gisdbase(), mGrassObject.location() );
 
   // Find the vector
-  const char *ms = G_find_vector2( mGrassObject.name().toUtf8().data(),  mGrassObject.mapset().toUtf8().data() );
+  const char *ms = G_find_vector2( mGrassObject.name().toUtf8().constData(),  mGrassObject.mapset().toUtf8().constData() );
 
   if ( !ms )
   {
@@ -135,7 +135,7 @@ bool QgsGrassVectorMap::openMap()
   G_TRY
   {
     Vect_set_open_level( 2 );
-    level = Vect_open_old_head( mMap, mGrassObject.name().toUtf8().data(), mGrassObject.mapset().toUtf8().data() );
+    level = Vect_open_old_head( mMap, mGrassObject.name().toUtf8().constData(), mGrassObject.mapset().toUtf8().constData() );
     Vect_close( mMap );
   }
   G_CATCH( QgsGrass::Exception & e )
@@ -167,7 +167,7 @@ bool QgsGrassVectorMap::openMap()
   G_TRY
   {
     Vect_set_open_level( level );
-    Vect_open_old( mMap, mGrassObject.name().toUtf8().data(), mGrassObject.mapset().toUtf8().data() );
+    Vect_open_old( mMap, mGrassObject.name().toUtf8().constData(), mGrassObject.mapset().toUtf8().constData() );
   }
   G_CATCH( QgsGrass::Exception & e )
   {
@@ -229,7 +229,7 @@ bool QgsGrassVectorMap::startEdit()
   {
     Vect_close( mMap );
     Vect_set_open_level( 2 );
-    level = Vect_open_update( mMap, mGrassObject.name().toUtf8().data(), mGrassObject.mapset().toUtf8().data() );
+    level = Vect_open_update( mMap, mGrassObject.name().toUtf8().constData(), mGrassObject.mapset().toUtf8().constData() );
     if ( level < 2 )
     {
       QgsDebugMsg( "Cannot open GRASS vector for update on level 2." );
@@ -247,7 +247,7 @@ bool QgsGrassVectorMap::startEdit()
     G_TRY
     {
       Vect_set_open_level( 2 );
-      level = Vect_open_old( mMap, mGrassObject.name().toUtf8().data(), mGrassObject.mapset().toUtf8().data() );
+      level = Vect_open_old( mMap, mGrassObject.name().toUtf8().constData(), mGrassObject.mapset().toUtf8().constData() );
       if ( level < 2 )
       {
         QgsDebugMsg( QString( "Cannot reopen GRASS vector: %1" ).arg( QgsGrass::errorMessage() ) );

--- a/src/providers/oracle/qgsoracletablecache.cpp
+++ b/src/providers/oracle/qgsoracletablecache.cpp
@@ -28,7 +28,7 @@ email                : wonder.sk at gmail dot com
 static bool _executeSqliteStatement( sqlite3 *db, const QString &sql )
 {
   sqlite3_stmt *stmt = nullptr;
-  if ( sqlite3_prepare_v2( db, sql.toUtf8().data(), -1, &stmt, nullptr ) != SQLITE_OK )
+  if ( sqlite3_prepare_v2( db, sql.toUtf8().constData(), -1, &stmt, nullptr ) != SQLITE_OK )
     return false;
 
   return sqlite3_step( stmt ) == SQLITE_DONE;
@@ -51,7 +51,7 @@ static bool _removeFromCache( sqlite3 *db, const QString &connName )
 static sqlite3 *_openCacheDatabase()
 {
   sqlite3 *database = nullptr;
-  if ( sqlite3_open_v2( QgsOracleTableCache::cacheDatabaseFilename().toUtf8().data(), &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr ) != SQLITE_OK )
+  if ( sqlite3_open_v2( QgsOracleTableCache::cacheDatabaseFilename().toUtf8().constData(), &database, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr ) != SQLITE_OK )
     return nullptr;
 
   if ( !_executeSqliteStatement( database, "CREATE TABLE IF NOT EXISTS meta_oracle(conn text primary_key, flags int)" ) )
@@ -149,7 +149,7 @@ bool QgsOracleTableCache::saveToCache( const QString &connName, CacheFlags flags
 
   QString sqlInsert = QString( "INSERT INTO %1 VALUES(?,?,?,?,?,?,?,?)" ).arg( tblName );
   sqlite3_stmt *stmtInsert = nullptr;
-  if ( sqlite3_prepare_v2( db, sqlInsert.toUtf8().data(), -1, &stmtInsert, nullptr ) != SQLITE_OK )
+  if ( sqlite3_prepare_v2( db, sqlInsert.toUtf8().constData(), -1, &stmtInsert, nullptr ) != SQLITE_OK )
   {
     sqlite3_close( db );
     return false;
@@ -158,23 +158,23 @@ bool QgsOracleTableCache::saveToCache( const QString &connName, CacheFlags flags
   bool insertOk = true;
   Q_FOREACH ( const QgsOracleLayerProperty &item, layers )
   {
-    sqlite3_bind_text( stmtInsert, 1, item.ownerName.toUtf8().data(), -1, SQLITE_TRANSIENT );
-    sqlite3_bind_text( stmtInsert, 2, item.tableName.toUtf8().data(), -1, SQLITE_TRANSIENT );
-    sqlite3_bind_text( stmtInsert, 3, item.geometryColName.toUtf8().data(), -1, SQLITE_TRANSIENT );
+    sqlite3_bind_text( stmtInsert, 1, item.ownerName.toUtf8().constData(), -1, SQLITE_TRANSIENT );
+    sqlite3_bind_text( stmtInsert, 2, item.tableName.toUtf8().constData(), -1, SQLITE_TRANSIENT );
+    sqlite3_bind_text( stmtInsert, 3, item.geometryColName.toUtf8().constData(), -1, SQLITE_TRANSIENT );
     sqlite3_bind_int( stmtInsert, 4, item.isView );
-    sqlite3_bind_text( stmtInsert, 5, item.sql.toUtf8().data(), -1, SQLITE_TRANSIENT );
+    sqlite3_bind_text( stmtInsert, 5, item.sql.toUtf8().constData(), -1, SQLITE_TRANSIENT );
 
-    sqlite3_bind_text( stmtInsert, 6, item.pkCols.join( "," ).toUtf8().data(), -1, SQLITE_TRANSIENT );
+    sqlite3_bind_text( stmtInsert, 6, item.pkCols.join( "," ).toUtf8().constData(), -1, SQLITE_TRANSIENT );
 
     QStringList geomTypes;
     Q_FOREACH ( QgsWkbTypes::Type geomType, item.types )
       geomTypes.append( QString::number( static_cast<ulong>( geomType ) ) );
-    sqlite3_bind_text( stmtInsert, 7, geomTypes.join( "," ).toUtf8().data(), -1, SQLITE_TRANSIENT );
+    sqlite3_bind_text( stmtInsert, 7, geomTypes.join( "," ).toUtf8().constData(), -1, SQLITE_TRANSIENT );
 
     QStringList geomSrids;
     Q_FOREACH ( int geomSrid, item.srids )
       geomSrids.append( QString::number( geomSrid ) );
-    sqlite3_bind_text( stmtInsert, 8, geomSrids.join( "," ).toUtf8().data(), -1, SQLITE_TRANSIENT );
+    sqlite3_bind_text( stmtInsert, 8, geomSrids.join( "," ).toUtf8().constData(), -1, SQLITE_TRANSIENT );
 
     if ( sqlite3_step( stmtInsert ) != SQLITE_DONE )
       insertOk = false;
@@ -202,7 +202,7 @@ bool QgsOracleTableCache::loadFromCache( const QString &connName, CacheFlags fla
 
   sqlite3_stmt *stmt = nullptr;
   QString sql = QString( "SELECT * FROM %1" ).arg( QgsOracleConn::quotedIdentifier( "oracle_" + connName ) );
-  if ( sqlite3_prepare_v2( db, sql.toUtf8().data(), -1, &stmt, nullptr ) != SQLITE_OK )
+  if ( sqlite3_prepare_v2( db, sql.toUtf8().constData(), -1, &stmt, nullptr ) != SQLITE_OK )
   {
     sqlite3_close( db );
     return false;

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -297,7 +297,7 @@ bool QgsPythonUtilsImpl::runStringUnsafe( const QString &command, bool single )
   // TODO: convert special characters from unicode strings u"…" to \uXXXX
   // so that they're not mangled to utf-8
   // (non-unicode strings can be mangled)
-  PyObject *obj = PyRun_String( command.toUtf8().data(), single ? Py_single_input : Py_file_input, mMainDict, mMainDict );
+  PyObject *obj = PyRun_String( command.toUtf8().constData(), single ? Py_single_input : Py_file_input, mMainDict, mMainDict );
   bool res = nullptr == PyErr_Occurred();
   Py_XDECREF( obj );
 
@@ -520,7 +520,7 @@ bool QgsPythonUtilsImpl::evalString( const QString &command, QString &result )
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
 
-  PyObject *res = PyRun_String( command.toUtf8().data(), Py_eval_input, mMainDict, mMainDict );
+  PyObject *res = PyRun_String( command.toUtf8().constData(), Py_eval_input, mMainDict, mMainDict );
   bool success = nullptr != res;
 
   // TODO: error handling


### PR DESCRIPTION
All your uses of toUtf8().data() actually just need a const char*
So use constData() that is semantically more correct, and documented
to be faster.

From http://doc.qt.io/qt-5/qbytearray.html#data
"For read-only access, constData() is faster because it never
causes a deep copy to occur."
