### PR TITLE
Fix #19465 - Don't delete expression when pressing enter in combo

### DIFF
--- a/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
@@ -224,6 +224,9 @@ updateLineEditStyle will re-style (color/font) the line edit depending on conten
     virtual void changeEvent( QEvent *event );
 
 
+    virtual bool eventFilter( QObject *watched, QEvent *event );
+
+
 };
 
 /************************************************************************

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -216,6 +216,8 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
   protected:
     void changeEvent( QEvent *event ) override;
 
+    bool eventFilter( QObject *watched, QEvent *event ) override;
+
   private slots:
     void reloadLayer();
 


### PR DESCRIPTION
Pressing enter will currently delete the expression the user is typing which is a bit poor.  This overrides the enter button to only trigger the expression editing finished slot and not select the first item in the list.

Seems like this bug has been here a loooooooooong time given my todo in the file for 2.6...

