### PR TITLE
Fix #13684 - Update conditional full row style on value change

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -679,7 +679,7 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
     case Qt::EditRole:
       return val;
 
-    case Qt::BackgroundColorRole:
+    case Qt::BackgroundRole:
     case Qt::TextColorRole:
     case Qt::DecorationRole:
     case Qt::FontRole:
@@ -704,7 +704,7 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
 
       if ( style.isValid() )
       {
-        if ( role == Qt::BackgroundColorRole && style.validBackgroundColor() )
+        if ( role == Qt::BackgroundRole && style.validBackgroundColor() )
           return style.backgroundColor();
         if ( role == Qt::TextColorRole && style.validTextColor() )
           return style.textColor();
@@ -754,6 +754,8 @@ bool QgsAttributeTableModel::setData( const QModelIndex &index, const QVariant &
       mChangedCellBounds.setBottom( index.row() );
     }
   }
+
+  mRowStylesMap.remove( index.row() );
 
   return true;
 }


### PR DESCRIPTION
The title says it all.  Fixes a super long bug (3 years... ). Conditional style now updates for the whole row when the value in the attribute table changes. 