### PR TITLE
Layer tree bgcolor

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -315,7 +315,12 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
       }
     }
   }
-
+  else if ( role == Qt::BackgroundColorRole )
+  {
+    QColor bgColor = node->customProperty( QStringLiteral( "backgroundColor" ), QColor() ).value<QColor>();
+    if ( bgColor.isValid() )
+      return bgColor;
+  }
   return QVariant();
 }
 


### PR DESCRIPTION
Simply check if `backgroundColor` custom property exists on the node to return the background color.

For current layer, simply do `QgsProject.instance().layerTreeRoot().findLayer(iface.activeLayer()).setCustomProperty('backgroundColor', QColor(Qt.red))` 

![image](https://user-images.githubusercontent.com/127259/46618918-b905ea80-caee-11e8-9a0c-c2af57f77e7a.png)

I think this is pretty secure. @wonder-sk do you agree it's safe to merge or would prefer to wait?

