### PR TITLE
[postgres] Fix addition of views from Data Source Manager (fixes #19424)

### DIFF
--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -253,6 +253,11 @@ QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, QgsPr
   mProxyModel.setFilterCaseSensitivity( Qt::CaseInsensitive );
   mProxyModel.setSourceModel( &mTableModel );
 
+  // Do not do dynamic sorting - otherwise whenever user selects geometry type / srid / pk columns,
+  // that item suddenly jumps to the end of the list (because the item gets changed) which is very annoying.
+  // The list gets sorted in finishList() method when the listing of tables and views has finished.
+  mProxyModel.setDynamicSortFilter( false );
+
   mTablesTreeView->setModel( &mProxyModel );
   mTablesTreeView->setSortingEnabled( true );
   mTablesTreeView->setEditTriggers( QAbstractItemView::CurrentChanged );


### PR DESCRIPTION
In order to add a PostgreSQL layer based on a view, one needs to explicitly pick one or more columns to serve as the primary key. However in both browser dock and in the DB manager user can add a view as a layer without specifying primary key. Users get confused about this behavior, therefore this commit makes the Data Source Manager behave consistently with browser and DB manager, that is it will pick the first column as the proposed primary key automatically.
    
While this may be a bit risky in letting user use wrong pkey, it is very convenient (and consistent with other part of QGIS). Also, usability of selection of geometry type / srid / pkey column(s) is not great so it is good not to force people to always choose pkey for their views. The list will still keep the warning icon and tooltip shown as before.

Bonus: Fix jumping item when changing pkey / geom type / srid. (On change of on of the properties the affected item would suddenly jump to the end of the list.)