### PR TITLE
[labeling] always consider data-defined property for line height

### DIFF
--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -3086,21 +3086,16 @@ void QgsPalLabeling::dataDefinedTextFormatting( QgsPalLayerSettings &tmpLyr,
     tmpLyr.autoWrapLength = ddValues.value( QgsPalLayerSettings::AutoWrapLength ).toInt();
   }
 
-  if ( !tmpLyr.wrapChar.isEmpty() || tmpLyr.getLabelExpression()->expression().contains( QLatin1String( "wordwrap" ) ) || tmpLyr.autoWrapLength > 0 )
+  if ( ddValues.contains( QgsPalLayerSettings::MultiLineHeight ) )
   {
+    QgsTextFormat format = tmpLyr.format();
+    format.setLineHeight( ddValues.value( QgsPalLayerSettings::MultiLineHeight ).toDouble() );
+    tmpLyr.setFormat( format );
+  }
 
-    if ( ddValues.contains( QgsPalLayerSettings::MultiLineHeight ) )
-    {
-      QgsTextFormat format = tmpLyr.format();
-      format.setLineHeight( ddValues.value( QgsPalLayerSettings::MultiLineHeight ).toDouble() );
-      tmpLyr.setFormat( format );
-    }
-
-    if ( ddValues.contains( QgsPalLayerSettings::MultiLineAlignment ) )
-    {
-      tmpLyr.multilineAlign = static_cast< QgsPalLayerSettings::MultiLineAlign >( ddValues.value( QgsPalLayerSettings::MultiLineAlignment ).toInt() );
-    }
-
+  if ( ddValues.contains( QgsPalLayerSettings::MultiLineAlignment ) )
+  {
+    tmpLyr.multilineAlign = static_cast< QgsPalLayerSettings::MultiLineAlign >( ddValues.value( QgsPalLayerSettings::MultiLineAlignment ).toInt() );
   }
 
   if ( ddValues.contains( QgsPalLayerSettings::DirSymbDraw ) )


### PR DESCRIPTION
## Description
This PR removes the conditional checks that prevents data-defined line-height property from being computed when none of the conditions are met, yet the passed string is multiline.

Until now, the data-defined property for line-height was only taken into consideration if the label was an expression-based string containing a wordwrap, or when the warp settings were set. This meant that if the user was simply passing a multi-line string (either a simple field value or an expression with '\n' value), the data-defined property would not be taken into consideration.

@nyalldawson , as per our discussion on hangout.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
