### PR TITLE
Fixes #20053 decimal separator in csv files

### DIFF
--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -70,6 +70,7 @@ QgsCoordinateReferenceSystem QgsJsonExporter::sourceCrs() const
 QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVariantMap &extraProperties,
                                         const QVariant &id ) const
 {
+
   QString s = QStringLiteral( "{\n   \"type\":\"Feature\",\n" );
 
   // ID
@@ -119,6 +120,12 @@ QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVarian
     if ( mIncludeAttributes )
     {
       QgsFields fields = mLayer ? mLayer->fields() : feature.fields();
+      // List of formatters through we want to pass the values
+      QStringList formattersWhiteList;
+      formattersWhiteList << QStringLiteral( "KeyValue" )
+                          << QStringLiteral( "List" )
+                          << QStringLiteral( "ValueRelation" )
+                          << QStringLiteral( "ValueMap" );
 
       for ( int i = 0; i < fields.count(); ++i )
       {
@@ -133,7 +140,7 @@ QString QgsJsonExporter::exportFeature( const QgsFeature &feature, const QVarian
         {
           QgsEditorWidgetSetup setup = fields.at( i ).editorWidgetSetup();
           QgsFieldFormatter *fieldFormatter = QgsApplication::fieldFormatterRegistry()->fieldFormatter( setup.type() );
-          if ( fieldFormatter != QgsApplication::fieldFormatterRegistry()->fallbackFieldFormatter() )
+          if ( formattersWhiteList.contains( fieldFormatter->id() ) )
             val = fieldFormatter->representValue( mLayer.data(), i, setup.config(), QVariant(), val );
         }
 


### PR DESCRIPTION
Actually it had nothing to do with CSV being the
source, but it was the json exporter passing
the values through all field formatters except for
the fallback.

This resulted in all fields using a 'Range' formatter
(which is the default for all numeric types) passing
through the formatter and being returned as strings
in the json. Worse, if the locale was not a "dot"
locale and decimal separator was on, the resulting
string could not be easily converted into its original
numeric type.

Now, instead of checking for the fallback formatter
only, there is a white list of formatters that
can be applied when we want a json.

This is a temporary solution because the "right" way
to do it would be either a flag in the formatter to
tell if it can be applied when converting to json
and/or other "data" formats (csv etc.) or a different
new method similar to representValue.

