### PR TITLE
[fix #19092] fix big cursors on Mac and center of cursor

### DIFF
--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -596,13 +596,6 @@ QCursor QgsApplication::getThemeCursor( Cursor cursor )
   {
     // Apply scaling
     float scale = Qgis::UI_SCALE_FACTOR * app->fontMetrics().height() / 32.0;
-#ifdef Q_OS_MACX
-    if ( app->devicePixelRatio() >= 2 )
-    {
-      scale *= app->devicePixelRatio();
-      activeX = activeY = 8;
-    }
-#endif
     cursorIcon = QCursor( icon.pixmap( std::ceil( scale * 32 ), std::ceil( scale * 32 ) ), std::ceil( scale * activeX ), std::ceil( scale * activeY ) );
   }
   if ( app )


### PR DESCRIPTION
This code was previously added to fix an issue with cursor being too small.
see https://github.com/qgis/QGIS/commit/3283afd33d75e13cb03bb4eec0755a884dfef41b
too small issue: https://issues.qgis.org/issues/18043

Here the icons were really too big.
@slarosa do you have any change to test this?
