### PR TITLE
Fixes #20064: Bug in Server WFS update transaction

### DIFF
--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -1093,7 +1093,7 @@ namespace QgsWfs
       typeName = typeName.section( ':', 1, 1 );
 
     QDomNodeList propertyNodeList = actionElem.elementsByTagName( QStringLiteral( "Property" ) );
-    if ( propertyNodeList.size() != 1 )
+    if ( propertyNodeList.isEmpty() )
     {
       throw QgsRequestNotWellFormedException( QStringLiteral( "Update action element must have one or more Property element" ) );
     }


### PR DESCRIPTION
## Description
Fixing bug in update transaction to check for one or more Property elements. Should throw exception if there are none Property elements and not when it is not one.
Link to issue https://issues.qgis.org/issues/20064

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
