### PR TITLE
[needs-docs] Fixes #18466: Switch Add and Close buttons

### DIFF
--- a/src/gui/qgsabstractdatasourcewidget.cpp
+++ b/src/gui/qgsabstractdatasourcewidget.cpp
@@ -38,11 +38,11 @@ const QgsMapCanvas *QgsAbstractDataSourceWidget::mapCanvas() const
 void QgsAbstractDataSourceWidget::setupButtons( QDialogButtonBox *buttonBox )
 {
 
-  buttonBox->setStandardButtons( QDialogButtonBox::Apply | QDialogButtonBox::Close | QDialogButtonBox::Help );
+  buttonBox->setStandardButtons( QDialogButtonBox::Ok | QDialogButtonBox::Close | QDialogButtonBox::Help );
 #ifdef Q_OS_MACX
   buttonBox->setStyleSheet( "* { button-layout: 2 }" );
 #endif
-  mAddButton = buttonBox->button( QDialogButtonBox::Apply );
+  mAddButton = buttonBox->button( QDialogButtonBox::Ok );
   mAddButton->setText( tr( "&Add" ) );
   mAddButton->setToolTip( tr( "Add selected layers to map" ) );
   mAddButton->setEnabled( false );


### PR DESCRIPTION
## Description
Updated the Add button type in the Add Layer dialog window from 'Accept' to 'Ok' to fix the order of buttons in Windows.

## Checklist
- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
