### PR TITLE
fix local variable will be copied despite being returned by name

### DIFF
--- a/external/o2/src/o2replyserver.cpp
+++ b/external/o2/src/o2replyserver.cpp
@@ -105,7 +105,7 @@ QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
         QString value = QUrl::fromPercentEncoding(QByteArray().append(tokenPair.second.trimmed().toLatin1()));
         queryParams.insert(key, value);
     }
-    return queryParams;
+    return std::move( queryParams );
 }
 
 void O2ReplyServer::closeServer(QTcpSocket *socket, bool hasparameters)

--- a/src/plugins/grass/qtermwidget/ColorScheme.cpp
+++ b/src/plugins/grass/qtermwidget/ColorScheme.cpp
@@ -33,6 +33,7 @@
 #include <QtDebug>
 #include <QSettings>
 #include <QDir>
+#include <QStringList>
 
 
 // KDE
@@ -698,7 +699,7 @@ QList<QString> ColorSchemeManager::listKDE3ColorSchemes()
   QStringList ret;
   foreach ( QString i, list )
     ret << dname + "/" + i;
-  return ret;
+  return std::move( ret );
   //return KGlobal::dirs()->findAllResources("data",
   //                                         "konsole/*.schema",
   //                                          KStandardDirs::NoDuplicates);
@@ -715,7 +716,7 @@ QList<QString> ColorSchemeManager::listColorSchemes()
   QStringList ret;
   foreach ( QString i, list )
     ret << dname + "/" + i;
-  return ret;
+  return std::move( ret );
 //    return KGlobal::dirs()->findAllResources("data",
 //                                             "konsole/*.colorscheme",
 //                                             KStandardDirs::NoDuplicates);


### PR DESCRIPTION
this is an error with clang 7
note: call 'std::move' explicitly to avoid copying

see https://travis-ci.org/qgis/QGIS/jobs/439416330#L723

may I ask a C++ guru to confirm?