### PR TITLE
Revert "Make values in attribute form better readable"

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -137,6 +137,7 @@ void QgsTextEditWrapper::initWidget( QWidget *editor )
 
     mWritablePalette = mLineEdit->palette();
     mReadOnlyPalette = mLineEdit->palette();
+    mReadOnlyPalette.setColor( QPalette::Text, mWritablePalette.color( QPalette::Disabled, QPalette::Text ) );
   }
 }
 
@@ -194,13 +195,7 @@ void QgsTextEditWrapper::setEnabled( bool enabled )
     if ( enabled )
       mLineEdit->setPalette( mWritablePalette );
     else
-    {
       mLineEdit->setPalette( mReadOnlyPalette );
-      // removing frame + setting transparent background to distinguish the readonly lineEdit from a normal one
-      // did not get this working via the Palette:
-      mLineEdit->setStyleSheet( QStringLiteral( "background-color: rgba(255, 255, 255, 75%);" ) );
-    }
-    mLineEdit->setFrame( enabled );
   }
 }
 


### PR DESCRIPTION
This reverts commit ca7df6efaf43263836f8136f1a538abb1adee1d5.

This does not work wel on Windows Custom forms, and it is
too hard for me to make it work with the other widgets.
Besides some argued that the old way looked better, or that
it was making styling/code more complex.

See: https://github.com/qgis/QGIS/pull/8064

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
