### PR TITLE
[FEATURE] Native file/folder properties in browser dock

### DIFF
--- a/src/native/linux/qgslinuxnative.cpp
+++ b/src/native/linux/qgslinuxnative.cpp
@@ -26,7 +26,7 @@
 
 QgsNative::Capabilities QgsLinuxNative::capabilities() const
 {
-  return NativeDesktopNotifications;
+  return NativeDesktopNotifications | NativeFilePropertiesDialog;
 }
 
 void QgsLinuxNative::initializeMainWindow( QWindow *,
@@ -55,6 +55,26 @@ void QgsLinuxNative::openFileExplorerAndSelectFile( const QString &path )
   if ( iface.lastError().type() != QDBusError::NoError )
   {
     QgsNative::openFileExplorerAndSelectFile( path );
+  }
+}
+
+void QgsLinuxNative::showFileProperties( const QString &path )
+{
+  if ( !QDBusConnection::sessionBus().isConnected() )
+  {
+    QgsNative::showFileProperties( path );
+    return;
+  }
+
+  QDBusInterface iface( QStringLiteral( "org.freedesktop.FileManager1" ),
+                        QStringLiteral( "/org/freedesktop/FileManager1" ),
+                        QStringLiteral( "org.freedesktop.FileManager1" ),
+                        QDBusConnection::sessionBus() );
+
+  iface.call( QDBus::NoBlock, QStringLiteral( "ShowItemProperties" ), QStringList( QUrl::fromLocalFile( path ).toString() ), QStringLiteral( "QGIS" ) );
+  if ( iface.lastError().type() != QDBusError::NoError )
+  {
+    QgsNative::showFileProperties( path );
   }
 }
 

--- a/src/native/linux/qgslinuxnative.h
+++ b/src/native/linux/qgslinuxnative.h
@@ -39,6 +39,7 @@ class NATIVE_EXPORT QgsLinuxNative : public QgsNative
                                const QString &organizationName,
                                const QString &version ) override;
     void openFileExplorerAndSelectFile( const QString &path ) override;
+    void showFileProperties( const QString &path ) override;
     void showUndefinedApplicationProgress() override;
     void setApplicationProgress( double progress ) override;
     void hideApplicationProgress() override;

--- a/src/native/qgsnative.cpp
+++ b/src/native/qgsnative.cpp
@@ -48,6 +48,11 @@ void QgsNative::openFileExplorerAndSelectFile( const QString &path )
   QDesktopServices::openUrl( QUrl::fromLocalFile( folder ) );
 }
 
+void QgsNative::showFileProperties( const QString & )
+{
+
+}
+
 void QgsNative::showUndefinedApplicationProgress()
 {
 

--- a/src/native/qgsnative.h
+++ b/src/native/qgsnative.h
@@ -44,6 +44,7 @@ class NATIVE_EXPORT QgsNative : public QObject
     enum Capability
     {
       NativeDesktopNotifications = 1 << 1, //!< Native desktop notifications are supported. See showDesktopNotification().
+      NativeFilePropertiesDialog = 1 << 2, //!< Platform can show a native "file" (or folder) properties dialog.
     };
     Q_DECLARE_FLAGS( Capabilities, Capability )
 
@@ -90,6 +91,16 @@ class NATIVE_EXPORT QgsNative : public QObject
      * \since QGIS 3.4
      */
     virtual void openFileExplorerAndSelectFile( const QString &path );
+
+    /**
+     * Opens the desktop explorer file (or folder) properties dialog, for the given \a path.
+     *
+     * The default implementation does nothing. Platforms which implement this interface should
+     * return the QgsNative::NativeFilePropertiesDialog capability.
+     *
+     * \since QGIS 3.6
+     */
+    virtual void showFileProperties( const QString &path );
 
     /**
      * Shows the application progress report, using an "undefined" total


### PR DESCRIPTION
Adds a native platform method to show the native file/folder properties dialog for paths (i.e. on windows this is the one which gives options for security, etc. Same on gnome). Implemented for linux (via dbus) and Windows.

This allows users to access the native file properties directly from the browser, e.g. to change file/folder permissions, rollback files, etc.