### PR TITLE
[FEATURE] Add "export to file" options for raster and vector layers within the browser panel

### DIFF
--- a/python/gui/auto_generated/qgsrasterlayersaveasdialog.sip.in
+++ b/python/gui/auto_generated/qgsrasterlayersaveasdialog.sip.in
@@ -52,7 +52,23 @@ Constructor for QgsRasterLayerSaveAsDialog
     int maximumTileSizeX() const;
     int maximumTileSizeY() const;
     bool tileMode() const;
+
     bool addToCanvas() const;
+%Docstring
+Returns true if the "add to canvas" checkbox is checked.
+
+.. seealso:: :py:func:`setAddToCanvas`
+%End
+
+    void setAddToCanvas( bool checked );
+%Docstring
+Sets whether the  "add to canvas" checkbox should be ``checked``.
+
+.. seealso:: :py:func:`addToCanvas`
+
+.. versionadded:: 3.6
+%End
+
     QString outputFileName() const;
 
     QString outputLayerName() const;

--- a/python/gui/auto_generated/qgswindowmanagerinterface.sip.in
+++ b/python/gui/auto_generated/qgswindowmanagerinterface.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsWindowManagerInterface
 {
 %Docstring
@@ -44,6 +45,40 @@ existing instance to the foreground.
 
 Returns the dialog if shown, or None if the dialog either could not be
 created or is not supported by the window manager implementation.
+%End
+
+    virtual QString executeExportVectorLayerDialog( QgsVectorLayer *layer );
+%Docstring
+Executes the standard "Export Vector Layer" dialog for the specified ``layer``,
+and performs an export using the settings accepted in the dialog.
+
+The created vector file name is returned.
+
+Depending on the window manager implementation the actual export of the
+layer may occur in a background task, in which case calling this method
+will immediately return after the dialog has been accepted, but before
+the exported layer has been finalized.
+
+.. seealso:: :py:func:`executeExportRasterLayerDialog`
+
+.. versionadded:: 3.6
+%End
+
+    virtual QString executeExportRasterLayerDialog( QgsRasterLayer *layer );
+%Docstring
+Executes the standard "Export Raster Layer" dialog for the specified ``layer``,
+and performs an export using the settings accepted in the dialog.
+
+The created raster file name is returned.
+
+Depending on the window manager implementation the actual export of the
+layer may occur in a background task, in which case calling this method
+will immediately return after the dialog has been accepted, but before
+the exported layer has been finalized.
+
+.. seealso:: :py:func:`executeExportVectorLayerDialog`
+
+.. versionadded:: 3.6
 %End
 
 };

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -703,7 +703,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
   public slots:
     //! save current vector layer
-    void saveAsFile( QgsMapLayer *layer = nullptr, bool onlySelected = false );
+    QString saveAsFile( QgsMapLayer *layer = nullptr, bool onlySelected = false, bool defaultToAddToMap = true );
 
     /**
      * Makes a memory layer permanent, by prompting users to save the layer to a disk-based (OGR)
@@ -716,7 +716,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! save qrl definition for the current layer
     void saveAsLayerDefinition();
     //! save current raster layer
-    void saveAsRasterFile( QgsRasterLayer *layer = nullptr );
+    QString saveAsRasterFile( QgsRasterLayer *layer = nullptr, bool defaultAddToCanvas = true );
     //! Process the list of URIs that have been dropped in QGIS
     void handleDropUriList( const QgsMimeDataUtils::UriList &lst );
     //! Convenience function to open either a project or a layer file.
@@ -1841,16 +1841,16 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void setLayoutAtlasFeature( QgsPrintLayout *layout, QgsMapLayer *layer, const QgsFeature &feat );
 
-    void saveAsVectorFileGeneral( QgsVectorLayer *vlayer = nullptr, bool symbologyOption = true, bool onlySelected = false );
+    QString saveAsVectorFileGeneral( QgsVectorLayer *vlayer = nullptr, bool symbologyOption = true, bool onlySelected = false, bool defaultToAddToMap = true );
 
-    void saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption, bool onlySelected,
-                                  const std::function< void ( const QString &newFilename,
-                                      bool addToCanvas,
-                                      const QString &layerName,
-                                      const QString &encoding,
-                                      const QString &vectorFileName )> &onSuccess, const std::function< void ( int error, const QString &errorMessage ) > &onFailure,
-                                  int dialogOptions = QgsVectorLayerSaveAsDialog::AllOptions,
-                                  const QString &dialogTitle = QString() );
+    QString saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbologyOption, bool onlySelected, bool defaultToAddToMap,
+                                     const std::function< void ( const QString &newFilename,
+                                         bool addToCanvas,
+                                         const QString &layerName,
+                                         const QString &encoding,
+                                         const QString &vectorFileName )> &onSuccess, const std::function< void ( int error, const QString &errorMessage ) > &onFailure,
+                                     int dialogOptions = QgsVectorLayerSaveAsDialog::AllOptions,
+                                     const QString &dialogTitle = QString() );
 
     //! Sets project properties, including map untis
     void projectProperties( const QString  &currentPage = QString() );

--- a/src/app/qgsappwindowmanager.cpp
+++ b/src/app/qgsappwindowmanager.cpp
@@ -18,6 +18,7 @@
 #include "qgsstyle.h"
 #include "qgisapp.h"
 #include "qgslayoutmanagerdialog.h"
+#include "qgsrasterlayer.h"
 
 QgsAppWindowManager::~QgsAppWindowManager()
 {
@@ -44,6 +45,16 @@ QWidget *QgsAppWindowManager::openStandardDialog( QgsWindowManagerInterface::Sta
     }
   }
   return nullptr;
+}
+
+QString QgsAppWindowManager::executeExportVectorLayerDialog( QgsVectorLayer *layer )
+{
+  return QgisApp::instance()->saveAsFile( layer, false, false );
+}
+
+QString QgsAppWindowManager::executeExportRasterLayerDialog( QgsRasterLayer *layer )
+{
+  return QgisApp::instance()->saveAsFile( layer, false, false );
 }
 
 QWidget *QgsAppWindowManager::openApplicationDialog( QgsAppWindowManager::ApplicationDialog dialog )

--- a/src/app/qgsappwindowmanager.h
+++ b/src/app/qgsappwindowmanager.h
@@ -41,6 +41,8 @@ class QgsAppWindowManager : public QgsWindowManagerInterface
     ~QgsAppWindowManager();
 
     QWidget *openStandardDialog( QgsWindowManagerInterface::StandardDialog dialog ) override;
+    QString executeExportVectorLayerDialog( QgsVectorLayer *layer ) override;
+    QString executeExportRasterLayerDialog( QgsRasterLayer *layer ) override;
 
     /**
      * Opens an instance of a application QGIS dialog. Depending on the dialog,

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -861,6 +861,11 @@ bool QgsVectorLayerSaveAsDialog::addToCanvas() const
   return mAddToCanvas->isChecked();
 }
 
+void QgsVectorLayerSaveAsDialog::setAddToCanvas( bool enabled )
+{
+  mAddToCanvas->setChecked( enabled );
+}
+
 int QgsVectorLayerSaveAsDialog::symbologyExport() const
 {
   return mSymbologyExportComboBox->currentData().toInt();

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.h
@@ -65,7 +65,21 @@ class GUI_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     QgsAttributeList selectedAttributes() const;
     //! Returns selected attributes that must be exported with their displayed values instead of their raw values. Added in QGIS 2.16
     QgsAttributeList attributesAsDisplayedValues() const;
+
+    /**
+     * Returns true if the "add to canvas" checkbox is checked.
+     *
+     * \see setAddToCanvas()
+     */
     bool addToCanvas() const;
+
+    /**
+     * Sets whether the  "add to canvas" checkbox should be \a checked.
+     *
+     * \see addToCanvas()
+     * \since QGIS 3.6
+     */
+    void setAddToCanvas( bool checked );
 
     /**
      * Returns type of symbology export.

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -33,6 +33,8 @@
 #include "qgssettings.h"
 #include "qgsnewnamedialog.h"
 #include "qgsbrowserproxymodel.h"
+#include "qgsgui.h"
+#include "qgswindowmanagerinterface.h"
 
 // browser layer properties dialog
 #include "qgsapplication.h"
@@ -228,6 +230,45 @@ void QgsBrowserDockWidget::showContextMenu( QPoint pt )
   }
   else if ( item->type() == QgsDataItem::Layer )
   {
+    QgsLayerItem *layerItem = qobject_cast<QgsLayerItem *>( item );
+    if ( layerItem && ( layerItem->mapLayerType() == QgsMapLayer::VectorLayer ||
+                        layerItem->mapLayerType() == QgsMapLayer::RasterLayer ) )
+    {
+      QMenu *exportMenu = new QMenu( tr( "Export Layer" ), menu );
+      menu->addMenu( exportMenu );
+      QAction *toFileAction = new QAction( tr( "To File…" ), exportMenu );
+      exportMenu->addAction( toFileAction );
+      connect( toFileAction, &QAction::triggered, layerItem, [ layerItem ]
+      {
+        switch ( layerItem->mapLayerType() )
+        {
+          case QgsMapLayer::VectorLayer:
+          {
+            std::unique_ptr<QgsVectorLayer> layer( new QgsVectorLayer( layerItem->uri(), layerItem->name(), layerItem->providerKey() ) );
+            if ( layer && layer->isValid() )
+            {
+              QgsGui::instance()->windowManager()->executeExportVectorLayerDialog( layer.get() );
+            }
+            break;
+          }
+
+          case QgsMapLayer::RasterLayer:
+          {
+            std::unique_ptr<QgsRasterLayer> layer( new QgsRasterLayer( layerItem->uri(), layerItem->name(), layerItem->providerKey() ) );
+            if ( layer && layer->isValid() )
+            {
+              QgsGui::instance()->windowManager()->executeExportRasterLayerDialog( layer.get() );
+            }
+            break;
+          }
+
+          case QgsMapLayer::PluginLayer:
+          case QgsMapLayer::MeshLayer:
+            break;
+        }
+      } );
+    }
+
     menu->addAction( tr( "Add Selected Layer(s) to Canvas" ), this, SLOT( addSelectedLayers() ) );
     menu->addAction( tr( "Properties…" ), this, SLOT( showProperties() ) );
   }

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -378,6 +378,11 @@ bool QgsRasterLayerSaveAsDialog::addToCanvas() const
   return mAddToCanvas->isChecked();
 }
 
+void QgsRasterLayerSaveAsDialog::setAddToCanvas( bool checked )
+{
+  mAddToCanvas->setChecked( checked );
+}
+
 QString QgsRasterLayerSaveAsDialog::outputFileName() const
 {
   QString fileName = mFilename->filePath();

--- a/src/gui/qgsrasterlayersaveasdialog.h
+++ b/src/gui/qgsrasterlayersaveasdialog.h
@@ -69,7 +69,22 @@ class GUI_EXPORT QgsRasterLayerSaveAsDialog: public QDialog, private Ui::QgsRast
     int maximumTileSizeX() const;
     int maximumTileSizeY() const;
     bool tileMode() const;
+
+    /**
+     * Returns true if the "add to canvas" checkbox is checked.
+     *
+     * \see setAddToCanvas()
+     */
     bool addToCanvas() const;
+
+    /**
+     * Sets whether the  "add to canvas" checkbox should be \a checked.
+     *
+     * \see addToCanvas()
+     * \since QGIS 3.6
+     */
+    void setAddToCanvas( bool checked );
+
     QString outputFileName() const;
 
     /**

--- a/src/gui/qgswindowmanagerinterface.h
+++ b/src/gui/qgswindowmanagerinterface.h
@@ -19,6 +19,9 @@
 #include "qgis.h"
 #include "qgis_gui.h"
 
+class QgsVectorLayer;
+class QgsRasterLayer;
+
 ///@cond NOT_STABLE
 
 /**
@@ -52,6 +55,48 @@ class GUI_EXPORT QgsWindowManagerInterface
      * created or is not supported by the window manager implementation.
      */
     virtual QWidget *openStandardDialog( StandardDialog dialog ) = 0;
+
+    /**
+     * Executes the standard "Export Vector Layer" dialog for the specified \a layer,
+     * and performs an export using the settings accepted in the dialog.
+     *
+     * The created vector file name is returned.
+     *
+     * Depending on the window manager implementation the actual export of the
+     * layer may occur in a background task, in which case calling this method
+     * will immediately return after the dialog has been accepted, but before
+     * the exported layer has been finalized.
+     *
+     * \see executeExportRasterLayerDialog()
+     *
+     * \since QGIS 3.6
+     */
+    virtual QString executeExportVectorLayerDialog( QgsVectorLayer *layer )
+    {
+      Q_UNUSED( layer );
+      return QString();
+    }
+
+    /**
+     * Executes the standard "Export Raster Layer" dialog for the specified \a layer,
+     * and performs an export using the settings accepted in the dialog.
+     *
+     * The created raster file name is returned.
+     *
+     * Depending on the window manager implementation the actual export of the
+     * layer may occur in a background task, in which case calling this method
+     * will immediately return after the dialog has been accepted, but before
+     * the exported layer has been finalized.
+     *
+     * \see executeExportVectorLayerDialog()
+     *
+     * \since QGIS 3.6
+     */
+    virtual QString executeExportRasterLayerDialog( QgsRasterLayer *layer )
+    {
+      Q_UNUSED( layer );
+      return QString();
+    }
 
 };
 


### PR DESCRIPTION
Allows direct export of these files (e.g. to a different format,
crs, etc) without having to actually load them into a project
first.
