### PR TITLE
Add F2 to rename browser favourite item

### DIFF
--- a/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsbrowserdockwidget.sip.in
@@ -136,6 +136,9 @@ Connections changed in the browser
 Show event override
 %End
 
+    virtual void keyPressEvent( QKeyEvent *event );
+
+
 };
 
 

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -157,6 +157,15 @@ void QgsBrowserDockWidget::showEvent( QShowEvent *e )
   QgsDockWidget::showEvent( e );
 }
 
+void QgsBrowserDockWidget::keyPressEvent( QKeyEvent *event )
+{
+  if ( event->key() == Qt::Key_F2 )
+  {
+    renameFavorite();
+    event->accept();
+  }
+}
+
 void QgsBrowserDockWidget::itemDoubleClicked( const QModelIndex &index )
 {
   QgsDataItem *item = mModel->dataItem( mProxyModel->mapToSource( index ) );

--- a/src/gui/qgsbrowserdockwidget.h
+++ b/src/gui/qgsbrowserdockwidget.h
@@ -110,6 +110,8 @@ class GUI_EXPORT QgsBrowserDockWidget : public QgsDockWidget, private Ui::QgsBro
     //! Show event override
     void showEvent( QShowEvent *event ) override;
 
+    void keyPressEvent( QKeyEvent *event ) override;
+
   private slots:
     void itemDoubleClicked( const QModelIndex &index );
     void renameFavorite();


### PR DESCRIPTION
Follow normal UX and use F2 to rename favourite browser items.