### PR TITLE
Use a proxy progress task for vacuuming gpkg

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -27,6 +27,7 @@
 #include "qgsogrdataitems.h"
 #ifdef HAVE_GUI
 #include "qgsnewgeopackagelayerdialog.h"
+#include "qgsproxyprogresstask.h"
 #endif
 #include "qgsmessageoutput.h"
 #include "qgsvectorlayerexporter.h"
@@ -535,6 +536,8 @@ void QgsGeoPackageAbstractLayerItem::deleteLayer()
 
 bool QgsGeoPackageCollectionItem::vacuumGeoPackageDb( const QString &path, const QString &name, QString &errCause )
 {
+  QgsScopedProxyProgressTask task( tr( "Vacuuming %1" ).arg( name ) );
+
   bool result = false;
   // Better safe than sorry
   if ( ! path.isEmpty( ) )

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -475,11 +475,7 @@ void QgsGeoPackageCollectionItem::vacuumGeoPackageDbAction()
 {
   QString errCause;
   bool result = QgsGeoPackageCollectionItem::vacuumGeoPackageDb( mPath, mName, errCause );
-  if ( result && errCause.isEmpty() )
-  {
-    QMessageBox::information( nullptr, tr( "Database compact (VACUUM)" ), tr( "Database <b>%1</b> has been compacted successfully." ).arg( mName ) );
-  }
-  else
+  if ( !result || !errCause.isEmpty() )
   {
     QMessageBox::warning( nullptr, tr( "Database compact (VACUUM)" ), errCause );
   }


### PR DESCRIPTION
Because:
- gives task bar progress indicator
- gives a system notification if the compact takes a long time.

I'd propose that we could remove the success messagebox as a result of this. @elpaso?