### PR TITLE
Fix error return-std-move

### DIFF
--- a/external/o2/src/o2replyserver.cpp
+++ b/external/o2/src/o2replyserver.cpp
@@ -97,7 +97,7 @@ QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
     QUrlQuery query(getTokenUrl);
     tokens = query.queryItems();
 #endif
-    QMultiMap<QString, QString> queryParams;
+    QMap<QString, QString> queryParams;
     QPair<QString, QString> tokenPair;
     foreach (tokenPair, tokens) {
         // FIXME: We are decoding key and value again. This helps with Google OAuth, but is it mandated by the standard?
@@ -105,7 +105,7 @@ QMap<QString, QString> O2ReplyServer::parseQueryParams(QByteArray *data) {
         QString value = QUrl::fromPercentEncoding(QByteArray().append(tokenPair.second.trimmed().toLatin1()));
         queryParams.insert(key, value);
     }
-    return std::move( queryParams );
+    return queryParams;
 }
 
 void O2ReplyServer::closeServer(QTcpSocket *socket, bool hasparameters)

--- a/src/plugins/grass/qtermwidget/ColorScheme.cpp
+++ b/src/plugins/grass/qtermwidget/ColorScheme.cpp
@@ -125,25 +125,25 @@ const char *const ColorScheme::translatedColorNames[TABLE_COLORS] =
 
 ColorScheme::ColorScheme()
 {
-  _table = 0;
-  _randomTable = 0;
+  _table = nullptr;
+  _randomTable = nullptr;
   _opacity = 1.0;
 }
 ColorScheme::ColorScheme( const ColorScheme &other )
   : _opacity( other._opacity )
-  , _table( 0 )
-  , _randomTable( 0 )
+  , _table( nullptr )
+  , _randomTable( nullptr )
 {
   setName( other.name() );
   setDescription( other.description() );
 
-  if ( other._table != 0 )
+  if ( other._table )
   {
     for ( int i = 0 ; i < TABLE_COLORS ; i++ )
       setColorTableEntry( i, other._table[i] );
   }
 
-  if ( other._randomTable != 0 )
+  if ( other._randomTable )
   {
     for ( int i = 0 ; i < TABLE_COLORS ; i++ )
     {
@@ -188,7 +188,7 @@ ColorEntry ColorScheme::colorEntry( int index, uint randomSeed ) const
   ColorEntry entry = colorTable()[index];
 
   if ( randomSeed != 0 &&
-       _randomTable != 0 &&
+       _randomTable &&
        !_randomTable[index].isNull() )
   {
     const RandomizationRange &range = _randomTable[index];
@@ -216,7 +216,7 @@ void ColorScheme::getColorTable( ColorEntry *table, uint randomSeed ) const
 }
 bool ColorScheme::randomizedBackgroundColor() const
 {
-  return _randomTable == 0 ? false : !_randomTable[1].isNull();
+  return _randomTable ? false : !_randomTable[1].isNull();
 }
 void ColorScheme::setRandomizedBackgroundColor( bool randomize )
 {
@@ -241,7 +241,7 @@ void ColorScheme::setRandomizationRange( int index, quint16 hue, quint8 saturati
   Q_ASSERT( hue <= MAX_HUE );
   Q_ASSERT( index >= 0 && index < TABLE_COLORS );
 
-  if ( _randomTable == 0 )
+  if ( ! _randomTable )
     _randomTable = new RandomizationRange[TABLE_COLORS];
 
   _randomTable[index].hue = hue;
@@ -696,15 +696,16 @@ QList<QString> ColorSchemeManager::listKDE3ColorSchemes()
   filters << QStringLiteral( "*.schema" );
   dir.setNameFilters( filters );
   QStringList list = dir.entryList( filters );
-  QStringList ret;
+  QList<QString> ret;
   foreach ( QString i, list )
     ret << dname + "/" + i;
-  return std::move( ret );
+  return ret;
   //return KGlobal::dirs()->findAllResources("data",
   //                                         "konsole/*.schema",
   //                                          KStandardDirs::NoDuplicates);
   //
 }
+
 QList<QString> ColorSchemeManager::listColorSchemes()
 {
   QString dname( get_color_schemes_dir() );
@@ -713,10 +714,10 @@ QList<QString> ColorSchemeManager::listColorSchemes()
   filters << QStringLiteral( "*.colorscheme" );
   dir.setNameFilters( filters );
   QStringList list = dir.entryList( filters );
-  QStringList ret;
+  QList<QString> ret;
   foreach ( QString i, list )
     ret << dname + "/" + i;
-  return std::move( ret );
+  return ret;
 //    return KGlobal::dirs()->findAllResources("data",
 //                                             "konsole/*.colorscheme",
 //                                             KStandardDirs::NoDuplicates);
@@ -778,11 +779,11 @@ const ColorScheme *ColorSchemeManager::findColorScheme( const QString &name )
 
     qDebug() << "Could not find color scheme - " << name;
 
-    return 0;
+    return nullptr;
   }
 }
 
-ColorSchemeManager *ColorSchemeManager::sColorSchemeManager = 0;
+ColorSchemeManager *ColorSchemeManager::sColorSchemeManager = nullptr;
 //K_GLOBAL_STATIC( ColorSchemeManager , colorSchemeManager )
 ColorSchemeManager *ColorSchemeManager::instance()
 {


### PR DESCRIPTION
std::move should not be used here because
it prevents RVO (copy elision) and it's
considered an anti-pattern.

To fix the original warning the returned
type must match the declared return
type or copy elision will not be possible
(and the warning will be triggered).

Also fixed some 0 -> nullptr along the way

@3nids this reverts you commits from https://github.com/qgis/QGIS/pull/8157