### PR TITLE
[ux] Make QgsFileWidget file picker default to opening at the currently displayed folder, if one is shown

### DIFF
--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -221,15 +221,17 @@ void QgsFileWidget::openFileDialog()
   QgsSettings settings;
   QString oldPath;
 
-  // If we use fixed default path
-  if ( !mDefaultRoot.isEmpty() )
-  {
-    oldPath = QDir::cleanPath( mDefaultRoot );
-  }
   // if we use a relative path option, we need to obtain the full path
-  else if ( !mFilePath.isEmpty() )
+  // first choice is the current file path, if one is entered
+  if ( !mFilePath.isEmpty() )
   {
     oldPath = relativePath( mFilePath, false );
+  }
+  // If we use fixed default path
+  // second choice is the default root
+  else if ( !mDefaultRoot.isEmpty() )
+  {
+    oldPath = QDir::cleanPath( mDefaultRoot );
   }
 
   // If there is no valid value, find a default path to use


### PR DESCRIPTION
And only fallback to the default root path if no file name has
been entered.

This change improves the UX of the widget, because it allows
users to manually enter a path (or paste a filename, etc)
into the widget and THEN click the browse button to tweak
that current location. Otherwise we always jump back to
some historic location on clicking that button, which is
annoying.
