### PR TITLE
add tooltips for aggregation operators in the Processing algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/AggregatesPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/AggregatesPanel.py
@@ -26,21 +26,12 @@ __copyright__ = '(C) 2017, Arnaud Morvan'
 __revision__ = '$Format:%H$'
 
 from qgis.PyQt.QtCore import (
-    QItemSelectionModel,
-    QAbstractTableModel,
-    QModelIndex,
+    QCoreApplication,
     QVariant,
     Qt,
-    pyqtSlot,
 )
-from qgis.PyQt.QtGui import QBrush
 from qgis.PyQt.QtWidgets import (
     QComboBox,
-    QHeaderView,
-    QLineEdit,
-    QSpacerItem,
-    QMessageBox,
-    QSpinBox,
     QStyledItemDelegate,
 )
 
@@ -54,8 +45,8 @@ from processing.algs.qgis.ui.FieldsMappingPanel import (
     FieldTypeDelegate,
 )
 
-
-AGGREGATES = ['first_value']
+AGGREGATES = dict()
+AGGREGATES['first_value'] = QCoreApplication.translate('aggregation', 'Returns the value from the first feature')
 for function in QgsExpression.Functions():
     if function.name()[0] == '_':
         continue
@@ -66,8 +57,7 @@ for function in QgsExpression.Functions():
         if function.name() in ('aggregate',
                                'relation_aggregate'):
             continue
-        AGGREGATES.append(function.name())
-AGGREGATES = sorted(AGGREGATES)
+        AGGREGATES[function.name()] = function.helpText()
 
 
 class AggregatesModel(FieldsMappingModel):
@@ -146,8 +136,9 @@ class AggregateDelegate(QStyledItemDelegate):
 
     def createEditor(self, parent, option, index):
         editor = QComboBox(parent)
-        for function in AGGREGATES:
-            editor.addItem(function, function)
+        for i, aggregate in enumerate(sorted(AGGREGATES.keys())):
+            editor.insertItem(i, aggregate, aggregate)
+            editor.setItemData(i, AGGREGATES[aggregate], Qt.ToolTipRole)
         return editor
 
     def setEditorData(self, editor, index):


### PR DESCRIPTION
## Description

Adding some tooltips on the combobox, not easy to choose sometimes the good one.

![downloads_003](https://user-images.githubusercontent.com/1609292/46843326-3c9a3280-cda0-11e8-85a4-b4b68a85dd28.png)

But for now, I agree, it's not the best tooltip, because the tooltip is designed for expressions. Is-it still fine like this? I think it's better than nothing.

Ping @arnaud-morvan as you are the author of this algorithm

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
