### PR TITLE
Fixes slow update in field calculator

### DIFF
--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -824,20 +824,6 @@ Emits the signal to collect all the strings of .qgs to be included in ts file
 .. versionadded:: 3.4
 %End
 
-    void blockAttributeTableUpdates( const QgsVectorLayer *layer );
-%Docstring
-Emits the signal to block updates for attribute tables connected a particular ``layer``
-
-.. versionadded:: 3.4
-%End
-
-    void unblockAttributeTableUpdates( const QgsVectorLayer *layer );
-%Docstring
-Emits the signal to unblock updates for attribute tables connected a particular ``layer``
-
-.. versionadded:: 3.4
-%End
-
 
 %If (ANDROID)
     //dummy method to workaround sip generation issue
@@ -863,20 +849,6 @@ Emitted whenever a custom global variable changes.
 %Docstring
 Emitted when project strings which require translation are being collected for inclusion in a .ts file.
 In order to register translatable strings, connect to this signal and register the strings within the specified ``translationContext``.
-
-.. versionadded:: 3.4
-%End
-
-    void attributeTableUpdateBlocked( const QgsVectorLayer *layer );
-%Docstring
-Emitted when attribute table updates for a particular ``layer`` must be blocked
-
-.. versionadded:: 3.4
-%End
-
-    void attributeTableUpdateUnblocked( const QgsVectorLayer *layer );
-%Docstring
-Emitted when all attribute table updates for a particular ``layer`` must be unblocked
 
 .. versionadded:: 3.4
 %End

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -824,6 +824,21 @@ Emits the signal to collect all the strings of .qgs to be included in ts file
 .. versionadded:: 3.4
 %End
 
+    void blockAttributeTableUpdates( const QgsVectorLayer *layer );
+%Docstring
+Emits the signal to block updates for attribute tables connected a particular ``layer``
+
+.. versionadded:: 3.4
+%End
+
+    void unblockAttributeTableUpdates( const QgsVectorLayer *layer );
+%Docstring
+Emits the signal to unblock updates for attribute tables connected a particular ``layer``
+
+.. versionadded:: 3.4
+%End
+
+
 %If (ANDROID)
     //dummy method to workaround sip generation issue
     bool x11EventFilter( XEvent *event );
@@ -851,6 +866,21 @@ In order to register translatable strings, connect to this signal and register t
 
 .. versionadded:: 3.4
 %End
+
+    void attributeTableUpdateBlocked( const QgsVectorLayer *layer );
+%Docstring
+Emitted when attribute table updates for a particular ``layer`` must be blocked
+
+.. versionadded:: 3.4
+%End
+
+    void attributeTableUpdateUnblocked( const QgsVectorLayer *layer );
+%Docstring
+Emitted when all attribute table updates for a particular ``layer`` must be unblocked
+
+.. versionadded:: 3.4
+%End
+
 
 };
 

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2373,6 +2373,13 @@ Is emitted, before changes are committed to the data provider
 Is emitted, before changes are rolled back
 %End
 
+    void afterRollBack();
+%Docstring
+Is emitted, after changes are rolled back
+
+.. versionadded:: 3.4
+%End
+
     void attributeAdded( int idx );
 %Docstring
 Will be emitted, when a new attribute has been added to this vector layer.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9190,16 +9190,6 @@ bool QgisApp::toggleEditing( QgsMapLayer *layer, bool allowCancel )
 }
 
 
-void QgisApp::unblockAttributeTableUpdates( const QgsVectorLayer *layer )
-{
-  emit attributeTableUpdateUnblocked( layer );
-}
-
-void QgisApp::blockAttributeTableUpdates( const QgsVectorLayer *layer )
-{
-  emit attributeTableUpdateBlocked( layer );
-}
-
 void QgisApp::saveActiveLayerEdits()
 {
   saveEdits( activeLayer(), true, true );
@@ -14161,4 +14151,9 @@ void QgisApp::triggerCrashHandler()
 #ifdef Q_OS_WIN
   RaiseException( 0x12345678, 0, 0, nullptr );
 #endif
+}
+
+void QgisApp::blockAttributeTableUpdates( const QgsVectorLayer *layer, const bool blocked )
+{
+  emit attributeTableUpdateBlocked( layer, blocked );
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9189,6 +9189,17 @@ bool QgisApp::toggleEditing( QgsMapLayer *layer, bool allowCancel )
   return res;
 }
 
+
+void QgisApp::unblockAttributeTableUpdates( const QgsVectorLayer *layer )
+{
+  emit attributeTableUpdateUnblocked( layer );
+}
+
+void QgisApp::blockAttributeTableUpdates( const QgsVectorLayer *layer )
+{
+  emit attributeTableUpdateBlocked( layer );
+}
+
 void QgisApp::saveActiveLayerEdits()
 {
   saveEdits( activeLayer(), true, true );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7090,13 +7090,14 @@ void QgisApp::fieldCalculator()
 
 void QgisApp::attributeTable( QgsAttributeTableFilterModel::FilterMode filter )
 {
-  QgsVectorLayer *myLayer = qobject_cast<QgsVectorLayer *>( activeLayer() );
-  if ( !myLayer )
+  QgsVectorLayer *vectorLayer = qobject_cast<QgsVectorLayer *>( activeLayer() );
+  if ( !vectorLayer )
   {
     return;
   }
 
-  QgsAttributeTableDialog *mDialog = new QgsAttributeTableDialog( myLayer, filter );
+  QgsAttributeTableDialog *mDialog = new QgsAttributeTableDialog( vectorLayer, filter );
+
   mDialog->show();
   // the dialog will be deleted by itself on close
 }

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1008,6 +1008,20 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      */
     void triggerCrashHandler();
 
+    /**
+     * Emits the signal to block updates for attribute tables connected a particular \a layer
+     *
+     * \since QGIS 3.4
+     */
+    void blockAttributeTableUpdates( const QgsVectorLayer *layer );
+
+    /**
+     * Emits the signal to unblock updates for attribute tables connected a particular \a layer
+     *
+     * \since QGIS 3.4
+     */
+    void unblockAttributeTableUpdates( const QgsVectorLayer *layer );
+
   protected:
 
     //! Handle state changes (WindowTitleChange)
@@ -1740,6 +1754,20 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * Emitted when the active layer is changed.
      */
     void activeLayerChanged( QgsMapLayer *layer );
+
+    /**
+     * Emitted when attribute table updates for a particular \a layer must be blocked
+     *
+     * \since QGIS 3.4
+     */
+    void attributeTableUpdateBlocked( const QgsVectorLayer *layer );
+
+    /**
+     * Emitted when all attribute table updates for a particular \a layer must be unblocked
+     *
+     * \since QGIS 3.4
+     */
+    void attributeTableUpdateUnblocked( const QgsVectorLayer *layer );
 
   private:
     void startProfile( const QString &name );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1009,18 +1009,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void triggerCrashHandler();
 
     /**
-     * Emits the signal to block updates for attribute tables connected a particular \a layer
+     * Emits the signal to set the \a blocked state of attribute tables connected a particular \a layer
      *
      * \since QGIS 3.4
      */
-    void blockAttributeTableUpdates( const QgsVectorLayer *layer );
-
-    /**
-     * Emits the signal to unblock updates for attribute tables connected a particular \a layer
-     *
-     * \since QGIS 3.4
-     */
-    void unblockAttributeTableUpdates( const QgsVectorLayer *layer );
+    void blockAttributeTableUpdates( const QgsVectorLayer *layer, const bool blocked );
 
   protected:
 
@@ -1756,18 +1749,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void activeLayerChanged( QgsMapLayer *layer );
 
     /**
-     * Emitted when attribute table updates for a particular \a layer must be blocked
+     * Emitted when \a blocked status of attribute table updates for a particular \a layer must change
      *
      * \since QGIS 3.4
      */
-    void attributeTableUpdateBlocked( const QgsVectorLayer *layer );
-
-    /**
-     * Emitted when all attribute table updates for a particular \a layer must be unblocked
-     *
-     * \since QGIS 3.4
-     */
-    void attributeTableUpdateUnblocked( const QgsVectorLayer *layer );
+    void attributeTableUpdateBlocked( const QgsVectorLayer *layer, const bool blocked );
 
   private:
     void startProfile( const QString &name );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -715,14 +715,19 @@ void QgsAttributeTableDialog::mActionOpenFieldCalculator_triggered()
   QgsAttributeTableModel *masterModel = mMainView->masterModel();
 
   QgsFieldCalculator calc( mLayer, this );
+  masterModel->layerCache()->blockSignals( true );
   if ( calc.exec() == QDialog::Accepted )
   {
+    masterModel->layerCache()->blockSignals( false );
     int col = masterModel->fieldCol( calc.changedAttributeId() );
-
     if ( col >= 0 )
     {
       masterModel->reload( masterModel->index( 0, col ), masterModel->index( masterModel->rowCount() - 1, col ) );
     }
+  }
+  else
+  {
+    masterModel->layerCache()->blockSignals( false );
   }
 }
 

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -112,16 +112,19 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   connect( mMainView, &QgsDualView::showContextMenuExternally, this, &QgsAttributeTableDialog::showContextMenu );
 
   // Block/unblock table updates (feature cache signals)
-  connect( QgsApplication::instance(), &QgsApplication::attributeTableUpdateBlocked, [ = ]( const QgsVectorLayer * layer )
+  connect( QgisApp::instance(), &QgisApp::attributeTableUpdateBlocked, [ = ]( const QgsVectorLayer * layer )
   {
     if ( layer == mLayer )
       this->blockCacheUpdateSignals( true );
   } );
-  connect( QgsApplication::instance(), &QgsApplication::attributeTableUpdateUnblocked, [ = ]( const QgsVectorLayer * layer )
+  connect( QgisApp::instance(), &QgisApp::attributeTableUpdateUnblocked, [ = ]( const QgsVectorLayer * layer )
   {
     if ( layer == mLayer )
       this->blockCacheUpdateSignals( false );
   } );
+  // Massive rollbacks can also freeze the GUI due to the feature cache signals
+  connect( mLayer, &QgsVectorLayer::beforeRollBack, [ = ] { this->blockCacheUpdateSignals( true ); } );
+  connect( mLayer, &QgsVectorLayer::afterRollBack, [ = ] { this->blockCacheUpdateSignals( false ); } );
 
   const QgsFields fields = mLayer->fields();
   for ( const QgsField &field : fields )

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -112,15 +112,10 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   connect( mMainView, &QgsDualView::showContextMenuExternally, this, &QgsAttributeTableDialog::showContextMenu );
 
   // Block/unblock table updates (feature cache signals)
-  connect( QgisApp::instance(), &QgisApp::attributeTableUpdateBlocked, [ = ]( const QgsVectorLayer * layer )
+  connect( QgisApp::instance(), &QgisApp::attributeTableUpdateBlocked, [ = ]( const QgsVectorLayer * layer, const bool blocked )
   {
     if ( layer == mLayer )
-      this->blockCacheUpdateSignals( true );
-  } );
-  connect( QgisApp::instance(), &QgisApp::attributeTableUpdateUnblocked, [ = ]( const QgsVectorLayer * layer )
-  {
-    if ( layer == mLayer )
-      this->blockCacheUpdateSignals( false );
+      this->blockCacheUpdateSignals( blocked );
   } );
   // Massive rollbacks can also freeze the GUI due to the feature cache signals
   connect( mLayer, &QgsVectorLayer::beforeRollBack, [ = ] { this->blockCacheUpdateSignals( true ); } );

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -242,6 +242,7 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
 
     void updateMultiEditButtonState();
     void deleteFeature( QgsFeatureId fid );
+    void blockCacheUpdateSignals( const bool block );
 
     friend class TestQgsAttributeTable;
 };

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -267,6 +267,10 @@ void QgsFieldCalculator::accept()
       return;
     }
 
+    // Begin feature modifications, block updates for attr tables
+    // connected to this layer
+    QgsApplication::instance()->blockAttributeTableUpdates( mVectorLayer );
+
     //go through all the features and change the new attribute
     QgsFeature feature;
     bool calculationSuccess = true;
@@ -316,6 +320,8 @@ void QgsFieldCalculator::accept()
 
       rownum++;
     }
+
+    QgsApplication::instance()->unblockAttributeTableUpdates( mVectorLayer );
 
     QApplication::restoreOverrideCursor();
 

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -269,7 +269,7 @@ void QgsFieldCalculator::accept()
 
     // Begin feature modifications, block updates for attr tables
     // connected to this layer
-    QgisApp::instance()->blockAttributeTableUpdates( mVectorLayer );
+    QgisApp::instance()->blockAttributeTableUpdates( mVectorLayer, true );
 
     //go through all the features and change the new attribute
     QgsFeature feature;
@@ -321,7 +321,7 @@ void QgsFieldCalculator::accept()
       rownum++;
     }
 
-    QgisApp::instance()->unblockAttributeTableUpdates( mVectorLayer );
+    QgisApp::instance()->blockAttributeTableUpdates( mVectorLayer, false );
 
     QApplication::restoreOverrideCursor();
 

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -269,7 +269,7 @@ void QgsFieldCalculator::accept()
 
     // Begin feature modifications, block updates for attr tables
     // connected to this layer
-    QgsApplication::instance()->blockAttributeTableUpdates( mVectorLayer );
+    QgisApp::instance()->blockAttributeTableUpdates( mVectorLayer );
 
     //go through all the features and change the new attribute
     QgsFeature feature;
@@ -321,7 +321,7 @@ void QgsFieldCalculator::accept()
       rownum++;
     }
 
-    QgsApplication::instance()->unblockAttributeTableUpdates( mVectorLayer );
+    QgisApp::instance()->unblockAttributeTableUpdates( mVectorLayer );
 
     QApplication::restoreOverrideCursor();
 

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -163,169 +163,177 @@ void QgsFieldCalculator::accept()
 {
   builder->saveToRecent( QStringLiteral( "fieldcalc" ) );
 
-  if ( !mVectorLayer )
-    return;
-
-  // Set up QgsDistanceArea each time we (re-)calculate
-  QgsDistanceArea myDa;
-
-  myDa.setSourceCrs( mVectorLayer->crs(), QgsProject::instance()->transformContext() );
-  myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
-
-  QString calcString = builder->expressionText();
-  QgsExpression exp( calcString );
-  exp.setGeomCalculator( &myDa );
-  exp.setDistanceUnits( QgsProject::instance()->distanceUnits() );
-  exp.setAreaUnits( QgsProject::instance()->areaUnits() );
-
-  QgsExpressionContext expContext( QgsExpressionContextUtils::globalProjectLayerScopes( mVectorLayer ) );
-
-  if ( !exp.prepare( &expContext ) )
+  if ( ! mVectorLayer )
   {
-    QMessageBox::critical( nullptr, tr( "Evaluation Error" ), exp.evalErrorString() );
     return;
   }
-
-  bool updatingGeom = false;
-
-  // Test for creating expression field based on ! mUpdateExistingGroupBox checked rather
-  // than on mNewFieldGroupBox checked, as if the provider does not support adding attributes
-  // then mUpdateExistingGroupBox is set to not checkable, and hence is not checked.  This
-  // is a minimum fix to resolve this - better would be some GUI redesign...
-  if ( ! mUpdateExistingGroupBox->isChecked() && mCreateVirtualFieldCheckbox->isChecked() )
+  else  // Need a scope for the blocker let's keep the else for clarity
   {
-    mVectorLayer->addExpressionField( calcString, fieldDefinition() );
-  }
-  else
-  {
-    if ( !mVectorLayer->isEditable() )
-      mVectorLayer->startEditing();
 
-    QApplication::setOverrideCursor( Qt::WaitCursor );
+    QgsSignalBlocker<QgsVectorLayer> vectorBlocker( mVectorLayer );
 
-    mVectorLayer->beginEditCommand( QStringLiteral( "Field calculator" ) );
+    // Set up QgsDistanceArea each time we (re-)calculate
+    QgsDistanceArea myDa;
 
-    //update existing field
-    if ( mUpdateExistingGroupBox->isChecked() || !mNewFieldGroupBox->isEnabled() )
+    myDa.setSourceCrs( mVectorLayer->crs(), QgsProject::instance()->transformContext() );
+    myDa.setEllipsoid( QgsProject::instance()->ellipsoid() );
+
+    QString calcString = builder->expressionText();
+    QgsExpression exp( calcString );
+    exp.setGeomCalculator( &myDa );
+    exp.setDistanceUnits( QgsProject::instance()->distanceUnits() );
+    exp.setAreaUnits( QgsProject::instance()->areaUnits() );
+
+    QgsExpressionContext expContext( QgsExpressionContextUtils::globalProjectLayerScopes( mVectorLayer ) );
+
+    if ( !exp.prepare( &expContext ) )
     {
-      if ( mExistingFieldComboBox->currentData().toString() == QLatin1String( "geom" ) )
-      {
-        //update geometry
-        mAttributeId = -1;
-        updatingGeom = true;
-      }
-      else
-      {
-        QMap<QString, int>::const_iterator fieldIt = mFieldMap.constFind( mExistingFieldComboBox->currentText() );
-        if ( fieldIt != mFieldMap.constEnd() )
-        {
-          mAttributeId = fieldIt.value();
-        }
-      }
+      QMessageBox::critical( nullptr, tr( "Evaluation Error" ), exp.evalErrorString() );
+      return;
+    }
+
+    bool updatingGeom = false;
+
+    // Test for creating expression field based on ! mUpdateExistingGroupBox checked rather
+    // than on mNewFieldGroupBox checked, as if the provider does not support adding attributes
+    // then mUpdateExistingGroupBox is set to not checkable, and hence is not checked.  This
+    // is a minimum fix to resolve this - better would be some GUI redesign...
+    if ( ! mUpdateExistingGroupBox->isChecked() && mCreateVirtualFieldCheckbox->isChecked() )
+    {
+      mVectorLayer->addExpressionField( calcString, fieldDefinition() );
     }
     else
     {
-      //create new field
-      const QgsField newField = fieldDefinition();
+      if ( !mVectorLayer->isEditable() )
+        mVectorLayer->startEditing();
 
-      if ( !mVectorLayer->addAttribute( newField ) )
+      QApplication::setOverrideCursor( Qt::WaitCursor );
+
+      mVectorLayer->beginEditCommand( QStringLiteral( "Field calculator" ) );
+
+      //update existing field
+      if ( mUpdateExistingGroupBox->isChecked() || !mNewFieldGroupBox->isEnabled() )
       {
-        QApplication::restoreOverrideCursor();
-        QMessageBox::critical( nullptr, tr( "Create New Field" ), tr( "Could not add the new field to the provider." ) );
-        mVectorLayer->destroyEditCommand();
-        return;
-      }
-
-      //get index of the new field
-      const QgsFields &fields = mVectorLayer->fields();
-
-      for ( int idx = 0; idx < fields.count(); ++idx )
-      {
-        if ( fields.at( idx ).name() == mOutputFieldNameLineEdit->text() )
+        if ( mExistingFieldComboBox->currentData().toString() == QLatin1String( "geom" ) )
         {
-          mAttributeId = idx;
-          break;
+          //update geometry
+          mAttributeId = -1;
+          updatingGeom = true;
         }
-      }
-
-      //update expression context with new fields
-      expContext.setFields( mVectorLayer->fields() );
-      if ( ! exp.prepare( &expContext ) )
-      {
-        QApplication::restoreOverrideCursor();
-        QMessageBox::critical( nullptr, tr( "Evaluation Error" ), exp.evalErrorString() );
-        return;
-      }
-    }
-
-    if ( mAttributeId == -1 && !updatingGeom )
-    {
-      mVectorLayer->destroyEditCommand();
-      QApplication::restoreOverrideCursor();
-      return;
-    }
-
-    //go through all the features and change the new attribute
-    QgsFeature feature;
-    bool calculationSuccess = true;
-    QString error;
-
-    bool useGeometry = exp.needsGeometry();
-    int rownum = 1;
-
-    QgsField field = !updatingGeom ? mVectorLayer->fields().at( mAttributeId ) : QgsField();
-
-    bool newField = !mUpdateExistingGroupBox->isChecked();
-    QVariant emptyAttribute;
-    if ( newField )
-      emptyAttribute = QVariant( field.type() );
-
-    QgsFeatureRequest req = QgsFeatureRequest().setFlags( useGeometry ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry );
-    if ( mOnlyUpdateSelectedCheckBox->isChecked() )
-    {
-      req.setFilterFids( mVectorLayer->selectedFeatureIds() );
-    }
-    QgsFeatureIterator fit = mVectorLayer->getFeatures( req );
-    while ( fit.nextFeature( feature ) )
-    {
-      expContext.setFeature( feature );
-      expContext.lastScope()->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "row_number" ), rownum, true ) );
-
-      QVariant value = exp.evaluate( &expContext );
-      if ( exp.hasEvalError() )
-      {
-        calculationSuccess = false;
-        error = exp.evalErrorString();
-        break;
-      }
-      else if ( updatingGeom )
-      {
-        if ( value.canConvert< QgsGeometry >() )
+        else
         {
-          QgsGeometry geom = value.value< QgsGeometry >();
-          mVectorLayer->changeGeometry( feature.id(), geom );
+          QMap<QString, int>::const_iterator fieldIt = mFieldMap.constFind( mExistingFieldComboBox->currentText() );
+          if ( fieldIt != mFieldMap.constEnd() )
+          {
+            mAttributeId = fieldIt.value();
+          }
         }
       }
       else
       {
-        ( void )field.convertCompatible( value );
-        mVectorLayer->changeAttributeValue( feature.id(), mAttributeId, value, newField ? emptyAttribute : feature.attributes().value( mAttributeId ) );
+        //create new field
+        const QgsField newField = fieldDefinition();
+
+        if ( !mVectorLayer->addAttribute( newField ) )
+        {
+          QApplication::restoreOverrideCursor();
+          QMessageBox::critical( nullptr, tr( "Create New Field" ), tr( "Could not add the new field to the provider." ) );
+          mVectorLayer->destroyEditCommand();
+          return;
+        }
+
+        //get index of the new field
+        const QgsFields &fields = mVectorLayer->fields();
+
+        for ( int idx = 0; idx < fields.count(); ++idx )
+        {
+          if ( fields.at( idx ).name() == mOutputFieldNameLineEdit->text() )
+          {
+            mAttributeId = idx;
+            break;
+          }
+        }
+
+        //update expression context with new fields
+        expContext.setFields( mVectorLayer->fields() );
+        if ( ! exp.prepare( &expContext ) )
+        {
+          QApplication::restoreOverrideCursor();
+          QMessageBox::critical( nullptr, tr( "Evaluation Error" ), exp.evalErrorString() );
+          return;
+        }
       }
 
-      rownum++;
+      if ( mAttributeId == -1 && !updatingGeom )
+      {
+        mVectorLayer->destroyEditCommand();
+        QApplication::restoreOverrideCursor();
+        return;
+      }
+
+      //go through all the features and change the new attribute
+      QgsFeature feature;
+      bool calculationSuccess = true;
+      QString error;
+
+      bool useGeometry = exp.needsGeometry();
+      int rownum = 1;
+
+      QgsField field = !updatingGeom ? mVectorLayer->fields().at( mAttributeId ) : QgsField();
+
+      bool newField = !mUpdateExistingGroupBox->isChecked();
+      QVariant emptyAttribute;
+      if ( newField )
+        emptyAttribute = QVariant( field.type() );
+
+      QgsFeatureRequest req = QgsFeatureRequest().setFlags( useGeometry ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry );
+      if ( mOnlyUpdateSelectedCheckBox->isChecked() )
+      {
+        req.setFilterFids( mVectorLayer->selectedFeatureIds() );
+      }
+      QgsFeatureIterator fit = mVectorLayer->getFeatures( req );
+      while ( fit.nextFeature( feature ) )
+      {
+        expContext.setFeature( feature );
+        expContext.lastScope()->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "row_number" ), rownum, true ) );
+
+        QVariant value = exp.evaluate( &expContext );
+        if ( exp.hasEvalError() )
+        {
+          calculationSuccess = false;
+          error = exp.evalErrorString();
+          break;
+        }
+        else if ( updatingGeom )
+        {
+          if ( value.canConvert< QgsGeometry >() )
+          {
+            QgsGeometry geom = value.value< QgsGeometry >();
+            mVectorLayer->changeGeometry( feature.id(), geom );
+          }
+        }
+        else
+        {
+          ( void )field.convertCompatible( value );
+          mVectorLayer->changeAttributeValue( feature.id(), mAttributeId, value, newField ? emptyAttribute : feature.attributes().value( mAttributeId ) );
+        }
+
+        rownum++;
+      }
+
+      QApplication::restoreOverrideCursor();
+
+      if ( !calculationSuccess )
+      {
+        QMessageBox::critical( nullptr, tr( "Evaluation Error" ), tr( "An error occurred while evaluating the calculation string:\n%1" ).arg( error ) );
+        mVectorLayer->destroyEditCommand();
+        return;
+      }
+      mVectorLayer->endEditCommand();
     }
-
-    QApplication::restoreOverrideCursor();
-
-    if ( !calculationSuccess )
-    {
-      QMessageBox::critical( nullptr, tr( "Evaluation Error" ), tr( "An error occurred while evaluating the calculation string:\n%1" ).arg( error ) );
-      mVectorLayer->destroyEditCommand();
-      return;
-    }
-
-    mVectorLayer->endEditCommand();
   }
+  // Vector signals unlocked! Tell the world that the layer has changed
+  mVectorLayer->dataChanged();
   QDialog::accept();
 }
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1535,15 +1535,6 @@ void QgsApplication::collectTranslatableObjects( QgsTranslationContext *translat
   emit requestForTranslatableObjects( translationContext );
 }
 
-void QgsApplication::unblockAttributeTableUpdates( const QgsVectorLayer *layer )
-{
-  emit attributeTableUpdateUnblocked( layer );
-}
-
-void QgsApplication::blockAttributeTableUpdates( const QgsVectorLayer *layer )
-{
-  emit attributeTableUpdateBlocked( layer );
-}
 
 QString QgsApplication::nullRepresentation()
 {

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1535,6 +1535,16 @@ void QgsApplication::collectTranslatableObjects( QgsTranslationContext *translat
   emit requestForTranslatableObjects( translationContext );
 }
 
+void QgsApplication::unblockAttributeTableUpdates( const QgsVectorLayer *layer )
+{
+  emit attributeTableUpdateUnblocked( layer );
+}
+
+void QgsApplication::blockAttributeTableUpdates( const QgsVectorLayer *layer )
+{
+  emit attributeTableUpdateBlocked( layer );
+}
+
 QString QgsApplication::nullRepresentation()
 {
   ApplicationMembers *appMembers = members();

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -49,6 +49,7 @@ class QgsLayoutItemRegistry;
 class QgsAuthManager;
 class QgsNetworkContentFetcherRegistry;
 class QTranslator;
+class QgsVectorLayer;
 
 /**
  * \ingroup core
@@ -757,6 +758,21 @@ class CORE_EXPORT QgsApplication : public QApplication
      */
     void collectTranslatableObjects( QgsTranslationContext *translationContext );
 
+    /**
+     * Emits the signal to block updates for attribute tables connected a particular \a layer
+     *
+     * \since QGIS 3.4
+     */
+    void blockAttributeTableUpdates( const QgsVectorLayer *layer );
+
+    /**
+     * Emits the signal to unblock updates for attribute tables connected a particular \a layer
+     *
+     * \since QGIS 3.4
+     */
+    void unblockAttributeTableUpdates( const QgsVectorLayer *layer );
+
+
 #ifdef SIP_RUN
     SIP_IF_FEATURE( ANDROID )
     //dummy method to workaround sip generation issue
@@ -787,6 +803,21 @@ class CORE_EXPORT QgsApplication : public QApplication
      * \since QGIS 3.4
      */
     void requestForTranslatableObjects( QgsTranslationContext *translationContext );
+
+    /**
+     * Emitted when attribute table updates for a particular \a layer must be blocked
+     *
+     * \since QGIS 3.4
+     */
+    void attributeTableUpdateBlocked( const QgsVectorLayer *layer );
+
+    /**
+     * Emitted when all attribute table updates for a particular \a layer must be unblocked
+     *
+     * \since QGIS 3.4
+     */
+    void attributeTableUpdateUnblocked( const QgsVectorLayer *layer );
+
 
   private:
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -49,7 +49,6 @@ class QgsLayoutItemRegistry;
 class QgsAuthManager;
 class QgsNetworkContentFetcherRegistry;
 class QTranslator;
-class QgsVectorLayer;
 
 /**
  * \ingroup core

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -758,20 +758,6 @@ class CORE_EXPORT QgsApplication : public QApplication
      */
     void collectTranslatableObjects( QgsTranslationContext *translationContext );
 
-    /**
-     * Emits the signal to block updates for attribute tables connected a particular \a layer
-     *
-     * \since QGIS 3.4
-     */
-    void blockAttributeTableUpdates( const QgsVectorLayer *layer );
-
-    /**
-     * Emits the signal to unblock updates for attribute tables connected a particular \a layer
-     *
-     * \since QGIS 3.4
-     */
-    void unblockAttributeTableUpdates( const QgsVectorLayer *layer );
-
 
 #ifdef SIP_RUN
     SIP_IF_FEATURE( ANDROID )
@@ -803,20 +789,6 @@ class CORE_EXPORT QgsApplication : public QApplication
      * \since QGIS 3.4
      */
     void requestForTranslatableObjects( QgsTranslationContext *translationContext );
-
-    /**
-     * Emitted when attribute table updates for a particular \a layer must be blocked
-     *
-     * \since QGIS 3.4
-     */
-    void attributeTableUpdateBlocked( const QgsVectorLayer *layer );
-
-    /**
-     * Emitted when all attribute table updates for a particular \a layer must be unblocked
-     *
-     * \since QGIS 3.4
-     */
-    void attributeTableUpdateUnblocked( const QgsVectorLayer *layer );
 
 
   private:

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2973,6 +2973,8 @@ bool QgsVectorLayer::rollBack( bool deleteBuffer )
 
   mEditBuffer->rollBack();
 
+  emit afterRollBack();
+
   if ( isModified() )
   {
     // new undo stack roll back method

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2168,6 +2168,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void beforeRollBack();
 
     /**
+     * Is emitted, after changes are rolled back
+     * \since QGIS 3.4
+     */
+    void afterRollBack();
+
+    /**
      * Will be emitted, when a new attribute has been added to this vector layer.
      * Applies only to types QgsFields::OriginEdit, QgsFields::OriginProvider and QgsFields::OriginExpression
      *


### PR DESCRIPTION
The diff is misleading, it's just a single
change in the logic: block the vector signals ...
... and emit dataChanged at
the end.

I don't really like the idea of blocking 
signals (the edit buffer basically) 
and I'm a bit worried of side effects,
but I can't see any other solution.

The root of the issue here is that
for each changed field/row an attribute
valueChanged signal is emitted, and the
QgsVectorLayerCache::featureAtId
loads the feature again.

Pocessing time for the test layer in the
issue tracker went down from ~20 minutes
to less than 3 seconds.
