### PR TITLE
Handle relative paths during style xml import

### DIFF
--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -1600,6 +1600,10 @@ bool QgsStyle::importXml( const QString &filename )
     return false;
   }
 
+  QgsReadWriteContext rwContext;
+  QgsPathResolver resolver;
+  rwContext.setPathResolver( QgsPathResolver( filename ) );
+
   QgsSymbolMap symbols;
 
   QDomElement symbolsElement = docEl.firstChildElement( QStringLiteral( "symbols" ) );
@@ -1628,7 +1632,7 @@ bool QgsStyle::importXml( const QString &filename )
           favorite = true;
         }
 
-        QgsSymbol *symbol = QgsSymbolLayerUtils::loadSymbol( e, QgsReadWriteContext() );
+        QgsSymbol *symbol = QgsSymbolLayerUtils::loadSymbol( e, rwContext );
         if ( symbol )
         {
           addSymbol( name, symbol );


### PR DESCRIPTION
If a style xml file contains relative paths to svg/etc files, these should be treated as relative to the xml file during symbol import