### PR TITLE
[WFS client] Try to handle layers of type GeometryCollection if the first GeometryCollection is made of geometries of the same type (fixes #19571)

### DIFF
--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -329,10 +329,20 @@ QUrl QgsWFSFeatureDownloader::buildURL( qint64 startIndex, int maxFeatures, bool
   else if ( !mShared->mRect.isNull() )
   {
     bool invertAxis = false;
-    if ( !mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) && !mShared->mURI.ignoreAxisOrientation() &&
-         mShared->mSourceCRS.hasAxisInverted() )
+    if ( !mShared->mWFSVersion.startsWith( QLatin1String( "1.0" ) ) &&
+         !mShared->mURI.ignoreAxisOrientation() )
     {
-      invertAxis = true;
+      // This is a bit nasty, but if the server reports OGC::CRS84
+      // mSourceCRS will report hasAxisInverted() == false, but srsName()
+      // will be urn:ogc:def:crs:EPSG::4326, so axis inversion is needed...
+      if ( mShared->srsName() == QLatin1String( "urn:ogc:def:crs:EPSG::4326" ) )
+      {
+        invertAxis = true;
+      }
+      else if ( mShared->mSourceCRS.hasAxisInverted() )
+      {
+        invertAxis = true;
+      }
     }
     if ( mShared->mURI.invertAxisOrientation() )
     {

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -18,6 +18,10 @@
 #include "qgsmessagelog.h"
 #include "qgsgeometry.h"
 #include "qgsgml.h"
+#include "qgsgeometrycollection.h"
+#include "qgsmultipoint.h"
+#include "qgsmultilinestring.h"
+#include "qgsmultipolygon.h"
 #include "qgsogcutils.h"
 #include "qgswfsconstants.h"
 #include "qgswfsfeatureiterator.h"
@@ -720,6 +724,49 @@ void QgsWFSFeatureDownloader::run( bool serializeFeatures, int maxFeatures )
             QgsGeometry g = f.geometry();
             g.transform( QTransform( 0, 1, 1, 0, 0, 0 ) );
             f.setGeometry( g );
+          }
+
+          // If receiving a geometry collection, but expecting a multipoint/...,
+          // then try to convert it
+          if ( f.hasGeometry() &&
+               f.geometry().wkbType() == QgsWkbTypes::GeometryCollection &&
+               ( mShared->mWKBType == QgsWkbTypes::MultiPoint ||
+                 mShared->mWKBType == QgsWkbTypes::MultiLineString ||
+                 mShared->mWKBType == QgsWkbTypes::MultiPolygon ) )
+          {
+            QgsWkbTypes::Type singleType = QgsWkbTypes::singleType( mShared->mWKBType );
+            auto g = f.geometry().constGet();
+            auto gc = qgsgeometry_cast<QgsGeometryCollection *>( g );
+            bool allExpectedType = true;
+            for ( int i = 0; i < gc->numGeometries(); ++i )
+            {
+              if ( gc->geometryN( i )->wkbType() != singleType )
+              {
+                allExpectedType = false;
+                break;
+              }
+            }
+            if ( allExpectedType )
+            {
+              QgsGeometryCollection *newGC;
+              if ( mShared->mWKBType == QgsWkbTypes::MultiPoint )
+              {
+                newGC =  new QgsMultiPoint();
+              }
+              else if ( mShared->mWKBType == QgsWkbTypes::MultiLineString )
+              {
+                newGC = new QgsMultiLineString();
+              }
+              else
+              {
+                newGC = new QgsMultiPolygon();
+              }
+              for ( int i = 0; i < gc->numGeometries(); ++i )
+              {
+                newGC->addGeometry( gc->geometryN( i )->clone() );
+              }
+              f.setGeometry( QgsGeometry( newGC ) );
+            }
           }
 
           featureList.push_back( QgsWFSFeatureGmlIdPair( f, gmlId ) );

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -104,7 +104,7 @@ QgsWFSProvider::QgsWFSProvider( const QString &uri, const ProviderOptions &optio
     //fetch attributes of layer and type of its geometry attribute
     //WBC 111221: extracting geometry type here instead of getFeature allows successful
     //layer creation even when no features are retrieved (due to, e.g., BBOX or FILTER)
-    if ( !describeFeatureType( mShared->mGeometryAttribute, mShared->mFields, mWKBType ) )
+    if ( !describeFeatureType( mShared->mGeometryAttribute, mShared->mFields, mShared->mWKBType ) )
     {
       mValid = false;
       return;
@@ -120,7 +120,7 @@ QgsWFSProvider::QgsWFSProvider( const QString &uri, const ProviderOptions &optio
   }
 
   //Failed to detect feature type from describeFeatureType -> get first feature from layer to detect type
-  if ( mWKBType == QgsWkbTypes::Unknown )
+  if ( mShared->mWKBType == QgsWkbTypes::Unknown )
   {
     QgsWFSFeatureDownloader downloader( mShared.get() );
     connect( &downloader, static_cast<void ( QgsWFSFeatureDownloader::* )( QVector<QgsWFSFeatureGmlIdPair> )>( &QgsWFSFeatureDownloader::featureReceived ),
@@ -478,7 +478,7 @@ bool QgsWFSProvider::processSQL( const QString &sqlString, QString &errorMsg, QS
     if ( typeName == mShared->mURI.typeName() )
     {
       mShared->mGeometryAttribute = geometryAttribute;
-      mWKBType = geomType;
+      mShared->mWKBType = geomType;
       mThisTypenameFields = fields;
     }
 
@@ -665,7 +665,53 @@ void QgsWFSProvider::featureReceivedAnalyzeOneFeature( QVector<QgsWFSFeatureGmlI
     QgsGeometry geometry = feat.geometry();
     if ( !geometry.isNull() )
     {
-      mWKBType = geometry.wkbType();
+      mShared->mWKBType = geometry.wkbType();
+
+      // Fragile heuristics that helps for
+      // https://sampleservices.luciad.com/ogc/wfs/sampleswfs?REQUEST=GetFeature&SERVICE=WFS&TYPENAME=rivers&VERSION=1.1.0
+      // In case the geometry is a geometry collection, analyze its members to
+      // see if they are of the same type. If then, assume that all features
+      // will be similar, and report the proper MultiPoint/MultiLineString/
+      // MultiPolygon type instead.
+      if ( mShared->mWKBType == QgsWkbTypes::GeometryCollection )
+      {
+        auto geomColl = geometry.asGeometryCollection();
+        mShared->mWKBType = QgsWkbTypes::Unknown;
+        for ( const auto &geom : geomColl )
+        {
+          if ( mShared->mWKBType == QgsWkbTypes::Unknown )
+          {
+            mShared->mWKBType = geom.wkbType();
+          }
+          else if ( mShared->mWKBType != geom.wkbType() )
+          {
+            mShared->mWKBType = QgsWkbTypes::Unknown;
+            break;
+          }
+        }
+        if ( mShared->mWKBType != QgsWkbTypes::Unknown )
+        {
+          if ( mShared->mWKBType == QgsWkbTypes::Point )
+          {
+            QgsDebugMsg( QStringLiteral( "Layer of unknown type. First element is a GeometryCollection of Point. Advertizing optimistically as MultiPoint" ) );
+            mShared->mWKBType = QgsWkbTypes::MultiPoint;
+          }
+          else if ( mShared->mWKBType == QgsWkbTypes::LineString )
+          {
+            QgsDebugMsg( QStringLiteral( "Layer of unknown type. First element is a GeometryCollection of LineString. Advertizing optimistically as MultiLineString" ) );
+            mShared->mWKBType = QgsWkbTypes::MultiLineString;
+          }
+          else if ( mShared->mWKBType == QgsWkbTypes::Polygon )
+          {
+            QgsDebugMsg( QStringLiteral( "Layer of unknown type. First element is a GeometryCollection of Polygon. Advertizing optimistically as MultiPolygon" ) );
+            mShared->mWKBType = QgsWkbTypes::MultiPolygon;
+          }
+          else
+          {
+            mShared->mWKBType = QgsWkbTypes::Unknown;
+          }
+        }
+      }
     }
   }
 }
@@ -744,7 +790,7 @@ void QgsWFSProvider::reloadData()
 
 QgsWkbTypes::Type QgsWFSProvider::wkbType() const
 {
-  return mWKBType;
+  return mShared->mWKBType;
 }
 
 long QgsWFSProvider::featureCount() const

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -134,8 +134,6 @@ class QgsWFSProvider : public QgsVectorDataProvider
     //! String used to define a subset of the layer
     QString mSubsetString;
 
-    //! Geometry type of the features in this layer
-    mutable QgsWkbTypes::Type mWKBType = QgsWkbTypes::Unknown;
     //! Flag if provider is valid
     bool mValid = true;
     //! Namespace URL of the server (comes from DescribeFeatureDocument)

--- a/src/providers/wfs/qgswfsshareddata.h
+++ b/src/providers/wfs/qgswfsshareddata.h
@@ -187,6 +187,9 @@ class QgsWFSSharedData : public QObject
         EPSG:XXXX srsName and not EPSG urns */
     bool mGetFeatureEPSGDotHonoursEPSGOrder;
 
+    //! Geometry type of the features in this layer
+    QgsWkbTypes::Type mWKBType = QgsWkbTypes::Unknown;
+
   private:
 
     //! Main mutex to protect most data members that can be modified concurrently


### PR DESCRIPTION
Also include another fix: [WFS client] Fix GetFeature BBOX in WFS 1.1 when the GetCapabilies CRS is urn:ogc:def:crs:OGC:1.3:CRS84 (refs #19571)