### PR TITLE
Fix #14897 - Remove double undo/redo buttons in style dock

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -75,6 +75,7 @@ QgsLayerStylingWidget::QgsLayerStylingWidget( QgsMapCanvas *canvas, const QList<
   mAutoApplyTimer->setSingleShot( true );
 
   mUndoWidget = new QgsUndoWidget( this, mMapCanvas );
+  mUndoWidget->setButtonsVisible( false );
   mUndoWidget->setAutoDelete( false );
   mUndoWidget->setObjectName( QStringLiteral( "Undo Styles" ) );
   mUndoWidget->hide();

--- a/src/app/qgsundowidget.cpp
+++ b/src/app/qgsundowidget.cpp
@@ -38,6 +38,11 @@ QgsUndoWidget::QgsUndoWidget( QWidget *parent, QgsMapCanvas *mapCanvas )
   mPreviousCount = 0;
 }
 
+void QgsUndoWidget::setButtonsVisible( bool show )
+{
+  undoButton->setVisible( show );
+  redoButton->setVisible( show );
+}
 
 void QgsUndoWidget::destroyStack()
 {

--- a/src/app/qgsundowidget.h
+++ b/src/app/qgsundowidget.h
@@ -56,6 +56,12 @@ class APP_EXPORT QgsUndoWidget : public QgsPanelWidget
     void setUndoStack( QUndoStack *undoStack );
 
     /**
+     * Show or hide the undo/redo buttons on the widget.
+     * \param show Show or hide the undo/redo buttons.
+     */
+    void setButtonsVisible( bool show );
+
+    /**
      * Handles destroying of stack when active layer is changed
      */
     void destroyStack();


### PR DESCRIPTION
Removes the duplicate undo/redo buttons from the style dock:

![image](https://user-images.githubusercontent.com/381660/46926571-a94d4f80-d074-11e8-80a2-b09d4a56deac.png)
