### PR TITLE
[processing][gdal][needs-docs] Rename crop to cutline option for clarity

### DIFF
--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -78,7 +78,7 @@ class ClipRasterByMask(GdalAlgorithm):
                                                         self.tr('Create an output alpha band'),
                                                         defaultValue=False))
         self.addParameter(QgsProcessingParameterBoolean(self.CROP_TO_CUTLINE,
-                                                        self.tr('Crop the extent of the target dataset to the extent of the cutline'),
+                                                        self.tr('Match the extent of the clipped raster to the extent of the mask layer'),
                                                         defaultValue=True))
         self.addParameter(QgsProcessingParameterBoolean(self.KEEP_RESOLUTION,
                                                         self.tr('Keep resolution of output raster'),


### PR DESCRIPTION
The previous name is unclear, as the option can expand as well as crop the raster extent. We also don't refer anywhere else in this dialog to the cutline, so that has no meaning to users
