### PR TITLE
Expression widget ux fixes

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -294,7 +294,18 @@ void QgsExpressionBuilderWidget::updateFunctionFileList( const QString &path )
     cmbFileNames->addItem( item );
   }
   if ( !cmbFileNames->currentItem() )
+  {
     cmbFileNames->setCurrentRow( 0 );
+  }
+
+  if ( cmbFileNames->count() == 0 )
+  {
+    // Create default sample entry.
+    newFunctionFile( "default" );
+    txtPython->setText( QString( "'''\n#Sample custom function file\n "
+                                 "(uncomment to use and customize or Add button to create a new file) \n%1 \n '''" ).arg( txtPython->text() ) );
+    saveFunctionFile( "default" );
+  }
 }
 
 void QgsExpressionBuilderWidget::newFunctionFile( const QString &fileName )

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -92,6 +92,8 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   txtSearchEditValues->setShowSearchIcon( true );
   txtSearchEditValues->setPlaceholderText( tr( "Search…" ) );
 
+  editorSplit->setSizes( QList<int>( {175, 300} ) );
+
   QgsSettings settings;
   splitter->restoreState( settings.value( QStringLiteral( "Windows/QgsExpressionBuilderWidget/splitter" ) ).toByteArray() );
   editorSplit->restoreState( settings.value( QStringLiteral( "Windows/QgsExpressionBuilderWidget/editorsplitter" ) ).toByteArray() );

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -624,9 +624,27 @@
          <property name="childrenCollapsible">
           <bool>false</bool>
          </property>
-         <widget class="QWidget" name="layoutWidget3">
-          <layout class="QVBoxLayout" name="verticalLayout_5">
-           <item>
+         <widget class="QWidget" name="widget3" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_7">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item row="0" column="0">
             <widget class="QListWidget" name="cmbFileNames">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -645,7 +663,7 @@
              </property>
             </widget>
            </item>
-           <item>
+           <item row="1" column="0">
             <layout class="QHBoxLayout" name="horizontalLayout_6">
              <property name="topMargin">
               <number>0</number>
@@ -689,10 +707,22 @@ Change the name of the script and save to allow QGIS to auto load on startup.</s
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="layoutWidget">
+         <widget class="QWidget" name="widget" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <layout class="QVBoxLayout" name="verticalLayout_3">
-           <property name="bottomMargin">
+           <property name="leftMargin">
             <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>1</number>
            </property>
            <item>
             <widget class="QgsCodeEditorPython" name="txtPython" native="true"/>


### PR DESCRIPTION
As requested by @nirvn (who has now run out of request credits due** :P ) the default view for custom expressions panel is now a bit saner.

- Default width for file list
- Default template sample file added.

![image](https://user-images.githubusercontent.com/381660/46932787-99456800-d094-11e8-8e3c-af2f91028d32.png)

** this is a joke, keep them coming!