### PR TITLE
UX - Add icon for field types in expression widget

### DIFF
--- a/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
+++ b/python/gui/auto_generated/qgsexpressionbuilderwidget.sip.in
@@ -198,7 +198,8 @@ preview result and for populating the list of available functions and variables.
     void registerItem( const QString &group, const QString &label, const QString &expressionText,
                        const QString &helpText = QString(),
                        QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
-                       bool highlightedItem = false, int sortOrder = 1 );
+                       bool highlightedItem = false, int sortOrder = 1,
+                       QIcon icon = QIcon() );
 %Docstring
 Registers a node item for the expression builder.
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -388,6 +388,7 @@ void QgsExpressionBuilderWidget::loadFieldNames()
   loadFieldNames( mLayer->fields() );
 }
 
+
 void QgsExpressionBuilderWidget::loadFieldNames( const QgsFields &fields )
 {
   if ( fields.isEmpty() )
@@ -396,13 +397,14 @@ void QgsExpressionBuilderWidget::loadFieldNames( const QgsFields &fields )
   txtExpressionString->setFields( fields );
 
   QStringList fieldNames;
-  //Q_FOREACH ( const QgsField& field, fields )
   fieldNames.reserve( fields.count() );
   for ( int i = 0; i < fields.count(); ++i )
   {
-    QString fieldName = fields.at( i ).name();
+    QgsField field = fields.at( i );
+    QString fieldName = field.name();
     fieldNames << fieldName;
-    registerItem( QStringLiteral( "Fields and Values" ), fieldName, " \"" + fieldName + "\" ", QString(), QgsExpressionItem::Field, false, i );
+    QIcon icon = fields.iconForField( i );
+    registerItem( QStringLiteral( "Fields and Values" ), fieldName, " \"" + fieldName + "\" ", QString(), QgsExpressionItem::Field, false, i, icon );
   }
 //  highlighter->addFields( fieldNames );
 }
@@ -465,11 +467,12 @@ void QgsExpressionBuilderWidget::registerItem( const QString &group,
     const QString &label,
     const QString &expressionText,
     const QString &helpText,
-    QgsExpressionItem::ItemType type, bool highlightedItem, int sortOrder )
+    QgsExpressionItem::ItemType type, bool highlightedItem, int sortOrder, QIcon icon )
 {
   QgsExpressionItem *item = new QgsExpressionItem( label, expressionText, helpText, type );
   item->setData( label, Qt::UserRole );
   item->setData( sortOrder, QgsExpressionItem::CUSTOM_SORT_ROLE );
+  item->setIcon( icon );
 
   // Look up the group and insert the new function.
   if ( mExpressionGroups.contains( group ) )

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -217,7 +217,8 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void registerItem( const QString &group, const QString &label, const QString &expressionText,
                        const QString &helpText = QString(),
                        QgsExpressionItem::ItemType type = QgsExpressionItem::ExpressionNode,
-                       bool highlightedItem = false, int sortOrder = 1 );
+                       bool highlightedItem = false, int sortOrder = 1,
+                       QIcon icon = QIcon() );
 
     bool isExpressionValid();
 


### PR DESCRIPTION
Adds missing icons to the expression widget to match rest of application use.

![image](https://user-images.githubusercontent.com/381660/46935229-e974f800-d09d-11e8-8689-5d8892a1ed28.png)
