### PR TITLE
[Processing] Allow reordering of items in the MultipleInputDialog.

### DIFF
--- a/python/plugins/processing/gui/MultipleInputDialog.py
+++ b/python/plugins/processing/gui/MultipleInputDialog.py
@@ -43,7 +43,8 @@ class MultipleInputDialog(BASE, WIDGET):
         super(MultipleInputDialog, self).__init__(None)
         self.setupUi(self)
 
-        self.lstLayers.setSelectionMode(QAbstractItemView.NoSelection)
+        self.lstLayers.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.lstLayers.setDragDropMode(QAbstractItemView.InternalMove)
 
         self.options = options
         self.selectedoptions = selectedoptions or []
@@ -69,8 +70,10 @@ class MultipleInputDialog(BASE, WIDGET):
         model = QStandardItemModel()
         for i, option in enumerate(self.options):
             item = QStandardItem(option)
+            item.setData(i, Qt.UserRole)
             item.setCheckState(Qt.Checked if i in self.selectedoptions else Qt.Unchecked)
             item.setCheckable(True)
+            item.setDropEnabled(False)
             model.appendRow(item)
 
         self.lstLayers.setModel(model)
@@ -78,10 +81,10 @@ class MultipleInputDialog(BASE, WIDGET):
     def accept(self):
         self.selectedoptions = []
         model = self.lstLayers.model()
-        for i in xrange(model.rowCount()):
+        for i in range(model.rowCount()):
             item = model.item(i)
             if item.checkState() == Qt.Checked:
-                self.selectedoptions.append(i)
+                self.selectedoptions.append(item.data(Qt.UserRole))
         QDialog.accept(self)
 
     def reject(self):


### PR DESCRIPTION
## Description
Items in MultipleItemDialog can now be reordered by dragging and dropping, in the same way as it is done in QGIS 3.2.

I would consider it a bug fix since the order of items is essential for proper utilization of some algorithms (e.g. GDAL merge or build virtual raster). However, no worries if core developers consider it a feature ;)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
