### PR TITLE
Correct hidden widgets from vector layer properties dialog Fixes #18554

### DIFF
--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -33,6 +33,7 @@ QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer,
   // available widgets tree
   QGridLayout *availableWidgetsWidgetLayout = new QGridLayout;
   mAvailableWidgetsTree = new DnDTree( mLayer );
+  mAvailableWidgetsTree->setObjectName( "mAvailableWidgetsTree" );
   availableWidgetsWidgetLayout->addWidget( mAvailableWidgetsTree );
   availableWidgetsWidgetLayout->setMargin( 0 );
   mAvailableWidgetsWidget->setLayout( availableWidgetsWidgetLayout );
@@ -782,9 +783,18 @@ QgsAttributesFormProperties::FieldConfig::FieldConfig( QgsVectorLayer *layer, in
   mConstraintStrength.insert( QgsFieldConstraints::ConstraintUnique, mFieldConstraints.constraintStrength( QgsFieldConstraints::ConstraintUnique ) );
   mConstraintStrength.insert( QgsFieldConstraints::ConstraintExpression, mFieldConstraints.constraintStrength( QgsFieldConstraints::ConstraintExpression ) );
   mConstraintDescription = mFieldConstraints.constraintDescription();
-  const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( layer, layer->fields().field( idx ).name() );
-  mEditorWidgetType = setup.type();
-  mEditorWidgetConfig = setup.config();
+
+  if ( layer->attributeTableConfig().columns()[idx].hidden )
+  {
+    mEditorWidgetType = "Hidden";
+    mEditorWidgetConfig = QVariantMap();
+  }
+  else
+  {
+    const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( layer, layer->fields().field( idx ).name() );
+    mEditorWidgetType = setup.type();
+    mEditorWidgetConfig = setup.config();
+  }
 }
 
 QgsAttributesFormProperties::FieldConfig::operator QVariant()

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -625,6 +625,11 @@ void QgsVectorLayerProperties::apply()
     {
       columns[i].hidden = !mActionDialog->showWidgetInAttributeTable();
     }
+    else
+    {
+      QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( mLayer, columns[i].name );
+      columns[i].hidden = ( setup.type() == QLatin1String( "Hidden" ) );
+    }
   }
 
   attributeTableConfig.setColumns( columns );

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -18,6 +18,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_SOURCE_DIR}/src/gui/editorwidgets/core
   ${CMAKE_SOURCE_DIR}/src/gui/attributetable
   ${CMAKE_SOURCE_DIR}/src/gui/symbology
+  ${CMAKE_SOURCE_DIR}/src/gui/layertree
   ${CMAKE_SOURCE_DIR}/src/gui/raster
   ${CMAKE_SOURCE_DIR}/src/python
   ${CMAKE_SOURCE_DIR}/src/app
@@ -110,4 +111,5 @@ ADD_QGIS_TEST(measuretool testqgsmeasuretool.cpp)
 ADD_QGIS_TEST(vertextool testqgsvertextool.cpp)
 ADD_QGIS_TEST(vectorlayersaveasdialogtest testqgsvectorlayersaveasdialog.cpp)
 ADD_QGIS_TEST(maptoolreverselinetest testqgsmaptoolreverseline.cpp)
+ADD_QGIS_TEST(qgsvectorlayerpropertiestest testqgsvectorlayerproperties.cpp)
 

--- a/tests/src/app/testqgsvectorlayerproperties.cpp
+++ b/tests/src/app/testqgsvectorlayerproperties.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+    testqgsvectorlayerproperties.cpp
+     --------------------------------------
+    Date                 : 15 10 2018
+    Copyright            : (C) 2018 Julien Cabieces
+    Email                : julien dot cabieces at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+
+#include <qgsvectorlayerproperties.h>
+#include <qgsattributesformproperties.h>
+#include <qgsattributetypedialog.h>
+#include <qgshiddenwidgetfactory.h>
+#include <qgstexteditwidgetfactory.h>
+#include <editorwidgets/core/qgseditorwidgetwrapper.h>
+#include <qgsapplication.h>
+#include "qgisapp.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the qgs vector layer properties dialog
+ */
+class TestQgsVectorLayerProperties : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsVectorLayerProperties();
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void testHiddenWidgetApply();
+    void testHiddenWidgetLoad();
+
+  private:
+    QgisApp *mQgisApp = nullptr;
+};
+
+TestQgsVectorLayerProperties::TestQgsVectorLayerProperties() = default;
+
+void TestQgsVectorLayerProperties::initTestCase()
+{
+  qDebug() << "TestQgsVectorLayerProperties::initTestCase()";
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  mQgisApp = new QgisApp();
+
+  // setup the test QSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+}
+
+void TestQgsVectorLayerProperties::cleanupTestCase() // will be called after the last testfunction was executed.
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsVectorLayerProperties::testHiddenWidgetApply()
+{
+  QString def = QStringLiteral( "Point?field=col0:integer&field=col1:integer" );
+  QgsVectorLayer layer( def, QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+
+  QgsVectorLayerProperties propertiesDialog( &layer );
+
+  // we hide first column
+  layer.setEditorWidgetSetup( 0, QgsEditorWidgetSetup( "Hidden", QVariantMap() ) );
+  propertiesDialog.apply();
+
+  QVERIFY( layer.attributeTableConfig().columns()[0].hidden );
+  QVERIFY( !layer.attributeTableConfig().columns()[1].hidden );
+}
+
+void TestQgsVectorLayerProperties::testHiddenWidgetLoad()
+{
+  QString def = QStringLiteral( "Point?field=col0:integer&field=col1:integer" );
+  QgsVectorLayer layer( def, QStringLiteral( "test" ), QStringLiteral( "memory" ) );
+
+  QgsGui::editorWidgetRegistry()->registerWidget( QStringLiteral( "Hidden" ), new QgsHiddenWidgetFactory( tr( "Hidden" ) ) );
+  QgsGui::editorWidgetRegistry()->registerWidget( QStringLiteral( "TextEdit" ), new QgsTextEditWidgetFactory( tr( "Text Edit" ) ) );
+
+  // we hide first column
+  layer.setEditorWidgetSetup( 0, QgsEditorWidgetSetup( "Hidden", QVariantMap() ) );
+
+  QgsAttributesFormProperties propertiesWidget( &layer );
+  propertiesWidget.initAvailableWidgetsTree();
+
+  // get widgets
+  QTreeWidget *widgetsTree = propertiesWidget.findChild<QTreeWidget *>( "mAvailableWidgetsTree" );
+  QgsAttributeTypeDialog *widgetTypeCmb = propertiesWidget.findChild<QgsAttributeTypeDialog *>();
+  QVERIFY( widgetTypeCmb );
+
+  QList<QTreeWidgetItem *> items = widgetsTree->findItems( "col0", Qt::MatchExactly | Qt::MatchRecursive );
+  QVERIFY( items.count() > 0 );
+  widgetsTree->setCurrentItem( items.at( 0 ) );
+  QVERIFY( widgetTypeCmb->editorWidgetType() == "Hidden" );
+
+  items = widgetsTree->findItems( "col1", Qt::MatchExactly | Qt::MatchRecursive );
+  QVERIFY( items.count() > 0 );
+  widgetsTree->setCurrentItem( items.at( 0 ) );
+  QVERIFY( widgetTypeCmb->editorWidgetType() == "TextEdit" );
+}
+
+QGSTEST_MAIN( TestQgsVectorLayerProperties )
+#include "testqgsvectorlayerproperties.moc"


### PR DESCRIPTION
When user selects the hidden widget type from vector layer attributes form properties, the field is set hidden in attribute table configuration.

## Description
There is two states that manage column visibility, one stored in QgsAttributeTableConfig and editable from QgsAttributeTable, the other one is stored in QgsWidgetEditorSetup and editable in QgsVectorLayerProperties.

The PR adds the "synchronisation" between the two states when opening the QgsVectorLayerProperties so it remains consistent whenever you modify it from the QgsAttributeTable or QgsVectorLayerProperties.

However, it seems that there is an other issue in attribute table because hidden state is no longer saved due to recent commit https://github.com/qgis/QGIS/commit/f928c2e5454 but I'm not sure about re-adding the missing following line :
```
mLayer->setAttributeTableConfig( mConfig );
```

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
