### PR TITLE
 Fix crash on layer save/rollback

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -114,14 +114,14 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *layer, QgsAttr
   connect( mMainView, &QgsDualView::showContextMenuExternally, this, &QgsAttributeTableDialog::showContextMenu );
 
   // Block/unblock table updates (feature cache signals)
-  connect( QgisApp::instance(), &QgisApp::attributeTableUpdateBlocked, [ = ]( const QgsVectorLayer * layer, const bool blocked )
+  connect( QgisApp::instance(), &QgisApp::attributeTableUpdateBlocked, this, [ = ]( const QgsVectorLayer * layer, const bool blocked )
   {
     if ( layer == mLayer )
       this->blockCacheUpdateSignals( blocked );
   } );
   // Massive rollbacks can also freeze the GUI due to the feature cache signals
-  connect( mLayer, &QgsVectorLayer::beforeRollBack, [ = ] { this->blockCacheUpdateSignals( true ); } );
-  connect( mLayer, &QgsVectorLayer::afterRollBack, [ = ] { this->blockCacheUpdateSignals( false ); } );
+  connect( mLayer, &QgsVectorLayer::beforeRollBack, this, [ = ] { this->blockCacheUpdateSignals( true ); } );
+  connect( mLayer, &QgsVectorLayer::afterRollBack, this, [ = ] { this->blockCacheUpdateSignals( false ); } );
 
   const QgsFields fields = mLayer->fields();
   for ( const QgsField &field : fields )

--- a/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationconfigdlg.cpp
@@ -94,6 +94,11 @@ void QgsValueRelationConfigDlg::editExpression()
   QgsExpressionContext context( QgsExpressionContextUtils::globalProjectLayerScopes( vl ) );
   context << QgsExpressionContextUtils::formScope( );
 
+  context.setHighlightedFunctions( QStringList() << QStringLiteral( "current_value" ) );
+  context.setHighlightedVariables( QStringList() << QStringLiteral( "current_geometry" )
+                                   << QStringLiteral( "current_feature" )
+                                   << QStringLiteral( "form_mode" ) );
+
   QgsExpressionBuilderDialog dlg( vl, mFilterExpression->toPlainText(), this, QStringLiteral( "generic" ), context );
   dlg.setWindowTitle( tr( "Edit Filter Expression" ) );
 


### PR DESCRIPTION
Context objects should always be used in lamda connects, or
the connection has a potentially infinite lifetime!