### PR TITLE
Expose application browser model instance to iface

### DIFF
--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -614,51 +614,51 @@ Take screenshots for user documentation
 
     virtual void zoomFull() = 0;
 %Docstring
-Zoom to full extent of map layers
+Zooms to the full extent of all map layers.
 %End
 
     virtual void zoomToPrevious() = 0;
 %Docstring
-Zoom to previous view extent
+Zooms to the previous view extent.
 %End
 
     virtual void zoomToNext() = 0;
 %Docstring
-Zoom to next view extent
+Zooms to the next view extent.
 %End
 
     virtual void zoomToActiveLayer() = 0;
 %Docstring
-Zoom to extent of the active layer
+Zooms to extent of the active layer.
 %End
 
     virtual QgsVectorLayer *addVectorLayer( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey ) = 0;
 %Docstring
-Add a vector layer
+Adds a vector layer to the current project.
 %End
 
     virtual QgsRasterLayer *addRasterLayer( const QString &rasterLayerPath, const QString &baseName = QString() ) = 0;
 %Docstring
-Add a raster layer given a raster layer file name
+Adds a raster layer to the current project, given a raster layer file name.
 %End
 
     virtual QgsRasterLayer *addRasterLayer( const QString &url, const QString &layerName, const QString &providerKey ) = 0;
 %Docstring
-Add a WMS layer
+Adds a raster layer to the current project, from the specified raster data provider.
 %End
 
     virtual QgsMeshLayer *addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) = 0;
 %Docstring
-Add a mesh layer
+Adds a mesh layer to the current project.
 %End
 
     virtual bool addProject( const QString &project ) = 0;
 %Docstring
-Add a project
+Adds (opens) a project
 %End
     virtual void newProject( bool promptToSaveFlag = false ) = 0;
 %Docstring
-Start a blank project
+Starts a new blank project
 %End
 
     virtual void reloadConnections( ) = 0;
@@ -810,7 +810,7 @@ Add a toolbar
 
     virtual void openMessageLog() = 0;
 %Docstring
-Open the message log dock widget *
+Opens the message log dock widget.
 %End
 
     virtual void addUserInputWidget( QWidget *widget ) = 0;
@@ -1065,7 +1065,8 @@ QGIS documentation, set useQgisDocDirectory to false.
 
     virtual bool openFeatureForm( QgsVectorLayer *l, QgsFeature &f, bool updateFeatureOnly = false, bool showModal = true ) = 0;
 %Docstring
-Open feature form
+Open feature form.
+Returns true if dialog was accepted (if shown modal, true otherwise).
 
 :param l: vector layer
 :param f: feature to show/modify

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1144,6 +1144,14 @@ is chosen. Dialog is shown only if global option is set accordingly.
 .. versionadded:: 3.0
 %End
 
+    virtual QgsBrowserModel *browserModel() = 0;
+%Docstring
+Returns the application browser model. Using this shared model is more efficient than
+creating a new browser model for every use.
+
+.. versionadded:: 3.4
+%End
+
   signals:
 
     void currentLayerChanged( QgsMapLayer *layer );

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1065,7 +1065,7 @@ QGIS documentation, set useQgisDocDirectory to false.
 
     virtual bool openFeatureForm( QgsVectorLayer *l, QgsFeature &f, bool updateFeatureOnly = false, bool showModal = true ) = 0;
 %Docstring
-Open feature form.
+Opens a new feature form.
 Returns true if dialog was accepted (if shown modal, true otherwise).
 
 :param l: vector layer

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -792,5 +792,10 @@ bool QgisAppInterface::askForDatumTransform( QgsCoordinateReferenceSystem source
 
 void QgisAppInterface::takeAppScreenShots( const QString &saveDirectory, const int categories )
 {
-  return qgis->takeAppScreenShots( saveDirectory, categories );
+  qgis->takeAppScreenShots( saveDirectory, categories );
+}
+
+QgsBrowserModel *QgisAppInterface::browserModel()
+{
+  return qgis->mBrowserModel;
 }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -553,6 +553,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
 
     void takeAppScreenShots( const QString &saveDirectory, const int categories = 0 ) override;
 
+    QgsBrowserModel *browserModel() override;
 
   private slots:
 

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -60,305 +60,96 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
 
     /* Exposed functions */
 
-    //! Zoom map to full extent
     void zoomFull() override;
-    //! Zoom map to previous extent
     void zoomToPrevious() override;
-    //! Zoom map to next extent
     void zoomToNext() override;
-    //! Zoom to active layer
     void zoomToActiveLayer() override;
-
-    //! Add a vector layer
     QgsVectorLayer *addVectorLayer( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey ) override;
-    //! Add a raster layer given its file name
     QgsRasterLayer *addRasterLayer( const QString &rasterLayerPath, const QString &baseName ) override;
-    //! Add a WMS layer
     QgsRasterLayer *addRasterLayer( const QString &url, const QString &baseName, const QString &providerKey ) override;
-    //! Add a mesh layer
     QgsMeshLayer *addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) override;
-
-    //! Add a project
     bool addProject( const QString &projectName ) override;
-
-    //! Start a new blank project
     void newProject( bool promptToSaveFlag = false ) override;
-
-    /**
-     * Triggered by plugins when connections have changed.
-     * This is forwarded to the GUI elements that needs to be updated (i.e. the source
-     * select dialogs and the browser widgets)
-     * \since QGIS 3.0
-     */
     void reloadConnections( ) override;
-
-    //! Gets pointer to the active layer (layer selected in the legend)
     QgsMapLayer *activeLayer() override;
-
-    //! Sets the active layer (layer selected in the legend)
     bool setActiveLayer( QgsMapLayer *layer ) override;
-
-    /**
-     * Copy selected features from the layer to clipboard
-     * \since QGIS 3.0
-     */
     void copySelectionToClipboard( QgsMapLayer *layer ) override;
-
-    /**
-     * Paste features from clipboard to the layer
-     * \since QGIS 3.0
-     */
     void pasteFromClipboard( QgsMapLayer *layer ) override;
-
-    //! Add an icon to the plugins toolbar
     int addToolBarIcon( QAction *qAction ) override;
-
-    /**
-     * Add a widget to the plugins toolbar.
-     * To remove this widget again, call removeToolBarIcon()
-     * with the returned QAction.
-     *
-     * \param widget widget to add. The toolbar will take ownership of this widget
-     * \returns the QAction you can use to remove this widget from the toolbar
-     */
     QAction *addToolBarWidget( QWidget *widget ) override;
-    //! Remove an icon (action) from the plugin toolbar
     void removeToolBarIcon( QAction *qAction ) override;
-    //! Add an icon to the Raster toolbar
     int addRasterToolBarIcon( QAction *qAction ) override;
-
-    /**
-     * Add a widget to the raster toolbar.
-     * To remove this widget again, call removeRasterToolBarIcon()
-     * with the returned QAction.
-     *
-     * \param widget widget to add. The toolbar will take ownership of this widget
-     * \returns the QAction you can use to remove this widget from the toolbar
-     */
     QAction *addRasterToolBarWidget( QWidget *widget ) override;
-    //! Remove an icon (action) from the Raster toolbar
     void removeRasterToolBarIcon( QAction *qAction ) override;
-    //! Add an icon to the Vector toolbar
     int addVectorToolBarIcon( QAction *qAction ) override;
-
-    /**
-     * Add a widget to the vector toolbar.
-     * To remove this widget again, call removeVectorToolBarIcon()
-     * with the returned QAction.
-     *
-     * \param widget widget to add. The toolbar will take ownership of this widget
-     * \returns the QAction you can use to remove this widget from the toolbar
-     */
     QAction *addVectorToolBarWidget( QWidget *widget ) override;
-    //! Remove an icon (action) from the Vector toolbar
     void removeVectorToolBarIcon( QAction *qAction ) override;
-    //! Add an icon to the Database toolbar
     int addDatabaseToolBarIcon( QAction *qAction ) override;
-
-    /**
-     * Add a widget to the database toolbar.
-     * To remove this widget again, call removeDatabaseToolBarIcon()
-     * with the returned QAction.
-     *
-     * \param widget widget to add. The toolbar will take ownership of this widget
-     * \returns the QAction you can use to remove this widget from the toolbar
-     */
     QAction *addDatabaseToolBarWidget( QWidget *widget ) override;
-    //! Remove an icon (action) from the Database toolbar
     void removeDatabaseToolBarIcon( QAction *qAction ) override;
-    //! Add an icon to the Web toolbar
     int addWebToolBarIcon( QAction *qAction ) override;
-
-    /**
-     * Add a widget to the web toolbar.
-     * To remove this widget again, call removeWebToolBarIcon()
-     * with the returned QAction.
-     *
-     * \param widget widget to add. The toolbar will take ownership of this widget
-     * \returns the QAction you can use to remove this widget from the toolbar
-     */
     QAction *addWebToolBarWidget( QWidget *widget ) override;
-    //! Remove an icon (action) from the Web toolbar
     void removeWebToolBarIcon( QAction *qAction ) override;
-
-    //! Add toolbar with specified name
     QToolBar *addToolBar( const QString &name ) override;
-
-    /**
-     * Add a toolbar
-     * \since QGIS 2.3
-     */
     void addToolBar( QToolBar *toolbar, Qt::ToolBarArea area = Qt::TopToolBarArea ) override;
 
-    /**
-     * Open a url in the users browser. By default the QGIS doc directory is used
-     * as the base for the URL. To open a URL that is not relative to the installed
-     * QGIS documentation, set useQgisDocDirectory to false.
-     * \param url URL to open
-     * \param useQgisDocDirectory If true, the URL will be formed by concatenating
-     * url to the QGIS documentation directory path (<prefix>/share/doc)
-     */
 #ifndef Q_MOC_RUN
     Q_DECL_DEPRECATED
 #endif
     void openURL( const QString &url, bool useQgisDocDirectory = true ) override;
 
-    //! Returns a pointer to the map canvas used by qgisapp
     QgsMapCanvas *mapCanvas() override;
-
     QList< QgsMapCanvas * > mapCanvases() override;
     QgsMapCanvas *createNewMapCanvas( const QString &name ) override;
     void closeMapCanvas( const QString &name ) override;
-
     QSize iconSize( bool dockedToolbar = false ) const override;
-
-    /**
-     * Returns a pointer to the layer tree canvas bridge
-     *
-     * \since QGIS 2.12
-     */
     QgsLayerTreeMapCanvasBridge *layerTreeCanvasBridge() override;
-
-    /**
-     * Gives access to main QgisApp object
-
-        Plugins don't need to know about QgisApp, as we pass it as QWidget,
-        it can be used for connecting slots and using as widget's parent
-     */
     QWidget *mainWindow() override;
-
     QgsMessageBar *messageBar() override;
-
-    //! Open the message log dock widget *
     void openMessageLog() override;
-
-    //! Adds a widget to the user input tool bar.
     void addUserInputWidget( QWidget *widget ) override;
-
     void showLayoutManager() override;
     QList<QgsLayoutDesignerInterface *> openLayoutDesigners() override;
     QgsLayoutDesignerInterface *openLayoutDesigner( QgsMasterLayoutInterface *layout ) override;
-
     void showOptionsDialog( QWidget *parent = nullptr, const QString &currentPage = QString() ) override;
-
-    //! Returns changeable options built from settings and/or defaults
     QMap<QString, QVariant> defaultStyleSheetOptions() override;
-
-    /**
-     * Generate stylesheet
-     * \param opts generated default option values, or a changed copy of them */
     void buildStyleSheet( const QMap<QString, QVariant> &opts ) override;
-
-    //! Save changed default option keys/values to user settings
     void saveStyleSheetOptions( const QMap<QString, QVariant> &opts ) override;
-
-    //! Gets reference font for initial qApp (may not be same as QgisApp)
     QFont defaultStyleSheetFont() override;
-
-    //! Add action to the plugins menu
     void addPluginToMenu( const QString &name, QAction *action ) override;
-    //! Remove action from the plugins menu
     void removePluginMenu( const QString &name, QAction *action ) override;
-
-    //! Add action to the Database menu
     void addPluginToDatabaseMenu( const QString &name, QAction *action ) override;
-    //! Remove action from the Database menu
     void removePluginDatabaseMenu( const QString &name, QAction *action ) override;
-
-    //! Add action to the Raster menu
     void addPluginToRasterMenu( const QString &name, QAction *action ) override;
-    //! Remove action from the Raster menu
     void removePluginRasterMenu( const QString &name, QAction *action ) override;
-
-    //! Add action to the Vector menu
     void addPluginToVectorMenu( const QString &name, QAction *action ) override;
-    //! Remove action from the Raster menu
     void removePluginVectorMenu( const QString &name, QAction *action ) override;
-
-    //! Add action to the Web menu
     void addPluginToWebMenu( const QString &name, QAction *action ) override;
-    //! Remove action from the Web menu
     void removePluginWebMenu( const QString &name, QAction *action ) override;
-
-    //! Add "add layer" action to the layer menu
     void insertAddLayerAction( QAction *action ) override;
-    //! Remove "add layer" action from the layer menu
     void removeAddLayerAction( QAction *action ) override;
-
-    //! Add a dock widget to the main window
     void addDockWidget( Qt::DockWidgetArea area, QDockWidget *dockwidget ) override;
-
-    //! Remove specified dock widget from main window (doesn't delete it).
     void removeDockWidget( QDockWidget *dockwidget ) override;
-
-    //! Returns the CAD dock widget
     QgsAdvancedDigitizingDockWidget *cadDockWidget() override;
-
-    /**
-     * Show layer properties dialog for layer
-     * \param l layer to show properties table for
-     */
     void showLayerProperties( QgsMapLayer *l ) override;
-
-    /**
-     * Show layer attribute dialog for layer
-     * \param l layer to show attribute table for
-     */
     QDialog *showAttributeTable( QgsVectorLayer *l, const QString &filterExpression = QString() ) override;
-
-    /**
-     * Add window to Window menu. The action title is the window title
-     * and the action should raise, unminimize and activate the window. */
     void addWindow( QAction *action ) override;
-
-    /**
-     * Remove window from Window menu. Calling this is necessary only for
-     * windows which are hidden rather than deleted when closed. */
     void removeWindow( QAction *action ) override;
-
-    //! Register action to the shortcuts manager so its shortcut can be changed in GUI.
     bool registerMainWindowAction( QAction *action, const QString &defaultShortcut ) override;
-
-    //! Unregister a previously registered action. (e.g. when plugin is going to be unloaded.
     bool unregisterMainWindowAction( QAction *action ) override;
-
     void registerMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory *factory ) override;
     void unregisterMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory *factory ) override;
-
     void registerOptionsWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
     void unregisterOptionsWidgetFactory( QgsOptionsWidgetFactory *factory ) override;
-
-    /**
-     * Register a new custom drop \a handler.
-     * \note Ownership of the factory is not transferred, and the factory must
-     *       be unregistered when plugin is unloaded.
-     * \see unregisterCustomDropHandler()
-     * \since QGIS 3.0
-     */
     void registerCustomDropHandler( QgsCustomDropHandler *handler ) override;
-
-    /**
-     * Unregister a previously registered custom drop \a handler.
-     * \see registerCustomDropHandler()
-     * \since QGIS 3.0
-     */
     void unregisterCustomDropHandler( QgsCustomDropHandler *handler ) override;
-
     void registerCustomLayoutDropHandler( QgsLayoutCustomDropHandler *handler ) override;
     void unregisterCustomLayoutDropHandler( QgsLayoutCustomDropHandler *handler ) override;
-
-    /**
-     * Accessors for inserting items into menus and toolbars.
-     * An item can be inserted before any existing action.
-     */
-
-    //! Menus
     QMenu *projectMenu() override;
     QMenu *editMenu() override;
     QMenu *viewMenu() override;
     QMenu *layerMenu() override;
     QMenu *newLayerMenu() override;
-    //! \since QGIS 2.5
     QMenu *addLayerMenu() override;
     QMenu *settingsMenu() override;
     QMenu *pluginMenu() override;
@@ -369,8 +160,6 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QMenu *firstRightStandardMenu() override;
     QMenu *windowMenu() override;
     QMenu *helpMenu() override;
-
-    //! ToolBars
     QToolBar *fileToolBar() override;
     QToolBar *layerToolBar() override;
     QToolBar *dataSourceManagerToolBar() override;
@@ -385,8 +174,6 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QToolBar *vectorToolBar() override;
     QToolBar *databaseToolBar() override;
     QToolBar *webToolBar() override;
-
-    //! Project menu actions
     QAction *actionNewProject() override;
     QAction *actionOpenProject() override;
     QAction *actionSaveProject() override;
@@ -396,8 +183,6 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QAction *actionCreatePrintLayout() override;
     QAction *actionShowLayoutManager() override;
     QAction *actionExit() override;
-
-    //! Edit menu actions
     QAction *actionCutFeatures() override;
     QAction *actionCopyFeatures() override;
     QAction *actionPasteFeatures() override;
@@ -412,8 +197,6 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QAction *actionDeleteRing() override;
     QAction *actionDeletePart() override;
     QAction *actionVertexTool() override;
-
-    //! View menu actions
     QAction *actionPan() override;
     QAction *actionPanToSelected() override;
     QAction *actionZoomIn() override;
@@ -437,16 +220,12 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QAction *actionNewBookmark() override;
     QAction *actionShowBookmarks() override;
     QAction *actionDraw() override;
-
-    //! Layer menu actions
     QAction *actionNewVectorLayer() override;
     QAction *actionAddOgrLayer() override;
     QAction *actionAddRasterLayer() override;
     QAction *actionAddPgLayer() override;
     QAction *actionAddWmsLayer() override;
-    //! Gets access to the native Add ArcGIS FeatureServer action.
     QAction *actionAddAfsLayer() override;
-    //! Gets access to the native Add ArcGIS MapServer action.
     QAction *actionAddAmsLayer() override;
     QAction *actionCopyLayerStyle() override;
     QAction *actionPasteLayerStyle() override;
@@ -473,86 +252,28 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QAction *actionHideSelectedLayers() override;
     QAction *actionHideDeselectedLayers() override;
     QAction *actionShowSelectedLayers() override;
-
-    //! Plugin menu actions
     QAction *actionManagePlugins() override;
     QAction *actionPluginListSeparator() override;
     QAction *actionShowPythonDialog() override;
-
-    //! Settings menu actions
     QAction *actionToggleFullScreen() override;
     QAction *actionOptions() override;
     QAction *actionCustomProjection() override;
-
-    //! Help menu actions
     QAction *actionHelpContents() override;
     QAction *actionQgisHomePage() override;
     QAction *actionCheckQgisVersion() override;
     QAction *actionAbout() override;
-
-    /**
-     * Open feature form
-     * returns true when dialog was accepted (if shown modal, true otherwise)
-     * \param l vector layer
-     * \param f feature to show/modify
-     * \param updateFeatureOnly only update the feature update (don't change any attributes of the layer) [UNUSED]
-     * \param showModal if true, will wait for the dialog to be executed (only shown otherwise)
-     */
     bool openFeatureForm( QgsVectorLayer *l, QgsFeature &f, bool updateFeatureOnly = false, bool showModal = true ) override;
-
-    /**
-     * Returns a feature form for a given feature
-     *
-     * \param layer   The layer for which the dialog will be created
-     * \param feature The feature for which the dialog will be created
-     *
-     * \returns A feature form
-     */
     QgsAttributeDialog *getFeatureForm( QgsVectorLayer *layer, QgsFeature &feature ) override;
-
-    /**
-     * Access the vector layer tools instance.
-     * With the help of this you can access methods like addFeature, startEditing
-     * or stopEditing while giving the user the appropriate dialogs.
-     *
-     * \returns An instance of the vector layer tools
-     */
     QgsVectorLayerTools *vectorLayerTools() override;
-
-    /**
-     * This method is only needed when using a UI form with a custom widget plugin and calling
-     * openFeatureForm or getFeatureForm from Python (PyQt4) and you haven't used the info tool first.
-     * Python will crash bringing QGIS with it
-     * if the custom form is not loaded from a C++ method call.
-     *
-     * This method uses a QTimer to call QUiLoader in order to load the form via C++
-     * you only need to call this once after that you can call openFeatureForm/getFeatureForm
-     * like normal
-     *
-     * More information here: http://qt-project.org/forums/viewthread/27098/
-     */
     void preloadForm( const QString &uifile ) override;
-
-    /**
-     * Returns the vector layers in edit mode
-     * \param modified whether to return only layers that have been modified
-     * \returns list of layers in legend order, or empty list
-     */
     QList<QgsMapLayer *> editableLayers( bool modified = false ) const override;
-
-    //! Gets timeout for timed messages: default of 5 seconds
     int messageTimeout() override;
-
     QgsStatusBar *statusBarIface() override;
-
     void registerLocatorFilter( QgsLocatorFilter *filter ) override;
     void deregisterLocatorFilter( QgsLocatorFilter *filter ) override;
     void invalidateLocatorResults() override;
-
     bool askForDatumTransform( QgsCoordinateReferenceSystem sourceCrs, QgsCoordinateReferenceSystem destinationCrs ) override;
-
     void takeAppScreenShots( const QString &saveDirectory, const int categories = 0 ) override;
-
     QgsBrowserModel *browserModel() override;
 
   private slots:

--- a/src/app/qgsstatisticalsummarydockwidget.h
+++ b/src/app/qgsstatisticalsummarydockwidget.h
@@ -33,7 +33,6 @@ class QModelIndex;
 class QgsDockBrowserTreeView;
 class QgsLayerItem;
 class QgsDataItem;
-class QgsBrowserTreeFilterProxyModel;
 class QgsVectorLayer;
 
 /**

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -885,7 +885,7 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void openURL( const QString &url, bool useQgisDocDirectory = true ) = 0 SIP_DEPRECATED;
 
     /**
-     * Open feature form.
+     * Opens a new feature form.
      * Returns true if dialog was accepted (if shown modal, true otherwise).
      * \param l vector layer
      * \param f feature to show/modify

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -541,33 +541,49 @@ class GUI_EXPORT QgisInterface : public QObject
 
     /* Exposed functions */
 
-    //! Zoom to full extent of map layers
+    /**
+     * Zooms to the full extent of all map layers.
+     */
     virtual void zoomFull() = 0;
 
-    //! Zoom to previous view extent
+    /**
+     * Zooms to the previous view extent.
+     */
     virtual void zoomToPrevious() = 0;
 
-    //! Zoom to next view extent
+    /**
+     * Zooms to the next view extent.
+     */
     virtual void zoomToNext() = 0;
 
-    //! Zoom to extent of the active layer
+    /**
+     * Zooms to extent of the active layer.
+     */
     virtual void zoomToActiveLayer() = 0;
 
-    //! Add a vector layer
+    /**
+     * Adds a vector layer to the current project.
+     */
     virtual QgsVectorLayer *addVectorLayer( const QString &vectorLayerPath, const QString &baseName, const QString &providerKey ) = 0;
 
-    //! Add a raster layer given a raster layer file name
+    /**
+     * Adds a raster layer to the current project, given a raster layer file name.
+     */
     virtual QgsRasterLayer *addRasterLayer( const QString &rasterLayerPath, const QString &baseName = QString() ) = 0;
 
-    //! Add a WMS layer
+    /**
+     * Adds a raster layer to the current project, from the specified raster data provider.
+     */
     virtual QgsRasterLayer *addRasterLayer( const QString &url, const QString &layerName, const QString &providerKey ) = 0;
 
-    //! Add a mesh layer
+    /**
+     * Adds a mesh layer to the current project.
+     */
     virtual QgsMeshLayer *addMeshLayer( const QString &url, const QString &baseName, const QString &providerKey ) = 0;
 
-    //! Add a project
+    //! Adds (opens) a project
     virtual bool addProject( const QString &project ) = 0;
-    //! Start a blank project
+    //! Starts a new blank project
     virtual void newProject( bool promptToSaveFlag = false ) = 0;
 
     /**
@@ -686,7 +702,9 @@ class GUI_EXPORT QgisInterface : public QObject
      */
     virtual void addToolBar( QToolBar *toolbar SIP_TRANSFER, Qt::ToolBarArea area = Qt::TopToolBarArea ) = 0;
 
-    //! Open the message log dock widget *
+    /**
+     * Opens the message log dock widget.
+     */
     virtual void openMessageLog() = 0;
 
     //! Adds a widget to the user input tool bar.
@@ -867,7 +885,8 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual void openURL( const QString &url, bool useQgisDocDirectory = true ) = 0 SIP_DEPRECATED;
 
     /**
-     * Open feature form
+     * Open feature form.
+     * Returns true if dialog was accepted (if shown modal, true otherwise).
      * \param l vector layer
      * \param f feature to show/modify
      * \param updateFeatureOnly only update the feature update (don't change any attributes of the layer) [UNUSED]

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -48,6 +48,7 @@ class QgsOptionsWidgetFactory;
 class QgsLocatorFilter;
 class QgsStatusBar;
 class QgsMeshLayer;
+class QgsBrowserModel;
 
 #include <QObject>
 #include <QFont>
@@ -936,6 +937,13 @@ class GUI_EXPORT QgisInterface : public QObject
       * \since 3.0
       */
     virtual bool askForDatumTransform( QgsCoordinateReferenceSystem sourceCrs, QgsCoordinateReferenceSystem destinationCrs ) = 0;
+
+    /**
+     * Returns the application browser model. Using this shared model is more efficient than
+     * creating a new browser model for every use.
+     * \since QGIS 3.4
+     */
+    virtual QgsBrowserModel *browserModel() = 0;
 
   signals:
 


### PR DESCRIPTION
Reusing the existing browser model is more efficient then reconstructing
new models, so it's useful for plugins to have access to this instance
too.