### PR TITLE
[needs-docs] Allow users to set tokens for connections to ArcGIS Feature/Map servers

### DIFF
--- a/src/providers/arcgisrest/CMakeLists.txt
+++ b/src/providers/arcgisrest/CMakeLists.txt
@@ -43,10 +43,12 @@ IF (WITH_GUI)
   SET(AFS_SRCS ${AFS_SRCS}
     qgsafssourceselect.cpp
     qgsarcgisservicesourceselect.cpp
+    qgsarcgisresttokenmanagerdialog.cpp
   )
   SET(AFS_MOC_HDRS ${AFS_MOC_HDRS}
     qgsafssourceselect.h
     qgsarcgisservicesourceselect.h
+    qgsarcgisresttokenmanagerdialog.h
   )
 ENDIF ()
 
@@ -94,10 +96,12 @@ IF (WITH_GUI)
   SET(AMS_SRCS ${AMS_SRCS}
     qgsamssourceselect.cpp
     qgsarcgisservicesourceselect.cpp
+    qgsarcgisresttokenmanagerdialog.cpp
   )
   SET(AMS_MOC_HDRS ${AMS_MOC_HDRS}
     qgsamssourceselect.h
     qgsarcgisservicesourceselect.h
+    qgsarcgisresttokenmanagerdialog.h
   )
 ENDIF ()
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -43,13 +43,14 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   mSharedData.reset( new QgsAfsSharedData() );
   mSharedData->mGeometryType = QgsWkbTypes::Unknown;
   mSharedData->mDataSource = QgsDataSourceUri( uri );
+  const QString token = QgsArcGisRestTokenManager::token( mSharedData->mDataSource.param( QStringLiteral( "url" ) ) );
 
   // Set CRS
   mSharedData->mSourceCRS.createFromString( mSharedData->mDataSource.param( QStringLiteral( "crs" ) ) );
 
   // Get layer info
   QString errorTitle, errorMessage;
-  const QVariantMap layerData = QgsArcGisRestUtils::getLayerInfo( mSharedData->mDataSource.param( QStringLiteral( "url" ) ), errorTitle, errorMessage );
+  const QVariantMap layerData = QgsArcGisRestUtils::getLayerInfo( mSharedData->mDataSource.param( QStringLiteral( "url" ) ), token, errorTitle, errorMessage );
   if ( layerData.isEmpty() )
   {
     pushError( errorTitle + ": " + errorMessage );
@@ -163,7 +164,8 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   // Read OBJECTIDs of all features: these may not be a continuous sequence,
   // and we need to store these to iterate through the features. This query
   // also returns the name of the ObjectID field.
-  QVariantMap objectIdData = QgsArcGisRestUtils::getObjectIds( mSharedData->mDataSource.param( QStringLiteral( "url" ) ), objectIdFieldName, errorTitle, errorMessage, limitBbox ? mSharedData->mExtent : QgsRectangle() );
+  QVariantMap objectIdData = QgsArcGisRestUtils::getObjectIds( mSharedData->mDataSource.param( QStringLiteral( "url" ) ), token,
+                             objectIdFieldName, errorTitle,  errorMessage, limitBbox ? mSharedData->mExtent : QgsRectangle() );
   if ( objectIdData.isEmpty() )
   {
     appendError( QgsErrorMessage( tr( "getObjectIds failed: %1 - %2" ).arg( errorTitle, errorMessage ), QStringLiteral( "AFSProvider" ) ) );

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -122,7 +122,8 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
   QString objectIdFieldName;
 
   // Read fields
-  foreach ( const QVariant &fieldData, layerData["fields"].toList() )
+  const QVariantList fields = layerData.value( QStringLiteral( "fields" ) ).toList();
+  for ( const QVariant &fieldData : fields )
   {
     const QVariantMap fieldDataMap = fieldData.toMap();
     const QString fieldName = fieldDataMap[QStringLiteral( "name" )].toString();
@@ -189,7 +190,8 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
       break;
     }
   }
-  foreach ( const QVariant &objectId, objectIdData["objectIds"].toList() )
+  const QVariantList objectIds = objectIdData.value( QStringLiteral( "objectIds" ) ).toList();
+  for ( const QVariant &objectId : objectIds )
   {
     mSharedData->mObjectIds.append( objectId.toInt() );
   }

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -68,8 +68,10 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
 
   // Query
   QString errorTitle, errorMessage;
+
+  const QString token = QgsArcGisRestTokenManager::token( mDataSource.param( QStringLiteral( "url" ) ) );
   const QVariantMap queryData = QgsArcGisRestUtils::getObjects(
-                                  mDataSource.param( QStringLiteral( "url" ) ), objectIds, mDataSource.param( QStringLiteral( "crs" ) ), true,
+                                  mDataSource.param( QStringLiteral( "url" ) ), token, objectIds, mDataSource.param( QStringLiteral( "crs" ) ), true,
                                   fetchAttribNames, QgsWkbTypes::hasM( mGeometryType ), QgsWkbTypes::hasZ( mGeometryType ),
                                   filterRect, errorTitle, errorMessage, feedback );
 
@@ -156,10 +158,10 @@ QgsFeatureIds QgsAfsSharedData::getFeatureIdsInExtent( const QgsRectangle &exten
   QString errorTitle;
   QString errorText;
 
-
+  const QString token = QgsArcGisRestTokenManager::token( mDataSource.param( QStringLiteral( "url" ) ) );
   const QList<quint32> featuresInRect = QgsArcGisRestUtils::getObjectIdsByExtent( mDataSource.param( QStringLiteral( "url" ) ),
                                         mObjectIdFieldName,
-                                        extent, errorTitle, errorText, feedback );
+                                        extent, errorTitle, errorText, token, feedback );
 
   QgsFeatureIds ids;
   for ( quint32 id : featuresInRect )

--- a/src/providers/arcgisrest/qgsafsshareddata.cpp
+++ b/src/providers/arcgisrest/qgsafsshareddata.cpp
@@ -100,7 +100,7 @@ bool QgsAfsSharedData::getFeature( QgsFeatureId id, QgsFeature &f, const QgsRect
       const QVariantMap attributesData = featureData[QStringLiteral( "attributes" )].toMap();
       feature.setFields( mFields );
       QgsAttributes attributes( mFields.size() );
-      foreach ( int idx, fetchAttribIdx )
+      for ( int idx : qgis::as_const( fetchAttribIdx ) )
       {
         QVariant attribute = attributesData[mFields.at( idx ).name()];
         if ( attribute.isNull() )

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -37,7 +37,10 @@ QgsAfsSourceSelect::QgsAfsSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
 {
   QString errorTitle, errorMessage;
-  QVariantMap serviceInfoMap = QgsArcGisRestUtils::getServiceInfo( connection.uri().param( QStringLiteral( "url" ) ), errorTitle, errorMessage );
+
+  const QString token = QgsArcGisRestTokenManager::token( connection.uri().param( QStringLiteral( "url" ) ) );
+
+  QVariantMap serviceInfoMap = QgsArcGisRestUtils::getServiceInfo( connection.uri().param( QStringLiteral( "url" ) ), token, errorTitle, errorMessage );
   if ( serviceInfoMap.isEmpty() )
   {
     QMessageBox::warning( this, tr( "Error" ), tr( "Failed to retrieve service capabilities:\n%1: %2" ).arg( errorTitle, errorMessage ) );
@@ -62,7 +65,7 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
     }
 
     // Get layer info
-    const QVariantMap layerData = QgsArcGisRestUtils::getLayerInfo( connection.uri().param( QStringLiteral( "url" ) ) + "/" + layerInfoMap[QStringLiteral( "id" )].toString(), errorTitle, errorMessage );
+    const QVariantMap layerData = QgsArcGisRestUtils::getLayerInfo( connection.uri().param( QStringLiteral( "url" ) ) + "/" + layerInfoMap[QStringLiteral( "id" )].toString(), token, errorTitle, errorMessage );
     if ( layerData.isEmpty() )
     {
       layerErrors.append( tr( "Layer %1: %2 - %3" ).arg( layerInfoMap[QStringLiteral( "id" )].toString(), errorTitle, errorMessage ) );

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -45,7 +45,8 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
   }
 
   QStringList layerErrors;
-  foreach ( const QVariant &layerInfo, serviceInfoMap["layers"].toList() )
+  const QVariantList layers = serviceInfoMap.value( QStringLiteral( "layers" ) ).toList();
+  for ( const QVariant &layerInfo : layers )
   {
     const QVariantMap layerInfoMap = layerInfo.toMap();
     if ( !layerInfoMap[QStringLiteral( "id" )].isValid() )

--- a/src/providers/arcgisrest/qgsamsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsamsdataitems.cpp
@@ -22,6 +22,7 @@
 #ifdef HAVE_GUI
 #include "qgsamssourceselect.h"
 #include "qgsnewhttpconnection.h"
+#include "qgsarcgisresttokenmanagerdialog.h"
 #endif
 
 #include <QImageReader>
@@ -53,7 +54,19 @@ QList<QAction *> QgsAmsRootItem::actions( QWidget *parent )
 {
   QAction *actionNew = new QAction( tr( "New Connection…" ), parent );
   connect( actionNew, &QAction::triggered, this, &QgsAmsRootItem::newConnection );
-  return QList<QAction *>() << actionNew;
+
+  QAction *tokenManager = new QAction( tr( "Manage Tokens…" ), parent );
+  connect( tokenManager, &QAction::triggered, this, [ = ]()
+  {
+    QgsArcGisRestTokenManagerDialog dlg( parent );
+    if ( dlg.exec() )
+    {
+      refresh();
+    }
+
+  } );
+
+  return QList<QAction *>() << actionNew << tokenManager;
 }
 
 
@@ -94,7 +107,9 @@ QVector<QgsDataItem *> QgsAmsConnectionItem::createChildren()
 {
   QVector<QgsDataItem *> layers;
   QString errorTitle, errorMessage;
-  QVariantMap serviceData = QgsArcGisRestUtils::getServiceInfo( mUrl, errorTitle, errorMessage );
+
+  const QString token = QgsArcGisRestTokenManager::token( mUrl );
+  QVariantMap serviceData = QgsArcGisRestUtils::getServiceInfo( mUrl, token, errorTitle,  errorMessage );
   if ( serviceData.isEmpty() )
   {
     return layers;
@@ -150,6 +165,23 @@ QList<QAction *> QgsAmsConnectionItem::actions( QWidget *parent )
   QAction *actionDelete = new QAction( tr( "Delete" ), parent );
   connect( actionDelete, &QAction::triggered, this, &QgsAmsConnectionItem::deleteConnection );
   lst.append( actionDelete );
+
+  QAction *sep = new QAction();
+  sep->setSeparator( true );
+  lst.append( sep );
+
+  QAction *tokenManager = new QAction( tr( "Manage Tokens…" ), parent );
+  connect( tokenManager, &QAction::triggered, this, [ = ]()
+  {
+    QgsArcGisRestTokenManagerDialog dlg( parent );
+    if ( dlg.exec() )
+    {
+      refresh();
+    }
+
+  } );
+
+  lst << tokenManager;
 
   return lst;
 }

--- a/src/providers/arcgisrest/qgsamsdataitems.h
+++ b/src/providers/arcgisrest/qgsamsdataitems.h
@@ -26,7 +26,7 @@ class QgsAmsRootItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsAmsRootItem( QgsDataItem *parent, QString name, QString path );
+    QgsAmsRootItem( QgsDataItem *parent, const QString &name, const QString &path );
 
     QVector<QgsDataItem *> createChildren() override;
 
@@ -49,7 +49,7 @@ class QgsAmsConnectionItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    QgsAmsConnectionItem( QgsDataItem *parent, QString name, QString path, QString url );
+    QgsAmsConnectionItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &url );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
 #ifdef HAVE_GUI

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -71,7 +71,8 @@ void QgsAmsLegendFetcher::handleFinished()
   QVariantMap queryResults = doc.object().toVariantMap();
   QgsDataSourceUri dataSource( mProvider->dataSourceUri() );
   QVector< QPair<QString, QImage> > legendEntries;
-  foreach ( const QVariant &result, queryResults["layers"].toList() )
+  const QVariantList layersList = queryResults.value( QStringLiteral( "layers" ) ).toList();
+  for ( const QVariant &result : layersList )
   {
     QVariantMap queryResultMap = result.toMap();
     QString layerId = queryResultMap[QStringLiteral( "layerId" )].toString();
@@ -79,8 +80,8 @@ void QgsAmsLegendFetcher::handleFinished()
     {
       continue;
     }
-    QVariantList legendSymbols = queryResultMap[QStringLiteral( "legend" )].toList();
-    foreach ( const QVariant &legendEntry, legendSymbols )
+    const QVariantList legendSymbols = queryResultMap[QStringLiteral( "legend" )].toList();
+    for ( const QVariant &legendEntry : legendSymbols )
     {
       QVariantMap legendEntryMap = legendEntry.toMap();
       QString label = legendEntryMap[QStringLiteral( "label" )].toString();
@@ -99,7 +100,7 @@ void QgsAmsLegendFetcher::handleFinished()
 
     typedef QPair<QString, QImage> LegendEntry_t;
     QSize maxImageSize( 0, 0 );
-    foreach ( const LegendEntry_t &legendEntry, legendEntries )
+    for ( const LegendEntry_t &legendEntry : qgis::as_const( legendEntries ) )
     {
       maxImageSize.setWidth( std::max( maxImageSize.width(), legendEntry.second.width() ) );
       maxImageSize.setHeight( std::max( maxImageSize.height(), legendEntry.second.height() ) );
@@ -111,7 +112,7 @@ void QgsAmsLegendFetcher::handleFinished()
     mLegendImage.fill( Qt::transparent );
     QPainter painter( &mLegendImage );
     int i = 0;
-    foreach ( const LegendEntry_t &legendEntry, legendEntries )
+    for ( const LegendEntry_t &legendEntry : qgis::as_const( legendEntries ) )
     {
       QImage symbol = legendEntry.second.scaled( legendEntry.second.width() * scaleFactor, legendEntry.second.height() * scaleFactor, Qt::KeepAspectRatio, Qt::SmoothTransformation );
       painter.drawImage( 0, vpadding + i * ( imageSize + vpadding ) + ( imageSize - symbol.height() ), symbol );
@@ -144,7 +145,9 @@ QgsAmsProvider::QgsAmsProvider( const QString &uri, const ProviderOptions &optio
     appendError( QgsErrorMessage( tr( "Could not parse spatial reference" ), QStringLiteral( "AMSProvider" ) ) );
     return;
   }
-  foreach ( const QVariant &sublayer, mLayerInfo["subLayers"].toList() )
+  const QVariantList subLayersList = mLayerInfo.value( QStringLiteral( "subLayers" ) ).toList();
+  mSubLayers.reserve( subLayersList.size() );
+  for ( const QVariant &sublayer : subLayersList )
   {
     mSubLayers.append( sublayer.toMap()[QStringLiteral( "id" )].toString() );
     mSubLayerVisibilities.append( true );
@@ -157,6 +160,7 @@ QgsAmsProvider::QgsAmsProvider( const QString &uri, const ProviderOptions &optio
 QStringList QgsAmsProvider::subLayerStyles() const
 {
   QStringList styles;
+  styles.reserve( mSubLayers.size() );
   for ( int i = 0, n = mSubLayers.size(); i < n; ++i )
   {
     styles.append( QString() );
@@ -170,7 +174,7 @@ void QgsAmsProvider::setLayerOrder( const QStringList &layers )
   QList<bool> oldSubLayerVisibilities = mSubLayerVisibilities;
   mSubLayers.clear();
   mSubLayerVisibilities.clear();
-  foreach ( const QString &layer, layers )
+  for ( const QString &layer : layers )
   {
     // Search for match
     for ( int i = 0, n = oldSubLayers.size(); i < n; ++i )
@@ -273,7 +277,7 @@ void QgsAmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int p
     double oy = origin[QStringLiteral( "y" )].toDouble();
 
     // Search matching resolution (tile resolution <= targetRes)
-    QList<QVariant> lodEntries = tileInfo[QStringLiteral( "lods" )].toList();
+    const QList<QVariant> lodEntries = tileInfo[QStringLiteral( "lods" )].toList();
     if ( lodEntries.isEmpty() )
     {
       mCachedImage = QImage();
@@ -282,7 +286,7 @@ void QgsAmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int p
     }
     int level = 0;
     double resolution = lodEntries.front().toMap()[QStringLiteral( "resolution" )].toDouble();
-    foreach ( const QVariant &lodEntry, lodEntries )
+    for ( const QVariant &lodEntry : lodEntries )
     {
       QVariantMap lodEntryMap = lodEntry.toMap();
       level = lodEntryMap[QStringLiteral( "level" )].toInt();

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -131,10 +131,13 @@ QgsAmsProvider::QgsAmsProvider( const QString &uri, const ProviderOptions &optio
   mLegendFetcher = new QgsAmsLegendFetcher( this );
 
   QgsDataSourceUri dataSource( dataSourceUri() );
-  mServiceInfo = QgsArcGisRestUtils::getServiceInfo( dataSource.param( QStringLiteral( "url" ) ), mErrorTitle, mError );
-  mLayerInfo = QgsArcGisRestUtils::getLayerInfo( dataSource.param( QStringLiteral( "url" ) ) + "/" + dataSource.param( QStringLiteral( "layer" ) ), mErrorTitle, mError );
 
-  QVariantMap extentData = mLayerInfo[QStringLiteral( "extent" )].toMap();
+  const QString token = QgsArcGisRestTokenManager::token( dataSource.param( QStringLiteral( "url" ) ) );
+
+  mServiceInfo = QgsArcGisRestUtils::getServiceInfo( dataSource.param( QStringLiteral( "url" ) ), token, mErrorTitle, mError );
+  mLayerInfo = QgsArcGisRestUtils::getLayerInfo( dataSource.param( QStringLiteral( "url" ) ) + "/" + dataSource.param( QStringLiteral( "layer" ) ), token, mErrorTitle, mError );
+
+  const QVariantMap extentData = mLayerInfo.value( QStringLiteral( "extent" ) ).toMap();
   mExtent.setXMinimum( extentData[QStringLiteral( "xmin" )].toDouble() );
   mExtent.setYMinimum( extentData[QStringLiteral( "ymin" )].toDouble() );
   mExtent.setXMaximum( extentData[QStringLiteral( "xmax" )].toDouble() );
@@ -258,6 +261,7 @@ void QgsAmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int p
     return;
   }
   QgsDataSourceUri dataSource( dataSourceUri() );
+  const QString token = QgsArcGisRestTokenManager::token( dataSource.param( QStringLiteral( "url" ) ) );
 
   // Use of tiles currently only implemented if service CRS is meter based
   if ( mServiceInfo[QStringLiteral( "singleFusedMapCache" )].toBool() && mCrs.mapUnits() == QgsUnitTypes::DistanceMeters )
@@ -349,7 +353,7 @@ void QgsAmsProvider::draw( const QgsRectangle &viewExtent, int pixelWidth, int p
     requestUrl.addQueryItem( QStringLiteral( "layers" ), QStringLiteral( "show:%1" ).arg( dataSource.param( QStringLiteral( "layer" ) ) ) );
     requestUrl.addQueryItem( QStringLiteral( "transparent" ), QStringLiteral( "true" ) );
     requestUrl.addQueryItem( QStringLiteral( "f" ), QStringLiteral( "image" ) );
-    QByteArray reply = QgsArcGisRestUtils::queryService( requestUrl, mErrorTitle, mError );
+    QByteArray reply = QgsArcGisRestUtils::queryService( requestUrl, token, mErrorTitle, mError );
     mCachedImage = QImage::fromData( reply, dataSource.param( QStringLiteral( "format" ) ).toLatin1() );
     if ( mCachedImage.format() != QImage::Format_ARGB32 )
     {
@@ -399,7 +403,9 @@ QgsRasterIdentifyResult QgsAmsProvider::identify( const QgsPointXY &point, QgsRa
   queryUrl.addQueryItem( QStringLiteral( "imageDisplay" ), QStringLiteral( "%1,%2,%3" ).arg( width ).arg( height ).arg( dpi ) );
   queryUrl.addQueryItem( QStringLiteral( "mapExtent" ), QStringLiteral( "%1,%2,%3,%4" ).arg( extent.xMinimum(), 0, 'f' ).arg( extent.yMinimum(), 0, 'f' ).arg( extent.xMaximum(), 0, 'f' ).arg( extent.yMaximum(), 0, 'f' ) );
   queryUrl.addQueryItem( QStringLiteral( "tolerance" ), QStringLiteral( "10" ) );
-  const QVariantList queryResults = QgsArcGisRestUtils::queryServiceJSON( queryUrl, mErrorTitle, mError ).value( QStringLiteral( "results" ) ).toList();
+
+  const QString token = QgsArcGisRestTokenManager::token( dataSource.param( QStringLiteral( "url" ) ) );
+  const QVariantList queryResults = QgsArcGisRestUtils::queryServiceJSON( queryUrl, token, mErrorTitle, mError ).value( QStringLiteral( "results" ) ).toList();
 
   QMap<int, QVariant> entries;
 

--- a/src/providers/arcgisrest/qgsamssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsamssourceselect.cpp
@@ -37,7 +37,9 @@ QgsAmsSourceSelect::QgsAmsSourceSelect( QWidget *parent, Qt::WindowFlags fl, Qgs
 bool QgsAmsSourceSelect::connectToService( const QgsOwsConnection &connection )
 {
   QString errorTitle, errorMessage;
-  QVariantMap serviceInfoMap = QgsArcGisRestUtils::getServiceInfo( connection.uri().param( QStringLiteral( "url" ) ), errorTitle, errorMessage );
+  const QString token = QgsArcGisRestTokenManager::token( connection.uri().param( QStringLiteral( "url" ) ) );
+
+  const QVariantMap serviceInfoMap = QgsArcGisRestUtils::getServiceInfo( connection.uri().param( QStringLiteral( "url" ) ), token, errorTitle, errorMessage );
   if ( serviceInfoMap.isEmpty() )
   {
     QMessageBox::warning( this, tr( "Error" ), tr( "Failed to retrieve service capabilities:\n%1: %2" ).arg( errorTitle, errorMessage ) );
@@ -57,7 +59,8 @@ bool QgsAmsSourceSelect::connectToService( const QgsOwsConnection &connection )
     }
 
     // Get layer info
-    QVariantMap layerData = QgsArcGisRestUtils::getLayerInfo( connection.uri().param( QStringLiteral( "url" ) ) + "/" + layerInfoMap[QStringLiteral( "id" )].toString(), errorTitle, errorMessage );
+    QVariantMap layerData = QgsArcGisRestUtils::getLayerInfo( connection.uri().param( QStringLiteral( "url" ) ) + "/" + layerInfoMap[QStringLiteral( "id" )].toString(),
+                            token, errorTitle, errorMessage );
     if ( layerData.isEmpty() )
     {
       layerErrors.append( QStringLiteral( "Layer %1: %2 - %3" ).arg( layerInfoMap[QStringLiteral( "id" )].toString(), errorTitle, errorMessage ) );

--- a/src/providers/arcgisrest/qgsamssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsamssourceselect.cpp
@@ -47,7 +47,8 @@ bool QgsAmsSourceSelect::connectToService( const QgsOwsConnection &connection )
   populateImageEncodings( serviceInfoMap[QStringLiteral( "supportedImageFormatTypes" )].toString().split( ',' ) );
 
   QStringList layerErrors;
-  foreach ( const QVariant &layerInfo, serviceInfoMap["layers"].toList() )
+  const QVariantList layersList = serviceInfoMap[QStringLiteral( "layers" )].toList();
+  for ( const QVariant &layerInfo : layersList )
   {
     QVariantMap layerInfoMap = layerInfo.toMap();
     if ( !layerInfoMap[QStringLiteral( "id" )].isValid() )

--- a/src/providers/arcgisrest/qgsarcgisresttokenmanagerdialog.cpp
+++ b/src/providers/arcgisrest/qgsarcgisresttokenmanagerdialog.cpp
@@ -1,0 +1,202 @@
+/***************************************************************************
+    qgsarcgisresttokenmanagerdialog.cpp
+     --------------------------------------
+    Date                 : October 2018
+    Copyright            : (C) 2018 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgsarcgisresttokenmanagerdialog.h"
+#include "qgsarcgisrestutils.h"
+#include "qgsgui.h"
+#include <QInputDialog>
+
+QgsArcGisRestTokenManagerTableModel::QgsArcGisRestTokenManagerTableModel( QObject *parent )
+  : QAbstractTableModel( parent )
+{
+  const QMap< QString, QString > t = QgsArcGisRestTokenManager::tokens();
+  for ( auto it = t.constBegin(); it != t.constEnd(); ++it )
+  {
+    mServers << it.key();
+    mTokens << it.value();
+  }
+}
+
+void QgsArcGisRestTokenManagerTableModel::removeTokens( const QModelIndexList &indexes )
+{
+  if ( indexes.isEmpty() )
+    return;
+
+  const int row = indexes.at( 0 ).row();
+  beginRemoveRows( QModelIndex(), row, row );
+  mServers.removeAt( row );
+  mTokens.removeAt( row );
+  endRemoveRows();
+}
+
+void QgsArcGisRestTokenManagerTableModel::addToken( const QString &server )
+{
+  beginInsertRows( QModelIndex(), mServers.count(), mServers.count() );
+  mServers << server;
+  mTokens << QString();
+  endInsertRows();
+}
+
+void QgsArcGisRestTokenManagerTableModel::saveTokens()
+{
+  QMap< QString, QString > tokens;
+  for ( int i = 0; i < mServers.count(); ++ i )
+  {
+    tokens.insert( mServers.at( i ), mTokens.at( i ) );
+  }
+  QgsArcGisRestTokenManager::setTokens( tokens );
+}
+
+
+int QgsArcGisRestTokenManagerTableModel::rowCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent );
+  return mServers.count();
+}
+
+int QgsArcGisRestTokenManagerTableModel::columnCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent );
+  return 2;
+}
+
+Qt::ItemFlags QgsArcGisRestTokenManagerTableModel::flags( const QModelIndex &index ) const
+{
+  Qt::ItemFlags f = QAbstractItemModel::flags( index );
+  return f | Qt::ItemIsEditable;
+}
+
+QVariant QgsArcGisRestTokenManagerTableModel::data( const QModelIndex &index, int role ) const
+{
+  if ( index.row() >= mServers.size() )
+    return QVariant();
+
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+    case Qt::EditRole:
+      switch ( index.column() )
+      {
+        case ServerColumn:
+          return mServers.at( index.row() );
+
+        case TokenColumn:
+          return mTokens.at( index.row() );
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  return QVariant();
+}
+
+bool QgsArcGisRestTokenManagerTableModel::setData( const QModelIndex &index, const QVariant &value, int )
+{
+  if ( index.row() >= mServers.size() )
+    return false;
+
+  switch ( index.column() )
+  {
+    case ServerColumn:
+      mServers[ index.row() ] = value.toString();
+      emit dataChanged( index, index );
+      return true;
+
+    case TokenColumn:
+    {
+      mTokens[ index.row() ] = value.toString();
+      emit dataChanged( index, index );
+      return true;
+    }
+  }
+  return false;
+}
+
+QVariant QgsArcGisRestTokenManagerTableModel::headerData( int section, Qt::Orientation orientation, int role ) const
+{
+  if ( orientation == Qt::Vertical )
+    return QVariant();
+
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+      switch ( section )
+      {
+        case ServerColumn :
+          return tr( "Server URL" );
+        case TokenColumn:
+          return tr( "Token" );
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  return QVariant();
+}
+
+
+QgsArcGisRestTokenManagerDialog::QgsArcGisRestTokenManagerDialog( QWidget *parent )
+  : QDialog( parent )
+{
+  setupUi( this );
+
+  QgsGui::enableAutoGeometryRestore( this );
+
+  mTableView->setModel( mModel );
+  mTableView->resizeColumnToContents( 0 );
+  mTableView->resizeColumnToContents( 1 );
+  mTableView->horizontalHeader()->setSectionResizeMode( QHeaderView::Interactive );
+  mTableView->horizontalHeader()->show();
+  mTableView->setSelectionMode( QAbstractItemView::SingleSelection );
+  mTableView->setSelectionBehavior( QAbstractItemView::SelectRows );
+  mTableView->setAlternatingRowColors( true );
+  connect( mAddButton, &QToolButton::clicked, this, &QgsArcGisRestTokenManagerDialog::addToken );
+  connect( mRemoveButton, &QToolButton::clicked, this, &QgsArcGisRestTokenManagerDialog::removeToken );
+
+  connect( mButtonBox, &QDialogButtonBox::accepted, this, &QDialog::accept );
+  connect( mButtonBox, &QDialogButtonBox::rejected, this, &QDialog::reject );
+}
+
+void QgsArcGisRestTokenManagerDialog::accept()
+{
+  mModel->saveTokens();
+  QDialog::accept();
+}
+
+void QgsArcGisRestTokenManagerDialog::addToken()
+{
+  bool ok;
+  const QString server = QInputDialog::getText( this, tr( "Add Token" ), tr( "Server name (http(s):// prefix is not required)" ),
+                         QLineEdit::Normal, QString(), &ok );
+  if ( !ok )
+    return;
+
+  mModel->addToken( server );
+}
+
+void QgsArcGisRestTokenManagerDialog::removeToken()
+{
+  QModelIndexList selectedIndexes = mTableView->selectionModel()->selectedIndexes();
+  if ( selectedIndexes.count() > 0 )
+  {
+    mModel->removeTokens( selectedIndexes );
+  }
+}
+

--- a/src/providers/arcgisrest/qgsarcgisresttokenmanagerdialog.h
+++ b/src/providers/arcgisrest/qgsarcgisresttokenmanagerdialog.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+    qgsarcgisresttokenmanagerdialog.h
+     --------------------------------------
+    Date                 : October 2018
+    Copyright            : (C) 2018 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSARCGISRESTTOKENMANAGERDIALOG_H
+#define QGSARCGISRESTTOKENMANAGERDIALOG_H
+
+#include <QDialog>
+
+#include "ui_qgsarcgisresttokenmanagerbase.h"
+
+class QgsArcGisRestTokenManagerTableModel : public QAbstractTableModel
+{
+    Q_OBJECT
+  public:
+
+    enum TableColumns
+    {
+      ServerColumn  = 0,
+      TokenColumn,
+    };
+
+    QgsArcGisRestTokenManagerTableModel( QObject *parent = nullptr );
+
+    void removeTokens( const QModelIndexList &indexes );
+    void addToken( const QString &server );
+
+    void saveTokens();
+
+    int rowCount( const QModelIndex &parent ) const override;
+    int columnCount( const QModelIndex &parent ) const override;
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
+    QVariant headerData( int section, Qt::Orientation orientation, int role ) const override;
+
+  private:
+
+    QStringList mServers;
+    QStringList mTokens;
+
+};
+
+class QgsArcGisRestTokenManagerDialog : public QDialog, private Ui::QgsArcgisRestTokenManagerBase
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsArcGisRestTokenManagerDialog( QWidget *parent = nullptr );
+
+  public slots:
+
+    void accept() override;
+
+    void addToken();
+    void removeToken();
+
+  private:
+
+    QgsArcGisRestTokenManagerTableModel *mModel = new QgsArcGisRestTokenManagerTableModel( this );
+};
+
+
+#endif // QGSARCGISRESTTOKENMANAGERDIALOG_H

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -125,12 +125,12 @@ static std::unique_ptr< QgsPoint > parsePoint( const QVariantList &coordList, Qg
 
 static std::unique_ptr< QgsCircularString > parseCircularString( const QVariantMap &curveData, QgsWkbTypes::Type pointType, const QgsPoint &startPoint )
 {
-  QVariantList coordsList = curveData[QStringLiteral( "c" )].toList();
+  const QVariantList coordsList = curveData[QStringLiteral( "c" )].toList();
   if ( coordsList.isEmpty() )
     return nullptr;
   QVector<QgsPoint> points;
   points.append( startPoint );
-  foreach ( const QVariant &coordData, coordsList )
+  for ( const QVariant &coordData : coordsList )
   {
     std::unique_ptr< QgsPoint > point = parsePoint( coordData.toList(), pointType );
     if ( !point )
@@ -150,7 +150,7 @@ static std::unique_ptr< QgsCompoundCurve > parseCompoundCurve( const QVariantLis
   std::unique_ptr< QgsCompoundCurve > compoundCurve = qgis::make_unique< QgsCompoundCurve >();
   QgsLineString *lineString = new QgsLineString();
   compoundCurve->addCurve( lineString );
-  foreach ( const QVariant &curveData, curvesList )
+  for ( const QVariant &curveData : curvesList )
   {
     if ( curveData.type() == QVariant::List )
     {
@@ -230,7 +230,7 @@ static std::unique_ptr< QgsMultiCurve > parseEsriGeometryPolyline( const QVarian
   if ( pathsList.isEmpty() )
     return nullptr;
   std::unique_ptr< QgsMultiCurve > multiCurve = qgis::make_unique< QgsMultiCurve >();
-  foreach ( const QVariant &pathData, pathsList )
+  for ( const QVariant &pathData : qgis::as_const( pathsList ) )
   {
     std::unique_ptr< QgsCompoundCurve > curve = parseCompoundCurve( pathData.toList(), pointType );
     if ( !curve )
@@ -392,7 +392,7 @@ QVariantMap QgsArcGisRestUtils::getObjects( const QString &layerurl, const QList
     QString &errorTitle, QString &errorText, QgsFeedback *feedback )
 {
   QStringList ids;
-  foreach ( int id, objectIds )
+  for ( int id : objectIds )
   {
     ids.append( QString::number( id ) );
   }
@@ -413,8 +413,8 @@ QVariantMap QgsArcGisRestUtils::getObjects( const QString &layerurl, const QList
     queryUrl.addQueryItem( QStringLiteral( "returnGeometry" ), QStringLiteral( "false" ) );
     queryUrl.addQueryItem( QStringLiteral( "outFields" ), outFields );
   }
-  queryUrl.addQueryItem( QStringLiteral( "returnM" ), fetchM ? "true" : "false" );
-  queryUrl.addQueryItem( QStringLiteral( "returnZ" ), fetchZ ? "true" : "false" );
+  queryUrl.addQueryItem( QStringLiteral( "returnM" ), fetchM ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
+  queryUrl.addQueryItem( QStringLiteral( "returnZ" ), fetchZ ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
   if ( !filterRect.isNull() )
   {
     queryUrl.addQueryItem( QStringLiteral( "geometry" ), QStringLiteral( "%1,%2,%3,%4" )

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -32,6 +32,52 @@ class QgsFillSymbol;
 class QgsMarkerSymbol;
 class QgsFeatureRenderer;
 
+/**
+ * Manages token storage and retrieval and ArcGIS rest servers.
+ */
+class QgsArcGisRestTokenManager
+{
+
+  public:
+
+    /**
+     * Sets the \a token required to connect to servers with a matching prefix. More explicit server prefixes
+     * take precedence over less explicit prefixes, so a token for "http://myserver.domain.com/portal/" would take precendence
+     * over a token set for "http://myserver.domain.com".
+     *
+     * Any existing tokens stored for the same prefix will be removed.
+     *
+     * \see setTokens()
+     * \see tokens()
+     */
+    static void setToken( const QString &serverPrefix, const QString &token );
+
+    /**
+     * Returns the current map of server prefix to tokens.
+     * \see setTokens()
+     * \see setToken()
+     */
+    static QMap< QString, QString > tokens();
+
+    /**
+     * Sets the map of server prefix to token, replacing all existing tokens stored in the manager.
+     *
+     * \see tokens()
+     */
+    static void setTokens( const QMap< QString, QString> &tokens );
+
+    /**
+     * Retrieves the token required to connect to the given \a url, or an
+     * empty string if no token is required.
+     */
+    static QString token( const QString &url );
+
+  private:
+
+    static QString cleanServerName( const QString &server );
+
+};
+
 class QgsArcGisRestUtils
 {
   public:
@@ -40,16 +86,16 @@ class QgsArcGisRestUtils
     static std::unique_ptr< QgsAbstractGeometry > parseEsriGeoJSON( const QVariantMap &geometryData, const QString &esriGeometryType, bool readM, bool readZ, QgsCoordinateReferenceSystem *crs = nullptr );
     static QgsCoordinateReferenceSystem parseSpatialReference( const QVariantMap &spatialReferenceMap );
 
-    static QVariantMap getServiceInfo( const QString &baseurl, QString &errorTitle, QString &errorText );
-    static QVariantMap getLayerInfo( const QString &layerurl, QString &errorTitle, QString &errorText );
-    static QVariantMap getObjectIds( const QString &layerurl, const QString &objectIdFieldName, QString &errorTitle, QString &errorText,
+    static QVariantMap getServiceInfo( const QString &baseurl, const QString &token, QString &errorTitle, QString &errorText );
+    static QVariantMap getLayerInfo( const QString &layerurl, const QString &token, QString &errorTitle, QString &errorText );
+    static QVariantMap getObjectIds( const QString &layerurl, const QString &token, const QString &objectIdFieldName, QString &errorTitle, QString &errorText,
                                      const QgsRectangle &bbox = QgsRectangle() );
-    static QVariantMap getObjects( const QString &layerurl, const QList<quint32> &objectIds, const QString &crs,
+    static QVariantMap getObjects( const QString &layerurl, const QString &token, const QList<quint32> &objectIds, const QString &crs,
                                    bool fetchGeometry, const QStringList &fetchAttributes, bool fetchM, bool fetchZ,
                                    const QgsRectangle &filterRect, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
-    static QList<quint32> getObjectIdsByExtent( const QString &layerurl, const QString &objectIdField, const QgsRectangle &filterRect, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
-    static QByteArray queryService( const QUrl &url, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
-    static QVariantMap queryServiceJSON( const QUrl &url, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
+    static QList<quint32> getObjectIdsByExtent( const QString &layerurl, const QString &objectIdField, const QgsRectangle &filterRect, QString &errorTitle, QString &errorText, const QString &token, QgsFeedback *feedback = nullptr );
+    static QByteArray queryService( const QUrl &url, const QString &token, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
+    static QVariantMap queryServiceJSON( const QUrl &url, const QString &token, QString &errorTitle, QString &errorText, QgsFeedback *feedback = nullptr );
 
     static std::unique_ptr< QgsSymbol > parseEsriSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsLineSymbol > parseEsriLineSymbolJson( const QVariantMap &symbolData );

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
@@ -118,11 +118,11 @@ void QgsArcGisServiceSourceSelect::populateImageEncodings( const QStringList &av
     delete item;
   }
   bool first = true;
-  QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
-  foreach ( const QString &encoding, availableEncodings )
+  const QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
+  for ( const QString &encoding : availableEncodings )
   {
     bool supported = false;
-    foreach ( const QByteArray &fmt, supportedFormats )
+    for ( const QByteArray &fmt : supportedFormats )
     {
       if ( encoding.startsWith( fmt, Qt::CaseInsensitive ) )
       {
@@ -149,9 +149,9 @@ QString QgsArcGisServiceSourceSelect::getSelectedImageEncoding() const
 
 void QgsArcGisServiceSourceSelect::populateConnectionList()
 {
-  QStringList conns = QgsOwsConnection::connectionList( mServiceName );
+  const QStringList conns = QgsOwsConnection::connectionList( mServiceName );
   cmbConnections->clear();
-  foreach ( const QString &item, conns )
+  for ( const QString &item : conns )
   {
     cmbConnections->addItem( item );
   }
@@ -383,7 +383,8 @@ void QgsArcGisServiceSourceSelect::changeCrsFilter()
     if ( crsIterator != mAvailableCRS.constEnd() )
     {
       QSet<QString> crsNames;
-      foreach ( const QString &crsName, crsIterator.value() )
+      const QStringList crsNamesList = crsIterator.value();
+      for ( const QString &crsName : crsNamesList )
       {
         crsNames.insert( crsName );
       }

--- a/src/ui/qgsarcgisresttokenmanagerbase.ui
+++ b/src/ui/qgsarcgisresttokenmanagerbase.ui
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsArcgisRestTokenManagerBase</class>
+ <widget class="QDialog" name="QgsArcgisRestTokenManagerBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>592</width>
+    <height>439</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Manage ArcGIS Rest Tokens</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QTableView" name="mTableView"/>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="mAddButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mRemoveButton">
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>237</width>
+         <height>17</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>


### PR DESCRIPTION
Without this it can be impossible to connect to authenticated/private servers.

Tokens are set via a "Manage Tokens" option available in the right click menu for ArcGIS Feature Server/Map Server connections in the browser panel.

Note that tokens are NOT stored as part of a layer's source, as tokens are temporary (at most lasting 2 weeks) and are accordingly unsuitable for long-term use. Keeping the token storage for servers local means that tokens can be updated whenever needed without requiring any updates to existing projects/layer linkage.

Possibly in longer term this handling should be moved to the authentication database, but I'm unsure if that's the correct approach to take here (and in the meantime I'd like this fix in place for 3.4).