### PR TITLE
Make it possible to skip memory layer check on project close

### DIFF
--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -65,6 +65,13 @@ to the data provider definition. type is one of "integer", "double", "string".
 
 An example url is "Point?crs=epsg:4326&field=id:integer&field=name:string(20)&index=yes"
 
+Since QGIS 3.4 when closing a project, the application shows a warning about potential data
+loss if there are any non-empty memory layers present. If your memory layer should not
+trigger such warning, it is possible to suppress that by setting the following custom variable:
+.. code-block:: python
+
+       layer.setCustomProperty("skipMemoryLayersCheck", 1)
+
 \subsection ogr OGR data provider (ogr)
 
 Accesses data using the OGR drivers (http://www.gdal.org/ogr/ogr_formats.html). The url

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11136,7 +11136,7 @@ bool QgisApp::checkMemoryLayers()
     if ( it.value() && it.value()->dataProvider()->name() == QLatin1String( "memory" ) )
     {
       QgsVectorLayer *vl = qobject_cast< QgsVectorLayer * >( it.value() );
-      if ( vl && vl->featureCount() != 0 )
+      if ( vl && vl->featureCount() != 0 && !vl->customProperty( QStringLiteral( "skipMemoryLayersCheck" ) ).toInt() )
       {
         hasMemoryLayers = true;
         break;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -124,6 +124,14 @@ typedef QSet<int> QgsAttributeIds;
  *
  * An example url is "Point?crs=epsg:4326&field=id:integer&field=name:string(20)&index=yes"
  *
+ * Since QGIS 3.4 when closing a project, the application shows a warning about potential data
+ * loss if there are any non-empty memory layers present. If your memory layer should not
+ * trigger such warning, it is possible to suppress that by setting the following custom variable:
+ * \code{.py}
+ *   layer.setCustomProperty("skipMemoryLayersCheck", 1)
+ * \endcode
+ *
+ *
  * \subsection ogr OGR data provider (ogr)
  *
  * Accesses data using the OGR drivers (http://www.gdal.org/ogr/ogr_formats.html). The url


### PR DESCRIPTION
In QGIS 3.4 there is the new feature that warns users about a potential data loss
when closing a project that contains memory layers. It displays the warning:

> This project includes one or more temporary scratch layers.
> These layers are not saved to disk and their contents will be
> permanently lost. Are you sure you want to proceed?"

While this is useful in general, there are various cases when this warning
is unwanted. For example, when a plugin creates memory layers by extracting data
from some custom data format (and possibly also writes changes from temporary
layers back to the data storage). In such situations the warning is very confusing
for the users who are unaware of the internals.

This commit adds a custom property "skipMemoryLayersCheck" to map layers,
so if all temporary layers have this property set to non-zero value the warning
will not show up.

layer.setCustomProperty("skipMemoryLayersCheck", 1)
