### PR TITLE
Allow searching for features with a short search string

### DIFF
--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -208,7 +208,8 @@ QgsActiveLayerFeaturesLocatorFilter *QgsActiveLayerFeaturesLocatorFilter::clone(
 
 void QgsActiveLayerFeaturesLocatorFilter::prepare( const QString &string, const QgsLocatorContext &context )
 {
-  if ( string.length() < 3 || context.usingPrefix )
+  // Normally skip very short search strings, unless when specifically searching using this filter
+  if ( string.length() < 3 && !context.usingPrefix )
     return;
 
   bool allowNumeric = false;
@@ -330,7 +331,8 @@ QgsAllLayersFeaturesLocatorFilter *QgsAllLayersFeaturesLocatorFilter::clone() co
 
 void QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const QgsLocatorContext &context )
 {
-  if ( string.length() < 3 || context.usingPrefix )
+  // Normally skip very short search strings, unless when specifically searching using this filter
+  if ( string.length() < 3 && !context.usingPrefix )
     return;
 
   const QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();


### PR DESCRIPTION
It's currently not possible to use the feature search locator filters with short search strings or with their prefix.

This patch enables the search for short strings (less than 3 chars) when the prefix is used (e.g. a streetnumber 3 `af 3`).
It looks like this was the original intention of https://github.com/qgis/QGIS/commit/efed0912709676104bc1d8fdfdad5e9707a26dd3 .