### PR TITLE
Use layer name for processing result layer

### DIFF
--- a/src/core/processing/qgsprocessingutils.cpp
+++ b/src/core/processing/qgsprocessingutils.cpp
@@ -473,6 +473,9 @@ QgsFeatureSink *QgsProcessingUtils::createFeatureSink( QString &destination, Qgs
       if ( !layerName.isEmpty() )
         uri += QStringLiteral( "|layername=%1" ).arg( layerName );
       std::unique_ptr< QgsVectorLayer > layer( new QgsVectorLayer( uri, destination, providerKey ) );
+      if ( !layerName.isEmpty() )
+        layer->setName( layerName );
+
       // update destination to layer ID
       destination = layer->id();
 


### PR DESCRIPTION
When the result of a processing algorithm is a geopackage layer and the processing option to use the filename as layer name is set, the resulting layer name is very cryptic (e.g. `ogr:dbname='/tmp/xz.gpkg' table="buffered_layer" (geom) sql=`). With this change it's the name of the table inside the gpkg (e.g. `buffered_layer`).

![image](https://user-images.githubusercontent.com/588407/47148996-891acc00-d2d2-11e8-81c5-576153872a48.png)


As a general question, what's the opinion on using the file name / table name for output layer names by default for anything but memory layers? Those filenames often have more semantics than just the algorithm output name itself.