### PR TITLE
[server] Fixes freeze of server during rendering

### DIFF
--- a/src/server/services/wms/qgsmaprendererjobproxy.cpp
+++ b/src/server/services/wms/qgsmaprendererjobproxy.cpp
@@ -58,7 +58,7 @@ namespace QgsWms
       renderJob.start();
 
       // Allows the main thread to manage blocking call coming from rendering
-      // threads (see discussion in #18988).
+      // threads (see discussion in https://issues.qgis.org/issues/18988).
       QEventLoop loop;
       QObject::connect( &renderJob, &QgsMapRendererParallelJob::finished, &loop, &QEventLoop::quit );
       loop.exec();

--- a/src/server/services/wms/qgsmaprendererjobproxy.cpp
+++ b/src/server/services/wms/qgsmaprendererjobproxy.cpp
@@ -56,6 +56,13 @@ namespace QgsWms
       renderJob.setFeatureFilterProvider( mFeatureFilterProvider );
 #endif
       renderJob.start();
+
+      // Allows the main thread to manage blocking call coming from rendering
+      // threads (see discussion in #18988).
+      QEventLoop loop;
+      QObject::connect( &renderJob, &QgsMapRendererParallelJob::finished, &loop, &QEventLoop::quit );
+      loop.exec();
+
       renderJob.waitForFinished();
       *image = renderJob.renderedImage();
       mPainter.reset( new QPainter( image ) );


### PR DESCRIPTION
## Description

On Debian Buster, the server is freezing when parallel rendering is activated.

See https://github.com/qgis/QGIS/pull/8063#issuecomment-430277253.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
