### PR TITLE
Select feature menu on action with multiple features

### DIFF
--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -75,7 +75,7 @@ void QgsMapToolFeatureAction::canvasReleaseEvent( QgsMapMouseEvent *e )
     return;
   }
 
-  if ( !doAction( vlayer, e->x(), e->y(), e->originalPixelPoint() ) )
+  if ( !doAction( vlayer, e->x(), e->y() ) )
     QgisApp::instance()->statusBarIface()->showMessage( tr( "No features at this position found." ) );
 }
 
@@ -89,12 +89,13 @@ void QgsMapToolFeatureAction::deactivate()
   QgsMapTool::deactivate();
 }
 
-bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y, QPoint pixelpos )
+bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
 {
   if ( !layer )
     return false;
 
   QgsPointXY point = mCanvas->getCoordinateTransform()->toMapCoordinates( x, y );
+  QPoint position = mCanvas->mapToGlobal( QPoint( x + 5, y + 5 ) );
 
   QgsRectangle r;
 
@@ -151,7 +152,7 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y, QPo
         }
       } );
 
-      featureMenu->exec( pixelpos );
+      featureMenu->exec( position );
     }
     return true;
   }

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -75,7 +75,7 @@ void QgsMapToolFeatureAction::canvasReleaseEvent( QgsMapMouseEvent *e )
     return;
   }
 
-  if ( !doAction( vlayer, e->x(), e->y(), e->pixelPoint() ) )
+  if ( !doAction( vlayer, e->x(), e->y(), e->originalPixelPoint() ) )
     QgisApp::instance()->statusBarIface()->showMessage( tr( "No features at this position found." ) );
 }
 
@@ -142,6 +142,15 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y, QPo
         QAction *featureAction = featureMenu->addAction( FID_TO_STRING( features.at( i ).id() ) );
         connect( featureAction, &QAction::triggered, this, [ = ] { doActionForFeature( layer, features.at( i ), point );} );
       }
+      QAction *allFeatureAction = featureMenu->addAction( tr( "All Features" ) );
+      connect( allFeatureAction, &QAction::triggered, this, [ = ]
+      {
+        for ( int i = 0; i < features.count(); i++ )
+        {
+          doActionForFeature( layer, features.at( i ), point );
+        }
+      } );
+
       featureMenu->exec( pixelpos );
     }
     return true;

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -138,17 +138,17 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
     else
     {
       QMenu *featureMenu = new QMenu();
-      for ( int idx = 0; idx < features.count(); idx++ )
+      for ( const QgsFeature &feature : features )
       {
-        QAction *featureAction = featureMenu->addAction( FID_TO_STRING( features.at( idx ).id() ) );
-        connect( featureAction, &QAction::triggered, this, [ = ] { doActionForFeature( layer, features.at( idx ), point );} );
+        QAction *featureAction = featureMenu->addAction( FID_TO_STRING( feature.id() ) );
+        connect( featureAction, &QAction::triggered, this, [ = ] { doActionForFeature( layer, feature, point );} );
       }
       QAction *allFeatureAction = featureMenu->addAction( tr( "All Features" ) );
       connect( allFeatureAction, &QAction::triggered, this, [ = ]
       {
-        for ( int idx = 0; idx < features.count(); idx++ )
+        for ( const QgsFeature &feature : features )
         {
-          doActionForFeature( layer, features.at( idx ), point );
+          doActionForFeature( layer, feature, point );
         }
       } );
       featureMenu->exec( position );

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -138,20 +138,19 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
     else
     {
       QMenu *featureMenu = new QMenu();
-      for ( int i = 0; i < features.count(); i++ )
+      for ( int idx = 0; idx < features.count(); idx++ )
       {
-        QAction *featureAction = featureMenu->addAction( FID_TO_STRING( features.at( i ).id() ) );
-        connect( featureAction, &QAction::triggered, this, [ = ] { doActionForFeature( layer, features.at( i ), point );} );
+        QAction *featureAction = featureMenu->addAction( FID_TO_STRING( features.at( idx ).id() ) );
+        connect( featureAction, &QAction::triggered, this, [ = ] { doActionForFeature( layer, features.at( idx ), point );} );
       }
       QAction *allFeatureAction = featureMenu->addAction( tr( "All Features" ) );
       connect( allFeatureAction, &QAction::triggered, this, [ = ]
       {
-        for ( int i = 0; i < features.count(); i++ )
+        for ( int idx = 0; idx < features.count(); idx++ )
         {
-          doActionForFeature( layer, features.at( i ), point );
+          doActionForFeature( layer, features.at( idx ), point );
         }
       } );
-
       featureMenu->exec( position );
     }
     return true;
@@ -159,7 +158,7 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
   return false;
 }
 
-void QgsMapToolFeatureAction::doActionForFeature( QgsVectorLayer *layer, QgsFeature feat, QgsPointXY point )
+void QgsMapToolFeatureAction::doActionForFeature( QgsVectorLayer *layer, const QgsFeature &feature, const QgsPointXY &point )
 {
   QgsAction defaultAction = layer->actions()->defaultAction( QStringLiteral( "Canvas" ) );
   if ( defaultAction.isValid() )
@@ -175,14 +174,14 @@ void QgsMapToolFeatureAction::doActionForFeature( QgsVectorLayer *layer, QgsFeat
     actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "action_scope" ), QStringLiteral( "Canvas" ), true ) );
     context << actionScope;
 
-    defaultAction.run( layer, feat, context );
+    defaultAction.run( layer, feature, context );
   }
   else
   {
     QgsMapLayerAction *mapLayerAction = QgsGui::mapLayerActionRegistry()->defaultActionForLayer( layer );
     if ( mapLayerAction )
     {
-      mapLayerAction->triggerForFeature( layer, &feat );
+      mapLayerAction->triggerForFeature( layer, &feature );
     }
   }
 }

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -138,7 +138,7 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
     else
     {
       QMenu *featureMenu = new QMenu();
-      for ( const QgsFeature &feature : features )
+      for ( const QgsFeature &feature : qgis::as_const( features ) )
       {
         QAction *featureAction = featureMenu->addAction( FID_TO_STRING( feature.id() ) );
         connect( featureAction, &QAction::triggered, this, [ = ] { doActionForFeature( layer, feature, point );} );
@@ -146,7 +146,7 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
       QAction *allFeatureAction = featureMenu->addAction( tr( "All Features" ) );
       connect( allFeatureAction, &QAction::triggered, this, [ = ]
       {
-        for ( const QgsFeature &feature : features )
+        for ( const QgsFeature &feature : qgis::as_const( features ) )
         {
           doActionForFeature( layer, feature, point );
         }

--- a/src/app/qgsmaptoolfeatureaction.h
+++ b/src/app/qgsmaptoolfeatureaction.h
@@ -52,7 +52,7 @@ class APP_EXPORT QgsMapToolFeatureAction : public QgsMapTool
     void deactivate() override;
 
   private:
-    bool doAction( QgsVectorLayer *layer, int x, int y, QPoint pixelpos );
+    bool doAction( QgsVectorLayer *layer, int x, int y );
     void doActionForFeature( QgsVectorLayer *layer, QgsFeature feat, QgsPointXY point );
 };
 

--- a/src/app/qgsmaptoolfeatureaction.h
+++ b/src/app/qgsmaptoolfeatureaction.h
@@ -18,13 +18,13 @@
 
 #include "qgis.h"
 #include "qgsmaptool.h"
-#include "qgsfeature.h"
 
 #include <QObject>
 #include <QPointer>
 #include "qgis_app.h"
 
 class QgsVectorLayer;
+class QgsFeature;
 
 /**
   \brief Map tool for running feature actions on the current layer

--- a/src/app/qgsmaptoolfeatureaction.h
+++ b/src/app/qgsmaptoolfeatureaction.h
@@ -53,7 +53,7 @@ class APP_EXPORT QgsMapToolFeatureAction : public QgsMapTool
 
   private:
     bool doAction( QgsVectorLayer *layer, int x, int y );
-    void doActionForFeature( QgsVectorLayer *layer, QgsFeature feat, QgsPointXY point );
+    void doActionForFeature( QgsVectorLayer *layer, const QgsFeature &feature, const QgsPointXY &point );
 };
 
 #endif

--- a/src/app/qgsmaptoolfeatureaction.h
+++ b/src/app/qgsmaptoolfeatureaction.h
@@ -52,7 +52,7 @@ class APP_EXPORT QgsMapToolFeatureAction : public QgsMapTool
     void deactivate() override;
 
   private:
-    bool doAction( QgsVectorLayer *layer, int x, int y );
+    bool doAction( QgsVectorLayer *layer, int x, int y, QPoint pixelpos );
     void doActionForFeature( QgsVectorLayer *layer, QgsFeature feat, QgsPointXY point );
 };
 

--- a/src/app/qgsmaptoolfeatureaction.h
+++ b/src/app/qgsmaptoolfeatureaction.h
@@ -18,6 +18,7 @@
 
 #include "qgis.h"
 #include "qgsmaptool.h"
+#include "qgsfeature.h"
 
 #include <QObject>
 #include <QPointer>
@@ -52,6 +53,7 @@ class APP_EXPORT QgsMapToolFeatureAction : public QgsMapTool
 
   private:
     bool doAction( QgsVectorLayer *layer, int x, int y );
+    void doActionForFeature( QgsVectorLayer *layer, QgsFeature feat, QgsPointXY point );
 };
 
 #endif


### PR DESCRIPTION
A menu listing all the intersecting features, where we can choose on which one the action should be run.

Looks like this:
![duplications](https://user-images.githubusercontent.com/28384354/47157623-0867ca00-d2ea-11e8-805e-dec364612875.gif)

If only one feature is intersecting, then the action is run on it without going over the menu.

As far I know, all feature actions we select over the canvas should only handle one feature at the time. 
The issue was, that on "Duplicate Feature" or even the default layer action "Get Feature Id" have been executed on every feature, if there have been intersecting more than one.

This function is effecting all the functions. That's why I still added the "All Feature" action in the menu, in case there are user defined actions we are backwards compatible.

This fixes #17853l