### PR TITLE
[layouts] Show more precision in map scale for map item properties

### DIFF
--- a/src/app/layout/qgslayoutmapwidget.cpp
+++ b/src/app/layout/qgslayoutmapwidget.cpp
@@ -483,7 +483,7 @@ void QgsLayoutMapWidget::mScaleLineEdit_editingFinished()
     return;
   }
 
-  if ( std::round( scaleDenominator ) == std::round( mMapItem->scale() ) )
+  if ( qgsDoubleNear( scaleDenominator, mMapItem->scale() ) )
     return;
 
   mMapItem->layout()->undoStack()->beginCommand( mMapItem, tr( "Change Map Scale" ) );
@@ -604,10 +604,14 @@ void QgsLayoutMapWidget::updateGuiElements()
   double scale = mMapItem->scale();
 
   //round scale to an appropriate number of decimal places
-  if ( scale >= 10 )
+  if ( scale >= 10000 )
   {
-    //round scale to integer if it's greater than 10
+    //round scale to integer if it's greater than 10000
     mScaleLineEdit->setText( QLocale().toString( mMapItem->scale(), 'f', 0 ) );
+  }
+  else if ( scale >= 10 )
+  {
+    mScaleLineEdit->setText( QLocale().toString( mMapItem->scale(), 'f', 3 ) );
   }
   else if ( scale >= 1 )
   {


### PR DESCRIPTION
Previously we would often round the scale displayed to the nearest
integer. Now ensure that the map scale widget shows more decimals
to allow verification that the actual map scale exactly matches
the desired scale.

Fixes #20133
