### PR TITLE
[needs-docs][layouts] Extend stable layout designer dialog API

### DIFF
--- a/python/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutdesignerinterface.sip.in
@@ -91,12 +91,230 @@ shown and raised to the top of the interface.
 %End
 
 
+    virtual QMenu *layoutMenu() = 0;
+%Docstring
+Returns a reference to the designer's "Layout" menu.
+
+.. seealso:: :py:func:`editMenu`
+
+.. seealso:: :py:func:`viewMenu`
+
+.. seealso:: :py:func:`itemsMenu`
+
+.. seealso:: :py:func:`atlasMenu`
+
+.. seealso:: :py:func:`reportMenu`
+
+.. seealso:: :py:func:`settingsMenu`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QMenu *editMenu() = 0;
+%Docstring
+Returns a reference to the designer's "Edit" menu.
+
+.. seealso:: :py:func:`layoutMenu`
+
+.. seealso:: :py:func:`viewMenu`
+
+.. seealso:: :py:func:`itemsMenu`
+
+.. seealso:: :py:func:`atlasMenu`
+
+.. seealso:: :py:func:`reportMenu`
+
+.. seealso:: :py:func:`settingsMenu`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QMenu *viewMenu() = 0;
+%Docstring
+Returns a reference to the designer's "View" menu.
+
+.. seealso:: :py:func:`layoutMenu`
+
+.. seealso:: :py:func:`editMenu`
+
+.. seealso:: :py:func:`itemsMenu`
+
+.. seealso:: :py:func:`atlasMenu`
+
+.. seealso:: :py:func:`reportMenu`
+
+.. seealso:: :py:func:`settingsMenu`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QMenu *itemsMenu() = 0;
+%Docstring
+Returns a reference to the designer's "Items" menu.
+
+.. seealso:: :py:func:`layoutMenu`
+
+.. seealso:: :py:func:`editMenu`
+
+.. seealso:: :py:func:`viewMenu`
+
+.. seealso:: :py:func:`atlasMenu`
+
+.. seealso:: :py:func:`reportMenu`
+
+.. seealso:: :py:func:`settingsMenu`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QMenu *atlasMenu() = 0;
+%Docstring
+Returns a reference to the designer's "Atlas" menu.
+
+Note that this may not exist or may be hidden if the designer is in report mode.
+
+.. seealso:: :py:func:`layoutMenu`
+
+.. seealso:: :py:func:`editMenu`
+
+.. seealso:: :py:func:`viewMenu`
+
+.. seealso:: :py:func:`itemsMenu`
+
+.. seealso:: :py:func:`reportMenu`
+
+.. seealso:: :py:func:`settingsMenu`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QMenu *reportMenu() = 0;
+%Docstring
+Returns a reference to the designer's "Report" menu.
+
+Note that this may not exist or may be hidden if the designer is not in report mode.
+
+.. seealso:: :py:func:`layoutMenu`
+
+.. seealso:: :py:func:`editMenu`
+
+.. seealso:: :py:func:`viewMenu`
+
+.. seealso:: :py:func:`itemsMenu`
+
+.. seealso:: :py:func:`atlasMenu`
+
+.. seealso:: :py:func:`settingsMenu`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QMenu *settingsMenu() = 0;
+%Docstring
+Returns a reference to the designer's "Settings" menu.
+
+.. seealso:: :py:func:`layoutMenu`
+
+.. seealso:: :py:func:`editMenu`
+
+.. seealso:: :py:func:`viewMenu`
+
+.. seealso:: :py:func:`itemsMenu`
+
+.. seealso:: :py:func:`atlasMenu`
+
+.. seealso:: :py:func:`reportMenu`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QToolBar *layoutToolbar() = 0;
+%Docstring
+Returns a reference to the designer's "Layout" toolbar.
+
+.. seealso:: :py:func:`navigationToolbar`
+
+.. seealso:: :py:func:`actionsToolbar`
+
+.. seealso:: :py:func:`atlasToolbar`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QToolBar *navigationToolbar() = 0;
+%Docstring
+Returns a reference to the designer's "Navigation" toolbar.
+
+.. seealso:: :py:func:`layoutToolbar`
+
+.. seealso:: :py:func:`actionsToolbar`
+
+.. seealso:: :py:func:`atlasToolbar`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QToolBar *actionsToolbar() = 0;
+%Docstring
+Returns a reference to the designer's "Actions" toolbar.
+
+.. seealso:: :py:func:`layoutToolbar`
+
+.. seealso:: :py:func:`navigationToolbar`
+
+.. seealso:: :py:func:`atlasToolbar`
+
+.. versionadded:: 3.4
+%End
+
+    virtual QToolBar *atlasToolbar() = 0;
+%Docstring
+Returns a reference to the designer's "Atlas" toolbar.
+
+Note that this toolbar may not exist or may be hidden if the
+designer is in report mode.
+
+.. seealso:: :py:func:`layoutToolbar`
+
+.. seealso:: :py:func:`navigationToolbar`
+
+.. seealso:: :py:func:`actionsToolbar`
+
+.. versionadded:: 3.4
+%End
+
+    virtual void addDockWidget( Qt::DockWidgetArea area, QDockWidget *dock ) = 0;
+%Docstring
+Adds a ``dock`` widget to the layout designer, in the specified dock ``area``.
+
+.. seealso:: :py:func:`removeDockWidget`
+
+.. versionadded:: 3.4
+%End
+
+    virtual void removeDockWidget( QDockWidget *dock ) = 0;
+%Docstring
+Removes the specified ``dock`` widget from layout designer (without deleting it).
+
+.. seealso:: :py:func:`addDockWidget`
+
+.. versionadded:: 3.4
+%End
+
   public slots:
 
     virtual void close() = 0;
 %Docstring
 Closes the layout designer.
 %End
+
+    virtual void showRulers( bool visible ) = 0;
+%Docstring
+Toggles whether or not the rulers should be ``visible`` in the designer.
+
+.. versionadded:: 3.4
+%End
+
 
 };
 

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -916,12 +916,16 @@ Remove action from the Web menu
 
     virtual void addDockWidget( Qt::DockWidgetArea area, QDockWidget *dockwidget ) = 0;
 %Docstring
-Add a dock widget to the main window
+Adds a ``dock`` widget to the main window, in the specified dock ``area``.
+
+.. seealso:: :py:func:`removeDockWidget`
 %End
 
     virtual void removeDockWidget( QDockWidget *dockwidget ) = 0;
 %Docstring
-Remove specified dock widget from main window (doesn't delete it).
+Removes the specified ``dock`` widget from main window (without deleting it).
+
+.. seealso:: :py:func:`addDockWidget`
 %End
 
     virtual void showLayerProperties( QgsMapLayer *l ) = 0;

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -142,9 +142,79 @@ void QgsAppLayoutDesignerInterface::showItemOptions( QgsLayoutItem *item, bool b
   mDesigner->showItemOptions( item, bringPanelToFront );
 }
 
+QMenu *QgsAppLayoutDesignerInterface::layoutMenu()
+{
+  return mDesigner->mLayoutMenu;
+}
+
+QMenu *QgsAppLayoutDesignerInterface::editMenu()
+{
+  return mDesigner->menuEdit;
+}
+
+QMenu *QgsAppLayoutDesignerInterface::viewMenu()
+{
+  return mDesigner->mMenuView;
+}
+
+QMenu *QgsAppLayoutDesignerInterface::itemsMenu()
+{
+  return mDesigner->menuLayout;
+}
+
+QMenu *QgsAppLayoutDesignerInterface::atlasMenu()
+{
+  return mDesigner->mMenuAtlas;
+}
+
+QMenu *QgsAppLayoutDesignerInterface::reportMenu()
+{
+  return mDesigner->mMenuReport;
+}
+
+QMenu *QgsAppLayoutDesignerInterface::settingsMenu()
+{
+  return mDesigner->menuSettings;
+}
+
+QToolBar *QgsAppLayoutDesignerInterface::layoutToolbar()
+{
+  return mDesigner->mLayoutToolbar;
+}
+
+QToolBar *QgsAppLayoutDesignerInterface::navigationToolbar()
+{
+  return mDesigner->mNavigationToolbar;
+}
+
+QToolBar *QgsAppLayoutDesignerInterface::actionsToolbar()
+{
+  return mDesigner->mActionsToolbar;
+}
+
+QToolBar *QgsAppLayoutDesignerInterface::atlasToolbar()
+{
+  return mDesigner->mAtlasToolbar;
+}
+
+void QgsAppLayoutDesignerInterface::addDockWidget( Qt::DockWidgetArea area, QDockWidget *dock )
+{
+  mDesigner->addDockWidget( area, dock );
+}
+
+void QgsAppLayoutDesignerInterface::removeDockWidget( QDockWidget *dock )
+{
+  mDesigner->removeDockWidget( dock );
+}
+
 void QgsAppLayoutDesignerInterface::close()
 {
   mDesigner->close();
+}
+
+void QgsAppLayoutDesignerInterface::showRulers( bool visible )
+{
+  mDesigner->showRulers( visible );
 }
 
 
@@ -1895,7 +1965,6 @@ void QgsLayoutDesignerDialog::exportToRaster()
 
   QgsLayoutExporter exporter( mLayout );
 
-  QFileInfo fi( fileNExt.first );
   QgsLayoutExporter::ExportResult result = exporter.exportToImage( fileNExt.first, settings );
 
   proxyTask->finalize( result == QgsLayoutExporter::Success );
@@ -2909,8 +2978,6 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
   pdfSettings.rasterizeWholeImage = mLayout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
   pdfSettings.forceVectorOutput = mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
 
-  QFileInfo fi( outputFileName );
-
   QString error;
   std::unique_ptr< QgsFeedback > feedback = qgis::make_unique< QgsFeedback >();
   std::unique_ptr< QProgressDialog > progressDialog = qgis::make_unique< QProgressDialog >( tr( "Rendering maps…" ), tr( "Abort" ), 0, 100, this );
@@ -3299,8 +3366,6 @@ void QgsLayoutDesignerDialog::exportReportToPdf()
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = rasterize;
   pdfSettings.forceVectorOutput = forceVectorOutput;
-
-  QFileInfo fi( outputFileName );
 
   QString error;
   std::unique_ptr< QgsFeedback > feedback = qgis::make_unique< QgsFeedback >();

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -63,9 +63,24 @@ class QgsAppLayoutDesignerInterface : public QgsLayoutDesignerInterface
     void setAtlasPreviewEnabled( bool enabled ) override;
     bool atlasPreviewEnabled() const override;
     void showItemOptions( QgsLayoutItem *item, bool bringPanelToFront = true ) override;
+    QMenu *layoutMenu() override;
+    QMenu *editMenu() override;
+    QMenu *viewMenu() override;
+    QMenu *itemsMenu() override;
+    QMenu *atlasMenu() override;
+    QMenu *reportMenu() override;
+    QMenu *settingsMenu() override;
+    QToolBar *layoutToolbar() override;
+    QToolBar *navigationToolbar() override;
+    QToolBar *actionsToolbar() override;
+    QToolBar *atlasToolbar() override;
+    void addDockWidget( Qt::DockWidgetArea area, QDockWidget *dock ) override;
+    void removeDockWidget( QDockWidget *dock ) override;
+
   public slots:
 
     void close() override;
+    void showRulers( bool visible ) override;
 
   private:
 
@@ -76,7 +91,7 @@ class QgsAppLayoutDesignerInterface : public QgsLayoutDesignerInterface
  * \ingroup app
  * \brief A window for designing layouts.
  */
-class QgsLayoutDesignerDialog: public QMainWindow, private Ui::QgsLayoutDesignerBase
+class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerBase
 {
     Q_OBJECT
 

--- a/src/gui/layout/qgslayoutdesignerinterface.h
+++ b/src/gui/layout/qgslayoutdesignerinterface.h
@@ -25,6 +25,9 @@ class QgsLayoutView;
 class QgsLayoutItem;
 class QgsMessageBar;
 class QgsMasterLayoutInterface;
+class QMenu;
+class QDockWidget;
+class QToolBar;
 
 /**
  * \ingroup gui
@@ -104,6 +107,174 @@ class GUI_EXPORT QgsLayoutDesignerInterface: public QObject
      */
     virtual void showItemOptions( QgsLayoutItem *item, bool bringPanelToFront = true ) = 0;
 
+    // Menus and toolbars
+
+    /**
+     * Returns a reference to the designer's "Layout" menu.
+     *
+     * \see editMenu()
+     * \see viewMenu()
+     * \see itemsMenu()
+     * \see atlasMenu()
+     * \see reportMenu()
+     * \see settingsMenu()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QMenu *layoutMenu() = 0;
+
+    /**
+     * Returns a reference to the designer's "Edit" menu.
+     *
+     * \see layoutMenu()
+     * \see viewMenu()
+     * \see itemsMenu()
+     * \see atlasMenu()
+     * \see reportMenu()
+     * \see settingsMenu()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QMenu *editMenu() = 0;
+
+    /**
+     * Returns a reference to the designer's "View" menu.
+     *
+     * \see layoutMenu()
+     * \see editMenu()
+     * \see itemsMenu()
+     * \see atlasMenu()
+     * \see reportMenu()
+     * \see settingsMenu()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QMenu *viewMenu() = 0;
+
+    /**
+     * Returns a reference to the designer's "Items" menu.
+     *
+     * \see layoutMenu()
+     * \see editMenu()
+     * \see viewMenu()
+     * \see atlasMenu()
+     * \see reportMenu()
+     * \see settingsMenu()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QMenu *itemsMenu() = 0;
+
+    /**
+     * Returns a reference to the designer's "Atlas" menu.
+     *
+     * Note that this may not exist or may be hidden if the designer is in report mode.
+     *
+     * \see layoutMenu()
+     * \see editMenu()
+     * \see viewMenu()
+     * \see itemsMenu()
+     * \see reportMenu()
+     * \see settingsMenu()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QMenu *atlasMenu() = 0;
+
+    /**
+     * Returns a reference to the designer's "Report" menu.
+     *
+     * Note that this may not exist or may be hidden if the designer is not in report mode.
+     *
+     * \see layoutMenu()
+     * \see editMenu()
+     * \see viewMenu()
+     * \see itemsMenu()
+     * \see atlasMenu()
+     * \see settingsMenu()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QMenu *reportMenu() = 0;
+
+    /**
+     * Returns a reference to the designer's "Settings" menu.
+     *
+     * \see layoutMenu()
+     * \see editMenu()
+     * \see viewMenu()
+     * \see itemsMenu()
+     * \see atlasMenu()
+     * \see reportMenu()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QMenu *settingsMenu() = 0;
+
+    /**
+     * Returns a reference to the designer's "Layout" toolbar.
+     *
+     * \see navigationToolbar()
+     * \see actionsToolbar()
+     * \see atlasToolbar()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QToolBar *layoutToolbar() = 0;
+
+    /**
+     * Returns a reference to the designer's "Navigation" toolbar.
+     *
+     * \see layoutToolbar()
+     * \see actionsToolbar()
+     * \see atlasToolbar()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QToolBar *navigationToolbar() = 0;
+
+    /**
+     * Returns a reference to the designer's "Actions" toolbar.
+     *
+     * \see layoutToolbar()
+     * \see navigationToolbar()
+     * \see atlasToolbar()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QToolBar *actionsToolbar() = 0;
+
+    /**
+     * Returns a reference to the designer's "Atlas" toolbar.
+     *
+     * Note that this toolbar may not exist or may be hidden if the
+     * designer is in report mode.
+     *
+     * \see layoutToolbar()
+     * \see navigationToolbar()
+     * \see actionsToolbar()
+     *
+     * \since QGIS 3.4
+     */
+    virtual QToolBar *atlasToolbar() = 0;
+
+    /**
+     * Adds a \a dock widget to the layout designer, in the specified dock \a area.
+     *
+     * \see removeDockWidget()
+     *
+     * \since QGIS 3.4
+     */
+    virtual void addDockWidget( Qt::DockWidgetArea area, QDockWidget *dock ) = 0;
+
+    /**
+     * Removes the specified \a dock widget from layout designer (without deleting it).
+     *
+     * \see addDockWidget()
+     *
+     * \since QGIS 3.4
+     */
+    virtual void removeDockWidget( QDockWidget *dock ) = 0;
 
   public slots:
 
@@ -111,6 +282,14 @@ class GUI_EXPORT QgsLayoutDesignerInterface: public QObject
      * Closes the layout designer.
      */
     virtual void close() = 0;
+
+    /**
+     * Toggles whether or not the rulers should be \a visible in the designer.
+     *
+     * \since QGIS 3.4
+     */
+    virtual void showRulers( bool visible ) = 0;
+
 
 };
 

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -776,10 +776,18 @@ class GUI_EXPORT QgisInterface : public QObject
     //! Remove action from the Web menu
     virtual void removePluginWebMenu( const QString &name, QAction *action ) = 0;
 
-    //! Add a dock widget to the main window
+    /**
+     * Adds a \a dock widget to the main window, in the specified dock \a area.
+     *
+     * \see removeDockWidget()
+     */
     virtual void addDockWidget( Qt::DockWidgetArea area, QDockWidget *dockwidget ) = 0;
 
-    //! Remove specified dock widget from main window (doesn't delete it).
+    /**
+     * Removes the specified \a dock widget from main window (without deleting it).
+     *
+     * \see addDockWidget()
+     */
     virtual void removeDockWidget( QDockWidget *dockwidget ) = 0;
 
     //! Open layer properties dialog


### PR DESCRIPTION
This commit adds more methods to the public, stable API for the layout designer dialog, allowing plugins and scripts greater flexibility in extending and hooking into the layout designer.

New API includes:
- access to the main menus shown in the dialog, allowing custom actions to be added to the dialog
- access to the dialog's toolbars
- methods for adding (and removing) additional dock widgets to the designer
- the method used to show/hide rulers in the designer

Suggestions for exposing other functionality is welcome. Note that I'm taking a "play it safe" approach with adding methods to this interface, and only exposing functionality on request. I'd rather have a tighter stable API here and more flexibility for core changes in future than exposing everything up-front and causing issues later...

