### PR TITLE
Fix svg marker doesn't render when size is very small

### DIFF
--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -2025,11 +2025,11 @@ void QgsSvgMarkerSymbolLayerV2::renderPoint( QPointF point, QgsSymbolV2RenderCon
   double hwRatio = 1.0;
   if ( !context.renderContext().forceVectorOutput() && !rotated )
   {
-    usePict = false;
     const QImage& img = QgsSvgCache::instance()->svgAsImage( path, size, fillColor, outlineColor, outlineWidth,
                         context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), fitsInCache );
     if ( fitsInCache && img.width() > 1 )
     {
+      usePict = false;
       //consider transparency
       if ( !qgsDoubleNear( context.alpha(), 1.0 ) )
       {


### PR DESCRIPTION
Backport from c6db18d
