### PR TITLE
[FEATURE] Layer tree indicator for layers with joined fields

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -723,6 +723,7 @@
         <file>themes/default/mIconFolderLink.svg</file>
         <file>themes/default/mIconFolderOpen.svg</file>
         <file>themes/default/mIconFolderProject.svg</file>
+        <file>themes/default/mIndicatorJoin.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mIndicatorJoin.svg
+++ b/images/themes/default/mIndicatorJoin.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333332 4.2333335"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="mIndicatorJoin.svg">
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4538">
+      <stop
+         style="stop-color:#bfbfbf;stop-opacity:1"
+         offset="0"
+         id="stop4534" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop4536" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="32"
+       x2="59.238998"
+       y1="32"
+       x1="26.847"
+       id="b"
+       xlink:href="#a"
+       gradientTransform="matrix(0.24197526,0,0,0.24197526,0.33740553,0.33037537)" />
+    <linearGradient
+       id="a">
+      <stop
+         id="stop822"
+         stop-color="#38608a"
+         offset="0"
+         style="stop-color:#bfbfbf;stop-opacity:1" />
+      <stop
+         id="stop824"
+         stop-color="#6d97c4"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4538"
+       id="linearGradient4540"
+       x1="7.1952038"
+       y1="7.9897809"
+       x2="16.412846"
+       y2="7.9897809"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.919596"
+     inkscape:cx="-33.401585"
+     inkscape:cy="22.639825"
+     inkscape:document-units="mm"
+     inkscape:current-layer="g837"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-162.85828,-202.27226)">
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,162.84214,202.23677)"
+       id="g837">
+      <path
+         id="path830"
+         d="M 5.0559231,8.0735837 14.976909,1.9032146 V 14.243953 Z"
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient4540);fill-rule:evenodd;stroke:#333333;stroke-width:0.75;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1" />
+      <rect
+         id="rect832"
+         ry="7.5"
+         rx="7.5"
+         height="3.3876536"
+         width="3.3876536"
+         y="6.5007443"
+         x="0.94234365"
+         style="fill:#bfbfbf;fill-opacity:1;stroke:#333333;stroke-width:0.49999997;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -64,6 +64,7 @@ SET(QGIS_APP_SRCS
   qgslayertreeviewfilterindicator.cpp
   qgslayertreeviewmemoryindicator.cpp
   qgslayertreeviewnonremovableindicator.cpp
+  qgslayertreeviewjoinindicator.cpp
   qgsmapcanvasdockwidget.cpp
   qgsmaplayerstylecategoriesmodel.cpp
   qgsmaplayerstyleguiutils.cpp
@@ -293,6 +294,7 @@ SET (QGIS_APP_MOC_HDRS
   qgslayertreeviewmemoryindicator.h
   qgslayertreeviewfilterindicator.h
   qgslayertreeviewnonremovableindicator.h
+  qgslayertreeviewjoinindicator.h
   qgsmapcanvasdockwidget.h
   qgsmaplayerstylecategoriesmodel.h
   qgsmaplayerstyleguiutils.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -210,6 +210,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayertreeviewfilterindicator.h"
 #include "qgslayertreeviewmemoryindicator.h"
 #include "qgslayertreeviewnonremovableindicator.h"
+#include "qgslayertreeviewjoinindicator.h"
 #include "qgslayout.h"
 #include "qgslayoutatlas.h"
 #include "qgslayoutcustomdrophandler.h"
@@ -3892,6 +3893,7 @@ void QgisApp::initLayerTreeView()
   new QgsLayerTreeViewEmbeddedIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewMemoryIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewNonRemovableIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
+  new QgsLayerTreeViewJoinIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
 
   setupLayerTreeViewFromSettings();
 

--- a/src/app/qgslayertreeviewjoinindicator.cpp
+++ b/src/app/qgslayertreeviewjoinindicator.cpp
@@ -1,0 +1,191 @@
+/***************************************************************************
+  qgslayertreeviewjoinindicator.cpp
+  --------------------------------------
+  Date                 : October 2018
+  Copyright            : (C) 2018 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayertreeviewjoinindicator.h"
+#include "qgslayertree.h"
+#include "qgslayertreemodel.h"
+#include "qgslayertreeutils.h"
+#include "qgslayertreeview.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectorlayerjoinbuffer.h"
+#include "qgsvectorlayerjoininfo.h"
+#include "qgisapp.h"
+
+
+QgsLayerTreeViewJoinIndicatorProvider::QgsLayerTreeViewJoinIndicatorProvider( QgsLayerTreeView *view )
+  : QObject( view )
+  , mLayerTreeView( view )
+{
+  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorJoin.svg" ) );
+
+  QgsLayerTree *tree = mLayerTreeView->layerTreeModel()->rootGroup();
+  onAddedChildren( tree, 0, tree->children().count() - 1 );
+
+  connect( tree, &QgsLayerTree::addedChildren, this, &QgsLayerTreeViewJoinIndicatorProvider::onAddedChildren );
+  connect( tree, &QgsLayerTree::willRemoveChildren, this, &QgsLayerTreeViewJoinIndicatorProvider::onWillRemoveChildren );
+}
+
+void QgsLayerTreeViewJoinIndicatorProvider::onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+{
+  // recursively populate indicators
+  QList<QgsLayerTreeNode *> children = node->children();
+  for ( int i = indexFrom; i <= indexTo; ++i )
+  {
+    QgsLayerTreeNode *childNode = children[i];
+
+    if ( QgsLayerTree::isGroup( childNode ) )
+    {
+      onAddedChildren( childNode, 0, childNode->children().count() - 1 );
+    }
+    else if ( QgsLayerTree::isLayer( childNode ) )
+    {
+      if ( QgsLayerTreeLayer *layerNode = dynamic_cast< QgsLayerTreeLayer * >( childNode ) )
+      {
+        if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layerNode->layer() ) )
+        {
+          if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), vlayer ) == 1 )
+            connect( vlayer, &QgsVectorLayer::updatedFields, this, &QgsLayerTreeViewJoinIndicatorProvider::onUpdatedFields );
+          addOrRemoveIndicator( childNode, vlayer );
+        }
+        else if ( !layerNode->layer() )
+        {
+          // wait for layer to be loaded (e.g. when loading project, first the tree is loaded, afterwards the references to layers are resolved)
+          connect( layerNode, &QgsLayerTreeLayer::layerLoaded, this, &QgsLayerTreeViewJoinIndicatorProvider::onLayerLoaded );
+        }
+      }
+    }
+  }
+}
+
+void QgsLayerTreeViewJoinIndicatorProvider::onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+{
+  // recursively disconnect from providers' dataChanged() signal
+
+  QList<QgsLayerTreeNode *> children = node->children();
+  for ( int i = indexFrom; i <= indexTo; ++i )
+  {
+    QgsLayerTreeNode *childNode = children[i];
+
+    if ( QgsLayerTree::isGroup( childNode ) )
+    {
+      onWillRemoveChildren( childNode, 0, childNode->children().count() - 1 );
+    }
+    else if ( QgsLayerTree::isLayer( childNode ) )
+    {
+      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
+      if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( childLayerNode->layer() ) )
+      {
+        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), childLayerNode->layer() ) == 1 )
+          disconnect( vlayer, &QgsVectorLayer::updatedFields, this, &QgsLayerTreeViewJoinIndicatorProvider::onUpdatedFields );
+      }
+    }
+  }
+}
+
+void QgsLayerTreeViewJoinIndicatorProvider::onLayerLoaded()
+{
+  QgsLayerTreeLayer *layerNode = qobject_cast<QgsLayerTreeLayer *>( sender() );
+  if ( !layerNode )
+    return;
+
+  if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layerNode->layer() ) )
+  {
+    if ( vlayer )
+    {
+      connect( vlayer, &QgsVectorLayer::updatedFields, this, &QgsLayerTreeViewJoinIndicatorProvider::onUpdatedFields );
+      addOrRemoveIndicator( layerNode, vlayer );
+    }
+  }
+}
+
+void QgsLayerTreeViewJoinIndicatorProvider::onUpdatedFields()
+{
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( sender() );
+  if ( !vlayer )
+    return;
+
+  // walk the tree and find layer node that needs to be updated
+  const QList<QgsLayerTreeLayer *> layerNodes = mLayerTreeView->layerTreeModel()->rootGroup()->findLayers();
+  for ( QgsLayerTreeLayer *node : layerNodes )
+  {
+    if ( node->layer() && node->layer() == vlayer )
+    {
+      addOrRemoveIndicator( node, vlayer );
+      break;
+    }
+  }
+}
+
+std::unique_ptr< QgsLayerTreeViewIndicator > QgsLayerTreeViewJoinIndicatorProvider::newIndicator(const QString &joinsNames)
+{
+  std::unique_ptr< QgsLayerTreeViewIndicator > indicator = qgis::make_unique< QgsLayerTreeViewIndicator >( this );
+  indicator->setIcon( mIcon );
+  updateIndicator( indicator.get(), joinsNames );
+  mIndicators.insert( indicator.get() );
+  return indicator;
+}
+
+void QgsLayerTreeViewJoinIndicatorProvider::updateIndicator( QgsLayerTreeViewIndicator *indicator, const QString &joinsNames )
+{
+  indicator->setToolTip( QStringLiteral( "<b>%1:</b><br>%2" ).arg( tr( "Joined layers" ), joinsNames ) );
+}
+
+void QgsLayerTreeViewJoinIndicatorProvider::addOrRemoveIndicator( QgsLayerTreeNode *node, QgsVectorLayer *vlayer )
+{
+  const bool haveJoins = vlayer->joinBuffer()->containsJoins();
+
+  if ( haveJoins )
+  {
+ 
+    QString joinsNames = QString("");
+    for ( QgsVectorLayerJoinInfo joinInfo : vlayer->joinBuffer()->vectorJoins() )
+    {
+      joinsNames += joinInfo.joinLayer()->name() + '\n';
+    }
+    
+    
+    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
+
+    // maybe the indicator exists already
+    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
+    {
+      if ( mIndicators.contains( indicator ) )
+      {
+        updateIndicator( indicator, joinsNames );
+        return;
+      }
+    }
+
+    // it does not exist: need to create a new one
+    mLayerTreeView->addIndicator( node, newIndicator( joinsNames ).release() );
+  }
+  else
+  {
+    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
+
+    // there may be existing indicator we need to get rid of
+    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
+    {
+      if ( mIndicators.contains( indicator ) )
+      {
+        mLayerTreeView->removeIndicator( node, indicator );
+        indicator->deleteLater();
+        return;
+      }
+    }
+
+    // no indicator was there before, nothing to do
+  }
+}

--- a/src/app/qgslayertreeviewjoinindicator.h
+++ b/src/app/qgslayertreeviewjoinindicator.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+  qgslayertreeviewjoinindicator.h
+  --------------------------------------
+  Date                 : October 2018
+  Copyright            : (C) 2018 by Nyall Dawson
+  Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSLAYERTREEVIEWJOININDICATOR_H
+#define QGSLAYERTREEVIEWJOININDICATOR_H
+
+#include "qgslayertreeviewindicator.h"
+
+#include <QSet>
+#include <memory>
+
+class QgsLayerTreeNode;
+class QgsLayerTreeView;
+class QgsVectorLayer;
+
+//! Adds indicators showing whether layers have joined data.
+class QgsLayerTreeViewJoinIndicatorProvider : public QObject
+{
+    Q_OBJECT
+  public:
+    explicit QgsLayerTreeViewJoinIndicatorProvider( QgsLayerTreeView *view );
+
+  private slots:
+    //! Connects to signals of layers newly added to the tree
+    void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+    //! Disconnects from layers about to be removed from the tree
+    void onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+    void onLayerLoaded();
+    //! Adds/removes indicator of a layer
+    void onUpdatedFields();
+
+  private:
+    std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator( const QString &joinsNames );
+    void updateIndicator( QgsLayerTreeViewIndicator *indicator, const QString &joinsNames );
+    void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsVectorLayer *vlayer );
+
+  private:
+    QgsLayerTreeView *mLayerTreeView = nullptr;
+    QIcon mIcon;
+    QSet<QgsLayerTreeViewIndicator *> mIndicators;
+};
+
+#endif // QGSLAYERTREEVIEWJOININDICATOR_H


### PR DESCRIPTION
Shows a join icon in the layer tree for all layers that have joined fields. A tooltip display the names of the layers from which the joined fields come. This feature help the user to have a quick overview of layers that depends on others layers and should help having a better understnding of the project organization.