### PR TITLE
[server] Removes assert

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -1527,7 +1527,6 @@ void QgsLayerTreeModel::invalidateLegendMapBasedData()
     Q_FOREACH ( QgsSymbolLegendNode *n, symbolNodes )
     {
       const QString parentKey( n->data( QgsLayerTreeModelLegendNode::ParentRuleKeyRole ).toString() );
-      Q_ASSERT( widthMax[parentKey] > 0 );
       const int twiceMarginWidth = 2; // a one pixel margin avoids hugly rendering of icon
       n->setIconSize( QSize( widthMax[parentKey] + twiceMarginWidth, n->iconSize().rheight() + twiceMarginWidth ) );
     }


### PR DESCRIPTION
## Description

Condition to reproduce the assert:
- `xvfb-run` is used 
- a legend item is defined in a layout within the .qgs project that the server is reading
- use a simple request with only the `MAP` parameter (like "http://localhost/qgisserver?MAP=/.../.../.../myproject.qgs")

Actually, for some obscure reason, the `QPainter` is, in this particular case, not correctly initialized in [QgsSymbolLayerUtils::symbolPreviewPixmap](https://github.com/qgis/QGIS/blob/master/src/core/symbology/qgssymbollayerutils.cpp#L658-L659) when the project is read (the xml concerning the layout):

```
QPainter::begin: Paint device returned engine == 0, type: 2
QPainter::setRenderHint: Painter must be active to set rendering hints
QPainter::setBrush: Painter not active
QPainter::setPen: Painter not active
QPainter::drawPath: Painter not active
QPainter::end: Painter not active, aborted
```

It leads to an assert raised by  https://github.com/qgis/QGIS/blob/master/src/core/layertree/qgslayertreemodel.cpp#L1530 when the server is reading the project file:

```
ASSERT: "widthMax[parentKey] > 0"
```

What is even more worrying is that the server is not aborted on the first request, but on the second one due to the default flag [DeferredLegendInvalidation](https://github.com/qgis/QGIS/blob/master/src/core/layertree/qgslayertreemodel.cpp#L1496) and the [qApp->processEvents();](https://github.com/qgis/QGIS/blob/master/src/server/qgsserver.cpp#L277).

I don't have a clue why the `QPainter` cannot be initialized, but it seems a bit overkill to abort the server when the icon size cannot be determined anyway.

Please, share your opinions :).

TODO:
- check the layout rendering once the Q_ASSERT is removed: rendered image is valid
- write a Python unit test with xvfbwrapper to reproduce the abort: cannot reproduce the issue

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
