### PR TITLE
fix GRASS7 r_stats_quantile

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.stats.quantile.out.txt
+++ b/python/plugins/processing/algs/grass7/description/r.stats.quantile.out.txt
@@ -8,5 +8,4 @@ QgsProcessingParameterString|percentiles|List of percentiles|None|False|True
 QgsProcessingParameterNumber|bins|Number of bins to use|QgsProcessingParameterNumber.Integer|1000|True|0|None
 *QgsProcessingParameterBoolean|-r|Create reclass map with statistics as category labels|False
 Hardcoded|-p
-QgsProcessingParameterFileDestination|output|Statistics File|Txt files (*.txt)|None|False
-
+QgsProcessingParameterFileDestination|file|Statistics File|Txt files (*.txt)|None|False

--- a/python/plugins/processing/algs/grass7/description/r.stats.quantile.rast.txt
+++ b/python/plugins/processing/algs/grass7/description/r.stats.quantile.rast.txt
@@ -7,5 +7,4 @@ QgsProcessingParameterNumber|quantiles|Number of quantiles|QgsProcessingParamete
 QgsProcessingParameterString|percentiles|List of percentiles|None|False|True
 QgsProcessingParameterNumber|bins|Number of bins to use|QgsProcessingParameterNumber.Integer|1000|True|0|None
 *QgsProcessingParameterBoolean|-r|Create reclass map with statistics as category labels|False
-QgsProcessingParameterFolderDestination|output_dir|Output Directory
-
+QgsProcessingParameterFolderDestination|output|Output Directory


### PR DESCRIPTION
## Description
This fixes 
https://issues.qgis.org/issues/20160

that is about the "r.stats.quantile.out" module (wrong output parameter name).

It also "fixes" the "r.stats.quantile.rast" module that also had the output parameter wrongly named ("output_dir" instead of "output"), unfortunately for some reason I can't understand why, despite this parameter being in the description file and despite being parsed by QGIS, it never shows in the actual GRASS command so it always fail, example:

```
Input parameters:
{ '-r' : False, 'GRASS_REGION_CELLSIZE_PARAMETER' : 0, 'GRASS_REGION_PARAMETER' : None, 'base' : '/home/giovanni/base.tif', 'bins' : 1000, 'cover' : '/home/giovanni/cover.tif', 'output' : '/tmp/processing_c1cc14a49c11459899c2d9ac5dabaa11/f9140c3da34745e29ab9c26ea1cc1f05/output', 'percentiles' : '', 'quantiles' : None }
```

`r.stats.quantile base=rast_5bc9c5092dbf04 cover=rast_5bc9c5092dc425 bins=1000 --overwrite`

(notice the lack of the "output" parameter in the GRASS command).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
