### PR TITLE
 [fix #17773] fix HiDPI in map canvas on mac

### DIFF
--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -21,10 +21,12 @@ The rendering itself is done by QgsMapRendererJob subclasses.
 In order to set up QgsMapSettings instance, it is necessary to set at least
 few members: extent, output size and layers.
 
-QgsMapSettings and QgsMapRendererJob (+subclasses) are intended to replace
-QgsMapRenderer class that existed before QGIS 2.4. The advantage of the new
-classes is that they separate the settings from the rendering and provide
-asynchronous API for map rendering.
+Some systems use high DPI scaling that is an alternative to the traditional
+DPI scaling. The operating system provides Qt with a scaling ratio and it
+scales window, event, and desktop geometry. The Cocoa platform plugin sets
+the scaling ratio as QWindow.devicePixelRatio().
+To properly render the map on such systems, the map settings device pixel
+ratio shall be set accordingly.
 
 .. versionadded:: 2.4
 %End
@@ -63,6 +65,7 @@ Sets the size of the resulting map image
     float devicePixelRatio() const;
 %Docstring
 Returns device pixel ratio
+Common values are 1 for normal-dpi displays and 2 for high-dpi "retina" displays.
 
 .. versionadded:: 3.4
 %End
@@ -70,6 +73,7 @@ Returns device pixel ratio
     void setDevicePixelRatio( float dpr );
 %Docstring
 Sets the device pixel ratio
+Common values are 1 for normal-dpi displays and 2 for high-dpi "retina" displays.
 
 .. versionadded:: 3.4
 %End

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -74,11 +74,11 @@ Sets the device pixel ratio
 .. versionadded:: 3.4
 %End
 
-    QSize physicalSize() const;
+    QSize deviceOutputSize() const;
 %Docstring
-Returns the physical size of the map canvas
+Returns the device output size of the map canvas
 This is equivalent to the output size multiplicated
-by the device pixel ratio
+by the device pixel ratio.
 
 .. versionadded:: 3.4
 %End

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -60,14 +60,14 @@ Returns the size of the resulting map image
 Sets the size of the resulting map image
 %End
 
-    int devicePixelRatio() const;
+    float devicePixelRatio() const;
 %Docstring
 Returns device pixel ratio
 
 .. versionadded:: 3.4
 %End
 
-    void setDevicePixelRatio( int dpr );
+    void setDevicePixelRatio( float dpr );
 %Docstring
 Sets the device pixel ratio
 

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -60,6 +60,29 @@ Returns the size of the resulting map image
 Sets the size of the resulting map image
 %End
 
+    int devicePixelRatio() const;
+%Docstring
+Returns device pixel ratio
+
+.. versionadded:: 3.4
+%End
+
+    void setDevicePixelRatio( int dpr );
+%Docstring
+Sets the device pixel ratio
+
+.. versionadded:: 3.4
+%End
+
+    QSize physicalSize() const;
+%Docstring
+Returns the physical size of the map canvas
+This is equivalent to the output size multiplicated
+by the device pixel ratio
+
+.. versionadded:: 3.4
+%End
+
     double rotation() const;
 %Docstring
 Returns the rotation of the resulting map image, in degrees clockwise.

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -60,7 +60,7 @@ void QgsMapRendererCustomPainterJob::start()
   prepareTime.start();
 
   // clear the background
-  mPainter->fillRect( 0, 0, mSettings.physicalSize().width(), mSettings.physicalSize().height(), mSettings.backgroundColor() );
+  mPainter->fillRect( 0, 0, mSettings.deviceOutputSize().width(), mSettings.deviceOutputSize().height(), mSettings.backgroundColor() );
 
   mPainter->setRenderHint( QPainter::Antialiasing, mSettings.testFlag( QgsMapSettings::Antialiasing ) );
 

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -60,14 +60,17 @@ void QgsMapRendererCustomPainterJob::start()
   prepareTime.start();
 
   // clear the background
-  mPainter->fillRect( 0, 0, mSettings.outputSize().width(), mSettings.outputSize().height(), mSettings.backgroundColor() );
+  mPainter->fillRect( 0, 0, mSettings.physicalSize().width(), mSettings.physicalSize().height(), mSettings.backgroundColor() );
 
   mPainter->setRenderHint( QPainter::Antialiasing, mSettings.testFlag( QgsMapSettings::Antialiasing ) );
 
 #ifndef QT_NO_DEBUG
   QPaintDevice *paintDevice = mPainter->device();
-  QString errMsg = QStringLiteral( "pre-set DPI not equal to painter's DPI (%1 vs %2)" ).arg( paintDevice->logicalDpiX() ).arg( mSettings.outputDpi() );
-  Q_ASSERT_X( qgsDoubleNear( paintDevice->logicalDpiX(), mSettings.outputDpi() ), "Job::startRender()", errMsg.toLatin1().data() );
+  QString errMsg = QStringLiteral( "pre-set DPI not equal to painter's DPI (%1 vs %2)" )
+                   .arg( paintDevice->logicalDpiX() )
+                   .arg( mSettings.outputDpi() );
+  Q_ASSERT_X( qgsDoubleNear( paintDevice->logicalDpiX(), mSettings.outputDpi() ),
+              "Job::startRender()", errMsg.toLatin1().data() );
 #endif
 
   mLabelingEngineV2.reset();

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -325,7 +325,7 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     if ( mCache || !painter || needTemporaryImage( ml ) )
     {
       // Flattened image for drawing when a blending mode is set
-      QImage *mypFlattenedImage = new QImage( mSettings.physicalSize(),
+      QImage *mypFlattenedImage = new QImage( mSettings.deviceOutputSize(),
                                               mSettings.outputImageFormat() );
       mypFlattenedImage->setDevicePixelRatio( mSettings.devicePixelRatio() );
       if ( mypFlattenedImage->isNull() )
@@ -375,7 +375,7 @@ LabelRenderJob QgsMapRendererJob::prepareLabelingJob( QPainter *painter, QgsLabe
     {
       // Flattened image for drawing labels
       QImage *mypFlattenedImage = nullptr;
-      mypFlattenedImage = new QImage( mSettings.physicalSize(),
+      mypFlattenedImage = new QImage( mSettings.deviceOutputSize(),
                                       mSettings.outputImageFormat() );
       mypFlattenedImage->setDevicePixelRatio( mSettings.devicePixelRatio() );
       if ( mypFlattenedImage->isNull() )
@@ -448,7 +448,7 @@ void QgsMapRendererJob::cleanupLabelJob( LabelRenderJob &job )
 
 QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings, const LayerRenderJobs &jobs, const LabelRenderJob &labelJob )
 {
-  QImage image( settings.physicalSize(), settings.outputImageFormat() );
+  QImage image( settings.deviceOutputSize(), settings.outputImageFormat() );
   image.setDevicePixelRatio( settings.devicePixelRatio() );
   image.fill( settings.backgroundColor().rgba() );
 

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -313,6 +313,7 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
       job.cached = true;
       job.imageInitialized = true;
       job.img = new QImage( mCache->cacheImage( ml->id() ) );
+      job.img->setDevicePixelRatio( mSettings.devicePixelRatio() );
       job.renderer = nullptr;
       job.context.setPainter( nullptr );
       continue;
@@ -324,10 +325,9 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter *painter, QgsLabelingEn
     if ( mCache || !painter || needTemporaryImage( ml ) )
     {
       // Flattened image for drawing when a blending mode is set
-      QImage *mypFlattenedImage = nullptr;
-      mypFlattenedImage = new QImage( mSettings.outputSize().width(),
-                                      mSettings.outputSize().height(),
-                                      mSettings.outputImageFormat() );
+      QImage *mypFlattenedImage = new QImage( mSettings.physicalSize(),
+                                              mSettings.outputImageFormat() );
+      mypFlattenedImage->setDevicePixelRatio( mSettings.devicePixelRatio() );
       if ( mypFlattenedImage->isNull() )
       {
         mErrors.append( Error( ml->id(), tr( "Insufficient memory for image %1x%2" ).arg( mSettings.outputSize().width() ).arg( mSettings.outputSize().height() ) ) );
@@ -366,6 +366,7 @@ LabelRenderJob QgsMapRendererJob::prepareLabelingJob( QPainter *painter, QgsLabe
     job.cached = true;
     job.complete = true;
     job.img = new QImage( mCache->cacheImage( LABEL_CACHE_ID ) );
+    Q_ASSERT( job.img->devicePixelRatio() == 2 );
     job.context.setPainter( nullptr );
   }
   else
@@ -374,9 +375,9 @@ LabelRenderJob QgsMapRendererJob::prepareLabelingJob( QPainter *painter, QgsLabe
     {
       // Flattened image for drawing labels
       QImage *mypFlattenedImage = nullptr;
-      mypFlattenedImage = new QImage( mSettings.outputSize().width(),
-                                      mSettings.outputSize().height(),
+      mypFlattenedImage = new QImage( mSettings.physicalSize(),
                                       mSettings.outputImageFormat() );
+      mypFlattenedImage->setDevicePixelRatio( mSettings.devicePixelRatio() );
       if ( mypFlattenedImage->isNull() )
       {
         mErrors.append( Error( QStringLiteral( "labels" ), tr( "Insufficient memory for label image %1x%2" ).arg( mSettings.outputSize().width() ).arg( mSettings.outputSize().height() ) ) );
@@ -447,7 +448,8 @@ void QgsMapRendererJob::cleanupLabelJob( LabelRenderJob &job )
 
 QImage QgsMapRendererJob::composeImage( const QgsMapSettings &settings, const LayerRenderJobs &jobs, const LabelRenderJob &labelJob )
 {
-  QImage image( settings.outputSize(), settings.outputImageFormat() );
+  QImage image( settings.physicalSize(), settings.outputImageFormat() );
+  image.setDevicePixelRatio( settings.devicePixelRatio() );
   image.fill( settings.backgroundColor().rgba() );
 
   QPainter painter( &image );

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -366,7 +366,7 @@ LabelRenderJob QgsMapRendererJob::prepareLabelingJob( QPainter *painter, QgsLabe
     job.cached = true;
     job.complete = true;
     job.img = new QImage( mCache->cacheImage( LABEL_CACHE_ID ) );
-    Q_ASSERT( job.img->devicePixelRatio() == 2 );
+    Q_ASSERT( job.img->devicePixelRatio() == mSettings.devicePixelRatio() );
     job.context.setPainter( nullptr );
   }
   else

--- a/src/core/qgsmaprenderersequentialjob.cpp
+++ b/src/core/qgsmaprenderersequentialjob.cpp
@@ -25,7 +25,8 @@ QgsMapRendererSequentialJob::QgsMapRendererSequentialJob( const QgsMapSettings &
 {
   QgsDebugMsgLevel( QStringLiteral( "SEQUENTIAL construct" ), 5 );
 
-  mImage = QImage( mSettings.outputSize(), mSettings.outputImageFormat() );
+  mImage = QImage( mSettings.physicalSize(), mSettings.outputImageFormat() );
+  mImage.setDevicePixelRatio( mSettings.devicePixelRatio() );
   mImage.setDotsPerMeterX( 1000 * settings.outputDpi() / 25.4 );
   mImage.setDotsPerMeterY( 1000 * settings.outputDpi() / 25.4 );
   mImage.fill( Qt::transparent );

--- a/src/core/qgsmaprenderersequentialjob.cpp
+++ b/src/core/qgsmaprenderersequentialjob.cpp
@@ -25,7 +25,7 @@ QgsMapRendererSequentialJob::QgsMapRendererSequentialJob( const QgsMapSettings &
 {
   QgsDebugMsgLevel( QStringLiteral( "SEQUENTIAL construct" ), 5 );
 
-  mImage = QImage( mSettings.physicalSize(), mSettings.outputImageFormat() );
+  mImage = QImage( mSettings.deviceOutputSize(), mSettings.outputImageFormat() );
   mImage.setDevicePixelRatio( mSettings.devicePixelRatio() );
   mImage.setDotsPerMeterX( 1000 * settings.outputDpi() / 25.4 );
   mImage.setDotsPerMeterY( 1000 * settings.outputDpi() / 25.4 );

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -146,8 +146,8 @@ void QgsMapSettings::updateDerived()
     }
   }
 
-  double myHeight = mSize.height();
-  double myWidth = mSize.width();
+  double myHeight = mSize.height() * mDevicePixelRatio;
+  double myWidth = mSize.width() * mDevicePixelRatio;
 
   if ( !myWidth || !myHeight )
   {
@@ -228,6 +228,21 @@ void QgsMapSettings::setOutputSize( QSize size )
   mSize = size;
 
   updateDerived();
+}
+
+int QgsMapSettings::devicePixelRatio() const
+{
+  return mDevicePixelRatio;
+}
+
+void QgsMapSettings::setDevicePixelRatio( int dpr )
+{
+  mDevicePixelRatio = dpr;
+}
+
+QSize QgsMapSettings::physicalSize() const
+{
+  return outputSize() * mDevicePixelRatio;
 }
 
 double QgsMapSettings::outputDpi() const

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -240,7 +240,7 @@ void QgsMapSettings::setDevicePixelRatio( int dpr )
   mDevicePixelRatio = dpr;
 }
 
-QSize QgsMapSettings::physicalSize() const
+QSize QgsMapSettings::deviceOutputSize() const
 {
   return outputSize() * mDevicePixelRatio;
 }

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -230,12 +230,12 @@ void QgsMapSettings::setOutputSize( QSize size )
   updateDerived();
 }
 
-int QgsMapSettings::devicePixelRatio() const
+float QgsMapSettings::devicePixelRatio() const
 {
   return mDevicePixelRatio;
 }
 
-void QgsMapSettings::setDevicePixelRatio( int dpr )
+void QgsMapSettings::setDevicePixelRatio( float dpr )
 {
   mDevicePixelRatio = dpr;
 }

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -82,6 +82,26 @@ class CORE_EXPORT QgsMapSettings
     void setOutputSize( QSize size );
 
     /**
+     * Returns device pixel ratio
+     * \since QGIS 3.4
+     */
+    int devicePixelRatio() const;
+
+    /**
+     * Sets the device pixel ratio
+     * \since QGIS 3.4
+     */
+    void setDevicePixelRatio( int dpr );
+
+    /**
+     * Returns the physical size of the map canvas
+     * This is equivalent to the output size multiplicated
+     * by the device pixel ratio
+     * \since QGIS 3.4
+     */
+    QSize physicalSize() const;
+
+    /**
      * Returns the rotation of the resulting map image, in degrees clockwise.
      * \see setRotation()
      * \since QGIS 2.8
@@ -403,6 +423,7 @@ class CORE_EXPORT QgsMapSettings
     double mDpi;
 
     QSize mSize;
+    int mDevicePixelRatio = 1;
 
     QgsRectangle mExtent;
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -85,13 +85,13 @@ class CORE_EXPORT QgsMapSettings
      * Returns device pixel ratio
      * \since QGIS 3.4
      */
-    int devicePixelRatio() const;
+    float devicePixelRatio() const;
 
     /**
      * Sets the device pixel ratio
      * \since QGIS 3.4
      */
-    void setDevicePixelRatio( int dpr );
+    void setDevicePixelRatio( float dpr );
 
     /**
      * Returns the device output size of the map canvas
@@ -423,7 +423,7 @@ class CORE_EXPORT QgsMapSettings
     double mDpi;
 
     QSize mSize;
-    int mDevicePixelRatio = 1;
+    float mDevicePixelRatio = 1.0;
 
     QgsRectangle mExtent;
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -94,12 +94,12 @@ class CORE_EXPORT QgsMapSettings
     void setDevicePixelRatio( int dpr );
 
     /**
-     * Returns the physical size of the map canvas
+     * Returns the device output size of the map canvas
      * This is equivalent to the output size multiplicated
-     * by the device pixel ratio
+     * by the device pixel ratio.
      * \since QGIS 3.4
      */
-    QSize physicalSize() const;
+    QSize deviceOutputSize() const;
 
     /**
      * Returns the rotation of the resulting map image, in degrees clockwise.

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -48,10 +48,12 @@ class QgsMapRendererJob;
  * In order to set up QgsMapSettings instance, it is necessary to set at least
  * few members: extent, output size and layers.
  *
- * QgsMapSettings and QgsMapRendererJob (+subclasses) are intended to replace
- * QgsMapRenderer class that existed before QGIS 2.4. The advantage of the new
- * classes is that they separate the settings from the rendering and provide
- * asynchronous API for map rendering.
+ * Some systems use high DPI scaling that is an alternative to the traditional
+ * DPI scaling. The operating system provides Qt with a scaling ratio and it
+ * scales window, event, and desktop geometry. The Cocoa platform plugin sets
+ * the scaling ratio as QWindow::devicePixelRatio().
+ * To properly render the map on such systems, the map settings device pixel
+ * ratio shall be set accordingly.
  *
  * \since QGIS 2.4
  */
@@ -83,12 +85,14 @@ class CORE_EXPORT QgsMapSettings
 
     /**
      * Returns device pixel ratio
+     * Common values are 1 for normal-dpi displays and 2 for high-dpi "retina" displays.
      * \since QGIS 3.4
      */
     float devicePixelRatio() const;
 
     /**
      * Sets the device pixel ratio
+     * Common values are 1 for normal-dpi displays and 2 for high-dpi "retina" displays.
      * \since QGIS 3.4
      */
     void setDevicePixelRatio( float dpr );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -31,9 +31,11 @@ email                : sherman at mrcc.com
 #include <QRect>
 #include <QTextStream>
 #include <QResizeEvent>
+#include <QScreen>
 #include <QString>
 #include <QStringList>
 #include <QWheelEvent>
+#include <QWindow>
 
 #include "qgis.h"
 #include "qgssettings.h"
@@ -168,6 +170,10 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   mScene->setSceneRect( QRectF( 0, 0, s.width(), s.height() ) );
 
   moveCanvasContents( true );
+
+  // keep device pixel ratio up to date on screen or resolution change
+  connect( window()->windowHandle(), &QWindow::screenChanged, this, [ = ]( QScreen * ) {mSettings.setDevicePixelRatio( devicePixelRatio() );} );
+  connect( window()->windowHandle()->screen(), &QScreen::physicalDotsPerInchChanged, [ = ]( qreal ) {mSettings.setDevicePixelRatio( devicePixelRatio() );} );
 
   connect( &mMapUpdateTimer, &QTimer::timeout, this, &QgsMapCanvas::mapUpdateTimeout );
   mMapUpdateTimer.setInterval( 250 );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -173,7 +173,8 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
 
   // keep device pixel ratio up to date on screen or resolution change
   connect( window()->windowHandle(), &QWindow::screenChanged, this, [ = ]( QScreen * ) {mSettings.setDevicePixelRatio( devicePixelRatio() );} );
-  connect( window()->windowHandle()->screen(), &QScreen::physicalDotsPerInchChanged, [ = ]( qreal ) {mSettings.setDevicePixelRatio( devicePixelRatio() );} );
+  if ( window()->windowHandle() )
+    connect( window()->windowHandle()->screen(), &QScreen::physicalDotsPerInchChanged, [ = ]( qreal ) {mSettings.setDevicePixelRatio( devicePixelRatio() );} );
 
   connect( &mMapUpdateTimer, &QTimer::timeout, this, &QgsMapCanvas::mapUpdateTimeout );
   mMapUpdateTimer.setInterval( 250 );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -163,6 +163,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
 
   QSize s = viewport()->size();
   mSettings.setOutputSize( s );
+  mSettings.setDevicePixelRatio( devicePixelRatio() );
   setSceneRect( 0, 0, s.width(), s.height() );
   mScene->setSceneRect( QRectF( 0, 0, s.width(), s.height() ) );
 
@@ -682,7 +683,8 @@ QgsRectangle QgsMapCanvas::imageRect( const QImage &img, const QgsMapSettings &m
   // expects (encoding of position and size of the item)
   const QgsMapToPixel &m2p = mapSettings.mapToPixel();
   QgsPointXY topLeft = m2p.toMapCoordinates( 0, 0 );
-  double res = m2p.mapUnitsPerPixel();
+  Q_ASSERT( img.devicePixelRatio() == mapSettings.devicePixelRatio() );
+  double res = m2p.mapUnitsPerPixel() / img.devicePixelRatioF();
   QgsRectangle rect( topLeft.x(), topLeft.y(), topLeft.x() + img.width()*res, topLeft.y() - img.height()*res );
   return rect;
 }

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -60,12 +60,20 @@ QRectF QgsMapCanvasMap::boundingRect() const
 
 void QgsMapCanvasMap::paint( QPainter *painter )
 {
-  int w = std::round( mItemSize.width() ) - 2, h = std::round( mItemSize.height() ) - 2; // setRect() makes the size +2 :-(
-  if ( mImage.size() != QSize( w, h ) )
+  // setRect() makes the size +2 :-(
+  int w = std::round( mItemSize.width() ) - 2;
+  int h = std::round( mItemSize.height() ) - 2;
+
+  bool scale = false;
+  if ( mImage.size() != QSize( w, h )*mImage.devicePixelRatioF() )
   {
-    QgsDebugMsg( QStringLiteral( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" ).arg( mImage.width() ).arg( mImage.height() ).arg( w ).arg( h ) );
+    QgsDebugMsg( QStringLiteral( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" )
+                 .arg( mImage.width() / mImage.devicePixelRatioF() )
+                 .arg( mImage.height() / mImage.devicePixelRatioF() )
+                 .arg( w ).arg( h ) );
     // This happens on zoom events when ::paint is called before
     // the renderer has completed
+    scale = true;
   }
 
   /*Offset between 0/0 and mRect.xMinimum/mRect.yMinimum.
@@ -83,12 +91,10 @@ void QgsMapCanvasMap::paint( QPainter *painter )
     painter->drawImage( QRectF( ul.x(), ul.y(), lr.x() - ul.x(), lr.y() - ul.y() ), imIt->first, QRect( 0, 0, imIt->first.width(), imIt->first.height() ) );
   }
 
-  qDebug() << "map painter: " << w << h << mImage.size() << mImage.devicePixelRatioF();
-  painter->drawImage( QRect( 0, 0, w, h ), mImage );
-  //Q_ASSERT(mImage.isNull() || mImage.devicePixelRatio()==2);
-  //QImage img = mImage;
-  //img.setDevicePixelRatio(2);
-  //painter->drawImage( 0,0, img );
+  if ( scale )
+    painter->drawImage( QRect( 0, 0, w, h ), mImage );
+  else
+    painter->drawImage( 0, 0, mImage );
 
   // For debugging:
 #if 0

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -83,7 +83,12 @@ void QgsMapCanvasMap::paint( QPainter *painter )
     painter->drawImage( QRectF( ul.x(), ul.y(), lr.x() - ul.x(), lr.y() - ul.y() ), imIt->first, QRect( 0, 0, imIt->first.width(), imIt->first.height() ) );
   }
 
+  qDebug() << "map painter: " << w << h << mImage.size() << mImage.devicePixelRatioF();
   painter->drawImage( QRect( 0, 0, w, h ), mImage );
+  //Q_ASSERT(mImage.isNull() || mImage.devicePixelRatio()==2);
+  //QImage img = mImage;
+  //img.setDevicePixelRatio(2);
+  //painter->drawImage( 0,0, img );
 
   // For debugging:
 #if 0


### PR DESCRIPTION
So much time for such small changes!

This fixes the issue by integrating the device pixel ratio from Qt.
The images in renderer are scaled up to match the physical size of the canvas.

Many kudos to @wonder-sk for leading me in this black hole.
And to the sponsors of the Mac OS bugfixing!

left current, right fixed:
![image](https://user-images.githubusercontent.com/127259/47218689-9e4b3580-d37a-11e8-89b8-cce656b591b1.png)

As a bonus, the scale was badly calculated before, and it's magically fixed :)

further reading: http://doc.qt.io/qt-5/scalability.html#high-dpi-scaling-on-macos-and-ios