### PR TITLE
Fix #19703, make filter translatable and add NetCDF

### DIFF
--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -28,7 +28,7 @@ QgsMdalSourceSelect::QgsMdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   setupButtons( buttonBox );
 
   mFileWidget->setDialogTitle( tr( "Open MDAL Supported Mesh Dataset(s)" ) );
-  mFileWidget->setFilter( QStringLiteral( "All files (*);;GRIB File(*.grb *.grb2 *.bin *.grib *.grib1 *.grib2);;2DM Mesh File(*.2dm);;3Di Results(results_3di.nc)" ) );
+  mFileWidget->setFilter( tr( "All files (*);;GRIB File(*.grb *.grb2 *.bin *.grib *.grib1 *.grib2);;2DM Mesh File(*.2dm);;3Di Results(results_3di.nc)" ) );
   mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
   {

--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -28,7 +28,7 @@ QgsMdalSourceSelect::QgsMdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   setupButtons( buttonBox );
 
   mFileWidget->setDialogTitle( tr( "Open MDAL Supported Mesh Dataset(s)" ) );
-  mFileWidget->setFilter( tr( "All files (*);;GRIB File(*.grb *.grb2 *.bin *.grib *.grib1 *.grib2);;NetCDF file(*.nc);;2DM Mesh File(*.2dm);;3Di Results(results_3di.nc)" ) );
+  mFileWidget->setFilter( tr( "All Files (*);;GRIB File (*.grb *.grb2 *.bin *.grib *.grib1 *.grib2);;NetCDF File (*.nc);;2DM Mesh File (*.2dm);;3Di Results (results_3di.nc)" ) );
   mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
   {

--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -28,7 +28,7 @@ QgsMdalSourceSelect::QgsMdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   setupButtons( buttonBox );
 
   mFileWidget->setDialogTitle( tr( "Open MDAL Supported Mesh Dataset(s)" ) );
-  mFileWidget->setFilter( QStringLiteral( "All files(*.*);;GRIB File(*.grb *.grb2 *.bin *.grib *.grib1 *.grib2);;2DM Mesh File(*.2dm);;3Di Results(results_3di.nc)" ) );
+  mFileWidget->setFilter( QStringLiteral( "All files (*);;GRIB File(*.grb *.grb2 *.bin *.grib *.grib1 *.grib2);;2DM Mesh File(*.2dm);;3Di Results(results_3di.nc)" ) );
   mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
   {

--- a/src/providers/mdal/qgsmdalsourceselect.cpp
+++ b/src/providers/mdal/qgsmdalsourceselect.cpp
@@ -28,7 +28,7 @@ QgsMdalSourceSelect::QgsMdalSourceSelect( QWidget *parent, Qt::WindowFlags fl, Q
   setupButtons( buttonBox );
 
   mFileWidget->setDialogTitle( tr( "Open MDAL Supported Mesh Dataset(s)" ) );
-  mFileWidget->setFilter( tr( "All files (*);;GRIB File(*.grb *.grb2 *.bin *.grib *.grib1 *.grib2);;2DM Mesh File(*.2dm);;3Di Results(results_3di.nc)" ) );
+  mFileWidget->setFilter( tr( "All files (*);;GRIB File(*.grb *.grb2 *.bin *.grib *.grib1 *.grib2);;NetCDF file(*.nc);;2DM Mesh File(*.2dm);;3Di Results(results_3di.nc)" ) );
   mFileWidget->setStorageMode( QgsFileWidget::GetMultipleFiles );
   connect( mFileWidget, &QgsFileWidget::fileChanged, this, [ = ]( const QString & path )
   {


### PR DESCRIPTION
## Description
This fixes https://issues.qgis.org/issues/19703 where files without an extension were not show in the Open Mesh dialog. 
Additionally the filter string is translatable.
And I added NetCDF (*.nc) files to filter list (which is working for me here, but beter @PeterPetrik checks if this is really the case).

## Checklist

- [ X ] Commit messages are descriptive and explain the rationale for changes
- [ X ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ X ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ X ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ X ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ X ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
