### PR TITLE
Apply WMS FILTER parameter in QgsVectorLayerDiagramProvider

### DIFF
--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -326,9 +326,13 @@ void QgsMapRendererJob::drawLabeling( const QgsMapSettings &settings, QgsRenderC
   // Reset the composition mode before rendering the labels
   painter->setCompositionMode( QPainter::CompositionMode_SourceOver );
 
+  const QgsFeatureFilterProvider *featureFilterProvider = renderContext.featureFilterProvider()->clone();
+
   // TODO: this is not ideal - we could override rendering stopped flag that has been set in meanwhile
   renderContext = QgsRenderContext::fromMapSettings( settings );
   renderContext.setPainter( painter );
+  renderContext.setFeatureFilterProvider( featureFilterProvider );
+  delete featureFilterProvider;
 
   if ( labelingEngine2 )
   {

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -359,6 +359,9 @@ LabelRenderJob QgsMapRendererJob::prepareLabelingJob( QPainter *painter, QgsLabe
   job.context.setLabelingEngine( labelingEngine2 );
   job.context.setExtent( mSettings.visibleExtent() );
 
+  if ( mFeatureFilterProvider )
+    job.context.setFeatureFilterProvider( mFeatureFilterProvider );
+
   // if we can use the cache, let's do it and avoid rendering!
   bool hasCache = canUseLabelCache && mCache && mCache->hasCacheImage( LABEL_CACHE_ID );
   if ( hasCache )

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -78,8 +78,12 @@ QList<QgsLabelFeature *> QgsVectorLayerDiagramProvider::labelFeatures( QgsRender
   QgsFeatureRequest request;
   request.setFilterRect( layerExtent );
   request.setSubsetOfAttributes( attributeNames, mFields );
+  const QgsFeatureFilterProvider *featureFilterProvider = context.featureFilterProvider();
+  if ( featureFilterProvider )
+  {
+    featureFilterProvider->filterFeatures( qobject_cast<QgsVectorLayer *>( mLayer ), request );
+  }
   QgsFeatureIterator fit = mSource->getFeatures( request );
-
 
   QgsFeature fet;
   while ( fit.nextFeature( fet ) )


### PR DESCRIPTION
## Description
As QgsVectorLayerDiagramProvider is created with it's "ownFeatureLoop", FILTER parameter was having no effect on diagrams.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
