### PR TITLE
fixes to the map tool zoom

### DIFF
--- a/python/gui/auto_generated/qgsmaptool.sip.in
+++ b/python/gui/auto_generated/qgsmaptool.sip.in
@@ -118,6 +118,13 @@ the previously used toolbutton to pop out. *
 Returns associated action with map tool or NULL if no action is associated
 %End
 
+    bool isActive() const;
+%Docstring
+Returns if the current map tool active on the map canvas
+
+.. versionadded:: 3.4
+%End
+
     void setButton( QAbstractButton *button );
 %Docstring
 Use this to associate a button to this maptool. It has the same meaning

--- a/python/gui/auto_generated/qgsmaptoolzoom.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolzoom.sip.in
@@ -34,6 +34,10 @@ constructor
 
     virtual void canvasReleaseEvent( QgsMapMouseEvent *e );
 
+    virtual void keyPressEvent( QKeyEvent *e );
+
+    virtual void keyReleaseEvent( QKeyEvent *e );
+
     virtual void deactivate();
 
 
@@ -41,6 +45,12 @@ constructor
 
 
 
+
+
+    void updateCursor();
+%Docstring
+Flag to indicate a map canvas drag operation is taking place
+%End
 };
 
 /************************************************************************

--- a/python/gui/auto_generated/qgsmaptoolzoom.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolzoom.sip.in
@@ -47,10 +47,6 @@ constructor
 
 
 
-    void updateCursor();
-%Docstring
-Flag to indicate a map canvas drag operation is taking place
-%End
 };
 
 /************************************************************************

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -130,6 +130,11 @@ QAction *QgsMapTool::action()
   return mAction;
 }
 
+bool QgsMapTool::isActive() const
+{
+  return mCanvas && mCanvas->mapTool() == this;
+}
+
 void QgsMapTool::setButton( QAbstractButton *button )
 {
   mButton = button;
@@ -143,6 +148,8 @@ QAbstractButton *QgsMapTool::button()
 void QgsMapTool::setCursor( const QCursor &cursor )
 {
   mCursor = cursor;
+  if ( isActive() )
+    mCanvas->setCursor( mCursor );
 }
 
 

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -138,6 +138,12 @@ class GUI_EXPORT QgsMapTool : public QObject
     QAction *action();
 
     /**
+     * Returns if the current map tool active on the map canvas
+     * \since QGIS 3.4
+     */
+    bool isActive() const;
+
+    /**
      * Use this to associate a button to this maptool. It has the same meaning
      * as setAction() function except it works with a button instead of an QAction. */
     void setButton( QAbstractButton *button );

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -31,13 +31,14 @@
 QgsMapToolZoom::QgsMapToolZoom( QgsMapCanvas *canvas, bool zoomOut )
   : QgsMapTool( canvas )
   , mZoomOut( zoomOut )
+  , mNativeZoomOut( zoomOut )
   , mDragging( false )
+  , mZoomOutCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomOut ) )
+  , mZoomInCursor( QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomIn ) )
 
 {
   mToolName = tr( "Zoom" );
-  // set the cursor
-  mCursor = zoomOut ? QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomOut ) :
-            QgsApplication::getThemeCursor( QgsApplication::Cursor::ZoomIn );
+  updateCursor();
 }
 
 QgsMapToolZoom::~QgsMapToolZoom()
@@ -64,8 +65,15 @@ void QgsMapToolZoom::canvasMoveEvent( QgsMapMouseEvent *e )
   mZoomRect.setBottomRight( e->pos() );
   if ( mRubberBand )
   {
-    mRubberBand->setToCanvasRectangle( mZoomRect );
-    mRubberBand->show();
+    if ( mZoomOut )
+    {
+      mRubberBand->hide();
+    }
+    else
+    {
+      mRubberBand->setToCanvasRectangle( mZoomRect );
+      mRubberBand->show();
+    }
   }
 }
 
@@ -84,21 +92,18 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
   if ( e->button() != Qt::LeftButton )
     return;
 
-  bool zoomOut = mZoomOut;
-  if ( e->modifiers() & Qt::AltModifier )
-    zoomOut = !zoomOut;
-
   // We are not really dragging in this case. This is sometimes caused by
   // a pen based computer reporting a press, move, and release, all the
   // one point.
-  if ( !mDragging || ( mZoomRect.topLeft() - mZoomRect.bottomRight() ).manhattanLength() < mMinPixelZoom )
+  bool tooShort = ( mZoomRect.topLeft() - mZoomRect.bottomRight() ).manhattanLength() < mMinPixelZoom;
+  if ( !mDragging || tooShort || mZoomOut )
   {
     mDragging = false;
     delete mRubberBand;
     mRubberBand = nullptr;
 
     // change to zoom in/out by the default multiple
-    mCanvas->zoomWithCenter( e->x(), e->y(), !zoomOut );
+    mCanvas->zoomWithCenter( e->x(), e->y(), !mZoomOut );
   }
   else
   {
@@ -124,7 +129,7 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
     const QgsMapToPixel *m2p = mCanvas->getCoordinateTransform();
     QgsPointXY c = m2p->toMapCoordinates( mZoomRect.center() );
 
-    mCanvas->zoomByFactor( zoomOut ? 1.0 / sf : sf, &c );
+    mCanvas->zoomByFactor( mZoomOut ? 1.0 / sf : sf, &c );
 
     mCanvas->refresh();
   }
@@ -136,4 +141,32 @@ void QgsMapToolZoom::deactivate()
   mRubberBand = nullptr;
 
   QgsMapTool::deactivate();
+}
+
+void QgsMapToolZoom::updateCursor()
+{
+  setCursor( mZoomOut ? mZoomOutCursor : mZoomInCursor );
+}
+
+void QgsMapToolZoom::keyPressEvent( QKeyEvent *e )
+{
+  if ( e->key() == Qt::Key_Alt )
+  {
+    mZoomOut = !mZoomOut;
+    updateCursor();
+  }
+}
+
+void QgsMapToolZoom::keyReleaseEvent( QKeyEvent *e )
+{
+  // key press events are not caught wile the mouse is pressed
+  // so we can't mess if we are already dragging
+  // we need to go back to native state, as it cannot be determine
+  // (since the press event is not detected while mouse is pressed)
+
+  if ( e->key() == Qt::Key_Alt )
+  {
+    mZoomOut = mNativeZoomOut;
+    updateCursor();
+  }
 }

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -65,15 +65,8 @@ void QgsMapToolZoom::canvasMoveEvent( QgsMapMouseEvent *e )
   mZoomRect.setBottomRight( e->pos() );
   if ( mRubberBand )
   {
-    if ( mZoomOut )
-    {
-      mRubberBand->hide();
-    }
-    else
-    {
-      mRubberBand->setToCanvasRectangle( mZoomRect );
-      mRubberBand->show();
-    }
+    mRubberBand->setToCanvasRectangle( mZoomRect );
+    mRubberBand->show();
   }
 }
 
@@ -96,7 +89,7 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
   // a pen based computer reporting a press, move, and release, all the
   // one point.
   bool tooShort = ( mZoomRect.topLeft() - mZoomRect.bottomRight() ).manhattanLength() < mMinPixelZoom;
-  if ( !mDragging || tooShort || mZoomOut )
+  if ( !mDragging || tooShort )
   {
     mDragging = false;
     delete mRubberBand;

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -91,14 +91,16 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
   // We are not really dragging in this case. This is sometimes caused by
   // a pen based computer reporting a press, move, and release, all the
   // one point.
-  if ( mDragging && ( mZoomRect.topLeft() == mZoomRect.bottomRight() ) )
+  if ( !mDragging || ( mZoomRect.topLeft() - mZoomRect.bottomRight() ).manhattanLength() < mMinPixelZoom )
   {
     mDragging = false;
     delete mRubberBand;
     mRubberBand = nullptr;
-  }
 
-  if ( mDragging )
+    // change to zoom in/out by the default multiple
+    mCanvas->zoomWithCenter( e->x(), e->y(), !zoomOut );
+  }
+  else
   {
     mDragging = false;
     delete mRubberBand;
@@ -125,11 +127,6 @@ void QgsMapToolZoom::canvasReleaseEvent( QgsMapMouseEvent *e )
     mCanvas->zoomByFactor( zoomOut ? 1.0 / sf : sf, &c );
 
     mCanvas->refresh();
-  }
-  else // not dragging
-  {
-    // change to zoom in/out by the default multiple
-    mCanvas->zoomWithCenter( e->x(), e->y(), !zoomOut );
   }
 }
 

--- a/src/gui/qgsmaptoolzoom.h
+++ b/src/gui/qgsmaptoolzoom.h
@@ -63,6 +63,7 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
     QCursor mZoomOutCursor;
     QCursor mZoomInCursor;
 
+  private:
     void updateCursor();
 };
 

--- a/src/gui/qgsmaptoolzoom.h
+++ b/src/gui/qgsmaptoolzoom.h
@@ -40,6 +40,8 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
     void canvasMoveEvent( QgsMapMouseEvent *e ) override;
     void canvasPressEvent( QgsMapMouseEvent *e ) override;
     void canvasReleaseEvent( QgsMapMouseEvent *e ) override;
+    void keyPressEvent( QKeyEvent *e ) override;
+    void keyReleaseEvent( QKeyEvent *e ) override;
     void deactivate() override;
 
   protected:
@@ -50,11 +52,18 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
 
     //! indicates whether we're zooming in or out
     bool mZoomOut;
+    //! native tool
+    bool mNativeZoomOut;
 
     //! Flag to indicate a map canvas drag operation is taking place
     bool mDragging;
 
     QgsRubberBand *mRubberBand = nullptr;
+
+    QCursor mZoomOutCursor;
+    QCursor mZoomInCursor;
+
+    void updateCursor();
 };
 
 #endif

--- a/src/gui/qgsmaptoolzoom.h
+++ b/src/gui/qgsmaptoolzoom.h
@@ -45,6 +45,8 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
   protected:
     //! stores actual zoom rect
     QRect mZoomRect;
+    // minimum pixel size of diagonal of the zoom rectangle
+    int mMinPixelZoom = 20;
 
     //! indicates whether we're zooming in or out
     bool mZoomOut;


### PR DESCRIPTION
* when zooming in avoid large jumps in scale due to too small rectangle (diagonal < 20 pixels)
* do not draw rectangle for zoom out tool
* update cursor when pressing alt

this also add `QgsMapTool::isActive()` to determine if the map tool is currently active.
Also fix that `QgsMapTool::setCursor()` was not updating the cursor if the tool was already active

see discussion in https://issues.qgis.org/issues/18892#change-94509