### PR TITLE
[hdpi] fix image scale when zooming to layer

### DIFF
--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -61,11 +61,11 @@ QRectF QgsMapCanvasMap::boundingRect() const
 void QgsMapCanvasMap::paint( QPainter *painter )
 {
   // setRect() makes the size +2 :-(
-  int w = std::round( mItemSize.width() ) - 2;
-  int h = std::round( mItemSize.height() ) - 2;
+  int w = std::round( mItemSize.width() * mImage.devicePixelRatioF() ) - 2;
+  int h = std::round( mItemSize.height() * mImage.devicePixelRatioF() ) - 2;
 
   bool scale = false;
-  if ( mImage.size() != QSize( w, h )*mImage.devicePixelRatioF() )
+  if ( mImage.size() != QSize( w, h ) * mImage.devicePixelRatioF() )
   {
     QgsDebugMsg( QStringLiteral( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" )
                  .arg( mImage.width() / mImage.devicePixelRatioF() )


### PR DESCRIPTION
## Description
After the recent changes for hdpi screen (thanks @3nids) the zoom to layer tool does not scale properly the canvas image. the proposed change should fix the issue.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
