### PR TITLE
fix addpart tool warning

### DIFF
--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -71,7 +71,7 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     QgsFeatureIterator selectedFeatures = vlayer->getSelectedFeatures();
     QgsFeature firstSelectedFeature;
     if ( selectedFeatures.nextFeature( firstSelectedFeature ) )
-      if ( !firstSelectedFeature.geometry().isNull() )
+      if ( firstSelectedFeature.geometry().isNull() )
         isGeometryEmpty = true;
   }
 


### PR DESCRIPTION
The isGeometryEmpty variable was true when geometry was present and viceversa (it should be the reverse..)
Thus the warning for multiple parts for single geometry was giving false positives and
negatives.
The variable is only used for the warning and it works fine now.