### PR TITLE
[needs-docs] Indicators refactoring + bad layers indicator

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -718,6 +718,7 @@
         <file>themes/default/mActionReverseLine.svg</file>
         <file>themes/default/mActionAdd3DMap.svg</file>
         <file>themes/default/mIndicatorNonRemovable.svg</file>
+        <file>themes/default/mIndicatorBadLayer.svg</file>
         <file>themes/default/mIconFolder.svg</file>
         <file>themes/default/mIconFolderHome.svg</file>
         <file>themes/default/mIconFolderLink.svg</file>

--- a/images/themes/default/mIndicatorBadLayer.svg
+++ b/images/themes/default/mIndicatorBadLayer.svg
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="16"
+   width="16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="mIndicatorBadLayer.svg">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2399"
+     inkscape:window-height="1418"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="83.4386"
+     inkscape:cx="12.748756"
+     inkscape:cy="5.9247031"
+     inkscape:window-x="435"
+     inkscape:window-y="344"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#2c2c2c;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.70588237"
+     d="M 2.8164423,12.943861 7.9702617,3.8470446 13.222692,12.94452 Z"
+     id="path4178"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccc" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 7.9012131,6.7183861 0,3.5932209"
+     id="path4180"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:1"
+     d="m 7.8899553,11.212798 c 0.011985,0.131834 0.00197,0.201347 0.00197,0.201347"
+     id="path4182"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
+</svg>

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -60,11 +60,12 @@ SET(QGIS_APP_SRCS
   qgslabelinggui.cpp
   qgslabelingwidget.cpp
   qgslayercapabilitiesmodel.cpp
+  qgslayertreeviewindicatorprovider.cpp
   qgslayertreeviewembeddedindicator.cpp
   qgslayertreeviewfilterindicator.cpp
   qgslayertreeviewmemoryindicator.cpp
   qgslayertreeviewnonremovableindicator.cpp
-  qgslayertreeviewbadlayerindicatorprovider.cpp
+  qgslayertreeviewbadlayerindicator.cpp
   qgsmapcanvasdockwidget.cpp
   qgsmaplayerstylecategoriesmodel.cpp
   qgsmaplayerstyleguiutils.cpp
@@ -290,11 +291,12 @@ SET (QGIS_APP_MOC_HDRS
   qgslabelingwidget.h
   qgslabelpropertydialog.h
   qgslayercapabilitiesmodel.h
+  qgslayertreeviewindicatorprovider.h
   qgslayertreeviewembeddedindicator.h
   qgslayertreeviewmemoryindicator.h
   qgslayertreeviewfilterindicator.h
   qgslayertreeviewnonremovableindicator.h
-  qgslayertreeviewbadlayerindicatorprovider.h
+  qgslayertreeviewbadlayerindicator.h
   qgsmapcanvasdockwidget.h
   qgsmaplayerstylecategoriesmodel.h
   qgsmaplayerstyleguiutils.h

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -64,6 +64,7 @@ SET(QGIS_APP_SRCS
   qgslayertreeviewfilterindicator.cpp
   qgslayertreeviewmemoryindicator.cpp
   qgslayertreeviewnonremovableindicator.cpp
+  qgslayertreeviewbadlayerindicatorprovider.cpp
   qgsmapcanvasdockwidget.cpp
   qgsmaplayerstylecategoriesmodel.cpp
   qgsmaplayerstyleguiutils.cpp
@@ -293,6 +294,7 @@ SET (QGIS_APP_MOC_HDRS
   qgslayertreeviewmemoryindicator.h
   qgslayertreeviewfilterindicator.h
   qgslayertreeviewnonremovableindicator.h
+  qgslayertreeviewbadlayerindicatorprovider.h
   qgsmapcanvasdockwidget.h
   qgsmaplayerstylecategoriesmodel.h
   qgsmaplayerstyleguiutils.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -209,6 +209,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayertreeviewembeddedindicator.h"
 #include "qgslayertreeviewfilterindicator.h"
 #include "qgslayertreeviewmemoryindicator.h"
+#include "qgslayertreeviewbadlayerindicatorprovider.h"
 #include "qgslayertreeviewnonremovableindicator.h"
 #include "qgslayout.h"
 #include "qgslayoutatlas.h"
@@ -3891,6 +3892,7 @@ void QgisApp::initLayerTreeView()
   new QgsLayerTreeViewFilterIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewEmbeddedIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewMemoryIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
+  new QgsLayerTreeViewBadLayerIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
   new QgsLayerTreeViewNonRemovableIndicatorProvider( mLayerTreeView );  // gets parented to the layer view
 
   setupLayerTreeViewFromSettings();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -209,7 +209,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgslayertreeviewembeddedindicator.h"
 #include "qgslayertreeviewfilterindicator.h"
 #include "qgslayertreeviewmemoryindicator.h"
-#include "qgslayertreeviewbadlayerindicatorprovider.h"
+#include "qgslayertreeviewbadlayerindicator.h"
 #include "qgslayertreeviewnonremovableindicator.h"
 #include "qgslayout.h"
 #include "qgslayoutatlas.h"

--- a/src/app/qgslayertreeviewbadlayerindicator.cpp
+++ b/src/app/qgslayertreeviewbadlayerindicator.cpp
@@ -49,7 +49,8 @@ QString QgsLayerTreeViewBadLayerIndicatorProvider::iconName( QgsMapLayer *layer 
 QString QgsLayerTreeViewBadLayerIndicatorProvider::tooltipText( QgsMapLayer *layer )
 {
   Q_UNUSED( layer );
-  return tr( "<b>Bad layer!</b><br>Layer data source could not be found, click here to set a new data source." );
+  // TODO, click here to set a new data source.
+  return tr( "<b>Bad layer!</b><br>Layer data source could not be found." );
 }
 
 bool QgsLayerTreeViewBadLayerIndicatorProvider::acceptLayer( QgsMapLayer *layer )

--- a/src/app/qgslayertreeviewbadlayerindicator.cpp
+++ b/src/app/qgslayertreeviewbadlayerindicator.cpp
@@ -1,9 +1,10 @@
 /***************************************************************************
-  qgslayertreeviewmemoryindicator.h
-  --------------------------------------
-  Date                 : July 2018
-  Copyright            : (C) 2018 by Nyall Dawson
-  Email                : nyall dot dawson at gmail dot com
+  qgslayertreeviewbadlayerindicatorprovider.cpp - QgsLayerTreeViewBadLayerIndicatorProvider
+
+ ---------------------
+ begin                : 17.10.2018
+ copyright            : (C) 2018 by Alessandro Pasotti
+ email                : elpaso@itopen.it
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -13,20 +14,20 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgslayertreeviewmemoryindicator.h"
-#include "qgslayertreeview.h"
+#include "qgslayertreeviewbadlayerindicator.h"
 #include "qgslayertree.h"
-#include "qgslayertreemodel.h"
+#include "qgslayertreeview.h"
 #include "qgslayertreeutils.h"
+#include "qgslayertreemodel.h"
 #include "qgsvectorlayer.h"
 #include "qgisapp.h"
 
-QgsLayerTreeViewMemoryIndicatorProvider::QgsLayerTreeViewMemoryIndicatorProvider( QgsLayerTreeView *view )
+QgsLayerTreeViewBadLayerIndicatorProvider::QgsLayerTreeViewBadLayerIndicatorProvider( QgsLayerTreeView *view )
   : QgsLayerTreeViewIndicatorProvider( view )
 {
 }
 
-void QgsLayerTreeViewMemoryIndicatorProvider::onIndicatorClicked( const QModelIndex &index )
+void QgsLayerTreeViewBadLayerIndicatorProvider::onIndicatorClicked( const QModelIndex &index )
 {
   QgsLayerTreeNode *node = mLayerTreeView->layerTreeModel()->index2node( index );
   if ( !QgsLayerTree::isLayer( node ) )
@@ -36,25 +37,20 @@ void QgsLayerTreeViewMemoryIndicatorProvider::onIndicatorClicked( const QModelIn
   if ( !vlayer )
     return;
 
-  QgisApp::instance()->makeMemoryLayerPermanent( vlayer );
+  // TODO: open source select dialog
 }
 
-
-bool QgsLayerTreeViewMemoryIndicatorProvider::acceptLayer( QgsMapLayer *layer )
+QString QgsLayerTreeViewBadLayerIndicatorProvider::iconName()
 {
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( !vlayer )
-    return false;
-  return  vlayer->dataProvider()->name() == QLatin1String( "memory" );
+  return QStringLiteral( "/mIndicatorBadLayer.svg" );
 }
 
-QString QgsLayerTreeViewMemoryIndicatorProvider::iconName()
+QString QgsLayerTreeViewBadLayerIndicatorProvider::tooltipText()
 {
-  return QStringLiteral( "/mIndicatorMemory.svg" );
+  return tr( "<b>Bad layer!</b><br>Layer data source could not be found, click here to set a new data source." );
 }
 
-QString QgsLayerTreeViewMemoryIndicatorProvider::tooltipText()
+bool QgsLayerTreeViewBadLayerIndicatorProvider::acceptLayer( QgsMapLayer *layer )
 {
-  return tr( "<b>Temporary scratch layer only!</b><br>Contents will be discarded after closing this project" );
+  return ! layer->isValid();
 }
-

--- a/src/app/qgslayertreeviewbadlayerindicator.cpp
+++ b/src/app/qgslayertreeviewbadlayerindicator.cpp
@@ -40,13 +40,15 @@ void QgsLayerTreeViewBadLayerIndicatorProvider::onIndicatorClicked( const QModel
   // TODO: open source select dialog
 }
 
-QString QgsLayerTreeViewBadLayerIndicatorProvider::iconName()
+QString QgsLayerTreeViewBadLayerIndicatorProvider::iconName( QgsMapLayer *layer )
 {
+  Q_UNUSED( layer );
   return QStringLiteral( "/mIndicatorBadLayer.svg" );
 }
 
-QString QgsLayerTreeViewBadLayerIndicatorProvider::tooltipText()
+QString QgsLayerTreeViewBadLayerIndicatorProvider::tooltipText( QgsMapLayer *layer )
 {
+  Q_UNUSED( layer );
   return tr( "<b>Bad layer!</b><br>Layer data source could not be found, click here to set a new data source." );
 }
 

--- a/src/app/qgslayertreeviewbadlayerindicator.h
+++ b/src/app/qgslayertreeviewbadlayerindicator.h
@@ -30,7 +30,7 @@ class QgsLayerTreeViewBadLayerIndicatorProvider : public QgsLayerTreeViewIndicat
     explicit QgsLayerTreeViewBadLayerIndicatorProvider( QgsLayerTreeView *view );
 
   private slots:
-    void onIndicatorClicked( const QModelIndex &index ) override;
+    void onIndicatorClicked( const QModelIndex &index );
 
   private:
     QString iconName( QgsMapLayer *layer ) override;

--- a/src/app/qgslayertreeviewbadlayerindicator.h
+++ b/src/app/qgslayertreeviewbadlayerindicator.h
@@ -33,8 +33,8 @@ class QgsLayerTreeViewBadLayerIndicatorProvider : public QgsLayerTreeViewIndicat
     void onIndicatorClicked( const QModelIndex &index ) override;
 
   private:
-    QString iconName() override;
-    QString tooltipText() override;
+    QString iconName( QgsMapLayer *layer ) override;
+    QString tooltipText( QgsMapLayer *layer ) override;
     bool acceptLayer( QgsMapLayer *layer ) override;
 };
 

--- a/src/app/qgslayertreeviewbadlayerindicator.h
+++ b/src/app/qgslayertreeviewbadlayerindicator.h
@@ -29,8 +29,8 @@ class QgsLayerTreeViewBadLayerIndicatorProvider : public QgsLayerTreeViewIndicat
   public:
     explicit QgsLayerTreeViewBadLayerIndicatorProvider( QgsLayerTreeView *view );
 
-  private slots:
-    void onIndicatorClicked( const QModelIndex &index );
+  protected slots:
+    void onIndicatorClicked( const QModelIndex &index ) override;
 
   private:
     QString iconName( QgsMapLayer *layer ) override;

--- a/src/app/qgslayertreeviewbadlayerindicator.h
+++ b/src/app/qgslayertreeviewbadlayerindicator.h
@@ -1,9 +1,10 @@
 /***************************************************************************
-  qgslayertreeviewmemoryindicator.h
-  --------------------------------------
-  Date                 : July 2018
-  Copyright            : (C) 2018 by Nyall Dawson
-  Email                : nyall dot dawson at gmail dot com
+  qgslayertreeviewbadlayerindicatorprovider.h - QgsLayerTreeViewBadLayerIndicatorProvider
+
+ ---------------------
+ begin                : 17.10.2018
+ copyright            : (C) 2018 by Alessandro Pasotti
+ email                : elpaso@itopen.it
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -12,27 +13,29 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-
-#ifndef QGSLAYERTREEVIEWMEMORYINDICATOR_H
-#define QGSLAYERTREEVIEWMEMORYINDICATOR_H
+#ifndef QGSLAYERTREEVIEWBADLAYERINDICATORPROVIDER_H
+#define QGSLAYERTREEVIEWBADLAYERINDICATORPROVIDER_H
 
 #include "qgslayertreeviewindicatorprovider.h"
 
-//! Adds indicators showing whether layers are memory layers.
-class QgsLayerTreeViewMemoryIndicatorProvider : public QgsLayerTreeViewIndicatorProvider
+#include <QObject>
+
+
+//! Indicators for bad layers
+class QgsLayerTreeViewBadLayerIndicatorProvider : public QgsLayerTreeViewIndicatorProvider
 {
     Q_OBJECT
+
   public:
-    explicit QgsLayerTreeViewMemoryIndicatorProvider( QgsLayerTreeView *view );
+    explicit QgsLayerTreeViewBadLayerIndicatorProvider( QgsLayerTreeView *view );
 
-  protected slots:
-
+  private slots:
     void onIndicatorClicked( const QModelIndex &index ) override;
 
   private:
-    bool acceptLayer( QgsMapLayer *layer ) override;
     QString iconName() override;
     QString tooltipText() override;
+    bool acceptLayer( QgsMapLayer *layer ) override;
 };
 
-#endif // QGSLAYERTREEVIEWMEMORYINDICATOR_H
+#endif // QGSLAYERTREEVIEWBADLAYERINDICATORPROVIDER_H

--- a/src/app/qgslayertreeviewfilterindicator.cpp
+++ b/src/app/qgslayertreeviewfilterindicator.cpp
@@ -24,114 +24,9 @@
 
 
 QgsLayerTreeViewFilterIndicatorProvider::QgsLayerTreeViewFilterIndicatorProvider( QgsLayerTreeView *view )
-  : QObject( view )
-  , mLayerTreeView( view )
+  : QgsLayerTreeViewIndicatorProvider( view )
 {
-  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorFilter.svg" ) );
-
-  QgsLayerTree *tree = mLayerTreeView->layerTreeModel()->rootGroup();
-  onAddedChildren( tree, 0, tree->children().count() - 1 );
-
-  connect( tree, &QgsLayerTree::addedChildren, this, &QgsLayerTreeViewFilterIndicatorProvider::onAddedChildren );
-  connect( tree, &QgsLayerTree::willRemoveChildren, this, &QgsLayerTreeViewFilterIndicatorProvider::onWillRemoveChildren );
 }
-
-
-void QgsLayerTreeViewFilterIndicatorProvider::onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
-{
-  // recursively connect to providers' dataChanged() signal
-
-  QList<QgsLayerTreeNode *> children = node->children();
-  for ( int i = indexFrom; i <= indexTo; ++i )
-  {
-    QgsLayerTreeNode *childNode = children[i];
-
-    if ( QgsLayerTree::isGroup( childNode ) )
-    {
-      onAddedChildren( childNode, 0, childNode->children().count() - 1 );
-    }
-    else if ( QgsLayerTree::isLayer( childNode ) )
-    {
-      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
-      if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( childLayerNode->layer() ) )
-      {
-        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), vlayer ) == 1 )
-          connect( vlayer, &QgsVectorLayer::subsetStringChanged, this, &QgsLayerTreeViewFilterIndicatorProvider::onSubsetStringChanged );
-
-        addOrRemoveIndicator( childLayerNode, vlayer );
-      }
-      else if ( !childLayerNode->layer() )
-      {
-        // wait for layer to be loaded (e.g. when loading project, first the tree is loaded, afterwards the references to layers are resolved)
-        connect( childLayerNode, &QgsLayerTreeLayer::layerLoaded, this, &QgsLayerTreeViewFilterIndicatorProvider::onLayerLoaded );
-      }
-    }
-  }
-}
-
-
-void QgsLayerTreeViewFilterIndicatorProvider::onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
-{
-  // recursively disconnect from providers' dataChanged() signal
-
-  QList<QgsLayerTreeNode *> children = node->children();
-  for ( int i = indexFrom; i <= indexTo; ++i )
-  {
-    QgsLayerTreeNode *childNode = children[i];
-
-    if ( QgsLayerTree::isGroup( childNode ) )
-    {
-      onWillRemoveChildren( childNode, 0, childNode->children().count() - 1 );
-    }
-    else if ( QgsLayerTree::isLayer( childNode ) )
-    {
-      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
-      if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( childLayerNode->layer() ) )
-      {
-        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), vlayer ) == 1 )
-          disconnect( vlayer, &QgsVectorLayer::subsetStringChanged, this, &QgsLayerTreeViewFilterIndicatorProvider::onSubsetStringChanged );
-      }
-    }
-  }
-}
-
-
-void QgsLayerTreeViewFilterIndicatorProvider::onLayerLoaded()
-{
-  QgsLayerTreeLayer *nodeLayer = qobject_cast<QgsLayerTreeLayer *>( sender() );
-  if ( !nodeLayer )
-    return;
-
-  if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( nodeLayer->layer() ) )
-  {
-    if ( vlayer )
-    {
-      connect( vlayer, &QgsVectorLayer::subsetStringChanged, this, &QgsLayerTreeViewFilterIndicatorProvider::onSubsetStringChanged );
-
-      addOrRemoveIndicator( nodeLayer, vlayer );
-    }
-  }
-}
-
-
-void QgsLayerTreeViewFilterIndicatorProvider::onSubsetStringChanged()
-{
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( sender() );
-  if ( !vlayer )
-    return;
-
-  // walk the tree and find layer node that needs to be updated
-  const QList<QgsLayerTreeLayer *> layerNodes = mLayerTreeView->layerTreeModel()->rootGroup()->findLayers();
-  for ( QgsLayerTreeLayer *node : layerNodes )
-  {
-    if ( node->layer() && node->layer() == vlayer )
-    {
-      addOrRemoveIndicator( node, vlayer );
-      break;
-    }
-  }
-}
-
 
 void QgsLayerTreeViewFilterIndicatorProvider::onIndicatorClicked( const QModelIndex &index )
 {
@@ -150,57 +45,41 @@ void QgsLayerTreeViewFilterIndicatorProvider::onIndicatorClicked( const QModelIn
     vlayer->setSubsetString( qb.sql() );
 }
 
-std::unique_ptr<QgsLayerTreeViewIndicator> QgsLayerTreeViewFilterIndicatorProvider::newIndicator( const QString &filter )
+QString QgsLayerTreeViewFilterIndicatorProvider::iconName( QgsMapLayer *layer )
 {
-  std::unique_ptr< QgsLayerTreeViewIndicator > indicator = qgis::make_unique< QgsLayerTreeViewIndicator >( this );
-  indicator->setIcon( mIcon );
-  updateIndicator( indicator.get(), filter );
-  connect( indicator.get(), &QgsLayerTreeViewIndicator::clicked, this, &QgsLayerTreeViewFilterIndicatorProvider::onIndicatorClicked );
-  mIndicators.insert( indicator.get() );
-  return indicator;
+  Q_UNUSED( layer );
+  return QStringLiteral( "/mIndicatorFilter.svg" );
 }
 
-void QgsLayerTreeViewFilterIndicatorProvider::updateIndicator( QgsLayerTreeViewIndicator *indicator, const QString &filter )
+QString QgsLayerTreeViewFilterIndicatorProvider::tooltipText( QgsMapLayer *layer )
 {
-  indicator->setToolTip( QStringLiteral( "<b>%1:</b><br>%2" ).arg( tr( "Filter" ), filter ) );
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
+  if ( !vlayer )
+    return QString();
+  return  QStringLiteral( "<b>%1:</b><br>%2" ).arg( tr( "Filter" ), vlayer->subsetString() );
 }
 
-
-void QgsLayerTreeViewFilterIndicatorProvider::addOrRemoveIndicator( QgsLayerTreeNode *node, QgsVectorLayer *vlayer )
+void QgsLayerTreeViewFilterIndicatorProvider::connectSignals( QgsMapLayer *layer )
 {
-  QString filter = vlayer->subsetString();
-  if ( !filter.isEmpty() )
-  {
-    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
-
-    // maybe the indicator exists already
-    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
-    {
-      if ( mIndicators.contains( indicator ) )
-      {
-        updateIndicator( indicator, filter );
-        return;
-      }
-    }
-
-    // it does not exist: need to create a new one
-    mLayerTreeView->addIndicator( node, newIndicator( filter ).release() );
-  }
-  else
-  {
-    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
-
-    // there may be existing indicator we need to get rid of
-    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
-    {
-      if ( mIndicators.contains( indicator ) )
-      {
-        mLayerTreeView->removeIndicator( node, indicator );
-        indicator->deleteLater();
-        return;
-      }
-    }
-
-    // no indicator was there before, nothing to do
-  }
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
+  if ( !vlayer )
+    return;
+  connect( vlayer, &QgsVectorLayer::subsetStringChanged, this, &QgsLayerTreeViewFilterIndicatorProvider::onLayerChanged );
 }
+
+void QgsLayerTreeViewFilterIndicatorProvider::disconnectSignals( QgsMapLayer *layer )
+{
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
+  if ( !vlayer )
+    return;
+  disconnect( vlayer, &QgsVectorLayer::subsetStringChanged, this, &QgsLayerTreeViewFilterIndicatorProvider::onLayerChanged );
+}
+
+bool QgsLayerTreeViewFilterIndicatorProvider::acceptLayer( QgsMapLayer *layer )
+{
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
+  if ( !vlayer )
+    return false;
+  return ! vlayer->subsetString().isEmpty();
+}
+

--- a/src/app/qgslayertreeviewfilterindicator.cpp
+++ b/src/app/qgslayertreeviewfilterindicator.cpp
@@ -61,6 +61,7 @@ QString QgsLayerTreeViewFilterIndicatorProvider::tooltipText( QgsMapLayer *layer
 
 void QgsLayerTreeViewFilterIndicatorProvider::connectSignals( QgsMapLayer *layer )
 {
+  QgsLayerTreeViewIndicatorProvider::connectSignals( layer );
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
   if ( !vlayer )
     return;
@@ -69,6 +70,7 @@ void QgsLayerTreeViewFilterIndicatorProvider::connectSignals( QgsMapLayer *layer
 
 void QgsLayerTreeViewFilterIndicatorProvider::disconnectSignals( QgsMapLayer *layer )
 {
+  QgsLayerTreeViewIndicatorProvider::disconnectSignals( layer );
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
   if ( !vlayer )
     return;

--- a/src/app/qgslayertreeviewfilterindicator.h
+++ b/src/app/qgslayertreeviewfilterindicator.h
@@ -32,11 +32,12 @@ class QgsLayerTreeViewFilterIndicatorProvider : public QgsLayerTreeViewIndicator
     QString iconName( QgsMapLayer *layer ) override;
     QString tooltipText( QgsMapLayer *layer ) override;
 
-    // QgsLayerTreeViewIndicatorProvider interface
   protected slots:
-    void onIndicatorClicked( const QModelIndex &index ) ;
-    void connectSignals( QgsMapLayer *layer ) ;
-    void disconnectSignals( QgsMapLayer *layer ) ;
+    void onIndicatorClicked( const QModelIndex &index ) override;
+
+  protected:
+    void connectSignals( QgsMapLayer *layer ) override ;
+    void disconnectSignals( QgsMapLayer *layer ) override;
 };
 
 #endif // QGSLAYERTREEVIEWFILTERINDICATOR_H

--- a/src/app/qgslayertreeviewfilterindicator.h
+++ b/src/app/qgslayertreeviewfilterindicator.h
@@ -34,9 +34,9 @@ class QgsLayerTreeViewFilterIndicatorProvider : public QgsLayerTreeViewIndicator
 
     // QgsLayerTreeViewIndicatorProvider interface
   protected slots:
-    void onIndicatorClicked( const QModelIndex &index ) override;
-    void connectSignals( QgsMapLayer *layer ) override;
-    void disconnectSignals( QgsMapLayer *layer ) override;
+    void onIndicatorClicked( const QModelIndex &index ) ;
+    void connectSignals( QgsMapLayer *layer ) ;
+    void disconnectSignals( QgsMapLayer *layer ) ;
 };
 
 #endif // QGSLAYERTREEVIEWFILTERINDICATOR_H

--- a/src/app/qgslayertreeviewfilterindicator.h
+++ b/src/app/qgslayertreeviewfilterindicator.h
@@ -16,44 +16,27 @@
 #ifndef QGSLAYERTREEVIEWFILTERINDICATOR_H
 #define QGSLAYERTREEVIEWFILTERINDICATOR_H
 
-#include "qgslayertreeviewindicator.h"
+#include "qgslayertreeviewindicatorprovider.h"
 
-#include <QSet>
-#include <memory>
-
-class QgsLayerTreeNode;
-class QgsLayerTreeView;
-class QgsVectorLayer;
-
+#include <QObject>
 
 //! Adds indicators showing whether vector layers have a filter applied.
-class QgsLayerTreeViewFilterIndicatorProvider : public QObject
+class QgsLayerTreeViewFilterIndicatorProvider : public QgsLayerTreeViewIndicatorProvider
 {
     Q_OBJECT
   public:
     explicit QgsLayerTreeViewFilterIndicatorProvider( QgsLayerTreeView *view );
 
-  private slots:
-    //! Connects to signals of layers newly added to the tree
-    void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
-    //! Disconnects from layers about to be removed from the tree
-    void onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
-    //! Starts listening to layer provider's dataChanged signal
-    void onLayerLoaded();
-    //! Adds/removes indicator of a layer
-    void onSubsetStringChanged();
-
-    void onIndicatorClicked( const QModelIndex &index );
-
   private:
-    std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator( const QString &filter );
-    void updateIndicator( QgsLayerTreeViewIndicator *indicator, const QString &filter );
-    void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsVectorLayer *vlayer );
+    bool acceptLayer( QgsMapLayer *layer ) override;
+    QString iconName( QgsMapLayer *layer ) override;
+    QString tooltipText( QgsMapLayer *layer ) override;
 
-  private:
-    QgsLayerTreeView *mLayerTreeView = nullptr;
-    QIcon mIcon;
-    QSet<QgsLayerTreeViewIndicator *> mIndicators;
+    // QgsLayerTreeViewIndicatorProvider interface
+  protected slots:
+    void onIndicatorClicked( const QModelIndex &index ) override;
+    void connectSignals( QgsMapLayer *layer ) override;
+    void disconnectSignals( QgsMapLayer *layer ) override;
 };
 
 #endif // QGSLAYERTREEVIEWFILTERINDICATOR_H

--- a/src/app/qgslayertreeviewindicatorprovider.cpp
+++ b/src/app/qgslayertreeviewindicatorprovider.cpp
@@ -1,0 +1,187 @@
+/***************************************************************************
+  qgslayertreeviewindicatorprovider.cpp - QgsLayerTreeViewIndicatorProvider
+
+ ---------------------
+ begin                : 17.10.2018
+ copyright            : (C) 2018 by ale
+ email                : [your-email-here]
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgslayertreeviewindicatorprovider.h"
+
+#include "qgslayertree.h"
+#include "qgslayertreemodel.h"
+#include "qgslayertreeutils.h"
+#include "qgslayertreeview.h"
+#include "qgsvectorlayer.h"
+#include "qgisapp.h"
+
+QgsLayerTreeViewIndicatorProvider::QgsLayerTreeViewIndicatorProvider( QgsLayerTreeView *view )
+  : QObject( view )
+  , mLayerTreeView( view )
+{
+
+  QgsLayerTree *tree = mLayerTreeView->layerTreeModel()->rootGroup();
+  onAddedChildren( tree, 0, tree->children().count() - 1 );
+
+  connect( tree, &QgsLayerTree::addedChildren, this, &QgsLayerTreeViewIndicatorProvider::onAddedChildren );
+  connect( tree, &QgsLayerTree::willRemoveChildren, this, &QgsLayerTreeViewIndicatorProvider::onWillRemoveChildren );
+}
+
+void QgsLayerTreeViewIndicatorProvider::onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+{
+  // recursively populate indicators
+  QList<QgsLayerTreeNode *> children = node->children();
+  for ( int i = indexFrom; i <= indexTo; ++i )
+  {
+    QgsLayerTreeNode *childNode = children[i];
+
+    if ( QgsLayerTree::isGroup( childNode ) )
+    {
+      onAddedChildren( childNode, 0, childNode->children().count() - 1 );
+    }
+    else if ( QgsLayerTree::isLayer( childNode ) )
+    {
+      if ( QgsLayerTreeLayer *layerNode = dynamic_cast< QgsLayerTreeLayer * >( childNode ) )
+      {
+        if ( layerNode->layer() )
+        {
+          connectSignals( layerNode->layer() );
+          addOrRemoveIndicator( childNode, layerNode->layer() );
+        }
+        else
+        {
+          // wait for layer to be loaded (e.g. when loading project, first the tree is loaded, afterwards the references to layers are resolved)
+          connect( layerNode, &QgsLayerTreeLayer::layerLoaded, this, &QgsLayerTreeViewIndicatorProvider::onLayerLoaded );
+        }
+      }
+    }
+  }
+}
+
+void QgsLayerTreeViewIndicatorProvider::onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+{
+  // recursively call disconnect signals
+
+  QList<QgsLayerTreeNode *> children = node->children();
+  for ( int i = indexFrom; i <= indexTo; ++i )
+  {
+    QgsLayerTreeNode *childNode = children[i];
+
+    if ( QgsLayerTree::isGroup( childNode ) )
+    {
+      onWillRemoveChildren( childNode, 0, childNode->children().count() - 1 );
+    }
+    else if ( QgsLayerTree::isLayer( childNode ) )
+    {
+      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
+      if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), childLayerNode->layer() ) == 1 )
+          disconnectSignals( childLayerNode->layer() );
+    }
+  }
+}
+
+void QgsLayerTreeViewIndicatorProvider::onLayerLoaded()
+{
+  QgsLayerTreeLayer *layerNode = qobject_cast<QgsLayerTreeLayer *>( sender() );
+  if ( !layerNode )
+    return;
+
+  if ( QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layerNode->layer() ) )
+  {
+    if ( vlayer )
+    {
+      connectSignals( vlayer );
+      addOrRemoveIndicator( layerNode, vlayer );
+    }
+  }
+}
+
+void QgsLayerTreeViewIndicatorProvider::onLayerChanged()
+{
+  QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( sender() );
+  if ( !layer )
+    return;
+
+  // walk the tree and find layer node that needs to be updated
+  const QList<QgsLayerTreeLayer *> layerNodes = mLayerTreeView->layerTreeModel()->rootGroup()->findLayers();
+  for ( QgsLayerTreeLayer *node : layerNodes )
+  {
+    if ( node->layer() && node->layer() == layer )
+    {
+      addOrRemoveIndicator( node, layer );
+      break;
+    }
+  }
+}
+
+void QgsLayerTreeViewIndicatorProvider::connectSignals(QgsMapLayer* layer)
+{
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
+  if ( !vlayer )
+    return;
+  connect( vlayer, &QgsVectorLayer::dataSourceChanged, this, &QgsLayerTreeViewIndicatorProvider::onLayerChanged );
+}
+
+void QgsLayerTreeViewIndicatorProvider::disconnectSignals(QgsMapLayer* layer)
+{
+  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
+  if ( !vlayer )
+    return;
+  disconnect( vlayer, &QgsVectorLayer::dataSourceChanged, this, &QgsLayerTreeViewIndicatorProvider::onLayerChanged );
+}
+
+std::unique_ptr< QgsLayerTreeViewIndicator > QgsLayerTreeViewIndicatorProvider::newIndicator()
+{
+  std::unique_ptr< QgsLayerTreeViewIndicator > indicator = qgis::make_unique< QgsLayerTreeViewIndicator >( this );
+  indicator->setIcon( QgsApplication::getThemeIcon( iconName() ) );
+  indicator->setToolTip( tooltipText() );
+  connect( indicator.get(), &QgsLayerTreeViewIndicator::clicked, this, &QgsLayerTreeViewIndicatorProvider::onIndicatorClicked );
+  mIndicators.insert( indicator.get() );
+  return indicator;
+}
+
+void QgsLayerTreeViewIndicatorProvider::addOrRemoveIndicator(QgsLayerTreeNode *node, QgsMapLayer* layer )
+{
+
+  if ( acceptLayer( layer ) )
+  {
+    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
+
+    // maybe the indicator exists already
+    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
+    {
+      if ( mIndicators.contains( indicator ) )
+      {
+        return;
+      }
+    }
+
+    // it does not exist: need to create a new one
+    mLayerTreeView->addIndicator( node, newIndicator().release() );
+  }
+  else
+  {
+    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
+
+    // there may be existing indicator we need to get rid of
+    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
+    {
+      if ( mIndicators.contains( indicator ) )
+      {
+        mLayerTreeView->removeIndicator( node, indicator );
+        indicator->deleteLater();
+        return;
+      }
+    }
+
+    // no indicator was there before, nothing to do
+  }
+}
+

--- a/src/app/qgslayertreeviewindicatorprovider.cpp
+++ b/src/app/qgslayertreeviewindicatorprovider.cpp
@@ -3,8 +3,8 @@
 
  ---------------------
  begin                : 17.10.2018
- copyright            : (C) 2018 by ale
- email                : [your-email-here]
+ copyright            : (C) 2018 by Alessandro Pasotti
+ email                : elpaso@itopen.it
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -82,7 +82,7 @@ void QgsLayerTreeViewIndicatorProvider::onWillRemoveChildren( QgsLayerTreeNode *
     {
       QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
       if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), childLayerNode->layer() ) == 1 )
-          disconnectSignals( childLayerNode->layer() );
+        disconnectSignals( childLayerNode->layer() );
     }
   }
 }
@@ -121,7 +121,7 @@ void QgsLayerTreeViewIndicatorProvider::onLayerChanged()
   }
 }
 
-void QgsLayerTreeViewIndicatorProvider::connectSignals(QgsMapLayer* layer)
+void QgsLayerTreeViewIndicatorProvider::connectSignals( QgsMapLayer *layer )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
   if ( !vlayer )
@@ -129,7 +129,7 @@ void QgsLayerTreeViewIndicatorProvider::connectSignals(QgsMapLayer* layer)
   connect( vlayer, &QgsVectorLayer::dataSourceChanged, this, &QgsLayerTreeViewIndicatorProvider::onLayerChanged );
 }
 
-void QgsLayerTreeViewIndicatorProvider::disconnectSignals(QgsMapLayer* layer)
+void QgsLayerTreeViewIndicatorProvider::disconnectSignals( QgsMapLayer *layer )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
   if ( !vlayer )
@@ -137,17 +137,17 @@ void QgsLayerTreeViewIndicatorProvider::disconnectSignals(QgsMapLayer* layer)
   disconnect( vlayer, &QgsVectorLayer::dataSourceChanged, this, &QgsLayerTreeViewIndicatorProvider::onLayerChanged );
 }
 
-std::unique_ptr< QgsLayerTreeViewIndicator > QgsLayerTreeViewIndicatorProvider::newIndicator()
+std::unique_ptr< QgsLayerTreeViewIndicator > QgsLayerTreeViewIndicatorProvider::newIndicator( QgsMapLayer *layer )
 {
   std::unique_ptr< QgsLayerTreeViewIndicator > indicator = qgis::make_unique< QgsLayerTreeViewIndicator >( this );
-  indicator->setIcon( QgsApplication::getThemeIcon( iconName() ) );
-  indicator->setToolTip( tooltipText() );
+  indicator->setIcon( QgsApplication::getThemeIcon( iconName( layer ) ) );
+  indicator->setToolTip( tooltipText( layer ) );
   connect( indicator.get(), &QgsLayerTreeViewIndicator::clicked, this, &QgsLayerTreeViewIndicatorProvider::onIndicatorClicked );
   mIndicators.insert( indicator.get() );
   return indicator;
 }
 
-void QgsLayerTreeViewIndicatorProvider::addOrRemoveIndicator(QgsLayerTreeNode *node, QgsMapLayer* layer )
+void QgsLayerTreeViewIndicatorProvider::addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer )
 {
 
   if ( acceptLayer( layer ) )
@@ -159,12 +159,15 @@ void QgsLayerTreeViewIndicatorProvider::addOrRemoveIndicator(QgsLayerTreeNode *n
     {
       if ( mIndicators.contains( indicator ) )
       {
+        // Update just in case ...
+        indicator->setToolTip( tooltipText( layer ) );
+        indicator->setIcon( QgsApplication::getThemeIcon( iconName( layer ) ) );
         return;
       }
     }
 
     // it does not exist: need to create a new one
-    mLayerTreeView->addIndicator( node, newIndicator().release() );
+    mLayerTreeView->addIndicator( node, newIndicator( layer ).release() );
   }
   else
   {

--- a/src/app/qgslayertreeviewindicatorprovider.h
+++ b/src/app/qgslayertreeviewindicatorprovider.h
@@ -1,0 +1,79 @@
+/***************************************************************************
+  qgslayertreeviewindicatorprovider.h - QgsLayerTreeViewIndicatorProvider
+
+ ---------------------
+ begin                : 17.10.2018
+ copyright            : (C) 2018 by ale
+ email                : [your-email-here]
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSLAYERTREEVIEWINDICATORPROVIDER_H
+#define QGSLAYERTREEVIEWINDICATORPROVIDER_H
+
+#include <QObject>
+#include <QSet>
+#include <memory>
+
+#include "qgslayertreeviewindicator.h"
+
+class QgsLayerTreeNode;
+class QgsLayerTreeView;
+class QgsMapLayer;
+
+
+/**
+ * The QgsLayerTreeViewIndicatorProvider class provides an interface for
+ * layer tree indicator providers.
+ *
+ * Subclasses must override:
+ * - iconName()
+ * - tooltipText()
+ * - acceptLayer() filter function to determine whether the indicator must be added for the layer
+ *
+ * Subclasses may override:
+ * - onIndicatorClicked() default implementation does nothing
+ * - connectSignals() default implementation connects vector layers to dataSourceChanged
+ * - disconnectSignals() default implementation disconnects vector layers from dataSourceChanged
+ */
+class QgsLayerTreeViewIndicatorProvider : public QObject
+{
+    Q_OBJECT
+  public:
+
+    explicit QgsLayerTreeViewIndicatorProvider( QgsLayerTreeView *view );
+
+  protected slots:
+    //! Connects to signals of layers newly added to the tree
+    virtual void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+    //! Disconnects from layers about to be removed from the tree
+    virtual void onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+    virtual void onLayerLoaded();
+    //! Adds/removes indicator of a layer
+    virtual void onLayerChanged();
+    //! Action on indicator clicked
+    virtual void onIndicatorClicked( const QModelIndex &index ) { Q_UNUSED( index ) }
+    //! Connect signals
+    virtual void connectSignals( QgsMapLayer *layer );
+    //! Disconnect signals
+    virtual void disconnectSignals( QgsMapLayer *layer );
+
+  private:
+    //! Layer filter
+    virtual bool acceptLayer( QgsMapLayer *layer ) = 0;
+    virtual QString iconName() = 0;
+    virtual QString tooltipText() = 0;
+    virtual std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator();
+    virtual void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer );
+
+  protected:
+    QgsLayerTreeView *mLayerTreeView = nullptr;
+    QSet<QgsLayerTreeViewIndicator *> mIndicators;
+};
+
+#endif // QGSLAYERTREEVIEWINDICATORPROVIDER_H

--- a/src/app/qgslayertreeviewindicatorprovider.h
+++ b/src/app/qgslayertreeviewindicatorprovider.h
@@ -3,8 +3,8 @@
 
  ---------------------
  begin                : 17.10.2018
- copyright            : (C) 2018 by ale
- email                : [your-email-here]
+ copyright            : (C) 2018 by Alessandro Pasotti
+ email                : elpaso@itopen.it
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -66,9 +66,9 @@ class QgsLayerTreeViewIndicatorProvider : public QObject
   private:
     //! Layer filter
     virtual bool acceptLayer( QgsMapLayer *layer ) = 0;
-    virtual QString iconName() = 0;
-    virtual QString tooltipText() = 0;
-    virtual std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator();
+    virtual QString iconName( QgsMapLayer *layer ) = 0;
+    virtual QString tooltipText( QgsMapLayer *layer ) = 0;
+    virtual std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator( QgsMapLayer *layer );
     virtual void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer );
 
   protected:

--- a/src/app/qgslayertreeviewindicatorprovider.h
+++ b/src/app/qgslayertreeviewindicatorprovider.h
@@ -48,15 +48,18 @@ class QgsLayerTreeViewIndicatorProvider : public QObject
 
     explicit QgsLayerTreeViewIndicatorProvider( QgsLayerTreeView *view );
 
-  protected slots:
+  protected:
 
     // Subclasses MAY override:
-    //! Action on indicator clicked, default implementation does nothing
-    void onIndicatorClicked( const QModelIndex &index ) { Q_UNUSED( index ) }
     //! Connect signals, default implementation connects vector layers to dataSourceChanged()
-    void connectSignals( QgsMapLayer *layer );
+    virtual void connectSignals( QgsMapLayer *layer );
     //! Disconnect signals, default implementation disconnects vector layers from dataSourceChanged()
-    void disconnectSignals( QgsMapLayer *layer );
+    virtual void disconnectSignals( QgsMapLayer *layer );
+
+  protected slots:
+
+    //! Action on indicator clicked, default implementation does nothing
+    virtual void onIndicatorClicked( const QModelIndex &index ) { Q_UNUSED( index ) }
     // End MAY overrides
 
     //! Connects to signals of layers newly added to the tree

--- a/src/app/qgslayertreeviewindicatorprovider.h
+++ b/src/app/qgslayertreeviewindicatorprovider.h
@@ -38,8 +38,8 @@ class QgsMapLayer;
  *
  * Subclasses may override:
  * - onIndicatorClicked() default implementation does nothing
- * - connectSignals() default implementation connects vector layers to dataSourceChanged
- * - disconnectSignals() default implementation disconnects vector layers from dataSourceChanged
+ * - connectSignals() default implementation connects vector layers to dataSourceChanged()
+ * - disconnectSignals() default implementation disconnects vector layers from dataSourceChanged()
  */
 class QgsLayerTreeViewIndicatorProvider : public QObject
 {
@@ -49,27 +49,39 @@ class QgsLayerTreeViewIndicatorProvider : public QObject
     explicit QgsLayerTreeViewIndicatorProvider( QgsLayerTreeView *view );
 
   protected slots:
+
+    // Subclasses MAY override:
+    //! Action on indicator clicked, default implementation does nothing
+    void onIndicatorClicked( const QModelIndex &index ) { Q_UNUSED( index ) }
+    //! Connect signals, default implementation connects vector layers to dataSourceChanged()
+    void connectSignals( QgsMapLayer *layer );
+    //! Disconnect signals, default implementation disconnects vector layers from dataSourceChanged()
+    void disconnectSignals( QgsMapLayer *layer );
+    // End MAY overrides
+
     //! Connects to signals of layers newly added to the tree
-    virtual void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+    void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
     //! Disconnects from layers about to be removed from the tree
-    virtual void onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
-    virtual void onLayerLoaded();
+    void onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
+    void onLayerLoaded();
     //! Adds/removes indicator of a layer
-    virtual void onLayerChanged();
-    //! Action on indicator clicked
-    virtual void onIndicatorClicked( const QModelIndex &index ) { Q_UNUSED( index ) }
-    //! Connect signals
-    virtual void connectSignals( QgsMapLayer *layer );
-    //! Disconnect signals
-    virtual void disconnectSignals( QgsMapLayer *layer );
+    void onLayerChanged();
 
   private:
-    //! Layer filter
+
+    // Subclasses MUST override:
+    //! Layer filter: layers that pass the test will get the indicator
     virtual bool acceptLayer( QgsMapLayer *layer ) = 0;
+    //! Returns the icon name for the given \a layer, icon name is passed to QgsApplication::getThemeIcon()
     virtual QString iconName( QgsMapLayer *layer ) = 0;
+    //! Returns the tooltip text for the given \a layer
     virtual QString tooltipText( QgsMapLayer *layer ) = 0;
-    virtual std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator( QgsMapLayer *layer );
-    virtual void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer );
+    // End MUST overrides
+
+    //! Indicator factory
+    std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator( QgsMapLayer *layer );
+    //! Add or remove the indicator to the given node
+    void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer );
 
   protected:
     QgsLayerTreeView *mLayerTreeView = nullptr;

--- a/src/app/qgslayertreeviewmemoryindicator.cpp
+++ b/src/app/qgslayertreeviewmemoryindicator.cpp
@@ -48,13 +48,15 @@ bool QgsLayerTreeViewMemoryIndicatorProvider::acceptLayer( QgsMapLayer *layer )
   return  vlayer->dataProvider()->name() == QLatin1String( "memory" );
 }
 
-QString QgsLayerTreeViewMemoryIndicatorProvider::iconName()
+QString QgsLayerTreeViewMemoryIndicatorProvider::iconName( QgsMapLayer *layer )
 {
+  Q_UNUSED( layer );
   return QStringLiteral( "/mIndicatorMemory.svg" );
 }
 
-QString QgsLayerTreeViewMemoryIndicatorProvider::tooltipText()
+QString QgsLayerTreeViewMemoryIndicatorProvider::tooltipText( QgsMapLayer *layer )
 {
+  Q_UNUSED( layer );
   return tr( "<b>Temporary scratch layer only!</b><br>Contents will be discarded after closing this project" );
 }
 

--- a/src/app/qgslayertreeviewmemoryindicator.h
+++ b/src/app/qgslayertreeviewmemoryindicator.h
@@ -27,7 +27,7 @@ class QgsLayerTreeViewMemoryIndicatorProvider : public QgsLayerTreeViewIndicator
 
   protected slots:
 
-    void onIndicatorClicked( const QModelIndex &index );
+    void onIndicatorClicked( const QModelIndex &index ) override;
 
   private:
     bool acceptLayer( QgsMapLayer *layer ) override;

--- a/src/app/qgslayertreeviewmemoryindicator.h
+++ b/src/app/qgslayertreeviewmemoryindicator.h
@@ -31,8 +31,8 @@ class QgsLayerTreeViewMemoryIndicatorProvider : public QgsLayerTreeViewIndicator
 
   private:
     bool acceptLayer( QgsMapLayer *layer ) override;
-    QString iconName() override;
-    QString tooltipText() override;
+    QString iconName( QgsMapLayer *layer ) override;
+    QString tooltipText( QgsMapLayer *layer ) override;
 };
 
 #endif // QGSLAYERTREEVIEWMEMORYINDICATOR_H

--- a/src/app/qgslayertreeviewmemoryindicator.h
+++ b/src/app/qgslayertreeviewmemoryindicator.h
@@ -27,7 +27,7 @@ class QgsLayerTreeViewMemoryIndicatorProvider : public QgsLayerTreeViewIndicator
 
   protected slots:
 
-    void onIndicatorClicked( const QModelIndex &index ) override;
+    void onIndicatorClicked( const QModelIndex &index );
 
   private:
     bool acceptLayer( QgsMapLayer *layer ) override;

--- a/src/app/qgslayertreeviewnonremovableindicator.cpp
+++ b/src/app/qgslayertreeviewnonremovableindicator.cpp
@@ -22,149 +22,34 @@
 
 
 QgsLayerTreeViewNonRemovableIndicatorProvider::QgsLayerTreeViewNonRemovableIndicatorProvider( QgsLayerTreeView *view )
-  : QObject( view )
-  , mLayerTreeView( view )
+  : QgsLayerTreeViewIndicatorProvider( view )
 {
-  mIcon = QgsApplication::getThemeIcon( QStringLiteral( "/mIndicatorNonRemovable.svg" ) );
-
-  QgsLayerTree *tree = mLayerTreeView->layerTreeModel()->rootGroup();
-  onAddedChildren( tree, 0, tree->children().count() - 1 );
-
-  connect( tree, &QgsLayerTree::addedChildren, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onAddedChildren );
-  connect( tree, &QgsLayerTree::willRemoveChildren, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onWillRemoveChildren );
 }
 
-void QgsLayerTreeViewNonRemovableIndicatorProvider::onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+QString QgsLayerTreeViewNonRemovableIndicatorProvider::iconName( QgsMapLayer *layer )
 {
-  // recursively connect to providers' dataChanged() signal
-
-  QList<QgsLayerTreeNode *> children = node->children();
-  for ( int i = indexFrom; i <= indexTo; ++i )
-  {
-    QgsLayerTreeNode *childNode = children[i];
-
-    if ( QgsLayerTree::isGroup( childNode ) )
-    {
-      onAddedChildren( childNode, 0, childNode->children().count() - 1 );
-    }
-    else if ( QgsLayerTree::isLayer( childNode ) )
-    {
-      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
-      if ( QgsMapLayer *layer = childLayerNode->layer() )
-      {
-        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), layer ) == 1 )
-          connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
-        addOrRemoveIndicator( childLayerNode, layer );
-      }
-      else if ( !childLayerNode->layer() )
-      {
-        // wait for layer to be loaded (e.g. when loading project, first the tree is loaded, afterwards the references to layers are resolved)
-        connect( childLayerNode, &QgsLayerTreeLayer::layerLoaded, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onLayerLoaded );
-      }
-    }
-  }
+  Q_UNUSED( layer );
+  return QStringLiteral( "/mIndicatorNonRemovable.svg" );
 }
 
-
-void QgsLayerTreeViewNonRemovableIndicatorProvider::onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo )
+QString QgsLayerTreeViewNonRemovableIndicatorProvider::tooltipText( QgsMapLayer *layer )
 {
-  // recursively disconnect from providers' dataChanged() signal
-
-  QList<QgsLayerTreeNode *> children = node->children();
-  for ( int i = indexFrom; i <= indexTo; ++i )
-  {
-    QgsLayerTreeNode *childNode = children[i];
-
-    if ( QgsLayerTree::isGroup( childNode ) )
-    {
-      onWillRemoveChildren( childNode, 0, childNode->children().count() - 1 );
-    }
-    else if ( QgsLayerTree::isLayer( childNode ) )
-    {
-      QgsLayerTreeLayer *childLayerNode = QgsLayerTree::toLayer( childNode );
-      if ( childLayerNode->layer() )
-      {
-        if ( QgsLayerTreeUtils::countMapLayerInTree( mLayerTreeView->layerTreeModel()->rootGroup(), childLayerNode->layer() ) == 1 )
-          disconnect( childLayerNode->layer(), &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
-      }
-    }
-  }
+  Q_UNUSED( layer );
+  return tr( "Layer required by the project" );
 }
 
-
-void QgsLayerTreeViewNonRemovableIndicatorProvider::onLayerLoaded()
+bool QgsLayerTreeViewNonRemovableIndicatorProvider::acceptLayer( QgsMapLayer *layer )
 {
-  QgsLayerTreeLayer *nodeLayer = qobject_cast<QgsLayerTreeLayer *>( sender() );
-  if ( !nodeLayer )
-    return;
-
-  if ( QgsMapLayer *layer = nodeLayer->layer() )
-  {
-    connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged );
-    addOrRemoveIndicator( nodeLayer, layer );
-  }
+  return layer->flags() & QgsMapLayer::Removable;
 }
 
-void QgsLayerTreeViewNonRemovableIndicatorProvider::onFlagsChanged()
+void QgsLayerTreeViewNonRemovableIndicatorProvider::connectSignals( QgsMapLayer *layer )
 {
-  QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( sender() );
-  if ( !layer )
-    return;
-
-  // walk the tree and find layer node that needs to be updated
-  const QList<QgsLayerTreeLayer *> layerNodes = mLayerTreeView->layerTreeModel()->rootGroup()->findLayers();
-  for ( QgsLayerTreeLayer *node : layerNodes )
-  {
-    if ( node->layer() && node->layer() == layer )
-    {
-      addOrRemoveIndicator( node, layer );
-      break;
-    }
-  }
+  connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onLayerChanged );
 }
 
-
-std::unique_ptr<QgsLayerTreeViewIndicator> QgsLayerTreeViewNonRemovableIndicatorProvider::newIndicator()
+void QgsLayerTreeViewNonRemovableIndicatorProvider::disconnectSignals( QgsMapLayer *layer )
 {
-  std::unique_ptr< QgsLayerTreeViewIndicator > indicator = qgis::make_unique< QgsLayerTreeViewIndicator >( this );
-  indicator->setIcon( mIcon );
-  indicator->setToolTip( tr( "Layer required by the project" ) );
-  mIndicators.insert( indicator.get() );
-  return indicator;
+  disconnect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onLayerChanged );
 }
 
-void QgsLayerTreeViewNonRemovableIndicatorProvider::addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer )
-{
-  bool removable = layer->flags() & QgsMapLayer::Removable;
-  if ( !removable )
-  {
-    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
-
-    // maybe the indicator exists already
-    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
-    {
-      if ( mIndicators.contains( indicator ) )
-        return;
-    }
-
-    // it does not exist: need to create a new one
-    mLayerTreeView->addIndicator( node, newIndicator().release() );
-  }
-  else
-  {
-    const QList<QgsLayerTreeViewIndicator *> nodeIndicators = mLayerTreeView->indicators( node );
-
-    // there may be existing indicator we need to get rid of
-    for ( QgsLayerTreeViewIndicator *indicator : nodeIndicators )
-    {
-      if ( mIndicators.contains( indicator ) )
-      {
-        mLayerTreeView->removeIndicator( node, indicator );
-        indicator->deleteLater();
-        return;
-      }
-    }
-
-    // no indicator was there before, nothing to do
-  }
-}

--- a/src/app/qgslayertreeviewnonremovableindicator.cpp
+++ b/src/app/qgslayertreeviewnonremovableindicator.cpp
@@ -40,16 +40,18 @@ QString QgsLayerTreeViewNonRemovableIndicatorProvider::tooltipText( QgsMapLayer 
 
 bool QgsLayerTreeViewNonRemovableIndicatorProvider::acceptLayer( QgsMapLayer *layer )
 {
-  return layer->flags() & QgsMapLayer::Removable;
+  return ! layer->flags().testFlag( QgsMapLayer::LayerFlag::Removable );
 }
 
 void QgsLayerTreeViewNonRemovableIndicatorProvider::connectSignals( QgsMapLayer *layer )
 {
+  QgsLayerTreeViewIndicatorProvider::connectSignals( layer );
   connect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onLayerChanged );
 }
 
 void QgsLayerTreeViewNonRemovableIndicatorProvider::disconnectSignals( QgsMapLayer *layer )
 {
+  QgsLayerTreeViewIndicatorProvider::disconnectSignals( layer );
   disconnect( layer, &QgsMapLayer::flagsChanged, this, &QgsLayerTreeViewNonRemovableIndicatorProvider::onLayerChanged );
 }
 

--- a/src/app/qgslayertreeviewnonremovableindicator.h
+++ b/src/app/qgslayertreeviewnonremovableindicator.h
@@ -16,39 +16,29 @@
 #ifndef QGSLAYERTREEVIEWNONREMOVABLEINDICATOR_H
 #define QGSLAYERTREEVIEWNONREMOVABLEINDICATOR_H
 
-#include "qgslayertreeviewindicator.h"
+#include "qgslayertreeviewindicatorprovider.h"
 
 #include <QSet>
 #include <memory>
 
-class QgsLayerTreeNode;
-class QgsLayerTreeView;
-class QgsMapLayer;
-
-class QgsLayerTreeViewNonRemovableIndicatorProvider : public QObject
+class QgsLayerTreeViewNonRemovableIndicatorProvider : public QgsLayerTreeViewIndicatorProvider
 {
     Q_OBJECT
   public:
     explicit QgsLayerTreeViewNonRemovableIndicatorProvider( QgsLayerTreeView *view );
 
-  private slots:
-    //! Connects to signals of layers newly added to the tree
-    void onAddedChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
-    //! Disconnects from layers about to be removed from the tree
-    void onWillRemoveChildren( QgsLayerTreeNode *node, int indexFrom, int indexTo );
-    //! Starts listening to layer provider's dataChanged signal
-    void onLayerLoaded();
-    void onFlagsChanged();
-
   private:
-    std::unique_ptr< QgsLayerTreeViewIndicator > newIndicator();
-    void addOrRemoveIndicator( QgsLayerTreeNode *node, QgsMapLayer *layer );
+    QString iconName( QgsMapLayer *layer ) override;
+    QString tooltipText( QgsMapLayer *layer ) override;
+    bool acceptLayer( QgsMapLayer *layer ) override;
 
-  private:
-    QgsLayerTreeView *mLayerTreeView = nullptr;
-    QIcon mIcon;
-    QSet<QgsLayerTreeViewIndicator *> mIndicators;
+  protected:
+
+    void connectSignals( QgsMapLayer *layer ) override;
+    void disconnectSignals( QgsMapLayer *layer ) override;
+
 };
+
 
 
 #endif // QGSLAYERTREEVIEWNONREMOVABLEINDICATOR_H

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -6323,10 +6323,7 @@ class QgsOgrVectorSourceSelectProvider : public QgsSourceSelectProvider
     QString text() const override { return QObject::tr( "Vector" ); }
     int ordering() const override { return QgsSourceSelectProvider::OrderLocalProvider + 10; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddOgrLayer.svg" ) ); }
-    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
-    {
-      return new QgsOgrSourceSelect( parent, fl, widgetMode );
-    }
+    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override;
 };
 
 
@@ -6335,14 +6332,12 @@ class QgsGeoPackageSourceSelectProvider : public QgsSourceSelectProvider
 {
   public:
 
+    virtual QString name() const override;
     QString providerKey() const override { return QStringLiteral( "ogr" ); }
     QString text() const override { return QObject::tr( "GeoPackage" ); }
     int ordering() const override { return QgsSourceSelectProvider::OrderLocalProvider + 45; }
     QIcon icon() const override { return QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddGeoPackageLayer.svg" ) ); }
-    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override
-    {
-      return new QgsOgrDbSourceSelect( QStringLiteral( "GPKG" ), QObject::tr( "GeoPackage" ), QObject::tr( "GeoPackage Database (*.gpkg)" ), parent, fl, widgetMode );
-    }
+    QgsAbstractDataSourceWidget *createDataSourceWidget( QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Widget, QgsProviderRegistry::WidgetMode widgetMode = QgsProviderRegistry::WidgetMode::Embedded ) const override;
 };
 
 
@@ -6394,4 +6389,16 @@ QGISEXTERN QgsTransaction *createTransaction( const QString &connString )
   }
 
   return new QgsOgrTransaction( connString, ds );
+}
+
+QString QgsGeoPackageSourceSelectProvider::name() const { return QStringLiteral( "GeoPackage" ); }
+
+QgsAbstractDataSourceWidget *QgsGeoPackageSourceSelectProvider::createDataSourceWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ) const
+{
+  return new QgsOgrDbSourceSelect( QStringLiteral( "GPKG" ), QObject::tr( "GeoPackage" ), QObject::tr( "GeoPackage Database (*.gpkg)" ), parent, fl, widgetMode );
+}
+
+QgsAbstractDataSourceWidget *QgsOgrVectorSourceSelectProvider::createDataSourceWidget( QWidget *parent, Qt::WindowFlags fl, QgsProviderRegistry::WidgetMode widgetMode ) const
+{
+  return new QgsOgrSourceSelect( parent, fl, widgetMode );
 }


### PR DESCRIPTION
Small refactoring of the indicator classes:
- new abstract interface (removes a lot of code duplication)
- remove limitation for vector layers (generic code will support rasters and vectors, it's up to the individual indicator implementations to filter the layer type if they are not supposed to support both)
- new indicator for handle bad layers (not yet really useful but it's part of a bigger plan about bad layers deferred handling)

![bad-layers](https://user-images.githubusercontent.com/142164/47264438-bf955880-d517-11e8-8275-b650f0276fbd.gif)
