### PR TITLE
Update data defined button on auxiliary field deletion correctly

### DIFF
--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -1663,11 +1663,6 @@ void QgsVectorLayerProperties::updateAuxiliaryStoragePage( bool reset )
     mAuxiliaryStorageFieldsLineEdit->setText( QString() );
     mAuxiliaryStorageFeaturesLineEdit->setText( QString() );
   }
-
-  if ( reset && labelingDialog )
-  {
-    labelingDialog->setLayer( mLayer );
-  }
 }
 
 void QgsVectorLayerProperties::onAuxiliaryLayerNew()

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -1602,7 +1602,7 @@ void QgsVectorLayerProperties::showHelp()
   }
 }
 
-void QgsVectorLayerProperties::updateAuxiliaryStoragePage( bool reset )
+void QgsVectorLayerProperties::updateAuxiliaryStoragePage()
 {
   const QgsAuxiliaryLayer *alayer = mLayer->auxiliaryLayer();
 
@@ -1675,7 +1675,7 @@ void QgsVectorLayerProperties::onAuxiliaryLayerNew()
   QgsNewAuxiliaryLayerDialog dlg( mLayer, this );
   if ( dlg.exec() == QDialog::Accepted )
   {
-    updateAuxiliaryStoragePage( true );
+    updateAuxiliaryStoragePage();
   }
 }
 
@@ -1695,7 +1695,7 @@ void QgsVectorLayerProperties::onAuxiliaryLayerClear()
     QApplication::setOverrideCursor( Qt::WaitCursor );
     alayer->clear();
     QApplication::restoreOverrideCursor();
-    updateAuxiliaryStoragePage( true );
+    updateAuxiliaryStoragePage();
     mLayer->triggerRepaint();
   }
 }
@@ -1726,7 +1726,7 @@ void QgsVectorLayerProperties::onAuxiliaryLayerDelete()
     mLayer->setAuxiliaryLayer(); // remove auxiliary layer
     QgsAuxiliaryStorage::deleteTable( uri );
     QApplication::restoreOverrideCursor();
-    updateAuxiliaryStoragePage( true );
+    updateAuxiliaryStoragePage();
     mLayer->triggerRepaint();
   }
 }
@@ -1814,7 +1814,7 @@ void QgsVectorLayerProperties::deleteAuxiliaryField( int index )
       labelingDialog->labelingGui()->deactivateField( static_cast<QgsPalLayerSettings::Property>( key ) );
     }
 
-    updateAuxiliaryStoragePage( true );
+    updateAuxiliaryStoragePage();
     mSourceFieldsPropertiesDialog->init();
   }
 }

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -222,7 +222,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     //! Adds a new join to mJoinTreeWidget
     void addJoinToTreeWidget( const QgsVectorLayerJoinInfo &join, int insertIndex = -1 );
 
-    void updateAuxiliaryStoragePage( bool reset = false );
+    void updateAuxiliaryStoragePage();
     void deleteAuxiliaryField( int index );
 
     QgsExpressionContext mContext;


### PR DESCRIPTION
## Description

At the time of the auxiliary storage implementation, I had some issues with data defined buttons within the `Layer Styling Panel` and signals. Now, everything seems fine and the manual update of the labeling widget is not necessary anymore.

Moreover, it fixes a bug reported on [stackexchange](https://gis.stackexchange.com/questions/296587/deactivate-auxiliary-field-labeling-after-deleting--%20the-table) about data defined buttons turning red after an auxiliary field deletion.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
