### PR TITLE
[FEATURE][needs-docs]Add buttons to load and save an external SQL file

### DIFF
--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -26,8 +26,8 @@ from builtins import next
 from builtins import str
 from hashlib import md5
 
-from qgis.PyQt.QtCore import Qt, pyqtSignal
-from qgis.PyQt.QtWidgets import QDialog, QWidget, QAction, QApplication, QInputDialog, QStyledItemDelegate, QTableWidgetItem
+from qgis.PyQt.QtCore import Qt, pyqtSignal, QDir
+from qgis.PyQt.QtWidgets import QDialog, QWidget, QAction, QApplication, QInputDialog, QStyledItemDelegate, QTableWidgetItem, QFileDialog
 from qgis.PyQt.QtGui import QKeySequence, QCursor, QClipboard, QIcon, QStandardItemModel, QStandardItem
 from qgis.PyQt.Qsci import QsciAPIs
 
@@ -120,6 +120,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         self.btnClear.clicked.connect(self.clearSql)
 
         self.presetStore.clicked.connect(self.storePreset)
+        self.presetSaveAsFile.clicked.connect(self.saveAsFilePreset)
         self.presetDelete.clicked.connect(self.deletePreset)
         self.presetCombo.activated[str].connect(self.loadPreset)
         self.presetCombo.activated[str].connect(self.presetName.setText)
@@ -227,6 +228,21 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
             self.presetCombo.setCurrentIndex(self.presetCombo.count() - 1)
         else:
             self.presetCombo.setCurrentIndex(index)
+
+    def saveAsFilePreset(self):
+        query = self._getSqlQuery()
+        if query == "":
+            return
+
+        filename, ext = QFileDialog.getSaveFileName(
+            self,
+            'Save SQL Query',
+            QDir.homePath(),
+            "SQL File (*.sql)")
+
+        if filename:
+            with open(filename, 'w') as f:
+                f.write(query)
 
     def deletePreset(self):
         name = self.presetCombo.currentText()

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -121,6 +121,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
 
         self.presetStore.clicked.connect(self.storePreset)
         self.presetSaveAsFile.clicked.connect(self.saveAsFilePreset)
+        self.presetLoadFile.clicked.connect(self.loadFilePreset)
         self.presetDelete.clicked.connect(self.deletePreset)
         self.presetCombo.activated[str].connect(self.loadPreset)
         self.presetCombo.activated[str].connect(self.presetName.setText)
@@ -236,13 +237,25 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
 
         filename, ext = QFileDialog.getSaveFileName(
             self,
-            'Save SQL Query',
+            self.tr('Save SQL Query'),
             QDir.homePath(),
             "SQL File (*.sql)")
 
         if filename:
             with open(filename, 'w') as f:
                 f.write(query)
+
+    def loadFilePreset(self):
+        filename = QFileDialog.getOpenFileName(
+                         self,
+                         self.tr("Load SQL Query"),
+                         QDir.homePath(),
+                         "SQL File (*.sql)");
+        if filename:
+            with open(filename[0], 'r') as f:
+                self.editSql.clear()
+                for line in f:
+                    self.editSql.insertText(line)
 
     def deletePreset(self):
         name = self.presetCombo.currentText()

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -244,9 +244,12 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
             self,
             self.tr('Save SQL Query'),
             lastDir,
-            "SQL File (*.sql)")
+            self.tr("SQL File (*.sql, *.SQL)"))
 
         if filename:
+            if not filename.lower().endswith('.sql'):
+                filename += ".sql"
+
             with open(filename, 'w') as f:
                 f.write(query)
                 lastDir = os.path.dirname(filename)
@@ -260,7 +263,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
             self,
             self.tr("Load SQL Query"),
             lastDir,
-            "SQL File (*.sql)")
+            self.tr("SQL File (*.sql, *.SQL)"))
 
         if filename:
             with open(filename, 'r') as f:

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -26,6 +26,8 @@ from builtins import next
 from builtins import str
 from hashlib import md5
 
+import os
+
 from qgis.PyQt.QtCore import Qt, pyqtSignal, QDir
 from qgis.PyQt.QtWidgets import QDialog, QWidget, QAction, QApplication, QInputDialog, QStyledItemDelegate, QTableWidgetItem, QFileDialog
 from qgis.PyQt.QtGui import QKeySequence, QCursor, QClipboard, QIcon, QStandardItemModel, QStandardItem
@@ -231,31 +233,42 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
             self.presetCombo.setCurrentIndex(index)
 
     def saveAsFilePreset(self):
+        settings = QgsSettings()
+        lastDir = settings.value('DB_Manager/lastDirSQLFIle', "")
+
         query = self._getSqlQuery()
         if query == "":
             return
 
-        filename, ext = QFileDialog.getSaveFileName(
+        filename, _ = QFileDialog.getSaveFileName(
             self,
             self.tr('Save SQL Query'),
-            QDir.homePath(),
+            lastDir,
             "SQL File (*.sql)")
 
         if filename:
             with open(filename, 'w') as f:
                 f.write(query)
+                lastDir = os.path.dirname(filename)
+                settings.setValue('DB_Manager/lastDirSQLFile', lastDir)
 
     def loadFilePreset(self):
-        filename = QFileDialog.getOpenFileName(
-                         self,
-                         self.tr("Load SQL Query"),
-                         QDir.homePath(),
-                         "SQL File (*.sql)");
+        settings = QgsSettings()
+        lastDir = settings.value('DB_Manager/lastDirSQLFIle', "")
+
+        filename, _ = QFileDialog.getOpenFileName(
+            self,
+            self.tr("Load SQL Query"),
+            lastDir,
+            "SQL File (*.sql)")
+
         if filename:
-            with open(filename[0], 'r') as f:
+            with open(filename, 'r') as f:
                 self.editSql.clear()
                 for line in f:
                     self.editSql.insertText(line)
+                lastDir = os.path.dirname(filename)
+                settings.setValue('DB_Manager/lastDirSQLFile', lastDir)
 
     def deletePreset(self):
         name = self.presetCombo.currentText()

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -25,7 +25,7 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
@@ -97,6 +97,16 @@
           <widget class="QPushButton" name="presetDelete">
            <property name="text">
             <string>Delete</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="presetSaveAsFile">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the query as SQL file&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Save As File</string>
            </property>
           </widget>
          </item>
@@ -226,7 +236,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QTableView" name="viewResult">
@@ -498,7 +508,6 @@ unique values</string>
   <tabstop>queryBuilderBtn</tabstop>
   <tabstop>presetCombo</tabstop>
   <tabstop>presetName</tabstop>
-  <tabstop>presetStore</tabstop>
   <tabstop>presetDelete</tabstop>
   <tabstop>editSql</tabstop>
   <tabstop>btnExecute</tabstop>

--- a/python/plugins/db_manager/ui/DlgSqlWindow.ui
+++ b/python/plugins/db_manager/ui/DlgSqlWindow.ui
@@ -101,6 +101,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="presetLoadFile">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load SQL file&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Load File</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="presetSaveAsFile">
            <property name="toolTip">
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save the query as SQL file&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>


### PR DESCRIPTION
## Description
The new buttons allow the user to load and save the query in an external SQL file.

![image](https://user-images.githubusercontent.com/7521540/48400313-4e1b8500-e726-11e8-8a80-1d7c513e111e.png)

cc @haubourg 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
