### PR TITLE
move value group box under help area [Expression builder] [needs-docs]

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -57,7 +57,6 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   connect( mValuesListView, &QListView::doubleClicked, this, &QgsExpressionBuilderWidget::mValuesListView_doubleClicked );
 
   mValueGroupBox->hide();
-  mLoadGroupBox->hide();
 //  highlighter = new QgsExpressionHighlighter( txtExpressionString->document() );
 
   mModel = new QStandardItemModel();
@@ -228,7 +227,6 @@ void QgsExpressionBuilderWidget::currentChanged( const QModelIndex &index, const
     mValuesModel->setStringList( values );
   }
 
-  mLoadGroupBox->setVisible( item->getItemType() == QgsExpressionItem::Field && mLayer );
   mValueGroupBox->setVisible( item->getItemType() == QgsExpressionItem::Field && mLayer );
 
   // Show the help for the current item.

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -93,6 +93,19 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
 
   editorSplit->setSizes( QList<int>( {175, 300} ) );
 
+  functionsplit->setCollapsible( 0, false );
+  connect( mShowHelpButton, &QPushButton::clicked, this, [ = ]()
+  {
+    functionsplit->setSizes( QList<int>( {mOperationListGroup->width() - mHelpAndValuesWidget->minimumWidth(),
+                                          mHelpAndValuesWidget->minimumWidth()} ) );
+    mShowHelpButton->setEnabled( false );
+  } );
+  connect( functionsplit, &QSplitter::splitterMoved, this, [ = ]( int, int )
+  {
+    mShowHelpButton->setEnabled( functionsplit->sizes().at( 1 ) == 0 );
+  } );
+
+
   QgsSettings settings;
   splitter->restoreState( settings.value( QStringLiteral( "Windows/QgsExpressionBuilderWidget/splitter" ) ).toByteArray() );
   editorSplit->restoreState( settings.value( QStringLiteral( "Windows/QgsExpressionBuilderWidget/editorsplitter" ) ).toByteArray() );
@@ -227,7 +240,9 @@ void QgsExpressionBuilderWidget::currentChanged( const QModelIndex &index, const
     mValuesModel->setStringList( values );
   }
 
-  mValueGroupBox->setVisible( item->getItemType() == QgsExpressionItem::Field && mLayer );
+  bool isField = mLayer && item->getItemType() == QgsExpressionItem::Field;
+  mValueGroupBox->setVisible( isField );
+  mShowHelpButton->setText( isField ? tr( "Show Values" ) : tr( "Show Help" ) );
 
   // Show the help for the current item.
   QString help = loadFunctionHelp( item );
@@ -1092,7 +1107,7 @@ void QgsExpressionBuilderWidget::indicatorClicked( int line, int index, Qt::Keyb
   if ( state & Qt::ControlModifier )
   {
     int position = txtExpressionString->positionFromLineIndex( line, index );
-    long fncIndex = txtExpressionString->SendScintilla( QsciScintilla::SCI_INDICATORVALUEAT, FUNCTION_MARKER_ID, ( long int )position );
+    long fncIndex = txtExpressionString->SendScintilla( QsciScintilla::SCI_INDICATORVALUEAT, FUNCTION_MARKER_ID, static_cast<long int>( position ) );
     QgsExpressionFunction *func = QgsExpression::Functions()[fncIndex];
     QString help = getFunctionHelp( func );
     txtHelpText->setText( help );

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -488,6 +488,20 @@
                  </attribute>
                 </widget>
                </item>
+              </layout>
+             </widget>
+             <widget class="QWidget" name="layoutWidget2">
+              <layout class="QVBoxLayout" name="verticalLayout_2">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QTextEdit" name="txtHelpText">
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
                <item>
                 <widget class="QFrame" name="mValueGroupBox">
                  <layout class="QGridLayout" name="gridLayout_5">
@@ -495,7 +509,7 @@
                    <number>0</number>
                   </property>
                   <property name="topMargin">
-                   <number>0</number>
+                   <number>10</number>
                   </property>
                   <property name="rightMargin">
                    <number>0</number>
@@ -503,24 +517,6 @@
                   <property name="bottomMargin">
                    <number>0</number>
                   </property>
-                  <item row="4" column="0">
-                   <widget class="QWidget" name="mLoadGroupBox" native="true">
-                    <layout class="QHBoxLayout" name="horizontalLayout">
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                    </layout>
-                   </widget>
-                  </item>
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_4">
                     <property name="sizePolicy">
@@ -570,17 +566,6 @@
                    </layout>
                   </item>
                  </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-             <widget class="QWidget" name="layoutWidget2">
-              <layout class="QVBoxLayout" name="verticalLayout_2">
-               <item>
-                <widget class="QTextEdit" name="txtHelpText">
-                 <property name="readOnly">
-                  <bool>true</bool>
-                 </property>
                 </widget>
                </item>
               </layout>
@@ -838,6 +823,36 @@ Saved scripts are auto loaded on QGIS startup.</string>
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -447,7 +447,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QFrame" name="moperationListGroup">
+         <widget class="QFrame" name="mOperationListGroup">
           <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="0">
             <widget class="QSplitter" name="functionsplit">
@@ -455,15 +455,22 @@
               <enum>Qt::Horizontal</enum>
              </property>
              <widget class="QWidget" name="layoutWidget1">
-              <layout class="QVBoxLayout" name="verticalLayout_4">
-               <item>
+              <layout class="QGridLayout" name="gridLayout_9">
+               <item row="0" column="0">
                 <widget class="QgsFilterLineEdit" name="txtSearchEdit">
                  <property name="enabled">
                   <bool>true</bool>
                  </property>
                 </widget>
                </item>
-               <item>
+               <item row="0" column="1">
+                <widget class="QPushButton" name="mShowHelpButton">
+                 <property name="text">
+                  <string>Show Help</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="0" colspan="2">
                 <widget class="QTreeView" name="expressionTree">
                  <property name="frameShape">
                   <enum>QFrame::StyledPanel</enum>
@@ -490,7 +497,13 @@
                </item>
               </layout>
              </widget>
-             <widget class="QWidget" name="layoutWidget2">
+             <widget class="QWidget" name="mHelpAndValuesWidget" native="true">
+              <property name="minimumSize">
+               <size>
+                <width>250</width>
+                <height>0</height>
+               </size>
+              </property>
               <layout class="QVBoxLayout" name="verticalLayout_2">
                <property name="spacing">
                 <number>0</number>
@@ -823,36 +836,6 @@ Saved scripts are auto loaded on QGIS startup.</string>
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
otherwise the value group box might might be on top of the item
fix #17727

Other approaches I consider, which I did not like:
* using a single shot to display the value box 500ms later
* scroll to move the row to the top of the tree


![image](https://user-images.githubusercontent.com/127259/47292595-7a376080-d5d5-11e8-8790-a397c640da10.png)
