### PR TITLE
[Bugfix] offline editing with gpkg

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -636,7 +636,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       char **options = nullptr;
 
       options = CSLSetNameValue( options, "OVERWRITE", "YES" );
-      options = CSLSetNameValue( options, "IDENTIFIER", layer->name().toUtf8().constData() );
+      options = CSLSetNameValue( options, "IDENTIFIER", tr( "%1 (offline)" ).arg( layer->name() ).toUtf8().constData() );
       options = CSLSetNameValue( options, "DESCRIPTION", layer->dataComment().toUtf8().constData() );
 #if 0
       options = CSLSetNameValue( options, "FID", featureId.toUtf8().constData() );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -750,12 +750,9 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       // fill gap in QgsAttributeMap if geometry column is not last (WORKAROUND)
       QgsAttributes attrs = f.attributes();
       int column = 0;
-      int indexOfFid = layer->dataProvider()->fields().lookupField( "fid" );
-      if ( containerType == GPKG && ( indexOfFid == -1 || ( layer->dataProvider()->fields().at( indexOfFid ).type() != QVariant::Int
-                                      && layer->dataProvider()->fields().at( indexOfFid ).type() != QVariant::LongLong ) ) )
+      if ( containerType == GPKG && layer->dataProvider()->fields().lookupField( "fid" ) == -1 )
       {
-        // newAttrs (1) has an additional attribute (fid) that is (2) of the correct type
-        // so we have to add a dummy because otherwise it messes up with the amount of attributes
+        // newAttrs has an addition FID attribute, so we have to add a dummy in the original set
         column++;
       }
       QgsAttributes newAttrs( attrs.count() + column );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -748,9 +748,13 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
 
       // NOTE: SpatiaLite provider ignores position of geometry column
       // fill gap in QgsAttributeMap if geometry column is not last (WORKAROUND)
-      int column = 0;
       QgsAttributes attrs = f.attributes();
-      QgsAttributes newAttrs( attrs.count() );
+
+      int column = 0;
+      //newAttrs have an additional attribute (fid), so we have to add a dummy
+      if ( containerType == GPKG && layer->dataProvider()->fields().lookupField( "fid" ) >= 0 )
+        column++;
+      QgsAttributes newAttrs( attrs.count() + column );
       for ( int it = 0; it < attrs.count(); ++it )
       {
         newAttrs[column++] = attrs.at( it );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -638,9 +638,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       options = CSLSetNameValue( options, "OVERWRITE", "YES" );
       options = CSLSetNameValue( options, "IDENTIFIER", tr( "%1 (offline)" ).arg( layer->name() ).toUtf8().constData() );
       options = CSLSetNameValue( options, "DESCRIPTION", layer->dataComment().toUtf8().constData() );
-#if 0
-      options = CSLSetNameValue( options, "FID", featureId.toUtf8().constData() );
-#endif
+      options = CSLSetNameValue( options, "FID", "gpkg_id" );
 
       if ( layer->isSpatial() )
       {
@@ -750,7 +748,7 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       // fill gap in QgsAttributeMap if geometry column is not last (WORKAROUND)
       QgsAttributes attrs = f.attributes();
       int column = 0;
-      if ( containerType == GPKG && layer->dataProvider()->fields().lookupField( "fid" ) == -1 )
+      if ( containerType == GPKG && layer->dataProvider()->fields().lookupField( "gpkg_fid" ) == -1 )
       {
         // newAttrs has an addition FID attribute, so we have to add a dummy in the original set
         column++;

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -749,11 +749,15 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       // NOTE: SpatiaLite provider ignores position of geometry column
       // fill gap in QgsAttributeMap if geometry column is not last (WORKAROUND)
       QgsAttributes attrs = f.attributes();
-
       int column = 0;
-      //newAttrs have an additional attribute (fid), so we have to add a dummy
-      if ( containerType == GPKG && layer->dataProvider()->fields().lookupField( "fid" ) >= 0 )
+      int indexOfFid = layer->dataProvider()->fields().lookupField( "fid" );
+      if ( containerType == GPKG && ( indexOfFid == -1 || ( layer->dataProvider()->fields().at( indexOfFid ).type() != QVariant::Int
+                                      && layer->dataProvider()->fields().at( indexOfFid ).type() != QVariant::LongLong ) ) )
+      {
+        // newAttrs (1) has an additional attribute (fid) that is (2) of the correct type
+        // so we have to add a dummy because otherwise it messes up with the amount of attributes
         column++;
+      }
       QgsAttributes newAttrs( attrs.count() + column );
       for ( int it = 0; it < attrs.count(); ++it )
       {

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -45,6 +45,8 @@
 #include <QFile>
 #include <QMessageBox>
 
+#include <ogr_srs_api.h>
+
 extern "C"
 {
 #include <sqlite3.h>
@@ -630,18 +632,80 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
     }
     case GPKG:
     {
-      QgsVectorFileWriter::SaveVectorOptions options;
-      options.driverName = QStringLiteral( "GPKG" );
-      options.layerName = tableName;
-      options.actionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
-      options.onlySelectedFeatures = onlySelected;
+      // Set options
+      char **options = nullptr;
 
-      QString error;
-      if ( QgsVectorFileWriter::writeAsVectorFormat( layer, offlineDbPath, options, &error ) != QgsVectorFileWriter::NoError )
+      options = CSLSetNameValue( options, "OVERWRITE", "YES" );
+      options = CSLSetNameValue( options, "IDENTIFIER", layer->name().toUtf8().constData() );
+      options = CSLSetNameValue( options, "DESCRIPTION", layer->dataComment().toUtf8().constData() );
+#if 0
+      options = CSLSetNameValue( options, "FID", featureId.toUtf8().constData() );
+#endif
+
+      if ( layer->isSpatial() )
       {
-        showWarning( tr( "Packaging layer %1 failed: %2" ).arg( layer->name(), error ) );
+        options = CSLSetNameValue( options, "GEOMETRY_COLUMN", "geom" );
+        options = CSLSetNameValue( options, "SPATIAL_INDEX", "YES" );
+      }
+
+      OGRSFDriverH hDriver = nullptr;
+      OGRSpatialReferenceH hSRS = OSRNewSpatialReference( layer->crs().toWkt().toLocal8Bit().data() );
+      gdal::ogr_datasource_unique_ptr hDS( OGROpen( offlineDbPath.toUtf8().constData(), true, &hDriver ) );
+      OGRLayerH hLayer = OGR_DS_CreateLayer( hDS.get(), tableName.toUtf8().constData(), hSRS, static_cast<OGRwkbGeometryType>( layer->wkbType() ), options );
+      CSLDestroy( options );
+      if ( hSRS )
+        OSRRelease( hSRS );
+      if ( !hLayer )
+      {
+        showWarning( tr( "Creation of layer failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
         return nullptr;
       }
+
+      const QgsFields providerFields = layer->dataProvider()->fields();
+      for ( const auto &field : providerFields )
+      {
+        const QString fieldName( field.name() );
+        const QVariant::Type type = field.type();
+        OGRFieldType ogrType( OFTString );
+        if ( type == QVariant::Int )
+          ogrType = OFTInteger;
+        else if ( type == QVariant::LongLong )
+          ogrType = OFTInteger64;
+        else if ( type == QVariant::Double )
+          ogrType = OFTReal;
+        else if ( type == QVariant::Time )
+          ogrType = OFTTime;
+        else if ( type == QVariant::Date )
+          ogrType = OFTDate;
+        else if ( type == QVariant::DateTime )
+          ogrType = OFTDateTime;
+        else
+          ogrType = OFTString;
+
+        int ogrWidth = field.length();
+
+        gdal::ogr_field_def_unique_ptr fld( OGR_Fld_Create( fieldName.toUtf8().constData(), ogrType ) );
+        OGR_Fld_SetWidth( fld.get(), ogrWidth );
+
+        if ( OGR_L_CreateField( hLayer, fld.get(), true ) != OGRERR_NONE )
+        {
+          showWarning( tr( "Creation of field %1 failed (OGR error: %2)" )
+                       .arg( fieldName, QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+          return nullptr;
+        }
+      }
+
+      // In GDAL >= 2.0, the driver implements a deferred creation strategy, so
+      // issue a command that will force table creation
+      CPLErrorReset();
+      OGR_L_ResetReading( hLayer );
+      if ( CPLGetLastErrorType() != CE_None )
+      {
+        QString msg( tr( "Creation of layer failed (OGR error: %1)" ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ) );
+        showWarning( msg );
+        return nullptr;
+      }
+      hDS.reset();
 
       QString uri = QStringLiteral( "%1|layername=%2" ).arg( offlineDbPath,  tableName );
       newLayer = new QgsVectorLayer( uri, layer->name() + " (offline)", QStringLiteral( "ogr" ) );

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -125,6 +125,7 @@ void TestQgsOfflineEditing::createGeopackageAndSynchronizeBack()
   QCOMPARE( mpLayer->featureCount(), numberOfFeatures );
   QCOMPARE( mpLayer->fields().size(), numberOfFields );
 
+  connect( mOfflineEditing, &QgsOfflineEditing::warning, this, []( const QString & title, const QString & message ) { qDebug() << title << message; } );
   //convert
   mOfflineEditing->convertToOfflineProject( offlineDataPath, offlineDbFile, layerIds, false, QgsOfflineEditing::GPKG );
 


### PR DESCRIPTION
Replaces the PR #7909 

> Up to now, all features were written twice, once with QgsVectorFileWriter, once via addFeature in a subsequent loop. Now it is only done once in a loop, because the loop needs to be done anyway to create the lookup table

Because on GPKG an OGR FID is created, the number of attributes is not the same.

This Problem is fixed, since I checked if it's using an existing column as OGR FID and if not, then we had to create a "dummy" attribute, that the number of attributes is correct on adding feature. 

BUT I integrated another logic in the end as well: Avoid using an existing column as OGR FID. Why? Because it's fault prone to take a column called "fid" as the OGR FID, because how should the user know, that "fid" is the magical name for OGR FID? 
If we need that, I would suggest to define the column used as FID in the plugin GUI. But if it's not needed yet, we can keep that in mind and have now a solid version available. What do you think @m-kuhn?
