### PR TITLE
Do not delete the clear action (and don't crash)

### DIFF
--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -201,7 +201,10 @@ QgsSnappingWidget::QgsSnappingWidget( QgsProject *project, QgsMapCanvas *canvas,
   mTracingOffsetSpinBox->setRange( -1000000, 1000000 );
   mTracingOffsetSpinBox->setDecimals( 6 );
   mTracingOffsetSpinBox->setClearValue( 0 );
-  mTracingOffsetSpinBox->setClearValueMode( QgsDoubleSpinBox::CustomValue );
+  mTracingOffsetSpinBox->setClearValueMode( QgsDoubleSpinBox::ClearValueMode::CustomValue );
+  // Note: set to false to "fix" a crash
+  // See https://github.com/qgis/QGIS/pull/8266 for some more context
+  mTracingOffsetSpinBox->setShowClearButton( false );
   QMenu *tracingMenu = new QMenu( this );
   QWidgetAction *widgetAction = new QWidgetAction( tracingMenu );
   QVBoxLayout *tracingWidgetLayout = new QVBoxLayout;

--- a/src/gui/qgsfilterlineedit.cpp
+++ b/src/gui/qgsfilterlineedit.cpp
@@ -37,6 +37,7 @@ QgsFilterLineEdit::QgsFilterLineEdit( QWidget *parent, const QString &nullValue 
 
   connect( this, &QLineEdit::textChanged, this,
            &QgsFilterLineEdit::onTextChanged );
+
 }
 
 void QgsFilterLineEdit::setShowClearButton( bool visible )
@@ -71,17 +72,8 @@ void QgsFilterLineEdit::updateClearIcon()
     addAction( mClearAction, QLineEdit::TrailingPosition );
     connect( mClearAction, &QAction::triggered, this, &QgsFilterLineEdit::clearValue );
   }
-  else if ( !showClear && mClearAction )
-  {
-    // pretty freakin weird... seems the deleteLater call on the mClearAction
-    // isn't sufficient to actually remove the action from the line edit, and
-    // a kind of "ghost" action gets left behind... resulting in duplicate
-    // clear actions appearing if later we re-create the action.
-    // in summary: don't remove this "removeAction" call!
-    removeAction( mClearAction );
-    mClearAction->deleteLater();
-    mClearAction = nullptr;
-  }
+  if ( mClearAction )
+    mClearAction->setVisible( showClear );
 }
 
 void QgsFilterLineEdit::focusInEvent( QFocusEvent *e )

--- a/src/gui/qgsfilterlineedit.cpp
+++ b/src/gui/qgsfilterlineedit.cpp
@@ -37,7 +37,6 @@ QgsFilterLineEdit::QgsFilterLineEdit( QWidget *parent, const QString &nullValue 
 
   connect( this, &QLineEdit::textChanged, this,
            &QgsFilterLineEdit::onTextChanged );
-
 }
 
 void QgsFilterLineEdit::setShowClearButton( bool visible )
@@ -72,8 +71,17 @@ void QgsFilterLineEdit::updateClearIcon()
     addAction( mClearAction, QLineEdit::TrailingPosition );
     connect( mClearAction, &QAction::triggered, this, &QgsFilterLineEdit::clearValue );
   }
-  if ( mClearAction )
-    mClearAction->setVisible( showClear );
+  else if ( !showClear && mClearAction )
+  {
+    // pretty freakin weird... seems the deleteLater call on the mClearAction
+    // isn't sufficient to actually remove the action from the line edit, and
+    // a kind of "ghost" action gets left behind... resulting in duplicate
+    // clear actions appearing if later we re-create the action.
+    // in summary: don't remove this "removeAction" call!
+    removeAction( mClearAction );
+    mClearAction->deleteLater();
+    mClearAction = nullptr;
+  }
 }
 
 void QgsFilterLineEdit::focusInEvent( QFocusEvent *e )


### PR DESCRIPTION
Fix #20180 - Tracing with Offset produces QGIS Crash

The crash was deep inside Qt and I couldn't really debug it,
the solution I'm proposing looks way too easy, but
apparently it just works.
