### PR TITLE
Disable ok button when a primary key cannot be selected

### DIFF
--- a/src/gui/qgsnewauxiliarylayerdialog.cpp
+++ b/src/gui/qgsnewauxiliarylayerdialog.cpp
@@ -20,6 +20,7 @@
 #include "qgsauxiliarystorage.h"
 
 #include <QMessageBox>
+#include <QPushButton>
 
 QgsNewAuxiliaryLayerDialog::QgsNewAuxiliaryLayerDialog( QgsVectorLayer *layer, QWidget *parent )
   : QDialog( parent )
@@ -30,6 +31,11 @@ QgsNewAuxiliaryLayerDialog::QgsNewAuxiliaryLayerDialog( QgsVectorLayer *layer, Q
   const QgsFields fields = mLayer->fields();
   for ( const QgsField &field : fields )
     comboBox->addItem( field.name() );
+
+  if ( fields.isEmpty() )
+  {
+    buttonBox->button( QDialogButtonBox::Ok )->setDisabled( true );
+  }
 }
 
 void QgsNewAuxiliaryLayerDialog::accept()


### PR DESCRIPTION
## Description

We should not be able to click on `OK` when a primary key cannot be selected to create an auxiliary layer.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
