### PR TITLE
Fix map tool when auxiliary layer creation is canceled

### DIFF
--- a/src/app/qgsmaptoolchangelabelproperties.cpp
+++ b/src/app/qgsmaptoolchangelabelproperties.cpp
@@ -71,6 +71,12 @@ void QgsMapToolChangeLabelProperties::canvasPressEvent( QgsMapMouseEvent *e )
     QgsPalIndexes indexes;
     bool newAuxiliaryLayer = createAuxiliaryFields( indexes );
 
+    if ( !newAuxiliaryLayer && !mCurrentLabel.layer->auxiliaryLayer() )
+    {
+      deleteRubberBands();
+      return;
+    }
+
     // in case of a new auxiliary layer, a dialog window is displayed and the
     // canvas release event is lost.
     if ( newAuxiliaryLayer )

--- a/src/app/qgsmaptoolmovelabel.cpp
+++ b/src/app/qgsmaptoolmovelabel.cpp
@@ -57,11 +57,14 @@ void QgsMapToolMoveLabel::canvasPressEvent( QgsMapMouseEvent *e )
 
   int xCol = -1, yCol = -1;
 
-  if ( !mCurrentLabel.pos.isDiagram &&  !labelMoveable( vlayer, mCurrentLabel.settings, xCol, yCol ) )
+  if ( !mCurrentLabel.pos.isDiagram && !labelMoveable( vlayer, mCurrentLabel.settings, xCol, yCol ) )
   {
     QgsPalIndexes indexes;
 
     if ( createAuxiliaryFields( indexes ) )
+      return;
+
+    if ( !labelMoveable( vlayer, mCurrentLabel.settings, xCol, yCol ) )
       return;
 
     xCol = indexes[ QgsPalLayerSettings::PositionX ];
@@ -72,6 +75,9 @@ void QgsMapToolMoveLabel::canvasPressEvent( QgsMapMouseEvent *e )
     QgsDiagramIndexes indexes;
 
     if ( createAuxiliaryFields( indexes ) )
+      return;
+
+    if ( !diagramMoveable( vlayer, xCol, yCol ) )
       return;
 
     xCol = indexes[ QgsDiagramLayerSettings::PositionX ];

--- a/src/app/qgsmaptoolrotatelabel.cpp
+++ b/src/app/qgsmaptoolrotatelabel.cpp
@@ -83,6 +83,9 @@ void QgsMapToolRotateLabel::canvasPressEvent( QgsMapMouseEvent *e )
       QgsPalIndexes indexes;
       if ( createAuxiliaryFields( indexes ) )
         return;
+
+      if ( !labelIsRotatable( mCurrentLabel.layer, mCurrentLabel.settings, rotationCol ) )
+        return;
     }
 
     if ( currentLabelDataDefinedRotation( mCurrentRotation, hasRotationValue, rotationCol, true ) )


### PR DESCRIPTION
## Description

When a label map tool (move, rotate or update properties) is used for the first time, a dialog window is displayed allowing to create the corresponding auxiliary layer. To do that, a primary key has to be selected. But if the auxiliary layer creation is canceled, then there's currently some issues depending on the map tool:
- the label rubber band is still displayed
- the feature is highlighted
 
This PR fixes these issues.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
