### PR TITLE
UX - Add NULL to expression builder buttons. Remove from tree

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -604,8 +604,6 @@ void QgsExpressionBuilderWidget::updateFunctionTree()
   QString casestring = QStringLiteral( "CASE WHEN condition THEN result END" );
   registerItem( QStringLiteral( "Conditionals" ), QStringLiteral( "CASE" ), casestring );
 
-  registerItem( QStringLiteral( "Fields and Values" ), QStringLiteral( "NULL" ), QStringLiteral( "NULL" ) );
-
   // Load the functions from the QgsExpression class
   int count = QgsExpression::functionCount();
   for ( int i = 0; i < count; i++ )

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -116,7 +116,7 @@
                 </property>
                 <property name="maximumSize">
                  <size>
-                  <width>300</width>
+                  <width>500</width>
                   <height>16777215</height>
                  </size>
                 </property>
@@ -153,6 +153,18 @@
                  </property>
                  <item>
                   <widget class="QPushButton" name="btnEqualPushButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>Equal operator</string>
                    </property>
@@ -169,6 +181,12 @@
                      <verstretch>0</verstretch>
                     </sizepolicy>
                    </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>Addition operator</string>
                    </property>
@@ -179,6 +197,12 @@
                  </item>
                  <item>
                   <widget class="QPushButton" name="btnMinusPushButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>Subtraction operator</string>
                    </property>
@@ -189,6 +213,12 @@
                  </item>
                  <item>
                   <widget class="QPushButton" name="btnDividePushButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>Division operator</string>
                    </property>
@@ -199,6 +229,12 @@
                  </item>
                  <item>
                   <widget class="QPushButton" name="btnMultiplyPushButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>Multiplication operator</string>
                    </property>
@@ -209,6 +245,12 @@
                  </item>
                  <item>
                   <widget class="QPushButton" name="btnExpButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>Power operator</string>
                    </property>
@@ -219,6 +261,12 @@
                  </item>
                  <item>
                   <widget class="QPushButton" name="btnConcatButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>String Concatenation</string>
                    </property>
@@ -241,6 +289,12 @@
                      <height>10</height>
                     </size>
                    </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>Open Bracket </string>
                    </property>
@@ -251,6 +305,12 @@
                  </item>
                  <item>
                   <widget class="QPushButton" name="btnCloseBracketPushButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>Close Bracket </string>
                    </property>
@@ -261,11 +321,33 @@
                  </item>
                  <item>
                   <widget class="QPushButton" name="btnNewLinePushButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
                    <property name="toolTip">
                     <string>New Line</string>
                    </property>
                    <property name="text">
                     <string>'\n'</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnNullValuePushButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Add null value</string>
+                   </property>
+                   <property name="text">
+                    <string>NULL</string>
                    </property>
                   </widget>
                  </item>


### PR DESCRIPTION
Removes the NULL value from the expression tree as it was confusing and readds it as a button above the editor.