### PR TITLE
Fix crash when changing application font/font size on Qt >= 5.11

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2403,6 +2403,14 @@ void QgisApp::createActionGroups()
 
 void QgisApp::setAppStyleSheet( const QString &stylesheet )
 {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+  // avoid crash on stylesheet change -- see https://bugreports.qt.io/browse/QTBUG-69204
+  static bool sOnce = false;
+  if ( sOnce )
+    return;
+  sOnce = true;
+#endif
+
   setStyleSheet( stylesheet );
 
   // cascade styles to any current layout designers

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3019,29 +3019,28 @@ void QgisApp::createStatusBar()
   mTaskManagerWidget = new QgsTaskManagerStatusBarWidget( QgsApplication::taskManager(), mStatusBar );
   mStatusBar->addPermanentWidget( mTaskManagerWidget, 0 );
 
-  // Bumped the font up one point size since 8 was too
-  // small on some platforms. A point size of 9 still provides
-  // plenty of display space on 1024x768 resolutions
-  QFont myFont( QStringLiteral( "Arial" ), 9 );
-  statusBar()->setFont( myFont );
+  // Drop the font size in the status bar by a couple of points
+  QFont statusBarFont = font();
+  statusBarFont.setPointSize( statusBarFont.pointSize() - 2 );
+  statusBar()->setFont( statusBarFont );
 
   //coords status bar widget
   mCoordsEdit = new QgsStatusBarCoordinatesWidget( mStatusBar );
   mCoordsEdit->setObjectName( QStringLiteral( "mCoordsEdit" ) );
   mCoordsEdit->setMapCanvas( mMapCanvas );
-  mCoordsEdit->setFont( myFont );
+  mCoordsEdit->setFont( statusBarFont );
   mStatusBar->addPermanentWidget( mCoordsEdit, 0 );
 
   mScaleWidget = new QgsStatusBarScaleWidget( mMapCanvas, mStatusBar );
   mScaleWidget->setObjectName( QStringLiteral( "mScaleWidget" ) );
-  mScaleWidget->setFont( myFont );
+  mScaleWidget->setFont( statusBarFont );
   connect( mScaleWidget, &QgsStatusBarScaleWidget::scaleLockChanged, mMapCanvas, &QgsMapCanvas::setScaleLocked );
   mStatusBar->addPermanentWidget( mScaleWidget, 0 );
 
   // zoom widget
   mMagnifierWidget = new QgsStatusBarMagnifierWidget( mStatusBar );
   mMagnifierWidget->setObjectName( QStringLiteral( "mMagnifierWidget" ) );
-  mMagnifierWidget->setFont( myFont );
+  mMagnifierWidget->setFont( statusBarFont );
   connect( mMapCanvas, &QgsMapCanvas::magnificationChanged, mMagnifierWidget, &QgsStatusBarMagnifierWidget::updateMagnification );
   connect( mMagnifierWidget, &QgsStatusBarMagnifierWidget::magnificationChanged, mMapCanvas, &QgsMapCanvas::setMagnificationFactor );
   mMagnifierWidget->updateMagnification( QSettings().value( QStringLiteral( "/qgis/magnifier_factor_default" ), 1.0 ).toDouble() );
@@ -3050,7 +3049,7 @@ void QgisApp::createStatusBar()
   // add a widget to show/set current rotation
   mRotationLabel = new QLabel( QString(), mStatusBar );
   mRotationLabel->setObjectName( QStringLiteral( "mRotationLabel" ) );
-  mRotationLabel->setFont( myFont );
+  mRotationLabel->setFont( statusBarFont );
   mRotationLabel->setMinimumWidth( 10 );
   //mRotationLabel->setMaximumHeight( 20 );
   mRotationLabel->setMargin( 3 );
@@ -3069,7 +3068,7 @@ void QgisApp::createStatusBar()
   mRotationEdit->setRange( -360.0, 360.0 );
   mRotationEdit->setWrapping( true );
   mRotationEdit->setSingleStep( 5.0 );
-  mRotationEdit->setFont( myFont );
+  mRotationEdit->setFont( statusBarFont );
   mRotationEdit->setSuffix( tr( " °" ) );
   mRotationEdit->setWhatsThis( tr( "Shows the current map clockwise rotation "
                                    "in degrees. It also allows editing to set "
@@ -3084,7 +3083,7 @@ void QgisApp::createStatusBar()
   mRenderSuppressionCBox = new QCheckBox( tr( "Render" ), mStatusBar );
   mRenderSuppressionCBox->setObjectName( QStringLiteral( "mRenderSuppressionCBox" ) );
   mRenderSuppressionCBox->setChecked( true );
-  mRenderSuppressionCBox->setFont( myFont );
+  mRenderSuppressionCBox->setFont( statusBarFont );
   mRenderSuppressionCBox->setWhatsThis( tr( "When checked, the map layers "
                                         "are rendered in response to map navigation commands and other "
                                         "events. When not checked, no rendering is done. This allows you "
@@ -3096,6 +3095,7 @@ void QgisApp::createStatusBar()
   // sculpted on OS X and the icon is never displayed [gsherman]
   mOnTheFlyProjectionStatusButton = new QToolButton( mStatusBar );
   mOnTheFlyProjectionStatusButton->setAutoRaise( true );
+  mOnTheFlyProjectionStatusButton->setFont( statusBarFont );
   mOnTheFlyProjectionStatusButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon );
   mOnTheFlyProjectionStatusButton->setObjectName( QStringLiteral( "mOntheFlyProjectionStatusButton" ) );
   // Maintain uniform widget height in status bar by setting button height same as labels

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -222,63 +222,21 @@ void QgisAppStyleSheet::setActiveValues()
   mStyle = qApp->style()->objectName(); // active style name (lowercase)
   QgsDebugMsg( QStringLiteral( "Style name: %1" ).arg( mStyle ) );
 
-  mMotifStyle = mStyle.contains( QLatin1String( "motif" ) ); // motif
-  mCdeStyle = mStyle.contains( QLatin1String( "cde" ) ); // cde
-  mPlastqStyle = mStyle.contains( QLatin1String( "plastique" ) ); // plastique
-  mCleanLkStyle = mStyle.contains( QLatin1String( "cleanlooks" ) ); // cleanlooks
-  mGtkStyle = mStyle.contains( QLatin1String( "gtk" ) ); // gtk+
-  mWinStyle = mStyle.contains( QLatin1String( "windows" ) ); // windows
-  mWinXpStyle = mStyle.contains( QLatin1String( "windowsxp" ) ); // windowsxp
-  mWinVistaStyle = mStyle.contains( QLatin1String( "windowsvista" ) ); // windowsvista
   mMacStyle = mStyle.contains( QLatin1String( "macintosh" ) ); // macintosh (aqua)
   mOxyStyle = mStyle.contains( QLatin1String( "oxygen" ) ); // oxygen
 
   mDefaultFont = qApp->font(); // save before it is changed in any way
 
   // platforms, specific
-#ifdef Q_OS_LINUX
-  mLinuxOS = true;
-#else
-  mLinuxOS = false;
-#endif
 #ifdef Q_OS_WIN
   mWinOS = true;
 #else
   mWinOS = false;
 #endif
-#ifdef Q_OS_MAC
-  mMacOS = true;
-#else
-  mMacOS = false;
-#endif
 #ifdef ANDROID
   mAndroidOS = true;
 #else
   mAndroidOS = false;
-#endif
-
-  // platforms, general
-#ifdef Q_OS_UNIX
-  mUnix = true;
-#else
-  mUnix = false;
-#endif
-
-  // window servers
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
-  mX11WS = true;
-#else
-  mX11WS = false;
-#endif
-#ifdef Q_OS_WIN
-  mWinWS = true;
-#else
-  mWinWS = false;
-#endif
-#ifdef Q_OS_MAC
-  mMacWS = true;
-#else
-  mMacWS = false;
 #endif
 
 }

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -68,13 +68,12 @@ QMap<QString, QVariant> QgisAppStyleSheet::defaultOptions()
   // make sure family exists on system
   if ( fontFamily != mDefaultFont.family() )
   {
-    QFont *tempFont = new QFont( fontFamily );
-    if ( tempFont->family() != fontFamily )
+    QFont tempFont( fontFamily );
+    if ( tempFont.family() != fontFamily )
     {
       // missing from system, drop back to default
       fontFamily = mDefaultFont.family();
     }
-    delete tempFont;
   }
   QgsDebugMsg( QStringLiteral( "fontFamily: %1" ).arg( fontFamily ) );
   opts.insert( QStringLiteral( "fontFamily" ), QVariant( fontFamily ) );

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -103,7 +103,10 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
   QgsDebugMsg( QStringLiteral( "fontFamily: %1" ).arg( fontFamily ) );
   if ( fontFamily.isEmpty() ) { return; }
 
-  ss += QStringLiteral( "* { font: %1pt \"%2\"} " ).arg( fontSize, fontFamily );
+  const QString defaultSize = QString::number( mDefaultFont.pointSize() );
+  const QString defaultFamily = mDefaultFont.family();
+  if ( fontSize != defaultSize || fontFamily != defaultFamily )
+    ss += QStringLiteral( "* { font: %1pt \"%2\"} " ).arg( fontSize, fontFamily );
 
 #if QT_VERSION >= 0x050900
   // Fix for macOS Qt 5.9+, where close boxes do not show on document mode tab bar tabs

--- a/src/app/qgisappstylesheet.h
+++ b/src/app/qgisappstylesheet.h
@@ -64,33 +64,15 @@ class APP_EXPORT QgisAppStyleSheet: public QObject
 
     // qt styles
     QString mStyle; // active style name (lowercase)
-    bool mMotifStyle; // motif
-    bool mCdeStyle; // cde
-    bool mPlastqStyle; // plastique
-    bool mCleanLkStyle; // cleanlooks
-    bool mGtkStyle; // gtk+
-    bool mWinStyle; // windows
-    bool mWinXpStyle; // windowsxp
-    bool mWinVistaStyle; // windowsvista
-    bool mMacStyle; // macintosh (aqua)
-    bool mOxyStyle; // oxygen
+    bool mMacStyle = false; // macintosh (aqua)
+    bool mOxyStyle = false; // oxygen
 
     // default font saved for reference
     QFont mDefaultFont;
 
     // platforms, specific
-    bool mLinuxOS;
-    bool mWinOS;
-    bool mMacOS;
-    bool mAndroidOS;
-
-    // platforms, general
-    bool mUnix;
-
-    // window servers
-    bool mX11WS;
-    bool mWinWS;
-    bool mMacWS;
+    bool mWinOS = false;
+    bool mAndroidOS = false;
 };
 
 #endif //QGISAPPSTYLESHEET_H

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -62,6 +62,12 @@ void QgsDoubleSpinBox::setExpressionsEnabled( const bool enabled )
 void QgsDoubleSpinBox::changeEvent( QEvent *event )
 {
   QDoubleSpinBox::changeEvent( event );
+
+  if ( event->type() == QEvent::FontChange )
+  {
+    lineEdit()->setFont( font() );
+  }
+
   mLineEdit->setShowClearButton( shouldShowClearForValue( value() ) );
 }
 

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -60,6 +60,12 @@ void QgsSpinBox::setExpressionsEnabled( const bool enabled )
 void QgsSpinBox::changeEvent( QEvent *event )
 {
   QSpinBox::changeEvent( event );
+
+  if ( event->type() == QEvent::FontChange )
+  {
+    lineEdit()->setFont( font() );
+  }
+
   mLineEdit->setShowClearButton( shouldShowClearForValue( value() ) );
 }
 

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -42,7 +42,7 @@ QgsLocatorWidget::QgsLocatorWidget( QWidget *parent )
 #endif
 
   int placeholderMinWidth = mLineEdit->fontMetrics().width( mLineEdit->placeholderText() );
-  int minWidth = std::max( 200, ( int )( placeholderMinWidth * 1.6 ) );
+  int minWidth = std::max( 200, static_cast< int >( placeholderMinWidth * 1.8 ) );
   resize( minWidth, 30 );
   QSizePolicy sizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Preferred );
   sizePolicy.setHorizontalStretch( 0 );


### PR DESCRIPTION
https://bugreports.qt.io/browse/QTBUG-69204 causes a segfault
in Qt >= 5.11 if we change the stylesheet on the fly.

Workaround this by only setting the stylesheet once at startup,
and require a restart if settings change which modify the
stylesheet.

Just a workaround -- the upstream bug is being looked at,
but better to require a restart than crash.