### PR TITLE
Move the "Link class boundaries" option next to class definition

### DIFF
--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -325,7 +325,7 @@ Negative rounds to powers of 10</string>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
+             <width>0</width>
              <height>20</height>
             </size>
            </property>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -360,6 +360,16 @@ Negative rounds to powers of 10</string>
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="cbxLinkBoundaries">
+           <property name="text">
+            <string>Link class boundaries</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>
@@ -470,20 +480,6 @@ Negative rounds to powers of 10</string>
          </item>
         </layout>
        </item>
-       <item>
-        <layout class="QHBoxLayout" name="_2">
-         <item>
-          <widget class="QCheckBox" name="cbxLinkBoundaries">
-           <property name="text">
-            <string>Link class boundaries</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="tab_2">
@@ -552,12 +548,12 @@ Negative rounds to powers of 10</string>
   <tabstop>viewGraduated</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
   <tabstop>spinGraduatedClasses</tabstop>
+  <tabstop>cbxLinkBoundaries</tabstop>
   <tabstop>btnGraduatedClassify</tabstop>
   <tabstop>btnGraduatedAdd</tabstop>
   <tabstop>btnGraduatedDelete</tabstop>
   <tabstop>btnDeleteAllClasses</tabstop>
   <tabstop>btnAdvanced</tabstop>
-  <tabstop>cbxLinkBoundaries</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
Current
![linkboundaries-old](https://user-images.githubusercontent.com/7983394/47371462-20738b00-d6e8-11e8-8455-bb1655c52c82.png)

Proposed ![linkboundaries-new](https://user-images.githubusercontent.com/7983394/47371459-20738b00-d6e8-11e8-801f-28849b257823.png)