### PR TITLE
[needs-docs] Save layer as CSV: add STRING_QUOTING option to the predefined drop-down widgets

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -843,6 +843,17 @@ class QgsVectorFileWriterMetadataContainer
                              QStringLiteral( "COMMA" ) // Default value
                            ) );
 
+#if defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,3,0)
+      layerOptions.insert( QStringLiteral( "STRING_QUOTING" ), new QgsVectorFileWriter::SetOption(
+                             QObject::tr( "Double-quote strings. IF_AMBIGUOUS means that string values that look like numbers will be quoted." ),
+                             QStringList()
+                             << QStringLiteral( "IF_AMBIGUOUS" )
+                             << QStringLiteral( "IF_NEEDED" )
+                             << QStringLiteral( "ALWAYS" ),
+                             QStringLiteral( "IF_AMBIGUOUS" ) // Default value
+                           ) );
+#endif
+
       layerOptions.insert( QStringLiteral( "WRITE_BOM" ), new QgsVectorFileWriter::BoolOption(
                              QObject::tr( "Write a UTF-8 Byte Order Mark (BOM) at the start of the file." ),
                              false  // Default value

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -847,8 +847,8 @@ class QgsVectorFileWriterMetadataContainer
       layerOptions.insert( QStringLiteral( "STRING_QUOTING" ), new QgsVectorFileWriter::SetOption(
                              QObject::tr( "Double-quote strings. IF_AMBIGUOUS means that string values that look like numbers will be quoted." ),
                              QStringList()
-                             << QStringLiteral( "IF_AMBIGUOUS" )
                              << QStringLiteral( "IF_NEEDED" )
+                             << QStringLiteral( "IF_AMBIGUOUS" )
                              << QStringLiteral( "ALWAYS" ),
                              QStringLiteral( "IF_AMBIGUOUS" ) // Default value
                            ) );


### PR DESCRIPTION
From GDAL 2.3, the default STRING_QUOTING for CSV files is IF_AMBIGUOUS, what makes  integer values double-quoted. This PR adds a predefined combobox for this create option. Note it's only available for GDAL >= 2.3. For more information see https://www.gdal.org/drv_csv.html

![zrzut_20181023_182412](https://user-images.githubusercontent.com/1000043/47376024-ec04cc80-d6f1-11e8-9973-c26ec6882b1a.png)

![zrzut_20181023_182503](https://user-images.githubusercontent.com/1000043/47376030-eeffbd00-d6f1-11e8-84c0-cd6a1b693116.png)

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
