### PR TITLE
Better visibility status for symmetric subwidgets depending on the mode applied

### DIFF
--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -527,6 +527,12 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   // default to collapsed symmetric group for ui simplicity
   mGroupBoxSymmetric->setCollapsed( true ); //
 
+  //ensure mutually exclusive visibility for symmetric group sub items
+  bool isVisibleCboSymmetryPointForPretty = ( cboGraduatedMode->currentData() == QgsGraduatedSymbolRenderer::Pretty );
+
+  cboSymmetryPointForPretty->setVisible( isVisibleCboSymmetryPointForPretty );
+  spinSymmetryPointForOtherMethods->setVisible( !isVisibleCboSymmetryPointForPretty );
+
   // menus for data-defined rotation/size
   QMenu *advMenu = new QMenu( this );
 

--- a/src/ui/qgsgraduatedsymbolrendererwidget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererwidget.ui
@@ -81,7 +81,7 @@
      <item>
       <widget class="QLineEdit" name="txtLegendFormat">
        <property name="toolTip">
-        <string>Template for the legend text associated with each classification.  
+        <string>Template for the legend text associated with each classification.
 Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot; for the upper bound.</string>
        </property>
        <property name="alignment">
@@ -390,14 +390,14 @@ Negative rounds to powers of 10</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
+          <item row="0" column="0" rowspan="2">
            <widget class="QLabel" name="label_2">
             <property name="text">
              <string>Around</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="0" colspan="2">
+          <item row="1" column="1">
            <widget class="QComboBox" name="cboSymmetryPointForPretty"/>
           </item>
           <item row="2" column="0" colspan="2">


### PR DESCRIPTION
Also ensure vertical alignment
I don't know if that solves the whole issue (alignment should be done, I hope) but the idea is to avoid situations like below where both combobox and spinbox are shown instead of being mutually exclusive

![symmetric_classif](https://user-images.githubusercontent.com/7983394/47379101-43a73600-d6fa-11e8-8e98-253dec18b4a2.png)

Any guidance is welcome (or if pushing your changes directly will be quicker, feel free!)