### PR TITLE
Fix QgsProjectLayerGroupDialog with qgz project

### DIFF
--- a/src/app/qgsprojectlayergroupdialog.cpp
+++ b/src/app/qgsprojectlayergroupdialog.cpp
@@ -168,37 +168,42 @@ void QgsProjectLayerGroupDialog::changeProjectFile()
     return;
   }
 
+  std::unique_ptr<QgsProjectArchive> archive;
+
   QDomDocument projectDom;
   if ( QgsZipUtils::isZipFile( mProjectFileWidget->filePath() ) )
   {
-    QgsProjectArchive archive;
+
+    archive = qgis::make_unique<QgsProjectArchive>();
 
     // unzip the archive
-    if ( !archive.unzip( mProjectFileWidget->filePath() ) )
+    if ( !archive->unzip( mProjectFileWidget->filePath() ) )
     {
       return;
     }
 
     // test if zip provides a .qgs file
-    if ( archive.projectFile().isEmpty() )
+    if ( archive->projectFile().isEmpty() )
     {
       return;
     }
 
-    projectFile.setFileName( archive.projectFile() );
+    projectFile.setFileName( archive->projectFile() );
     if ( !projectFile.exists() )
     {
       return;
     }
   }
-
-  if ( !projectDom.setContent( &projectFile ) )
+  QString errorMesssage;
+  int errorLine;
+  if ( !projectDom.setContent( &projectFile, &errorMesssage, &errorLine ) )
   {
+    QgsDebugMsg( QStringLiteral( "Error reading the project file %1 at line %2: %3" )
+                 .arg( projectFile.fileName() )
+                 .arg( errorLine )
+                 .arg( errorMesssage ) );
     return;
   }
-
-
-
 
   mRootGroup->removeAllChildren();
 

--- a/src/app/qgsprojectlayergroupdialog.cpp
+++ b/src/app/qgsprojectlayergroupdialog.cpp
@@ -194,14 +194,14 @@ void QgsProjectLayerGroupDialog::changeProjectFile()
       return;
     }
   }
-  QString errorMesssage;
+  QString errorMessage;
   int errorLine;
-  if ( !projectDom.setContent( &projectFile, &errorMesssage, &errorLine ) )
+  if ( !projectDom.setContent( &projectFile, &errorMessage, &errorLine ) )
   {
     QgsDebugMsg( QStringLiteral( "Error reading the project file %1 at line %2: %3" )
                  .arg( projectFile.fileName() )
                  .arg( errorLine )
-                 .arg( errorMesssage ) );
+                 .arg( errorMessage ) );
     return;
   }
 


### PR DESCRIPTION
Maybe also fix #20134 - crash when trying to set exluded layer in QGIS Server WMS capabilities

I could not reproduce the crash but
QgsProjectLayerGroupDialog was broken
and it was probably the root of the
crash.
