### PR TITLE
Attribute table filter: force geometry extraction when needed

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -1116,6 +1116,11 @@ void QgsAttributeTableDialog::setFilterExpression( const QString &filterString, 
   {
     request.setFlags( QgsFeatureRequest::NoGeometry );
   }
+  else
+  {
+    // force geometry extraction if the filter requests it
+    request.setFlags( request.flags() & ~QgsFeatureRequest::NoGeometry );
+  }
   QgsFeatureIterator featIt = mLayer->getFeatures( request );
 
   QgsFeature f;


### PR DESCRIPTION
Fixes #18286

By default features are extracted without geometry when filtering. Now if a filter expression really requests a geometry (for $geometry, $area and so on), make sure to extract them when applying the filter.

