### PR TITLE
[Bugfix] Do not overwrite values in attribute form while SearchMode

### DIFF
--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -268,9 +268,13 @@ void QgsAttributeForm::setFeature( const QgsFeature &feature )
       }
       break;
     }
-    case QgsAttributeEditorContext::MultiEditMode:
     case QgsAttributeEditorContext::SearchMode:
     case QgsAttributeEditorContext::AggregateSearchMode:
+    {
+      resetValues();
+      break;
+    }
+    case QgsAttributeEditorContext::MultiEditMode:
     {
       //ignore setFeature
       break;


### PR DESCRIPTION
Because it can be in `SearchMode` during editing state, and a change of selection in the feature list did overwrite the values of the selected one by the one selected before. This because the widget-values were not reset for the current feature and are saved.

The saving is not avoided here, because on edit, and switching to `SearchMode` and changing selection, the old feature still has to be saved. But it does reset the values of the current widget in `SearchMode` after changing selection like on the other modes - even if it's not visible for the user - to avoid to have wrong values there.

fixes #17751