### PR TITLE
Fix import sip on python 3.5

### DIFF
--- a/python/PyQt/PyQt5/sip.py
+++ b/python/PyQt/PyQt5/sip.py
@@ -25,5 +25,5 @@ __revision__ = '$Format:%H$'
 
 try:
     from PyQt5.sip import *
-except ModuleNotFoundError:
+except ImportError:
     from sip import *


### PR DESCRIPTION
Followup 0fad3e5731b32680acab9a43b146c73f4e1dab6a