### PR TITLE
Check if we have a numeric value before stripping the group separator

### DIFF
--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -229,8 +229,13 @@ void QgsTextEditWrapper::setWidgetValue( const QVariant &val )
   // For numbers, remove the group separator that might cause validation errors
   // when the user is editing the field value.
   // We are checking for editable layer because in the form field context we do not
-  // want to strip the separator unless the layer is editable
-  if ( layer() && layer()->isEditable() && ! QLocale().groupSeparator().isNull() && field().isNumeric() )
+  // want to strip the separator unless the layer is editable.
+  // Also check that we have something like a number in the value to avoid
+  // stripping out dots from nextval when we have a schema: see https://issues.qgis.org/issues/20200
+  // "Wrong sequence detection with Postgres"
+  bool canConvertToDouble;
+  QLocale().toDouble( v, &canConvertToDouble );
+  if ( canConvertToDouble && layer() && layer()->isEditable() && ! QLocale().groupSeparator().isNull() && field().isNumeric() )
   {
     v = v.remove( QLocale().groupSeparator() );
   }


### PR DESCRIPTION
Fix #20200 - wrong sequence detection under postgres

This is to avoid stripping out the dot from nextval
when schema is not public and locale has a dot
decimal separator.
