### PR TITLE
Do not persist estimated metadata

### DIFF
--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -301,6 +301,8 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
 
     /** \brief sublayers list saved for subsequent access */
     QStringList mSubLayers;
+
+    bool mStatisticsAreReliable;
 };
 
 #endif


### PR DESCRIPTION
GDAL saves metadata like min and max values into a .aux.xml sidecar file next to raster files.
It does this always, even when the calculated values are estimated. In subsequent runs of GDAL processing tools
it will use these values as if they were reliable.

This patch takes care of deleting newly written .aux.xml files if there is a risk that they include estimated data.

Fix #19517 https://issues.qgis.org/issues/19517

Backport of https://github.com/qgis/QGIS/pull/8230