### PR TITLE
[WIP]fix snapping indicator when advance digitizing tools is enabled

### DIFF
--- a/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
+++ b/python/gui/auto_generated/qgsadvanceddigitizingdockwidget.sip.in
@@ -243,6 +243,10 @@ Constraint on the Y coordinate
 %Docstring
 Constraint on a common angle
 %End
+    QgsPointLocator::Match mapPointMatch() const;
+%Docstring
+SnapMatch for indicator
+%End
 
     void clearPoints();
 %Docstring

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -28,6 +28,7 @@ QgsAdvancedDigitizingCanvasItem::QgsAdvancedDigitizingCanvasItem( QgsMapCanvas *
   , mSnapPen( QPen( QColor( 127, 0, 0, 150 ), 1 ) )
   , mSnapLinePen( QPen( QColor( 127, 0, 0, 150 ), 1, Qt::DashLine ) )
   , mCursorPen( QPen( QColor( 127, 127, 127, 255 ), 1 ) )
+  , mSnapIndicator( qgis::make_unique< QgsSnapIndicator>( canvas ) )
   , mAdvancedDigitizingDockWidget( cadDockWidget )
 {
 }
@@ -236,7 +237,16 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
                        curPointPix + QPointF( +5, +5 ) );
     painter->drawLine( curPointPix + QPointF( -5, +5 ),
                        curPointPix + QPointF( +5, -5 ) );
-
   }
+
+
+  QgsPointLocator::Match match = mAdvancedDigitizingDockWidget->mapPointMatch();
+  if ( match.isValid() )
+  {
+    mSnapIndicator->setMatch( match );
+    mSnapIndicator->setVisible( true );
+  }
+  else
+    mSnapIndicator->setVisible( false );
 
 }

--- a/src/gui/qgsadvanceddigitizingcanvasitem.h
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.h
@@ -20,6 +20,7 @@
 
 #include "qgsmapcanvasitem.h"
 #include "qgis_gui.h"
+#include "qgssnapindicator.h"
 
 class QgsAdvancedDigitizingDockWidget;
 
@@ -41,6 +42,8 @@ class GUI_EXPORT QgsAdvancedDigitizingCanvasItem : public QgsMapCanvasItem
     QPen mSnapPen;
     QPen mSnapLinePen;
     QPen mCursorPen;
+    //! Snapping indicators
+    std::unique_ptr<QgsSnapIndicator> mSnapIndicator;
 
   private:
     QgsAdvancedDigitizingDockWidget *mAdvancedDigitizingDockWidget = nullptr;

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -557,6 +557,8 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   // set the point coordinates in the map event
   e->setMapPoint( point );
 
+  mSnapMatch = context.snappingUtils->snapToMap( point );
+
   // update the point list
   updateCurrentPoint( point );
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -26,6 +26,7 @@
 #include "qgsdockwidget.h"
 #include "qgsmessagebaritem.h"
 #include "qgspointxy.h"
+#include "qgspointlocator.h"
 
 
 class QgsAdvancedDigitizingCanvasItem;
@@ -255,6 +256,8 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     const CadConstraint *constraintY() const { return mYConstraint.get(); }
     //! Constraint on a common angle
     bool commonAngleConstraint() const { return !qgsDoubleNear( mCommonAngleConstraint, 0.0 ); }
+    //! SnapMatch for indicator
+    QgsPointLocator::Match mapPointMatch() const { return mSnapMatch; }
 
     /**
      * Removes all points from the CAD point list
@@ -485,6 +488,9 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     QAction *mEnableAction = nullptr;
     QMap< QAction *, double > mCommonAngleActions; // map the common angle actions with their angle values
 
+    // Snap indicator
+
+    QgsPointLocator::Match mSnapMatch;
   private:
 #ifdef SIP_RUN
     //! event filter for line edits in the dock UI (angle/distance/x/y line edits)

--- a/src/gui/qgssnapindicator.cpp
+++ b/src/gui/qgssnapindicator.cpp
@@ -30,7 +30,6 @@ QgsSnapIndicator::QgsSnapIndicator( QgsMapCanvas *canvas )
 
 QgsSnapIndicator::~QgsSnapIndicator() = default;
 
-
 void QgsSnapIndicator::setMatch( const QgsPointLocator::Match &match )
 {
   mMatch = match;
@@ -65,6 +64,7 @@ void QgsSnapIndicator::setMatch( const QgsPointLocator::Match &match )
     {
       iconType = QgsVertexMarker::ICON_DOUBLE_TRIANGLE;
     }
+
     mSnappingMarker->setIconType( iconType );
 
     mSnappingMarker->setCenter( match.point() );
@@ -83,10 +83,14 @@ void QgsSnapIndicator::setMatch( const QgsPointLocator::Match &match )
 
 void QgsSnapIndicator::setVisible( bool visible )
 {
-  mSnappingMarker->setVisible( visible );
+  if ( mSnappingMarker )
+    mSnappingMarker->setVisible( visible );
 }
 
 bool QgsSnapIndicator::isVisible() const
 {
-  return mSnappingMarker->isVisible();
+  if ( mSnappingMarker )
+    return mSnappingMarker->isVisible();
+
+  return false;
 }


### PR DESCRIPTION
## Description
Fixes #18104 and #19127

The (new style) snapping indicator is not shown when the advanced digitizing tool is enabled.

My changes in the QgsSnapIndicator class bypasses a SIGBUS Error in Qt5Widgets, but when I quit qgis, I have another one:
```
Thread 1 received signal SIGBUS, Bus error.
0x0000000802527c68 in std::__1::default_delete<QgsVertexMarker>::operator()
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
