### PR TITLE
Don't capitalize menu entries and dialog titles in languages other than English - a second attempt

### DIFF
--- a/python/gui/auto_generated/qgsgui.sip.in
+++ b/python/gui/auto_generated/qgsgui.sip.in
@@ -100,11 +100,29 @@ Sets the global window ``manager``. Ownership is transferred to the QgsGui insta
 .. versionadded:: 3.4
 %End
 
+    enum HigFlag
+    {
+      HigMenuTextIsTitleCase,
+      HigDialogTitleIsTitleCase
+    };
+    typedef QFlags<QgsGui::HigFlag> HigFlags;
+
+
+    static QgsGui::HigFlags higFlags();
+%Docstring
+Returns HIG flags. Currently indicates whether titles should be title case depending on the current locale.
+
+.. versionadded:: 3.4
+%End
+
     ~QgsGui();
 
   private:
     QgsGui( const QgsGui &other );
 };
+
+QFlags<QgsGui::HigFlag> operator|(QgsGui::HigFlag f1, QFlags<QgsGui::HigFlag> f2);
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/plugins/processing/gui/menus.py
+++ b/python/plugins/processing/gui/menus.py
@@ -33,6 +33,7 @@ from processing.gui.MessageDialog import MessageDialog
 from processing.gui.AlgorithmDialog import AlgorithmDialog
 from qgis.utils import iface
 from qgis.core import QgsApplication, QgsMessageLog, QgsStringUtils, QgsProcessingAlgorithm
+from qgis.gui import QgsGui
 from processing.gui.MessageBarProgress import MessageBarProgress
 from processing.gui.AlgorithmExecutor import execute
 from processing.gui.Postprocessing import handleAlgorithmResults
@@ -183,10 +184,10 @@ def removeMenus():
 
 def addAlgorithmEntry(alg, menuName, submenuName, actionText=None, icon=None, addButton=False):
     if actionText is None:
-        if alg.flags() & QgsProcessingAlgorithm.FlagDisplayNameIsLiteral:
-            alg_title = alg.displayName()
-        else:
+        if (QgsGui.higFlags() & QgsGui.HigMenuTextIsTitleCase) and not (alg.flags() & QgsProcessingAlgorithm.FlagDisplayNameIsLiteral):
             alg_title = QgsStringUtils.capitalize(alg.displayName(), QgsStringUtils.TitleCase)
+        else:
+            alg_title = alg.displayName()
         actionText = alg_title + QCoreApplication.translate('Processing', '…')
     action = QAction(icon or alg.icon(), actionText, iface.mainWindow())
     alg_id = alg.id()

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -123,10 +123,14 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
 {
   mAlgorithm = algorithm;
   QString title;
-  if ( algorithm->flags() & QgsProcessingAlgorithm::FlagDisplayNameIsLiteral )
-    title = mAlgorithm->displayName();
-  else
+  if ( ( QgsGui::higFlags() & QgsGui::HigDialogTitleIsTitleCase ) and !( algorithm->flags() & QgsProcessingAlgorithm::FlagDisplayNameIsLiteral ) )
+  {
     title = QgsStringUtils::capitalize( mAlgorithm->displayName(), QgsStringUtils::TitleCase );
+  }
+  else
+  {
+    title = mAlgorithm->displayName();
+  }
   setWindowTitle( title );
 
   QString algHelp = formatHelp( algorithm );

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -123,7 +123,7 @@ void QgsProcessingAlgorithmDialogBase::setAlgorithm( QgsProcessingAlgorithm *alg
 {
   mAlgorithm = algorithm;
   QString title;
-  if ( ( QgsGui::higFlags() & QgsGui::HigDialogTitleIsTitleCase ) and !( algorithm->flags() & QgsProcessingAlgorithm::FlagDisplayNameIsLiteral ) )
+  if ( ( QgsGui::higFlags() & QgsGui::HigDialogTitleIsTitleCase ) && !( algorithm->flags() & QgsProcessingAlgorithm::FlagDisplayNameIsLiteral ) )
   {
     title = QgsStringUtils::capitalize( mAlgorithm->displayName(), QgsStringUtils::TitleCase );
   }

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -42,6 +42,7 @@
 #include "qgslogger.h"
 #include "qgsprocessingrecentalgorithmlog.h"
 #include "qgswindowmanagerinterface.h"
+#include "qgssettings.h"
 
 QgsGui *QgsGui::instance()
 {
@@ -111,6 +112,19 @@ QgsWindowManagerInterface *QgsGui::windowManager()
 void QgsGui::setWindowManager( QgsWindowManagerInterface *manager )
 {
   instance()->mWindowManager.reset( manager );
+}
+
+QgsGui::HigFlags QgsGui::higFlags()
+{
+  QgsSettings settings;
+  if ( settings.value( QStringLiteral( "locale/userLocale" ), "" ).toString().startsWith( "en" ) )
+  {
+    return HigMenuTextIsTitleCase | HigDialogTitleIsTitleCase;
+  }
+  else
+  {
+    return NULL;
+  }
 }
 
 QgsGui::~QgsGui()

--- a/src/gui/qgsgui.cpp
+++ b/src/gui/qgsgui.cpp
@@ -123,7 +123,7 @@ QgsGui::HigFlags QgsGui::higFlags()
   }
   else
   {
-    return NULL;
+    return nullptr;
   }
 }
 

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -125,6 +125,23 @@ class GUI_EXPORT QgsGui
      */
     static void setWindowManager( QgsWindowManagerInterface *manager SIP_TRANSFER );
 
+    /**
+    * HIG flags. Currently indicate whether titles should be title case depending on the current locale.
+    * \since QGIS 3.4
+    */
+    enum HigFlag
+    {
+      HigMenuTextIsTitleCase = 1 << 0,       //!< Menu action texts should be title case
+      HigDialogTitleIsTitleCase = 1 << 1     //!< Dialog titles should be title case
+    };
+    Q_DECLARE_FLAGS( HigFlags, HigFlag )
+
+    /**
+    * Returns HIG flags. Currently indicates whether titles should be title case depending on the current locale.
+    * \since QGIS 3.4
+    */
+    static QgsGui::HigFlags higFlags();
+
     ~QgsGui();
 
   private:
@@ -148,5 +165,7 @@ class GUI_EXPORT QgsGui
 #endif
 
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsGui::HigFlags )
 
 #endif // QGSGUI_H


### PR DESCRIPTION
Supersedes #8269
Introduces QgsGui::HigFlags. See https://github.com/qgis/QGIS/pull/8269#issuecomment-431973695

Please note all the algorithm menu entries are saved in QSettings, thus once they got capitalized and saved, this commit won't fix them automatically. You need to run Settings -> Options -> Processing -> Menu -> Restore defaults in order to regenerate them without capitalization.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
