### PR TITLE
Make the coordinate widget a little bit wider

### DIFF
--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -317,7 +317,7 @@ void QgsStatusBarCoordinatesWidget::ensureCoordinatesVisible()
 {
 
   //ensure the label is big (and small) enough
-  int width = std::max( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 10, mMinimumWidth );
+  int width = std::max( mLineEdit->fontMetrics().width( mLineEdit->text() ) + 16, mMinimumWidth );
   if ( mLineEdit->minimumWidth() < width || ( mLineEdit->minimumWidth() - width ) > mTwoCharSize )
   {
     mLineEdit->setMinimumWidth( width );


### PR DESCRIPTION
The coordinate widget is a little bit too narrow for modern KDE styles (Breeze and Oxygen), so the contents is slightly cropped and one digit is unreadable (at least in Debian):

![zrzut_20181024_235317](https://user-images.githubusercontent.com/1000043/47464220-db834d80-d7e8-11e8-8bef-ce37ca319b84.png)

This PR makes it 6 px wider. Unfortunately in means bigger margins in other OSes and styles. 

## Checklist
- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
