### PR TITLE
Use time.process_time() instead of time.clock()

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -328,7 +328,8 @@ def startPlugin(packageName):
 
     errMsg = QCoreApplication.translate("Python", "Couldn't load plugin '{0}'").format(packageName)
 
-    start = time.clock()
+    start = time.process_time()
+
     # create an instance of the plugin
     try:
         plugins[packageName] = package.classFactory(iface)
@@ -350,7 +351,7 @@ def startPlugin(packageName):
 
     # add to active plugins
     active_plugins.append(packageName)
-    end = time.clock()
+    end = time.process_time()
     plugin_times[packageName] = "{0:02f}s".format(end - start)
 
     return True


### PR DESCRIPTION
time.clock is set to be deprecated in python3.8,
and was replaced by time.process_time in python3.3

I am not sure if this should be considered a bug or a small feature, since nothing is _technically_ broken, unless one is running python 3.8, which isn't very common.
