### PR TITLE
[BUGFIX][DbManager] SQL Layer: fix unique combo setting in QGIS 3

### DIFF
--- a/python/plugins/db_manager/dlg_sql_layer_window.py
+++ b/python/plugins/db_manager/dlg_sql_layer_window.py
@@ -177,9 +177,8 @@ class DlgSqlLayerWindow(QWidget, Ui_Dialog):
                         item.setCheckState(Qt.Checked)
             else:
                 keyColumn = uri.keyColumn()
-                for item in self.uniqueModel.findItems("*", Qt.MatchWildcard):
-                    if item.data() == keyColumn:
-                        self.uniqueCombo.setCurrentIndex(self.uniqueModel.indexFromItem(item).row())
+                if self.uniqueModel.findItems(keyColumn):
+                    self.uniqueCombo.setEditText(keyColumn)
 
         # Finally layer name, filter and selectAtId
         self.layerNameEdit.setText(layer.name())


### PR DESCRIPTION
## Description
When opening Update SQL layer, the unique combobox is not well set specifically with oracle.

It's a forward porting of #7872

Funded by Ifremer

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
