### PR TITLE
Fix spatialite FilterFid and FilterRect handling without primary key [WIP]

### DIFF
--- a/.ci/travis/linux/blacklist.txt
+++ b/.ci/travis/linux/blacklist.txt
@@ -19,8 +19,9 @@ qgis_wcsprovidertest
 PyQgsWFSProviderGUI
 qgis_ziplayertest
 
-# Flaky, see https://dash.orfeo-toolbox.org/testDetails.php?test=63061783&build=297405
-PyQgsSpatialiteProvider
+# Flaky, the ms odbc driver crashes a lot on the ubuntu docker image. Retest when
+# the docker base image is upgraded
+PyQgsMssqlProvider
 
 # Need a local postgres installation
 PyQgsAuthManagerPKIPostgresTest

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.h
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.h
@@ -17,6 +17,7 @@
 
 #include "qgsfeatureiterator.h"
 #include "qgsfields.h"
+#include "qgsgeometryengine.h"
 
 extern "C"
 {
@@ -74,7 +75,7 @@ class QgsSpatiaLiteFeatureIterator : public QgsAbstractFeatureIteratorFromSource
     QString whereClauseFid();
     QString whereClauseFids();
     QString mbr( const QgsRectangle &rect );
-    bool prepareStatement( const QString &whereClause, long limit = -1, const QString &orderBy = QString() );
+    bool prepareStatement( const QString &whereClause, long limit = -1, long offset = -1, const QString &orderBy = QString() );
     QString quotedPrimaryKey();
     bool getFeature( sqlite3_stmt *stmt, QgsFeature &feature );
     QString fieldName( const QgsField &fld );
@@ -105,6 +106,7 @@ class QgsSpatiaLiteFeatureIterator : public QgsAbstractFeatureIteratorFromSource
 
     QgsRectangle mFilterRect;
     QgsCoordinateTransform mTransform;
+    std::unique_ptr<QgsGeometryEngine> mRectEngine;
 };
 
 #endif // QGSSPATIALITEFEATUREITERATOR_H

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -656,14 +656,14 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         f = QgsVectorLayerUtils.createFeature(vl)
         self.assertEqual(f.attributes(), [None, "qgis 'is good", 5, 5.7, None])
 
-        # check that provider default literals take precedence over passed attribute values
+        # If an attribute map is provided, QgsVectorLayerUtils.createFeature must
+        # respect it, otherwise default values from provider are checked.
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 'qgis is great', 0: 3})
-        self.assertEqual(f.attributes(), [3, "qgis 'is good", 5, 5.7, None])
+        self.assertEqual(f.attributes(), [3, "qgis is great", 5, 5.7, None])
 
-        # test that vector layer default value expression overrides provider default literal
         vl.setDefaultValueDefinition(3, QgsDefaultValue("4*3"))
         f = QgsVectorLayerUtils.createFeature(vl, attributes={1: 'qgis is great', 0: 3})
-        self.assertEqual(f.attributes(), [3, "qgis 'is good", 5, 12, None])
+        self.assertEqual(f.attributes(), [3, "qgis is great", 5, 12, None])
 
     def testCreateAttributeIndex(self):
         vl = QgsVectorLayer("dbname=%s table='test_defaults' key='id'" % self.dbname, "test_defaults", "spatialite")


### PR DESCRIPTION
(fixes #15600)

## Description
When no primary key is defined, features returned have an id defined by an
autoincremented integer.

So we cannot use SQL filters because it would return a subset of
features and then an autoincremented id that does not correspond to
ids without filters.

FilterRect requests are fixed by requesting all the features and then
filtering them (not by SQL).

For FilterFid requests, we can use a nice hack by adding "LIMIT 1
OFFSET id" to the SQL.

