### PR TITLE
fix crash when changing screen while rendering

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -690,7 +690,13 @@ QgsRectangle QgsMapCanvas::imageRect( const QImage &img, const QgsMapSettings &m
   // expects (encoding of position and size of the item)
   const QgsMapToPixel &m2p = mapSettings.mapToPixel();
   QgsPointXY topLeft = m2p.toMapCoordinates( 0, 0 );
-  Q_ASSERT( img.devicePixelRatio() == mapSettings.devicePixelRatio() );
+#ifdef QGISDEBUG
+  // do not assert this, since it might lead to crashes when changing screen while rendering
+  if( img.devicePixelRatio() != mapSettings.devicePixelRatio() )
+    {
+      QgsLogger::warning( QStringLiteral( "The renderer map has a wrong device pixel ratio" ) );
+    }
+#endif
 #if QT_VERSION >= 0x050600
   double res = m2p.mapUnitsPerPixel() / img.devicePixelRatioF();
 #else

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -692,7 +692,7 @@ QgsRectangle QgsMapCanvas::imageRect( const QImage &img, const QgsMapSettings &m
   QgsPointXY topLeft = m2p.toMapCoordinates( 0, 0 );
 #ifdef QGISDEBUG
   // do not assert this, since it might lead to crashes when changing screen while rendering
-  if( img.devicePixelRatio() != mapSettings.devicePixelRatio() )
+  if ( img.devicePixelRatio() != mapSettings.devicePixelRatio() )
   {
     QgsLogger::warning( QStringLiteral( "The renderer map has a wrong device pixel ratio" ) );
   }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -693,9 +693,9 @@ QgsRectangle QgsMapCanvas::imageRect( const QImage &img, const QgsMapSettings &m
 #ifdef QGISDEBUG
   // do not assert this, since it might lead to crashes when changing screen while rendering
   if( img.devicePixelRatio() != mapSettings.devicePixelRatio() )
-    {
-      QgsLogger::warning( QStringLiteral( "The renderer map has a wrong device pixel ratio" ) );
-    }
+  {
+    QgsLogger::warning( QStringLiteral( "The renderer map has a wrong device pixel ratio" ) );
+  }
 #endif
 #if QT_VERSION >= 0x050600
   double res = m2p.mapUnitsPerPixel() / img.devicePixelRatioF();


### PR DESCRIPTION
remove this assert since by the time the map is rendered the screen changed and might not have the same DPR.

