### PR TITLE
Disable overwriting GPKG layers with rasters in the Browser Panel

### DIFF
--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -333,8 +333,14 @@ bool QgsGeoPackageCollectionItem::handleDrop( const QMimeData *data, Qt::DropAct
             exists = true;
           }
         }
-        if ( ! exists || QMessageBox::question( nullptr, tr( "Overwrite Layer" ),
-                                                tr( "Destination layer <b>%1</b> already exists. Do you want to overwrite it?" ).arg( dropUri.name ), QMessageBox::Yes |  QMessageBox::No ) == QMessageBox::Yes )
+
+        if ( exists && !isVector )
+        {
+          QMessageBox::warning( nullptr, tr( "Cannot Overwrite Layer" ),
+                                tr( "Destination layer <b>%1</b> already exists. Overwriting with raster layers is not currently supported." ).arg( dropUri.name ) );
+        }
+        else if ( ! exists || QMessageBox::question( nullptr, tr( "Overwrite Layer" ),
+                  tr( "Destination layer <b>%1</b> already exists. Do you want to overwrite it?" ).arg( dropUri.name ), QMessageBox::Yes |  QMessageBox::No ) == QMessageBox::Yes )
         {
           if ( isVector ) // Import vectors and aspatial
           {


### PR DESCRIPTION
The Browser Panel allows to overwrite existing GPKG layers when drag'n'dropping, however, it only works if both layers are vectors. Overwriting a raster with a vector results in an error message (still not so bad), while overwriting anything with a raster is totally broken and may cause data loss (tested on Debian and Windows):

 1. raster over raster: quietly prints an error message in the log console, **removes the source raster (!)** and doesn't refresh the tree, so the user doesn't even know the layer is removed.

 2. raster over vector: quietly prints an error message to the log console and breaks the whole GPKG. Maybe because the gpkg_geometry_columns and gpkg_ogr_contents tables still contain vector metadata. After refreshing the tree, all layers disappear (not only for the QGIS session), and although they appear again after copying some more layers, I haven't found a way to repair the file permanently. 

This PR only allows GPKG layer overwrite if the new layer is vector.



- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit

