### PR TITLE
[Bugfix][Server][WFS] Segfault when converting geom to multi

### DIFF
--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -2070,12 +2070,11 @@ QDomElement QgsWFSServer::createFeatureGML2( QgsFeature* feat, QDomDocument& doc
   typeNameElement.setAttribute( "fid", mTypeName + "." + gmlId );
   featureElement.appendChild( typeNameElement );
 
-  const QgsGeometry* geom = feat->constGeometry();
+  const QgsGeometry* cGeom = feat->constGeometry();
+  QgsGeometry *geom = new QgsGeometry( *cGeom );
   if ( isMultiGeom && QgsWKBTypes::isSingleType( QGis::fromOldWkbType( geom->wkbType() ) ) )
   {
-    QgsGeometry cloneGeom( *geom );
-    cloneGeom.convertToMultiType();
-    geom = &cloneGeom;
+    geom->convertToMultiType();
   }
   if ( geom && mWithGeom && mGeometryName != "NONE" )
   {
@@ -2121,6 +2120,7 @@ QDomElement QgsWFSServer::createFeatureGML2( QgsFeature* feat, QDomDocument& doc
       typeNameElement.appendChild( geomElem );
     }
   }
+  delete geom;
 
   //read all attribute values from the feature
   QgsAttributes featureAttributes = feat->attributes();
@@ -2160,12 +2160,12 @@ QDomElement QgsWFSServer::createFeatureGML3( QgsFeature* feat, QDomDocument& doc
   typeNameElement.setAttribute( "gml:id", mTypeName + "." + gmlId );
   featureElement.appendChild( typeNameElement );
 
-  const QgsGeometry* geom = feat->constGeometry();
+
+  const QgsGeometry* cGeom = feat->constGeometry();
+  QgsGeometry *geom = new QgsGeometry( *cGeom );
   if ( isMultiGeom && QgsWKBTypes::isSingleType( QGis::fromOldWkbType( geom->wkbType() ) ) )
   {
-    QgsGeometry cloneGeom( *geom );
-    cloneGeom.convertToMultiType();
-    geom = &cloneGeom;
+    geom->convertToMultiType();
   }
   if ( geom && mWithGeom && mGeometryName != "NONE" )
   {
@@ -2211,6 +2211,7 @@ QDomElement QgsWFSServer::createFeatureGML3( QgsFeature* feat, QDomDocument& doc
       typeNameElement.appendChild( geomElem );
     }
   }
+  delete geom;
 
   //read all attribute values from the feature
   QgsAttributes featureAttributes = feat->attributes();


### PR DESCRIPTION
## Description
Following 55928c0, [Bugfix][Server][WFS] In GML geometry has all to be multi, in which to avoid memory leak, I don't use a pointer but convertToMuli segfaults in this case.

@nyalldawson has mentioned in the PR #8243 to ignore is comment about pointer, what I missed. So the code has segfaulting.

This commit fixed it by using point and delete it.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
