### PR TITLE
Do not report envelope as gap

### DIFF
--- a/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrygapcheck.cpp
@@ -98,7 +98,8 @@ void QgsGeometryGapCheck::collectErrors( const QMap<QString, QgsFeaturePool *> &
   {
     std::unique_ptr<QgsAbstractGeometry> gapGeom( QgsGeometryCheckerUtils::getGeomPart( diffGeom.get(), iPart )->clone() );
     // Skip the gap between features and boundingbox
-    if ( gapGeom->boundingBox() == envelope->boundingBox() )
+    const double spacing = context()->tolerance;
+    if ( gapGeom->boundingBox().snappedToGrid( spacing ) == envelope->boundingBox().snappedToGrid( spacing ) )
     {
       continue;
     }


### PR DESCRIPTION
Under some circumstances, the envelope of a check region would be reported as a gap.
While a check that this doesn't happen is normally enforced, this check doesn't work
when the features happen to be placed unfortunate enough to have their bounding box
rounded differently than the envelope.