### PR TITLE
use Exclude field by default for relation search widget wrapper

### DIFF
--- a/python/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/editorwidgets/qgsrelationreferencesearchwidgetwrapper.sip.in
@@ -47,8 +47,6 @@ Returns a variant representing the current state of the widget.
 
     virtual QgsSearchWidgetWrapper::FilterFlags supportedFlags() const;
 
-    virtual QgsSearchWidgetWrapper::FilterFlags defaultFlags() const;
-
     virtual QString createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const;
 
 

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -56,11 +56,6 @@ QgsSearchWidgetWrapper::FilterFlags QgsRelationReferenceSearchWidgetWrapper::sup
   return EqualTo | NotEqualTo | IsNull | IsNotNull;
 }
 
-QgsSearchWidgetWrapper::FilterFlags QgsRelationReferenceSearchWidgetWrapper::defaultFlags() const
-{
-  return EqualTo;
-}
-
 QString QgsRelationReferenceSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const
 {
   QString fieldName = createFieldIdentifier();

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.h
@@ -58,7 +58,6 @@ class GUI_EXPORT QgsRelationReferenceSearchWidgetWrapper : public QgsSearchWidge
     QString expression() const override;
     bool valid() const override;
     QgsSearchWidgetWrapper::FilterFlags supportedFlags() const override;
-    QgsSearchWidgetWrapper::FilterFlags defaultFlags() const override;
     QString createExpression( QgsSearchWidgetWrapper::FilterFlags flags ) const override;
 
   public slots:


### PR DESCRIPTION
fix #20201

