### PR TITLE
Fix crashes when right clicking a layer with a broken source

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreelayer.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreelayer.sip.in
@@ -39,13 +39,31 @@ Constructor for QgsLayerTreeLayer using weak references to layer ID, ``name``, p
 %End
 
     QString layerId() const;
+%Docstring
+Returns the ID for the map layer associated with this node.
+
+.. seealso:: :py:func:`layer`
+%End
 
     QgsMapLayer *layer() const;
+%Docstring
+Returns the map layer associated with this node.
+
+.. warning::
+
+   This can be (and often is!) a None, e.g. in the case of a layer node representing a layer
+   which has not yet been fully loaded into a project, or a layer node representing a layer
+   with an invalid data source. The returned pointer must ALWAYS be checked to avoid dereferencing a None.
+
+.. seealso:: :py:func:`layerId`
+%End
 
     virtual QString name() const;
 
 %Docstring
 Returns the layer's name.
+
+.. seealso:: :py:func:`setName`
 
 .. versionadded:: 3.0
 %End
@@ -54,6 +72,8 @@ Returns the layer's name.
 
 %Docstring
 Sets the layer's name.
+
+.. seealso:: :py:func:`name`
 
 .. versionadded:: 3.0
 %End

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -353,7 +353,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           menuStyleManager->addAction( tr( "Copy Style" ), app, SLOT( copyStyle() ) );
         }
 
-        if ( app->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
+        if ( layer && app->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
         {
           if ( layer->type() == QgsMapLayer::VectorLayer )
           {
@@ -802,7 +802,9 @@ bool QgsAppLayerTreeViewMenuProvider::removeActionEnabled()
   const QList<QgsLayerTreeLayer *> selectedLayers = mView->selectedLayerNodes();
   for ( QgsLayerTreeLayer *nodeLayer : selectedLayers )
   {
-    if ( !nodeLayer->layer()->flags().testFlag( QgsMapLayer::Removable ) )
+    // be careful with the logic here -- if nodeLayer->layer() is false, will still must return true
+    // to allow the broken layer to be removed from the project
+    if ( nodeLayer->layer() && !nodeLayer->layer()->flags().testFlag( QgsMapLayer::Removable ) )
       return false;
   }
   return true;

--- a/src/app/qgsmaplayerstyleguiutils.cpp
+++ b/src/app/qgsmaplayerstyleguiutils.cpp
@@ -79,6 +79,9 @@ QList<QAction *> QgsMapLayerStyleGuiUtils::actionsUseStyle( QgsMapLayer *layer, 
 
 void QgsMapLayerStyleGuiUtils::addStyleManagerActions( QMenu *m, QgsMapLayer *layer )
 {
+  if ( ! layer )
+    return;
+
   m->addAction( actionAddStyle( layer, m ) );
   if ( layer->styleManager()->styles().count() > 1 )
     m->addAction( actionRemoveStyle( layer, m ) );

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2084,16 +2084,19 @@ void QgsProjectProperties::checkOWS( QgsLayerTreeGroup *treeGroup, QStringList &
     {
       QgsLayerTreeLayer *treeLayer = static_cast<QgsLayerTreeLayer *>( treeNode );
       QgsMapLayer *l = treeLayer->layer();
-      QString shortName = l->shortName();
-      if ( shortName.isEmpty() )
-        owsNames << l->name();
-      else
-        owsNames << shortName;
-      if ( l->type() == QgsMapLayer::VectorLayer )
+      if ( l )
       {
-        QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( l );
-        if ( vl->dataProvider()->encoding() == QLatin1String( "System" ) )
-          encodingMessages << tr( "Update layer \"%1\" encoding" ).arg( l->name() );
+        QString shortName = l->shortName();
+        if ( shortName.isEmpty() )
+          owsNames << l->name();
+        else
+          owsNames << shortName;
+        if ( l->type() == QgsMapLayer::VectorLayer )
+        {
+          QgsVectorLayer *vl = static_cast<QgsVectorLayer *>( l );
+          if ( vl->dataProvider()->encoding() == QLatin1String( "System" ) )
+            encodingMessages << tr( "Update layer \"%1\" encoding" ).arg( l->name() );
+        }
       }
     }
   }

--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -548,7 +548,7 @@ void QgsSnappingWidget::cleanGroup( QgsLayerTreeNode *node )
   QList<QgsLayerTreeNode *> toRemove;
   Q_FOREACH ( QgsLayerTreeNode *child, node->children() )
   {
-    if ( QgsLayerTree::isLayer( child ) && QgsLayerTree::toLayer( child )->layer()->type() != QgsMapLayer::VectorLayer )
+    if ( QgsLayerTree::isLayer( child ) && ( !QgsLayerTree::toLayer( child )->layer() || QgsLayerTree::toLayer( child )->layer()->type() != QgsMapLayer::VectorLayer ) )
     {
       toRemove << child;
       continue;

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -54,18 +54,38 @@ class CORE_EXPORT QgsLayerTreeLayer : public QgsLayerTreeNode
      */
     explicit QgsLayerTreeLayer( const QString &layerId, const QString &name = QString(), const QString &source = QString(), const QString &provider = QString() );
 
+    /**
+     * Returns the ID for the map layer associated with this node.
+     *
+     * \see layer()
+     */
     QString layerId() const { return mRef.layerId; }
 
+    /**
+     * Returns the map layer associated with this node.
+     *
+     * \warning This can be (and often is!) a nullptr, e.g. in the case of a layer node representing a layer
+     * which has not yet been fully loaded into a project, or a layer node representing a layer
+     * with an invalid data source. The returned pointer must ALWAYS be checked to avoid dereferencing a nullptr.
+     *
+     * \see layerId()
+     */
     QgsMapLayer *layer() const { return mRef.get(); }
 
     /**
      * Returns the layer's name.
+     *
+     * \see setName()
+     *
      * \since QGIS 3.0
      */
     QString name() const override;
 
     /**
      * Sets the layer's name.
+     *
+     * \see name()
+     *
      * \since QGIS 3.0
      */
     void setName( const QString &n ) override;


### PR DESCRIPTION
e.g. a layer loaded from a qlyr with missing layer reference