### PR TITLE
remove translations for expression group to fix duplicated entries in the tree

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -831,17 +831,22 @@ QString QgsExpression::group( const QString &name )
 {
   if ( sGroups.isEmpty() )
   {
+    sGroups.insert( QStringLiteral( "Aggregates" ), tr( "Aggregates" ) );
+    sGroups.insert( QStringLiteral( "Arrays" ), tr( "Arrays" ) );
     sGroups.insert( QStringLiteral( "General" ), tr( "General" ) );
     sGroups.insert( QStringLiteral( "Operators" ), tr( "Operators" ) );
     sGroups.insert( QStringLiteral( "Conditionals" ), tr( "Conditionals" ) );
     sGroups.insert( QStringLiteral( "Fields and Values" ), tr( "Fields and Values" ) );
+    sGroups.insert( QStringLiteral( "Map Layers" ), tr( "Map Layers" ) );
+    sGroups.insert( QStringLiteral( "Maps" ), tr( "Maps" ) );
     sGroups.insert( QStringLiteral( "Math" ), tr( "Math" ) );
     sGroups.insert( QStringLiteral( "Conversions" ), tr( "Conversions" ) );
     sGroups.insert( QStringLiteral( "Date and Time" ), tr( "Date and Time" ) );
     sGroups.insert( QStringLiteral( "String" ), tr( "String" ) );
     sGroups.insert( QStringLiteral( "Color" ), tr( "Color" ) );
     sGroups.insert( QStringLiteral( "GeometryGroup" ), tr( "Geometry" ) );
-    sGroups.insert( QStringLiteral( "Record" ), tr( "Record" ) );
+    sGroups.insert( QStringLiteral( "Rasters" ), tr( "Rasters" ) );
+    sGroups.insert( QStringLiteral( "Record and Attributes" ), tr( "Record and Attributes" ) );
     sGroups.insert( QStringLiteral( "Variables" ), tr( "Variables" ) );
     sGroups.insert( QStringLiteral( "Fuzzy Matching" ), tr( "Fuzzy Matching" ) );
     sGroups.insert( QStringLiteral( "Recent (%1)" ), tr( "Recent (%1)" ) );

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -5015,7 +5015,7 @@ QgsArrayForeachExpressionFunction::QgsArrayForeachExpressionFunction()
   : QgsExpressionFunction( QStringLiteral( "array_foreach" ), QgsExpressionFunction::ParameterList()
                            << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) )
                            << QgsExpressionFunction::Parameter( QStringLiteral( "expression" ) ),
-                           QCoreApplication::tr( "Arrays" ) )
+                           QStringLiteral( "Arrays" ) )
 {
 
 }
@@ -5109,7 +5109,7 @@ QgsArrayFilterExpressionFunction::QgsArrayFilterExpressionFunction()
   : QgsExpressionFunction( QStringLiteral( "array_filter" ), QgsExpressionFunction::ParameterList()
                            << QgsExpressionFunction::Parameter( QStringLiteral( "array" ) )
                            << QgsExpressionFunction::Parameter( QStringLiteral( "expression" ) ),
-                           QCoreApplication::tr( "Arrays" ) )
+                           QStringLiteral( "Arrays" ) )
 {
 
 }
@@ -5204,7 +5204,7 @@ QgsWithVariableExpressionFunction::QgsWithVariableExpressionFunction()
                            QgsExpressionFunction::Parameter( QStringLiteral( "name" ) )
                            << QgsExpressionFunction::Parameter( QStringLiteral( "value" ) )
                            << QgsExpressionFunction::Parameter( QStringLiteral( "expression" ) ),
-                           QCoreApplication::tr( "General" ) )
+                           QStringLiteral( "General" ) )
 {
 
 }


### PR DESCRIPTION
I just noticed that some expressions in a translated QGIS are not going in the same group:
`array_filter`, `array_foreach` and `with_variable`.

![screenshot from 2018-10-25 20-55-51](https://user-images.githubusercontent.com/1609292/47539557-fa441b80-d89e-11e8-800b-7080c5142614.png)

So I noticed that all other groups were not translated in the code in `qgsexpressionfunction.cpp`, but they are translated in the UI. Look above for `Colors` or `Strings` which are translated.
So I tried to remove translation for `array_filter`, `array_foreach` and `with_variable` in this PR.

![screenshot from 2018-10-25 21-46-01](https://user-images.githubusercontent.com/1609292/47539653-66bf1a80-d89f-11e8-94c4-1741fe3c1c71.png)

 It's better.
So is-it correct to remove translations? But in Transifex, all `Arrays` strings are translated, but not in UI. So I'm confused if my PR shouldn't be the reverse, to add a translation on all groups in qgsexpressionfunction.cpp. Where the translation come from with the current implementation?