### PR TITLE
Update snap to grid rect on extentChange

### DIFF
--- a/src/gui/qgssnaptogridcanvasitem.cpp
+++ b/src/gui/qgssnaptogridcanvasitem.cpp
@@ -31,8 +31,6 @@ void QgsSnapToGridCanvasItem::paint( QPainter *painter )
 
   painter->save();
   QgsRectangle mapRect = mMapCanvas->extent();
-  if ( rect() != mapRect )
-    setRect( mapRect );
 
   painter->setRenderHints( QPainter::Antialiasing );
   painter->setCompositionMode( QPainter::CompositionMode_Difference );
@@ -144,6 +142,10 @@ void QgsSnapToGridCanvasItem::updateZoomFactor()
   try
   {
     const int threshold = 5;
+
+    const QgsRectangle extent = mMapCanvas->extent();
+    if ( extent != rect() )
+      setRect( extent );
 
     const QgsPointXY centerPoint = mMapCanvas->extent().center();
     const QPointF canvasCenter = toCanvasCoordinates( centerPoint );


### PR DESCRIPTION
The grid should always be shown on the current canvas extent. So its rect needs to be set whenever the extent changes. Setting it on paint as before is fragile, because the paint event is not actually called if the new extent is outside the previous extent.

Fix #20222