### PR TITLE
Black mssql test on Travis

### DIFF
--- a/.ci/travis/linux/blacklist.txt
+++ b/.ci/travis/linux/blacklist.txt
@@ -22,6 +22,10 @@ qgis_ziplayertest
 # Flaky, see https://dash.orfeo-toolbox.org/testDetails.php?test=63061783&build=297405
 PyQgsSpatialiteProvider
 
+# Flaky, the ms odbc driver crashes a lot on the ubuntu docker image. Retest when
+# the docker base image is upgraded
+PyQgsMssqlProvider
+
 # Need a local postgres installation
 PyQgsAuthManagerPKIPostgresTest
 PyQgsAuthManagerPasswordPostgresTest


### PR DESCRIPTION
The mssql odbc driver is proving very crashy on the Travis
docker image. Revisit when the docker image is upgraded
