### PR TITLE
fix gdal_contour in test

### DIFF
--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -109,6 +109,7 @@ tests:
       BAND: 1
       CREATE_3D: false
       FIELD_NAME: ELEV
+      CREATE_3D: true
       IGNORE_NODATA: false
       INPUT:
         name: dem.tif


### PR DESCRIPTION
now gdal_contour does not create 3D by default
see upstream issue https://github.com/OSGeo/gdal/issues/336
and fix https://github.com/OSGeo/gdal/commit/abae82ccf4f46d7aa1a9d3252296c207e6652ba9

