### PR TITLE
Avoid creating temporary project properties and options dialogs for locator filter

### DIFF
--- a/src/3d/qgscameracontroller.cpp
+++ b/src/3d/qgscameracontroller.cpp
@@ -168,7 +168,7 @@ void QgsCameraController::setCamera( Qt3DRender::QCamera *camera )
   emit cameraChanged();
 }
 
-void QgsCameraController::setViewport( const QRect &viewport )
+void QgsCameraController::setViewport( QRect viewport )
 {
   if ( mViewport == viewport )
     return;
@@ -178,7 +178,7 @@ void QgsCameraController::setViewport( const QRect &viewport )
 }
 
 
-static QVector3D unproject( const QVector3D &v, const QMatrix4x4 &modelView, const QMatrix4x4 &projection, const QRect &viewport )
+static QVector3D unproject( QVector3D v, const QMatrix4x4 &modelView, const QMatrix4x4 &projection, QRect viewport )
 {
   // Reimplementation of QVector3D::unproject() - see qtbase/src/gui/math3d/qvector3d.cpp
   // The only difference is that the original implementation uses tolerance 1e-5
@@ -208,7 +208,7 @@ float find_x_on_line( float x0, float y0, float x1, float y1, float y )
   return x0 + k * d_x;
 }
 
-QPointF screen_point_to_point_on_plane( const QPointF &pt, const QRect &viewport, Qt3DRender::QCamera *camera, float y )
+QPointF screen_point_to_point_on_plane( QPointF pt, QRect viewport, Qt3DRender::QCamera *camera, float y )
 {
   // get two points of the ray
   QVector3D l0 = unproject( QVector3D( pt.x(), viewport.height() - pt.y(), 0 ), camera->viewMatrix(), camera->projectionMatrix(), viewport );
@@ -432,7 +432,7 @@ void QgsCameraController::setCameraPose( const QgsCameraPose &camPose )
 
 QDomElement QgsCameraController::writeXml( QDomDocument &doc ) const
 {
-  QDomElement elemCamera = doc.createElement( "camera" );
+  QDomElement elemCamera = doc.createElement( QStringLiteral( "camera" ) );
   elemCamera.setAttribute( QStringLiteral( "x" ), mCameraPose.centerPoint().x() );
   elemCamera.setAttribute( QStringLiteral( "y" ), mCameraPose.centerPoint().z() );
   elemCamera.setAttribute( QStringLiteral( "elev" ), mCameraPose.centerPoint().y() );

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -60,7 +60,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
     //! Assigns camera that should be controlled by this class. Called internally from 3D scene.
     void setCamera( Qt3DRender::QCamera *camera );
     //! Sets viewport rectangle. Called internally from 3D canvas. Allows conversion of mouse coordinates.
-    void setViewport( const QRect &viewport );
+    void setViewport( QRect viewport );
     //! Called internally from 3D scene when a new frame is generated. Updates camera according to keyboard/mouse input
     void frameTriggered( float dt );
 

--- a/src/3d/terrain/qgsflatterraingenerator.cpp
+++ b/src/3d/terrain/qgsflatterraingenerator.cpp
@@ -113,8 +113,8 @@ void QgsFlatTerrainGenerator::writeXml( QDomElement &elem ) const
   QDomElement elemExtent = elem.ownerDocument().createElement( QStringLiteral( "extent" ) );
   elemExtent.setAttribute( QStringLiteral( "xmin" ), QString::number( r.xMinimum() ) );
   elemExtent.setAttribute( QStringLiteral( "xmax" ), QString::number( r.xMaximum() ) );
-  elemExtent.setAttribute( "ymin", QString::number( r.yMinimum() ) );
-  elemExtent.setAttribute( "ymax", QString::number( r.yMaximum() ) );
+  elemExtent.setAttribute( QStringLiteral( "ymin" ), QString::number( r.yMinimum() ) );
+  elemExtent.setAttribute( QStringLiteral( "ymax" ), QString::number( r.yMaximum() ) );
 
   // crs is not read/written - it should be the same as destination crs of the map
 }
@@ -124,8 +124,8 @@ void QgsFlatTerrainGenerator::readXml( const QDomElement &elem )
   QDomElement elemExtent = elem.firstChildElement( QStringLiteral( "extent" ) );
   double xmin = elemExtent.attribute( QStringLiteral( "xmin" ) ).toDouble();
   double xmax = elemExtent.attribute( QStringLiteral( "xmax" ) ).toDouble();
-  double ymin = elemExtent.attribute( "ymin" ).toDouble();
-  double ymax = elemExtent.attribute( "ymax" ).toDouble();
+  double ymin = elemExtent.attribute( QStringLiteral( "ymin" ) ).toDouble();
+  double ymax = elemExtent.attribute( QStringLiteral( "ymax" ) ).toDouble();
 
   setExtent( QgsRectangle( xmin, ymin, xmax, ymax ) );
 

--- a/src/analysis/network/qgsvectorlayerdirector.cpp
+++ b/src/analysis/network/qgsvectorlayerdirector.cpp
@@ -384,6 +384,7 @@ void QgsVectorLayerDirector::makeGraph( QgsGraphBuilderInterface *builder, const
             {
               double distance = builder->distanceArea()->measureLine( arcPt1, arcPt2 );
               QVector< QVariant > prop;
+              prop.reserve( mStrategies.size() );
               for ( QgsNetworkStrategy *strategy : mStrategies )
               {
                 prop.push_back( strategy->cost( distance, feature ) );

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.cpp
@@ -149,6 +149,7 @@ QgsFeatureList QgsAddIncrementalFieldAlgorithm::processFeature( const QgsFeature
   else
   {
     QgsAttributes groupAttributes;
+    groupAttributes.reserve( mGroupedFields.size() );
     for ( int index : qgis::as_const( mGroupedFields ) )
     {
       groupAttributes << f.attribute( index );

--- a/src/analysis/processing/qgsalgorithmcentroid.cpp
+++ b/src/analysis/processing/qgsalgorithmcentroid.cpp
@@ -99,6 +99,7 @@ QgsFeatureList QgsCentroidAlgorithm::processFeature( const QgsFeature &f, QgsPro
     {
       const QgsGeometryCollection *geomCollection = static_cast<const QgsGeometryCollection *>( geom.constGet() );
 
+      list.reserve( geomCollection->partCount() );
       for ( int i = 0; i < geomCollection->partCount(); ++i )
       {
         QgsGeometry partGeometry( geomCollection->geometryN( i )->clone() );

--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -86,6 +86,7 @@ void QgsLocationBasedAlgorithm::process( const QgsProcessingContext &context, Qg
   // we actually test the reverse of what the user wants (allowing us
   // to prepare geometries and optimise the algorithm)
   QList< Predicate > predicates;
+  predicates.reserve( selectedPredicates.count() );
   for ( int i : selectedPredicates )
   {
     predicates << reversePredicate( static_cast< Predicate >( i ) );

--- a/src/analysis/processing/qgsalgorithmimportphotos.cpp
+++ b/src/analysis/processing/qgsalgorithmimportphotos.cpp
@@ -94,7 +94,7 @@ bool QgsImportPhotosAlgorithm::extractGeoTagFromMetadata( const QVariantMap &met
     if ( !ok )
       return false;
 
-    if ( metadata.value( QStringLiteral( "EXIF_GPSLongitudeRef" ) ).toString().right( 1 ).compare( QLatin1String( "W" ), Qt::CaseInsensitive ) == 0
+    if ( metadata.value( QStringLiteral( "EXIF_GPSLongitudeRef" ) ).toString().rightRef( 1 ).compare( QLatin1String( "W" ), Qt::CaseInsensitive ) == 0
          || metadata.value( QStringLiteral( "EXIF_GPSLongitudeRef" ) ).toDouble() < 0 )
       x = -x;
   }
@@ -111,7 +111,7 @@ bool QgsImportPhotosAlgorithm::extractGeoTagFromMetadata( const QVariantMap &met
     if ( !ok )
       return false;
 
-    if ( metadata.value( QStringLiteral( "EXIF_GPSLatitudeRef" ) ).toString().right( 1 ).compare( QLatin1String( "S" ), Qt::CaseInsensitive ) == 0
+    if ( metadata.value( QStringLiteral( "EXIF_GPSLatitudeRef" ) ).toString().rightRef( 1 ).compare( QLatin1String( "S" ), Qt::CaseInsensitive ) == 0
          || metadata.value( QStringLiteral( "EXIF_GPSLatitudeRef" ) ).toDouble() < 0 )
       y = -y;
   }

--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.cpp
@@ -130,6 +130,7 @@ QVariantMap QgsJoinByAttributeAlgorithm::processAlgorithm( const QVariantMap &pa
   if ( fieldsToCopy.empty() )
   {
     outFields2 = input2->fields();
+    fields2Indices.reserve( outFields2.count() );
     for ( int i = 0; i < outFields2.count(); ++i )
     {
       fields2Indices << i;
@@ -137,6 +138,7 @@ QVariantMap QgsJoinByAttributeAlgorithm::processAlgorithm( const QVariantMap &pa
   }
   else
   {
+    fields2Indices.reserve( fieldsToCopy.count() );
     for ( const QString &field : fieldsToCopy )
     {
       int index = input2->fields().lookupField( field );

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.cpp
@@ -111,6 +111,7 @@ QVariantMap QgsJoinWithLinesAlgorithm::processAlgorithm( const QVariantMap &para
   if ( hubFieldsToCopy.empty() )
   {
     hubOutFields = hubSource->fields();
+    hubFieldIndices.reserve( hubOutFields.count() );
     for ( int i = 0; i < hubOutFields.count(); ++i )
     {
       hubFieldIndices << i;
@@ -118,6 +119,7 @@ QVariantMap QgsJoinWithLinesAlgorithm::processAlgorithm( const QVariantMap &para
   }
   else
   {
+    hubFieldIndices.reserve( hubOutFields.count() );
     for ( const QString &field : hubFieldsToCopy )
     {
       int index = hubSource->fields().lookupField( field );

--- a/src/analysis/processing/qgsalgorithmreclassifybylayer.cpp
+++ b/src/analysis/processing/qgsalgorithmreclassifybylayer.cpp
@@ -315,6 +315,7 @@ QVector<QgsReclassifyUtils::RasterClass> QgsReclassifyByTableAlgorithm::createCl
 
   const int rows = table.count() / 3;
   QVector< QgsReclassifyUtils::RasterClass > classes;
+  classes.reserve( rows );
   for ( int row = 0; row < rows; ++row )
   {
     bool ok = false;

--- a/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
+++ b/src/analysis/processing/qgsalgorithmzonalhistogram.cpp
@@ -170,7 +170,7 @@ QVariantMap QgsZonalHistogramAlgorithm::processAlgorithm( const QVariantMap &par
   QgsFields newFields;
   for ( auto it = uniqueValues.constBegin(); it != uniqueValues.constEnd(); ++it )
   {
-    newFields.append( QgsField( QStringLiteral( "%1%2" ).arg( fieldPrefix ).arg( mHasNoDataValue && *it == mNodataValue ? QStringLiteral( "NODATA" ) : QString::number( *it ) ), QVariant::LongLong, QString(), -1, 0 ) );
+    newFields.append( QgsField( QStringLiteral( "%1%2" ).arg( fieldPrefix, mHasNoDataValue && *it == mNodataValue ? QStringLiteral( "NODATA" ) : QString::number( *it ) ), QVariant::LongLong, QString(), -1, 0 ) );
   }
   QgsFields fields = QgsProcessingUtils::combineFields( zones->fields(), newFields );
 

--- a/src/app/layout/qgslayout3dmapwidget.cpp
+++ b/src/app/layout/qgslayout3dmapwidget.cpp
@@ -95,7 +95,7 @@ QgsLayout3DMapWidget::QgsLayout3DMapWidget( QgsLayoutItem3DMap *map3D )
 
   QList<QgsDoubleSpinBox *> lst;
   lst << mCenterXSpinBox << mCenterYSpinBox << mCenterZSpinBox << mDistanceToCenterSpinBox << mPitchAngleSpinBox << mHeadingAngleSpinBox;
-  for ( QgsDoubleSpinBox *spinBox : lst )
+  for ( QgsDoubleSpinBox *spinBox : qgis::as_const( lst ) )
     connect( spinBox, qgis::overload<double>::of( &QgsDoubleSpinBox::valueChanged ), this, &QgsLayout3DMapWidget::updateCameraPose );
 
   updateCameraPoseWidgetsFromItem();

--- a/src/app/layout/qgslayoutatlaswidget.cpp
+++ b/src/app/layout/qgslayoutatlaswidget.cpp
@@ -91,7 +91,7 @@ void QgsLayoutAtlasWidget::mUseAtlasCheckBox_stateChanged( int state )
 
 void QgsLayoutAtlasWidget::changeCoverageLayer( QgsMapLayer *layer )
 {
-  QgsVectorLayer *vl = dynamic_cast<QgsVectorLayer *>( layer );
+  QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
 
   mLayout->undoStack()->beginCommand( mAtlas, tr( "Change Atlas Layer" ) );
   mLayout->reportContext().setLayer( vl );
@@ -266,7 +266,7 @@ void QgsLayoutAtlasWidget::mAtlasFeatureFilterEdit_editingFinished()
 
 void QgsLayoutAtlasWidget::mAtlasFeatureFilterButton_clicked()
 {
-  QgsVectorLayer *vl = dynamic_cast<QgsVectorLayer *>( mAtlasCoverageLayerComboBox->currentLayer() );
+  QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( mAtlasCoverageLayerComboBox->currentLayer() );
 
   if ( !vl )
   {

--- a/src/app/layout/qgslayoutattributeselectiondialog.cpp
+++ b/src/app/layout/qgslayoutattributeselectiondialog.cpp
@@ -97,7 +97,7 @@ QVariant QgsLayoutAttributeTableColumnModel::data( const QModelIndex &index, int
   if ( role == Qt::UserRole )
   {
     //user role stores reference in column object
-    return qVariantFromValue( qobject_cast<QObject *>( column ) );
+    return qVariantFromValue( column );
   }
 
   switch ( index.column() )

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -235,7 +235,7 @@ void QgsActiveLayerFeaturesLocatorFilter::prepare( const QString &string, const 
     }
     else if ( allowNumeric && field.isNumeric() )
     {
-      expressionParts << QStringLiteral( "%1 = %2" ).arg( QgsExpression::quotedColumnRef( field.name() ) ).arg( QString::number( numericalValue, 'g', 17 ) );
+      expressionParts << QStringLiteral( "%1 = %2" ).arg( QgsExpression::quotedColumnRef( field.name() ), QString::number( numericalValue, 'g', 17 ) );
     }
   }
 
@@ -352,8 +352,8 @@ void QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const Qg
     if ( !expression.needsGeometry() )
       req.setFlags( QgsFeatureRequest::NoGeometry );
     req.setFilterExpression( QStringLiteral( "%1 ILIKE '%%2%'" )
-                             .arg( layer->displayExpression() )
-                             .arg( string ) );
+                             .arg( layer->displayExpression(),
+                                   string ) );
     req.setLimit( 30 );
 
     PreparedLayer preparedLayer;
@@ -474,13 +474,13 @@ void QgsSettingsLocatorFilter::fetchResults( const QString &string, const QgsLoc
 {
   QMap<QString, QMap<QString, QString>> matchingSettingsPagesMap;
 
-  QMap<QString, QString> optionsPagesMap = QgisApp::instance()->optionsPagesMap();
+  QMap<QString, int > optionsPagesMap = QgisApp::instance()->optionsPagesMap();
   for ( auto optionsPagesIterator = optionsPagesMap.constBegin(); optionsPagesIterator != optionsPagesMap.constEnd(); ++optionsPagesIterator )
   {
     QString title = optionsPagesIterator.key();
     if ( stringMatches( title, string ) || ( context.usingPrefix && string.isEmpty() ) )
     {
-      matchingSettingsPagesMap.insert( title + " (" + tr( "Options" ) + ")", settingsPage( QStringLiteral( "optionpage" ), optionsPagesIterator.value() ) );
+      matchingSettingsPagesMap.insert( title + " (" + tr( "Options" ) + ")", settingsPage( QStringLiteral( "optionpage" ), QString::number( optionsPagesIterator.value() ) ) );
     }
   }
 
@@ -534,7 +534,8 @@ void QgsSettingsLocatorFilter::triggerResult( const QgsLocatorResult &result )
 
   if ( type == QLatin1String( "optionpage" ) )
   {
-    QgisApp::instance()->showOptionsDialog( QgisApp::instance(), page );
+    const int pageNumber = page.toInt();
+    QgisApp::instance()->showOptionsDialog( QgisApp::instance(), QString(), pageNumber );
   }
   else if ( type == QLatin1String( "projectpropertypage" ) )
   {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10296,12 +10296,22 @@ void QgisApp::options()
 
 QMap< QString, QString > QgisApp::projectPropertiesPagesMap()
 {
-  if ( mProjectPropertiesPagesMap.isEmpty() )
+  static QMap< QString, QString > sProjectPropertiesPagesMap;
+  static std::once_flag initialized;
+  std::call_once( initialized, []
   {
-    std::unique_ptr< QgsProjectProperties > pp( new QgsProjectProperties( mMapCanvas, this ) );
-    mProjectPropertiesPagesMap = pp->pageWidgetNameMap();
-  }
-  return mProjectPropertiesPagesMap;
+    sProjectPropertiesPagesMap.insert( tr( "General" ), QStringLiteral( "mProjOptsGeneral" ) );
+    sProjectPropertiesPagesMap.insert( tr( "Metadata" ), QStringLiteral( "mMetadataPage" ) );
+    sProjectPropertiesPagesMap.insert( tr( "CRS" ), QStringLiteral( "mProjOptsCRS" ) );
+    sProjectPropertiesPagesMap.insert( tr( "Default Styles" ), QStringLiteral( "mProjOptsSymbols" ) );
+    sProjectPropertiesPagesMap.insert( tr( "Data Sources" ), QStringLiteral( "mTab_DataSources" ) );
+    sProjectPropertiesPagesMap.insert( tr( "Relations" ), QStringLiteral( "mTabRelations" ) );
+    sProjectPropertiesPagesMap.insert( tr( "Variables" ), QStringLiteral( "mTab_Variables" ) );
+    sProjectPropertiesPagesMap.insert( tr( "Macros" ), QStringLiteral( "mProjOptsMacros" ) );
+    sProjectPropertiesPagesMap.insert( tr( "QGIS Server" ), QStringLiteral( "mProjOptsOWS" ) );
+  } );
+
+  return sProjectPropertiesPagesMap;
 }
 
 void QgisApp::showProjectProperties( const QString &page )
@@ -10311,14 +10321,17 @@ void QgisApp::showProjectProperties( const QString &page )
 
 QMap< QString, QString > QgisApp::settingPagesMap()
 {
-  if ( mSettingPagesMap.isEmpty() )
+  static QMap< QString, QString > sSettingPagesMap;
+  static std::once_flag initialized;
+  std::call_once( initialized, []
   {
-    mSettingPagesMap.insert( tr( "Style Manager" ), QStringLiteral( "stylemanager" ) );
-    mSettingPagesMap.insert( tr( "Keyboard Shortcuts" ), QStringLiteral( "shortcuts" ) );
-    mSettingPagesMap.insert( tr( "Custom Projections" ), QStringLiteral( "customprojection" ) );
-    mSettingPagesMap.insert( tr( "Interface Customization" ), QStringLiteral( "customize" ) );
-  }
-  return mSettingPagesMap;
+    sSettingPagesMap.insert( tr( "Style Manager" ), QStringLiteral( "stylemanager" ) );
+    sSettingPagesMap.insert( tr( "Keyboard Shortcuts" ), QStringLiteral( "shortcuts" ) );
+    sSettingPagesMap.insert( tr( "Custom Projections" ), QStringLiteral( "customprojection" ) );
+    sSettingPagesMap.insert( tr( "Interface Customization" ), QStringLiteral( "customize" ) );
+  } );
+
+  return sSettingPagesMap;
 }
 
 void QgisApp::showSettings( const QString &page )
@@ -10341,21 +10354,44 @@ void QgisApp::showSettings( const QString &page )
   }
 }
 
-QMap< QString, QString > QgisApp::optionsPagesMap()
+QMap< QString, int > QgisApp::optionsPagesMap()
 {
-  if ( mOptionsPagesMap.isEmpty() )
+  static QMap< QString, int > sOptionsPagesMap;
+  static std::once_flag initialized;
+  std::call_once( initialized, []
   {
-    QList< QgsOptionsWidgetFactory * > factories;
-    Q_FOREACH ( const QPointer< QgsOptionsWidgetFactory > &f, mOptionsWidgetFactories )
+    sOptionsPagesMap.insert( tr( "General" ), 0 );
+    sOptionsPagesMap.insert( tr( "System" ), 1 );
+    sOptionsPagesMap.insert( tr( "CRS" ), 2 );
+    sOptionsPagesMap.insert( tr( "Data Sources" ), 3 );
+    sOptionsPagesMap.insert( tr( "Rendering" ), 4 );
+    sOptionsPagesMap.insert( tr( "Canvas & Legend" ), 5 );
+    sOptionsPagesMap.insert( tr( "Map Tools" ), 6 );
+    sOptionsPagesMap.insert( tr( "Colors" ), 7 );
+    sOptionsPagesMap.insert( tr( "Digitizing" ), 8 );
+    sOptionsPagesMap.insert( tr( "Layouts" ), 9 );
+    sOptionsPagesMap.insert( tr( "GDAL" ), 10 );
+    sOptionsPagesMap.insert( tr( "Variables" ), 11 );
+    sOptionsPagesMap.insert( tr( "Authentication" ), 12 );
+    sOptionsPagesMap.insert( tr( "Network" ), 13 );
+    sOptionsPagesMap.insert( tr( "Locator" ), 14 );
+    sOptionsPagesMap.insert( tr( "Advanced" ), 15 );
+    sOptionsPagesMap.insert( tr( "Acceleration" ), 16 );
+  } );
+
+  QMap< QString, int > map = sOptionsPagesMap;
+  int idx = map.count();
+  for ( const QPointer< QgsOptionsWidgetFactory > &f : qgis::as_const( mOptionsWidgetFactories ) )
+  {
+    // remove any deleted factories
+    if ( f )
     {
-      // remove any deleted factories
-      if ( f )
-        factories << f;
+      map.insert( f->title(), idx );
     }
-    std::unique_ptr< QgsOptions > f( new QgsOptions( this, QgsGuiUtils::ModalDialogFlags, factories ) );
-    mOptionsPagesMap = f->pageWidgetNameMap();
+    idx++;
   }
-  return mOptionsPagesMap;
+
+  return map;
 }
 
 QgsOptions *QgisApp::createOptionsDialog( QWidget *parent )
@@ -10370,7 +10406,7 @@ QgsOptions *QgisApp::createOptionsDialog( QWidget *parent )
   return new QgsOptions( parent, QgsGuiUtils::ModalDialogFlags, factories );
 }
 
-void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage )
+void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage, int pageNumber )
 {
   std::unique_ptr< QgsOptions > optionsDialog( createOptionsDialog( parent ) );
 
@@ -10380,6 +10416,11 @@ void QgisApp::showOptionsDialog( QWidget *parent, const QString &currentPage )
   if ( !currentPage.isEmpty() )
   {
     optionsDialog->setCurrentPage( currentPage );
+  }
+
+  if ( pageNumber >= 0 )
+  {
+    optionsDialog->setCurrentPage( pageNumber );
   }
 
   if ( optionsDialog->exec() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -69,6 +69,7 @@
 #include <QVBoxLayout>
 #include <QWhatsThis>
 #include <QWidgetAction>
+#include <mutex>
 
 #include "qgssettings.h"
 #include "qgsnetworkaccessmanager.h"

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -959,7 +959,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * Settings pages section
      */
     //! Gets map of option pages
-    QMap< QString, QString > optionsPagesMap();
+    QMap<QString, int> optionsPagesMap();
     //! Gets map of project property pages
     QMap< QString, QString > projectPropertiesPagesMap();
     //! Gets map of setting pages
@@ -970,7 +970,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     // End Settings pages section
 
     //! Opens the options dialog
-    void showOptionsDialog( QWidget *parent = nullptr, const QString &currentPage = QString() );
+    void showOptionsDialog( QWidget *parent = nullptr, const QString &currentPage = QString(), int pageNumber = -1 );
 
     /**
      * Refreshes the state of the layer actions toolbar action
@@ -2281,11 +2281,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgsFeature duplicateFeatures( QgsMapLayer *mlayer, const QgsFeature &feature );
     QgsFeature duplicateFeatureDigitized( QgsMapLayer *mlayer, const QgsFeature &feature );
-
-    //! Internal vars supporting Settings Pages function
-    QMap< QString, QString > mOptionsPagesMap;
-    QMap< QString, QString > mProjectPropertiesPagesMap;
-    QMap< QString, QString > mSettingPagesMap;
 
     QgsProxyProgressTask *mProjectLoadingProxyTask = nullptr;
 

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -61,8 +61,7 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
      */
     void setCurrentPage( const QString &pageWidgetName );
 
-    QMap<QString, QString> pageWidgetNameMap();
-
+    void setCurrentPage( int pageNumber );
 
   public slots:
     void cbxProjectDefaultNew_toggled( bool checked );
@@ -271,6 +270,8 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     QgsLocatorOptionsWidget *mLocatorOptionsWidget = nullptr;
 
     void updateActionsForCurrentColorScheme( QgsColorScheme *scheme );
+
+    void checkPageWidgetNameMap();
 
     friend class QgsAppScreenShots;
 };

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -48,8 +48,6 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     //! Constructor
     QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *parent = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
 
-    QMap< QString, QString > pageWidgetNameMap();
-
     void setCurrentPage( const QString & );
 
     ~QgsProjectProperties() override;
@@ -191,6 +189,8 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     QgsLayerCapabilitiesModel *mLayerCapabilitiesModel = nullptr;
 
     QgsCoordinateReferenceSystem mCrs;
+
+    void checkPageWidgetNameMap();
 
     void populateStyles();
     void editSymbol( QComboBox *cbo );

--- a/src/core/geometry/qgscompoundcurve.cpp
+++ b/src/core/geometry/qgscompoundcurve.cpp
@@ -76,9 +76,10 @@ int QgsCompoundCurve::dimension() const
 QgsCompoundCurve::QgsCompoundCurve( const QgsCompoundCurve &curve ): QgsCurve( curve )
 {
   mWkbType = curve.wkbType();
+  mCurves.reserve( curve.mCurves.size() );
   for ( const QgsCurve *c : curve.mCurves )
   {
-    mCurves.append( static_cast<QgsCurve *>( c->clone() ) );
+    mCurves.append( c->clone() );
   }
 }
 
@@ -90,7 +91,7 @@ QgsCompoundCurve &QgsCompoundCurve::operator=( const QgsCompoundCurve &curve )
     QgsCurve::operator=( curve );
     for ( const QgsCurve *c : curve.mCurves )
     {
-      mCurves.append( static_cast<QgsCurve *>( c->clone() ) );
+      mCurves.append( c->clone() );
     }
   }
   return *this;
@@ -221,6 +222,7 @@ QByteArray QgsCompoundCurve::asWkb() const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   QVector<QByteArray> wkbForCurves;
+  wkbForCurves.reserve( mCurves.size() );
   for ( const QgsCurve *curve : mCurves )
   {
     QByteArray wkbForCurve = curve->asWkb();

--- a/src/core/geometry/qgscurvepolygon.cpp
+++ b/src/core/geometry/qgscurvepolygon.cpp
@@ -62,12 +62,12 @@ QgsCurvePolygon::QgsCurvePolygon( const QgsCurvePolygon &p )
   mWkbType = p.mWkbType;
   if ( p.mExteriorRing )
   {
-    mExteriorRing.reset( static_cast<QgsCurve *>( p.mExteriorRing->clone() ) );
+    mExteriorRing.reset( p.mExteriorRing->clone() );
   }
 
   for ( const QgsCurve *ring : p.mInteriorRings )
   {
-    mInteriorRings.push_back( static_cast<QgsCurve *>( ring->clone() ) );
+    mInteriorRings.push_back( ring->clone() );
   }
 }
 
@@ -79,12 +79,12 @@ QgsCurvePolygon &QgsCurvePolygon::operator=( const QgsCurvePolygon &p )
     QgsSurface::operator=( p );
     if ( p.mExteriorRing )
     {
-      mExteriorRing.reset( static_cast<QgsCurve *>( p.mExteriorRing->clone() ) );
+      mExteriorRing.reset( p.mExteriorRing->clone() );
     }
 
     for ( const QgsCurve *ring : p.mInteriorRings )
     {
-      mInteriorRings.push_back( static_cast<QgsCurve *>( ring->clone() ) );
+      mInteriorRings.push_back( ring->clone() );
     }
   }
   return *this;
@@ -282,6 +282,7 @@ QByteArray QgsCurvePolygon::asWkb() const
 {
   int binarySize = sizeof( char ) + sizeof( quint32 ) + sizeof( quint32 );
   QVector<QByteArray> wkbForRings;
+  wkbForRings.reserve( 1 + mInteriorRings.size() );
   if ( mExteriorRing )
   {
     QByteArray wkb( mExteriorRing->asWkb() );
@@ -580,6 +581,7 @@ QgsPolygon *QgsCurvePolygon::toPolygon( double tolerance, SegmentationToleranceT
   poly->setExteriorRing( mExteriorRing->curveToLine( tolerance, toleranceType ) );
 
   QVector<QgsCurve *> rings;
+  rings.reserve( mInteriorRings.size() );
   for ( const QgsCurve *ring : mInteriorRings )
   {
     rings.push_back( ring->curveToLine( tolerance, toleranceType ) );

--- a/src/core/geometry/qgsellipse.cpp
+++ b/src/core/geometry/qgsellipse.cpp
@@ -200,6 +200,7 @@ QgsPointSequence QgsEllipse::points( unsigned int segments ) const
   double m = mCenter.m();
 
   QVector<double> t;
+  t.reserve( segments );
   double azimuth = std::atan2( quadrant().at( 0 ).y() - mCenter.y(), quadrant().at( 0 ).x() - mCenter.x() );
   for ( unsigned int i = 0; i < segments; ++i )
   {

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -748,6 +748,7 @@ QgsGeometry QgsGeometry::removeInteriorRings( double minimumRingArea ) const
   {
     const QVector<QgsGeometry> parts = asGeometryCollection();
     QVector<QgsGeometry> results;
+    results.reserve( parts.count() );
     for ( const QgsGeometry &part : parts )
     {
       QgsGeometry result = part.removeInteriorRings( minimumRingArea );

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -621,7 +621,7 @@ bool QgsGeometryCollection::fromCollectionWkt( const QString &wkt, const QVector
   }
   mWkbType = parts.first;
 
-  QString defChildWkbType = QStringLiteral( "%1%2%3 " ).arg( defaultChildWkbType, is3D() ? "Z" : "", isMeasure() ? "M" : "" );
+  QString defChildWkbType = QStringLiteral( "%1%2%3 " ).arg( defaultChildWkbType, is3D() ? QStringLiteral( "Z" ) : QString(), isMeasure() ? QStringLiteral( "M" ) : QString() );
 
   const QStringList blocks = QgsGeometryUtils::wktGetChildBlocks( parts.second, defChildWkbType );
   for ( const QString &childWkt : blocks )

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -169,6 +169,7 @@ std::unique_ptr<QgsPolygon> QgsGeometryFactory::fromPolygonXY( const QgsPolygonX
   std::unique_ptr< QgsPolygon > poly = qgis::make_unique< QgsPolygon >();
 
   QVector<QgsCurve *> holes;
+  holes.reserve( polygon.size() );
   for ( int i = 0; i < polygon.size(); ++i )
   {
     std::unique_ptr< QgsLineString > l = linestringFromPolyline( polygon.at( i ) );

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -1079,7 +1079,7 @@ QString QgsGeometryUtils::pointsToWKT( const QgsPointSequence &points, int preci
   return wkt;
 }
 
-QDomElement QgsGeometryUtils::pointsToGML2( const QgsPointSequence &points, QDomDocument &doc, int precision, const QString &ns, const QgsAbstractGeometry::AxisOrder &axisOrder )
+QDomElement QgsGeometryUtils::pointsToGML2( const QgsPointSequence &points, QDomDocument &doc, int precision, const QString &ns, QgsAbstractGeometry::AxisOrder axisOrder )
 {
   QDomElement elemCoordinates = doc.createElementNS( ns, QStringLiteral( "coordinates" ) );
 
@@ -1106,7 +1106,7 @@ QDomElement QgsGeometryUtils::pointsToGML2( const QgsPointSequence &points, QDom
   return elemCoordinates;
 }
 
-QDomElement QgsGeometryUtils::pointsToGML3( const QgsPointSequence &points, QDomDocument &doc, int precision, const QString &ns, bool is3D, const QgsAbstractGeometry::AxisOrder &axisOrder )
+QDomElement QgsGeometryUtils::pointsToGML3( const QgsPointSequence &points, QDomDocument &doc, int precision, const QString &ns, bool is3D, QgsAbstractGeometry::AxisOrder axisOrder )
 {
   QDomElement elemPosList = doc.createElementNS( ns, QStringLiteral( "posList" ) );
   elemPosList.setAttribute( QStringLiteral( "srsDimension" ), is3D ? 3 : 2 );

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -372,13 +372,13 @@ class CORE_EXPORT QgsGeometryUtils
      * Returns a gml::coordinates DOM element.
      * \note not available in Python bindings
      */
-    static QDomElement pointsToGML2( const QgsPointSequence &points, QDomDocument &doc, int precision, const QString &ns, const QgsAbstractGeometry::AxisOrder &axisOrder = QgsAbstractGeometry::AxisOrder::XY ) SIP_SKIP;
+    static QDomElement pointsToGML2( const QgsPointSequence &points, QDomDocument &doc, int precision, const QString &ns, QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) SIP_SKIP;
 
     /**
      * Returns a gml::posList DOM element.
      * \note not available in Python bindings
      */
-    static QDomElement pointsToGML3( const QgsPointSequence &points, QDomDocument &doc, int precision, const QString &ns, bool is3D, const QgsAbstractGeometry::AxisOrder &axisOrder = QgsAbstractGeometry::AxisOrder::XY ) SIP_SKIP;
+    static QDomElement pointsToGML3( const QgsPointSequence &points, QDomDocument &doc, int precision, const QString &ns, bool is3D, QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) SIP_SKIP;
 
     /**
      * Returns a geoJSON coordinates string.

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -157,7 +157,7 @@ QgsGeometry QgsGeos::geometryFromGeos( GEOSGeometry *geos )
   return g;
 }
 
-QgsGeometry QgsGeos::geometryFromGeos( geos::unique_ptr geos )
+QgsGeometry QgsGeos::geometryFromGeos( const geos::unique_ptr &geos )
 {
   QgsGeometry g( QgsGeos::fromGeos( geos.get() ) );
   return g;
@@ -1187,7 +1187,9 @@ std::unique_ptr<QgsPolygon> QgsGeos::fromGeosPolygon( const GEOSGeometry *geos )
   }
 
   QVector<QgsCurve *> interiorRings;
-  for ( int i = 0; i < GEOSGetNumInteriorRings_r( geosinit.ctxt, geos ); ++i )
+  const int ringCount = GEOSGetNumInteriorRings_r( geosinit.ctxt, geos );
+  interiorRings.reserve( ringCount );
+  for ( int i = 0; i < ringCount; ++i )
   {
     ring = GEOSGetInteriorRingN_r( geosinit.ctxt, geos, i );
     if ( ring )

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -120,7 +120,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     /**
      * Creates a new QgsGeometry object, feeding in a geometry in GEOS format.
      */
-    static QgsGeometry geometryFromGeos( geos::unique_ptr geos );
+    static QgsGeometry geometryFromGeos( const geos::unique_ptr &geos );
 
     /**
      * Adds a new island polygon to a multipolygon feature

--- a/src/core/geometry/qgsinternalgeometryengine.cpp
+++ b/src/core/geometry/qgsinternalgeometryengine.cpp
@@ -49,6 +49,7 @@ QgsGeometry QgsInternalGeometryEngine::extrude( double x, double y ) const
   const QgsMultiCurve *multiCurve = qgsgeometry_cast< const QgsMultiCurve * >( mGeometry );
   if ( multiCurve )
   {
+    linesToProcess.reserve( multiCurve->partCount() );
     for ( int i = 0; i < multiCurve->partCount(); ++i )
     {
       linesToProcess << static_cast<QgsLineString *>( multiCurve->geometryN( i )->clone() );
@@ -920,6 +921,7 @@ QgsGeometry QgsInternalGeometryEngine::variableWidthBuffer( int segments, const 
   }
 
   QVector<QgsGeometry> bufferedLines;
+  bufferedLines.reserve( linesToProcess.size() );
 
   for ( std::unique_ptr< QgsLineString > &line : linesToProcess )
   {

--- a/src/core/geometry/qgslinestring.cpp
+++ b/src/core/geometry/qgslinestring.cpp
@@ -466,7 +466,7 @@ QgsLineString *QgsLineString::curveToLine( double tolerance, SegmentationToleran
 {
   Q_UNUSED( tolerance );
   Q_UNUSED( toleranceType );
-  return static_cast<QgsLineString *>( clone() );
+  return clone();
 }
 
 int QgsLineString::numPoints() const


### PR DESCRIPTION
This is expensive and results in a lengthy delay when first using the locator in a QGIS session.

Replace with an alternative approach which doesn't rely on creation of temporary dialogs, yet should still ensure that these dialogs don't go out of sync with the locator.
