### PR TITLE
fix qgsDoubleString printing -0

### DIFF
--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -20,7 +20,6 @@
 
 #include <QEvent>
 #include <QString>
-#include <QRegExp>
 #include <QMetaType>
 #include <QMap>
 #include <QMetaEnum>
@@ -239,9 +238,35 @@ CORE_EXPORT uint qHash( const QVariant &variant );
 inline QString qgsDoubleToString( double a, int precision = 17 )
 {
   if ( precision )
-    return QString::number( a, 'f', precision ).remove( QRegExp( "\\.?0+$" ) );
+  {
+    QString str = QString::number( a, 'f', precision );
+    if ( str.contains( QLatin1Char( '.' ) ) )
+    {
+      // remove ending 0s
+      int idx = str.length() - 1;
+      while ( str.at( idx ) == '0' && idx > 1 )
+      {
+        idx--;
+      }
+      if ( idx < str.length() - 1 )
+        str.truncate( str.at( idx ) == '.' ? idx : idx + 1 );
+    }
+    return str;
+  }
   else
-    return QString::number( a, 'f', precision );
+  {
+    // avoid printing -0
+    // see https://bugreports.qt.io/browse/QTBUG-71439
+    const QString str( QString::number( a, 'f', precision ) );
+    if ( str == QLatin1String( "-0" ) )
+    {
+      return QLatin1String( "0" );
+    }
+    else
+    {
+      return str;
+    }
+  }
 }
 
 /**

--- a/tests/src/app/testqgsmaptoolregularpolygon.cpp
+++ b/tests/src/app/testqgsmaptoolregularpolygon.cpp
@@ -99,7 +99,7 @@ void TestQgsMapToolRegularPolygon::testRegularPolygonFrom2Points()
   QCOMPARE( mLayer->featureCount(), ( long )1 );
   QgsFeature f = mLayer->getFeature( newFid );
 
-  QString wkt = "LineStringZ (0 0 333, 2 1 333, 4 -0 333, 4 -2 333, 2 -3 333, -0 -2 333, 0 0 333)";
+  QString wkt = "LineStringZ (0 0 333, 2 1 333, 4 0 333, 4 -2 333, 2 -3 333, 0 -2 333, 0 0 333)";
   QCOMPARE( f.geometry().asWkt( 0 ), wkt );
 
   mLayer->rollBack();
@@ -123,7 +123,7 @@ void TestQgsMapToolRegularPolygon::testRegularPolygonFromCenterAndPoint()
   QCOMPARE( mLayer->featureCount(), ( long )1 );
   QgsFeature f = mLayer->getFeature( newFid );
 
-  QString wkt = "LineStringZ (1 2 222, 3 -0 222, 1 -2 222, -1 -2 222, -3 0 222, -1 2 222, 1 2 222)";
+  QString wkt = "LineStringZ (1 2 222, 3 0 222, 1 -2 222, -1 -2 222, -3 0 222, -1 2 222, 1 2 222)";
   QCOMPARE( f.geometry().asWkt( 0 ), wkt );
 
   mLayer->rollBack();
@@ -147,7 +147,7 @@ void TestQgsMapToolRegularPolygon::testRegularPolygonFromCenterAndCroner()
   QCOMPARE( mLayer->featureCount(), ( long )1 );
   QgsFeature f = mLayer->getFeature( newFid );
 
-  QString wkt = "LineStringZ (2 1 111, 2 -1 111, -0 -2 111, -2 -1 111, -2 1 111, 0 2 111, 2 1 111)";
+  QString wkt = "LineStringZ (2 1 111, 2 -1 111, 0 -2 111, -2 -1 111, -2 1 111, 0 2 111, 2 1 111)";
   QCOMPARE( f.geometry().asWkt( 0 ), wkt );
 
   mLayer->rollBack();

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -169,6 +169,9 @@ void TestQgis::doubleToString()
   QCOMPARE( qgsDoubleToString( 12000, 1 ), QString( "12000" ) );
   QCOMPARE( qgsDoubleToString( 12000, 10 ), QString( "12000" ) );
   QCOMPARE( qgsDoubleToString( 12345, -1 ), QString( "12345" ) );
+  QCOMPARE( qgsDoubleToString( 12345.12300000 ), QString( "12345.123" ) );
+  QCOMPARE( qgsDoubleToString( 12345.00011111, 2 ), QString( "12345" ) );
+  QCOMPARE( qgsDoubleToString( -0.000000000708115, 0 ), QString( "0" ) );
 }
 
 void TestQgis::signalBlocker()

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -169,7 +169,7 @@ void TestQgis::doubleToString()
   QCOMPARE( qgsDoubleToString( 12000, 1 ), QString( "12000" ) );
   QCOMPARE( qgsDoubleToString( 12000, 10 ), QString( "12000" ) );
   QCOMPARE( qgsDoubleToString( 12345, -1 ), QString( "12345" ) );
-  QCOMPARE( qgsDoubleToString( 12345.12300000 ), QString( "12345.123" ) );
+  QCOMPARE( qgsDoubleToString( 12345.12300000, 7 ), QString( "12345.123" ) );
   QCOMPARE( qgsDoubleToString( 12345.00011111, 2 ), QString( "12345" ) );
   QCOMPARE( qgsDoubleToString( -0.000000000708115, 0 ), QString( "0" ) );
 }

--- a/tests/src/python/test_qgsfeaturesource.py
+++ b/tests/src/python/test_qgsfeaturesource.py
@@ -135,7 +135,7 @@ class TestQgsFeatureSource(unittest.TestCase):
                              2: 'Point (222639 222684)',
                              3: 'Point (333958 222684)',
                              4: 'Point (445278 334111)',
-                             5: 'Point (0 -0)'}
+                             5: 'Point (0 0)'}
         for id, f in original_features.items():
             self.assertEqual(new_features[id].attributes(), f.attributes())
             self.assertEqual(new_features[id].geometry().asWkt(0), expected_geometry[id])


### PR DESCRIPTION
In latest Qt versions (5.11 maybe 5.10), `QString::number(-0.000000000708115, 'f', 0)` prints `-0` and not `0` anymore.
I have reported upstream and this is not seen as a bug.

> That's also the result from C's printf and Python's.
> IEEE 754 floating point is not mathematically perfect and it does have the concept of negative zero.

https://bugreports.qt.io/browse/QTBUG-71439

This method is using in comparing geometries (via WKT) and leads to failing test.
To my understanding, the precision acts as a rounding and there is not reason to print -0.

If you think differently, please tell me why :)