### PR TITLE
fix crash when connecting layerOrderChanged signal

### DIFF
--- a/src/core/layertree/qgslayertree.cpp
+++ b/src/core/layertree/qgslayertree.cpp
@@ -20,7 +20,7 @@
 QgsLayerTree::QgsLayerTree()
 {
   connect( this, &QgsLayerTree::addedChildren, this, &QgsLayerTree::nodeAddedChildren );
-  connect( this, &QgsLayerTree::removedChildren, this, &QgsLayerTree::nodeRemovedChildren );
+  connect( this, &QgsLayerTree::willRemoveChildren, this, &QgsLayerTree::nodeRemovedChildren );
 }
 
 QgsLayerTree::QgsLayerTree( const QgsLayerTree &other )
@@ -29,7 +29,7 @@ QgsLayerTree::QgsLayerTree( const QgsLayerTree &other )
   , mHasCustomLayerOrder( other.mHasCustomLayerOrder )
 {
   connect( this, &QgsLayerTree::addedChildren, this, &QgsLayerTree::nodeAddedChildren );
-  connect( this, &QgsLayerTree::removedChildren, this, &QgsLayerTree::nodeRemovedChildren );
+  connect( this, &QgsLayerTree::willRemoveChildren, this, &QgsLayerTree::nodeRemovedChildren );
 }
 
 QList<QgsMapLayer *> QgsLayerTree::customLayerOrder() const


### PR DESCRIPTION
there is now a little glitch of the selection that goes back to its previous place and then to the dropped node.

![screen-recording-2018-10-29-at-13 49 46](https://user-images.githubusercontent.com/127259/47669806-189d6600-db82-11e8-9289-830349a1be96.gif)


