### PR TITLE
[browser] Fix some items which are marked as "Collapse" capability are incorrectly expanded on startup

### DIFF
--- a/src/gui/qgsbrowsertreeview.cpp
+++ b/src/gui/qgsbrowsertreeview.cpp
@@ -62,7 +62,7 @@ void QgsBrowserTreeView::saveState()
   QgsSettings settings;
   QStringList expandedPaths = expandedPathsList( QModelIndex() );
   settings.setValue( expandedPathsKey(), expandedPaths );
-  QgsDebugMsgLevel( "expandedPaths = " + expandedPaths.join( " " ), 4 );
+  QgsDebugMsgLevel( "expandedPaths = " + expandedPaths.join( ' ' ), 4 );
 }
 
 void QgsBrowserTreeView::restoreState()
@@ -70,7 +70,7 @@ void QgsBrowserTreeView::restoreState()
   QgsSettings settings;
   mExpandPaths = settings.value( expandedPathsKey(), QVariant() ).toStringList();
 
-  QgsDebugMsgLevel( "mExpandPaths = " + mExpandPaths.join( " " ), 4 );
+  QgsDebugMsgLevel( "mExpandPaths = " + mExpandPaths.join( ' ' ), 4 );
   if ( !mExpandPaths.isEmpty() )
   {
     QSet<QModelIndex> expandIndexSet;
@@ -167,7 +167,7 @@ void QgsBrowserTreeView::rowsInserted( const QModelIndex &parentIndex, int start
   if ( mExpandPaths.isEmpty() )
     return;
 
-  QgsDebugMsgLevel( "mExpandPaths = " + mExpandPaths.join( "," ), 2 );
+  QgsDebugMsgLevel( "mExpandPaths = " + mExpandPaths.join( ',' ), 2 );
 
   QString parentPath = model()->data( parentIndex, QgsBrowserModel::PathRole ).toString();
   QgsDebugMsgLevel( "parentPath = " + parentPath, 2 );
@@ -197,7 +197,15 @@ void QgsBrowserTreeView::rowsInserted( const QModelIndex &parentIndex, int start
     if ( mExpandPaths.contains( childPath ) || mExpandPaths.indexOf( QRegExp( "^" + escapedChildPath + "/.*" ) ) != -1 )
     {
       QgsDebugMsgLevel( QStringLiteral( "-> expand" ), 2 );
-      expand( childIndex );
+      QModelIndex modelIndex = browserModel()->findPath( childPath, Qt::MatchExactly );
+      if ( modelIndex.isValid() )
+      {
+        QgsDataItem *ptr = browserModel()->dataItem( modelIndex );
+        if ( !ptr || !( ptr->capabilities2() & QgsDataItem::Capability::Collapse ) )
+        {
+          expand( childIndex );
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This flag is supposed to be used to avoid automatically populating expensive groups on startup (such as network based providers), but it's currently ignored for most of these.