### PR TITLE
Prevent flooding (and app freeze) of items added to the message bar

### DIFF
--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -298,6 +298,17 @@ QgsMessageBarItem *QgsMessageBar::pushWidget( QWidget *widget, Qgis::MessageLeve
 
 void QgsMessageBar::pushMessage( const QString &title, const QString &text, Qgis::MessageLevel level, int duration )
 {
+  // keep the number of items in the message bar to a maximum of 20, avoids flooding (and freezing) of the main window
+  if ( mItems.count() > 20 )
+    mItems.removeFirst();
+
+  // block duplicate items, avoids flooding (and freezing) of the main window
+  for ( auto it = mItems.constBegin(); it != mItems.constEnd(); ++it )
+  {
+    if ( level == ( *it )->level() && title == ( *it )->title() && text == ( *it )->text() )
+      return;
+  }
+
   QgsMessageBarItem *item = new QgsMessageBarItem( title, text, level, duration );
   pushItem( item );
 }


### PR DESCRIPTION
## Description
This PR adds some flooding prevention to the message bar by:
- limiting the number of items contained in the message bar to _20_ (I'm open to the maximum count here, but really, if the bar has more than 20 items, something has gone wrong already :) )
- preventing item duplicates (defined by item's title, text, and level being equal)

@nyalldawson , as discussed on hangout.

This prevents QGIS freezing when flooded with auth error messages:
![image](https://user-images.githubusercontent.com/1728657/47696569-f6671f00-dc39-11e8-9f5b-d895622fcfb6.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
