### PR TITLE
[oracle] Fix performance issue

### DIFF
--- a/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
+++ b/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
@@ -99,7 +99,8 @@
 #include <cstdlib>
 
 #define QOCISPATIAL_DYNAMIC_CHUNK_SIZE 65535
-#define QOCISPATIAL_PREFETCH_MEM  10240
+#define QOCISPATIAL_PREFETCH_ROWS 10000
+#define QOCISPATIAL_PREFETCH_MEM 8388608 // 8MB
 
 // setting this define will allow using a query from a different
 // thread than its database connection.
@@ -341,8 +342,8 @@ class QOCISpatialDriverPrivate : public QSqlDriverPrivate
     OCIError *err = nullptr;
     bool transaction = false;
     int serverVersion = -1;
-    ub4 prefetchRows = 0xffffffff;
-    ub2 prefetchMem = QOCISPATIAL_PREFETCH_MEM;
+    ub4 prefetchRows = QOCISPATIAL_PREFETCH_ROWS;
+    ub4 prefetchMem = QOCISPATIAL_PREFETCH_MEM;
     QString user;
 
     OCIType *geometryTDO = nullptr;
@@ -429,7 +430,7 @@ class QOCISpatialResultPrivate: public QSqlCachedResultPrivate
     QList<QOCISDOGeometryInd *> sdoind;
     bool transaction;
     int serverVersion;
-    int prefetchRows, prefetchMem;
+    ub4 prefetchRows, prefetchMem;
     OCIType *geometryTDO = nullptr;
     QOCISDOGeometryObj *geometryObj = nullptr;
     QOCISDOGeometryInd *geometryInd = nullptr;
@@ -3833,13 +3834,13 @@ static void qParseOpts( const QString &options, QOCISpatialDriverPrivate *d )
     {
       d->prefetchRows = val.toInt( &ok );
       if ( !ok )
-        d->prefetchRows = 0xffffffff;
+        d->prefetchRows = QOCISPATIAL_PREFETCH_ROWS;
     }
     else if ( opt == QLatin1String( "OCI_ATTR_PREFETCH_MEMORY" ) )
     {
       d->prefetchMem = val.toInt( &ok );
       if ( !ok )
-        d->prefetchMem = 0xffff;
+        d->prefetchMem = QOCISPATIAL_PREFETCH_MEM;
     }
     else
     {


### PR DESCRIPTION
## Description

I've been digging into performance issues for reads of larger amounts of data from Oracle, with observations of 50x-100x slower than if consuming the same data from PostGIS (running on the same server).  It could be observed that CPU load was low on both server and client and that the probable cause was network I/O. Initially I thought it was implementation details as the same data consumed in MapServer was no more than 2x slower compared to PostGIS and linked to the use of a custom QtSql implementation in QGIS. However in the end I could determine that the issue is simply a clamped OCI_ATTR_PREFETCH_MEMORY parameter. Currently in QGIS it's default set to 10240 bytes which obviously is quite low and moreover it is clamped as a 16-bit unsigned integer which AFAIK is wrong it should accept 32-bit unsigned integer just like the setting for OCI_ATTR_PREFETCH_ROWS.

This PR changes the type to 32-bit and defaults it to 8MB. It also changes the default for OCI_ATTR_PREFETCH_ROWS to 10000 instead of 0xffffffff as I thought it was more reasonable. It also makes the use of the defaults consistent.

I have not verified that a user can actually change these settings in runtime via data source UX but it should be. In either case it would not have been possible to go higher than 65K which i still very low and can cause ineffective prefetching depending on data.

I've verified that with a reasonable OCI_ATTR_PREFETCH_MEMORY the QGIS implementation is on par with MapServer.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
