### PR TITLE
[FEATURE] Show QGIS style xml libraries in browser and support drag and drop of style .xml files to main QGIS window

### DIFF
--- a/python/gui/auto_generated/symbology/qgsstyleexportimportdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstyleexportimportdialog.sip.in
@@ -17,14 +17,28 @@ class QgsStyleExportImportDialog : QDialog
 #include "qgsstyleexportimportdialog.h"
 %End
   public:
+
     enum Mode
     {
       Export,
-      Import
+      Import,
     };
 
     QgsStyleExportImportDialog( QgsStyle *style, QWidget *parent /TransferThis/ = 0, Mode mode = Export );
+%Docstring
+Constructor for QgsStyleExportImportDialog, with the specified ``parent`` widget.
+
+Creates a dialog for importing symbols into the given ``style``, or exporting symbols from the ``style``.
+The ``mode`` argument dictates whether the dialog is to be used for exporting or importing symbols.
+%End
     ~QgsStyleExportImportDialog();
+
+    void setImportFilePath( const QString &path );
+%Docstring
+Sets the initial ``path`` to use for importing files, when the dialog is in a Import mode.
+
+.. versionadded:: 3.6
+%End
 
     void selectSymbols( const QStringList &symbolNames );
 %Docstring

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1149,6 +1149,9 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   registerCustomDropHandler( new QgsQlrDropHandler() );
   QgsApplication::dataItemProviderRegistry()->addProvider( new QgsQptDataItemProvider() );
   registerCustomDropHandler( new QgsQptDropHandler() );
+  QgsApplication::dataItemProviderRegistry()->addProvider( new QgsStyleXmlDataItemProvider() );
+  registerCustomDropHandler( new QgsStyleXmlDropHandler() );
+
   mSplash->showMessage( tr( "Starting Python" ), Qt::AlignHCenter | Qt::AlignBottom );
   qApp->processEvents();
   loadPythonSupport();

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -146,4 +146,47 @@ class QgsPyDropHandler : public QgsCustomDropHandler
     bool handleFileDrop( const QString &file ) override;
 };
 
+
+/**
+ * Custom data item for XML style libraries.
+ */
+class QgsStyleXmlDataItem : public QgsDataItem
+{
+    Q_OBJECT
+
+  public:
+
+    QgsStyleXmlDataItem( QgsDataItem *parent, const QString &name, const QString &path );
+    bool hasDragEnabled() const override;
+    QgsMimeDataUtils::Uri mimeUri() const override;
+    bool handleDoubleClick() override;
+    QList< QAction * > actions( QWidget *parent ) override;
+
+};
+
+/**
+ * Data item provider for showing style XML libraries in the browser.
+ */
+class QgsStyleXmlDataItemProvider : public QgsDataItemProvider
+{
+  public:
+    QString name() override;
+    int capabilities() override;
+    QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
+};
+
+/**
+ * Handles drag and drop of style XML libraries to app.
+ */
+class QgsStyleXmlDropHandler : public QgsCustomDropHandler
+{
+    Q_OBJECT
+
+  public:
+
+    QString customUriProviderKey() const override;
+    void handleCustomUriDrop( const QgsMimeDataUtils::Uri &uri ) const override;
+    bool handleFileDrop( const QString &file ) override;
+};
+
 #endif // QGSAPPBROWSERPROVIDERS_H

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -370,6 +370,11 @@ QgsStyleExportImportDialog::~QgsStyleExportImportDialog()
   delete mGroupSelectionDlg;
 }
 
+void QgsStyleExportImportDialog::setImportFilePath( const QString &path )
+{
+  mImportFileWidget->setFilePath( path );
+}
+
 void QgsStyleExportImportDialog::selectAll()
 {
   listItems->selectAll();

--- a/src/gui/symbology/qgsstyleexportimportdialog.h
+++ b/src/gui/symbology/qgsstyleexportimportdialog.h
@@ -44,16 +44,29 @@ class GUI_EXPORT QgsStyleExportImportDialog : public QDialog, private Ui::QgsSty
     Q_OBJECT
 
   public:
+
+    //! Dialog modes
     enum Mode
     {
-      Export,
-      Import
+      Export, //!< Export existing symbols mode
+      Import, //!< Import xml file mode
     };
 
-    // constructor
-    // mode argument must be 0 for saving and 1 for loading
+    /**
+     * Constructor for QgsStyleExportImportDialog, with the specified \a parent widget.
+     *
+     * Creates a dialog for importing symbols into the given \a style, or exporting symbols from the \a style.
+     * The \a mode argument dictates whether the dialog is to be used for exporting or importing symbols.
+     */
     QgsStyleExportImportDialog( QgsStyle *style, QWidget *parent SIP_TRANSFERTHIS = nullptr, Mode mode = Export );
     ~QgsStyleExportImportDialog() override;
+
+    /**
+     * Sets the initial \a path to use for importing files, when the dialog is in a Import mode.
+     *
+     * \since QGIS 3.6
+     */
+    void setImportFilePath( const QString &path );
 
     /**
      * \brief selectSymbols select symbols by name


### PR DESCRIPTION
Double clicking the databases or dragging them to QGIS triggers the import from style dialog with the corresponding input file already selected