### PR TITLE
[oracle] Prefetch memory variable changed to 32-bit and default raised to 8MB

### DIFF
--- a/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
+++ b/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
@@ -86,8 +86,8 @@
 #include <stdlib.h>
 
 #define QOCISPATIAL_DYNAMIC_CHUNK_SIZE 65535
-#define QOCISPATIAL_PREFETCH_MEM  10240
-
+#define QOCISPATIAL_PREFETCH_ROWS  10000
+#define QOCISPATIAL_PREFETCH_MEM  8388608 // 8MB
 // setting this define will allow using a query from a different
 // thread than its database connection.
 // warning - this is not fully tested and can lead to race conditions
@@ -355,7 +355,7 @@ struct QOCISpatialResultPrivate
   QList<QOCISDOGeometryInd*> sdoind;
   bool transaction;
   int serverVersion;
-  int prefetchRows, prefetchMem;
+  ub4 prefetchRows, prefetchMem;
   OCIType *geometryTDO;
   QOCISDOGeometryObj *geometryObj;
   QOCISDOGeometryInd *geometryInd;
@@ -765,7 +765,7 @@ struct QOCISpatialDriverPrivate
   bool transaction;
   int serverVersion;
   ub4 prefetchRows;
-  ub2 prefetchMem;
+  ub4 prefetchMem;
   QString user;
 
   OCIType *geometryTDO;
@@ -782,7 +782,7 @@ QOCISpatialDriverPrivate::QOCISpatialDriverPrivate()
     , err( 0 )
     , transaction( false )
     , serverVersion( -1 )
-    , prefetchRows( 0xffffffff )
+    , prefetchRows( QOCISPATIAL_PREFETCH_ROWS )
     , prefetchMem( QOCISPATIAL_PREFETCH_MEM )
     , geometryTDO( 0 )
 {
@@ -3381,13 +3381,13 @@ static void qParseOpts( const QString &options, QOCISpatialDriverPrivate *d )
     {
       d->prefetchRows = val.toInt( &ok );
       if ( !ok )
-        d->prefetchRows = 0xffffffff;
+        d->prefetchRows = QOCISPATIAL_PREFETCH_ROWS;
     }
     else if ( opt == QLatin1String( "OCI_ATTR_PREFETCH_MEMORY" ) )
     {
       d->prefetchMem = val.toInt( &ok );
       if ( !ok )
-        d->prefetchMem = 0xffff;
+        d->prefetchMem = QOCISPATIAL_PREFETCH_MEM;
     }
     else
     {

--- a/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
+++ b/src/providers/oracle/ocispatial/qsql_ocispatial.cpp
@@ -415,28 +415,23 @@ void QOCISpatialResultPrivate::setStatementAttributes()
 
   int r = OCI_SUCCESS;
 
-  if ( prefetchRows >= 0 )
-  {
-    r = OCIAttrSet( sql,
-                    OCI_HTYPE_STMT,
-                    &prefetchRows,
-                    0,
-                    OCI_ATTR_PREFETCH_ROWS,
-                    err );
-    if ( r != OCI_SUCCESS )
-      qOraWarning( "Couldn't set OCI_ATTR_PREFETCH_ROWS: ", err );
-  }
-  if ( prefetchMem >= 0 )
-  {
-    r = OCIAttrSet( sql,
-                    OCI_HTYPE_STMT,
-                    &prefetchMem,
-                    0,
-                    OCI_ATTR_PREFETCH_MEMORY,
-                    err );
-    if ( r != OCI_SUCCESS )
-      qOraWarning( "Couldn't set OCI_ATTR_PREFETCH_MEMORY: ", err );
-  }
+  r = OCIAttrSet( sql,
+                  OCI_HTYPE_STMT,
+                  &prefetchRows,
+                  0,
+                  OCI_ATTR_PREFETCH_ROWS,
+                  err );
+  if ( r != OCI_SUCCESS )
+    qOraWarning( "Couldn't set OCI_ATTR_PREFETCH_ROWS: ", err );
+  r = OCIAttrSet( sql,
+                  OCI_HTYPE_STMT,
+                  &prefetchMem,
+                  0,
+                  OCI_ATTR_PREFETCH_MEMORY,
+                  err );
+  if ( r != OCI_SUCCESS )
+    qOraWarning( "QOCISpatialResultPrivate::setStatementAttributes:"
+                 " Couldn't set OCI_ATTR_PREFETCH_MEMORY: ", err );
 }
 
 int QOCISpatialResultPrivate::bindValue( OCIStmt *sql, OCIBind **hbnd, OCIError *err, int pos,
@@ -3379,15 +3374,19 @@ static void qParseOpts( const QString &options, QOCISpatialDriverPrivate *d )
     bool ok;
     if ( opt == QLatin1String( "OCI_ATTR_PREFETCH_ROWS" ) )
     {
-      d->prefetchRows = val.toInt( &ok );
+      int intVal = val.toInt( &ok );
       if ( !ok )
         d->prefetchRows = QOCISPATIAL_PREFETCH_ROWS;
+      else if ( intVal >= 0 )
+        d->prefetchRows = static_cast<ub4>( intVal );
     }
     else if ( opt == QLatin1String( "OCI_ATTR_PREFETCH_MEMORY" ) )
     {
-      d->prefetchMem = val.toInt( &ok );
+      int intVal = val.toInt( &ok );
       if ( !ok )
         d->prefetchMem = QOCISPATIAL_PREFETCH_MEM;
+      else if ( intVal >= 0 )
+        d->prefetchMem = static_cast<ub4>( intVal );
     }
     else
     {


### PR DESCRIPTION
## Description
Speeds up oracle table access by orders of magnitude

(cherry-pick from commit c3e7632)

Author :     @bjornharrtell 
Date :       Mon Oct 29 21:27:46 2018 +0100

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
