### PR TITLE
[wms] Do not pass null QStrings to QgsWmsProvider::setQueryItem

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -483,7 +483,7 @@ void QgsWmsProvider::setQueryItem( QUrl &url, const QString &item, const QString
 {
   url.removeQueryItem( item );
   if ( value.isNull() )
-    url.addQueryItem( item, QStringLiteral( "" ) );
+    url.addQueryItem( item, QStringLiteral( "" ) ); // skip-keyword-check
   else
     url.addQueryItem( item, value );
 }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -482,7 +482,10 @@ bool QgsWmsProvider::setImageCrs( QString const &crs )
 void QgsWmsProvider::setQueryItem( QUrl &url, const QString &item, const QString &value )
 {
   url.removeQueryItem( item );
-  url.addQueryItem( item, value );
+  if ( value.isNull() )
+    url.addQueryItem( item, QStringLiteral( "" ) );
+  else
+    url.addQueryItem( item, value );
 }
 
 void QgsWmsProvider::setFormatQueryItem( QUrl &url )

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -461,6 +461,9 @@ class QgsWmsProvider : public QgsRasterDataProvider
 
     //! User's settings (URI, authorization, layer, style, ...)
     QgsWmsSettings mSettings;
+
+    friend class TestQgsWmsProvider;
+
 };
 
 

--- a/tests/src/providers/testqgswmsprovider.cpp
+++ b/tests/src/providers/testqgswmsprovider.cpp
@@ -76,6 +76,17 @@ class TestQgsWmsProvider: public QObject
       QCOMPARE( provider.getLegendGraphicUrl(), QString( "http://localhost:8380/mapserv?" ) );
     }
 
+    // regression #20271 - WMS is not displayed in QGIS 3.4.0
+    void queryItemsWithNullValue()
+    {
+      QString failingAddress( "http://localhost:8380/mapserv" );
+      QgsWmsProvider provider( failingAddress, QgsDataProvider::ProviderOptions(), mCapabilities );
+      QUrl url( provider.createRequestUrlWMS( QgsRectangle( 0, 0, 90, 90 ), 100, 100 ) );
+      QCOMPARE( url.toString(), QString( "http://localhost:8380/mapserv?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap"
+                                         "&BBOX=0,0,90,90&CRS=CRS:84&WIDTH=100&HEIGHT=100&LAYERS=&"
+                                         "STYLES=&FORMAT=&TRANSPARENT=TRUE" ) );
+    }
+
   private:
     QgsWmsCapabilities *mCapabilities = nullptr;
 };


### PR DESCRIPTION
Fix #20271 - WMS is not displayed in QGIS 3.4.0

With test

Cherry-picked from 94aa628e3e94e5998ba762810e19be104c0f820b
