### PR TITLE
QgsDataSourceSelectDialog: a simple browser-based reusable data sourc…

### DIFF
--- a/python/gui/auto_generated/qgsdatasourceselectdialog.sip.in
+++ b/python/gui/auto_generated/qgsdatasourceselectdialog.sip.in
@@ -1,0 +1,65 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsdatasourceselectdialog.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsDataSourceSelectDialog: QDialog
+{
+%Docstring
+The QgsDataSourceSelectDialog class embeds the browser view to
+select an existing data source.
+
+By default any layer type can be chosen, the valid layer
+type can be restricted by setting a layer type filter with
+setLayerTypeFilter(layerType) or by activating the filter
+directly from the constructor.
+
+To retrieve the selected data source, uri() can be called and it
+will return a (possibly invalid) QgsMimeDataUtils.Uri.
+
+.. versionadded:: 3.6
+%End
+
+%TypeHeaderCode
+#include "qgsdatasourceselectdialog.h"
+%End
+  public:
+
+    QgsDataSourceSelectDialog( bool setFilterByLayerType = false,
+                               const QgsMapLayer::LayerType &layerType = QgsMapLayer::LayerType::VectorLayer,
+                               QWidget *parent = 0 );
+%Docstring
+Constructs a QgsDataSourceSelectDialog, optionally filtering by layer type
+
+:param setFilterByLayerType: activates filtering by layer type
+:param layerType: sets the layer type filter, this is in effect only if filtering by layer type is also active
+:param parent: the object
+%End
+
+    ~QgsDataSourceSelectDialog();
+
+    void setLayerTypeFilter( const QgsMapLayer::LayerType &layerType );
+%Docstring
+Sets layer type filter to ``layerType`` and activates the filtering
+%End
+
+    QgsMimeDataUtils::Uri uri() const;
+%Docstring
+Returns the (possibly invalid) uri of the selected data source
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/gui/qgsdatasourceselectdialog.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/gui/gui_auto.sip
+++ b/python/gui/gui_auto.sip
@@ -17,6 +17,7 @@
 %Include auto_generated/qgsuserinputwidget.sip
 %Include auto_generated/qgsbrowserdockwidget.sip
 %Include auto_generated/qgsvertexmarker.sip
+%Include auto_generated/qgsdatasourceselectdialog.sip
 %Include auto_generated/qgsabstractdatasourcewidget.sip
 %Include auto_generated/qgssourceselectprovider.sip
 %Include auto_generated/qgssourceselectproviderregistry.sip

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -244,6 +244,7 @@ SET(QGIS_GUI_SRCS
   qgscustomdrophandler.cpp
   qgscurveeditorwidget.cpp
   qgsdatumtransformdialog.cpp
+  qgsdatasourceselectdialog.cpp
   qgsdetaileditemdata.cpp
   qgsdetaileditemdelegate.cpp
   qgsdetaileditemwidget.cpp
@@ -422,6 +423,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgscurveeditorwidget.h
   qgscustomdrophandler.h
   qgsdatumtransformdialog.h
+  qgsdatasourceselectdialog.h
   qgsdetaileditemdelegate.h
   qgsdetaileditemwidget.h
   qgsdial.h
@@ -787,6 +789,7 @@ SET(QGIS_GUI_HDRS
   qgsbrowserdockwidget_p.h
   qgsvertexmarker.h
   qgsdatasourcemanagerdialog.h
+  qgsdatasourceselectdialog.h
   qgsabstractdatasourcewidget.h
   qgswidgetstatehelper_p.h
   qgssourceselectprovider.h

--- a/src/gui/qgsdatasourceselectdialog.cpp
+++ b/src/gui/qgsdatasourceselectdialog.cpp
@@ -3,8 +3,8 @@
 
  ---------------------
  begin                : 1.11.2018
- copyright            : (C) 2018 by ale
- email                : [your-email-here]
+ copyright            : (C) 2018 by Alessandro Pasotti
+ email                : elpaso@itopen.it
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/gui/qgsdatasourceselectdialog.cpp
+++ b/src/gui/qgsdatasourceselectdialog.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+  qgsdatasourceselectdialog.cpp - QgsDataSourceSelectDialog
+
+ ---------------------
+ begin                : 1.11.2018
+ copyright            : (C) 2018 by ale
+ email                : [your-email-here]
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdatasourceselectdialog.h"
+#include "ui_qgsdatasourceselectdialog.h"
+#include "qgssettings.h"
+#include "qgis.h"
+
+#include <QPushButton>
+
+QgsDataSourceSelectDialog::QgsDataSourceSelectDialog( bool setFilterByLayerType,
+    const QgsMapLayer::LayerType &layerType,
+    QWidget *parent )
+  : QDialog( parent )
+{
+  setupUi( this );
+  setWindowTitle( tr( "Select a data source" ) );
+  QByteArray dlgGeom( QgsSettings().value( QStringLiteral( "/Windows/selectDataSourceDialog/geometry" ), QVariant(), QgsSettings::Section::Gui ).toByteArray() );
+  restoreGeometry( dlgGeom );
+
+  mBrowserModel.initialize();
+  mBrowserProxyModel.setBrowserModel( &mBrowserModel );
+  mBrowserTreeView->setHeaderHidden( true );
+
+  if ( setFilterByLayerType )
+  {
+    setLayerTypeFilter( layerType );
+  }
+  else
+  {
+    mBrowserTreeView->setModel( &mBrowserProxyModel );
+    buttonBox->button( QDialogButtonBox::StandardButton::Ok )->setEnabled( false );
+  }
+  connect( mBrowserTreeView, &QgsBrowserTreeView::clicked, this, &QgsDataSourceSelectDialog::onLayerSelected );
+}
+
+
+QgsDataSourceSelectDialog::~QgsDataSourceSelectDialog()
+{
+  QgsSettings().setValue( QStringLiteral( "/Windows/selectDataSourceDialog/geometry" ), saveGeometry(), QgsSettings::Section::Gui );
+}
+
+void QgsDataSourceSelectDialog::setLayerTypeFilter( const QgsMapLayer::LayerType &layerType )
+{
+  mBrowserProxyModel.setFilterByLayerType( true );
+  mBrowserProxyModel.setLayerType( layerType );
+  // reset model and button
+  mBrowserTreeView->setModel( &mBrowserProxyModel );
+  buttonBox->button( QDialogButtonBox::StandardButton::Ok )->setEnabled( false );
+}
+
+QgsMimeDataUtils::Uri QgsDataSourceSelectDialog::uri() const
+{
+  return mUri;
+}
+
+void QgsDataSourceSelectDialog::onLayerSelected( const QModelIndex &index )
+{
+  bool isLayerCompatible = false;
+  mUri = QgsMimeDataUtils::Uri();
+  if ( index.isValid() )
+  {
+    const QgsDataItem *dataItem( mBrowserProxyModel.dataItem( index ) );
+    if ( dataItem )
+    {
+      const QgsLayerItem *layerItem = qobject_cast<const QgsLayerItem *>( dataItem );
+      if ( layerItem && ( ! mBrowserProxyModel.filterByLayerType() ||
+                          ( layerItem->mapLayerType() == mBrowserProxyModel.layerType() ) ) )
+      {
+        isLayerCompatible = true;
+        mUri = layerItem->mimeUri();
+      }
+    }
+  }
+  buttonBox->button( QDialogButtonBox::StandardButton::Ok )->setEnabled( isLayerCompatible );
+}
+

--- a/src/gui/qgsdatasourceselectdialog.h
+++ b/src/gui/qgsdatasourceselectdialog.h
@@ -1,0 +1,83 @@
+/***************************************************************************
+  qgsdatasourceselectdialog.h - QgsDataSourceSelectDialog
+
+ ---------------------
+ begin                : 1.11.2018
+ copyright            : (C) 2018 by ale
+ email                : [your-email-here]
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDATASOURCESELECTDIALOG_H
+#define QGSDATASOURCESELECTDIALOG_H
+
+#include <QObject>
+#include "ui_qgsdatasourceselectdialog.h"
+
+#include "qgis_gui.h"
+#include "qgsmaplayer.h"
+#include "qgsmimedatautils.h"
+#include "qgsbrowsermodel.h"
+#include "qgsbrowserproxymodel.h"
+
+
+/**
+ * \ingroup gui
+ * The QgsDataSourceSelectDialog class embeds the browser view to
+ * select an existing data source.
+ *
+ * By default it allows to select all layer types, the allowed layer
+ * type can be restricted by setting a layer type filter with
+ * setLayerTypeFilter(layerType) or by activating the filter
+ * directly from the constructor.
+ *
+ * To retrieve the selected data source, uri() can be called and it
+ * will return a (possibly invalid) QgsMimeDataUtils::Uri.
+ *
+ * \since QGIS 3.6
+ */
+class GUI_EXPORT QgsDataSourceSelectDialog: public QDialog, private Ui::QgsDataSourceSelectDialog
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructs a QgsDataSourceSelectDialog, optionally filtering by layer type
+     *
+     * \param setFilterByLayerType activates filtering by layer type
+     * \param layerType sets the layer type filter, this is in effect only if filtering by layer type is also active
+     * \param parent the object
+     */
+    QgsDataSourceSelectDialog( bool setFilterByLayerType = false,
+                               const QgsMapLayer::LayerType &layerType = QgsMapLayer::LayerType::VectorLayer,
+                               QWidget *parent = nullptr );
+
+    ~QgsDataSourceSelectDialog() override;
+
+    /**
+     * Sets layer type filter to \a layerType and activates the filtering
+     */
+    void setLayerTypeFilter( const QgsMapLayer::LayerType &layerType );
+
+    QgsMimeDataUtils::Uri uri() const;
+
+  private slots:
+
+    //! Triggered when a layer is selected in the browser
+    void onLayerSelected( const QModelIndex &index );
+
+  private:
+
+    QgsBrowserModel mBrowserModel;
+    QgsBrowserProxyModel mBrowserProxyModel;
+    QgsMimeDataUtils::Uri mUri;
+
+};
+
+#endif // QGSDATASOURCESELECTDIALOG_H

--- a/src/gui/qgsdatasourceselectdialog.h
+++ b/src/gui/qgsdatasourceselectdialog.h
@@ -3,8 +3,8 @@
 
  ---------------------
  begin                : 1.11.2018
- copyright            : (C) 2018 by ale
- email                : [your-email-here]
+ copyright            : (C) 2018 by Alessandro Pasotti
+ email                : elpaso@itopen.it
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -31,7 +31,7 @@
  * The QgsDataSourceSelectDialog class embeds the browser view to
  * select an existing data source.
  *
- * By default it allows to select all layer types, the allowed layer
+ * By default any layer type can be chosen, the valid layer
  * type can be restricted by setting a layer type filter with
  * setLayerTypeFilter(layerType) or by activating the filter
  * directly from the constructor.
@@ -65,6 +65,9 @@ class GUI_EXPORT QgsDataSourceSelectDialog: public QDialog, private Ui::QgsDataS
      */
     void setLayerTypeFilter( const QgsMapLayer::LayerType &layerType );
 
+    /**
+     * Returns the (possibly invalid) uri of the selected data source
+     */
     QgsMimeDataUtils::Uri uri() const;
 
   private slots:

--- a/src/ui/qgsdatasourceselectdialog.ui
+++ b/src/ui/qgsdatasourceselectdialog.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDataSourceSelectDialog</class>
+ <widget class="QDialog" name="QgsDataSourceSelectDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QgsBrowserTreeView" name="mBrowserTreeView"/>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsBrowserTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qgsbrowsertreeview.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsDataSourceSelectDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsDataSourceSelectDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
…e select dialog

## Data Source Select Dialog

This PR introduces a new simple and reusable data source select dialog, it is based on the browser model and view, but its capabilities are limited limited to the selection of a data source, optionally filtered by layer type.

The selected data source (if any) can be retrieved as `QgsMimeDataUtils::Uri`

![immagine](https://user-images.githubusercontent.com/142164/47848309-4119a000-ddce-11e8-934b-e049edffe106.png)

