### PR TITLE
Activate geometry checks when changing layer properties

### DIFF
--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -88,6 +88,11 @@ void QgsGeometryValidationService::onLayersAdded( const QList<QgsMapLayer *> &la
         enableLayerChecks( vectorLayer );
       } );
 
+      connect( vectorLayer->geometryOptions(), &QgsGeometryOptions::geometryChecksChanged, this, [this, vectorLayer]()
+      {
+        enableLayerChecks( vectorLayer );
+      } );
+
       connect( vectorLayer, &QgsVectorLayer::destroyed, this, [vectorLayer, this]()
       {
         cleanupLayerChecks( vectorLayer );

--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -180,9 +180,12 @@ void QgsGeometryValidationService::cleanupLayerChecks( QgsVectorLayer *layer )
   VectorLayerCheckInformation &checkInformation = mLayerChecks[layer];
 
   cancelTopologyCheck( layer );
+  clearTopologyChecks( layer );
 
   qDeleteAll( checkInformation.singleFeatureChecks );
+  checkInformation.singleFeatureChecks.clear();
   qDeleteAll( checkInformation.topologyChecks );
+  checkInformation.topologyChecks.clear();
   checkInformation.context.reset();
 }
 
@@ -320,6 +323,7 @@ void QgsGeometryValidationService::clearTopologyChecks( QgsVectorLayer *layer )
 {
   QList<std::shared_ptr<QgsGeometryCheckError>> &allErrors = mLayerChecks[layer].topologyCheckErrors;
   allErrors.clear();
+  layer->setAllowCommit( mLayerChecks[layer].singleFeatureCheckErrors.empty() );
 
   emit topologyChecksCleared( layer );
 }
@@ -368,6 +372,7 @@ void QgsGeometryValidationService::triggerTopologyChecks( QgsVectorLayer *layer 
 {
   cancelTopologyCheck( layer );
   clearTopologyChecks( layer );
+  layer->setAllowCommit( false );
 
   QgsFeatureIds affectedFeatureIds;
   if ( layer->editBuffer() )


### PR DESCRIPTION
No longer requires a reload of the project

Fix #20218
https://issues.qgis.org/issues/20218
