### PR TITLE
Make sure QgsFeatureSelectionDlg does not outgrow the window

### DIFF
--- a/python/gui/auto_generated/qgsfeatureselectiondlg.sip.in
+++ b/python/gui/auto_generated/qgsfeatureselectiondlg.sip.in
@@ -48,6 +48,13 @@ Set the selected features
 :param ids: The feature ids to select
 %End
 
+  protected:
+
+    virtual void showEvent( QShowEvent *event );
+
+%Docstring
+Make sure the dialog does not grow too much
+%End
 };
 
 /************************************************************************

--- a/src/gui/qgsfeatureselectiondlg.cpp
+++ b/src/gui/qgsfeatureselectiondlg.cpp
@@ -20,6 +20,7 @@
 #include "qgsfeaturerequest.h"
 #include "qgsattributeeditorcontext.h"
 
+#include <QWindow>
 
 QgsFeatureSelectionDlg::QgsFeatureSelectionDlg( QgsVectorLayer *vl, QgsAttributeEditorContext &context, QWidget *parent )
   : QDialog( parent )
@@ -43,6 +44,32 @@ const QgsFeatureIds &QgsFeatureSelectionDlg::selectedFeatures()
 void QgsFeatureSelectionDlg::setSelectedFeatures( const QgsFeatureIds &ids )
 {
   mFeatureSelection->setSelectedFeatures( ids );
+}
+
+void QgsFeatureSelectionDlg::showEvent( QShowEvent *event )
+{
+
+  QWindow *mainWindow = nullptr;
+  for ( const auto &w : QgsApplication::instance()->topLevelWindows() )
+  {
+    if ( w->objectName() == QStringLiteral( "QgisAppWindow" ) )
+    {
+      mainWindow = w;
+      break;
+    }
+  }
+
+  if ( mainWindow )
+  {
+    QSize margins( size() - scrollAreaWidgetContents->size() );
+    QSize innerWinSize( mainWindow->width(), mainWindow->height() );
+    setMaximumSize( innerWinSize );
+    QSize minSize( scrollAreaWidgetContents->sizeHint() );
+    setMinimumSize( std::min( minSize.width() + margins.width( ), innerWinSize.width() ),
+                    std::min( minSize.height() + margins.width( ), innerWinSize.height() ) );
+  }
+
+  QDialog::showEvent( event );
 }
 
 

--- a/src/gui/qgsfeatureselectiondlg.h
+++ b/src/gui/qgsfeatureselectiondlg.h
@@ -69,6 +69,12 @@ class GUI_EXPORT QgsFeatureSelectionDlg : public QDialog, private Ui::QgsFeature
   private:
     QgsGenericFeatureSelectionManager *mFeatureSelection = nullptr;
     QgsVectorLayer *mVectorLayer = nullptr;
+
+    // QWidget interface
+  protected:
+
+    //! Make sure the dialog does not grow too much
+    void showEvent( QShowEvent *event ) override;
 };
 
 #endif // QGSFEATURESELECTIONDLG_H

--- a/src/ui/qgsfeatureselectiondlg.ui
+++ b/src/ui/qgsfeatureselectiondlg.ui
@@ -15,9 +15,28 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QgsDualView" name="mDualView">
-     <widget class="QWidget" name="page"/>
-     <widget class="QWidget" name="page_2"/>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>448</width>
+        <height>444</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QgsDualView" name="mDualView">
+         <widget class="QWidget" name="page"/>
+         <widget class="QWidget" name="page_2"/>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Fixes #20338 - Can not scroll through attribute list in dialog window when linking existing child features
