### PR TITLE
[vertex tool] Respect topo editing when adding a vertex (fixes #18046)

### DIFF
--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -156,6 +156,9 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     //! Gets list of matches of all vertices of a layer exactly snapped to a map point
     QList<QgsPointLocator::Match> layerVerticesSnappedToPoint( QgsVectorLayer *layer, const QgsPointXY &mapPoint );
 
+    //! Gets list of matches of all segments of a layer coincident with the given segment
+    QList<QgsPointLocator::Match> layerSegmentsSnappedToSegment( QgsVectorLayer *layer, const QgsPointXY &mapPoint1, const QgsPointXY &mapPoint2 );
+
     void startDraggingAddVertex( const QgsPointLocator::Match &m );
 
     void startDraggingAddVertexAtEndpoint( const QgsPointXY &mapPoint );
@@ -176,6 +179,8 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     typedef QHash<QgsVectorLayer *, QHash<QgsFeatureId, QgsGeometry> > VertexEdits;
 
     void addExtraVerticesToEdits( VertexEdits &edits, const QgsPointXY &mapPoint, QgsVectorLayer *dragLayer = nullptr, const QgsPointXY &layerPoint = QgsPointXY() );
+
+    void addExtraSegmentsToEdits( QgsVertexTool::VertexEdits &edits, const QgsPointXY &mapPoint, QgsVectorLayer *dragLayer, const QgsPointXY &layerPoint );
 
     void applyEditsToLayers( VertexEdits &edits );
 
@@ -329,6 +334,12 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
      * vertex (mDraggingVertex)
      */
     QList<QgsVector> mDraggingExtraVerticesOffset;
+
+    /**
+     * list of Vertex instances identifying segments (by their first vertex index) that should
+     * also get a new vertex: this is used for topo editing when adding a vertex to existing segment
+     */
+    QList<Vertex> mDraggingExtraSegments;
 
     // members for selection handling
 


### PR DESCRIPTION
When adding a vertex to a segment that is coincident with some other
segments and topological editing is enabled, vertex tool will now correctly
add new vertex also the coincident segments to preserve shared borders.
