### PR TITLE
Fix a bunch of MS SQL provider issues

### DIFF
--- a/src/providers/mssql/qgsmssqlconnection.cpp
+++ b/src/providers/mssql/qgsmssqlconnection.cpp
@@ -98,7 +98,12 @@ QSqlDatabase QgsMssqlConnection::getDatabase( const QString &service, const QStr
 #ifdef Q_OS_WIN
     connectionString = "driver={SQL Server}";
 #else
-    connectionString = QStringLiteral( "driver={FreeTDS};port=1433" );
+    // It seems that FreeTDS driver by default uses an ancient TDS protocol version (4.2) to communicate with MS SQL
+    // which was causing various data corruption errors, for example:
+    // - truncating data from varchar columns to 255 chars - failing to read WKT for CRS
+    // - truncating binary data to 4096 bytes (see @@TEXTSIZE) - failing to parse larger geometries
+    // The added "TDS_Version=auto" should negotiate more recent version (manually setting e.g. 7.2 worked fine too)
+    connectionString = QStringLiteral( "driver={FreeTDS};port=1433;TDS_Version=auto" );
 #endif
   }
 

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -347,6 +347,14 @@ void QgsMssqlConnectionItem::setLayerType( QgsMssqlLayerProperty layerProperty )
     layerProperty.srid = sridList[i];
     schemaItem->addLayer( layerProperty, true );
   }
+
+  if ( typeList.isEmpty() )
+  {
+    // this suggests that retrieval of geometry type and CRS failed if no results were returned
+    // for examle due to invalid geometries in the table (WHAAAT?)
+    // but we still want to add have such table in the list
+    schemaItem->addLayer( layerProperty, true );
+  }
 }
 
 bool QgsMssqlConnectionItem::equal( const QgsDataItem *other )
@@ -727,6 +735,11 @@ QgsMssqlLayerItem *QgsMssqlSchemaItem::addLayer( const QgsMssqlLayerProperty &la
       {
         layerType = QgsLayerItem::TableLayer;
         tip = tr( "as geometryless table" );
+      }
+      else if ( !layerProperty.geometryColName.isEmpty() && layerProperty.type.isEmpty() )
+      {
+        // geometry column is there but we failed to determine geometry type (e.g. due to invalid geometries)
+        layerType = QgsLayerItem::Vector;
       }
       else
       {

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1490,10 +1490,6 @@ QgsCoordinateReferenceSystem QgsMssqlProvider::crs() const
 {
   if ( !mCrs.isValid() && mSRId > 0 )
   {
-    mCrs.createFromSrid( mSRId );
-    if ( mCrs.isValid() )
-      return mCrs;
-
     // try to load crs from the database tables as a fallback
     QSqlQuery query = createQuery();
     query.setForwardOnly( true );


### PR DESCRIPTION
Testing MS SQL Server container running on Linux, I have quickly run into a combination of bugs in MS SQL provider that made it unusable in my quick tests (import a layer, display it on the map).

The bugs fixed in this PR:
- after import of a layer in QGIS, the layer does not show up in browser and in data sources dialog it shows up but can't be loaded (need explicit choice of geometry type + srid). Caused by invalid geometries (but valid according to QGIS)
- after import of a layer in QGIS, when loaded it will have wrong CRS assigned
- features not showing up on the map or in attribute table (low TEXTSIZE value due to old TDS version)

There are still few things that make MS SQL provider annoying, but at least I they are not complete blockers:
- importing a layer with valid geometries may get MS SQL scream about invalid geometries. Not sure yet why, but at least those can be fixed with a SQL query `update [my_table] set [geom] = [geom].MakeValid() where [geom].STIsValid()=0`  ... maybe something we could have available on right-click in browser :-)
- when importing layers to MS SQL, the logic for handling SRIDs is wrong. Provider uses internal SRS ID from srs.db for SRIDs and assumes if a particular SRID already exists, it is the one we need for the layer.
- importing attributes with international characters fails https://issues.qgis.org/issues/20123