### PR TITLE
Fix equality comparison when saving vertex tool edits

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1824,8 +1824,6 @@ Downgrades a point list from QgsPoint to :py:class:`QgsPointXY`
 
     operator QVariant() const;
 
-    operator bool() const;
-
 }; // class QgsGeometry
 
 

--- a/src/analysis/interpolation/qgsinterpolator.cpp
+++ b/src/analysis/interpolation/qgsinterpolator.cpp
@@ -114,7 +114,7 @@ QgsInterpolator::Result QgsInterpolator::cacheBaseData( QgsFeedback *feedback )
 
 bool QgsInterpolator::addVerticesToCache( const QgsGeometry &geom, ValueSource source, double attributeValue )
 {
-  if ( !geom || geom.isEmpty() )
+  if ( geom.isNull() || geom.isEmpty() )
     return true; // nothing to do
 
   //validate source

--- a/src/analysis/processing/qgsalgorithmboundary.cpp
+++ b/src/analysis/processing/qgsalgorithmboundary.cpp
@@ -109,7 +109,7 @@ QgsFeatureList QgsBoundaryAlgorithm::processFeature( const QgsFeature &feature, 
   {
     QgsGeometry inputGeometry = feature.geometry();
     QgsGeometry outputGeometry = QgsGeometry( inputGeometry.constGet()->boundary() );
-    if ( !outputGeometry )
+    if ( outputGeometry.isNull() )
     {
       feedback->reportError( QObject::tr( "No boundary for feature %1 (possibly a closed linestring?)'" ).arg( feature.id() ) );
       outFeature.clearGeometry();

--- a/src/analysis/processing/qgsalgorithmbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmbuffer.cpp
@@ -136,7 +136,7 @@ QVariantMap QgsBufferAlgorithm::processAlgorithm( const QVariantMap &parameters,
       }
 
       QgsGeometry outputGeometry = f.geometry().buffer( distance, segments, endCapStyle, joinStyle, miterLimit );
-      if ( !outputGeometry )
+      if ( outputGeometry.isNull() )
       {
         QgsMessageLog::logMessage( QObject::tr( "Error calculating buffer for feature %1" ).arg( f.id() ), QObject::tr( "Processing" ), Qgis::Warning );
       }

--- a/src/analysis/processing/qgsalgorithmcentroid.cpp
+++ b/src/analysis/processing/qgsalgorithmcentroid.cpp
@@ -104,7 +104,7 @@ QgsFeatureList QgsCentroidAlgorithm::processFeature( const QgsFeature &f, QgsPro
       {
         QgsGeometry partGeometry( geomCollection->geometryN( i )->clone() );
         QgsGeometry outputGeometry = partGeometry.centroid();
-        if ( !outputGeometry )
+        if ( outputGeometry.isNull() )
         {
           feedback->pushInfo( QObject::tr( "Error calculating centroid for feature %1 part %2: %3" ).arg( feature.id() ).arg( i ).arg( outputGeometry.lastError() ) );
         }
@@ -115,7 +115,7 @@ QgsFeatureList QgsCentroidAlgorithm::processFeature( const QgsFeature &f, QgsPro
     else
     {
       QgsGeometry outputGeometry = feature.geometry().centroid();
-      if ( !outputGeometry )
+      if ( outputGeometry.isNull() )
       {
         feedback->pushInfo( QObject::tr( "Error calculating centroid for feature %1: %2" ).arg( feature.id() ).arg( outputGeometry.lastError() ) );
       }

--- a/src/analysis/processing/qgsalgorithmconvexhull.cpp
+++ b/src/analysis/processing/qgsalgorithmconvexhull.cpp
@@ -83,11 +83,11 @@ QgsFeatureList QgsConvexHullAlgorithm::processFeature( const QgsFeature &feature
     else
     {
       outputGeometry = f.geometry().convexHull();
-      if ( !outputGeometry )
+      if ( outputGeometry.isNull() )
         feedback->reportError( outputGeometry.lastError() );
       f.setGeometry( outputGeometry );
     }
-    if ( outputGeometry )
+    if ( !outputGeometry.isNull() )
     {
       QgsAttributes attrs = f.attributes();
       attrs << outputGeometry.constGet()->area()

--- a/src/analysis/processing/qgsalgorithmdissolve.cpp
+++ b/src/analysis/processing/qgsalgorithmdissolve.cpp
@@ -67,7 +67,7 @@ QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &paramet
         firstFeature = false;
       }
 
-      if ( f.hasGeometry() && f.geometry() )
+      if ( f.hasGeometry() && !f.geometry().isNull() )
       {
         geomQueue.append( f.geometry() );
         if ( maxQueueLength > 0 && geomQueue.length() > maxQueueLength )
@@ -118,7 +118,7 @@ QVariantMap QgsCollectorAlgorithm::processCollection( const QVariantMap &paramet
         attributeHash.insert( indexAttributes, f.attributes() );
       }
 
-      if ( f.hasGeometry() && f.geometry() )
+      if ( f.hasGeometry() && !f.geometry().isNull() )
       {
         geometryHash[ indexAttributes ].append( f.geometry() );
       }

--- a/src/analysis/processing/qgsalgorithmextendlines.cpp
+++ b/src/analysis/processing/qgsalgorithmextendlines.cpp
@@ -129,7 +129,7 @@ QgsFeatureList QgsExtendLinesAlgorithm::processFeature( const QgsFeature &featur
       endDistance = mEndDistanceProperty.valueAsDouble( context.expressionContext(), endDistance );
 
     const QgsGeometry outGeometry = geometry.extendLine( startDistance, endDistance );
-    if ( !outGeometry )
+    if ( outGeometry.isNull() )
       throw QgsProcessingException( QObject::tr( "Error calculating extended line" ) ); // don't think this can actually happen!
 
     f.setGeometry( outGeometry );

--- a/src/analysis/processing/qgsalgorithmfixgeometries.cpp
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.cpp
@@ -93,7 +93,7 @@ QgsFeatureList QgsFixGeometriesAlgorithm::processFeature( const QgsFeature &feat
   QgsFeature outputFeature = feature;
 
   QgsGeometry outputGeometry = outputFeature.geometry().makeValid();
-  if ( !outputGeometry )
+  if ( outputGeometry.isNull() )
   {
     feedback->pushInfo( QObject::tr( "makeValid failed for feature %1 " ).arg( feature.id() ) );
     outputFeature.clearGeometry();

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.cpp
@@ -115,7 +115,7 @@ QVariantMap QgsKMeansClusteringAlgorithm::processAlgorithm( const QVariantMap &p
     else
     {
       QgsGeometry centroid = feat.geometry().centroid();
-      if ( !centroid )
+      if ( centroid.isNull() )
         continue; // centroid failed, e.g. empty linestring
 
       point = QgsPointXY( *qgsgeometry_cast< const QgsPoint * >( centroid.constGet() ) );

--- a/src/analysis/processing/qgsalgorithmmergelines.cpp
+++ b/src/analysis/processing/qgsalgorithmmergelines.cpp
@@ -83,7 +83,7 @@ QgsFeatureList QgsMergeLinesAlgorithm::processFeature( const QgsFeature &feature
 
   QgsFeature out = feature;
   QgsGeometry outputGeometry = feature.geometry().mergeLines();
-  if ( !outputGeometry )
+  if ( outputGeometry.isNull() )
     feedback->reportError( QObject::tr( "Error merging lines for feature %1" ).arg( feature.id() ) );
 
   out.setGeometry( outputGeometry );

--- a/src/analysis/processing/qgsalgorithmmultiringconstantbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmmultiringconstantbuffer.cpp
@@ -133,7 +133,7 @@ QgsFeatureList QgsMultiRingConstantBufferAlgorithm::processFeature( const QgsFea
     QgsFeature out;
     currentDistance = i * distance;
     outputGeometry = feature.geometry().buffer( currentDistance, 40 );
-    if ( !outputGeometry )
+    if ( outputGeometry.isNull() )
     {
       feedback->reportError( QObject::tr( "Error calculating buffer for feature %1" ).arg( feature.id() ) );
       continue;

--- a/src/analysis/processing/qgsalgorithmpointonsurface.cpp
+++ b/src/analysis/processing/qgsalgorithmpointonsurface.cpp
@@ -102,7 +102,7 @@ QgsFeatureList QgsPointOnSurfaceAlgorithm::processFeature( const QgsFeature &f, 
       {
         QgsGeometry partGeometry( geomCollection->geometryN( i )->clone() );
         QgsGeometry outputGeometry = partGeometry.pointOnSurface();
-        if ( !outputGeometry )
+        if ( outputGeometry.isNull() )
         {
           feedback->pushInfo( QObject::tr( "Error calculating point on surface for feature %1 part %2: %3" ).arg( feature.id() ).arg( i ).arg( outputGeometry.lastError() ) );
         }
@@ -113,7 +113,7 @@ QgsFeatureList QgsPointOnSurfaceAlgorithm::processFeature( const QgsFeature &f, 
     else
     {
       QgsGeometry outputGeometry = feature.geometry().pointOnSurface();
-      if ( !outputGeometry )
+      if ( outputGeometry.isNull() )
       {
         feedback->pushInfo( QObject::tr( "Error calculating point on surface for feature %1: %2" ).arg( feature.id() ).arg( outputGeometry.lastError() ) );
       }

--- a/src/analysis/processing/qgsalgorithmrotate.cpp
+++ b/src/analysis/processing/qgsalgorithmrotate.cpp
@@ -129,7 +129,7 @@ QgsFeatureList QgsRotateFeaturesAlgorithm::processFeature( const QgsFeature &fea
     else
     {
       QgsGeometry centroid = geometry.centroid();
-      if ( centroid )
+      if ( !centroid.isNull() )
       {
         geometry.rotate( angle, centroid.asPoint() );
         f.setGeometry( geometry );

--- a/src/analysis/processing/qgsalgorithmsmooth.cpp
+++ b/src/analysis/processing/qgsalgorithmsmooth.cpp
@@ -147,7 +147,7 @@ QgsFeatureList QgsSmoothAlgorithm::processFeature( const QgsFeature &feature, Qg
       maxAngle = mMaxAngleProperty.valueAsDouble( context.expressionContext(), maxAngle );
 
     QgsGeometry outputGeometry = f.geometry().smooth( iterations, offset, -1, maxAngle );
-    if ( !outputGeometry )
+    if ( outputGeometry.isNull() )
     {
       feedback->reportError( QObject::tr( "Error smoothing geometry %1" ).arg( feature.id() ) );
     }

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
@@ -145,7 +145,7 @@ QgsFeatureList QgsSnapToGridAlgorithm::processFeature( const QgsFeature &feature
       intervalM = mIntervalMProperty.valueAsDouble( context.expressionContext(), intervalM );
 
     QgsGeometry outputGeometry = f.geometry().snappedToGrid( intervalX, intervalY, intervalZ, intervalM );
-    if ( !outputGeometry )
+    if ( outputGeometry.isNull() )
     {
       feedback->reportError( QObject::tr( "Error snapping geometry %1" ).arg( feature.id() ) );
     }

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
@@ -192,7 +192,7 @@ QVariantMap QgsSplitWithLinesAlgorithm::processAlgorithm( const QVariantMap &par
             }
 
             QgsGeometry inGeom = inGeoms.takeFirst();
-            if ( !inGeom )
+            if ( inGeom.isNull() )
               continue;
 
             if ( splitGeomEngine->intersects( inGeom.constGet() ) )

--- a/src/analysis/processing/qgsalgorithmsubdivide.cpp
+++ b/src/analysis/processing/qgsalgorithmsubdivide.cpp
@@ -90,7 +90,7 @@ QgsFeatureList QgsSubdivideAlgorithm::processFeature( const QgsFeature &f, QgsPr
       maxNodes = mMaxNodesProperty.valueAsDouble( context.expressionContext(), maxNodes );
 
     feature.setGeometry( feature.geometry().subdivide( maxNodes ) );
-    if ( !feature.geometry() )
+    if ( !feature.hasGeometry() )
     {
       feedback->reportError( QObject::tr( "Error calculating subdivision for feature %1" ).arg( feature.id() ) );
     }

--- a/src/analysis/processing/qgsalgorithmtaperedbuffer.cpp
+++ b/src/analysis/processing/qgsalgorithmtaperedbuffer.cpp
@@ -141,7 +141,7 @@ QgsFeatureList QgsTaperedBufferAlgorithm::processFeature( const QgsFeature &feat
     endWidth = mEndWidthProperty.valueAsDouble( context.expressionContext(), endWidth );
 
   QgsGeometry outputGeometry = feature.geometry().taperedBuffer( startWidth, endWidth, segments );
-  if ( !outputGeometry )
+  if ( outputGeometry.isNull() )
   {
     feedback->reportError( QObject::tr( "Error buffering geometry %1: %2" ).arg( feature.id() ).arg( outputGeometry.lastError() ) );
   }
@@ -241,7 +241,7 @@ QgsFeatureList QgsVariableWidthBufferByMAlgorithm::processFeature( const QgsFeat
     segments = mSegmentsProperty.valueAsInt( context.expressionContext(), segments );
 
   QgsGeometry outputGeometry = feature.geometry().variableWidthBufferByM( segments );
-  if ( !outputGeometry )
+  if ( outputGeometry.isNull() )
   {
     feedback->reportError( QObject::tr( "Error buffering geometry %1: %2" ).arg( feature.id() ).arg( outputGeometry.lastError() ) );
   }

--- a/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
+++ b/src/analysis/vector/geometry_checker/qgsgeometrycheckerutils.cpp
@@ -45,7 +45,7 @@ QgsGeometryCheckerUtils::LayerFeature::LayerFeature( const QgsFeaturePool *pool,
     {
       mGeometry.transform( transform );
     }
-    catch ( const QgsCsException &e )
+    catch ( const QgsCsException & )
     {
       QgsDebugMsg( QStringLiteral( "Shrug. What shall we do with a geometry that cannot be converted?" ) );
     }
@@ -195,7 +195,7 @@ bool QgsGeometryCheckerUtils::LayerFeatures::iterator::nextFeature( bool begin )
     if ( mParent->mFeedback )
       mParent->mFeedback->setProgress( mParent->mFeedback->progress() + 1.0 );
     QgsFeature feature;
-    if ( featurePool->getFeature( *mFeatureIt, feature ) && feature.geometry() && feature.geometry().constGet() )
+    if ( featurePool->getFeature( *mFeatureIt, feature ) && !feature.geometry().isNull() )
     {
       mCurrentFeature.reset( new LayerFeature( mParent->mFeaturePools[*mLayerIt], feature, mParent->mContext, mParent->mUseMapCrs ) );
       return true;

--- a/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
+++ b/src/analysis/vector/geometry_checker/qgssinglegeometrycheck.cpp
@@ -49,9 +49,9 @@ void QgsSingleGeometryCheckError::update( const QgsSingleGeometryCheckError *oth
 
 bool QgsSingleGeometryCheckError::isEqual( const QgsSingleGeometryCheckError *other ) const
 {
-  return mGeometry == other->mGeometry
+  return mGeometry.equals( other->mGeometry )
          && mCheck == other->mCheck
-         && mErrorLocation == other->mErrorLocation
+         && mErrorLocation.equals( other->mErrorLocation )
          && mVertexId == other->mVertexId;
 }
 

--- a/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
+++ b/src/analysis/vector/geometry_checker/qgsvectordataproviderfeaturepool.cpp
@@ -35,7 +35,7 @@ QgsVectorDataProviderFeaturePool::QgsVectorDataProviderFeaturePool( QgsVectorLay
   QgsFeatureIterator it = layer->getFeatures( req );
   while ( it.nextFeature( feature ) )
   {
-    if ( feature.geometry() )
+    if ( feature.hasGeometry() )
     {
       insertFeature( feature );
       featureIds.insert( feature.id() );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1631,7 +1631,7 @@ void QgsIdentifyResultsDialog::highlightFeature( QTreeWidgetItem *item )
   if ( mHighlights.contains( featItem ) )
     return;
 
-  if ( !featItem->feature().geometry() || featItem->feature().geometry().wkbType() == QgsWkbTypes::Unknown )
+  if ( !featItem->feature().hasGeometry() || featItem->feature().geometry().wkbType() == QgsWkbTypes::Unknown )
     return;
 
   QgsHighlight *highlight = nullptr;

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -594,7 +594,7 @@ void QgsMapToolOffsetCurve::updateGeometryAndRubberBand( double offset )
     offsetGeom = mManipulatedGeometry.buffer( offset, quadSegments, capStyle, joinStyle, miterLimit );
   }
 
-  if ( !offsetGeom )
+  if ( offsetGeom.isNull() )
   {
     deleteRubberBandAndGeometry();
     deleteUserInputWidget();

--- a/src/app/qgsmaptoolreverseline.cpp
+++ b/src/app/qgsmaptoolreverseline.cpp
@@ -115,7 +115,7 @@ void QgsMapToolReverseLine::canvasReleaseEvent( QgsMapMouseEvent *e )
 
     }
 
-    if ( geom )
+    if ( !geom.isNull() )
     {
       vlayer->beginEditCommand( tr( "Reverse line" ) );
       vlayer->changeGeometry( f.id(), geom );

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1639,7 +1639,7 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
       layer->changeGeometry( it2.key(), it2.value() );
       for ( int i = 0; i < mSelectedVertices.length(); ++i )
       {
-        if ( mSelectedVertices.at( i ).layer == layer && mSelectedVertices.at( i ).fid == it2.value() )
+        if ( mSelectedVertices.at( i ).layer == layer && mSelectedVertices.at( i ).fid == it2.key() )
         {
           mSelectedFeature->selectVertex( mSelectedVertices.at( i ).vertexId );
         }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -729,7 +729,7 @@ QgsGeometry::OperationResult QgsGeometry::addPart( const QgsGeometry &newPart )
   {
     return QgsGeometry::InvalidBaseGeometry;
   }
-  if ( !newPart || !newPart.d->geometry )
+  if ( newPart.isNull() || !newPart.d->geometry )
   {
     return QgsGeometry::AddPartNotMultiGeometry;
   }
@@ -752,7 +752,7 @@ QgsGeometry QgsGeometry::removeInteriorRings( double minimumRingArea ) const
     for ( const QgsGeometry &part : parts )
     {
       QgsGeometry result = part.removeInteriorRings( minimumRingArea );
-      if ( result )
+      if ( !result.isNull() )
         results << result;
     }
     if ( results.isEmpty() )
@@ -1729,7 +1729,7 @@ QgsGeometry QgsGeometry::offsetCurve( double distance, int segments, JoinStyle j
     for ( const QgsGeometry &part : parts )
     {
       QgsGeometry result = part.offsetCurve( distance, segments, joinStyle, miterLimit );
-      if ( result )
+      if ( !result.isNull() )
         results << result;
     }
     if ( results.isEmpty() )
@@ -1772,7 +1772,7 @@ QgsGeometry QgsGeometry::singleSidedBuffer( double distance, int segments, Buffe
     for ( const QgsGeometry &part : parts )
     {
       QgsGeometry result = part.singleSidedBuffer( distance, segments, side, joinStyle, miterLimit );
-      if ( result )
+      if ( !result.isNull() )
         results << result;
     }
     if ( results.isEmpty() )
@@ -1830,7 +1830,7 @@ QgsGeometry QgsGeometry::extendLine( double startDistance, double endDistance ) 
     for ( const QgsGeometry &part : parts )
     {
       QgsGeometry result = part.extendLine( startDistance, endDistance );
-      if ( result )
+      if ( !result.isNull() )
         results << result;
     }
     if ( results.isEmpty() )
@@ -2673,11 +2673,6 @@ void QgsGeometry::convertPointList( const QgsPointSequence &input, QVector<QgsPo
   {
     output.append( QgsPointXY( p.x(), p.y() ) );
   }
-}
-
-QgsGeometry::operator bool() const
-{
-  return d->geometry.get();
 }
 
 void QgsGeometry::convertToPolyline( const QgsPointSequence &input, QgsPolylineXY &output )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1823,13 +1823,6 @@ class CORE_EXPORT QgsGeometry
       return QVariant::fromValue( *this );
     }
 
-    /**
-     * Returns true if the geometry is non empty (ie, isNull() returns false),
-     * or false if it is an empty, uninitialized geometry (ie, isNull() returns true).
-     * \since QGIS 3.0
-     */
-    operator bool() const;
-
   private:
 
     QgsGeometryPrivate *d; //implicitly shared data pointer

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -393,7 +393,7 @@ QgsAbstractGeometry *QgsGeos::combine( const QVector<QgsGeometry> &geomList, QSt
   geosGeometries.reserve( geomList.size() );
   for ( const QgsGeometry &g : geomList )
   {
-    if ( !g )
+    if ( g.isNull() )
       continue;
 
     geosGeometries << asGeos( g.constGet(), mPrecision ).release();

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -152,7 +152,7 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols,
   {
     context.expressionContext().setFeature( f );
     // filter out elements outside of the polygon
-    if ( f.geometry() && polygonEngine )
+    if ( f.hasGeometry() && polygonEngine )
     {
       if ( !polygonEngine->intersects( f.geometry().constGet() ) )
       {

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1135,7 +1135,7 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry &geometry, QDomDocumen
                                         const QString &gmlIdBase,
                                         int precision )
 {
-  if ( !geometry )
+  if ( geometry.isNull() )
     return QDomElement();
 
   // coordinate separator

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1567,7 +1567,7 @@ void QgsPalLayerSettings::registerFeature( QgsFeature &f, QgsRenderContext &cont
   }
 
   geos::unique_ptr geosObstacleGeomClone;
-  if ( obstacleGeometry )
+  if ( !obstacleGeometry.isNull() )
   {
     geosObstacleGeomClone = QgsGeos::asGeos( obstacleGeometry );
   }
@@ -2000,7 +2000,7 @@ void QgsPalLayerSettings::registerObstacleFeature( QgsFeature &f, QgsRenderConte
   mCurFeat = &f;
 
   QgsGeometry geom;
-  if ( obstacleGeometry )
+  if ( !obstacleGeometry.isNull() )
   {
     geom = obstacleGeometry;
   }

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -233,7 +233,7 @@ QgsLabelFeature *QgsVectorLayerDiagramProvider::registerDiagram( QgsFeature &fea
 
   geos::unique_ptr geosObstacleGeomClone;
   std::unique_ptr<QgsGeometry> scopedObstacleGeom;
-  if ( isObstacle && obstacleGeometry && QgsPalLabeling::geometryRequiresPreparation( obstacleGeometry, context, mSettings.coordinateTransform(), extentGeom ) )
+  if ( isObstacle && !obstacleGeometry.isNull() && QgsPalLabeling::geometryRequiresPreparation( obstacleGeometry, context, mSettings.coordinateTransform(), extentGeom ) )
   {
     QgsGeometry preparedObstacleGeom = QgsPalLabeling::prepareGeometry( obstacleGeometry, context, mSettings.coordinateTransform(), extentGeom );
     geosObstacleGeomClone = QgsGeos::asGeos( preparedObstacleGeom );

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -707,7 +707,7 @@ void QgsMapToolCapture::validateGeometry()
       break;
   }
 
-  if ( !geom )
+  if ( geom.isNull() )
     return;
 
   QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal;

--- a/src/plugins/topology/topolTest.cpp
+++ b/src/plugins/topology/topolTest.cpp
@@ -583,7 +583,7 @@ ErrorList topolTest::checkGaps( QgsVectorLayer *layer1, QgsVectorLayer *layer2, 
   //qDebug() << "extent wkt - " << bufferExtent->exportToWkt();
 
   QgsGeometry diffGeoms = bufferExtent.difference( test );
-  if ( !diffGeoms )
+  if ( diffGeoms.isNull() )
   {
     qDebug() << "difference result 0-";
     return errorList;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2750,7 +2750,7 @@ void QgsPostgresProvider::appendGeomParam( const QgsGeometry &geom, QStringList 
   QString param;
 
   QgsGeometry convertedGeom( convertToProviderType( geom ) );
-  QByteArray wkb( convertedGeom ? convertedGeom.asWkb() : geom.asWkb() );
+  QByteArray wkb( !convertedGeom.isNull() ? convertedGeom.asWkb() : geom.asWkb() );
   const unsigned char *buf = reinterpret_cast< const unsigned char * >( wkb.constData() );
   int wkbSize = wkb.length();
 

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1268,7 +1268,7 @@ namespace QgsWfs
 
       //add geometry column (as gml)
       QgsGeometry geom = feat->geometry();
-      if ( geom && params.withGeom && params.geometryName != QLatin1String( "NONE" ) )
+      if ( !geom.isNull() && params.withGeom && params.geometryName != QLatin1String( "NONE" ) )
       {
         int prec = params.precision;
         QgsCoordinateReferenceSystem crs = params.crs;
@@ -1365,7 +1365,7 @@ namespace QgsWfs
 
       //add geometry column (as gml)
       QgsGeometry geom = feat->geometry();
-      if ( geom && params.withGeom && params.geometryName != QLatin1String( "NONE" ) )
+      if ( !geom.isNull() && params.withGeom && params.geometryName != QLatin1String( "NONE" ) )
       {
         int prec = params.precision;
         QgsCoordinateReferenceSystem crs = params.crs;

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -5308,7 +5308,7 @@ void TestQgsProcessing::processingFeatureSource()
   QgsFeature f2;
   QVERIFY( source.get() );
   QVERIFY( source->getFeatures().nextFeature( f2 ) );
-  QCOMPARE( f2.geometry(), f.geometry() );
+  QCOMPARE( f2.geometry().asWkt(), f.geometry().asWkt() );
 
   // direct map layer
   params.insert( QStringLiteral( "layer" ), QVariant::fromValue( layer ) );
@@ -5316,7 +5316,7 @@ void TestQgsProcessing::processingFeatureSource()
   // can't directly match it to layer, so instead just get the feature and test that it matches what we expect
   QVERIFY( source.get() );
   QVERIFY( source->getFeatures().nextFeature( f2 ) );
-  QCOMPARE( f2.geometry(), f.geometry() );
+  QCOMPARE( f2.geometry().asWkt(), f.geometry().asWkt() );
 
   // next using property based definition
   params.insert( QStringLiteral( "layer" ), QgsProcessingFeatureSourceDefinition( QgsProperty::fromExpression( QStringLiteral( "trim('%1' + ' ')" ).arg( layer->id() ) ), false ) );
@@ -5324,7 +5324,7 @@ void TestQgsProcessing::processingFeatureSource()
   // can't directly match it to layer, so instead just get the feature and test that it matches what we expect
   QVERIFY( source.get() );
   QVERIFY( source->getFeatures().nextFeature( f2 ) );
-  QCOMPARE( f2.geometry(), f.geometry() );
+  QCOMPARE( f2.geometry().asWkt(), f.geometry().asWkt() );
 
   // we also must accept QgsProcessingOutputLayerDefinition - e.g. to allow outputs from earlier child algorithms in models
   params.insert( QStringLiteral( "layer" ), QgsProcessingOutputLayerDefinition( QgsProperty::fromValue( layer->id() ) ) );
@@ -5332,7 +5332,7 @@ void TestQgsProcessing::processingFeatureSource()
   // can't directly match it to layer, so instead just get the feature and test that it matches what we expect
   QVERIFY( source.get() );
   QVERIFY( source->getFeatures().nextFeature( f2 ) );
-  QCOMPARE( f2.geometry(), f.geometry() );
+  QCOMPARE( f2.geometry().asWkt(), f.geometry().asWkt() );
 }
 
 void TestQgsProcessing::processingFeatureSink()

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -16933,7 +16933,7 @@ void TestQgsGeometry::minimalEnclosingCircle()
   QCOMPARE( radius, 0.0 );
   QVERIFY( result.isNull() );
 
-  // caase 1
+  // case 1
   geomTest = QgsGeometry::fromPointXY( QgsPointXY( 5, 5 ) );
   result = geomTest.minimalEnclosingCircle( center, radius );
   QCOMPARE( center, QgsPointXY( 5, 5 ) );
@@ -16943,47 +16943,44 @@ void TestQgsGeometry::minimalEnclosingCircle()
 
   // case 2
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 3 8, 7 4 )" ) );
-  result = geomTest.minimalEnclosingCircle( center, radius );
+  result = geomTest.minimalEnclosingCircle( center, radius, 6 );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 5, 6 ), 0.0001 );
   QGSCOMPARENEAR( radius, sqrt( 2 ) * 2, 0.0001 );
-  resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result.asWkt(), resultTest.asWkt() );
+  QCOMPARE( result.asWkt( 1 ), QStringLiteral( "Polygon ((7 4, 4.3 3.3, 2.3 5.3, 3 8, 5.7 8.7, 7.7 6.7, 7 4))" ) );
 
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "LINESTRING( 0 5, 2 2, 0 -5, -1 -1 )" ) );
-  result = geomTest.minimalEnclosingCircle( center, radius );
+  result = geomTest.minimalEnclosingCircle( center, radius, 6 );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0, 0 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5, 0.0001 );
-  resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result.asWkt(), resultTest.asWkt() );
+  QCOMPARE( result.asWkt( 1 ), QStringLiteral( "Polygon ((0 5, 4.3 2.5, 4.3 -2.5, -0 -5, -4.3 -2.5, -4.3 2.5, 0 5))" ) );
 
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 0 5, 2 2, 0 -5, -1 -1 )" ) );
-  result = geomTest.minimalEnclosingCircle( center, radius );
+  result = geomTest.minimalEnclosingCircle( center, radius, 6 );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0, 0 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5, 0.0001 );
-  resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result.asWkt(), resultTest.asWkt() );
+  QCOMPARE( result.asWkt( 1 ), QStringLiteral( "Polygon ((0 5, 4.3 2.5, 4.3 -2.5, -0 -5, -4.3 -2.5, -4.3 2.5, 0 5))" ) );
 
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "POLYGON(( 0 5, 2 2, 0 -5, -1 -1 ))" ) );
-  result = geomTest.minimalEnclosingCircle( center, radius );
+  result = geomTest.minimalEnclosingCircle( center, radius, 6 );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0, 0 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result.asWkt(), resultTest.asWkt() );
+  QCOMPARE( result.asWkt( 1 ), QStringLiteral( "Polygon ((0 5, 4.3 2.5, 4.3 -2.5, -0 -5, -4.3 -2.5, -4.3 2.5, 0 5))" ) );
 
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 0 5, 0 -5, 0 0 )" ) );
-  result = geomTest.minimalEnclosingCircle( center, radius );
+  result = geomTest.minimalEnclosingCircle( center, radius, 6 );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0, 0 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result.asWkt(), resultTest.asWkt() );
+  QCOMPARE( result.asWkt( 1 ), QStringLiteral( "Polygon ((0 5, 4.3 2.5, 4.3 -2.5, -0 -5, -4.3 -2.5, -4.3 2.5, 0 5))" ) );
 
   // case 3
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT((0 0), (5 5), (0 -5), (0 5), (-5 0))" ) );
-  result = geomTest.minimalEnclosingCircle( center, radius );
+  result = geomTest.minimalEnclosingCircle( center, radius, 6 );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0.8333, 0.8333 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5.8926, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result.asWkt(), resultTest.asWkt() );
+  QCOMPARE( result.asWkt( 1 ), QStringLiteral( "Polygon ((0.8 6.7, 5.9 3.8, 5.9 -2.1, 0.8 -5.1, -4.3 -2.1, -4.3 3.8, 0.8 6.7))" ) );
 
 }
 

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -80,7 +80,6 @@ class TestQgsGeometry : public QObject
     void assignment();
     void asVariant(); //test conversion to and from a QVariant
     void isEmpty();
-    void operatorBool();
     void equality();
     void vertexIterator();
 
@@ -422,18 +421,6 @@ void TestQgsGeometry::isEmpty()
 
   QgsGeometryCollection collection;
   QVERIFY( collection.isEmpty() );
-}
-
-void TestQgsGeometry::operatorBool()
-{
-  QgsGeometry geom;
-  QVERIFY( !geom );
-
-  geom.set( new QgsPoint( 1.0, 2.0 ) );
-  QVERIFY( geom );
-
-  geom.set( nullptr );
-  QVERIFY( !geom );
 }
 
 void TestQgsGeometry::equality()
@@ -16944,7 +16931,7 @@ void TestQgsGeometry::minimalEnclosingCircle()
   result = geomTest.minimalEnclosingCircle( center, radius );
   QCOMPARE( center, QgsPointXY() );
   QCOMPARE( radius, 0.0 );
-  QCOMPARE( result, QgsGeometry() );
+  QVERIFY( result.isNull() );
 
   // caase 1
   geomTest = QgsGeometry::fromPointXY( QgsPointXY( 5, 5 ) );
@@ -16952,7 +16939,7 @@ void TestQgsGeometry::minimalEnclosingCircle()
   QCOMPARE( center, QgsPointXY( 5, 5 ) );
   QCOMPARE( radius, 0.0 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result, resultTest );
+  QCOMPARE( result.asWkt(), resultTest.asWkt() );
 
   // case 2
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 3 8, 7 4 )" ) );
@@ -16960,35 +16947,35 @@ void TestQgsGeometry::minimalEnclosingCircle()
   QGSCOMPARENEARPOINT( center, QgsPointXY( 5, 6 ), 0.0001 );
   QGSCOMPARENEAR( radius, sqrt( 2 ) * 2, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result, resultTest );
+  QCOMPARE( result.asWkt(), resultTest.asWkt() );
 
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "LINESTRING( 0 5, 2 2, 0 -5, -1 -1 )" ) );
   result = geomTest.minimalEnclosingCircle( center, radius );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0, 0 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result, resultTest );
+  QCOMPARE( result.asWkt(), resultTest.asWkt() );
 
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 0 5, 2 2, 0 -5, -1 -1 )" ) );
   result = geomTest.minimalEnclosingCircle( center, radius );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0, 0 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result, resultTest );
+  QCOMPARE( result.asWkt(), resultTest.asWkt() );
 
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "POLYGON(( 0 5, 2 2, 0 -5, -1 -1 ))" ) );
   result = geomTest.minimalEnclosingCircle( center, radius );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0, 0 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result, resultTest );
+  QCOMPARE( result.asWkt(), resultTest.asWkt() );
 
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT( 0 5, 0 -5, 0 0 )" ) );
   result = geomTest.minimalEnclosingCircle( center, radius );
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0, 0 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result, resultTest );
+  QCOMPARE( result.asWkt(), resultTest.asWkt() );
 
   // case 3
   geomTest = QgsGeometry::fromWkt( QStringLiteral( "MULTIPOINT((0 0), (5 5), (0 -5), (0 5), (-5 0))" ) );
@@ -16996,7 +16983,7 @@ void TestQgsGeometry::minimalEnclosingCircle()
   QGSCOMPARENEARPOINT( center, QgsPointXY( 0.8333, 0.8333 ), 0.0001 );
   QGSCOMPARENEAR( radius, 5.8926, 0.0001 );
   resultTest.set( QgsCircle( QgsPoint( center ), radius ).toPolygon( 36 ) );
-  QCOMPARE( result, resultTest );
+  QCOMPARE( result.asWkt(), resultTest.asWkt() );
 
 }
 

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -82,23 +82,23 @@ void TestQgsOgcUtils::testGeometryFromGML()
 {
   // Test GML2
   QgsGeometry geom( QgsOgcUtils::geometryFromGML( QStringLiteral( "<Point><coordinates>123,456</coordinates></Point>" ) ) );
-  QVERIFY( geom );
+  QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == QgsWkbTypes::Point );
   QVERIFY( geom.asPoint() == QgsPointXY( 123, 456 ) );
 
   QgsGeometry geomBox( QgsOgcUtils::geometryFromGML( QStringLiteral( "<gml:Box srsName=\"foo\"><gml:coordinates>135.2239,34.4879 135.8578,34.8471</gml:coordinates></gml:Box>" ) ) );
-  QVERIFY( geomBox );
+  QVERIFY( !geomBox.isNull() );
   QVERIFY( geomBox.wkbType() == QgsWkbTypes::Polygon );
 
 
   // Test GML3
   geom = QgsOgcUtils::geometryFromGML( QStringLiteral( "<Point><pos>123 456</pos></Point>" ) );
-  QVERIFY( geom );
+  QVERIFY( !geom.isNull() );
   QVERIFY( geom.wkbType() == QgsWkbTypes::Point );
   QVERIFY( geom.asPoint() == QgsPointXY( 123, 456 ) );
 
   geomBox = QgsOgcUtils::geometryFromGML( QStringLiteral( "<gml:Envelope srsName=\"foo\"><gml:lowerCorner>135.2239 34.4879</gml:lowerCorner><gml:upperCorner>135.8578 34.8471</gml:upperCorner></gml:Envelope>" ) );
-  QVERIFY( geomBox );
+  QVERIFY( !geomBox.isNull() );
   QVERIFY( geomBox.wkbType() == QgsWkbTypes::Polygon );
 }
 

--- a/tests/src/core/testqgsvectorlayer.cpp
+++ b/tests/src/core/testqgsvectorlayer.cpp
@@ -355,19 +355,19 @@ void TestQgsVectorLayer::testAddTopologicalPoints()
   layerLine->addTopologicalPoints( QgsPointXY( 2, 2 ) );
 
   QCOMPARE( layerLine->undoStack()->index(), 1 );
-  QCOMPARE( layerLine->getFeature( fidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 3)" ) );
+  QCOMPARE( layerLine->getFeature( fidLineF1 ).geometry().asWkt(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 3)" ).asWkt() );
 
   // add point at an existing vertex
   layerLine->addTopologicalPoints( QgsPointXY( 1, 1 ) );
 
   QCOMPARE( layerLine->undoStack()->index(), 1 );
-  QCOMPARE( layerLine->getFeature( fidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 3)" ) );
+  QCOMPARE( layerLine->getFeature( fidLineF1 ).geometry().asWkt(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 3)" ).asWkt() );
 
   // add point on segment of linestring
   layerLine->addTopologicalPoints( QgsPointXY( 1, 2 ) );
 
   QCOMPARE( layerLine->undoStack()->index(), 2 );
-  QCOMPARE( layerLine->getFeature( fidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 2, 1 3)" ) );
+  QCOMPARE( layerLine->getFeature( fidLineF1 ).geometry().asWkt(), QgsGeometry::fromWkt( "LINESTRING(2 1, 1 1, 1 2, 1 3)" ).asWkt() );
 
   delete layerLine;
 }


### PR DESCRIPTION
Fixes a comparison between feature id and feature geometry when saving vertex tool edits.

If I'm reading this right, I'm not sure how this even builds...