### PR TITLE
Fix mangled fonts in script editors

### DIFF
--- a/python/plugins/db_manager/sqledit.py
+++ b/python/plugins/db_manager/sqledit.py
@@ -107,8 +107,6 @@ class SqlEdit(QsciScintilla):
         self.defaultFont.setFixedPitch(True)
         self.defaultFont.setPointSize(fontSize)
         self.defaultFont.setStyleHint(QFont.TypeWriter)
-        self.defaultFont.setStretch(QFont.SemiCondensed)
-        self.defaultFont.setLetterSpacing(QFont.PercentageSpacing, 87.0)
         self.defaultFont.setBold(False)
 
         self.boldFont = QFont(self.defaultFont)

--- a/python/plugins/processing/script/ScriptEdit.py
+++ b/python/plugins/processing/script/ScriptEdit.py
@@ -62,7 +62,7 @@ class ScriptEdit(QsciScintilla):
     FOLD_COLOR = "#efefef"
 
     def __init__(self, parent=None):
-        QsciScintilla.__init__(self, parent)
+        super().__init__(parent)
 
         self.lexer = None
         self.api = None
@@ -128,7 +128,7 @@ class ScriptEdit(QsciScintilla):
         self.setTabWidth(4)
         self.setIndentationGuides(True)
 
-        # Autocomletion
+        # Autocompletion
         self.setAutoCompletionThreshold(2)
         self.setAutoCompletionSource(QsciScintilla.AcsAPIs)
 
@@ -145,8 +145,6 @@ class ScriptEdit(QsciScintilla):
         self.defaultFont.setFixedPitch(True)
         self.defaultFont.setPointSize(fontSize)
         self.defaultFont.setStyleHint(QFont.TypeWriter)
-        self.defaultFont.setStretch(QFont.SemiCondensed)
-        self.defaultFont.setLetterSpacing(QFont.PercentageSpacing, 87.0)
         self.defaultFont.setBold(False)
 
         self.boldFont = QFont(self.defaultFont)

--- a/src/gui/qgscodeeditor.cpp
+++ b/src/gui/qgscodeeditor.cpp
@@ -178,8 +178,6 @@ QFont QgsCodeEditor::getMonospaceFont()
   font.setFixedPitch( true );
   font.setPointSize( fontSize );
   font.setStyleHint( QFont::TypeWriter );
-  font.setStretch( QFont::SemiCondensed );
-  font.setLetterSpacing( QFont::PercentageSpacing, 87.0 );
   font.setBold( false );
   return font;
 }


### PR DESCRIPTION
Don't override default font letter spacing or stretch -- it's not
safe to do because the results are very dependent on the individual
font's appearance and rendering hints.

Fixes #20349
