### PR TITLE
Bump minimum Qt version to 5.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,14 +315,7 @@ IF(WITH_CORE)
   ENDIF(WITH_QTWEBKIT)
   #############################################################
   # search for Qt5
-  IF (WITH_3D)
-    # for 3D support we strictly require Qt >= 5.9
-    # (Qt 3D was introduced in 5.7 but it is not stable enough in that branch)
-    # Qt 5.8 is missing some classes, https://github.com/qgis/QGIS/pull/5203#discussion_r142319862
-    SET(QT_MIN_VERSION 5.9.0)
-  ELSE ()
-    SET(QT_MIN_VERSION 5.4.0)
-  ENDIF()
+  SET(QT_MIN_VERSION 5.9.0)
   FIND_PACKAGE(Qt5Core QUIET)
   FIND_PACKAGE(Qt5Gui REQUIRED)
   FIND_PACKAGE(Qt5Widgets REQUIRED)

--- a/INSTALL
+++ b/INSTALL
@@ -97,7 +97,7 @@ Required build tools:
 
 Required build dependencies:
 
-- Qt >= 5.3.0
+- Qt >= 5.9.0
 - Proj >= 4.4.x
 - GEOS >= 3.4
 - Sqlite3 >= 3.0.0

--- a/doc/overview.t2t
+++ b/doc/overview.t2t
@@ -15,7 +15,7 @@ Required build tools:
 
 Required build dependencies:
 
-- Qt >= 5.3.0
+- Qt >= 5.9.0
 - Proj >= 4.4.x
 - GEOS >= 3.4
 - Sqlite3 >= 3.0.0

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -97,11 +97,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         self.btnCancel.setText(self.tr("Cancel (ESC)"))
         self.btnCancel.setEnabled(False)
         self.btnCancel.clicked.connect(self.executeSqlCanceled)
-        try:
-            self.btnCancel.setShortcut(QKeySequence.Cancel)
-        except AttributeError:
-            # QKeySequence.Cancel only available in Qt >= 5.6
-            pass
+        self.btnCancel.setShortcut(QKeySequence.Cancel)
         self.progressBar.setEnabled(False)
         self.progressBar.setRange(0, 100)
         self.progressBar.setValue(0)

--- a/src/app/decorations/qgsdecorationcopyright.cpp
+++ b/src/app/decorations/qgsdecorationcopyright.cpp
@@ -125,13 +125,8 @@ void QgsDecorationCopyright::render( const QgsMapSettings &mapSettings, QgsRende
   double textHeight = QgsTextRenderer::textHeight( context, mTextFormat, displayStringList, QgsTextRenderer::Point, &fm );
 
   QPaintDevice *device = context.painter()->device();
-#if QT_VERSION < 0x050600
-  int deviceHeight = device->height() / device->devicePixelRatio();
-  int deviceWidth = device->width() / device->devicePixelRatio();
-#else
   int deviceHeight = device->height() / device->devicePixelRatioF();
   int deviceWidth = device->width() / device->devicePixelRatioF();
-#endif
 
   float xOffset( 0 ), yOffset( 0 );
 

--- a/src/app/decorations/qgsdecorationnortharrow.cpp
+++ b/src/app/decorations/qgsdecorationnortharrow.cpp
@@ -169,13 +169,8 @@ void QgsDecorationNorthArrow::render( const QgsMapSettings &mapSettings, QgsRend
                                    ) - centerYDouble );
     // need width/height of paint device
     QPaintDevice *device = context.painter()->device();
-#if QT_VERSION < 0x050600
-    int deviceHeight = device->height() / device->devicePixelRatio();
-    int deviceWidth = device->width() / device->devicePixelRatio();
-#else
     int deviceHeight = device->height() / device->devicePixelRatioF();
     int deviceWidth = device->width() / device->devicePixelRatioF();
-#endif
 
     // Set  margin according to selected units
     int xOffset = 0;

--- a/src/app/decorations/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/decorations/qgsdecorationnortharrowdialog.cpp
@@ -52,7 +52,7 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
   spinAngle->setEnabled( !mDeco.mAutomatic );
   sliderRotation->setEnabled( !mDeco.mAutomatic );
 
-  connect( cboxAutomatic, &QAbstractButton::toggled, [ = ]( bool checked )
+  connect( cboxAutomatic, &QAbstractButton::toggled, this, [ = ]( bool checked )
   {
     spinAngle->setEnabled( !checked );
     sliderRotation->setEnabled( !checked );

--- a/src/app/decorations/qgsdecorationscalebar.cpp
+++ b/src/app/decorations/qgsdecorationscalebar.cpp
@@ -178,13 +178,8 @@ void QgsDecorationScaleBar::render( const QgsMapSettings &mapSettings, QgsRender
 
   //Get canvas dimensions
   QPaintDevice *device = context.painter()->device();
-#if QT_VERSION < 0x050600
-  int deviceHeight = device->height() / device->devicePixelRatio();
-  int deviceWidth = device->width() / device->devicePixelRatio();
-#else
   int deviceHeight = device->height() / device->devicePixelRatioF();
   int deviceWidth = device->width() / device->devicePixelRatioF();
-#endif
 
   //Get map units per pixel. This can be negative at times (to do with
   //projections) and that just confuses the rest of the code in this

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -248,9 +248,7 @@ QgsLayoutDesignerDialog::QgsLayoutDesignerDialog( QWidget *parent, Qt::WindowFla
   setAcceptDrops( true );
 
   setAttribute( Qt::WA_DeleteOnClose );
-#if QT_VERSION >= 0x050600
   setDockOptions( dockOptions() | QMainWindow::GroupedDragging );
-#endif
 
   //create layout view
   QGridLayout *viewLayout = new QGridLayout();

--- a/src/app/layout/qgslayoutlegendwidget.cpp
+++ b/src/app/layout/qgslayoutlegendwidget.cpp
@@ -1159,7 +1159,7 @@ QMenu *QgsLayoutLegendMenuProvider::createContextMenu()
 
   if ( QgsLayerTree::isLayer( mView->currentNode() ) )
   {
-    menu->addAction( QObject::tr( "Reset to Defaults" ), mWidget, SLOT( resetLayerNodeToDefaults() ) );
+    menu->addAction( QObject::tr( "Reset to Defaults" ), mWidget, &QgsLayoutLegendWidget::resetLayerNodeToDefaults );
     menu->addSeparator();
   }
 
@@ -1169,7 +1169,7 @@ QMenu *QgsLayoutLegendMenuProvider::createContextMenu()
   lst << QgsLegendStyle::Hidden << QgsLegendStyle::Group << QgsLegendStyle::Subgroup;
   for ( QgsLegendStyle::Style style : qgis::as_const( lst ) )
   {
-    QAction *action = menu->addAction( QgsLegendStyle::styleLabel( style ), mWidget, SLOT( setCurrentNodeStyleFromAction() ) );
+    QAction *action = menu->addAction( QgsLegendStyle::styleLabel( style ), mWidget, &QgsLayoutLegendWidget::setCurrentNodeStyleFromAction );
     action->setCheckable( true );
     action->setChecked( currentStyle == style );
     action->setData( ( int ) style );

--- a/src/app/layout/qgslayoutmanagerdialog.cpp
+++ b/src/app/layout/qgslayoutmanagerdialog.cpp
@@ -85,7 +85,7 @@ QgsLayoutManagerDialog::QgsLayoutManagerDialog( QWidget *parent, Qt::WindowFlags
 #ifdef Q_OS_MAC
   // Create action to select this window
   mWindowAction = new QAction( windowTitle(), this );
-  connect( mWindowAction, SIGNAL( triggered() ), this, SLOT( activate() ) );
+  connect( mWindowAction, SIGNAL( triggered() ), this, &QgsLayoutManagerDialog::activate );
 #endif
 
   mTemplate->addItem( tr( "Empty layout" ) );

--- a/src/app/layout/qgslayoutmapwidget.cpp
+++ b/src/app/layout/qgslayoutmapwidget.cpp
@@ -225,7 +225,7 @@ void QgsLayoutMapWidget::aboutToShowKeepLayersVisibilityPresetsMenu()
   menu->clear();
   Q_FOREACH ( const QString &presetName, QgsProject::instance()->mapThemeCollection()->mapThemes() )
   {
-    menu->addAction( presetName, this, SLOT( keepLayersVisibilityPresetSelected() ) );
+    menu->addAction( presetName, this, &QgsLayoutMapWidget::keepLayersVisibilityPresetSelected );
   }
 
   if ( menu->actions().isEmpty() )

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -411,11 +411,9 @@ void myMessageOutput( QtMsgType type, const char *msg )
       break; // silence warnings
     }
 
-#if QT_VERSION >= 0x050500
     case QtInfoMsg:
       myPrint( "Info: %s\n", msg );
       break;
-#endif
   }
 }
 

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1655,7 +1655,7 @@ void QgsPluginManager::showEvent( QShowEvent *e )
   }
   else
   {
-    QTimer::singleShot( 0, this, SLOT( warnAboutMissingObjects() ) );
+    QTimer::singleShot( 0, this, &QgsPluginManager::warnAboutMissingObjects );
   }
 
   QgsOptionsDialogBase::showEvent( e );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -712,9 +712,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   this->addAction( mActionToggleMapOnly );
   endProfile();
 
-#if QT_VERSION >= 0x050600
   setDockOptions( dockOptions() | QMainWindow::GroupedDragging );
-#endif
 
   //////////
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -850,6 +850,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! pastes group or layer from the clipboard to layer tree
     void pasteLayer();
 
+    //! Apply the same style to selected layers or to current legend group
+    void applyStyleToGroup();
+
     //! Sets CRS of a layer
     void setLayerCrs();
     //! Assign layer CRS to project
@@ -891,9 +894,23 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! layer selection changed
     void legendLayerSelectionChanged();
 
+    /**
+     * Zooms so that the pixels of the raster layer occupies exactly one screen pixel.
+        Only works on raster layers*/
+    void legendLayerZoomNative();
+
+    /**
+     * Stretches the raster layer, if stretching is active, based on the min and max of the current extent.
+        Only works on raster layers*/
+    void legendLayerStretchUsingCurrentExtent();
+
     //! Watch for QFileOpenEvent.
     bool event( QEvent *event ) override;
 
+    //! Sets the CRS of the current legend group
+    void legendGroupSetCrs();
+    //! Sets the WMS data of the current legend group
+    void legendGroupSetWmsData();
 
     /**
      * \brief dataSourceManager Open the DataSourceManager dialog
@@ -901,6 +918,24 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      *        or "ogr" (vector layers) or "raster" (raster layers)
      */
     void dataSourceManager( const QString &pageName = QString() );
+
+    //! Add a virtual layer
+    void addVirtualLayer();
+
+    //! Remove a layer from the map and legend
+    void removeLayer();
+
+    //! Duplicate map layer(s) in legend
+    void duplicateLayers( const QList<QgsMapLayer *> &lyrList = QList<QgsMapLayer *>() );
+
+    //! change layer subset of current vector layer
+    void layerSubsetString();
+
+    //! Sets scale visibility of selected layers
+    void setLayerScaleVisibility();
+
+    //! Zoom to nearest scale such that current layer is visible
+    void zoomToLayerScale();
 
     /**
      * Returns the shared application browser model.
@@ -1061,8 +1096,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void addSelectedVectorLayer( const QString &uri, const QString &layerName, const QString &provider );
     //! Replace the selected layer by a vector layer defined by uri, layer name, data source uri
     void replaceSelectedVectorLayer( const QString &oldId, const QString &uri, const QString &layerName, const QString &provider );
-    //! Add a virtual layer
-    void addVirtualLayer();
+
     //! toggles whether the current selected layer is in overview or not
     void isInOverview();
     //! Store the position for map tool tip
@@ -1075,32 +1109,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
      * \since QGIS 2.8
      */
     void userRotation();
-    //! Remove a layer from the map and legend
-    void removeLayer();
-    //! Duplicate map layer(s) in legend
-    void duplicateLayers( const QList<QgsMapLayer *> &lyrList = QList<QgsMapLayer *>() );
-    //! Sets scale visibility of selected layers
-    void setLayerScaleVisibility();
-    //! Zoom to nearest scale such that current layer is visible
-    void zoomToLayerScale();
-
-    /**
-     * Zooms so that the pixels of the raster layer occupies exactly one screen pixel.
-        Only works on raster layers*/
-    void legendLayerZoomNative();
-
-    /**
-     * Stretches the raster layer, if stretching is active, based on the min and max of the current extent.
-        Only workds on raster layers*/
-    void legendLayerStretchUsingCurrentExtent();
-
-    //! Apply the same style to selected layers or to current legend group
-    void applyStyleToGroup();
-
-    //! Sets the CRS of the current legend group
-    void legendGroupSetCrs();
-    //! Sets the WMS data of the current legend group
-    void legendGroupSetWmsData();
 
     //! zoom to extent of layer
     void zoomToLayerExtent();
@@ -1458,9 +1466,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! Update gui actions/menus when layers are modified
     void updateLayerModifiedActions();
-
-    //! change layer subset of current vector layer
-    void layerSubsetString();
 
     //! map tool changed
     void mapToolChanged( QgsMapTool *newTool, QgsMapTool *oldTool );

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -108,7 +108,6 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
   if ( fontSize != defaultSize || fontFamily != defaultFamily )
     ss += QStringLiteral( "* { font: %1pt \"%2\"} " ).arg( fontSize, fontFamily );
 
-#if QT_VERSION >= 0x050900
   // Fix for macOS Qt 5.9+, where close boxes do not show on document mode tab bar tabs
   // See: https://bugreports.qt.io/browse/QTBUG-61092
   //      https://bugreports.qt.io/browse/QTBUG-61742
@@ -121,7 +120,6 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
     ss += QLatin1String( "QTabBar::close-button{ image: url(:/images/themes/default/mIconCloseTab.svg); }" );
     ss += QLatin1String( "QTabBar::close-button:hover{ image: url(:/images/themes/default/mIconCloseTabHover.svg); }" );
   }
-#endif
 
   // QGroupBox and QgsCollapsibleGroupBox, mostly for Ubuntu and Mac
   bool gbxCustom = opts.value( QStringLiteral( "groupBoxCustom" ) ).toBool();

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -80,7 +80,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
     {
       menu->addAction( actions->actionZoomToGroup( mCanvas, menu ) );
 
-      menu->addAction( tr( "Copy Group" ), QgisApp::instance(), SLOT( copyLayer() ) );
+      menu->addAction( tr( "Copy Group" ), QgisApp::instance(), &QgisApp::copyLayer );
       if ( QgisApp::instance()->clipboard()->hasFormat( QGSCLIPBOARD_MAPLAYER_MIME ) )
       {
         QAction *actionPasteLayerOrGroup = new QAction( tr( "Paste Layer/Group" ), menu );
@@ -92,13 +92,13 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       menu->addSeparator();
       menu->addAction( actions->actionAddGroup( menu ) );
-      QAction *removeAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionRemoveLayer.svg" ) ), tr( "&Remove Group…" ), QgisApp::instance(), SLOT( removeLayer() ) );
+      QAction *removeAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionRemoveLayer.svg" ) ), tr( "&Remove Group…" ), QgisApp::instance(), &QgisApp::removeLayer );
       removeAction->setEnabled( removeActionEnabled() );
       menu->addSeparator();
 
       menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionSetCRS.png" ) ),
-                       tr( "&Set Group CRS…" ), QgisApp::instance(), SLOT( legendGroupSetCrs() ) );
-      menu->addAction( tr( "&Set Group WMS Data…" ), QgisApp::instance(), SLOT( legendGroupSetWmsData() ) );
+                       tr( "&Set Group CRS…" ), QgisApp::instance(), &QgisApp::legendGroupSetCrs );
+      menu->addAction( tr( "&Set Group WMS Data…" ), QgisApp::instance(), &QgisApp::legendGroupSetWmsData );
 
       menu->addSeparator();
 
@@ -120,7 +120,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       if ( QgisApp::instance()->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
       {
-        menu->addAction( tr( "Paste Style" ), QgisApp::instance(), SLOT( applyStyleToGroup() ) );
+        menu->addAction( tr( "Paste Style" ), QgisApp::instance(), &QgisApp::applyStyleToGroup );
       }
 
       menu->addSeparator();
@@ -161,23 +161,23 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       if ( rlayer )
       {
-        menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomActual.svg" ) ), tr( "&Zoom to Native Resolution (100%)" ), QgisApp::instance(), SLOT( legendLayerZoomNative() ) );
+        menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionZoomActual.svg" ) ), tr( "&Zoom to Native Resolution (100%)" ), QgisApp::instance(), &QgisApp::legendLayerZoomNative );
 
         if ( rlayer->rasterType() != QgsRasterLayer::Palette )
-          menu->addAction( tr( "&Stretch Using Current Extent" ), QgisApp::instance(), SLOT( legendLayerStretchUsingCurrentExtent() ) );
+          menu->addAction( tr( "&Stretch Using Current Extent" ), QgisApp::instance(), &QgisApp::legendLayerStretchUsingCurrentExtent );
       }
 
       addCustomLayerActions( menu, layer );
       if ( layer && layer->type() == QgsMapLayer::VectorLayer && static_cast<QgsVectorLayer *>( layer )->providerType() == QLatin1String( "virtual" ) )
       {
-        menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddVirtualLayer.svg" ) ), tr( "Edit Virtual Layer…" ), QgisApp::instance(), SLOT( addVirtualLayer() ) );
+        menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionAddVirtualLayer.svg" ) ), tr( "Edit Virtual Layer…" ), QgisApp::instance(), &QgisApp::addVirtualLayer );
       }
 
       menu->addSeparator();
 
       // duplicate layer
-      QAction *duplicateLayersAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateLayer.svg" ) ), tr( "&Duplicate Layer" ), QgisApp::instance(), SLOT( duplicateLayers() ) );
-      QAction *removeAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionRemoveLayer.svg" ) ), tr( "&Remove Layer…" ), QgisApp::instance(), SLOT( removeLayer() ) );
+      QAction *duplicateLayersAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionDuplicateLayer.svg" ) ), tr( "&Duplicate Layer" ), QgisApp::instance(), [] { QgisApp::instance()->duplicateLayers(); } );
+      QAction *removeAction = menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionRemoveLayer.svg" ) ), tr( "&Remove Layer…" ), QgisApp::instance(), &QgisApp::removeLayer );
       removeAction->setEnabled( removeActionEnabled() );
 
       menu->addSeparator();
@@ -207,7 +207,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         // attribute table
         menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionOpenTable.svg" ) ), tr( "&Open Attribute Table" ),
-                         QgisApp::instance(), SLOT( attributeTable() ) );
+                         QgisApp::instance(), [ = ] { QgisApp::instance()->attributeTable(); } );
 
         // allow editing
         int cap = vlayer->dataProvider()->capabilities();
@@ -234,7 +234,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
         if ( vlayer->dataProvider()->supportsSubsetString() )
         {
-          QAction *action = menu->addAction( tr( "&Filter…" ), QgisApp::instance(), SLOT( layerSubsetString() ) );
+          QAction *action = menu->addAction( tr( "&Filter…" ), QgisApp::instance(), &QgisApp::layerSubsetString );
           action->setEnabled( !vlayer->isEditable() );
         }
       }
@@ -244,10 +244,10 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       if ( layer && layer->isSpatial() )
       {
         // set layer scale visibility
-        menu->addAction( tr( "&Set Layer Scale Visibility…" ), QgisApp::instance(), SLOT( setLayerScaleVisibility() ) );
+        menu->addAction( tr( "&Set Layer Scale Visibility…" ), QgisApp::instance(), &QgisApp::setLayerScaleVisibility );
 
         if ( !layer->isInScaleRange( mCanvas->scale() ) )
-          menu->addAction( tr( "Zoom to &Visible Scale" ), QgisApp::instance(), SLOT( zoomToLayerScale() ) );
+          menu->addAction( tr( "Zoom to &Visible Scale" ), QgisApp::instance(), &QgisApp::zoomToLayerScale );
 
         QMenu *menuSetCRS = new QMenu( tr( "Set CRS" ), menu );
         // set layer crs
@@ -344,7 +344,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
         }
         else
         {
-          menuStyleManager->addAction( tr( "Copy Style" ), app, SLOT( copyStyle() ) );
+          menuStyleManager->addAction( tr( "Copy Style" ), app, [ = ] { app->copyStyle(); } );
         }
 
         if ( layer && app->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
@@ -387,7 +387,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           }
           else
           {
-            menuStyleManager->addAction( tr( "Paste Style" ), app, SLOT( pasteStyle() ) );
+            menuStyleManager->addAction( tr( "Paste Style" ), app, [ = ] { app->pasteStyle(); } );
           }
         }
 
@@ -441,12 +441,12 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       {
         if ( QgisApp::instance()->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
         {
-          menu->addAction( tr( "Paste Style" ), QgisApp::instance(), SLOT( applyStyleToGroup() ) );
+          menu->addAction( tr( "Paste Style" ), QgisApp::instance(), &QgisApp::applyStyleToGroup );
         }
       }
 
       if ( layer && QgsProject::instance()->layerIsEmbedded( layer->id() ).isEmpty() )
-        menu->addAction( tr( "&Properties…" ), QgisApp::instance(), SLOT( layerProperties() ) );
+        menu->addAction( tr( "&Properties…" ), QgisApp::instance(), &QgisApp::layerProperties );
     }
   }
   else if ( QgsLayerTreeModelLegendNode *node = mView->layerTreeModel()->index2legendNode( idx ) )
@@ -457,9 +457,9 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
       if ( symbolNode->flags() & Qt::ItemIsUserCheckable )
       {
         menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionShowAllLayers.svg" ) ), tr( "&Show All Items" ),
-                         symbolNode, SLOT( checkAllItems() ) );
+                         symbolNode, &QgsSymbolLegendNode::checkAllItems );
         menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionHideAllLayers.svg" ) ), tr( "&Hide All Items" ),
-                         symbolNode, SLOT( uncheckAllItems() ) );
+                         symbolNode, &QgsSymbolLegendNode::uncheckAllItems );
         menu->addSeparator();
       }
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -61,8 +61,8 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
   {
     // global menu
     menu->addAction( actions->actionAddGroup( menu ) );
-    menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionExpandTree.svg" ) ), tr( "&Expand All" ), mView, SLOT( expandAll() ) );
-    menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionCollapseTree.svg" ) ), tr( "&Collapse All" ), mView, SLOT( collapseAll() ) );
+    menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionExpandTree.svg" ) ), tr( "&Expand All" ), mView, &QgsLayerTreeView::expandAll );
+    menu->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mActionCollapseTree.svg" ) ), tr( "&Collapse All" ), mView, &QgsLayerTreeView::collapseAll );
     menu->addSeparator();
     if ( QgisApp::instance()->clipboard()->hasFormat( QGSCLIPBOARD_MAPLAYER_MIME ) )
     {

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -330,13 +330,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
           for ( int row = 0; row < model->rowCount(); ++row )
           {
             QModelIndex index = model->index( row, 0 );
-#if QT_VERSION <= 0x050601
-            // in Qt 5.6.1 and former, QVariant does not correctly convert enum using value
-            // see https://bugreports.qt.io/browse/QTBUG-53384
-            QgsMapLayer::StyleCategory category = static_cast<QgsMapLayer::StyleCategory>( model->data( index, Qt::UserRole ).toInt() );
-#else
             QgsMapLayer::StyleCategory category = model->data( index, Qt::UserRole ).value<QgsMapLayer::StyleCategory>();
-#endif
             QString name = model->data( index, Qt::DisplayRole ).toString();
             QString tooltip = model->data( index, Qt::ToolTipRole ).toString();
             QIcon icon = model->data( index, Qt::DecorationRole ).value<QIcon>();
@@ -375,13 +369,7 @@ QMenu *QgsAppLayerTreeViewMenuProvider::createContextMenu()
                 for ( int row = 0; row < model->rowCount(); ++row )
                 {
                   QModelIndex index = model->index( row, 0 );
-#if QT_VERSION <= 0x050601
-                  // in Qt 5.6.1 and former, QVariant does not correctly convert enum using value
-                  // see https://bugreports.qt.io/browse/QTBUG-53384
-                  QgsMapLayer::StyleCategory category = static_cast<QgsMapLayer::StyleCategory>( model->data( index, Qt::UserRole ).toInt() );
-#else
                   QgsMapLayer::StyleCategory category = model->data( index, Qt::UserRole ).value<QgsMapLayer::StyleCategory>();
-#endif
                   QString name = model->data( index, Qt::DisplayRole ).toString();
                   QString tooltip = model->data( index, Qt::ToolTipRole ).toString();
                   QIcon icon = model->data( index, Qt::DecorationRole ).value<QIcon>();

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1062,18 +1062,18 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent *event )
       mActionPopup->addAction(
         QgsApplication::getThemeIcon( QStringLiteral( "/mActionFormView.svg" ) ),
         vlayer->isEditable() ? tr( "Edit Feature Form…" ) : tr( "View Feature Form…" ),
-        this, SLOT( featureForm() ) );
+        this, &QgsIdentifyResultsDialog::featureForm );
     }
 
     if ( featItem->feature().isValid() )
     {
-      mActionPopup->addAction( tr( "Zoom to Feature" ), this, SLOT( zoomToFeature() ) );
-      mActionPopup->addAction( tr( "Copy Feature" ), this, SLOT( copyFeature() ) );
-      mActionPopup->addAction( tr( "Toggle Feature Selection" ), this, SLOT( toggleFeatureSelection() ) );
+      mActionPopup->addAction( tr( "Zoom to Feature" ), this, &QgsIdentifyResultsDialog::zoomToFeature );
+      mActionPopup->addAction( tr( "Copy Feature" ), this, &QgsIdentifyResultsDialog::copyFeature );
+      mActionPopup->addAction( tr( "Toggle Feature Selection" ), this, &QgsIdentifyResultsDialog::toggleFeatureSelection );
     }
 
-    mActionPopup->addAction( tr( "Copy Attribute Value" ), this, SLOT( copyAttributeValue() ) );
-    mActionPopup->addAction( tr( "Copy Feature Attributes" ), this, SLOT( copyFeatureAttributes() ) );
+    mActionPopup->addAction( tr( "Copy Attribute Value" ), this, &QgsIdentifyResultsDialog::copyAttributeValue );
+    mActionPopup->addAction( tr( "Copy Feature Attributes" ), this, &QgsIdentifyResultsDialog::copyFeatureAttributes );
 
     if ( item->parent() == featItem && item->childCount() == 0 )
     {
@@ -1086,7 +1086,7 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent *event )
     QTreeWidgetItem *layItem = layerItem( item );
     if ( layItem && !layItem->data( 0, GetFeatureInfoUrlRole ).toString().isEmpty() )
     {
-      mActionPopup->addAction( tr( "Copy GetFeatureInfo request URL" ), this, SLOT( copyGetFeatureInfoUrl() ) );
+      mActionPopup->addAction( tr( "Copy GetFeatureInfo request URL" ), this, &QgsIdentifyResultsDialog::copyGetFeatureInfoUrl );
     }
   }
   if ( !mActionPopup->children().isEmpty() )
@@ -1094,18 +1094,18 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent *event )
     mActionPopup->addSeparator();
   }
 
-  mActionPopup->addAction( tr( "Clear Results" ), this, SLOT( clear() ) );
-  mActionPopup->addAction( tr( "Clear Highlights" ), this, SLOT( clearHighlights() ) );
-  mActionPopup->addAction( tr( "Highlight All" ), this, SLOT( highlightAll() ) );
-  mActionPopup->addAction( tr( "Highlight Layer" ), this, SLOT( highlightLayer() ) );
+  mActionPopup->addAction( tr( "Clear Results" ), this, &QgsIdentifyResultsDialog::clear );
+  mActionPopup->addAction( tr( "Clear Highlights" ), this, &QgsIdentifyResultsDialog::clearHighlights );
+  mActionPopup->addAction( tr( "Highlight All" ), this, &QgsIdentifyResultsDialog::highlightAll );
+  mActionPopup->addAction( tr( "Highlight Layer" ), this, [ = ] { highlightLayer(); } );
   if ( layer && QgsProject::instance()->layerIsEmbedded( layer->id() ).isEmpty() )
   {
-    mActionPopup->addAction( tr( "Activate Layer" ), this, SLOT( activateLayer() ) );
-    mActionPopup->addAction( tr( "Layer Properties…" ), this, SLOT( layerProperties() ) );
+    mActionPopup->addAction( tr( "Activate Layer" ), this, [ = ] { activateLayer(); } );
+    mActionPopup->addAction( tr( "Layer Properties…" ), this, [ = ] { layerProperties(); } );
   }
   mActionPopup->addSeparator();
-  mActionPopup->addAction( tr( "Expand All" ), this, SLOT( expandAll() ) );
-  mActionPopup->addAction( tr( "Collapse All" ), this, SLOT( collapseAll() ) );
+  mActionPopup->addAction( tr( "Expand All" ), this, &QgsIdentifyResultsDialog::expandAll );
+  mActionPopup->addAction( tr( "Collapse All" ), this, &QgsIdentifyResultsDialog::collapseAll );
   mActionPopup->addSeparator();
 
   if ( featItem && vlayer )
@@ -1126,7 +1126,7 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent *event )
           continue;
 
         QgsFeatureAction *a = new QgsFeatureAction( action.name(), mFeatures[ featIdx ], vlayer, action.id(), idx, this );
-        mActionPopup->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mAction.svg" ) ), action.name(), a, SLOT( execute() ) );
+        mActionPopup->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mAction.svg" ) ), action.name(), a, &QgsFeatureAction::execute );
       }
     }
   }
@@ -1150,7 +1150,7 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent *event )
           continue;
 
         QgsIdentifyResultsDialogMapLayerAction *a = new QgsIdentifyResultsDialogMapLayerAction( ( *actionIt )->text(), this, ( *actionIt ), vlayer, &( mFeatures[ featIdx ] ) );
-        mActionPopup->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mAction.svg" ) ), ( *actionIt )->text(), a, SLOT( execute() ) );
+        mActionPopup->addAction( QgsApplication::getThemeIcon( QStringLiteral( "/mAction.svg" ) ), ( *actionIt )->text(), a, &QgsIdentifyResultsDialogMapLayerAction::execute );
       }
     }
   }

--- a/src/app/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/app/qgsmaplayerstylecategoriesmodel.cpp
@@ -242,13 +242,7 @@ bool QgsMapLayerStyleCategoriesModel::setData( const QModelIndex &index, const Q
 
   if ( role == Qt::CheckStateRole )
   {
-#if QT_VERSION <= 0x050601
-    // in Qt 5.6.1 and former, QVariant does not correctly convert enum using value
-    // see https://bugreports.qt.io/browse/QTBUG-53384
-    QgsMapLayer::StyleCategory category = static_cast<QgsMapLayer::StyleCategory>( data( index, Qt::UserRole ).toInt() );
-#else
     QgsMapLayer::StyleCategory category = data( index, Qt::UserRole ).value<QgsMapLayer::StyleCategory>();
-#endif
     if ( value.value<Qt::CheckState>() == Qt::Checked )
     {
       mCategories |= category;

--- a/src/app/qgsmapthemes.cpp
+++ b/src/app/qgsmapthemes.cpp
@@ -47,10 +47,10 @@ QgsMapThemes::QgsMapThemes()
 
   mReplaceMenu = new QMenu( tr( "Replace Theme" ) );
   mMenu->addMenu( mReplaceMenu );
-  mActionAddPreset = mMenu->addAction( tr( "Add Theme…" ), this, SLOT( addPreset() ) );
+  mActionAddPreset = mMenu->addAction( tr( "Add Theme…" ), this, [ = ] { addPreset(); } );
   mMenuSeparator = mMenu->addSeparator();
 
-  mActionRemoveCurrentPreset = mMenu->addAction( tr( "Remove Current Theme" ), this, SLOT( removeCurrentPreset() ) );
+  mActionRemoveCurrentPreset = mMenu->addAction( tr( "Remove Current Theme" ), this, &QgsMapThemes::removeCurrentPreset );
 
   connect( mMenu, &QMenu::aboutToShow, this, &QgsMapThemes::menuAboutToShow );
 }

--- a/src/app/qgsmaptoolcircle2tangentspoint.cpp
+++ b/src/app/qgsmaptoolcircle2tangentspoint.cpp
@@ -200,7 +200,7 @@ void QgsMapToolCircle2TangentsPoint::createRadiusSpinBox()
   mRadiusSpinBox->setValue( mRadius );
   QgisApp::instance()->addUserInputWidget( mRadiusSpinBox );
   mRadiusSpinBox->setFocus( Qt::TabFocusReason );
-  QObject::connect( mRadiusSpinBox, SIGNAL( valueChanged( int ) ), this, SLOT( radiusSpinBoxChanged( int ) ) );
+  QObject::connect( mRadiusSpinBox, qgis::overload< int >::of( &QgsSpinBox::valueChanged ), this, &QgsMapToolCircle2TangentsPoint::radiusSpinBoxChanged );
 }
 
 void QgsMapToolCircle2TangentsPoint::deleteRadiusSpinBox()

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -1608,13 +1608,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/disable_enter_attribute_values_dialog" ), chkDisableAttributeValuesDlg->isChecked() );
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/validate_geometries" ), mValidateGeometries->currentIndex() );
 
-#if QT_VERSION <= 0x050601
-  // in Qt 5.6.1 and former, QVariant does not correctly convert enum using value
-  // see https://bugreports.qt.io/browse/QTBUG-53384
-  mSettings->setEnumValue( QStringLiteral( "/qgis/digitizing/offset_join_style" ), static_cast<QgsGeometry::JoinStyle>( mOffsetJoinStyleComboBox->currentData().toInt() ) );
-#else
   mSettings->setEnumValue( QStringLiteral( "/qgis/digitizing/offset_join_style" ), mOffsetJoinStyleComboBox->currentData().value<QgsGeometry::JoinStyle>() );
-#endif
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/offset_quad_seg" ), mOffsetQuadSegSpinBox->value() );
   mSettings->setValue( QStringLiteral( "/qgis/digitizing/offset_miter_limit" ), mCurveOffsetMiterLimitComboBox->value() );
 

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -101,7 +101,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   connect( mCustomVariablesChkBx, &QCheckBox::toggled, this, &QgsOptions::mCustomVariablesChkBx_toggled );
   connect( mCurrentVariablesQGISChxBx, &QCheckBox::toggled, this, &QgsOptions::mCurrentVariablesQGISChxBx_toggled );
   connect( buttonBox, &QDialogButtonBox::helpRequested, this, &QgsOptions::showHelp );
-  connect( cboGlobalLocale, qgis::overload< int >::of( &QComboBox::currentIndexChanged ), [ = ]( int ) { updateSampleLocaleText( ); } );
+  connect( cboGlobalLocale, qgis::overload< int >::of( &QComboBox::currentIndexChanged ), this, [ = ]( int ) { updateSampleLocaleText( ); } );
   connect( cbShowGroupSeparator, &QCheckBox::toggled, this, [ = ]( bool ) { updateSampleLocaleText(); } );
 
   // QgsOptionsDialogBase handles saving/restoring of geometry, splitter and current tab states,

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -112,22 +112,22 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanv
 
   mBtnStyle = new QPushButton( tr( "Style" ) );
   QMenu *menuStyle = new QMenu( this );
-  menuStyle->addAction( tr( "Load Style…" ), this, SLOT( loadStyle_clicked() ) );
-  menuStyle->addAction( tr( "Save Style…" ), this, SLOT( saveStyleAs_clicked() ) );
+  menuStyle->addAction( tr( "Load Style…" ), this, &QgsRasterLayerProperties::loadStyle_clicked );
+  menuStyle->addAction( tr( "Save Style…" ), this, &QgsRasterLayerProperties::saveStyleAs_clicked );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, SLOT( saveDefaultStyle_clicked() ) );
-  menuStyle->addAction( tr( "Restore Default" ), this, SLOT( loadDefaultStyle_clicked() ) );
+  menuStyle->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultStyle_clicked );
+  menuStyle->addAction( tr( "Restore Default" ), this, &QgsRasterLayerProperties::loadDefaultStyle_clicked );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsRasterLayerProperties::aboutToShowStyleMenu );
   buttonBox->addButton( mBtnStyle, QDialogButtonBox::ResetRole );
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, SLOT( loadMetadata() ) );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, SLOT( saveMetadataAs() ) );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, &QgsRasterLayerProperties::loadMetadata );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsRasterLayerProperties::saveMetadataAs );
   menuMetadata->addSeparator();
-  menuMetadata->addAction( tr( "Save as Default" ), this, SLOT( saveDefaultMetadata() ) );
-  menuMetadata->addAction( tr( "Restore Default" ), this, SLOT( loadDefaultMetadata() ) );
+  menuMetadata->addAction( tr( "Save as Default" ), this, &QgsRasterLayerProperties::saveDefaultMetadata );
+  menuMetadata->addAction( tr( "Restore Default" ), this, &QgsRasterLayerProperties::loadDefaultMetadata );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 

--- a/src/app/qgsrelationadddlg.cpp
+++ b/src/app/qgsrelationadddlg.cpp
@@ -80,13 +80,7 @@ QString QgsRelationAddDlg::relationName()
 
 QgsRelation::RelationStrength QgsRelationAddDlg::relationStrength()
 {
-#if QT_VERSION <= 0x050601
-  // in Qt 5.6.1 and former, QVariant does not correctly convert enum using value
-  // see https://bugreports.qt.io/browse/QTBUG-53384
-  return static_cast<QgsRelation::RelationStrength>( mCbxRelationStrength->currentData().toInt() );
-#else
   return mCbxRelationStrength->currentData().value<QgsRelation::RelationStrength>();
-#endif
 }
 
 void QgsRelationAddDlg::checkDefinitionValid()

--- a/src/app/qgsvectorlayerloadstyledialog.cpp
+++ b/src/app/qgsvectorlayerloadstyledialog.cpp
@@ -115,13 +115,7 @@ QgsMapLayer::StyleCategories QgsVectorLayerLoadStyleDialog::styleCategories() co
 
 QgsVectorLayerProperties::StyleType QgsVectorLayerLoadStyleDialog::currentStyleType() const
 {
-#if QT_VERSION <= 0x050601
-  // in Qt 5.6.1 and former, QVariant does not correctly convert enum using value
-  // see https://bugreports.qt.io/browse/QTBUG-53384
-  QgsVectorLayerProperties::StyleType type = static_cast<QgsVectorLayerProperties::StyleType>( mStyleTypeComboBox->currentData().toInt() );
-#else
   QgsVectorLayerProperties::StyleType type = mStyleTypeComboBox->currentData().value<QgsVectorLayerProperties::StyleType>();
-#endif
   if ( type == QgsVectorLayerProperties::QML )
   {
     QFileInfo fi( mFileWidget->filePath() );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -127,19 +127,19 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   mActionSaveStyle = menuStyle->addAction( tr( "Save Style…" ) );
   connect( mActionSaveStyle, &QAction::triggered, this, &QgsVectorLayerProperties::saveStyleAs );
   menuStyle->addSeparator();
-  menuStyle->addAction( tr( "Save as Default" ), this, SLOT( saveDefaultStyle_clicked() ) );
-  menuStyle->addAction( tr( "Restore Default" ), this, SLOT( loadDefaultStyle_clicked() ) );
+  menuStyle->addAction( tr( "Save as Default" ), this, &QgsVectorLayerProperties::saveDefaultStyle_clicked );
+  menuStyle->addAction( tr( "Restore Default" ), this, &QgsVectorLayerProperties::loadDefaultStyle_clicked );
   mBtnStyle->setMenu( menuStyle );
   connect( menuStyle, &QMenu::aboutToShow, this, &QgsVectorLayerProperties::aboutToShowStyleMenu );
   buttonBox->addButton( mBtnStyle, QDialogButtonBox::ResetRole );
 
   mBtnMetadata = new QPushButton( tr( "Metadata" ), this );
   QMenu *menuMetadata = new QMenu( this );
-  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, SLOT( loadMetadata() ) );
-  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, SLOT( saveMetadataAs() ) );
+  mActionLoadMetadata = menuMetadata->addAction( tr( "Load Metadata…" ), this, &QgsVectorLayerProperties::loadMetadata );
+  mActionSaveMetadataAs = menuMetadata->addAction( tr( "Save Metadata…" ), this, &QgsVectorLayerProperties::saveMetadataAs );
   menuMetadata->addSeparator();
-  menuMetadata->addAction( tr( "Save as Default" ), this, SLOT( saveDefaultMetadata() ) );
-  menuMetadata->addAction( tr( "Restore Default" ), this, SLOT( loadDefaultMetadata() ) );
+  menuMetadata->addAction( tr( "Save as Default" ), this, &QgsVectorLayerProperties::saveDefaultMetadata );
+  menuMetadata->addAction( tr( "Restore Default" ), this, &QgsVectorLayerProperties::loadDefaultMetadata );
   mBtnMetadata->setMenu( menuMetadata );
   buttonBox->addButton( mBtnMetadata, QDialogButtonBox::ResetRole );
 

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -845,7 +845,7 @@ const QString QgsAuthManager::uniqueConfigId() const
   int len = 7;
   // sleep just a bit to make sure the current time has changed
   QEventLoop loop;
-  QTimer::singleShot( 3, &loop, SLOT( quit() ) );
+  QTimer::singleShot( 3, &loop, &QEventLoop::quit );
   loop.exec();
 
   uint seed = static_cast< uint >( QTime::currentTime().msec() );

--- a/src/core/dxf/qgsdxfpaintdevice.cpp
+++ b/src/core/dxf/qgsdxfpaintdevice.cpp
@@ -57,10 +57,8 @@ int QgsDxfPaintDevice::metric( PaintDeviceMetric metric ) const
       return 96;
     case QPaintDevice::PdmDevicePixelRatio:
       return 1;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
     case QPaintDevice::PdmDevicePixelRatioScaled:
       return 1;
-#endif
   }
   return 0;
 }

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -264,7 +264,6 @@ QList<int> QgsProcessingParameters::parameterAsEnums( const QgsProcessingParamet
   if ( !definition )
     return QList<int>();
 
-  QVariantList resultList;
   return parameterAsEnums( definition, parameters.value( definition->name() ), context );
 }
 

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -562,13 +562,7 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorDestination : public QgsProces
     ParameterFlags flags() const override
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
-
-#if QT_VERSION >= 0x50700
       flags.setFlag( ParameterFlag::ExposeToModeler, false );
-#else
-      flags &= ~ParameterFlag::ExposeToModeler;
-#endif
-
       return flags;
     }
 
@@ -613,13 +607,7 @@ class CORE_EXPORT QgsProcessingParameterTypeFileDestination : public QgsProcessi
     ParameterFlags flags() const override
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
-
-#if QT_VERSION >= 0x50700
       flags.setFlag( ParameterFlag::ExposeToModeler, false );
-#else
-      flags &= ~ParameterFlag::ExposeToModeler;
-#endif
-
       return flags;
     }
 
@@ -664,13 +652,7 @@ class CORE_EXPORT QgsProcessingParameterTypeFolderDestination : public QgsProces
     ParameterFlags flags() const override
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
-
-#if QT_VERSION >= 0x50700
       flags.setFlag( ParameterFlag::ExposeToModeler, false );
-#else
-      flags &= ~ParameterFlag::ExposeToModeler;
-#endif
-
       return flags;
     }
 
@@ -714,13 +696,7 @@ class CORE_EXPORT QgsProcessingParameterTypeRasterDestination : public QgsProces
     ParameterFlags flags() const override
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
-
-#if QT_VERSION >= 0x50700
       flags.setFlag( ParameterFlag::ExposeToModeler, false );
-#else
-      flags &= ~ParameterFlag::ExposeToModeler;
-#endif
-
       return flags;
     }
 
@@ -976,13 +952,7 @@ class CORE_EXPORT QgsProcessingParameterTypeFeatureSink : public QgsProcessingPa
     ParameterFlags flags() const override
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
-
-#if QT_VERSION >= 0x50700
       flags.setFlag( ParameterFlag::ExposeToModeler, false );
-#else
-      flags &= ~ParameterFlag::ExposeToModeler;
-#endif
-
       return flags;
     }
 

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -264,30 +264,9 @@ uint qHash( const QVariant &variant )
     case QVariant::Char:
       return qHash( variant.toChar() );
     case QVariant::List:
-
-#if QT_VERSION >= 0x050600
       return qHash( variant.toList() );
-#else
-      {
-        QVariantList list = variant.toList();
-        if ( list.isEmpty() )
-          return -1;
-        else
-          return qHash( list.at( 0 ) );
-      }
-#endif
     case QVariant::StringList:
-#if QT_VERSION >= 0x050600
       return qHash( variant.toStringList() );
-#else
-      {
-        QStringList list = variant.toStringList();
-        if ( list.isEmpty() )
-          return -1;
-        else
-          return qHash( list.at( 0 ) );
-      }
-#endif
     case QVariant::ByteArray:
       return qHash( variant.toByteArray() );
     case QVariant::Date:

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -969,7 +969,7 @@ void QgsDirectoryItem::directoryChanged()
     // this happens when a new file appears in the directory and
     // the item's children thread will try to open the file with
     // GDAL or OGR even if it is still being written.
-    QTimer::singleShot( 100, this, SLOT( refresh() ) );
+    QTimer::singleShot( 100, this, [ = ] { refresh(); } );
   }
 }
 
@@ -1124,7 +1124,7 @@ void QgsDirectoryParamWidget::mousePressEvent( QMouseEvent *event )
     labels << tr( "Name" ) << tr( "Size" ) << tr( "Date" ) << tr( "Permissions" ) << tr( "Owner" ) << tr( "Group" ) << tr( "Type" );
     for ( int i = 0; i < labels.count(); i++ )
     {
-      QAction *action = popupMenu.addAction( labels[i], this, SLOT( showHideColumn() ) );
+      QAction *action = popupMenu.addAction( labels[i], this, &QgsDirectoryParamWidget::showHideColumn );
       action->setObjectName( QString::number( i ) );
       action->setCheckable( true );
       action->setChecked( !isColumnHidden( i ) );

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -256,12 +256,7 @@ void QgsFeatureFilterModel::updateCompleter()
       if ( mExtraIdentifierValueIndex != 0 )
       {
         beginMoveRows( QModelIndex(), mExtraIdentifierValueIndex, mExtraIdentifierValueIndex, QModelIndex(), 0 );
-#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
-        Entry extraEntry = mEntries.takeAt( mExtraIdentifierValueIndex );
-        mEntries.prepend( extraEntry );
-#else
         mEntries.move( mExtraIdentifierValueIndex, 0 );
-#endif
         endMoveRows();
       }
       firstRow = 1;

--- a/src/core/qgsfontutils.cpp
+++ b/src/core/qgsfontutils.cpp
@@ -493,7 +493,6 @@ QString QgsFontUtils::asCSS( const QFont &font, double pointToPixelScale )
     case QFont::Black:
       cssWeight = 900;
       break;
-#if QT_VERSION >= 0x050500
     case QFont::Thin:
       cssWeight = 100;
       break;
@@ -506,7 +505,6 @@ QString QgsFontUtils::asCSS( const QFont &font, double pointToPixelScale )
     case QFont::ExtraBold:
       cssWeight = 800;
       break;
-#endif
   }
   css += QStringLiteral( "font-weight: %1;" ).arg( cssWeight );
 

--- a/src/core/qgsprojectstorageregistry.cpp
+++ b/src/core/qgsprojectstorageregistry.cpp
@@ -20,7 +20,7 @@
 
 QgsProjectStorageRegistry::~QgsProjectStorageRegistry()
 {
-  qDeleteAll( mBackends.values() );
+  qDeleteAll( mBackends );
 }
 
 QgsProjectStorage *QgsProjectStorageRegistry::projectStorageFromType( const QString &type )

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -194,9 +194,7 @@ bool QgsRenderChecker::runTest( const QString &testName,
   mElapsedTime = myTime.elapsed();
 
   QImage myImage = job.renderedImage();
-#if QT_VERSION >= 0x050600
   Q_ASSERT( myImage.devicePixelRatioF() == mMapSettings.devicePixelRatio() );
-#endif
 
   //
   // Save the pixmap to disk so the user can make a

--- a/src/core/qgstaskmanager.cpp
+++ b/src/core/qgstaskmanager.cpp
@@ -82,15 +82,11 @@ void QgsTask::cancel()
     return;
 
   mShouldTerminate = true;
-
-#if QT_VERSION >= 0x050500
-  //can't cancel queued tasks with qt < 5.5
   if ( mStatus == Queued || mStatus == OnHold )
   {
     // immediately terminate unstarted jobs
     terminated();
   }
-#endif
 
   if ( mStatus == Terminated )
   {
@@ -661,14 +657,11 @@ void QgsTaskManager::taskStatusChanged( int status )
   if ( id < 0 )
     return;
 
-
-#if QT_VERSION >= 0x050500
   mTaskMutex->lock();
   QgsTaskRunnableWrapper *runnable = mTasks.value( id ).runnable;
   mTaskMutex->unlock();
   if ( runnable )
     QThreadPool::globalInstance()->cancel( runnable );
-#endif
 
   if ( status == QgsTask::Terminated || status == QgsTask::Complete )
   {
@@ -770,10 +763,8 @@ bool QgsTaskManager::cleanupAndDeleteTask( QgsTask *task )
   }
   else
   {
-#if QT_VERSION >= 0x050500
     if ( runnable )
       QThreadPool::globalInstance()->cancel( runnable );
-#endif
     if ( isParent )
     {
       //task already finished, kill it

--- a/src/core/qgstransactiongroup.cpp
+++ b/src/core/qgstransactiongroup.cpp
@@ -117,7 +117,7 @@ void QgsTransactionGroup::onCommitChanges()
   {
     emit commitError( errMsg );
     // Restart editing the calling layer in the next event loop cycle
-    QTimer::singleShot( 0, triggeringLayer, SLOT( startEditing() ) );
+    QTimer::singleShot( 0, triggeringLayer, &QgsVectorLayer::startEditing );
   }
   mEditingStopping = false;
 }
@@ -144,7 +144,7 @@ void QgsTransactionGroup::onRollback()
   else
   {
     // Restart editing the calling layer in the next event loop cycle
-    QTimer::singleShot( 0, triggeringLayer, SLOT( startEditing() ) );
+    QTimer::singleShot( 0, triggeringLayer, &QgsVectorLayer::startEditing );
   }
   mEditingStopping = false;
 }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -35,9 +35,7 @@
 #include <QVector>
 #include <QStringBuilder>
 #include <QUrl>
-#if QT_VERSION >= 0x050900
 #include <QUndoCommand>
-#endif
 
 #include "qgssettings.h"
 #include "qgsvectorlayer.h"
@@ -3272,7 +3270,6 @@ void QgsVectorLayer::destroyEditCommand()
   undoStack()->endMacro();
   undoStack()->undo();
 
-#if QT_VERSION >= 0x050900  // setObsolete is new in Qt 5.9
   // it's not directly possible to pop the last command off the stack (the destroyed one)
   // and delete, so we add a dummy obsolete command to force this to occur.
   // Pushing the new command deletes the destroyed one, and since the new
@@ -3280,7 +3277,6 @@ void QgsVectorLayer::destroyEditCommand()
   std::unique_ptr< QUndoCommand > command = qgis::make_unique< QUndoCommand >();
   command->setObsolete( true );
   undoStack()->push( command.release() );
-#endif
 
   mEditCommandActive = false;
   mDeletedFids.clear();

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -810,7 +810,7 @@ void QgsAttributeTableModel::bulkEditCommandEnded()
   if ( fullModelUpdate )
   {
     // Invalidates the cache (there is no API for doing this directly)
-    mLayerCache->layer()->dataChanged();
+    emit mLayerCache->layer()->dataChanged();
     emit dataChanged( createIndex( 0, 0 ), createIndex( rowCount() - 1, columnCount() - 1 ) );
   }
   else

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -574,11 +574,7 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &atInd
         continue;
 
       QgsAttributeTableAction *a = new QgsAttributeTableAction( action.name(), this, action.id(), sourceIndex );
-#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
-      menu->addAction( action.name(), a, SLOT( execute() ) );
-#else
       menu->addAction( action.name(), a, &QgsAttributeTableAction::execute );
-#endif
     }
   }
 
@@ -592,21 +588,13 @@ void QgsDualView::viewWillShowContextMenu( QMenu *menu, const QModelIndex &atInd
     Q_FOREACH ( QgsMapLayerAction *action, registeredActions )
     {
       QgsAttributeTableMapLayerAction *a = new QgsAttributeTableMapLayerAction( action->text(), this, action, sourceIndex );
-#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
-      menu->addAction( action->text(), a, SLOT( execut() ) );
-#else
       menu->addAction( action->text(), a, &QgsAttributeTableMapLayerAction::execute );
-#endif
     }
   }
 
   menu->addSeparator();
   QgsAttributeTableAction *a = new QgsAttributeTableAction( tr( "Open Form" ), this, QString(), sourceIndex );
-#if QT_VERSION < QT_VERSION_CHECK(5, 6, 0)
-  menu->addAction( tr( "Open Form" ), a, SLOT( featureForm() ) );
-#else
   menu->addAction( tr( "Open Form" ), a, &QgsAttributeTableAction::featureForm );
-#endif
 }
 
 

--- a/src/gui/processing/qgsprocessingconfigurationwidgets.cpp
+++ b/src/gui/processing/qgsprocessingconfigurationwidgets.cpp
@@ -62,7 +62,7 @@ QgsFilterAlgorithmConfigurationWidget::QgsFilterAlgorithmConfigurationWidget( QW
   connect( addOutputButton, &QToolButton::clicked, this, &QgsFilterAlgorithmConfigurationWidget::addOutput );
   connect( removeOutputButton, &QToolButton::clicked, this, &QgsFilterAlgorithmConfigurationWidget::removeSelectedOutputs );
 
-  connect( mOutputExpressionWidget->selectionModel(), &QItemSelectionModel::selectionChanged, [removeOutputButton, this]
+  connect( mOutputExpressionWidget->selectionModel(), &QItemSelectionModel::selectionChanged, this, [removeOutputButton, this]
   {
     removeOutputButton->setEnabled( !mOutputExpressionWidget->selectionModel()->selectedIndexes().isEmpty() );
   } );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -697,11 +697,7 @@ QgsRectangle QgsMapCanvas::imageRect( const QImage &img, const QgsMapSettings &m
     QgsLogger::warning( QStringLiteral( "The renderer map has a wrong device pixel ratio" ) );
   }
 #endif
-#if QT_VERSION >= 0x050600
   double res = m2p.mapUnitsPerPixel() / img.devicePixelRatioF();
-#else
-  double res = m2p.mapUnitsPerPixel() / img.devicePixelRatio();
-#endif
   QgsRectangle rect( topLeft.x(), topLeft.y(), topLeft.x() + img.width()*res, topLeft.y() - img.height()*res );
   return rect;
 }

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -65,23 +65,12 @@ void QgsMapCanvasMap::paint( QPainter *painter )
   int h = std::round( mItemSize.height() ) - 2;
 
   bool scale = false;
-#if QT_VERSION >= 0x050600
   if ( mImage.size() != QSize( w, h ) * mImage.devicePixelRatioF() )
-#else
-  if ( mImage.size() != QSize( w, h ) * mImage.devicePixelRatio() )
-#endif
   {
-#if QT_VERSION >= 0x050600
     QgsDebugMsg( QStringLiteral( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" )
                  .arg( mImage.width() / mImage.devicePixelRatioF() )
                  .arg( mImage.height() / mImage.devicePixelRatioF() )
                  .arg( w ).arg( h ) );
-#else
-    QgsDebugMsg( QStringLiteral( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" )
-                 .arg( mImage.width() / mImage.devicePixelRatio() )
-                 .arg( mImage.height() / mImage.devicePixelRatio() )
-                 .arg( w ).arg( h ) );
-#endif
     // This happens on zoom events when ::paint is called before
     // the renderer has completed
     scale = true;

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -584,7 +584,7 @@ void QgsGeorefPluginGui::showCoordDialog( const QgsPointXY &pixelCoords )
   if ( mLayer && !mMapCoordsDialog )
   {
     mMapCoordsDialog = new QgsMapCoordsDialog( mIface->mapCanvas(), pixelCoords, this );
-    connect( mMapCoordsDialog, &QgsMapCoordsDialog::pointAdded,
+    connect( mMapCoordsDialog, &QgsMapCoordsDialog::pointAdded, this,
     [this]( const QgsPointXY & a, const QgsPointXY & b ) { this->addPoint( a, b ); }
            );
     mMapCoordsDialog->show();

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -472,12 +472,12 @@ QgsGdalProvider::~QgsGdalProvider()
       {
         // Check if already a PAM (persistent auxiliary metadata) file exists
         QString pamFile = dataSourceUri( true ) + QLatin1String( ".aux.xml" );
-        bool pamFileAlreadyExists = QFileInfo( pamFile ).exists();
+        bool pamFileAlreadyExists = QFileInfo::exists( pamFile );
 
         GDALClose( mGdalDataset );
 
         // If GDAL created a PAM file right now by using estimated metadata, delete it right away
-        if ( !mStatisticsAreReliable && !pamFileAlreadyExists && QFileInfo( pamFile ).exists() )
+        if ( !mStatisticsAreReliable && !pamFileAlreadyExists && QFileInfo::exists( pamFile ) )
           QFile( pamFile ).remove();
       }
 

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -287,7 +287,7 @@ bool QgsPgTableModel::setData( const QModelIndex &idx, const QVariant &value, in
     {
       QSet<QString> s0( idx.sibling( idx.row(), DbtmPkCol ).data( Qt::UserRole + 2 ).toStringList().toSet() );
       QSet<QString> s1( pkCols.toSet() );
-      if ( s0.intersect( s1 ).isEmpty() )
+      if ( !s0.intersects( s1 ) )
         tip = tr( "Select columns in the '%1' column that uniquely identify features of this layer" ).arg( tr( "Feature id" ) );
     }
 
@@ -342,7 +342,7 @@ QString QgsPgTableModel::layerURI( const QModelIndex &index, const QString &conn
   QStandardItem *pkItem = itemFromIndex( index.sibling( index.row(), DbtmPkCol ) );
   QSet<QString> s0( pkItem->data( Qt::UserRole + 1 ).toStringList().toSet() );
   QSet<QString> s1( pkItem->data( Qt::UserRole + 2 ).toStringList().toSet() );
-  if ( !s0.isEmpty() && s0.intersect( s1 ).isEmpty() )
+  if ( !s0.isEmpty() && !s0.intersects( s1 ) )
   {
     // no valid primary candidate selected
     QgsDebugMsg( QStringLiteral( "no pk candidate selected" ) );

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -373,17 +373,6 @@ QString QgsPostgresProvider::storageType() const
   return QStringLiteral( "PostgreSQL database with PostGIS extension" );
 }
 
-#if QT_VERSION < 0x050600
-#include <algorithm>
-template <typename T>
-bool operator<( const QList<T> &lhs, const QList<T> &rhs )
-{
-  return std::lexicographical_compare( lhs.begin(), lhs.end(),
-                                       rhs.begin(), rhs.end() );
-}
-#endif
-
-
 QgsFeatureIterator QgsPostgresProvider::getFeatures( const QgsFeatureRequest &request ) const
 {
   if ( !mValid )

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -523,7 +523,7 @@ namespace QgsWms
     const QRegExp composerParamRegExp( QStringLiteral( "^MAP\\d+:" ) );
     if ( key.contains( composerParamRegExp ) )
     {
-      const int mapId = key.mid( 3, key.indexOf( ':' ) - 3 ).toInt();
+      const int mapId = key.midRef( 3, key.indexOf( ':' ) - 3 ).toInt();
       const QString theKey = key.mid( key.indexOf( ':' ) + 1 );
       const QgsWmsParameter::Name name = QgsWmsParameter::name( theKey );
 

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -333,9 +333,7 @@ void TestQgsField::displayString()
   QgsField doubleFieldNoPrec( QStringLiteral( "double" ), QVariant::Double, QStringLiteral( "double" ), 10 );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005 ), QString( "5.005005" ) );
   QCOMPARE( doubleFieldNoPrec.displayString( 5.005005005 ), QString( "5.005005005" ) );
-#if QT_VERSION >= 0x050700
   QCOMPARE( QLocale().numberOptions() & QLocale::NumberOption::OmitGroupSeparator, QLocale::NumberOption::DefaultNumberOptions );
-#endif
   QCOMPARE( doubleFieldNoPrec.displayString( 599999898999.0 ), QString( "599,999,898,999" ) );
 
   //test NULL double

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -35,12 +35,7 @@ class TestQgsOgcUtils : public QObject
     void initTestCase()
     {
       // Needed on Qt 5 so that the serialization of XML is consistent among all executions
-#if QT_VERSION >= 0x50600
       qSetGlobalQHashSeed( 0 );
-#else
-      extern Q_CORE_EXPORT QBasicAtomicInt qt_qhash_seed;
-      qt_qhash_seed.store( 0 );
-#endif
 
       //
       // Runs once before any tests are run


### PR DESCRIPTION
As discussed on the mailing list, this PR proposes a bump to Qt 5.9 or greater for QGIS 3.6.  The current minimum Qt dependency is very old and a direct cause of numerous serious issues on Qt <= 5.7, so I'm proposing a more modern minimum version which will allow us to deliver a consistently better experience across the supported platforms (basically, by dropping off the support for distros with older/buggier Qt versions!).