### PR TITLE
partial fix for SAGA RGB composite tool

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithm.py
@@ -321,7 +321,7 @@ class SagaAlgorithm(SagaAlgorithmBase):
                 filename = self.parameterAsOutputLayer(parameters, out.name(), context)
                 filename2 = os.path.splitext(filename)[0] + '.sgrd'
                 if self.cmdname == 'RGB Composite':
-                    commands.append('io_grid_image 0 -IS_RGB -GRID:"{}" -FILE:"{}"'.format(filename2, filename))
+                    commands.append('io_grid_image 0 -COLOURING 4 -GRID:"{}" -FILE:"{}"'.format(filename2, filename))
 
         # 3: Run SAGA
         commands = self.editCommands(commands)

--- a/python/plugins/processing/algs/saga/description/RGBComposite.txt
+++ b/python/plugins/processing/algs/saga/description/RGBComposite.txt
@@ -1,8 +1,8 @@
 RGB Composite
 grid_visualisation
-QgsProcessingParameterRasterLayer|GRID_R|R|None|False
-QgsProcessingParameterRasterLayer|GRID_G|G|None|False
-QgsProcessingParameterRasterLayer|GRID_B|B|None|False
+QgsProcessingParameterRasterLayer|R_GRID|R|None|False
+QgsProcessingParameterRasterLayer|G_GRID|G|None|False
+QgsProcessingParameterRasterLayer|B_GRID|B|None|False
 QgsProcessingParameterEnum|R_METHOD|Method for R value|0 - 255;Rescale to 0 - 255;User defined rescale;Percentiles;Percentage of standard deviation
 QgsProcessingParameterEnum|G_METHOD|Method for G value|0 - 255;Rescale to 0 - 255;User defined rescale;Percentiles;Percentage of standard deviation
 QgsProcessingParameterEnum|B_METHOD|Method for B value|0 - 255;Rescale to 0 - 255;User defined rescale;Percentiles;Percentage of standard deviation
@@ -10,15 +10,15 @@ QgsProcessingParameterNumber|R_RANGE_MIN|Rescale Range for RED min|QgsProcessing
 QgsProcessingParameterNumber|R_RANGE_MAX|Rescale Range for RED max|QgsProcessingParameterNumber.Integer|255|False|0|255
 QgsProcessingParameterNumber|R_PERCTL_MIN|Percentiles Range for RED max|QgsProcessingParameterNumber.Integer|1|False|1|99
 QgsProcessingParameterNumber|R_PERCTL_MAX|Percentiles Range for RED max|QgsProcessingParameterNumber.Integer|99|False|1|99
-QgsProcessingParameterNumber|R_PERCENT|Percentage of standard deviation for RED|QgsProcessingParameterNumber.Double|150.0|False|0|None
+QgsProcessingParameterNumber|R_STDDEV|Standard deviation for RED|QgsProcessingParameterNumber.Double|2.0|False|0|None
 QgsProcessingParameterNumber|G_RANGE_MIN|Rescale Range for GREEN min|QgsProcessingParameterNumber.Integer|0|False|0|255
 QgsProcessingParameterNumber|G_RANGE_MAX|Rescale Range for GREEN max|QgsProcessingParameterNumber.Integer|255|False|0|255
 QgsProcessingParameterNumber|G_PERCTL_MIN|Percentiles Range for GREEN max|QgsProcessingParameterNumber.Integer|1|False|1|99
 QgsProcessingParameterNumber|G_PERCTL_MAX|Percentiles Range for GREEN max|QgsProcessingParameterNumber.Integer|99|False|1|99
-QgsProcessingParameterNumber|G_PERCENT|Percentage of standard deviation for GREEN|QgsProcessingParameterNumber.Double|150.0|False|0|None
+QgsProcessingParameterNumber|G_STDDEV|Standard deviation for GREEN|QgsProcessingParameterNumber.Double|2.0|False|0|None
 QgsProcessingParameterNumber|B_RANGE_MIN|Rescale Range for BLUE min|QgsProcessingParameterNumber.Integer|0|False|0|255
 QgsProcessingParameterNumber|B_RANGE_MAX|Rescale Range for BLUE max|QgsProcessingParameterNumber.Integer|255|False|0|255
 QgsProcessingParameterNumber|B_PERCTL_MIN|Percentiles Range for BLUE max|QgsProcessingParameterNumber.Integer|1|False|1|99
 QgsProcessingParameterNumber|B_PERCTL_MAX|Percentiles Range for BLUE max|QgsProcessingParameterNumber.Integer|99|False|1|99
-QgsProcessingParameterNumber|B_PERCENT|Percentage of standard deviation for BLUE|QgsProcessingParameterNumber.Double|150.0|False|0|None
-QgsProcessingParameterRasterDestination|GRID_RGB|Output RGB
+QgsProcessingParameterNumber|B_STDDEV|Standard deviation for BLUE|QgsProcessingParameterNumber.Double|2.0|False|0|None
+QgsProcessingParameterRasterDestination|RGB|Output RGB


### PR DESCRIPTION
## Description

The SAGA "RGB Composite" has wrong parameters names. Anyway this is not a complete fix:

this tool MUST output an "image", explanation here:

https://gis.stackexchange.com/a/301146

and this is the reason the tool output is generated as a special case here:

https://github.com/qgis/QGIS/blob/master/python/plugins/processing/algs/saga/SagaAlgorithm.py#L324

but the problem (unresolved by this patch) is that now SAGA outputs only in its native format, while this export operations MUST generate a TIFF (for example), otherwise the output (now generated because of the correct parameters names) will not show the expected values/colors (in fact it won't even be a RGB raster).


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
