### PR TITLE
[3d] fix camera controller using wrong shift/ctrl status (fixes #20131)

### DIFF
--- a/src/3d/qgs3dmapscene.cpp
+++ b/src/3d/qgs3dmapscene.cpp
@@ -17,7 +17,11 @@
 
 #include <Qt3DRender/QCamera>
 #include <Qt3DRender/QMesh>
+#include <Qt3DRender/QObjectPicker>
+#include <Qt3DRender/QPickEvent>
 #include <Qt3DRender/QPickingSettings>
+#include <Qt3DRender/QPickTriangleEvent>
+#include <Qt3DRender/QPointLight>
 #include <Qt3DRender/QRenderSettings>
 #include <Qt3DRender/QSceneLoader>
 #include <Qt3DExtras/QForwardRenderer>

--- a/src/3d/qgscameracontroller.h
+++ b/src/3d/qgscameracontroller.h
@@ -18,9 +18,26 @@
 
 #include "qgis_3d.h"
 
+#include <QPointer>
+#include <QRect>
 #include <Qt3DCore/QEntity>
-#include <Qt3DInput>
-#include <Qt3DRender>
+
+namespace Qt3DInput
+{
+  class QKeyEvent;
+  class QKeyboardDevice;
+  class QKeyboardHandler;
+  class QMouseEvent;
+  class QMouseDevice;
+  class QMouseHandler;
+  class QWheelEvent;
+}
+
+namespace Qt3DRender
+{
+  class QCamera;
+  class QPickEvent;
+}
 
 #include "qgscamerapose.h"
 
@@ -120,6 +137,7 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
   private:
     void rotateCamera( float diffPitch, float diffYaw );
+    void updateCameraFromPose( bool centerPointChanged = false );
 
   signals:
     //! Emitted when camera has been updated
@@ -129,6 +147,11 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
   private slots:
     void onPositionChanged( Qt3DInput::QMouseEvent *mouse );
+    void onWheel( Qt3DInput::QWheelEvent *wheel );
+    void onMousePressed( Qt3DInput::QMouseEvent *mouse );
+    void onMouseReleased( Qt3DInput::QMouseEvent *mouse );
+    void onKeyPressed( Qt3DInput::QKeyEvent *event );
+    void onKeyReleased( Qt3DInput::QKeyEvent *event );
     void onPickerMousePressed( Qt3DRender::QPickEvent *pick );
 
   private:
@@ -146,50 +169,14 @@ class _3D_EXPORT QgsCameraController : public Qt3DCore::QEntity
 
     //! Last mouse position recorded
     QPoint mMousePos;
-    //! Mouse position used in the previous frame
-    QPoint mLastMousePos;
 
     //! Delegates mouse events to the attached MouseHandler objects
     Qt3DInput::QMouseDevice *mMouseDevice = nullptr;
-
     Qt3DInput::QKeyboardDevice *mKeyboardDevice = nullptr;
 
     Qt3DInput::QMouseHandler *mMouseHandler = nullptr;
+    Qt3DInput::QKeyboardHandler *mKeyboardHandler = nullptr;
 
-    /**
-     * Allows us to define a set of actions that we wish to use
-     * (it is a component that can be attached to 3D scene)
-     */
-    Qt3DInput::QLogicalDevice *mLogicalDevice = nullptr;
-
-    Qt3DInput::QAction *mLeftMouseButtonAction = nullptr;
-    Qt3DInput::QActionInput *mLeftMouseButtonInput = nullptr;
-
-    Qt3DInput::QAction *mMiddleMouseButtonAction = nullptr;
-    Qt3DInput::QActionInput *mMiddleMouseButtonInput = nullptr;
-
-    Qt3DInput::QAction *mRightMouseButtonAction = nullptr;
-    Qt3DInput::QActionInput *mRightMouseButtonInput = nullptr;
-
-    Qt3DInput::QAction *mShiftAction = nullptr;
-    Qt3DInput::QActionInput *mShiftInput = nullptr;
-
-    Qt3DInput::QAction *mCtrlAction = nullptr;
-    Qt3DInput::QActionInput *mCtrlInput = nullptr;
-
-    Qt3DInput::QAxis *mWheelAxis = nullptr;
-    Qt3DInput::QAnalogAxisInput *mMouseWheelInput = nullptr;
-
-    Qt3DInput::QAxis *mTxAxis = nullptr;
-    Qt3DInput::QAxis *mTyAxis = nullptr;
-    Qt3DInput::QButtonAxisInput *mKeyboardTxPosInput = nullptr;
-    Qt3DInput::QButtonAxisInput *mKeyboardTyPosInput = nullptr;
-    Qt3DInput::QButtonAxisInput *mKeyboardTxNegInput = nullptr;
-    Qt3DInput::QButtonAxisInput *mKeyboardTyNegInput = nullptr;
-
-    Qt3DInput::QAxis *mTelevAxis = nullptr;
-    Qt3DInput::QButtonAxisInput *mKeyboardTelevPosInput = nullptr;
-    Qt3DInput::QButtonAxisInput *mKeyboardTelevNegInput = nullptr;
 };
 
 #endif // QGSCAMERACONTROLLER_H

--- a/src/app/3d/qgs3dmapcanvas.cpp
+++ b/src/app/3d/qgs3dmapcanvas.cpp
@@ -18,6 +18,7 @@
 #include <QBoxLayout>
 #include <Qt3DExtras/Qt3DWindow>
 #include <Qt3DRender/QRenderCapture>
+#include <QMouseEvent>
 
 #include "qgscameracontroller.h"
 #include "qgs3dmapsettings.h"


### PR DESCRIPTION
We used Qt3DInput::QLogicalDevice with its axes and actions for camera
controller, but over time this got quite impractical, moreover we started
to have problems with shift/ctrl actions getting stuck in wrong state
in case they were pressed or released while 3D canvas was not focused
(which is in fact relatively common when using other widgets in the GUI)

This commit switches over to using just QMouseHandler and QKeyboardHandler
for handling key and mouse events and this not only makes the code easier
to read, but also the issues with shift/ctrl go away (because we do not
keep their status anymore, we just check whether they are active inside
event handlers).

The speed of change with mouse wheel and keys should be similar or a bit
less than what it was before.
