### PR TITLE
[3d] Fix 3D line symbol in 3D views in print layouts (fixes #20118)

### DIFF
--- a/src/3d/qgsoffscreen3dengine.cpp
+++ b/src/3d/qgsoffscreen3dengine.cpp
@@ -32,12 +32,28 @@
 #include <Qt3DRender/QRenderSurfaceSelector>
 #include <Qt3DRender/QTexture>
 #include <Qt3DRender/QViewport>
+#include <QtGui/QOpenGLContext>
 
 
 QgsOffscreen3DEngine::QgsOffscreen3DEngine()
 {
   // Set up the default OpenGL surface format.
   QSurfaceFormat format;
+
+  // by default we get just some older version of OpenGL from the system,
+  // but for 3D lines we use "primitive restart" functionality supported in OpenGL >= 3.1
+  // Qt3DWindow uses this - requesting OpenGL 4.3 - so let's request the same version.
+#ifdef QT_OPENGL_ES_2
+  format.setRenderableType( QSurfaceFormat::OpenGLES );
+#else
+  if ( QOpenGLContext::openGLModuleType() == QOpenGLContext::LibGL )
+  {
+    format.setVersion( 4, 3 );
+    format.setProfile( QSurfaceFormat::CoreProfile );
+  }
+#endif
+
+  format.setMajorVersion( 3 );
   format.setDepthBufferSize( 32 ); // TODO: or 24?  (used by QWindow3D)
   format.setSamples( 8 );
   QSurfaceFormat::setDefaultFormat( format );


### PR DESCRIPTION
Turned out we were getting an old version of OpenGL that does not
support the "primitive restart" functionality and so wherever
a linestring should be broken it was connected through (0,0,0)
to the next linestring.