### PR TITLE
Fix data loss (use GPKG as default format, not SHP)

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -137,6 +137,9 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
     def svgIconPath(self):
         return QgsApplication.iconPath("/providerGrass.svg")
 
+    def defaultVectorFileExtension(self, hasGeometry=True):
+        return 'gpkg'
+
     def supportsNonFileBasedOutput(self):
         """
         GRASS7 Provider doesn't support non file based outputs


### PR DESCRIPTION
As per https://issues.qgis.org/issues/19733 this addresses the issue that SHP only supports 10-char DBF column names which easily become longer when using v.rast.stats etc. The solution implemented here is to switch to GPKG as default format in the QGIS-GRASS-Processing internal data exchange and no longer use SHP.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
