### PR TITLE
[afs] Fix missing layers/services when connection url does not point at an individual service endpoint

### DIFF
--- a/src/core/qgsstringutils.cpp
+++ b/src/core/qgsstringutils.cpp
@@ -431,7 +431,7 @@ QString QgsStringUtils::insertLinks( const QString &string, bool *foundLinks )
   {
     found = true;
     QString email = emailRegEx.cap( 1 );
-    QString anchor = QStringLiteral( "<a href=\"mailto:%1\">%1</a>" ).arg( email.toHtmlEscaped(), email.toHtmlEscaped() );
+    QString anchor = QStringLiteral( "<a href=\"mailto:%1\">%1</a>" ).arg( email.toHtmlEscaped() );
     converted.replace( emailRegEx.pos( 1 ), email.length(), anchor );
     offset = emailRegEx.pos( 1 ) + anchor.length();
   }

--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -21,6 +21,9 @@
 #ifdef HAVE_GUI
 #include "qgsnewhttpconnection.h"
 #include "qgsafssourceselect.h"
+#include <QMenu>
+#include <QAction>
+#include <QDesktopServices>
 #endif
 
 #include <QMessageBox>
@@ -183,6 +186,12 @@ bool QgsAfsConnectionItem::equal( const QgsDataItem *other )
 {
   const QgsAfsConnectionItem *o = qobject_cast<const QgsAfsConnectionItem *>( other );
   return ( type() == other->type() && o && mPath == o->mPath && mName == o->mName );
+}
+
+QString QgsAfsConnectionItem::url() const
+{
+  const QgsOwsConnection connection( QStringLiteral( "ARCGISFEATURESERVER" ), mConnName );
+  return connection.uri().param( QStringLiteral( "url" ) );
 }
 
 #ifdef HAVE_GUI
@@ -381,3 +390,66 @@ QgsDataItem *QgsAfsDataItemProvider::createDataItem( const QString &path, QgsDat
 
   return nullptr;
 }
+
+#ifdef HAVE_GUI
+
+//
+// QgsAfsItemGuiProvider
+//
+
+QString QgsAfsItemGuiProvider::name()
+{
+  return QStringLiteral( "afs_items" );
+}
+
+void QgsAfsItemGuiProvider::populateContextMenu( QgsDataItem *item, QMenu *menu, const QList<QgsDataItem *> &, QgsDataItemGuiContext )
+{
+  if ( QgsAfsConnectionItem *connectionItem = qobject_cast< QgsAfsConnectionItem * >( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [ = ]
+    {
+      QDesktopServices::openUrl( QUrl( connectionItem->url() ) );
+    } );
+    menu->addAction( viewInfo );
+  }
+  else if ( QgsAfsFolderItem *folderItem = qobject_cast< QgsAfsFolderItem * >( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [ = ]
+    {
+      QDesktopServices::openUrl( QUrl( folderItem->path() ) );
+    } );
+    menu->addAction( viewInfo );
+  }
+  else if ( QgsAfsServiceItem *serviceItem = qobject_cast< QgsAfsServiceItem * >( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [ = ]
+    {
+      QDesktopServices::openUrl( QUrl( serviceItem->path() ) );
+    } );
+    menu->addAction( viewInfo );
+  }
+  else if ( QgsAfsParentLayerItem *layerItem = qobject_cast< QgsAfsParentLayerItem * >( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [ = ]
+    {
+      QDesktopServices::openUrl( QUrl( layerItem->path() ) );
+    } );
+    menu->addAction( viewInfo );
+  }
+  else if ( QgsAfsLayerItem *layerItem = qobject_cast< QgsAfsLayerItem * >( item ) )
+  {
+    QAction *viewInfo = new QAction( tr( "View Service Info" ), menu );
+    connect( viewInfo, &QAction::triggered, this, [ = ]
+    {
+      QDesktopServices::openUrl( QUrl( layerItem->path() ) );
+    } );
+    menu->addAction( viewInfo );
+    menu->addSeparator();
+  }
+}
+
+#endif

--- a/src/providers/arcgisrest/qgsafsdataitems.h
+++ b/src/providers/arcgisrest/qgsafsdataitems.h
@@ -20,6 +20,10 @@
 #include "qgswkbtypes.h"
 #include "qgsdataitemprovider.h"
 
+#ifdef HAVE_GUI
+#include "qgsdataitemguiprovider.h"
+#endif
+
 class QgsAfsRootItem : public QgsDataCollectionItem
 {
     Q_OBJECT
@@ -49,6 +53,7 @@ class QgsAfsConnectionItem : public QgsDataCollectionItem
     QgsAfsConnectionItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &connectionName );
     QVector<QgsDataItem *> createChildren() override;
     bool equal( const QgsDataItem *other ) override;
+    QString url() const;
 #ifdef HAVE_GUI
     QList<QAction *> actions( QWidget *parent ) override;
 #endif
@@ -126,5 +131,25 @@ class QgsAfsDataItemProvider : public QgsDataItemProvider
 
     QgsDataItem *createDataItem( const QString &path, QgsDataItem *parentItem ) override;
 };
+
+#ifdef HAVE_GUI
+
+class QgsAfsItemGuiProvider : public QObject, public QgsDataItemGuiProvider
+{
+    Q_OBJECT
+
+  public:
+
+    QgsAfsItemGuiProvider() = default;
+
+    QString name() override;
+
+    void populateContextMenu( QgsDataItem *item, QMenu *menu,
+                              const QList<QgsDataItem *> &selectedItems, QgsDataItemGuiContext context ) override;
+
+
+};
+
+#endif
 
 #endif // QGSAFSDATAITEMS_H

--- a/src/providers/arcgisrest/qgsafsdataitems.h
+++ b/src/providers/arcgisrest/qgsafsdataitems.h
@@ -64,13 +64,56 @@ class QgsAfsConnectionItem : public QgsDataCollectionItem
     QString mConnName;
 };
 
+class QgsAfsFolderItem : public QgsDataCollectionItem
+{
+    Q_OBJECT
+  public:
+    QgsAfsFolderItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg );
+    QVector<QgsDataItem *> createChildren() override;
+    bool equal( const QgsDataItem *other ) override;
+
+  private:
+    QString mFolder;
+    QString mBaseUrl;
+    QString mAuthCfg;
+};
+
+class QgsAfsServiceItem : public QgsDataCollectionItem
+{
+    Q_OBJECT
+  public:
+    QgsAfsServiceItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &baseUrl, const QString &authcfg );
+    QVector<QgsDataItem *> createChildren() override;
+    bool equal( const QgsDataItem *other ) override;
+
+  private:
+    QString mFolder;
+    QString mBaseUrl;
+    QString mAuthCfg;
+};
+
+class QgsAfsParentLayerItem : public QgsDataItem
+{
+    Q_OBJECT
+  public:
+
+    QgsAfsParentLayerItem( QgsDataItem *parent, const QString &name, const QString &path, const QString &authcfg );
+    bool equal( const QgsDataItem *other ) override;
+
+  private:
+
+    QString mAuthCfg;
+
+};
 
 class QgsAfsLayerItem : public QgsLayerItem
 {
     Q_OBJECT
 
   public:
+
     QgsAfsLayerItem( QgsDataItem *parent, const QString &name, const QString &url, const QString &title, const QString &authid, const QString &authcfg );
+
 };
 
 //! Provider for afs root data item

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -346,4 +346,16 @@ QGISEXTERN QList<QgsDataItemProvider *> *dataItemProviders()
   return providers;
 }
 
+#ifdef HAVE_GUI
+QGISEXTERN QList<QgsDataItemGuiProvider *> *dataItemGuiProviders()
+{
+  QList<QgsDataItemGuiProvider *> *providers = new QList<QgsDataItemGuiProvider *>();
+
+  *providers
+      << new QgsAfsItemGuiProvider();
+
+  return providers;
+}
+#endif
+
 #endif

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -39,68 +39,116 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
   QString errorTitle, errorMessage;
 
   const QString authcfg = connection.uri().param( QStringLiteral( "authcfg" ) );
-  QVariantMap serviceInfoMap = QgsArcGisRestUtils::getServiceInfo( connection.uri().param( QStringLiteral( "url" ) ), authcfg, errorTitle, errorMessage );
-  if ( serviceInfoMap.isEmpty() )
+  const QString baseUrl = connection.uri().param( QStringLiteral( "url" ) );
+
+  std::function< bool( const QString &, QStandardItem *, const QString & )> visitItemsRecursive;
+  visitItemsRecursive = [this, &visitItemsRecursive, baseUrl, authcfg, &errorTitle, &errorMessage]( const QString & baseItemUrl, QStandardItem * parentItem, const QString & parentName ) -> bool
   {
+    const QVariantMap serviceInfoMap = QgsArcGisRestUtils::getServiceInfo( baseItemUrl, authcfg, errorTitle, errorMessage );
+
+    if ( serviceInfoMap.isEmpty() )
+    {
+      return false;
+    }
+
+    bool res = true;
+
+    QgsArcGisRestUtils::visitFolderItems( [ =, &res ]( const QString & name, const QString & url )
+    {
+      QStandardItem *nameItem = new QStandardItem( name );
+      nameItem->setToolTip( url );
+      if ( parentItem )
+        parentItem->appendRow( QList<QStandardItem *>() << nameItem );
+      else
+        mModel->appendRow( QList<QStandardItem *>() << nameItem );
+
+      if ( !visitItemsRecursive( url, nameItem, name ) )
+        res = false;
+    }, serviceInfoMap, baseUrl );
+
+    QgsArcGisRestUtils::visitServiceItems(
+      [ =, &res]( const QString & name, const QString & url )
+    {
+      QStandardItem *nameItem = new QStandardItem( name );
+      nameItem->setToolTip( url );
+      if ( parentItem )
+        parentItem->appendRow( QList<QStandardItem *>() << nameItem );
+      else
+        mModel->appendRow( QList<QStandardItem *>() << nameItem );
+
+      if ( !visitItemsRecursive( url, nameItem, name ) )
+        res = false;
+    }, serviceInfoMap, baseUrl, parentName );
+
+    QMap< QString, QList<QStandardItem *> > layerItems;
+    QMap< QString, QString > parents;
+
+    QgsArcGisRestUtils::addLayerItems( [ =, &layerItems, &parents]( const QString & parentLayerId, const QString & layerId, const QString & name, const QString & description, const QString & url, bool isParentLayer, const QString & authid )
+    {
+      if ( !parentLayerId.isEmpty() )
+        parents.insert( layerId, parentLayerId );
+
+      if ( isParentLayer )
+      {
+        QStandardItem *nameItem = new QStandardItem( name );
+        nameItem->setToolTip( url );
+        layerItems.insert( layerId, QList<QStandardItem *>() << nameItem );
+      }
+      else
+      {
+        // insert the typenames, titles and abstracts into the tree view
+        QStandardItem *idItem = new QStandardItem( layerId );
+        bool ok = false;
+        int idInt = layerId.toInt( &ok );
+        if ( ok )
+        {
+          // force display role to be int value, so that sorting works correctly
+          idItem->setData( idInt, Qt::DisplayRole );
+        }
+        idItem->setData( url, UrlRole );
+        idItem->setData( true, IsLayerRole );
+        QStandardItem *nameItem = new QStandardItem( name );
+        QStandardItem *abstractItem = new QStandardItem( description );
+        abstractItem->setToolTip( description );
+        QStandardItem *cachedItem = new QStandardItem();
+        QStandardItem *filterItem = new QStandardItem();
+        cachedItem->setCheckable( true );
+        cachedItem->setCheckState( Qt::Checked );
+
+        mAvailableCRS[name] = QList<QString>()  << authid;
+
+        layerItems.insert( layerId, QList<QStandardItem *>() << idItem << nameItem << abstractItem << cachedItem << filterItem );
+      }
+    }, serviceInfoMap, baseItemUrl );
+
+    // create layer groups
+    for ( auto it = layerItems.constBegin(); it != layerItems.constEnd(); ++it )
+    {
+      const QString id = it.key();
+      QList<QStandardItem *> row = it.value();
+      const QString parentId = parents.value( id );
+      QList<QStandardItem *> parentRow;
+      if ( !parentId.isEmpty() )
+        parentRow = layerItems.value( parentId );
+      if ( !parentRow.isEmpty() )
+      {
+        parentRow.at( 0 )->appendRow( row );
+      }
+      else
+      {
+        if ( parentItem )
+          parentItem->appendRow( row );
+        else
+          mModel->appendRow( row );
+      }
+    }
+
+    return res;
+  };
+
+  if ( !visitItemsRecursive( baseUrl, nullptr, QString() ) )
     QMessageBox::warning( this, tr( "Error" ), tr( "Failed to retrieve service capabilities:\n%1: %2" ).arg( errorTitle, errorMessage ) );
-    return false;
-  }
 
-  QStringList layerErrors;
-  const QVariantList layers = serviceInfoMap.value( QStringLiteral( "layers" ) ).toList();
-  for ( const QVariant &layerInfo : layers )
-  {
-    const QVariantMap layerInfoMap = layerInfo.toMap();
-    if ( !layerInfoMap[QStringLiteral( "id" )].isValid() )
-    {
-      continue;
-    }
-
-    if ( !layerInfoMap.value( QStringLiteral( "subLayerIds" ) ).toList().empty() )
-    {
-      // group layer - do not show as it is not possible to load
-      // TODO - turn model into a tree and show nested groups
-      continue;
-    }
-
-    // Get layer info
-    const QVariantMap layerData = QgsArcGisRestUtils::getLayerInfo( connection.uri().param( QStringLiteral( "url" ) ) + "/" + layerInfoMap[QStringLiteral( "id" )].toString(), authcfg, errorTitle, errorMessage );
-    if ( layerData.isEmpty() )
-    {
-      layerErrors.append( tr( "Layer %1: %2 - %3" ).arg( layerInfoMap[QStringLiteral( "id" )].toString(), errorTitle, errorMessage ) );
-      continue;
-    }
-    if ( !layerData.value( QStringLiteral( "capabilities" ) ).toString().contains( QStringLiteral( "query" ), Qt::CaseInsensitive ) )
-    {
-      QgsDebugMsg( QStringLiteral( "Layer %1 does not support query capabilities" ).arg( layerInfoMap[QStringLiteral( "id" )].toString() ) );
-      continue;
-    }
-    // insert the typenames, titles and abstracts into the tree view
-    QStandardItem *idItem = new QStandardItem( layerData[QStringLiteral( "id" )].toString() );
-    bool ok = false;
-    int idInt = layerData[QStringLiteral( "id" )].toInt( &ok );
-    if ( ok )
-    {
-      // force display role to be int value, so that sorting works correctly
-      idItem->setData( idInt, Qt::DisplayRole );
-    }
-    QStandardItem *nameItem = new QStandardItem( layerData[QStringLiteral( "name" )].toString() );
-    QStandardItem *abstractItem = new QStandardItem( layerData[QStringLiteral( "description" )].toString() );
-    abstractItem->setToolTip( layerData[QStringLiteral( "description" )].toString() );
-    QStandardItem *cachedItem = new QStandardItem();
-    QStandardItem *filterItem = new QStandardItem();
-    cachedItem->setCheckable( true );
-    cachedItem->setCheckState( Qt::Checked );
-
-    QgsCoordinateReferenceSystem crs = QgsArcGisRestUtils::parseSpatialReference( serviceInfoMap[QStringLiteral( "spatialReference" )].toMap() );
-    mAvailableCRS[layerData[QStringLiteral( "name" )].toString()] = QList<QString>()  << crs.authid();
-
-    mModel->appendRow( QList<QStandardItem *>() << idItem << nameItem << abstractItem << cachedItem << filterItem );
-  }
-  if ( !layerErrors.isEmpty() )
-  {
-    QMessageBox::warning( this, tr( "Error" ), tr( "Failed to query some layers:\n%1" ).arg( layerErrors.join( QStringLiteral( "\n" ) ) ) );
-  }
   return true;
 }
 
@@ -111,11 +159,10 @@ void QgsAfsSourceSelect::buildQuery( const QgsOwsConnection &connection, const Q
     return;
   }
   QModelIndex filterIndex = index.sibling( index.row(), 4 );
-  QString id = index.sibling( index.row(), 0 ).data().toString();
+  const QString url = index.sibling( index.row(), 0 ).data( UrlRole ).toString();
 
   // Query available fields
   QgsDataSourceUri ds = connection.uri();
-  QString url = ds.param( QStringLiteral( "url" ) ) + "/" + id;
   ds.removeParam( QStringLiteral( "url" ) );
   ds.setParam( QStringLiteral( "url" ), url );
   QgsDataProvider::ProviderOptions providerOptions;
@@ -146,7 +193,7 @@ QString QgsAfsSourceSelect::getLayerURI( const QgsOwsConnection &connection,
     const QgsRectangle &bBox ) const
 {
   QgsDataSourceUri ds = connection.uri();
-  QString url = ds.param( QStringLiteral( "url" ) ) + "/" + layerTitle;
+  QString url = layerTitle;
   ds.removeParam( QStringLiteral( "url" ) );
   ds.setParam( QStringLiteral( "url" ), url );
   ds.setParam( QStringLiteral( "filter" ), filter );

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -110,14 +110,11 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
         QStandardItem *nameItem = new QStandardItem( name );
         QStandardItem *abstractItem = new QStandardItem( description );
         abstractItem->setToolTip( description );
-        QStandardItem *cachedItem = new QStandardItem();
         QStandardItem *filterItem = new QStandardItem();
-        cachedItem->setCheckable( true );
-        cachedItem->setCheckState( Qt::Checked );
 
         mAvailableCRS[name] = QList<QString>()  << authid;
 
-        layerItems.insert( layerId, QList<QStandardItem *>() << idItem << nameItem << abstractItem << cachedItem << filterItem );
+        layerItems.insert( layerId, QList<QStandardItem *>() << idItem << nameItem << abstractItem << filterItem );
       }
     }, serviceInfoMap, baseItemUrl );
 
@@ -158,7 +155,7 @@ void QgsAfsSourceSelect::buildQuery( const QgsOwsConnection &connection, const Q
   {
     return;
   }
-  QModelIndex filterIndex = index.sibling( index.row(), 4 );
+  QModelIndex filterIndex = index.sibling( index.row(), 3 );
   const QString url = index.sibling( index.row(), 0 ).data( UrlRole ).toString();
 
   // Query available fields

--- a/src/providers/arcgisrest/qgsamssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsamssourceselect.cpp
@@ -68,6 +68,7 @@ bool QgsAmsSourceSelect::connectToService( const QgsOwsConnection &connection )
     }
     // insert the typenames, titles and abstracts into the tree view
     QStandardItem *idItem = new QStandardItem( layerData[QStringLiteral( "id" )].toString() );
+    idItem->setData( true, IsLayerRole );
     bool ok = false;
     int idInt = layerData[QStringLiteral( "id" )].toInt( &ok );
     if ( ok )

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -64,6 +64,9 @@ class QgsArcGisRestUtils
     static QDateTime parseDateTime( const QVariant &value );
 
     static QUrl parseUrl( const QUrl &url );
+    static void visitFolderItems( const std::function<void ( const QString &folderName, const QString &url )> &visitor, const QVariantMap &serviceData, const QString &baseUrl );
+    static void visitServiceItems( const std::function<void ( const QString &serviceName, const QString &url )> &visitor, const QVariantMap &serviceData, const QString &baseUrl, const QString &parentName );
+    static void addLayerItems( const std::function<void ( const QString &parentLayerId, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QString &authid )> &visitor, const QVariantMap &serviceData, const QString &parentUrl );
 };
 
 class QgsArcGisAsyncQuery : public QObject
@@ -91,6 +94,7 @@ class QgsArcGisAsyncParallelQuery : public QObject
   public:
     QgsArcGisAsyncParallelQuery( QObject *parent = nullptr );
     void start( const QVector<QUrl> &urls, QVector<QByteArray> *results, bool allowCache = false );
+
   signals:
     void finished( QStringList errors );
   private slots:

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
@@ -338,11 +338,16 @@ void QgsArcGisServiceSourceSelect::addButtonClicked()
     {
       continue;
     }
+
     int row = idx.row();
-    QString layerTitle = mModel->item( row, 0 )->text(); //layer title/id
-    QString layerName = mModel->item( row, 1 )->text(); //layer name
-    bool cacheFeatures = mServiceType == FeatureService ? mModel->item( row, 3 )->checkState() == Qt::Checked : false;
-    QString filter = mServiceType == FeatureService ? mModel->item( row, 4 )->text() : QString(); //optional filter specified by user
+    if ( !mModel->itemFromIndex( mModel->index( row, 0, idx.parent() ) )->data( IsLayerRole ).toBool() )
+      continue;
+
+    QString layerTitle = mModel->itemFromIndex( mModel->index( row, 0, idx.parent() ) )->text();  //layer title/id
+    QString layerName = mModel->itemFromIndex( mModel->index( row, 1, idx.parent() ) )->text(); //layer name
+    const QString layerUri = mModel->itemFromIndex( mModel->index( row, 0, idx.parent() ) )->data( UrlRole ).toString();
+    bool cacheFeatures = mServiceType == FeatureService ? mModel->itemFromIndex( mModel->index( row, 3, idx.parent() ) )->checkState() == Qt::Checked : false;
+    QString filter = mServiceType == FeatureService ? mModel->itemFromIndex( mModel->index( row, 4, idx.parent() ) )->text() : QString(); //optional filter specified by user
     if ( cbxUseTitleLayerName->isChecked() && !layerTitle.isEmpty() )
     {
       layerName = layerTitle;
@@ -352,7 +357,7 @@ void QgsArcGisServiceSourceSelect::addButtonClicked()
     {
       layerExtent = extent;
     }
-    QString uri = getLayerURI( connection, layerTitle, layerName, pCrsString, filter, layerExtent );
+    QString uri = getLayerURI( connection, layerUri.isEmpty() ? layerTitle : layerUri, layerName, pCrsString, filter, layerExtent );
 
     QgsDebugMsg( "Layer " + layerName + ", uri: " + uri );
     addServiceLayer( uri, layerName );

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
@@ -78,8 +78,7 @@ QgsArcGisServiceSourceSelect::QgsArcGisServiceSourceSelect( const QString &servi
   mModel->setHorizontalHeaderItem( 2, new QStandardItem( QStringLiteral( "Abstract" ) ) );
   if ( serviceType == FeatureService )
   {
-    mModel->setHorizontalHeaderItem( 3, new QStandardItem( QStringLiteral( "Cache Feature" ) ) );
-    mModel->setHorizontalHeaderItem( 4, new QStandardItem( QStringLiteral( "Filter" ) ) );
+    mModel->setHorizontalHeaderItem( 3, new QStandardItem( QStringLiteral( "Filter" ) ) );
     gbImageEncoding->hide();
   }
   else
@@ -346,14 +345,13 @@ void QgsArcGisServiceSourceSelect::addButtonClicked()
     QString layerTitle = mModel->itemFromIndex( mModel->index( row, 0, idx.parent() ) )->text();  //layer title/id
     QString layerName = mModel->itemFromIndex( mModel->index( row, 1, idx.parent() ) )->text(); //layer name
     const QString layerUri = mModel->itemFromIndex( mModel->index( row, 0, idx.parent() ) )->data( UrlRole ).toString();
-    bool cacheFeatures = mServiceType == FeatureService ? mModel->itemFromIndex( mModel->index( row, 3, idx.parent() ) )->checkState() == Qt::Checked : false;
-    QString filter = mServiceType == FeatureService ? mModel->itemFromIndex( mModel->index( row, 4, idx.parent() ) )->text() : QString(); //optional filter specified by user
+    QString filter = mServiceType == FeatureService ? mModel->itemFromIndex( mModel->index( row, 3, idx.parent() ) )->text() : QString(); //optional filter specified by user
     if ( cbxUseTitleLayerName->isChecked() && !layerTitle.isEmpty() )
     {
       layerName = layerTitle;
     }
     QgsRectangle layerExtent;
-    if ( mServiceType == FeatureService && ( cbxFeatureCurrentViewExtent->isChecked() || !cacheFeatures ) )
+    if ( mServiceType == FeatureService && ( cbxFeatureCurrentViewExtent->isChecked() ) )
     {
       layerExtent = extent;
     }

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.cpp
@@ -91,6 +91,7 @@ QgsArcGisServiceSourceSelect::QgsArcGisServiceSourceSelect( const QString &servi
   mModelProxy->setSourceModel( mModel );
   mModelProxy->setSortCaseSensitivity( Qt::CaseInsensitive );
   treeView->setModel( mModelProxy );
+  treeView->setSortingEnabled( true );
 
   connect( treeView, &QAbstractItemView::doubleClicked, this, &QgsArcGisServiceSourceSelect::treeWidgetItemDoubleClicked );
   connect( treeView->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &QgsArcGisServiceSourceSelect::treeWidgetCurrentRowChanged );
@@ -265,16 +266,10 @@ void QgsArcGisServiceSourceSelect::connectToServer()
 
     if ( haveLayers )
     {
-      for ( int i = 0; i < treeView->header()->count(); ++i )
-      {
-        treeView->resizeColumnToContents( i );
-        if ( i < 2 && treeView->columnWidth( i ) > 300 )
-        {
-          treeView->setColumnWidth( i, 300 );
-        }
-      }
       treeView->selectionModel()->select( mModel->index( 0, 0 ), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows );
       treeView->setFocus();
+
+      treeView->sortByColumn( 0, Qt::AscendingOrder );
     }
     else
     {

--- a/src/providers/arcgisrest/qgsarcgisservicesourceselect.h
+++ b/src/providers/arcgisrest/qgsarcgisservicesourceselect.h
@@ -39,6 +39,13 @@ class QgsArcGisServiceSourceSelect : public QgsAbstractDataSourceWidget, protect
     Q_OBJECT
 
   public:
+
+    enum Roles
+    {
+      UrlRole = Qt::UserRole + 1,
+      IsLayerRole,
+    };
+
     //! Whether the dialog is for a map service or a feature service
     enum ServiceType { MapService, FeatureService };
 


### PR DESCRIPTION
Previously the provider would only show layers if a FeatureService endpoint was used for the url, and would show nothing if users enter the base server url.

Fix this by implementing a tree view for AFS items so that if users enter a connection url at a higher level than we show nested services/folders containing the layers.

(I intend to backport the bugfix components of this PR)