### PR TITLE
Using of QgsVectorLayerUtils::createFeature on move and copy tool

### DIFF
--- a/src/core/qgsvectorlayertools.cpp
+++ b/src/core/qgsvectorlayertools.cpp
@@ -18,6 +18,7 @@
 #include "qgsvectorlayertools.h"
 #include "qgsfeaturerequest.h"
 #include "qgslogger.h"
+#include "qgsvectorlayerutils.h"
 
 
 QgsVectorLayerTools::QgsVectorLayerTools()
@@ -34,7 +35,6 @@ bool QgsVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureReq
 
   QgsFeatureIterator fi = layer->getFeatures( request );
   QgsFeature f;
-  QgsAttributeList pkAttrList = layer->primaryKeyAttributes();
 
   int browsedFeatureCount = 0;
   int couldNotWriteCount = 0;
@@ -45,29 +45,27 @@ bool QgsVectorLayerTools::copyMoveFeatures( QgsVectorLayer *layer, QgsFeatureReq
   while ( fi.nextFeature( f ) )
   {
     browsedFeatureCount++;
-    // remove pkey values
-    Q_FOREACH ( auto idx, pkAttrList )
-    {
-      f.setAttribute( idx, QVariant() );
-    }
+
+    QgsFeature newFeature = QgsVectorLayerUtils::createFeature( layer, f.geometry(), f.attributes().toMap() );
+
     // translate
-    if ( f.hasGeometry() )
+    if ( newFeature.hasGeometry() )
     {
-      QgsGeometry geom = f.geometry();
+      QgsGeometry geom = newFeature.geometry();
       geom.translate( dx, dy );
-      f.setGeometry( geom );
+      newFeature.setGeometry( geom );
 #ifdef QGISDEBUG
-      const QgsFeatureId fid = f.id();
+      const QgsFeatureId fid = newFeature.id();
 #endif
       // paste feature
-      if ( !layer->addFeature( f ) )
+      if ( !layer->addFeature( newFeature ) )
       {
         couldNotWriteCount++;
         QgsDebugMsg( QStringLiteral( "Could not add new feature. Original copied feature id: %1" ).arg( fid ) );
       }
       else
       {
-        fidList.insert( f.id() );
+        fidList.insert( newFeature.id() );
       }
     }
     else

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -464,15 +464,7 @@ QgsFeature QgsVectorLayerUtils::duplicateFeature( QgsVectorLayer *layer, const Q
   QgsExpressionContext context = layer->createExpressionContext();
   context.setFeature( feature );
 
-  //create the attribute map
-  QgsAttributes srcAttr = feature.attributes();
-  QgsAttributeMap dstAttr;
-  for ( int src = 0; src < srcAttr.count(); ++src )
-  {
-    dstAttr[ src ] = srcAttr.at( src );
-  }
-
-  QgsFeature newFeature = createFeature( layer, feature.geometry(), dstAttr, &context );
+  QgsFeature newFeature = createFeature( layer, feature.geometry(), feature.attributes().toMap(), &context );
 
   const QList<QgsRelation> relations = project->relationManager()->referencedRelations( layer );
 


### PR DESCRIPTION
... and there the logic of unique not null fields (like primary keys) is used.

This would fix #20347

@3nids since you originally made that part in the move and copy tool. Do you see risks on this approach?