### PR TITLE
[3d] fix inevitable crashes when terrain bounding boxes were shown

### DIFF
--- a/src/3d/chunks/qgschunkboundsentity_p.cpp
+++ b/src/3d/chunks/qgschunkboundsentity_p.cpp
@@ -48,9 +48,9 @@ void LineMeshGeometry::setVertices( const QList<QVector3D> &vertices )
     rawVertexArray[idx++] = v.x();
     rawVertexArray[idx++] = v.y();
     rawVertexArray[idx++] = v.z();
-    mVertices.append( v );
   }
 
+  mVertexCount = vertices.count();
   mVertexBuffer->setData( vertexBufferData );
 }
 

--- a/src/3d/chunks/qgschunkboundsentity_p.h
+++ b/src/3d/chunks/qgschunkboundsentity_p.h
@@ -67,7 +67,7 @@ class LineMeshGeometry : public Qt3DRender::QGeometry
 
     int vertexCount()
     {
-      return mVertices.size();
+      return mVertexCount;
     }
 
     void setVertices( const QList<QVector3D> &vertices );
@@ -75,7 +75,7 @@ class LineMeshGeometry : public Qt3DRender::QGeometry
   private:
     Qt3DRender::QAttribute *mPositionAttribute = nullptr;
     Qt3DRender::QBuffer *mVertexBuffer = nullptr;
-    QList<QVector3D> mVertices;
+    int mVertexCount = 0;
 
 };
 


### PR DESCRIPTION
The list of vertices just kept growing and growing (and we didn't even need another copy!)
