### PR TITLE
Fix raster block output when block extent is outside of valid area

### DIFF
--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -640,6 +640,13 @@ QgsRasterBlock *QgsGdalProvider::block( int bandNo, const QgsRectangle &extent, 
     return block;
   }
 
+  if ( !mExtent.intersects( extent ) )
+  {
+    // the requested extent is completely outside of the raster's extent - nothing to do
+    block->setIsNoData();
+    return block;
+  }
+
   if ( !mExtent.contains( extent ) )
   {
     QRect subRect = QgsRasterBlock::subRect( extent, width, height, mExtent );


### PR DESCRIPTION
This was causing problems in 3D view when raster was used as DEM... terrain tiles were generated also where they should not appear and contained random heights that caused failures of camera center adjustment to terrain. In the areas completely outside of raster's extent the block was being returned with some values uninitialized (instead of having correctly set no-data values)