### PR TITLE
Range widget: Remove null representator during editing

### DIFF
--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -107,6 +107,8 @@ void QgsDoubleSpinBox::changed( double value )
 void QgsDoubleSpinBox::clear()
 {
   setValue( clearValue() );
+  if ( mLineEdit->isNull() )
+    mLineEdit->clear();
 }
 
 void QgsDoubleSpinBox::setClearValue( double customValue, const QString &specialValueText )

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -155,9 +155,15 @@ void QgsDoubleSpinBox::setLineEditAlignment( Qt::Alignment alignment )
 void QgsDoubleSpinBox::setSpecialValueText( const QString &txt )
 {
   if ( txt.isEmpty() )
+  {
     QDoubleSpinBox::setSpecialValueText( SPECIAL_TEXT_WHEN_EMPTY );
+    mLineEdit->setNullValue( SPECIAL_TEXT_WHEN_EMPTY );
+  }
   else
+  {
     QDoubleSpinBox::setSpecialValueText( txt );
+    mLineEdit->setNullValue( SPECIAL_TEXT_WHEN_EMPTY );
+  }
 }
 
 QString QgsDoubleSpinBox::stripped( const QString &originalText ) const

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -104,6 +104,8 @@ void QgsSpinBox::changed( int value )
 void QgsSpinBox::clear()
 {
   setValue( clearValue() );
+  if ( mLineEdit->isNull() )
+    mLineEdit->clear();
 }
 
 void QgsSpinBox::setClearValue( int customValue, const QString &specialValueText )

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -152,9 +152,15 @@ void QgsSpinBox::setLineEditAlignment( Qt::Alignment alignment )
 void QgsSpinBox::setSpecialValueText( const QString &txt )
 {
   if ( txt.isEmpty() )
+  {
     QSpinBox::setSpecialValueText( SPECIAL_TEXT_WHEN_EMPTY );
+    mLineEdit->setNullValue( SPECIAL_TEXT_WHEN_EMPTY );
+  }
   else
+  {
     QSpinBox::setSpecialValueText( txt );
+    mLineEdit->setNullValue( txt );
+  }
 }
 
 int QgsSpinBox::valueFromText( const QString &text ) const

--- a/src/gui/qgsfilterlineedit.cpp
+++ b/src/gui/qgsfilterlineedit.cpp
@@ -89,7 +89,6 @@ void QgsFilterLineEdit::focusInEvent( QFocusEvent *e )
   QLineEdit::focusInEvent( e );
   if ( e->reason() == Qt::MouseFocusReason && ( isNull() || mSelectOnFocus ) )
   {
-    mFocusInEvent = true;
     mWaitingForMouseRelease = true;
   }
 }

--- a/src/gui/qgsfilterlineedit.cpp
+++ b/src/gui/qgsfilterlineedit.cpp
@@ -212,3 +212,22 @@ bool QgsFilterLineEdit::event( QEvent *event )
 
   return QLineEdit::event( event );;
 }
+
+void QgsSpinBoxLineEdit::focusInEvent( QFocusEvent *e )
+{
+  QLineEdit::focusInEvent( e );
+  if ( e->reason() == Qt::MouseFocusReason && ( isNull() ) )
+  {
+    mWaitingForMouseRelease = true;
+  }
+}
+
+void QgsSpinBoxLineEdit::mouseReleaseEvent( QMouseEvent *e )
+{
+  QLineEdit::mouseReleaseEvent( e );
+  if ( mWaitingForMouseRelease )
+  {
+    mWaitingForMouseRelease = false;
+    clear();
+  }
+}

--- a/src/gui/qgsfilterlineedit.cpp
+++ b/src/gui/qgsfilterlineedit.cpp
@@ -213,21 +213,13 @@ bool QgsFilterLineEdit::event( QEvent *event )
   return QLineEdit::event( event );;
 }
 
+/// @cond PRIVATE
 void QgsSpinBoxLineEdit::focusInEvent( QFocusEvent *e )
 {
   QLineEdit::focusInEvent( e );
-  if ( e->reason() == Qt::MouseFocusReason && ( isNull() ) )
+  if ( isNull() )
   {
-    mWaitingForMouseRelease = true;
-  }
-}
-
-void QgsSpinBoxLineEdit::mouseReleaseEvent( QMouseEvent *e )
-{
-  QLineEdit::mouseReleaseEvent( e );
-  if ( mWaitingForMouseRelease )
-  {
-    mWaitingForMouseRelease = false;
     clear();
   }
 }
+/// @endcond

--- a/src/gui/qgsfilterlineedit.h
+++ b/src/gui/qgsfilterlineedit.h
@@ -286,7 +286,6 @@ class GUI_EXPORT QgsFilterLineEdit : public QLineEdit
     QString mNullValue;
     QString mDefaultValue;
     QString mStyleSheet;
-    bool mFocusInEvent = false;
     bool mWaitingForMouseRelease = false;
     bool mSelectOnFocus = false;
 

--- a/src/gui/qgsfilterlineedit.h
+++ b/src/gui/qgsfilterlineedit.h
@@ -324,6 +324,14 @@ class SIP_SKIP QgsSpinBoxLineEdit : public QgsFilterLineEdit
       setModified( true );
       emit cleared();
     }
+
+  protected:
+    void focusInEvent( QFocusEvent *e ) override;
+    void mouseReleaseEvent( QMouseEvent *e ) override;
+
+  private:
+    bool mWaitingForMouseRelease = false;
+
 };
 /// @endcond
 

--- a/src/gui/qgsfilterlineedit.h
+++ b/src/gui/qgsfilterlineedit.h
@@ -327,11 +327,6 @@ class SIP_SKIP QgsSpinBoxLineEdit : public QgsFilterLineEdit
 
   protected:
     void focusInEvent( QFocusEvent *e ) override;
-    void mouseReleaseEvent( QMouseEvent *e ) override;
-
-  private:
-    bool mWaitingForMouseRelease = false;
-
 };
 /// @endcond
 


### PR DESCRIPTION
It has been anoying to have the null representator as text in the SpinBox althoug the SpinBox does not accept strings. When clicking on it, you where in the middle of the null representator text.

Getting focus (by mouse) on null:
![getting_focus_on_null](https://user-images.githubusercontent.com/28384354/48213934-2a9bb780-e37f-11e8-826a-6c3c060147e3.gif)

Getting focus (by mouse) on value:
![getting_focus_on_value](https://user-images.githubusercontent.com/28384354/48213943-2ec7d500-e37f-11e8-91bd-4fa662c27a71.gif)

Since the QSpinBox only accepts numeric values except the `SpecialValueText` the sollution has to be with `SpecialValueText`.

Now it does clear the field on mouseClick and gets the value back on leaving. Here we don't have the problem that the field could contain empty strings as values and we need to make a difference to NULL.
![getting_focus_new](https://user-images.githubusercontent.com/28384354/48213958-37201000-e37f-11e8-9e8d-a8a7318ddc50.gif)

If this approach is okay, I will seperate the `QgsSpinBoxLineEdit` to seperate files and add some testings.

- [x] Seperating Files
- [ ] Testing

This fixes #20153

PS. When the TextEdit widget is multiline, then it doesn't make the selection (because it's no QgsFilterLineEdit). Do you agree, that the same implementation (like in single line TextEdit widget) would make sence here?
