### PR TITLE
fix the SAGA Points Distances tool

### DIFF
--- a/python/plugins/processing/algs/saga/description/DistanceMatrix.txt
+++ b/python/plugins/processing/algs/saga/description/DistanceMatrix.txt
@@ -1,4 +1,0 @@
-Distance Matrix
-shapes_points
-QgsProcessingParameterFeatureSource|POINTS|Points|0|None|False
-QgsProcessingParameterVectorDestination|TABLE|Distance Matrix Table

--- a/python/plugins/processing/algs/saga/description/PointDistances.txt
+++ b/python/plugins/processing/algs/saga/description/PointDistances.txt
@@ -1,9 +1,9 @@
 Point Distances
 shapes_points
 QgsProcessingParameterFeatureSource|POINTS|Points|0|None|False
-QgsProcessingParameterFeatureSource|ID_POINTS|Identifier|5|None|False
-QgsProcessingParameterFeatureSource|NEAR|Near Points|-1|None|True
-QgsProcessingParameterFeatureSource|ID_NEAR|Identifier|5|None|False
-QgsProcessingParameterFeatureSource|DISTANCES|Distances|5|None|False
+QgsProcessingParameterField|ID_POINTS|Identifier|None|POINTS|-1|False|False
+QgsProcessingParameterFeatureSource|NEAR|Near Points|0|None|True
+QgsProcessingParameterField|ID_NEAR|Identifier|None|NEAR|-1|False|True
 QgsProcessingParameterEnum|FORMAT|Output Format|[0] complete input times near points matrix;[1] each pair with a single record|False|1
 QgsProcessingParameterNumber|MAX_DIST|Maximum Distance|QgsProcessingParameterNumber.Double|0.000000|False|0.000000|None
+QgsProcessingParameterVectorDestination|DISTANCES|Distances|5|None|False


### PR DESCRIPTION
## Description

1) The "Points Distances" tool had wrong parameters
2) This "Points Distances" tool is the *real* "Distance Matrix" in SAGA, as no "Distance Matrix" tool exist in SAGA
3) The deleted "Distance Matrix" tool was moreover a copy of the "Minimum Distance Analysis" that does a different thing


Note:

It seems there is a bug the way the SAGA provider outputs to tables:

when the output type is a table and the output is a temp one then it returns always an error like

_Cannot open /tmp/processing_15aceb9bb22a4a719ab200d6b673a637/5d7c3d2d4db043259315b26dd65e6748/DISTANCES.shp.()_

that ".shp.()" looks suspicious.

Also when electing to save the output to a specific location the default format is SHP (same error as above if chosen) rather than DBF (works ok if chosen).



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
