### PR TITLE
add the -te and -te_srs and -multi parameters to the gdalwarp tool used to clip rasters by mask layers. Fixes #20415

### DIFF
--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -101,7 +101,6 @@ class ClipRasterByMask(GdalAlgorithm):
         target_extent_crs_param.setFlags(target_extent_crs_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(target_extent_crs_param)
 
-
         multithreading_param = QgsProcessingParameterBoolean(self.MULTITHREADING,
                                                              self.tr('Use multithreaded warping implementation'),
                                                              defaultValue=False)

--- a/python/plugins/processing/algs/gdal/ClipRasterByMask.py
+++ b/python/plugins/processing/algs/gdal/ClipRasterByMask.py
@@ -34,10 +34,12 @@ from qgis.core import (QgsRasterFileWriter,
                        QgsProcessingException,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameterFeatureSource,
+                       QgsProcessingParameterCrs,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterString,
                        QgsProcessingParameterNumber,
+                       QgsProcessingParameterExtent,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterRasterDestination)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
@@ -56,6 +58,9 @@ class ClipRasterByMask(GdalAlgorithm):
     KEEP_RESOLUTION = 'KEEP_RESOLUTION'
     OPTIONS = 'OPTIONS'
     DATA_TYPE = 'DATA_TYPE'
+    TARGET_EXTENT = 'TARGET_EXTENT'
+    TARGET_EXTENT_CRS = 'TARGET_EXTENT_CRS'
+    MULTITHREADING = 'MULTITHREADING'
     OUTPUT = 'OUTPUT'
 
     TYPES = ['Use input layer data type', 'Byte', 'Int16', 'UInt16', 'UInt32', 'Int32', 'Float32', 'Float64', 'CInt16', 'CInt32', 'CFloat32', 'CFloat64']
@@ -83,6 +88,25 @@ class ClipRasterByMask(GdalAlgorithm):
         self.addParameter(QgsProcessingParameterBoolean(self.KEEP_RESOLUTION,
                                                         self.tr('Keep resolution of output raster'),
                                                         defaultValue=False))
+
+        target_extent_param = QgsProcessingParameterExtent(self.TARGET_EXTENT,
+                                                           self.tr('Georeferenced extents of output file to be created'),
+                                                           optional=True)
+        target_extent_param.setFlags(target_extent_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(target_extent_param)
+
+        target_extent_crs_param = QgsProcessingParameterCrs(self.TARGET_EXTENT_CRS,
+                                                            self.tr('CRS of the target raster extent'),
+                                                            optional=True)
+        target_extent_crs_param.setFlags(target_extent_crs_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(target_extent_crs_param)
+
+
+        multithreading_param = QgsProcessingParameterBoolean(self.MULTITHREADING,
+                                                             self.tr('Use multithreaded warping implementation'),
+                                                             defaultValue=False)
+        multithreading_param.setFlags(multithreading_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(multithreading_param)
 
         options_param = QgsProcessingParameterString(self.OPTIONS,
                                                      self.tr('Additional creation options'),
@@ -163,6 +187,22 @@ class ClipRasterByMask(GdalAlgorithm):
 
         if nodata is not None:
             arguments.append('-dstnodata {}'.format(nodata))
+
+        extent = self.parameterAsExtent(parameters, self.TARGET_EXTENT, context)
+        if not extent.isNull():
+            arguments.append('-te')
+            arguments.append(extent.xMinimum())
+            arguments.append(extent.yMinimum())
+            arguments.append(extent.xMaximum())
+            arguments.append(extent.yMaximum())
+
+            extentCrs = self.parameterAsCrs(parameters, self.TARGET_EXTENT_CRS, context)
+            if extentCrs:
+                arguments.append('-te_srs')
+                arguments.append(extentCrs.authid())
+
+        if self.parameterAsBool(parameters, self.MULTITHREADING, context):
+            arguments.append('-multi')
 
         if options:
             arguments.extend(GdalUtils.parseCreationOptions(options))


### PR DESCRIPTION
## Description

Those parameters are already implemented in the "warp" tool, as the clip raster by mask layer also uses gdalwarp it makes sense to have them in both tools. Fixes: https://issues.qgis.org/issues/20415

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
