### PR TITLE
Revert "[pal] Use QgsGeometry::makeValid instead of buffer(0) to repair geometries"

### DIFF
--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2976,13 +2976,13 @@ QgsGeometry QgsPalLabeling::prepareGeometry( const QgsGeometry &geometry, QgsRen
   // fix invalid polygons
   if ( geom.type() == QgsWkbTypes::PolygonGeometry && !geom.isGeosValid() )
   {
-    QgsGeometry validGeom = geom.makeValid();
-    if ( validGeom.isNull() )
+    QgsGeometry bufferGeom = geom.buffer( 0, 0 );
+    if ( bufferGeom.isNull() )
     {
-      QgsDebugMsg( QStringLiteral( "Could not repair geometry: %1" ).arg( validGeom.lastError() ) );
+      QgsDebugMsg( QStringLiteral( "Could not repair geometry: %1" ).arg( bufferGeom.lastError() ) );
       return QgsGeometry();
     }
-    geom = validGeom;
+    geom = bufferGeom;
   }
 
   if ( !clipGeometry.isNull() &&


### PR DESCRIPTION
The makeValid call is much slower than the previous "buffer( 0 )" approach

Fixes #20260
