### PR TITLE
OGC parameter names are case-insensitive

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -30,7 +30,7 @@ Build-Depends:
  pyqt5-dev-tools, pyqt5-dev, pyqt5.qsci-dev,
  python3-pyqt5, python3-pyqt5.qsci, python3-pyqt5.qtsql, python3-pyqt5.qtsvg,
  python3-gdal,
- python3-nose2, python3-yaml, python3-mock, python3-psycopg2, python3-future, python3-termcolor,
+ python3-nose2, python3-yaml, python3-mock, python3-psycopg2, python3-future, python3-termcolor, python3-owslib,
  pkg-config,
  git,
  txt2tags,

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -28,6 +28,21 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString &uri )
   // http://example.com/?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=x&SRSNAME=y&username=foo&password=
   if ( !mURI.hasParam( QgsWFSConstants::URI_PARAM_URL ) )
   {
+    static QSet<QString> sFilter
+    {
+      QStringLiteral( "service" ),
+      QgsWFSConstants::URI_PARAM_VERSION,
+      QgsWFSConstants::URI_PARAM_TYPENAME,
+      QStringLiteral( "request" ),
+      QgsWFSConstants::URI_PARAM_BBOX,
+      QgsWFSConstants::URI_PARAM_SRSNAME,
+      QgsWFSConstants::URI_PARAM_FILTER,
+      QgsWFSConstants::URI_PARAM_OUTPUTFORMAT,
+      QgsWFSConstants::URI_PARAM_USERNAME,
+      QgsWFSConstants::URI_PARAM_PASSWORD,
+      QgsWFSConstants::URI_PARAM_AUTHCFG
+    };
+
     QUrl url( uri );
     // Transform all param keys to lowercase
     QList<queryItem> items( url.queryItems() );
@@ -58,17 +73,11 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString &uri )
     }
 
     // Now remove all stuff that is not the core URL
-    url.removeQueryItem( QStringLiteral( "service" ) );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_VERSION );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_TYPENAME );
-    url.removeQueryItem( QStringLiteral( "request" ) );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_BBOX );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_SRSNAME );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_FILTER );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_OUTPUTFORMAT );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_USERNAME );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_PASSWORD );
-    url.removeQueryItem( QgsWFSConstants::URI_PARAM_AUTHCFG );
+    for ( auto param : url.queryItems() )
+    {
+      if ( sFilter.contains( param.first.toLower() ) )
+        url.removeAllQueryItems( param.first );
+    }
 
     mURI = QgsDataSourceUri();
     mURI.setParam( QgsWFSConstants::URI_PARAM_URL, url.toEncoded() );

--- a/src/server/services/wcs/qgswcsutils.cpp
+++ b/src/server/services/wcs/qgswcsutils.cpp
@@ -233,6 +233,14 @@ namespace QgsWcs
 
   QString serviceUrl( const QgsServerRequest &request, const QgsProject *project )
   {
+    static QSet< QString > sFilter
+    {
+      QStringLiteral( "REQUEST" ),
+      QStringLiteral( "VERSION" ),
+      QStringLiteral( "SERVICE" ),
+      QStringLiteral( "_DC" )
+    };
+
     QString href;
     if ( project )
     {
@@ -245,10 +253,11 @@ namespace QgsWcs
       QUrl url = request.url();
       QUrlQuery q( url );
 
-      q.removeAllQueryItems( QStringLiteral( "REQUEST" ) );
-      q.removeAllQueryItems( QStringLiteral( "VERSION" ) );
-      q.removeAllQueryItems( QStringLiteral( "SERVICE" ) );
-      q.removeAllQueryItems( QStringLiteral( "_DC" ) );
+      for ( auto param : q.queryItems() )
+      {
+        if ( sFilter.contains( param.first.toUpper() ) )
+          q.removeAllQueryItems( param.first );
+      }
 
       url.setQuery( q );
       href = url.toString();

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -946,6 +946,22 @@ namespace QgsWfs
 
   namespace
   {
+    static QSet< QString > sParamFilter
+    {
+      QStringLiteral( "REQUEST" ),
+      QStringLiteral( "FORMAT" ),
+      QStringLiteral( "OUTPUTFORMAT" ),
+      QStringLiteral( "BBOX" ),
+      QStringLiteral( "FEATUREID" ),
+      QStringLiteral( "TYPENAME" ),
+      QStringLiteral( "FILTER" ),
+      QStringLiteral( "EXP_FILTER" ),
+      QStringLiteral( "MAXFEATURES" ),
+      QStringLiteral( "STARTINDEX" ),
+      QStringLiteral( "PROPERTYNAME" ),
+      QStringLiteral( "_DC" )
+    };
+
 
     void hitGetFeature( const QgsServerRequest &request, QgsServerResponse &response, const QgsProject *project, QgsWfsParameters::Format format,
                         int numberOfFeatures, const QStringList &typeNames )
@@ -983,18 +999,11 @@ namespace QgsWfs
         else
           query.addQueryItem( QStringLiteral( "VERSION" ), QStringLiteral( "1.0.0" ) );
 
-        query.removeAllQueryItems( QStringLiteral( "REQUEST" ) );
-        query.removeAllQueryItems( QStringLiteral( "FORMAT" ) );
-        query.removeAllQueryItems( QStringLiteral( "OUTPUTFORMAT" ) );
-        query.removeAllQueryItems( QStringLiteral( "BBOX" ) );
-        query.removeAllQueryItems( QStringLiteral( "FEATUREID" ) );
-        query.removeAllQueryItems( QStringLiteral( "TYPENAME" ) );
-        query.removeAllQueryItems( QStringLiteral( "FILTER" ) );
-        query.removeAllQueryItems( QStringLiteral( "EXP_FILTER" ) );
-        query.removeAllQueryItems( QStringLiteral( "MAXFEATURES" ) );
-        query.removeAllQueryItems( QStringLiteral( "STARTINDEX" ) );
-        query.removeAllQueryItems( QStringLiteral( "PROPERTYNAME" ) );
-        query.removeAllQueryItems( QStringLiteral( "_DC" ) );
+        for ( auto param : query.queryItems() )
+        {
+          if ( sParamFilter.contains( param.first.toUpper() ) )
+            query.removeAllQueryItems( param.first );
+        }
 
         query.addQueryItem( QStringLiteral( "REQUEST" ), QStringLiteral( "DescribeFeatureType" ) );
         query.addQueryItem( QStringLiteral( "TYPENAME" ), typeNames.join( ',' ) );
@@ -1092,18 +1101,11 @@ namespace QgsWfs
         else
           query.addQueryItem( QStringLiteral( "VERSION" ), QStringLiteral( "1.0.0" ) );
 
-        query.removeAllQueryItems( QStringLiteral( "REQUEST" ) );
-        query.removeAllQueryItems( QStringLiteral( "FORMAT" ) );
-        query.removeAllQueryItems( QStringLiteral( "OUTPUTFORMAT" ) );
-        query.removeAllQueryItems( QStringLiteral( "BBOX" ) );
-        query.removeAllQueryItems( QStringLiteral( "FEATUREID" ) );
-        query.removeAllQueryItems( QStringLiteral( "TYPENAME" ) );
-        query.removeAllQueryItems( QStringLiteral( "FILTER" ) );
-        query.removeAllQueryItems( QStringLiteral( "EXP_FILTER" ) );
-        query.removeAllQueryItems( QStringLiteral( "MAXFEATURES" ) );
-        query.removeAllQueryItems( QStringLiteral( "STARTINDEX" ) );
-        query.removeAllQueryItems( QStringLiteral( "PROPERTYNAME" ) );
-        query.removeAllQueryItems( QStringLiteral( "_DC" ) );
+        for ( auto param : query.queryItems() )
+        {
+          if ( sParamFilter.contains( param.first.toUpper() ) )
+            query.removeAllQueryItems( param.first );
+        }
 
         query.addQueryItem( QStringLiteral( "REQUEST" ), QStringLiteral( "DescribeFeatureType" ) );
         query.addQueryItem( QStringLiteral( "TYPENAME" ), typeNames.join( ',' ) );

--- a/src/server/services/wms/qgswmsutils.cpp
+++ b/src/server/services/wms/qgswmsutils.cpp
@@ -45,15 +45,25 @@ namespace QgsWms
     // Build default url
     if ( href.isEmpty() )
     {
+      static QSet<QString> sFilter
+      {
+        QStringLiteral( "REQUEST" ),
+        QStringLiteral( "VERSION" ),
+        QStringLiteral( "SERVICE" ),
+        QStringLiteral( "LAYERS" ),
+        QStringLiteral( "STYLES" ),
+        QStringLiteral( "SLD_VERSION" ),
+        QStringLiteral( "_DC" )
+      };
+
       href = request.url();
       QUrlQuery q( href );
 
-      q.removeAllQueryItems( QStringLiteral( "REQUEST" ) );
-      q.removeAllQueryItems( QStringLiteral( "VERSION" ) );
-      q.removeAllQueryItems( QStringLiteral( "SERVICE" ) );
-      q.removeAllQueryItems( QStringLiteral( "LAYERS" ) );
-      q.removeAllQueryItems( QStringLiteral( "SLD_VERSION" ) );
-      q.removeAllQueryItems( QStringLiteral( "_DC" ) );
+      for ( auto param : q.queryItems() )
+      {
+        if ( sFilter.contains( param.first.toUpper() ) )
+          q.removeAllQueryItems( param.first );
+      }
 
       href.setQuery( q );
     }

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -71,9 +71,9 @@ ADD_QGIS_TEST(gdalprovidertest testqgsgdalprovider.cpp)
 
 ADD_QGIS_TEST(ogrprovidertest testqgsogrprovider.cpp)
 
-ADD_QGIS_TEST(wmscapabilititestest
+ADD_QGIS_TEST(wmscapabilitiestest
               testqgswmscapabilities.cpp)
-TARGET_LINK_LIBRARIES(qgis_wmscapabilititestest wmsprovider_a)
+TARGET_LINK_LIBRARIES(qgis_wmscapabilitiestest wmsprovider_a)
 
 ADD_QGIS_TEST(wmsprovidertest
               testqgswmsprovider.cpp)


### PR DESCRIPTION
## Description
when GetCapabilities is requested with a non-uppercase 'request' parameter it ends up in the URLs advertised in the response before this

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] Unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
