### PR TITLE
Tweak logic relating to suppressing attribute form for new features

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -760,6 +760,7 @@ void QgsAttributeTableDialog::mActionAddFeature_triggered()
 
   QgsFeature f;
   QgsFeatureAction action( tr( "Geometryless feature added" ), f, mLayer, QString(), -1, this );
+  action.setForceSuppressFormPopup( true ); // we're already showing the table, allowing users to enter the new feature's attributes directly
   if ( action.addFeature() )
   {
     masterModel->reload( masterModel->index( 0, 0 ), masterModel->index( masterModel->rowCount() - 1, masterModel->columnCount() - 1 ) );

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -54,6 +54,13 @@ class APP_EXPORT QgsFeatureAction : public QAction
      */
     bool addFeature( const QgsAttributeMap &defaultAttributes = QgsAttributeMap(), bool showModal = true, QgsExpressionContextScope *scope = nullptr );
 
+    /**
+     * Sets whether to force suppression of the attribute form popup after creating a new feature.
+     * If \a force is true, then regardless of any user settings, form settings, etc, the attribute
+     * form will ALWAYS be suppressed.
+     */
+    void setForceSuppressFormPopup( bool force );
+
   private slots:
     void onFeatureSaved( const QgsFeature &feature );
 
@@ -66,6 +73,8 @@ class APP_EXPORT QgsFeatureAction : public QAction
     int mIdx;
 
     bool mFeatureSaved;
+
+    bool mForceSuppressFormPopup = false;
 
     static QHash<QgsVectorLayer *, QgsAttributeMap> sLastUsedValues;
 };


### PR DESCRIPTION
For non-spatial layers, creating a new feature from the main window now ALWAYS shows the attribute form for the new feature, regardless of the user's "suppress form" setting. We do this because,
unlike for spatial layers, there's zero feedback given when adding a new feature to a non spatial layer. (Spatial layers have instead feedback even when the form is suppressed, because you see the
new feature appear on the map instantly)

But when a new feature is added from the attri bute table window, then we never show the new feature's form -- because that's already visible inside the attribute table dialog itself.
