### PR TITLE
Db2dev

### DIFF
--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -5,7 +5,7 @@
   Copyright : (C) 2016 by David Adler
                           Shirley Xiao, David Nguyen
   Email     : dadler at adtechgeospatial.com
-              xshirley2012 at yahoo.com, davidng0123 at gmail.com
+              xshirley2012 at yahoo.com,  davidng0123 at gmail.com
   Adapted from MSSQL provider by Tamas Szekeres
 ****************************************************************************
  *
@@ -302,23 +302,23 @@ bool QgsDb2FeatureIterator::fetchFeature( QgsFeature &feature )
   if ( !mDatabase.isValid() )
   {
     // No existing connection, so set it up now. It's safe to do here as we're now in
-    // the thread were iteration is actually occurring.  
-  // connect to the database
-  QString errMsg;
-  QgsDebugMsg( QStringLiteral( "fetchFeature getDatabase" ) );
-  mDatabase = QgsDb2Provider::getDatabase( mSource->mConnInfo, errMsg );
-  QgsDebugMsg( QStringLiteral( "fetchFeature back from getDatabase" ) );
-  if ( !errMsg.isEmpty() )
-  {
-    QgsDebugMsg( "Failed to open database: " + errMsg );
-    return false;
-  }
+    // the thread were iteration is actually occurring.
+    // connect to the database
+    QString errMsg;
+    QgsDebugMsg( QStringLiteral( "fetchFeature getDatabase" ) );
+    mDatabase = QgsDb2Provider::getDatabase( mSource->mConnInfo, errMsg );
+    QgsDebugMsg( QStringLiteral( "fetchFeature back from getDatabase" ) );
+    if ( !errMsg.isEmpty() )
+    {
+      QgsDebugMsg( "Failed to open database: " + errMsg );
+      return false;
+    }
 
-  // create sql query
-  mQuery.reset( new QSqlQuery( mDatabase ) );
+    // create sql query
+    mQuery.reset( new QSqlQuery( mDatabase ) );
 
-  // start selection
-  if ( !rewind() )
+    // start selection
+    if ( !rewind() )
       return false;
   }
 

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -222,14 +222,14 @@ QSqlDatabase QgsDb2Provider::getDatabase( const QString &connInfo, QString &errM
         QSqlDatabase::removeDatabase( connectionName );
       }, Qt::DirectConnection );
     }
-	}
+  }
   else  /* if existing database connection */
   {
     QgsDebugMsg( QStringLiteral( "found existing connection, use the existing one" ) );
     db = QSqlDatabase::database( threadSafeConnectionName );
   }
-  locker.unlock();  
-  
+  locker.unlock();
+
   db.setHostName( host );
   db.setPort( port.toInt() );
   bool connected = false;

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -34,6 +34,7 @@ static const QString PROVIDER_KEY = QStringLiteral( "DB2" );
 static const QString PROVIDER_DESCRIPTION = QStringLiteral( "DB2 Spatial Extender provider" );
 
 int QgsDb2Provider::sConnectionId = 0;
+QMutex QgsDb2Provider::sMutex{ QMutex::Recursive };
 
 QgsDb2Provider::QgsDb2Provider( const QString &uri, const ProviderOptions &options )
   : QgsVectorDataProvider( uri, options )
@@ -193,17 +194,42 @@ QSqlDatabase QgsDb2Provider::getDatabase( const QString &connInfo, QString &errM
   const QString threadSafeConnectionName = dbConnectionName( connectionName );
   QgsDebugMsg( "threadSafeConnectionName: " + threadSafeConnectionName );
 
+  // while everything we use from QSqlDatabase here is thread safe, we need to ensure
+  // that the connection cleanup on thread finalization happens in a predictable order
+  QMutexLocker locker( &sMutex );
+
   /* if new database connection */
   if ( !QSqlDatabase::contains( threadSafeConnectionName ) )
   {
     QgsDebugMsg( QStringLiteral( "new connection. create new QODBC mapping" ) );
     db = QSqlDatabase::addDatabase( QStringLiteral( "QODBC3" ), threadSafeConnectionName );
-  }
+    db.setConnectOptions( QStringLiteral( "SQL_ATTR_CONNECTION_POOLING=SQL_CP_ONE_PER_HENV" ) );
+
+    // for background threads, remove database when current thread finishes
+    if ( QThread::currentThread() != QCoreApplication::instance()->thread() )
+    {
+      QgsDebugMsgLevel( QStringLiteral( "Scheduled auth db remove on thread close" ), 2 );
+
+      // IMPORTANT - we use a direct connection here, because the database removal must happen immediately
+      // when the thread finishes, and we cannot let this get queued on the main thread's event loop.
+      // Otherwise, the QSqlDatabase's private data's thread gets reset immediately the QThread::finished,
+      // and a subsequent call to QSqlDatabase::database with the same thread address (yep it happens, actually a lot)
+      // triggers a condition in QSqlDatabase which detects the nullptr private thread data and returns an invalid database instead.
+      // QSqlDatabase::removeDatabase is thread safe, so this is ok to do.
+      QObject::connect( QThread::currentThread(), &QThread::finished, QThread::currentThread(), [connectionName]
+      {
+        QMutexLocker locker( &sMutex );
+        QSqlDatabase::removeDatabase( connectionName );
+      }, Qt::DirectConnection );
+    }
+	}
   else  /* if existing database connection */
   {
     QgsDebugMsg( QStringLiteral( "found existing connection, use the existing one" ) );
     db = QSqlDatabase::database( threadSafeConnectionName );
   }
+  locker.unlock();  
+  
   db.setHostName( host );
   db.setPort( port.toInt() );
   bool connected = false;
@@ -1759,8 +1785,7 @@ QString QgsDb2Provider::dbConnectionName( const QString &name )
   // Starting with Qt 5.11, sharing the same connection between threads is not allowed.
   // We use a dedicated connection for each thread requiring access to the database,
   // using the thread address as connection name.
-  const QString threadAddress = QStringLiteral( ":0x%1" ).arg( QString::number( reinterpret_cast< quintptr >( QThread::currentThread() ), 16 ) );
-  return name + threadAddress;
+  return QStringLiteral( "%1:0x%2" ).arg( name ).arg( reinterpret_cast<quintptr>( QThread::currentThread() ), 2 * QT_POINTER_SIZE, 16, QLatin1Char( '0' ) );
 }
 
 #ifdef HAVE_GUI

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -5,7 +5,7 @@
   Copyright : (C) 2016 by David Adler
                           Shirley Xiao, David Nguyen
   Email     : dadler at adtechgeospatial.com
-              xshirley2012 at yahoo.com, davidng0123 at gmail.com
+              xshirley2012 at yahoo.com,  davidng0123 at gmail.com
   Adapted from MSSQL provider by Tamas Szekeres
 ****************************************************************************
  *
@@ -192,7 +192,7 @@ QSqlDatabase QgsDb2Provider::getDatabase( const QString &connInfo, QString &errM
   // using the thread address as connection name.
   const QString threadSafeConnectionName = dbConnectionName( connectionName );
   QgsDebugMsg( "threadSafeConnectionName: " + threadSafeConnectionName );
-	
+
   /* if new database connection */
   if ( !QSqlDatabase::contains( threadSafeConnectionName ) )
   {

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -118,6 +118,10 @@ class QgsDb2Provider : public QgsVectorDataProvider
   private:
     static void db2WkbTypeAndDimension( QgsWkbTypes::Type wkbType, QString &geometryType, int &dim );
     static QString db2TypeName( int typeId );
+	/**
+     * Returns a thread-safe connection name for use with QSqlDatabase
+     */
+    static QString dbConnectionName( const QString &name );
 
     QgsFields mAttributeFields; //fields
     QMap<int, QVariant> mDefaultValues;

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -24,6 +24,7 @@
 #include "qgsgeometry.h"
 #include "qgsfields.h"
 #include <QtSql>
+#include <QMutex>
 
 /**
  * \class QgsDb2Provider
@@ -123,6 +124,8 @@ class QgsDb2Provider : public QgsVectorDataProvider
        * Returns a thread-safe connection name for use with QSqlDatabase
        */
     static QString dbConnectionName( const QString &name );
+	
+    static QMutex sMutex;	
 
     QgsFields mAttributeFields; //fields
     QMap<int, QVariant> mDefaultValues;

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -124,8 +124,8 @@ class QgsDb2Provider : public QgsVectorDataProvider
        * Returns a thread-safe connection name for use with QSqlDatabase
        */
     static QString dbConnectionName( const QString &name );
-	
-    static QMutex sMutex;	
+
+    static QMutex sMutex;
 
     QgsFields mAttributeFields; //fields
     QMap<int, QVariant> mDefaultValues;

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -5,7 +5,7 @@
   Copyright : (C) 2016 by David Adler
                           Shirley Xiao, David Nguyen
   Email     : dadler at adtechgeospatial.com
-              xshirley2012 at yahoo.com, davidng0123 at gmail.com
+              xshirley2012 at yahoo.com,  davidng0123 at gmail.com
 ****************************************************************************
  *
  * This program is free software; you can redistribute it and/or modify
@@ -118,9 +118,10 @@ class QgsDb2Provider : public QgsVectorDataProvider
   private:
     static void db2WkbTypeAndDimension( QgsWkbTypes::Type wkbType, QString &geometryType, int &dim );
     static QString db2TypeName( int typeId );
-	/**
-     * Returns a thread-safe connection name for use with QSqlDatabase
-     */
+
+    /**
+       * Returns a thread-safe connection name for use with QSqlDatabase
+       */
     static QString dbConnectionName( const QString &name );
 
     QgsFields mAttributeFields; //fields


### PR DESCRIPTION
## Description
Fix DB2 provider crash per issue #20337.  Migrate changed logic from mssql provider to ensure database connections are in distinct threads and query logic in the same thread.

## Checklist

- [x ] Commit messages are descriptive and explain the rationale for changes
- [x ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [na ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [na ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ na] New unit tests have been added for core changes
- [x ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
