### PR TITLE
[ui] Remove save as action from the project toolbar

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -395,7 +395,6 @@
    <addaction name="mActionNewProject"/>
    <addaction name="mActionOpenProject"/>
    <addaction name="mActionSaveProject"/>
-   <addaction name="mActionSaveProjectAs"/>
    <addaction name="mActionNewPrintLayout"/>
    <addaction name="mActionShowLayoutManager"/>
    <addaction name="mActionStyleManager"/>


### PR DESCRIPTION
## Description
A rarely seen event in QGIS' development, a PR that actually shrinks the size of our toolbar! 

It occurred to me while accidentally clicking on the "Save [project] as..." toolbar action that this really shouldn't be in our toolbar to begin with. Toolbars are about making most-used actions more accessible, and I'd argue the "Save [project] as..." action simply doesn't fall within most-used.

@nyalldawson , @NathanW2 , others , speak now or forever hold your peace. :wink: 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
