### PR TITLE
DarkTheme support for compilation on macos10.14, but running on macos10.13

### DIFF
--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -121,9 +121,19 @@ QgsNative::NotificationResult QgsMacNative::showDesktopNotification( const QStri
 
 bool QgsMacNative::hasDarkTheme()
 {
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 101400
-  return ( NSApp.effectiveAppearance.name == NSAppearanceNameDarkAqua );
-#else
-  return false;
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14
+  if (@available(macOS 10.14, *)) {
+    // compiled on macos 10.14+ AND running on macos 10.14+
+    // check the settings of effective apperance of the user
+    return ( NSApp.effectiveAppearance.name == NSAppearanceNameDarkAqua );
+  } else {
+    // compiled on macos 10.14+ BUT running on macos 10.13-
+    // DarkTheme was introduced in MacOS 10.14, fallback to light theme
+    return false;
+  }
 #endif
+  // compiled on macos 10.13- AND running anywhere
+  // NSAppearanceNameDarkAqua is not in SDK headers
+  // fallback to light theme
+  return false;
 }

--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -124,7 +124,7 @@ bool QgsMacNative::hasDarkTheme()
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14
   if (@available(macOS 10.14, *)) {
     // compiled on macos 10.14+ AND running on macos 10.14+
-    // check the settings of effective apperance of the user
+    // check the settings of effective appearance of the user
     return ( NSApp.effectiveAppearance.name == NSAppearanceNameDarkAqua );
   } else {
     // compiled on macos 10.14+ BUT running on macos 10.13-


### PR DESCRIPTION
Trying to fix https://github.com/lutraconsulting/qgis-mac-packager/issues/2

I do have only macos 10.14. Quite hard to test, since I need to build it on macos 10.14 and test on 10.13

https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html#//apple_ref/doc/uid/20002000-SW6

https://pfandrade.me/blog/adopting-dark-mode-and-older-macs/