### PR TITLE
[browser] Restore attribute preview from 2.x standalone browser

### DIFF
--- a/src/gui/qgsbrowserdockwidget_p.h
+++ b/src/gui/qgsbrowserdockwidget_p.h
@@ -128,7 +128,11 @@ class QgsBrowserLayerProperties : public QgsBrowserPropertiesWidget, private Ui:
     void urlClicked( const QUrl &url );
 
   private:
+
+    void loadAttributeTable();
+
     std::unique_ptr<QgsMapLayer> mLayer;
+    QgsAttributeTableFilterModel *mAttributeTableFilterModel = nullptr;
 
 };
 

--- a/src/ui/qgsbrowserlayerpropertiesbase.ui
+++ b/src/ui/qgsbrowserlayerpropertiesbase.ui
@@ -71,7 +71,29 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QgsMapCanvas" name="mMapCanvas" native="true"/>
+        <widget class="QgsMapCanvas" name="mMapCanvas"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="mAttributesTab">
+      <attribute name="title">
+       <string>Attributes</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QgsAttributeTableView" name="mAttributeTable"/>
        </item>
       </layout>
      </widget>
@@ -92,9 +114,14 @@
  <customwidgets>
   <customwidget>
    <class>QgsMapCanvas</class>
-   <extends>QWidget</extends>
+   <extends>QGraphicsView</extends>
    <header>qgsmapcanvas.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsAttributeTableView</class>
+   <extends>QTableView</extends>
+   <header>qgsattributetableview.h</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
This resurrects an "attributes" tab in the browser layer properties panel/window, showing a preview of the attributes for a vector layer.

For performance, we limit the table to show a maximum of the first 100 rows. (There's no way to "page" attribute table requests currently or load them in the background). But besides, the table is really only good for a quick preview and in this case it's ok to only show a subset of records.

Tagging as a bugfix, since it's a functional regression since 2.x due to the standalone browser cull.