### PR TITLE
[RPM] Add an explicit dependency for GDAL

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -107,6 +107,10 @@ BuildRequires:  qwt-devel
 BuildRequires:  qwt-qt5-devel
 BuildRequires:  qwt-qt5-devel
 
+# GDAL must be explicit. It is required by some raster tools
+# like Warp (Reproject) which relies on gdalwarp
+Requires:       gdal
+
 # Installation of QCA plugins must be explicit
 Requires:       qca-qt5-ossl
 Requires:       gpsbabel


### PR DESCRIPTION
## Description
Trying to reproject a raster layer using QGIS from RPM on Fedora I got

```
Loading resulting layers
The following layers were not correctly generated.<ul><li>/tmp/processing_22a1c797a97348499be837e8f9cd9df8/94bfcb797bf24f8b9bc2c85b8e2d409d/OUTPUT.tif</li></ul>You can check the 'Log Messages Panel' in QGIS main window to find more information about the execution of the algorithm.
```

Because `GDAL` was not installed as dependency of QGIS by default. I'm modifying the RPM to require GDAL:

```
Results:
{'OUTPUT': <QgsProcessingOutputLayerDefinition {'sink':/tmp/processing_22a1c797a97348499be837e8f9cd9df8/6ae649116d784d47bfc1cb44068738b6/OUTPUT.tif, 'createOptions': {'fileEncoding': 'System'}}>}

Loading resulting layers
Algorithm 'Warp (reproject)' finished
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
