### PR TITLE
On some architectures, time_t is not equal to int64

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1877,7 +1877,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
     }
 
     QFileInfo fi( fileName() );
-    struct utimbuf tb = { static_cast<time_t>( fi.lastRead().toTime_t() ), static_cast<time_t>( fi.lastModified().toTime_t() ) };
+    struct utimbuf tb = { static_cast<time_t>( fi.lastRead().toSecsSinceEpoch() ), static_cast<time_t>( fi.lastModified().toSecsSinceEpoch() ) };
     utime( backupFile.fileName().toUtf8().constData(), &tb );
   }
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1877,7 +1877,7 @@ bool QgsProject::writeProjectFile( const QString &filename )
     }
 
     QFileInfo fi( fileName() );
-    struct utimbuf tb = { fi.lastRead().toTime_t(), fi.lastModified().toTime_t() };
+    struct utimbuf tb = { static_cast<time_t>( fi.lastRead().toTime_t() ), static_cast<time_t>( fi.lastModified().toTime_t() ) };
     utime( backupFile.fileName().toUtf8().constData(), &tb );
   }
 


### PR DESCRIPTION
## Description
Fix build on FreeBSD / i386 (and maybe others).

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
