### PR TITLE
Macos darktheme fix

### DIFF
--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -30,7 +30,7 @@ IF(APPLE)
       MESSAGE(FATAL_ERROR "Couldn't find Apple's '${_lib}' framework or library")
     ENDIF(NOT APPLE_${_lib_var}_LIBRARY)
 
-    LIST(APPEND NATIVE_LINK_LIBS "-framework ${_lib}")
+    LIST(APPEND NATIVE_LINK_LIBS "-weak_framework ${_lib}")
   ENDFOREACH(_lib ${APPLE_LIB_LIST})
 ENDIF(APPLE)
 

--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -125,14 +125,15 @@ bool QgsMacNative::hasDarkTheme()
   if (@available(macOS 10.14, *)) {
     // compiled on macos 10.14+ AND running on macos 10.14+
     // check the settings of effective appearance of the user
-    return ( NSApp.effectiveAppearance.name == NSAppearanceNameDarkAqua );
+    NSAppearanceName appearanceName = [NSApp.effectiveAppearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+    return ([appearanceName isEqualToString:NSAppearanceNameDarkAqua]);
   } else {
     // compiled on macos 10.14+ BUT running on macos 10.13-
     // DarkTheme was introduced in MacOS 10.14, fallback to light theme
     return false;
   }
 #endif
-  // compiled on macos 10.13- AND running anywhere
+  // compiled on macos 10.13-
   // NSAppearanceNameDarkAqua is not in SDK headers
   // fallback to light theme
   return false;

--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -122,7 +122,7 @@ QgsNative::NotificationResult QgsMacNative::showDesktopNotification( const QStri
 bool QgsMacNative::hasDarkTheme()
 {
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14
-  if (@available(macOS 10.14, *)) {
+  if ([NSApp respondsToSelector:@selector(effectiveAppearance)]) {
     // compiled on macos 10.14+ AND running on macos 10.14+
     // check the settings of effective appearance of the user
     NSAppearanceName appearanceName = [NSApp.effectiveAppearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];


### PR DESCRIPTION
- sys frameworks must be weakly linked to resolve symbols on runtime
- explicitely check if effectiveAppearance symbol is defined (it is 10.14+ SDK) and use it only when defined on runtime

tested on Sierra and it works 🎉 
related to: https://github.com/lutraconsulting/qgis-mac-packager/issues/2

works for 10.11 and 10.14 with dark theme https://www.dropbox.com/s/jbkq4uw33wi05ud/qgis_nightly_master_20181113_104807.dmg?dl=0