### PR TITLE
[mssql] Fix import of layers with invalid geometries (fixes #20122)

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -927,10 +927,10 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList &flist, Flags flags )
       if ( mGeometryColType == QLatin1String( "geometry" ) )
       {
         if ( mUseWkb )
-          values += QStringLiteral( "geometry::STGeomFromWKB(%1,%2)" ).arg(
+          values += QStringLiteral( "geometry::STGeomFromWKB(%1,%2).MakeValid()" ).arg(
                       QStringLiteral( "?" ), QString::number( mSRId ) );
         else
-          values += QStringLiteral( "geometry::STGeomFromText(%1,%2)" ).arg(
+          values += QStringLiteral( "geometry::STGeomFromText(%1,%2).MakeValid()" ).arg(
                       QStringLiteral( "?" ), QString::number( mSRId ) );
       }
       else


### PR DESCRIPTION
This essentially reverts 62f4534

Rationale:
- even valid geometries according to GEOS may be considered as invalid by MS SQL
  so there is no way of knowing that a geometry may be fail to be added
- change of geometries applies MakeValid() so it is consistent again
- GDAL driver also applies MakeValid() on all added/changed geometries
- QGIS since 3.4 has optional geometry checks for validity etc. so some truly
  invalid geometries may be fixed before submitted to the provider

See also https://github.com/qgis/QGIS/pull/8411

cc @NathanW2 