### PR TITLE
fedora packaging: add exiv2-devel dependency

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -69,6 +69,7 @@ BuildRequires:  libzip-devel
 BuildRequires:  postgresql-devel
 BuildRequires:  sqlite-devel
 BuildRequires:  fcgi-devel
+BuildRequires:  exiv2-devel
 
 # OpenCL
 BuildRequires:  opencl-headers


### PR DESCRIPTION
Relates to e0c79c457467bc423053c6e64c6cd7d54a17e16b

## Description
This fixes a build failure in fedora due to a missing dependency in rpm spec file.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
