### PR TITLE
correct spatialindex include paths

### DIFF
--- a/cmake/FindSpatialindex.cmake
+++ b/cmake/FindSpatialindex.cmake
@@ -11,7 +11,7 @@
 #
 
 
-FIND_PATH(SPATIALINDEX_INCLUDE_DIR NAMES SpatialIndex.h PATHS
+FIND_PATH(SPATIALINDEX_INCLUDE_DIR spatialindex/SpatialIndex.h PATHS
   /usr/include
   /usr/local/include
   "$ENV{LIB_DIR}/include"

--- a/cmake/FindSpatialindex.cmake
+++ b/cmake/FindSpatialindex.cmake
@@ -17,7 +17,6 @@ FIND_PATH(SPATIALINDEX_INCLUDE_DIR spatialindex/SpatialIndex.h PATHS
   "$ENV{LIB_DIR}/include"
   "$ENV{INCLUDE}"
   "$ENV{OSGEO4W_ROOT}/include"
-  PATH_SUFFIXES spatialindex
   )
 
 FIND_LIBRARY(SPATIALINDEX_LIBRARY NAMES spatialindex_i spatialindex spatialindex-64 PATHS

--- a/src/analysis/network/qgsvectorlayerdirector.cpp
+++ b/src/analysis/network/qgsvectorlayerdirector.cpp
@@ -32,7 +32,7 @@
 #include <QString>
 #include <QtAlgorithms>
 
-#include "SpatialIndex.h"
+#include <spatialindex/SpatialIndex.h>
 
 using namespace SpatialIndex;
 

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -23,7 +23,7 @@
 #include "qgslogger.h"
 #include "qgsrenderer.h"
 
-#include <SpatialIndex.h>
+#include <spatialindex/SpatialIndex.h>
 
 #include <QLinkedListIterator>
 

--- a/src/core/qgsspatialindex.cpp
+++ b/src/core/qgsspatialindex.cpp
@@ -23,7 +23,7 @@
 #include "qgsfeaturesource.h"
 #include "qgsfeedback.h"
 
-#include "SpatialIndex.h"
+#include <spatialindex/SpatialIndex.h>
 #include <QMutex>
 #include <QMutexLocker>
 


### PR DESCRIPTION
avoid conflicting geos spatialindex.h include file
correct includes for spatialindex

## Description
spatialindex.h also exists in the geos distribution therefore change the find to use the include directory that spatialindex uses. as spatialindex puts the include files in a subdirectory of include use that in any include directives.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit