### PR TITLE
Expose QgsCoordinateUtils functions via Q_INVOKABLE

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -593,6 +593,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgsbrowsermodel.h
   qgsbrowserproxymodel.h
   qgscoordinatereferencesystem.h
+  qgscoordinateutils.h
   qgscredentials.h
   qgsdataitem.h
   qgsdataprovider.h
@@ -840,7 +841,6 @@ SET(QGIS_CORE_HDRS
   qgscoordinateformatter.h
   qgscoordinatetransform.h
   qgscoordinatetransformcontext.h
-  qgscoordinateutils.h
   qgsdartmeasurement.h
   qgsdatadefinedsizelegend.h
   qgsdataitemprovider.h

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -24,15 +24,17 @@
 #include "qgscoordinateformatter.h"
 ///@cond NOT_STABLE_API
 
-int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs )
+int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs, QgsProject *project )
 {
+  if ( !project )
+    project = QgsProject::instance();
   // Get the display precision from the project settings
-  bool automatic = QgsProject::instance()->readBoolEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ) );
+  bool automatic = project->readBoolEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/Automatic" ) );
   int dp = 0;
 
   if ( automatic )
   {
-    QString format = QgsProject::instance()->readEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DegreeFormat" ), QStringLiteral( "MU" ) );
+    QString format = project->readEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DegreeFormat" ), QStringLiteral( "MU" ) );
     bool formatGeographic = ( format == QLatin1String( "DM" ) || format == QLatin1String( "DMS" ) || format == QLatin1String( "D" ) );
 
     // we can only calculate an automatic precision if one of these is true:
@@ -49,11 +51,14 @@ int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, c
     }
     else
     {
-      dp = format == QLatin1String( "D" ) ? 4 : 2; //guess sensible fallback
+      if ( format == QLatin1String( "D" ) )
+        dp = 4;
+      else
+        dp = 2;
     }
   }
   else
-    dp = QgsProject::instance()->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ) );
+    dp = project->readNumEntry( QStringLiteral( "PositionPrecision" ), QStringLiteral( "/DecimalPlaces" ) );
 
   // Keep dp sensible
   if ( dp < 0 )

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -53,8 +53,8 @@ class CORE_EXPORT QgsCoordinateUtils
      * having enough decimal places to show the difference in position between adjacent
      * pixels.
      *
-     * \since QGIS 3.6 a new \a project parameter is available. Using the method without this
-     *        a \a project paramter is deprecated and will be removed with QGIS 4.
+     * \note  Since QGIS 3.6 a new \a project parameter is available. Using the method without this
+     *        a \a project parameter is deprecated and will be removed with QGIS 4.
      *        For backward compatibility, QgsProject.instance() will be used if the \a project
      *        parameter is not specified.
      */

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -21,6 +21,7 @@
 #define SIP_NO_FILE
 
 #include <QString>
+#include <QObject>
 
 #include "qgis_core.h"
 
@@ -39,6 +40,8 @@ class QgsProject;
  */
 class CORE_EXPORT QgsCoordinateUtils
 {
+    Q_GADGET
+
   public:
 
     /**
@@ -52,14 +55,14 @@ class CORE_EXPORT QgsCoordinateUtils
      * \param mapCrs CRS of map
      * \returns optimal number of decimal places for coordinates
      */
-    static int calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs );
+    Q_INVOKABLE static int calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs );
 
     /**
      * Formats a \a point coordinate for use with the specified \a project, respecting the project's
      * coordinate display settings.
      * \since QGIS 3.2
      */
-    static QString formatCoordinateForProject( QgsProject *project, const QgsPointXY &point, const QgsCoordinateReferenceSystem &destCrs, int precision );
+    Q_INVOKABLE static QString formatCoordinateForProject( QgsProject *project, const QgsPointXY &point, const QgsCoordinateReferenceSystem &destCrs, int precision );
 
 };
 

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -45,17 +45,20 @@ class CORE_EXPORT QgsCoordinateUtils
   public:
 
     /**
-     * Returns the precision to use for displaying coordinates to the user, respecting
-     * the user's project settings. If the user has set the project to use "automatic"
-     * precision, this function tries to calculate an optimal coordinate precision for a given
-     * map units per pixel by calculating the number of decimal places for the coordinates
-     * with the aim of always having enough decimal places to show the difference in position
-     * between adjacent pixels.
-     * \param mapUnitsPerPixel number of map units per pixel
-     * \param mapCrs CRS of map
-     * \returns optimal number of decimal places for coordinates
+     * Returns the precision to use for displaying coordinates in \a mapCrs to the user.
+     * It respects the user's \a project settings.
+     * If the user has set the project to use "automatic" precision, this function tries
+     * to calculate an optimal coordinate precision for a given \a mapUnitsPerPixel by
+     * calculating the number of decimal places for the coordinates with the aim of always
+     * having enough decimal places to show the difference in position between adjacent
+     * pixels.
+     *
+     * \since QGIS 3.6 a new \a project parameter is available. Using the method without this
+     *        a \a project paramter is deprecated and will be removed with QGIS 4.
+     *        For backward compatibility, QgsProject.instance() will be used if the \a project
+     *        parameter is not specified.
      */
-    Q_INVOKABLE static int calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs );
+    Q_INVOKABLE static int calculateCoordinatePrecision( double mapUnitsPerPixel, const QgsCoordinateReferenceSystem &mapCrs, QgsProject *project = nullptr );
 
     /**
      * Formats a \a point coordinate for use with the specified \a project, respecting the project's


### PR DESCRIPTION
And some general cleanup.

@nyalldawson there's a comment in there from you targetting QGIS 2.16. Is that still valid?