### PR TITLE
Mention that display name is used by the locator search tool

### DIFF
--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1395,7 +1395,7 @@ border-radius: 2px;</string>
                  <item row="1" column="0">
                   <widget class="QLabel" name="labelDisplayNameInfo">
                    <property name="text">
-                    <string>The feature display name is used in identify results, locator searches and attribute table's dual view list.</string>
+                    <string>The feature display name is used in identify results, locator searches and the attribute table's dual view list.</string>
                    </property>
                    <property name="wordWrap">
                     <bool>true</bool>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1395,7 +1395,7 @@ border-radius: 2px;</string>
                  <item row="1" column="0">
                   <widget class="QLabel" name="labelDisplayNameInfo">
                    <property name="text">
-                    <string>The feature display name is used in identify results and attribute table's dual view list.</string>
+                    <string>The feature display name is used in identify results, locator searches and attribute table's dual view list.</string>
                    </property>
                    <property name="wordWrap">
                     <bool>true</bool>


### PR DESCRIPTION
Because it's not obvious where the locator all search option does look. Actually i think the information should be somehow in the locator tab.