### PR TITLE
Don't handle defaultValueClause as not unique value

### DIFF
--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -413,7 +413,7 @@ QgsFeature QgsVectorLayerUtils::createFeature( const QgsVectorLayer *layer, cons
 
     // 4. provider side default literal
     // note - deliberately not using else if!
-    if ( ( !v.isValid() || ( fields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique  && QgsVectorLayerUtils::valueExists( layer, idx, v ) ) )
+    if ( ( !v.isValid() || ( checkUnique && fields.at( idx ).constraints().constraints() & QgsFieldConstraints::ConstraintUnique  && QgsVectorLayerUtils::valueExists( layer, idx, v ) ) )
          && fields.fieldOrigin( idx ) == QgsFields::OriginProvider )
     {
       int providerIndex = fields.fieldOriginIndex( idx );


### PR DESCRIPTION
The steps 2, 3, 4 and 6 have two reasons to exist:
- if the value is not yet valid, enter a value
- if the value is valid but not unique like it should be, enter a value 

In step 4 and 6 there is possibly a valid value there that is not (anymore) unique because there is a placeholder like the `defaultValueClause`. Means we give the responsibility to the provider and do not check again for uniqueness -> that's why the checkUnique flag exists that should be false then.

Because step 4 has only been used as fallback for 3, this worked before the implementation.

This fixes https://issues.qgis.org/issues/20431 and https://issues.qgis.org/issues/20397