### PR TITLE
Backport: Remove null representation during editing (range widget) 

### DIFF
--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -107,6 +107,8 @@ void QgsDoubleSpinBox::changed( double value )
 void QgsDoubleSpinBox::clear()
 {
   setValue( clearValue() );
+  if ( mLineEdit->isNull() )
+    mLineEdit->clear();
 }
 
 void QgsDoubleSpinBox::setClearValue( double customValue, const QString &specialValueText )
@@ -155,9 +157,15 @@ void QgsDoubleSpinBox::setLineEditAlignment( Qt::Alignment alignment )
 void QgsDoubleSpinBox::setSpecialValueText( const QString &txt )
 {
   if ( txt.isEmpty() )
+  {
     QDoubleSpinBox::setSpecialValueText( SPECIAL_TEXT_WHEN_EMPTY );
+    mLineEdit->setNullValue( SPECIAL_TEXT_WHEN_EMPTY );
+  }
   else
+  {
     QDoubleSpinBox::setSpecialValueText( txt );
+    mLineEdit->setNullValue( SPECIAL_TEXT_WHEN_EMPTY );
+  }
 }
 
 QString QgsDoubleSpinBox::stripped( const QString &originalText ) const

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -104,6 +104,8 @@ void QgsSpinBox::changed( int value )
 void QgsSpinBox::clear()
 {
   setValue( clearValue() );
+  if ( mLineEdit->isNull() )
+    mLineEdit->clear();
 }
 
 void QgsSpinBox::setClearValue( int customValue, const QString &specialValueText )
@@ -152,9 +154,15 @@ void QgsSpinBox::setLineEditAlignment( Qt::Alignment alignment )
 void QgsSpinBox::setSpecialValueText( const QString &txt )
 {
   if ( txt.isEmpty() )
+  {
     QSpinBox::setSpecialValueText( SPECIAL_TEXT_WHEN_EMPTY );
+    mLineEdit->setNullValue( SPECIAL_TEXT_WHEN_EMPTY );
+  }
   else
+  {
     QSpinBox::setSpecialValueText( txt );
+    mLineEdit->setNullValue( txt );
+  }
 }
 
 int QgsSpinBox::valueFromText( const QString &text ) const

--- a/src/gui/qgsfilterlineedit.cpp
+++ b/src/gui/qgsfilterlineedit.cpp
@@ -89,7 +89,6 @@ void QgsFilterLineEdit::focusInEvent( QFocusEvent *e )
   QLineEdit::focusInEvent( e );
   if ( e->reason() == Qt::MouseFocusReason && ( isNull() || mSelectOnFocus ) )
   {
-    mFocusInEvent = true;
     mWaitingForMouseRelease = true;
   }
 }
@@ -213,3 +212,14 @@ bool QgsFilterLineEdit::event( QEvent *event )
 
   return QLineEdit::event( event );;
 }
+
+/// @cond PRIVATE
+void QgsSpinBoxLineEdit::focusInEvent( QFocusEvent *e )
+{
+  QLineEdit::focusInEvent( e );
+  if ( isNull() )
+  {
+    clear();
+  }
+}
+/// @endcond

--- a/src/gui/qgsfilterlineedit.h
+++ b/src/gui/qgsfilterlineedit.h
@@ -286,7 +286,6 @@ class GUI_EXPORT QgsFilterLineEdit : public QLineEdit
     QString mNullValue;
     QString mDefaultValue;
     QString mStyleSheet;
-    bool mFocusInEvent = false;
     bool mWaitingForMouseRelease = false;
     bool mSelectOnFocus = false;
 
@@ -325,6 +324,9 @@ class SIP_SKIP QgsSpinBoxLineEdit : public QgsFilterLineEdit
       setModified( true );
       emit cleared();
     }
+
+  protected:
+    void focusInEvent( QFocusEvent *e ) override;
 };
 /// @endcond
 


### PR DESCRIPTION
Backport of #8442