### PR TITLE
Docker testing env tests

### DIFF
--- a/.ci/travis/linux/docker_test.sh
+++ b/.ci/travis/linux/docker_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+###########################################################################
+#    docker_test.sh
+#
+#    Run a particular test on docker testing env and return its exit code
+#
+#    Arguments:
+#
+#        $1:  test name in dotted notation
+#
+#    ---------------------
+#    Date                 : November 2018
+#    Copyright            : (C) 2018 by Alessandro Pasotti
+#    Email                : elpaso at itopen dot it
+###########################################################################
+#                                                                         #
+#   This program is free software; you can redistribute it and/or modify  #
+#   it under the terms of the GNU General Public License as published by  #
+#   the Free Software Foundation; either version 2 of the License, or     #
+#   (at your option) any later version.                                   #
+#                                                                         #
+###########################################################################
+
+TEST_NAME=$1
+
+docker exec -it qgis-testing-environment sh -c "cd /tests_directory && qgis_testrunner.sh ${TEST_NAME}"
+
+echo $?

--- a/.ci/travis/linux/docker_test.sh
+++ b/.ci/travis/linux/docker_test.sh
@@ -23,6 +23,6 @@
 
 TEST_NAME=$1
 
-docker exec -it qgis-testing-environment sh -c "cd /tests_directory && qgis_testrunner.sh ${TEST_NAME}"
+docker exec -it qgis-testing-environment sh -c "cd /tests_directory && qgis_testrunner.sh ${TEST_NAME}" &>/dev/null
 
 echo $?

--- a/.ci/travis/linux/script.sh
+++ b/.ci/travis/linux/script.sh
@@ -42,15 +42,13 @@ else
   sleep 10  # Wait for xvfb to finish starting
   # Temporary workaround until docker images are built
   docker cp ${TRAVIS_BUILD_DIR}/.docker/qgis_resources/test_runner/qgis_testrunner.sh qgis-testing-environment:/usr/bin/qgis_testrunner.sh
-  docker exec -it qgis-testing-environment sh -c "cd /tests_directory && qgis_testrunner.sh test_testrunner.run_passing"
-  docker exec -it qgis-testing-environment sh -c "cd /tests_directory && qgis_testrunner.sh test_testrunner.run_skipped_and_passing"
+  # Run tests in the docker
+  # Passing cases:
+  TEST_SCRIPT_PATH=${TRAVIS_BUILD_DIR}/.ci/linux/docker_test.sh
+  [[ $(${TEST_SCRIPT_PATH} test_testrunner.run_passing) -eq '0' ]]
+  [[ $(${TEST_SCRIPT_PATH} test_testrunner.run_skipped_and_passing) -eq '0' ]]
   # Failing cases:
-  set +e
-  ret=0 && docker exec -it qgis-testing-environment sh -c "cd /tests_directory && qgis_testrunner.sh test_testrunner" || ret=127
-  [ $ret -eq 127 ] || exit 1  # expected failure
-  ret=0 && docker exec -it qgis-testing-environment sh -c "cd /tests_directory && qgis_testrunner.sh test_testrunner.run_all" || ret=127
-  [ $ret -eq 127 ] || exit 1  # expected failure
-  ret=0 && docker exec -it qgis-testing-environment sh -c "cd /tests_directory && qgis_testrunner.sh test_testrunner.run_failing" || ret=127
-  [ $ret -eq 127 ] || exit 1  # expected failure
-  set -e
+  [[ $(${TEST_SCRIPT_PATH} test_testrunner) -eq '1' ]]
+  [[ $(${TEST_SCRIPT_PATH} test_testrunner.run_all) -eq '1' ]]
+  [[ $(${TEST_SCRIPT_PATH} test_testrunner.run_failing) -eq '1' ]]
 fi

--- a/.ci/travis/linux/script.sh
+++ b/.ci/travis/linux/script.sh
@@ -44,7 +44,7 @@ else
   docker cp ${TRAVIS_BUILD_DIR}/.docker/qgis_resources/test_runner/qgis_testrunner.sh qgis-testing-environment:/usr/bin/qgis_testrunner.sh
   # Run tests in the docker
   # Passing cases:
-  TEST_SCRIPT_PATH=${TRAVIS_BUILD_DIR}/.ci/linux/docker_test.sh
+  TEST_SCRIPT_PATH=${TRAVIS_BUILD_DIR}/.ci/travis/linux/docker_test.sh
   [[ $(${TEST_SCRIPT_PATH} test_testrunner.run_passing) -eq '0' ]]
   [[ $(${TEST_SCRIPT_PATH} test_testrunner.run_skipped_and_passing) -eq '0' ]]
   # Failing cases:

--- a/.docker/qgis_resources/test_runner/qgis_testrunner.sh
+++ b/.docker/qgis_resources/test_runner/qgis_testrunner.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
-# Run a test inside QGIS
+# Run a python test inside QGIS
+# Note: the test module and function are specified in dotted notation
+# for example, to run the test function run_all (which is the default anyway)
+# $ qgis_testrunner.sh tests_folder.test_module.run_all
+# tests_folder must be in PYTHONPATH (plugins main folders are automatically added to path)
+
 ### Turn on debug mode ###
 #set -x
 
 TEST_NAME=$1
 
-cd /tests_directory || exit
 echo "Running test $1 ..."
 OUTPUT=$(QGIS_TEST_MODULE=${TEST_NAME} unbuffer qgis --version-migration --nologo --code /usr/bin/qgis_testrunner.py "$TEST_NAME"  2>/dev/null | tee /dev/tty)
 EXIT_CODE="$?"
@@ -13,13 +17,13 @@ if [ -z "$OUTPUT" ]; then
     echo "ERROR: no output from the test runner! (exit code: ${EXIT_CODE})"
     exit 1
 fi
-echo "$OUTPUT" | grep -q FAILED
+echo "$OUTPUT" | grep -q 'FAILED'
 IS_FAILED="$?"
-echo "$OUTPUT" | grep OK | grep -q 'Ran'
+echo "$OUTPUT" | grep -q 'OK' && echo "$OUTPUT" | grep -q 'Ran'
 IS_PASSED="$?"
 echo "$OUTPUT" | grep "QGIS died on signal"
 IS_DEAD="$?"
-echo "Finished running test $1."
+echo "Finished running test $1 (codes: IS_DEAD=$IS_DEAD IS_FAILED=$IS_FAILED IS_PASSED=$IS_PASSED)."
 if [ "$IS_PASSED" -eq "0" ] && [ "$IS_FAILED" -eq "1" ] && [ "$IS_DEAD" -eq "1" ]; then
     exit 0;
 fi

--- a/python/testing/__init__.py
+++ b/python/testing/__init__.py
@@ -394,6 +394,11 @@ def start_app(cleanup=True):
     except NameError:
         myGuiFlag = True  # All test will run qgis in gui mode
 
+        try:
+            sys.argv
+        except:
+            sys.argv = ['']
+
         # In python3 we need to convert to a bytes object (or should
         # QgsApplication accept a QString instead of const char* ?)
         try:

--- a/tests/src/python/test_testrunner.py
+++ b/tests/src/python/test_testrunner.py
@@ -1,0 +1,72 @@
+
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for the docker python test runner
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Alessandro Pasotti'
+__date__ = '19.11.2018'
+__copyright__ = 'Copyright 2018, The QGIS Project'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+import qgis  # NOQA
+import sys
+
+from qgis.testing import unittest, start_app
+from console import console
+from qgis.core import Qgis
+from qgis.PyQt.QtCore import QCoreApplication
+
+start_app()
+
+
+class TestTestRunner(unittest.TestCase):
+
+    def test_fails(self):
+        self.assertTrue(False)
+
+    def test_passes(self):
+        self.assertTrue(Qgis.QGIS_VERSION_INT > 0)
+
+    @unittest.skip('Skipped!')
+    def test_skipped(self):
+        self.assertTrue(False)
+
+
+def _make_runner(tests=[]):
+    suite = unittest.TestSuite()
+    for t in tests:
+        suite.addTest(TestTestRunner(t))
+    runner = unittest.TextTestRunner(verbosity=2)
+    return runner.run(suite)
+
+
+# Test functions to be called by the runner
+
+def run_all():
+    """Default function that is called by the runner if nothing else is specified"""
+    return _make_runner(['test_fails', 'test_skipped', 'test_passes'])
+
+
+def run_failing():
+    """Run failing test only"""
+    return _make_runner(['test_fails'])
+
+
+def run_passes():
+    """Run passing test only"""
+    return _make_runner(['test_passes'])
+
+
+def run_skipped():
+    """Run skipped test only"""
+    return _make_runner(['test_skipped'])
+
+
+def run_skipped_and_passing():
+    """Run skipped and passing test only"""
+    return _make_runner(['test_skipped', 'test_passes'])

--- a/tests/src/python/test_testrunner.py
+++ b/tests/src/python/test_testrunner.py
@@ -16,12 +16,9 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 import sys
 
-from qgis.testing import unittest, start_app
+from qgis.testing import unittest
 from console import console
 from qgis.core import Qgis
-from qgis.PyQt.QtCore import QCoreApplication
-
-start_app()
 
 
 class TestTestRunner(unittest.TestCase):
@@ -57,7 +54,7 @@ def run_failing():
     return _make_runner(['test_fails'])
 
 
-def run_passes():
+def run_passing():
     """Run passing test only"""
     return _make_runner(['test_passes'])
 


### PR DESCRIPTION
This PR fixes a false positive case for tests with skipped cases and adds some tests for the test runner itself.

There should be no impact on regular QGIS travis tests because they do not currently use the test runner.

Another small change is that there is no hardcoded `/tests_directory` anymore, and it's up to the caller to ensure that the python module containing the tests to be run is in python path either by `cd` -ing in the test folder or adding the path to `PYTHONPATH`, this will eventually end up in the documentation.
