### PR TITLE
Add method to set QgsFeature geometry directly from QgsAbstractGeometry

### DIFF
--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -13,7 +13,6 @@
 
 
 
-
 class QgsFeature
 {
 %Docstring
@@ -327,6 +326,21 @@ Set the feature's geometry. The feature will be valid after.
 .. seealso:: :py:func:`geometry`
 
 .. seealso:: :py:func:`clearGeometry`
+%End
+
+    void setGeometry( QgsAbstractGeometry *geometry /Transfer/ );
+%Docstring
+Set the feature's ``geometry``. Ownership of the geometry is transferred to the feature.
+The feature will be made valid after calling this method.
+
+.. seealso:: :py:func:`geometry`
+
+.. seealso:: :py:func:`clearGeometry`
+
+.. versionadded:: 3.6
+%End
+%MethodCode
+    sipCpp->setGeometry( std::unique_ptr< QgsAbstractGeometry>( a0 ) );
 %End
 
     void clearGeometry();

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -333,6 +333,24 @@ Set the feature's geometry. The feature will be valid after.
 Set the feature's ``geometry``. Ownership of the geometry is transferred to the feature.
 The feature will be made valid after calling this method.
 
+This method is a shortcut for calling:
+.. code-block:: python
+
+       feature.setGeometry( QgsGeometry( geometry ) )
+
+* Example:
+.. code-block:: python
+
+       # Sets a feature's geometry to a point geometry
+       feature.setGeometry( QgsPoint( 210, 41 ) )
+       print(feature.geometry())
+       # output: <QgsGeometry: Point (210 41)>
+
+       # Sets a feature's geometry to a line string
+       feature.setGeometry( QgsLineString( [ QgsPoint( 210, 41 ), QgsPoint( 301, 55 ) ] ) )
+       print(feature.geometry())
+       # output: <QgsGeometry: LineString (210 41, 301 55)>
+
 .. seealso:: :py:func:`geometry`
 
 .. seealso:: :py:func:`clearGeometry`

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -141,6 +141,13 @@ void QgsFeature::setGeometry( const QgsGeometry &geometry )
   d->valid = true;
 }
 
+void QgsFeature::setGeometry( std::unique_ptr<QgsAbstractGeometry> geometry )
+{
+  d.detach();
+  d->geometry = QgsGeometry( std::move( geometry ) );
+  d->valid = true;
+}
+
 void QgsFeature::clearGeometry()
 {
   setGeometry( QgsGeometry() );

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -349,6 +349,25 @@ class CORE_EXPORT QgsFeature
     /**
      * Set the feature's \a geometry. Ownership of the geometry is transferred to the feature.
      * The feature will be made valid after calling this method.
+     *
+     * This method is a shortcut for calling:
+     * \code{.py}
+     *   feature.setGeometry( QgsGeometry( geometry ) )
+     * \endcode
+     *
+     * * Example:
+     * \code{.py}
+     *   # Sets a feature's geometry to a point geometry
+     *   feature.setGeometry( QgsPoint( 210, 41 ) )
+     *   print(feature.geometry())
+     *   # output: <QgsGeometry: Point (210 41)>
+     *
+     *   # Sets a feature's geometry to a line string
+     *   feature.setGeometry( QgsLineString( [ QgsPoint( 210, 41 ), QgsPoint( 301, 55 ) ] ) )
+     *   print(feature.geometry())
+     *   # output: <QgsGeometry: LineString (210 41, 301 55)>
+     * \endcode
+     *
      * \see geometry()
      * \see clearGeometry()
      * \since QGIS 3.6

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -30,12 +30,13 @@ email                : sherman at mrcc.com
 #include "qgsattributes.h"
 #include "qgsfields.h"
 #include "qgsfeatureid.h"
-
+#include <memory>
 class QgsFeature;
 class QgsFeaturePrivate;
 class QgsField;
 class QgsGeometry;
 class QgsRectangle;
+class QgsAbstractGeometry;
 
 
 /***************************************************************************
@@ -344,6 +345,22 @@ class CORE_EXPORT QgsFeature
      * \see clearGeometry()
      */
     void setGeometry( const QgsGeometry &geometry );
+
+    /**
+     * Set the feature's \a geometry. Ownership of the geometry is transferred to the feature.
+     * The feature will be made valid after calling this method.
+     * \see geometry()
+     * \see clearGeometry()
+     * \since QGIS 3.6
+     */
+#ifndef SIP_RUN
+    void setGeometry( std::unique_ptr< QgsAbstractGeometry > geometry );
+#else
+    void setGeometry( QgsAbstractGeometry *geometry SIP_TRANSFER );
+    % MethodCode
+    sipCpp->setGeometry( std::unique_ptr< QgsAbstractGeometry>( a0 ) );
+    % End
+#endif
 
     /**
      * Removes any geometry associated with the feature.

--- a/tests/src/core/testqgsfeature.cpp
+++ b/tests/src/core/testqgsfeature.cpp
@@ -306,6 +306,13 @@ void TestQgsFeature::geometry()
   QCOMPARE( copy.geometry().asWkb(), geomByRef.asWkb() );
   QCOMPARE( feature.geometry().asWkb(), mGeometry.asWkb() );
 
+  //setGeometry using abstract geom
+  copy = feature;
+  QCOMPARE( copy.geometry().asWkb(), mGeometry.asWkb() );
+  copy.setGeometry( qgis::make_unique< QgsPoint >( 5, 6 ) );
+  QCOMPARE( copy.geometry().asWkt(), QStringLiteral( "Point (5 6)" ) );
+  QCOMPARE( feature.geometry().asWkb(), mGeometry.asWkb() );
+
   //clearGeometry
   QgsFeature geomFeature;
   geomFeature.setGeometry( QgsGeometry( mGeometry2 ) );

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -15,7 +15,14 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 import os
-from qgis.core import QgsFeature, QgsGeometry, QgsPointXY, QgsVectorLayer, NULL, QgsFields, QgsField
+from qgis.core import (QgsFeature,
+                       QgsPoint,
+                       QgsGeometry,
+                       QgsPointXY,
+                       QgsVectorLayer,
+                       NULL,
+                       QgsFields,
+                       QgsField)
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
 
@@ -137,6 +144,10 @@ class TestQgsFeature(unittest.TestCase):
         myExpectedGeometry = "!None"
         myMessage = '\nExpected: %s\nGot: %s' % (myExpectedGeometry, myGeometry)
         assert myGeometry is not None, myMessage
+
+        # set from QgsAbstractGeometry
+        feat.setGeometry(QgsPoint(12, 34))
+        self.assertEqual(feat.geometry().asWkt(), 'Point (12 34)')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows

    feat.setGeometry(QgsPoint(1,2))

instead of the more obscure

    feat.setGeometry(QgsGeometry(QgsPoint(1,2)))
