### PR TITLE
Hide newly added layer(s) when in group. Fixes #19174

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4937,6 +4937,7 @@ void QgisApp::askUserForGDALSublayers( QgsRasterLayer *layer )
 
     QgsLayerTreeGroup *group = nullptr;
     bool addToGroup = settings.value( QStringLiteral( "/qgis/openSublayersInGroup" ), true ).toBool();
+    bool newLayersVisible = settings.value( QStringLiteral( "/qgis/new_layers_visible" ), true ).toBool();
     if ( addToGroup )
     {
       group = QgsProject::instance()->layerTreeRoot()->insertGroup( 0, layer->name() );
@@ -4970,6 +4971,10 @@ void QgisApp::askUserForGDALSublayers( QgsRasterLayer *layer )
         }
       }
     }
+
+    // Respect if user don't want the new group of layers visible.
+    if ( addToGroup && ! newLayersVisible )
+      group->setItemVisibilityCheckedRecursive( newLayersVisible );
   }
 }
 
@@ -5134,6 +5139,7 @@ void QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
   {
     QgsSettings settings;
     bool addToGroup = settings.value( QStringLiteral( "/qgis/openSublayersInGroup" ), true ).toBool();
+    bool newLayersVisible = settings.value( QStringLiteral( "/qgis/new_layers_visible" ), true ).toBool();
     QgsLayerTreeGroup *group = nullptr;
     if ( addToGroup )
       group = QgsProject::instance()->layerTreeRoot()->insertGroup( 0, name );
@@ -5147,6 +5153,10 @@ void QgisApp::askUserForOGRSublayers( QgsVectorLayer *layer )
       if ( addToGroup )
         group->addLayer( l );
     }
+
+    // Respect if user don't want the new group of layers visible.
+    if ( addToGroup && ! newLayersVisible )
+      group->setItemVisibilityCheckedRecursive( newLayersVisible );
   }
 }
 


### PR DESCRIPTION
When loading a single layer QGIS will set it as invisible if the user have chosen so in the settings (new_layers_visible=false). When a data set contains more than one layer and the user
chooses "Add layers to a group" the layers (and group) are added as visible no matter what.

This commit is fixing that problem for both GDAL and OGR data sets by setting both the group and its layers as invisible/unchecked.

Fixes #19174