### PR TITLE
API Experiment: SIP unique_ptr bindings

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1400,7 +1400,7 @@ Exports the geometry to WKT
 Exports the geometry to a GeoJSON string.
 %End
 
-    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const /Factory/;
+    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const;
 %Docstring
 Try to convert the geometry to the requested type
 
@@ -1742,7 +1742,7 @@ geometry will be a polyline.
 .. versionadded:: 2.7
 %End
 
-    static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon ) /Factory/;
+    static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon );
 %Docstring
 Creates a QgsPolylineXY from a QPolygonF.
 
@@ -1753,7 +1753,7 @@ Creates a QgsPolylineXY from a QPolygonF.
 .. seealso:: :py:func:`createPolygonFromQPolygonF`
 %End
 
-    static QgsPolygonXY createPolygonFromQPolygonF( const QPolygonF &polygon ) /Factory/;
+    static QgsPolygonXY createPolygonFromQPolygonF( const QPolygonF &polygon );
 %Docstring
 Creates a QgsPolygonXYfrom a QPolygonF.
 
@@ -1906,7 +1906,11 @@ geometry will retain the same dimensionality as the input geometry.
 
     static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry ) /Factory/;
 %Docstring
-Creates and returns a new geometry engine
+Creates and returns a new geometry engine. The caller takes ownership of the returned
+engine.
+%End
+%MethodCode
+    return sipConvertFromType( QgsGeometry::createGeometryEngine( a0 ).release(), sipType_QgsGeometryEngine, Py_None );
 %End
 
     static void convertPointList( const QVector<QgsPointXY> &input, QgsPointSequence &output );

--- a/src/analysis/processing/qgsalgorithmextractbylocation.cpp
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.cpp
@@ -138,7 +138,7 @@ void QgsLocationBasedAlgorithm::process( const QgsProcessingContext &context, Qg
 
       if ( !engine )
       {
-        engine.reset( QgsGeometry::createGeometryEngine( f.geometry().constGet() ) );
+        engine = QgsGeometry::createGeometryEngine( f.geometry().constGet() );
         engine->prepareGeometry();
       }
 

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.cpp
@@ -163,7 +163,7 @@ QVariantMap QgsSplitWithLinesAlgorithm::processAlgorithm( const QVariantMap &par
         QgsGeometry splitGeom = splitGeoms.value( line );
         if ( !engine )
         {
-          engine.reset( QgsGeometry::createGeometryEngine( inGeom.constGet() ) );
+          engine = QgsGeometry::createGeometryEngine( inGeom.constGet() );
           engine->prepareGeometry();
         }
 

--- a/src/analysis/processing/qgsoverlayutils.cpp
+++ b/src/analysis/processing/qgsoverlayutils.cpp
@@ -116,7 +116,7 @@ void QgsOverlayUtils::difference( const QgsFeatureSource &sourceA, const QgsFeat
       if ( !intersects.isEmpty() )
       {
         // use prepared geometries for faster intersection tests
-        engine.reset( QgsGeometry::createGeometryEngine( geom.constGet() ) );
+        engine = QgsGeometry::createGeometryEngine( geom.constGet() );
         engine->prepareGeometry();
       }
 
@@ -211,7 +211,7 @@ void QgsOverlayUtils::intersection( const QgsFeatureSource &sourceA, const QgsFe
     if ( !intersects.isEmpty() )
     {
       // use prepared geometries for faster intersection tests
-      engine.reset( QgsGeometry::createGeometryEngine( geom.constGet() ) );
+      engine = QgsGeometry::createGeometryEngine( geom.constGet() );
       engine->prepareGeometry();
     }
 
@@ -311,7 +311,7 @@ void QgsOverlayUtils::resolveOverlaps( const QgsFeatureSource &source, QgsFeatur
       if ( !g1engine )
       {
         // use prepared geometries for faster intersection tests
-        g1engine.reset( QgsGeometry::createGeometryEngine( g1.constGet() ) );
+        g1engine = QgsGeometry::createGeometryEngine( g1.constGet() );
         g1engine->prepareGeometry();
       }
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -3368,9 +3368,9 @@ QgsGeometry QgsGeometry::convertToPolygon( bool destMultipart ) const
   }
 }
 
-QgsGeometryEngine *QgsGeometry::createGeometryEngine( const QgsAbstractGeometry *geometry )
+std::unique_ptr< QgsGeometryEngine > QgsGeometry::createGeometryEngine( const QgsAbstractGeometry *geometry )
 {
-  return new QgsGeos( geometry );
+  return qgis::make_unique< QgsGeos >( geometry );
 }
 
 QDataStream &operator<<( QDataStream &out, const QgsGeometry &geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1409,7 +1409,7 @@ class CORE_EXPORT QgsGeometry
      * \returns the converted geometry or nullptr if the conversion fails.
      * \since QGIS 2.2
      */
-    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const SIP_FACTORY;
+    QgsGeometry convertToType( QgsWkbTypes::GeometryType destType, bool destMultipart = false ) const;
 
     /* Accessor functions for getting geometry data */
 
@@ -1756,7 +1756,7 @@ class CORE_EXPORT QgsGeometry
      * \returns QgsPolylineXY
      * \see createPolygonFromQPolygonF
      */
-    static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon ) SIP_FACTORY;
+    static QgsPolylineXY createPolylineFromQPolygonF( const QPolygonF &polygon );
 
     /**
      * Creates a QgsPolygonXYfrom a QPolygonF.
@@ -1764,7 +1764,7 @@ class CORE_EXPORT QgsGeometry
      * \returns QgsPolygon
      * \see createPolylineFromQPolygonF
      */
-    static QgsPolygonXY createPolygonFromQPolygonF( const QPolygonF &polygon ) SIP_FACTORY;
+    static QgsPolygonXY createPolygonFromQPolygonF( const QPolygonF &polygon );
 
 #ifndef SIP_RUN
 
@@ -1943,9 +1943,17 @@ class CORE_EXPORT QgsGeometry
                         double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 
     /**
-     * Creates and returns a new geometry engine
+     * Creates and returns a new geometry engine. The caller takes ownership of the returned
+     * engine.
      */
+#ifndef SIP_RUN
+    static std::unique_ptr< QgsGeometryEngine > createGeometryEngine( const QgsAbstractGeometry *geometry );
+#else
     static QgsGeometryEngine *createGeometryEngine( const QgsAbstractGeometry *geometry ) SIP_FACTORY;
+    % MethodCode
+    return sipConvertFromType( QgsGeometry::createGeometryEngine( a0 ).release(), sipType_QgsGeometryEngine, Py_None );
+    % End
+#endif
 
     /**
      * Upgrades a point list from QgsPointXY to QgsPoint

--- a/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
+++ b/src/core/providers/memory/qgsmemoryfeatureiterator.cpp
@@ -52,7 +52,7 @@ QgsMemoryFeatureIterator::QgsMemoryFeatureIterator( QgsMemoryFeatureSource *sour
   if ( !mFilterRect.isNull() && mRequest.flags() & QgsFeatureRequest::ExactIntersect )
   {
     mSelectRectGeom = QgsGeometry::fromRect( mFilterRect );
-    mSelectRectEngine.reset( QgsGeometry::createGeometryEngine( mSelectRectGeom.constGet() ) );
+    mSelectRectEngine = QgsGeometry::createGeometryEngine( mSelectRectGeom.constGet() );
     mSelectRectEngine->prepareGeometry();
   }
 

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -132,7 +132,7 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer *vl, SymbolSet &usedSymbols,
     else
     {
       request.setFilterRect( transformedPolygon.boundingBox() );
-      polygonEngine.reset( QgsGeometry::createGeometryEngine( transformedPolygon.constGet() ) );
+      polygonEngine = QgsGeometry::createGeometryEngine( transformedPolygon.constGet() );
       polygonEngine->prepareGeometry();
     }
   }

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2602,7 +2602,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::prepareWriteAsVectorFormat
       req.setFilterRect( filterRect );
     }
     details.filterRectGeometry = QgsGeometry::fromRect( options.filterExtent );
-    details.filterRectEngine.reset( QgsGeometry::createGeometryEngine( details.filterRectGeometry.constGet() ) );
+    details.filterRectEngine = QgsGeometry::createGeometryEngine( details.filterRectGeometry.constGet() );
     details.filterRectEngine->prepareGeometry();
   }
   details.sourceFeatureIterator = layer->getFeatures( req );


### PR DESCRIPTION
Here's a little API experiment for feedback. What I'm exploring here is a way for us to use modern c++ practices within the c++ API and return std::unique_ptrs from API calls which return pointers with ownership. Unfortunately, sip has no concept of these and cannot bind these methods directly.

So what I've done here is create a small MethodCode wrapper around the c++ code which gets the unique_ptr from the c++ api, and then releases it and transfers ownership to Python.

(This won't fully compile -- there's c++ code which calls this method which hasn't been updated).  It's for comment only at this stage.