### PR TITLE
[Bugfix] Release cell from focus on editing off

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -875,6 +875,12 @@ void QgsAttributeTableDialog::mActionToggleEditing_toggled( bool )
 {
   if ( !mLayer )
     return;
+
+  //this has to be done, because in case only one cell has been changed and is still enabled, the change
+  //would not be added to the mEditBuffer. By disabling, it looses focus and the change will be stored.
+  if ( mLayer->isEditable() && mMainView->tableView()->indexWidget( mMainView->tableView()->currentIndex() ) )
+    mMainView->tableView()->indexWidget( mMainView->tableView()->currentIndex() )->setEnabled( false );
+
   if ( !QgisApp::instance()->toggleEditing( mLayer ) )
   {
     // restore gui state if toggling was canceled or layer commit/rollback failed


### PR DESCRIPTION
On editing of a cell in the attribute table it uses to store the change in the `mEditBuffer` on loosing focus (disabling widget). This leaded to the behavior that if a cell is changed and edit-mode is toggled off without loosing focus on, that the cell still has been enabled and so no loose of focus happened -> means the change has not been stored.
![bonzo](https://user-images.githubusercontent.com/28384354/48827202-db855780-ed6c-11e8-9f52-7773f795561a.gif)


This is solved by disabling the current cell widget on toggling editing. If editing is toggled outside the attribute table this has not to be done, because the cell looses focus anyway.

fixes #15975