### PR TITLE
Backport project dirtying fixes

### DIFF
--- a/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
+++ b/python/core/auto_generated/qgscoordinatetransformcontext.sip.in
@@ -63,6 +63,7 @@ Copy constructor
 %End
 
 
+    bool operator==( const QgsCoordinateTransformContext &rhs ) const;
 
     void clear();
 %Docstring

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -1010,7 +1010,8 @@ void QgsProjectProperties::apply()
     canvas->setSelectionColor( selectionColor );
     canvas->enableMapTileRendering( mMapTileRenderingCheckBox->isChecked() );
   }
-  QgisApp::instance()->mapOverviewCanvas()->setBackgroundColor( canvasColor );
+  if ( QgisApp::instance()->mapOverviewCanvas() )
+    QgisApp::instance()->mapOverviewCanvas()->setBackgroundColor( canvasColor );
 
   //save project scales
   QStringList myScales;
@@ -1395,7 +1396,8 @@ void QgsProjectProperties::apply()
   {
     canvas->refresh();
   }
-  QgisApp::instance()->mapOverviewCanvas()->refresh();
+  if ( QgisApp::instance()->mapOverviewCanvas() )
+    QgisApp::instance()->mapOverviewCanvas()->refresh();
 }
 
 void QgsProjectProperties::showProjectionsTab()

--- a/src/core/qgscoordinatetransformcontext.cpp
+++ b/src/core/qgscoordinatetransformcontext.cpp
@@ -36,6 +36,19 @@ QgsCoordinateTransformContext &QgsCoordinateTransformContext::operator=( const Q
   return *this;
 }
 
+bool QgsCoordinateTransformContext::operator==( const QgsCoordinateTransformContext &rhs ) const
+{
+  if ( d == rhs.d )
+    return true;
+
+  d->mLock.lockForRead();
+  rhs.d->mLock.lockForRead();
+  bool equal = d->mSourceDestDatumTransforms == rhs.d->mSourceDestDatumTransforms;
+  d->mLock.unlock();
+  rhs.d->mLock.unlock();
+  return equal;
+}
+
 void QgsCoordinateTransformContext::clear()
 {
   d.detach();

--- a/src/core/qgscoordinatetransformcontext.h
+++ b/src/core/qgscoordinatetransformcontext.h
@@ -80,6 +80,7 @@ class CORE_EXPORT QgsCoordinateTransformContext
      */
     QgsCoordinateTransformContext &operator=( const QgsCoordinateTransformContext &rhs ) SIP_SKIP;
 
+    bool operator==( const QgsCoordinateTransformContext &rhs ) const ;
 
     /**
      * Clears all stored transform information from the context.

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -278,6 +278,13 @@ QgsProjectProperty *addKey_( const QString &scope,
   return nullptr;
 }
 
+/**
+ * Remove a given key
+
+\param scope scope of key
+\param key key name
+\param rootProperty is the property from which to start adding
+*/
 
 void removeKey_( const QString &scope,
                  const QString &key,
@@ -614,6 +621,9 @@ QgsCoordinateReferenceSystem QgsProject::crs() const
 
 void QgsProject::setCrs( const QgsCoordinateReferenceSystem &crs )
 {
+  if ( crs == mCrs )
+    return;
+
   mCrs = crs;
   writeEntry( QStringLiteral( "SpatialRefSys" ), QStringLiteral( "/ProjectionsEnabled" ), crs.isValid() ? 1 : 0 );
   setDirty( true );
@@ -631,7 +641,6 @@ QString QgsProject::ellipsoid() const
 void QgsProject::setEllipsoid( const QString &ellipsoid )
 {
   writeEntry( QStringLiteral( "Measure" ), QStringLiteral( "/Ellipsoid" ), ellipsoid );
-  setDirty( true );
   emit ellipsoidChanged( ellipsoid );
 }
 
@@ -642,6 +651,9 @@ QgsCoordinateTransformContext QgsProject::transformContext() const
 
 void QgsProject::setTransformContext( const QgsCoordinateTransformContext &context )
 {
+  if ( context == mTransformContext )
+    return;
+
   mTransformContext = context;
   emit transformContextChanged();
 }
@@ -834,7 +846,7 @@ void QgsProject::setSnappingConfig( const QgsSnappingConfig &snappingConfig )
     return;
 
   mSnappingConfig = snappingConfig;
-  setDirty();
+  setDirty( true );
   emit snappingConfigChanged( mSnappingConfig );
 }
 
@@ -2084,9 +2096,11 @@ bool QgsProject::readBoolEntry( const QString &scope, const QString &key, bool d
 
 bool QgsProject::removeEntry( const QString &scope, const QString &key )
 {
-  removeKey_( scope, key, mProperties );
-
-  setDirty( true );
+  if ( findKey_( scope, key, mProperties ) )
+  {
+    removeKey_( scope, key, mProperties );
+    setDirty( true );
+  }
 
   return !findKey_( scope, key, mProperties );
 }
@@ -2357,6 +2371,9 @@ bool QgsProject::evaluateDefaultValues() const
 
 void QgsProject::setEvaluateDefaultValues( bool evaluateDefaultValues )
 {
+  if ( evaluateDefaultValues == mEvaluateDefaultValues )
+    return;
+
   const QMap<QString, QgsMapLayer *> layers = mapLayers();
   QMap<QString, QgsMapLayer *>::const_iterator layerIt = layers.constBegin();
   for ( ; layerIt != layers.constEnd(); ++layerIt )
@@ -2848,6 +2865,9 @@ const QgsProjectMetadata &QgsProject::metadata() const
 
 void QgsProject::setMetadata( const QgsProjectMetadata &metadata )
 {
+  if ( metadata == mMetadata )
+    return;
+
   mMetadata = metadata;
   emit metadataChanged();
 

--- a/tests/src/app/CMakeLists.txt
+++ b/tests/src/app/CMakeLists.txt
@@ -110,4 +110,4 @@ ADD_QGIS_TEST(measuretool testqgsmeasuretool.cpp)
 ADD_QGIS_TEST(vertextool testqgsvertextool.cpp)
 ADD_QGIS_TEST(vectorlayersaveasdialogtest testqgsvectorlayersaveasdialog.cpp)
 ADD_QGIS_TEST(maptoolreverselinetest testqgsmaptoolreverseline.cpp)
-
+ADD_QGIS_TEST(projectproperties testqgsprojectproperties.cpp)

--- a/tests/src/app/testqgsprojectproperties.cpp
+++ b/tests/src/app/testqgsprojectproperties.cpp
@@ -1,0 +1,87 @@
+/***************************************************************************
+     testqgsprojectproperties.cpp
+     -------------------------
+    Date                 : 2018-11-21
+    Copyright            : (C) 2018 by Mathieu Pellerin
+    Email                : nirvn dot asia at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+#include "qgisapp.h"
+#include "qgsapplication.h"
+#include "qgsvectorlayer.h"
+#include "qgsprojectproperties.h"
+#include "qgsproject.h"
+#include "qgsmapcanvas.h"
+
+/**
+ * \ingroup UnitTests
+ * This is a unit test for the project properties dialog
+ */
+class TestQgsProjectProperties : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsProjectProperties();
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+
+    void testProjectPropertiesDirty();
+
+  private:
+    QgisApp *mQgisApp = nullptr;
+};
+
+TestQgsProjectProperties::TestQgsProjectProperties() = default;
+
+//runs before all tests
+void TestQgsProjectProperties::initTestCase()
+{
+  qDebug() << "TestQgsProjectProperties::initTestCase()";
+  // init QGIS's paths - true means that all path will be inited from prefix
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  mQgisApp = new QgisApp();
+}
+
+//runs after all tests
+void TestQgsProjectProperties::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsProjectProperties::testProjectPropertiesDirty()
+{
+  // create a temporary layer
+  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "none?field=code:int&field=regular:string" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+  QVERIFY( tempLayer->isValid() );
+
+  // add layer to project, to insure presence of layer-related project settings
+  QgsProject::instance()->addMapLayer( tempLayer.get() );
+
+  // opening the project properties for the first time in a new project does write new entries
+  // call apply twice here to test that subsequent opening will not dirty project
+  QgsProjectProperties *pp = new QgsProjectProperties( mQgisApp->mapCanvas() );
+  pp->apply();
+  delete pp;
+  QgsProject::instance()->setDirty( false );
+  pp = new QgsProjectProperties( mQgisApp->mapCanvas() );
+  pp->apply();
+  delete pp;
+  QCOMPARE( QgsProject::instance()->isDirty(), false );
+}
+
+QGSTEST_MAIN( TestQgsProjectProperties )
+
+#include "testqgsprojectproperties.moc"

--- a/tests/src/python/test_qgscoordinatetransformcontext.py
+++ b/tests/src/python/test_qgscoordinatetransformcontext.py
@@ -408,6 +408,19 @@ class TestQgsCoordinateTransformContext(unittest.TestCase):
                          {('EPSG:4204', 'EPSG:4326'): QgsDatumTransform.TransformPair(source_id_1, dest_id_1),
                           ('EPSG:4205', 'EPSG:4326'): QgsDatumTransform.TransformPair(source_id_2, dest_id_2)})
 
+    def testEqualOperator(self):
+        context1 = QgsCoordinateTransformContext()
+        context2 = QgsCoordinateTransformContext()
+        self.assertTrue(context1 == context2)
+
+        context1.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem('EPSG:3111'),
+                                                    QgsCoordinateReferenceSystem('EPSG:4283'), 1, 2)
+        self.assertFalse(context1 == context2)
+
+        context2.addSourceDestinationDatumTransform(QgsCoordinateReferenceSystem('EPSG:3111'),
+                                                    QgsCoordinateReferenceSystem('EPSG:4283'), 1, 2)
+        self.assertTrue(context1 == context2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgsproject.py
+++ b/tests/src/python/test_qgsproject.py
@@ -1121,7 +1121,7 @@ class TestQgsProject(unittest.TestCase):
         self.assertTrue(ok)
         self.assertEqual(q, query)
 
-    def testWriteEntryDirtying(self):
+    def testDirtying(self):
 
         project = QgsProject()
 
@@ -1139,6 +1139,27 @@ class TestQgsProject(unittest.TestCase):
         project.setDirty(False)
         self.assertTrue(project.writeEntry('myscope', 'myentry', False))
         self.assertTrue(project.isDirty())
+
+        # removing an existing entry should dirty the project
+        project.setDirty(False)
+        self.assertTrue(project.removeEntry('myscope', 'myentry'))
+        self.assertTrue(project.isDirty())
+
+        # removing a non-existing entry should _not_ dirty the project
+        project.setDirty(False)
+        self.assertTrue(project.removeEntry('myscope', 'myentry'))
+        self.assertFalse(project.isDirty())
+
+        # setting a project CRS with a new value should dirty the project
+        project.setCrs(QgsCoordinateReferenceSystem('EPSG:4326'))
+        project.setDirty(False)
+        project.setCrs(QgsCoordinateReferenceSystem('EPSG:3148'))
+        self.assertTrue(project.isDirty())
+
+        # setting a project CRS with the same project CRS should not dirty the project
+        project.setDirty(False)
+        project.setCrs(QgsCoordinateReferenceSystem('EPSG:3148'))
+        self.assertFalse(project.isDirty())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
Backport project dirtying fixes.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
