### PR TITLE
[Server] Null field value in GML has to be empty string 2.18

### DIFF
--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -2242,7 +2242,7 @@ QDomElement QgsWFSServer::createFeatureGML3( QgsFeature* feat, QDomDocument& doc
 QString QgsWFSServer::encodeValueToText( const QVariant& value )
 {
   if ( value.isNull() )
-    return "null";
+    return QString();
 
   switch ( value.type() )
   {


### PR DESCRIPTION
## Description
In GML, the null field value has not to be displayed as NULL but an empty string.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
