### PR TITLE
[Server][WFS] Null field value in GML has to be empty string 3.4

### DIFF
--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -1455,7 +1455,7 @@ namespace QgsWfs
     QString encodeValueToText( const QVariant &value, const QgsEditorWidgetSetup &setup )
     {
       if ( value.isNull() )
-        return QStringLiteral( "null" );
+        return QString();
 
       if ( setup.type() ==  QStringLiteral( "DateTime" ) )
       {


### PR DESCRIPTION
## Description
In GML, the null field value has not to be displayed as NULL but an empty string.

Forward porting #8536 

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
