### PR TITLE
[browser] Add API to access the drive data items

### DIFF
--- a/python/core/auto_generated/qgsbrowsermodel.sip.in
+++ b/python/core/auto_generated/qgsbrowsermodel.sip.in
@@ -130,6 +130,16 @@ Returns true if the model has been initialized.
 .. seealso:: :py:func:`initialize`
 %End
 
+    QMap<QString, QgsDirectoryItem *> driveItems() const;
+%Docstring
+Returns a map of the root drive items shown in the browser.
+
+These correspond to the top-level directory items shown, e.g. on Windows the C:\, D:\, etc,
+and on Linux the "/" root directory.
+
+.. versionadded:: 3.6
+%End
+
   signals:
     void stateChanged( const QModelIndex &index, QgsDataItem::State oldState );
 %Docstring

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -173,6 +173,11 @@ void QgsBrowserModel::removeRootItems()
   mDriveItems.clear();
 }
 
+QMap<QString, QgsDirectoryItem *> QgsBrowserModel::driveItems() const
+{
+  return mDriveItems;
+}
+
 void QgsBrowserModel::initialize()
 {
   if ( ! mInitialized )
@@ -401,7 +406,7 @@ void QgsBrowserModel::refreshDrives()
       continue;
 
     // drive has been removed, remove corresponding item
-    if ( QgsDataItem *driveItem = mDriveItems.value( drivePath ) )
+    if ( QgsDirectoryItem *driveItem = mDriveItems.value( drivePath ) )
       removeRootItem( driveItem );
   }
 
@@ -528,7 +533,7 @@ void QgsBrowserModel::setupItemConnections( QgsDataItem *item )
            this, &QgsBrowserModel::itemStateChanged );
 
   // if it's a collection item, also forwards connectionsChanged
-  QgsDataCollectionItem *collectionItem = dynamic_cast<QgsDataCollectionItem *>( item );
+  QgsDataCollectionItem *collectionItem = qobject_cast<QgsDataCollectionItem *>( item );
   if ( collectionItem )
     connect( collectionItem, &QgsDataCollectionItem::connectionsChanged, this, &QgsBrowserModel::connectionsChanged );
 }
@@ -628,7 +633,7 @@ void QgsBrowserModel::addFavoriteDirectory( const QString &directory, const QStr
 
 void QgsBrowserModel::removeFavorite( const QModelIndex &index )
 {
-  QgsDirectoryItem *item = dynamic_cast<QgsDirectoryItem *>( dataItem( index ) );
+  QgsDirectoryItem *item = qobject_cast<QgsDirectoryItem *>( dataItem( index ) );
   if ( !item )
     return;
 
@@ -674,9 +679,10 @@ void QgsBrowserModel::removeRootItem( QgsDataItem *item )
   int i = mRootItems.indexOf( item );
   beginRemoveRows( QModelIndex(), i, i );
   mRootItems.remove( i );
-  if ( !mDriveItems.key( item ).isEmpty() )
+  QgsDirectoryItem *dirItem = qobject_cast< QgsDirectoryItem * >( item );
+  if ( !mDriveItems.key( dirItem ).isEmpty() )
   {
-    mDriveItems.remove( mDriveItems.key( item ) );
+    mDriveItems.remove( mDriveItems.key( dirItem ) );
   }
   item->deleteLater();
   endRemoveRows();

--- a/src/core/qgsbrowsermodel.h
+++ b/src/core/qgsbrowsermodel.h
@@ -148,6 +148,16 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
      */
     bool initialized() const { return mInitialized;  }
 
+    /**
+     * Returns a map of the root drive items shown in the browser.
+     *
+     * These correspond to the top-level directory items shown, e.g. on Windows the C:\, D:\, etc,
+     * and on Linux the "/" root directory.
+     *
+     * \since QGIS 3.6
+     */
+    QMap<QString, QgsDirectoryItem *> driveItems() const;
+
   signals:
     //! Emitted when item children fetch was finished
     void stateChanged( const QModelIndex &index, QgsDataItem::State oldState );
@@ -225,7 +235,7 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
 
   private:
     bool mInitialized = false;
-    QMap< QString, QgsDataItem * > mDriveItems;
+    QMap< QString, QgsDirectoryItem * > mDriveItems;
 
     void setupItemConnections( QgsDataItem *item );
 

--- a/tests/src/core/testqgsbrowsermodel.cpp
+++ b/tests/src/core/testqgsbrowsermodel.cpp
@@ -37,6 +37,7 @@ class TestQgsBrowserModel : public QObject
     void cleanup() {} // will be called after every testfunction.
 
     void testModel();
+    void driveItems();
 
 };
 
@@ -159,6 +160,20 @@ void TestQgsBrowserModel::testModel()
   QCOMPARE( model.data( model.index( 0, 0, child2Index ) ).toString(), QStringLiteral( "Child3" ) );
   QCOMPARE( model.rowCount( root2Index ), 1 );
   QCOMPARE( model.data( model.index( 0, 0, root2Index ) ).toString(), QStringLiteral( "Child4" ) );
+}
+
+void TestQgsBrowserModel::driveItems()
+{
+  // an unapologetically linux-directed test ;)
+  QgsBrowserModel model;
+  QVERIFY( model.driveItems().empty() );
+
+  model.initialize();
+  QVERIFY( !model.driveItems().empty() );
+  QVERIFY( model.driveItems().contains( QStringLiteral( "/" ) ) );
+  QgsDirectoryItem *rootItem = model.driveItems().value( QStringLiteral( "/" ) );
+  QVERIFY( rootItem );
+  QCOMPARE( rootItem->path(), QStringLiteral( "/" ) );
 }
 
 QGSTEST_MAIN( TestQgsBrowserModel )


### PR DESCRIPTION
Adds a method to directly retrieve the browser items corresponding to the top-level drives, e.g. c: