### PR TITLE
Deactivate help button for SAGA algorithms

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
@@ -128,9 +128,6 @@ class SagaAlgorithmProvider(QgsProcessingProvider):
     def id(self):
         return 'saga'
 
-    def helpId(self):
-        return 'saga'
-
     def defaultVectorFileExtension(self, hasGeometry=True):
         return 'shp' if hasGeometry else 'dbf'
 


### PR DESCRIPTION
to avoid user frustration (see https://github.com/qgis/QGIS-Documentation/issues/3068 - which should not be a QGIS Docs issue) because no help is provided in user manual (simply listing parameters and options already shown in GUI can't be called a help). Currently around 30/230 algs are fully or partially documented in our docs repo. Not worth a use (see also https://github.com/qgis/QGIS-Documentation/pull/3190).

A help button should actually fetch SAGA official docs (this is what GRASS and OTB -for those I checked- do) but here is the quickest and working solution I have reached without having to abuse coffee.