### PR TITLE
Also prompt to save projects with no layers, but changes

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11262,13 +11262,11 @@ bool QgisApp::saveDirty()
   QgsSettings settings;
   bool askThem = settings.value( QStringLiteral( "qgis/askToSaveProjectChanges" ), true ).toBool();
 
-  if ( askThem && QgsProject::instance()->isDirty() && QgsProject::instance()->count() > 0 )
+  if ( askThem && QgsProject::instance()->isDirty() )
   {
     // flag project as dirty since dirty state of canvas is reset if "dirty"
     // is based on a zoom or pan
     markDirty();
-
-    // old code: mProjectIsDirtyFlag = true;
 
     // prompt user to save
     answer = QMessageBox::question( this, tr( "Save Project" ),


### PR DESCRIPTION
Because if a user wants a "layout only" project, we should still give them unsaved changes warnings!

I'm unsure if there's a valid reason why we'd not show the unsaved project changes when a project has no layers, but my suspicion is that this is just a legacy artefact. I'd guess it was put in place as a workaround back when we used to dirty projects when no changes were actually made, but that's no longer the case.
