### PR TITLE
Add macro for proj_api.h to work with new releases of proj4.

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -344,6 +344,9 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #ifdef PROJ_HAS_INFO
 #include <proj.h>
 #endif
+#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#endif	
 #include <proj_api.h>
 
 //

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -40,6 +40,9 @@
 //proj4 includes
 extern "C"
 {
+#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#endif		
 #include <proj_api.h>
 }
 

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -38,6 +38,9 @@
 #include "qgssettings.h"
 
 #include <sqlite3.h>
+#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#endif
 #include <proj_api.h>
 
 //gdal and ogr includes (needed for == operator)
@@ -45,6 +48,7 @@
 #include <cpl_error.h>
 #include <cpl_conv.h>
 #include <cpl_csv.h>
+
 
 //! The length of the string "+lat_1="
 const int LAT_PREFIX_LEN = 7;

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -34,6 +34,9 @@
 
 extern "C"
 {
+#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#endif
 #include <proj_api.h>
 }
 #include <sqlite3.h>

--- a/src/core/qgscoordinatetransform_p.cpp
+++ b/src/core/qgscoordinatetransform_p.cpp
@@ -21,6 +21,9 @@
 
 extern "C"
 {
+#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#endif	
 #include <proj_api.h>
 }
 #include <sqlite3.h>

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -24,6 +24,9 @@ Email                : sherman at mrcc dot com
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
 
+#ifndef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+#endif	
 #include <proj_api.h>
 #include <gdal.h>
 #include <cpl_conv.h>


### PR DESCRIPTION

## Description
Defined a macro to accept 'ACCEPT_USE_OF_DEPRECATED_PROJ_API_H' in 6 cpp files:
- src/core/qgscoordinatereferencesystem.cpp
- src/core/qgscoordinatetransform.cpp
- src/core/qgscoordinatetransform_p.cpp
- src/app/qgisapp.cpp
- src/app/qgscustomprojectiondialog
- tests/src/core/testqgscoordinatereferencesystem.cpp

Otherwise, this error occurs during build:
```
/usr/local/include/proj_api.h:37:2: error: #error 'To use the proj_api.h you must define the macro ACCEPT_USE_OF_DEPRECATED_PROJ_API_H'
 #error 'To use the proj_api.h you must define the macro ACCEPT_USE_OF_DEPRECATED_PROJ_API_H'
```
Ref: https://github.com/OSGeo/proj.4/issues/836 