### PR TITLE
Backport PyQGIS parts iterator to 3.4

### DIFF
--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -610,9 +610,64 @@ Converts the geometry to a specified type.
 %End
 
 
+    QgsGeometryPartIterator parts();
+%Docstring
+Returns Java-style iterator for traversal of parts of the geometry. This iterator
+can safely be used to modify parts of the geometry.
+
+* Example:
+.. code-block:: python
+
+       # print the WKT representation of each part in a multi-point geometry
+       geometry = QgsMultiPoint.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+       for part in geometry.parts():
+           print(part.asWkt())
+
+       # single part geometries only have one part - this loop will iterate once only
+       geometry = QgsLineString.fromWkt( 'LineString( 0 0, 10 10 )' )
+       for part in geometry.parts():
+           print(part.asWkt())
+
+       # parts can be modified during the iteration
+       geometry = QgsMultiPoint.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+       for part in geometry.parts():
+           part.transform(ct)
+
+       # part iteration can also be combined with vertex iteration
+       geometry = QgsMultiPolygon.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+       for part in geometry.parts():
+           for v in part.vertices():
+               print(v.x(), v.y())
+
+.. seealso:: :py:func:`vertices`
+
+.. versionadded:: 3.6
+%End
+
+
     QgsVertexIterator vertices() const;
 %Docstring
-Returns Java-style iterator for traversal of vertices of the geometry
+Returns a read-only, Java-style iterator for traversal of vertices of all the geometry, including all geometry parts and rings.
+
+.. warning::
+
+   The iterator returns a copy of individual vertices, and accordingly geometries cannot be
+   modified using the iterator. See transformVertices() for a safe method to modify vertices "in-place".
+
+* Example:
+.. code-block:: python
+
+       # print the x and y coordinate for each vertex in a LineString
+       geometry = QgsLineString.fromWkt( 'LineString( 0 0, 1 1, 2 2)' )
+       for v in geometry.vertices():
+           print(v.x(), v.y())
+
+       # vertex iteration includes all parts and rings
+       geometry = QgsMultiPolygon.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+       for v in geometry.vertices():
+           print(v.x(), v.y())
+
+.. seealso:: :py:func:`parts`
 
 .. versionadded:: 3.0
 %End
@@ -765,6 +820,101 @@ Returns next vertex of the geometry (undefined behavior if hasNext() returns fal
 %MethodCode
     if ( sipCpp->hasNext() )
       sipRes = sipConvertFromType( new QgsPoint( sipCpp->next() ), sipType_QgsPoint, Py_None );
+    else
+      PyErr_SetString( PyExc_StopIteration, "" );
+%End
+
+};
+
+class QgsGeometryPartIterator
+{
+%Docstring
+Java-style iterator for traversal of parts of a geometry
+
+.. versionadded:: 3.6
+%End
+
+%TypeHeaderCode
+#include "qgsabstractgeometry.h"
+%End
+  public:
+    QgsGeometryPartIterator();
+%Docstring
+Constructor for QgsGeometryPartIterator
+%End
+
+    QgsGeometryPartIterator( QgsAbstractGeometry *geometry );
+%Docstring
+Constructs iterator for the given geometry
+%End
+
+    bool hasNext() const;
+%Docstring
+Find out whether there are more parts
+%End
+
+    QgsAbstractGeometry *next();
+%Docstring
+Returns next part of the geometry (undefined behavior if hasNext() returns false before calling next())
+%End
+
+    QgsGeometryPartIterator *__iter__();
+%MethodCode
+    sipRes = sipCpp;
+%End
+
+    SIP_PYOBJECT __next__();
+%MethodCode
+    if ( sipCpp->hasNext() )
+      sipRes = sipConvertFromType( sipCpp->next(), sipType_QgsAbstractGeometry, NULL );
+    else
+      PyErr_SetString( PyExc_StopIteration, "" );
+%End
+
+};
+
+
+class QgsGeometryConstPartIterator
+{
+%Docstring
+Java-style iterator for const traversal of parts of a geometry
+
+.. versionadded:: 3.6
+%End
+
+%TypeHeaderCode
+#include "qgsabstractgeometry.h"
+%End
+  public:
+    QgsGeometryConstPartIterator();
+%Docstring
+Constructor for QgsGeometryConstPartIterator
+%End
+
+    QgsGeometryConstPartIterator( const QgsAbstractGeometry *geometry );
+%Docstring
+Constructs iterator for the given geometry
+%End
+
+    bool hasNext() const;
+%Docstring
+Find out whether there are more parts
+%End
+
+    const QgsAbstractGeometry *next();
+%Docstring
+Returns next part of the geometry (undefined behavior if hasNext() returns false before calling next())
+%End
+
+    QgsGeometryConstPartIterator *__iter__();
+%MethodCode
+    sipRes = sipCpp;
+%End
+
+    SIP_PYOBJECT __next__();
+%MethodCode
+    if ( sipCpp->hasNext() )
+      sipRes = sipConvertFromType( const_cast< QgsAbstractGeometry * >( sipCpp->next() ), sipType_QgsAbstractGeometry, NULL );
     else
       PyErr_SetString( PyExc_StopIteration, "" );
 %End

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -641,7 +641,7 @@ can safely be used to modify parts of the geometry.
 
 .. seealso:: :py:func:`vertices`
 
-.. versionadded:: 3.6
+.. versionadded:: 3.4.3
 %End
 
 
@@ -831,7 +831,7 @@ class QgsGeometryPartIterator
 %Docstring
 Java-style iterator for traversal of parts of a geometry
 
-.. versionadded:: 3.6
+.. versionadded:: 3.4.3
 %End
 
 %TypeHeaderCode
@@ -879,7 +879,7 @@ class QgsGeometryConstPartIterator
 %Docstring
 Java-style iterator for const traversal of parts of a geometry
 
-.. versionadded:: 3.6
+.. versionadded:: 3.4.3
 %End
 
 %TypeHeaderCode

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -415,7 +415,7 @@ if the parts are not going to be modified.
 
 .. seealso:: :py:func:`vertices`
 
-.. versionadded:: 3.6
+.. versionadded:: 3.4.3
 %End
 
     QgsGeometryConstPartIterator constParts() const;
@@ -449,7 +449,7 @@ iteration only is required.
 
 .. seealso:: :py:func:`vertices`
 
-.. versionadded:: 3.6
+.. versionadded:: 3.4.3
 %End
 
     double hausdorffDistance( const QgsGeometry &geom ) const;

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -353,9 +353,103 @@ Will return a negative value if a geometry is missing.
 
     QgsVertexIterator vertices() const;
 %Docstring
-Returns Java-style iterator for traversal of vertices of the geometry
+Returns a read-only, Java-style iterator for traversal of vertices of all the geometry, including all geometry parts and rings.
+
+.. warning::
+
+   The iterator returns a copy of individual vertices, and accordingly geometries cannot be
+   modified using the iterator. See transformVertices() for a safe method to modify vertices "in-place".
+
+* Example:
+.. code-block:: python
+
+       # print the x and y coordinate for each vertex in a LineString
+       geometry = QgsGeometry.fromWkt( 'LineString( 0 0, 1 1, 2 2)' )
+       for v in geometry.vertices():
+           print(v.x(), v.y())
+
+       # vertex iteration includes all parts and rings
+       geometry = QgsGeometry.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+       for v in geometry.vertices():
+           print(v.x(), v.y())
+
+.. seealso:: :py:func:`parts`
 
 .. versionadded:: 3.0
+%End
+
+
+    QgsGeometryPartIterator parts();
+%Docstring
+Returns Java-style iterator for traversal of parts of the geometry. This iterator
+can safely be used to modify parts of the geometry.
+
+This method forces a detach. Use constParts() to avoid the detach
+if the parts are not going to be modified.
+
+* Example:
+.. code-block:: python
+
+       # print the WKT representation of each part in a multi-point geometry
+       geometry = QgsGeometry.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+       for part in geometry.parts():
+           print(part.asWkt())
+
+       # single part geometries only have one part - this loop will iterate once only
+       geometry = QgsGeometry.fromWkt( 'LineString( 0 0, 10 10 )' )
+       for part in geometry.parts():
+           print(part.asWkt())
+
+       # parts can be modified during the iteration
+       geometry = QgsGeometry.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+       for part in geometry.parts():
+           part.transform(ct)
+
+       # part iteration can also be combined with vertex iteration
+       geometry = QgsGeometry.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+       for part in geometry.parts():
+           for v in part.vertices():
+               print(v.x(), v.y())
+
+.. seealso:: :py:func:`constParts`
+
+.. seealso:: :py:func:`vertices`
+
+.. versionadded:: 3.6
+%End
+
+    QgsGeometryConstPartIterator constParts() const;
+%Docstring
+Returns Java-style iterator for traversal of parts of the geometry. This iterator
+returns read-only references to parts and cannot be used to modify the parts.
+
+Unlike parts(), this method does not force a detach and is more efficient if read-only
+iteration only is required.
+
+* Example:
+.. code-block:: python
+
+       # print the WKT representation of each part in a multi-point geometry
+       geometry = QgsGeometry.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+       for part in geometry.parts():
+           print(part.asWkt())
+
+       # single part geometries only have one part - this loop will iterate once only
+       geometry = QgsGeometry.fromWkt( 'LineString( 0 0, 10 10 )' )
+       for part in geometry.parts():
+           print(part.asWkt())
+
+       # part iteration can also be combined with vertex iteration
+       geometry = QgsGeometry.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+       for part in geometry.parts():
+           for v in part.vertices():
+               print(v.x(), v.y())
+
+.. seealso:: :py:func:`parts`
+
+.. seealso:: :py:func:`vertices`
+
+.. versionadded:: 3.6
 %End
 
     double hausdorffDistance( const QgsGeometry &geom ) const;

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -58,7 +58,7 @@ Returns the number of geometries within the collection.
 
 
 
-    SIP_PYOBJECT geometryN( int n ) const;
+    SIP_PYOBJECT geometryN( int n );
 %Docstring
 Returns a geometry from within the collection.
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -42,12 +42,40 @@ Returns the number of geometries within the collection.
 %End
 
 
-    QgsAbstractGeometry *geometryN( int n );
+    int __len__() const;
+%Docstring
+Returns the number of geometries within the collection.
+%End
+%MethodCode
+    sipRes = sipCpp->numGeometries();
+%End
+
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+%MethodCode
+    sipRes = true;
+%End
+
+
+
+    SIP_PYOBJECT geometryN( int n ) const;
 %Docstring
 Returns a geometry from within the collection.
 
 :param n: index of geometry to return
 %End
+%MethodCode
+    if ( a0 < 0 || a0 >= sipCpp->numGeometries() )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      return sipConvertFromType( sipCpp->geometryN( a0 ), sipType_QgsAbstractGeometry, NULL );
+    }
+%End
+
 
     virtual bool isEmpty() const;
 

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -13,7 +13,6 @@
 
 
 
-
 class QgsFeature
 {
 %Docstring
@@ -327,6 +326,21 @@ Set the feature's geometry. The feature will be valid after.
 .. seealso:: :py:func:`geometry`
 
 .. seealso:: :py:func:`clearGeometry`
+%End
+
+    void setGeometry( QgsAbstractGeometry *geometry /Transfer/ );
+%Docstring
+Set the feature's ``geometry``. Ownership of the geometry is transferred to the feature.
+The feature will be made valid after calling this method.
+
+.. seealso:: :py:func:`geometry`
+
+.. seealso:: :py:func:`clearGeometry`
+
+.. versionadded:: 3.6
+%End
+%MethodCode
+    sipCpp->setGeometry( std::unique_ptr< QgsAbstractGeometry>( a0 ) );
 %End
 
     void clearGeometry();

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -337,7 +337,7 @@ The feature will be made valid after calling this method.
 
 .. seealso:: :py:func:`clearGeometry`
 
-.. versionadded:: 3.6
+.. versionadded:: 3.4.3
 %End
 %MethodCode
     sipCpp->setGeometry( std::unique_ptr< QgsAbstractGeometry>( a0 ) );

--- a/python/core/auto_generated/qgsfeature.sip.in
+++ b/python/core/auto_generated/qgsfeature.sip.in
@@ -333,6 +333,24 @@ Set the feature's geometry. The feature will be valid after.
 Set the feature's ``geometry``. Ownership of the geometry is transferred to the feature.
 The feature will be made valid after calling this method.
 
+This method is a shortcut for calling:
+.. code-block:: python
+
+       feature.setGeometry( QgsGeometry( geometry ) )
+
+* Example:
+.. code-block:: python
+
+       # Sets a feature's geometry to a point geometry
+       feature.setGeometry( QgsPoint( 210, 41 ) )
+       print(feature.geometry())
+       # output: <QgsGeometry: Point (210 41)>
+
+       # Sets a feature's geometry to a line string
+       feature.setGeometry( QgsLineString( [ QgsPoint( 210, 41 ), QgsPoint( 301, 55 ) ] ) )
+       print(feature.geometry())
+       # output: <QgsGeometry: LineString (210 41, 301 55)>
+
 .. seealso:: :py:func:`geometry`
 
 .. seealso:: :py:func:`clearGeometry`

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -36,6 +36,8 @@ class QgsVertexIterator;
 class QPainter;
 class QDomDocument;
 class QDomElement;
+class QgsGeometryPartIterator;
+class QgsGeometryConstPartIterator;
 
 typedef QVector< QgsPoint > QgsPointSequence;
 #ifndef SIP_RUN
@@ -606,6 +608,136 @@ class CORE_EXPORT QgsAbstractGeometry
 
     /**
      * \ingroup core
+     * The part_iterator class provides STL-style iterator for geometry parts.
+     * \since QGIS 3.6
+     */
+    class CORE_EXPORT part_iterator
+    {
+      private:
+
+        int mIndex = 0; //!< Current part in the geometry
+        QgsAbstractGeometry *mGeometry = nullptr;
+
+      public:
+        //! Create invalid iterator
+        part_iterator() = default;
+
+        //! Create part iterator for a geometry
+        part_iterator( QgsAbstractGeometry *g, int index );
+
+        /**
+         * The prefix ++ operator (++it) advances the iterator to the next part and returns an iterator to the new current part.
+         * Calling this function on iterator that is already past the last item leads to undefined results.
+         */
+        part_iterator &operator++();
+
+        //! The postfix ++ operator (it++) advances the iterator to the next part and returns an iterator to the previously current part.
+        part_iterator operator++( int );
+
+        //! Returns the current item.
+        QgsAbstractGeometry *operator*() const;
+
+        //! Returns the part number of the current item.
+        int partNumber() const;
+
+        bool operator==( part_iterator other ) const;
+        bool operator!=( part_iterator other ) const { return !( *this == other ); }
+    };
+
+    /**
+     * Returns STL-style iterator pointing to the first part of the geometry.
+     *
+     * \see parts_end()
+     * \see parts()
+     *
+     * \since QGIS 3.6
+     */
+    part_iterator parts_begin()
+    {
+      return part_iterator( this, 0 );
+    }
+
+    /**
+     * Returns STL-style iterator pointing to the imaginary part after the last part of the geometry.
+     *
+     * \see parts_begin()
+     * \see parts()
+     *
+     * \since QGIS 3.6
+     */
+    part_iterator parts_end();
+
+    /**
+     * Returns Java-style iterator for traversal of parts of the geometry. This iterator
+     * returns read-only references to parts and cannot be used to modify the parts.
+     *
+     * \note Not available in Python bindings
+     * \since QGIS 3.6
+     */
+    QgsGeometryConstPartIterator parts() const;
+
+    /**
+     * \ingroup core
+     * The part_iterator class provides STL-style iterator for const references to geometry parts.
+     * \since QGIS 3.6
+     */
+    class CORE_EXPORT const_part_iterator
+    {
+      private:
+
+        int mIndex = 0; //!< Current part in the geometry
+        const QgsAbstractGeometry *mGeometry = nullptr;
+
+      public:
+        //! Create invalid iterator
+        const_part_iterator() = default;
+
+        //! Create part iterator for a geometry
+        const_part_iterator( const QgsAbstractGeometry *g, int index );
+
+        /**
+         * The prefix ++ operator (++it) advances the iterator to the next part and returns an iterator to the new current part.
+         * Calling this function on iterator that is already past the last item leads to undefined results.
+         */
+        const_part_iterator &operator++();
+
+        //! The postfix ++ operator (it++) advances the iterator to the next part and returns an iterator to the previously current part.
+        const_part_iterator operator++( int );
+
+        //! Returns the current item.
+        const QgsAbstractGeometry *operator*() const;
+
+        //! Returns the part number of the current item.
+        int partNumber() const;
+
+        bool operator==( const_part_iterator other ) const;
+        bool operator!=( const_part_iterator other ) const { return !( *this == other ); }
+    };
+
+    /**
+     * Returns STL-style iterator pointing to the const first part of the geometry.
+     *
+     * \see const_parts_end()
+     *
+     * \since QGIS 3.6
+     */
+    const_part_iterator const_parts_begin() const
+    {
+      return const_part_iterator( this, 0 );
+    }
+
+    /**
+     * Returns STL-style iterator pointing to the imaginary const part after the last part of the geometry.
+     *
+     * \see const_parts_begin()
+     *
+     * \since QGIS 3.6
+     */
+    const_part_iterator const_parts_end() const;
+
+
+    /**
+     * \ingroup core
      * The vertex_iterator class provides STL-style iterator for vertices.
      * \since QGIS 3.0
      */
@@ -656,7 +788,11 @@ class CORE_EXPORT QgsAbstractGeometry
     };
 
     /**
-     * Returns STL-style iterator pointing to the first vertex of the geometry
+     * Returns STL-style iterator pointing to the first vertex of the geometry.
+     *
+     * \see vertices_end()
+     * \see vertices()
+     *
      * \since QGIS 3.0
      */
     vertex_iterator vertices_begin() const
@@ -665,7 +801,11 @@ class CORE_EXPORT QgsAbstractGeometry
     }
 
     /**
-     * Returns STL-style iterator pointing to the imaginary vertex after the last vertex of the geometry
+     * Returns STL-style iterator pointing to the imaginary vertex after the last vertex of the geometry.
+     *
+     * \see vertices_begin()
+     * \see vertices()
+     *
      * \since QGIS 3.0
      */
     vertex_iterator vertices_end() const
@@ -675,7 +815,60 @@ class CORE_EXPORT QgsAbstractGeometry
 #endif
 
     /**
-     * Returns Java-style iterator for traversal of vertices of the geometry
+     * Returns Java-style iterator for traversal of parts of the geometry. This iterator
+     * can safely be used to modify parts of the geometry.
+     *
+     * * Example:
+     * \code{.py}
+     *   # print the WKT representation of each part in a multi-point geometry
+     *   geometry = QgsMultiPoint.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+     *   for part in geometry.parts():
+     *       print(part.asWkt())
+     *
+     *   # single part geometries only have one part - this loop will iterate once only
+     *   geometry = QgsLineString.fromWkt( 'LineString( 0 0, 10 10 )' )
+     *   for part in geometry.parts():
+     *       print(part.asWkt())
+     *
+     *   # parts can be modified during the iteration
+     *   geometry = QgsMultiPoint.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+     *   for part in geometry.parts():
+     *       part.transform(ct)
+     *
+     *   # part iteration can also be combined with vertex iteration
+     *   geometry = QgsMultiPolygon.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+     *   for part in geometry.parts():
+     *       for v in part.vertices():
+     *           print(v.x(), v.y())
+     *
+     * \endcode
+     *
+     * \see vertices()
+     * \since QGIS 3.6
+     */
+    QgsGeometryPartIterator parts();
+
+
+    /**
+     * Returns a read-only, Java-style iterator for traversal of vertices of all the geometry, including all geometry parts and rings.
+     *
+     * \warning The iterator returns a copy of individual vertices, and accordingly geometries cannot be
+     * modified using the iterator. See transformVertices() for a safe method to modify vertices "in-place".
+     *
+     * * Example:
+     * \code{.py}
+     *   # print the x and y coordinate for each vertex in a LineString
+     *   geometry = QgsLineString.fromWkt( 'LineString( 0 0, 1 1, 2 2)' )
+     *   for v in geometry.vertices():
+     *       print(v.x(), v.y())
+     *
+     *   # vertex iteration includes all parts and rings
+     *   geometry = QgsMultiPolygon.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+     *   for v in geometry.vertices():
+     *       print(v.x(), v.y())
+     * \endcode
+     *
+     * \see parts()
      * \since QGIS 3.0
      */
     QgsVertexIterator vertices() const;
@@ -858,6 +1051,105 @@ class CORE_EXPORT QgsVertexIterator
   private:
     const QgsAbstractGeometry *g = nullptr;
     QgsAbstractGeometry::vertex_iterator i, n;
+
+};
+
+/**
+ * \ingroup core
+ * \brief Java-style iterator for traversal of parts of a geometry
+ * \since QGIS 3.6
+ */
+class CORE_EXPORT QgsGeometryPartIterator
+{
+  public:
+    //! Constructor for QgsGeometryPartIterator
+    QgsGeometryPartIterator() = default;
+
+    //! Constructs iterator for the given geometry
+    QgsGeometryPartIterator( QgsAbstractGeometry *geometry )
+      : g( geometry )
+      , i( g->parts_begin() )
+      , n( g->parts_end() )
+    {
+    }
+
+    //! Find out whether there are more parts
+    bool hasNext() const
+    {
+      return g && g->parts_end() != i;
+    }
+
+    //! Returns next part of the geometry (undefined behavior if hasNext() returns false before calling next())
+    QgsAbstractGeometry *next();
+
+#ifdef SIP_RUN
+    QgsGeometryPartIterator *__iter__();
+    % MethodCode
+    sipRes = sipCpp;
+    % End
+
+    SIP_PYOBJECT __next__();
+    % MethodCode
+    if ( sipCpp->hasNext() )
+      sipRes = sipConvertFromType( sipCpp->next(), sipType_QgsAbstractGeometry, NULL );
+    else
+      PyErr_SetString( PyExc_StopIteration, "" );
+    % End
+#endif
+
+  private:
+    QgsAbstractGeometry *g = nullptr;
+    QgsAbstractGeometry::part_iterator i, n;
+
+};
+
+
+/**
+ * \ingroup core
+ * \brief Java-style iterator for const traversal of parts of a geometry
+ * \since QGIS 3.6
+ */
+class CORE_EXPORT QgsGeometryConstPartIterator
+{
+  public:
+    //! Constructor for QgsGeometryConstPartIterator
+    QgsGeometryConstPartIterator() = default;
+
+    //! Constructs iterator for the given geometry
+    QgsGeometryConstPartIterator( const QgsAbstractGeometry *geometry )
+      : g( geometry )
+      , i( g->const_parts_begin() )
+      , n( g->const_parts_end() )
+    {
+    }
+
+    //! Find out whether there are more parts
+    bool hasNext() const
+    {
+      return g && g->const_parts_end() != i;
+    }
+
+    //! Returns next part of the geometry (undefined behavior if hasNext() returns false before calling next())
+    const QgsAbstractGeometry *next();
+
+#ifdef SIP_RUN
+    QgsGeometryConstPartIterator *__iter__();
+    % MethodCode
+    sipRes = sipCpp;
+    % End
+
+    SIP_PYOBJECT __next__();
+    % MethodCode
+    if ( sipCpp->hasNext() )
+      sipRes = sipConvertFromType( const_cast< QgsAbstractGeometry * >( sipCpp->next() ), sipType_QgsAbstractGeometry, NULL );
+    else
+      PyErr_SetString( PyExc_StopIteration, "" );
+    % End
+#endif
+
+  private:
+    const QgsAbstractGeometry *g = nullptr;
+    QgsAbstractGeometry::const_part_iterator i, n;
 
 };
 

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -609,7 +609,7 @@ class CORE_EXPORT QgsAbstractGeometry
     /**
      * \ingroup core
      * The part_iterator class provides STL-style iterator for geometry parts.
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     class CORE_EXPORT part_iterator
     {
@@ -650,7 +650,7 @@ class CORE_EXPORT QgsAbstractGeometry
      * \see parts_end()
      * \see parts()
      *
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     part_iterator parts_begin()
     {
@@ -663,7 +663,7 @@ class CORE_EXPORT QgsAbstractGeometry
      * \see parts_begin()
      * \see parts()
      *
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     part_iterator parts_end();
 
@@ -672,14 +672,14 @@ class CORE_EXPORT QgsAbstractGeometry
      * returns read-only references to parts and cannot be used to modify the parts.
      *
      * \note Not available in Python bindings
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     QgsGeometryConstPartIterator parts() const;
 
     /**
      * \ingroup core
      * The part_iterator class provides STL-style iterator for const references to geometry parts.
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     class CORE_EXPORT const_part_iterator
     {
@@ -719,7 +719,7 @@ class CORE_EXPORT QgsAbstractGeometry
      *
      * \see const_parts_end()
      *
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     const_part_iterator const_parts_begin() const
     {
@@ -731,7 +731,7 @@ class CORE_EXPORT QgsAbstractGeometry
      *
      * \see const_parts_begin()
      *
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     const_part_iterator const_parts_end() const;
 
@@ -844,7 +844,7 @@ class CORE_EXPORT QgsAbstractGeometry
      * \endcode
      *
      * \see vertices()
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     QgsGeometryPartIterator parts();
 
@@ -1057,7 +1057,7 @@ class CORE_EXPORT QgsVertexIterator
 /**
  * \ingroup core
  * \brief Java-style iterator for traversal of parts of a geometry
- * \since QGIS 3.6
+ * \since QGIS 3.4.3
  */
 class CORE_EXPORT QgsGeometryPartIterator
 {
@@ -1107,7 +1107,7 @@ class CORE_EXPORT QgsGeometryPartIterator
 /**
  * \ingroup core
  * \brief Java-style iterator for const traversal of parts of a geometry
- * \since QGIS 3.6
+ * \since QGIS 3.4.3
  */
 class CORE_EXPORT QgsGeometryConstPartIterator
 {

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -1676,6 +1676,53 @@ QgsVertexIterator QgsGeometry::vertices() const
   return QgsVertexIterator( d->geometry.get() );
 }
 
+QgsAbstractGeometry::part_iterator QgsGeometry::parts_begin()
+{
+  if ( !d->geometry )
+    return QgsAbstractGeometry::part_iterator();
+
+  detach();
+  return d->geometry->parts_begin();
+}
+
+QgsAbstractGeometry::part_iterator QgsGeometry::parts_end()
+{
+  if ( !d->geometry )
+    return QgsAbstractGeometry::part_iterator();
+  return d->geometry->parts_end();
+}
+
+QgsAbstractGeometry::const_part_iterator QgsGeometry::const_parts_begin() const
+{
+  if ( !d->geometry )
+    return QgsAbstractGeometry::const_part_iterator();
+  return d->geometry->const_parts_begin();
+}
+
+QgsAbstractGeometry::const_part_iterator QgsGeometry::const_parts_end() const
+{
+  if ( !d->geometry )
+    return QgsAbstractGeometry::const_part_iterator();
+  return d->geometry->const_parts_end();
+}
+
+QgsGeometryPartIterator QgsGeometry::parts()
+{
+  if ( !d->geometry )
+    return QgsGeometryPartIterator();
+
+  detach();
+  return QgsGeometryPartIterator( d->geometry.get() );
+}
+
+QgsGeometryConstPartIterator QgsGeometry::constParts() const
+{
+  if ( !d->geometry )
+    return QgsGeometryConstPartIterator();
+
+  return QgsGeometryConstPartIterator( d->geometry.get() );
+}
+
 QgsGeometry QgsGeometry::buffer( double distance, int segments ) const
 {
   if ( !d->geometry )

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -377,6 +377,9 @@ class CORE_EXPORT QgsGeometry
 
 #ifndef SIP_RUN
 
+    // TODO QGIS 4: consider renaming vertices_begin, vertices_end, parts_begin, parts_end, etc
+    // to camelCase
+
     /**
      * Returns STL-style iterator pointing to the first vertex of the geometry
      * \since QGIS 3.0
@@ -391,10 +394,142 @@ class CORE_EXPORT QgsGeometry
 #endif
 
     /**
-     * Returns Java-style iterator for traversal of vertices of the geometry
+     * Returns a read-only, Java-style iterator for traversal of vertices of all the geometry, including all geometry parts and rings.
+     *
+     * \warning The iterator returns a copy of individual vertices, and accordingly geometries cannot be
+     * modified using the iterator. See transformVertices() for a safe method to modify vertices "in-place".
+     *
+     * * Example:
+     * \code{.py}
+     *   # print the x and y coordinate for each vertex in a LineString
+     *   geometry = QgsGeometry.fromWkt( 'LineString( 0 0, 1 1, 2 2)' )
+     *   for v in geometry.vertices():
+     *       print(v.x(), v.y())
+     *
+     *   # vertex iteration includes all parts and rings
+     *   geometry = QgsGeometry.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+     *   for v in geometry.vertices():
+     *       print(v.x(), v.y())
+     * \endcode
+     *
+     * \see parts()
      * \since QGIS 3.0
      */
     QgsVertexIterator vertices() const;
+
+#ifndef SIP_RUN
+
+    /**
+     * Returns STL-style iterator pointing to the first part of the geometry.
+     *
+     * This method forces a detach. Use const_parts_begin() to avoid the detach
+     * if the parts are not going to be modified.
+     *
+     * \since QGIS 3.6
+     */
+    QgsAbstractGeometry::part_iterator parts_begin();
+
+    /**
+     * Returns STL-style iterator pointing to the imaginary part after the last part of the geometry.
+     *
+     * This method forces a detach. Use const_parts_begin() to avoid the detach
+     * if the parts are not going to be modified.
+     *
+     * \since QGIS 3.6
+     */
+    QgsAbstractGeometry::part_iterator parts_end();
+
+    /**
+     * Returns STL-style const iterator pointing to the first part of the geometry.
+     *
+     * This method avoids a detach and is more efficient then parts_begin() for read
+     * only iteration.
+     *
+     * \since QGIS 3.6
+     */
+    QgsAbstractGeometry::const_part_iterator const_parts_begin() const;
+
+    /**
+     * Returns STL-style iterator pointing to the imaginary part after the last part of the geometry.
+     *
+     * This method avoids a detach and is more efficient then parts_end() for read
+     * only iteration.
+     *
+     * \since QGIS 3.6
+     */
+    QgsAbstractGeometry::const_part_iterator const_parts_end() const;
+#endif
+
+    /**
+     * Returns Java-style iterator for traversal of parts of the geometry. This iterator
+     * can safely be used to modify parts of the geometry.
+     *
+     * This method forces a detach. Use constParts() to avoid the detach
+     * if the parts are not going to be modified.
+     *
+     * * Example:
+     * \code{.py}
+     *   # print the WKT representation of each part in a multi-point geometry
+     *   geometry = QgsGeometry.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+     *   for part in geometry.parts():
+     *       print(part.asWkt())
+     *
+     *   # single part geometries only have one part - this loop will iterate once only
+     *   geometry = QgsGeometry.fromWkt( 'LineString( 0 0, 10 10 )' )
+     *   for part in geometry.parts():
+     *       print(part.asWkt())
+     *
+     *   # parts can be modified during the iteration
+     *   geometry = QgsGeometry.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+     *   for part in geometry.parts():
+     *       part.transform(ct)
+     *
+     *   # part iteration can also be combined with vertex iteration
+     *   geometry = QgsGeometry.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+     *   for part in geometry.parts():
+     *       for v in part.vertices():
+     *           print(v.x(), v.y())
+     *
+     * \endcode
+     *
+     * \see constParts()
+     * \see vertices()
+     * \since QGIS 3.6
+     */
+    QgsGeometryPartIterator parts();
+
+    /**
+     * Returns Java-style iterator for traversal of parts of the geometry. This iterator
+     * returns read-only references to parts and cannot be used to modify the parts.
+     *
+     * Unlike parts(), this method does not force a detach and is more efficient if read-only
+     * iteration only is required.
+     *
+     * * Example:
+     * \code{.py}
+     *   # print the WKT representation of each part in a multi-point geometry
+     *   geometry = QgsGeometry.fromWkt( 'MultiPoint( 0 0, 1 1, 2 2)' )
+     *   for part in geometry.parts():
+     *       print(part.asWkt())
+     *
+     *   # single part geometries only have one part - this loop will iterate once only
+     *   geometry = QgsGeometry.fromWkt( 'LineString( 0 0, 10 10 )' )
+     *   for part in geometry.parts():
+     *       print(part.asWkt())
+     *
+     *   # part iteration can also be combined with vertex iteration
+     *   geometry = QgsGeometry.fromWkt( 'MultiPolygon((( 0 0, 0 10, 10 10, 10 0, 0 0 ),( 5 5, 5 6, 6 6, 6 5, 5 5)),((20 2, 22 2, 22 4, 20 4, 20 2)))' )
+     *   for part in geometry.parts():
+     *       for v in part.vertices():
+     *           print(v.x(), v.y())
+     *
+     * \endcode
+     *
+     * \see parts()
+     * \see vertices()
+     * \since QGIS 3.6
+     */
+    QgsGeometryConstPartIterator constParts() const;
 
     /**
      * Returns the Hausdorff distance between this geometry and \a geom. This is basically a measure of how similar or dissimilar 2 geometries are.

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -425,7 +425,7 @@ class CORE_EXPORT QgsGeometry
      * This method forces a detach. Use const_parts_begin() to avoid the detach
      * if the parts are not going to be modified.
      *
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     QgsAbstractGeometry::part_iterator parts_begin();
 
@@ -435,7 +435,7 @@ class CORE_EXPORT QgsGeometry
      * This method forces a detach. Use const_parts_begin() to avoid the detach
      * if the parts are not going to be modified.
      *
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     QgsAbstractGeometry::part_iterator parts_end();
 
@@ -445,7 +445,7 @@ class CORE_EXPORT QgsGeometry
      * This method avoids a detach and is more efficient then parts_begin() for read
      * only iteration.
      *
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     QgsAbstractGeometry::const_part_iterator const_parts_begin() const;
 
@@ -455,7 +455,7 @@ class CORE_EXPORT QgsGeometry
      * This method avoids a detach and is more efficient then parts_end() for read
      * only iteration.
      *
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     QgsAbstractGeometry::const_part_iterator const_parts_end() const;
 #endif
@@ -494,7 +494,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \see constParts()
      * \see vertices()
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     QgsGeometryPartIterator parts();
 
@@ -527,7 +527,7 @@ class CORE_EXPORT QgsGeometry
      *
      * \see parts()
      * \see vertices()
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
     QgsGeometryConstPartIterator constParts() const;
 

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -88,7 +88,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
 #ifndef SIP_RUN
     QgsAbstractGeometry *geometryN( int n );
 #else
-    SIP_PYOBJECT geometryN( int n ) const;
+    SIP_PYOBJECT geometryN( int n );
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->numGeometries() )
     {

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -53,6 +53,24 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
       return mGeometries.size();
     }
 
+#ifdef SIP_RUN
+
+    /**
+     * Returns the number of geometries within the collection.
+     */
+    int __len__() const;
+    % MethodCode
+    sipRes = sipCpp->numGeometries();
+    % End
+
+    //! Ensures that bool(obj) returns true (otherwise __len__() would be used)
+    int __bool__() const;
+    % MethodCode
+    sipRes = true;
+    % End
+#endif
+
+
     /**
      * Returns a const reference to a geometry from within the collection.
      * \param n index of geometry to return
@@ -67,7 +85,23 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
      * Returns a geometry from within the collection.
      * \param n index of geometry to return
      */
+#ifndef SIP_RUN
     QgsAbstractGeometry *geometryN( int n );
+#else
+    SIP_PYOBJECT geometryN( int n ) const;
+    % MethodCode
+    if ( a0 < 0 || a0 >= sipCpp->numGeometries() )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      return sipConvertFromType( sipCpp->geometryN( a0 ), sipType_QgsAbstractGeometry, NULL );
+    }
+    % End
+#endif
+
 
     //methods inherited from QgsAbstractGeometry
     bool isEmpty() const override;

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -141,6 +141,13 @@ void QgsFeature::setGeometry( const QgsGeometry &geometry )
   d->valid = true;
 }
 
+void QgsFeature::setGeometry( std::unique_ptr<QgsAbstractGeometry> geometry )
+{
+  d.detach();
+  d->geometry = QgsGeometry( std::move( geometry ) );
+  d->valid = true;
+}
+
 void QgsFeature::clearGeometry()
 {
   setGeometry( QgsGeometry() );

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -351,7 +351,7 @@ class CORE_EXPORT QgsFeature
      * The feature will be made valid after calling this method.
      * \see geometry()
      * \see clearGeometry()
-     * \since QGIS 3.6
+     * \since QGIS 3.4.3
      */
 #ifndef SIP_RUN
     void setGeometry( std::unique_ptr< QgsAbstractGeometry > geometry );

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -349,6 +349,25 @@ class CORE_EXPORT QgsFeature
     /**
      * Set the feature's \a geometry. Ownership of the geometry is transferred to the feature.
      * The feature will be made valid after calling this method.
+     *
+     * This method is a shortcut for calling:
+     * \code{.py}
+     *   feature.setGeometry( QgsGeometry( geometry ) )
+     * \endcode
+     *
+     * * Example:
+     * \code{.py}
+     *   # Sets a feature's geometry to a point geometry
+     *   feature.setGeometry( QgsPoint( 210, 41 ) )
+     *   print(feature.geometry())
+     *   # output: <QgsGeometry: Point (210 41)>
+     *
+     *   # Sets a feature's geometry to a line string
+     *   feature.setGeometry( QgsLineString( [ QgsPoint( 210, 41 ), QgsPoint( 301, 55 ) ] ) )
+     *   print(feature.geometry())
+     *   # output: <QgsGeometry: LineString (210 41, 301 55)>
+     * \endcode
+     *
      * \see geometry()
      * \see clearGeometry()
      * \since QGIS 3.4.3

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -30,12 +30,13 @@ email                : sherman at mrcc.com
 #include "qgsattributes.h"
 #include "qgsfields.h"
 #include "qgsfeatureid.h"
-
+#include <memory>
 class QgsFeature;
 class QgsFeaturePrivate;
 class QgsField;
 class QgsGeometry;
 class QgsRectangle;
+class QgsAbstractGeometry;
 
 
 /***************************************************************************
@@ -344,6 +345,22 @@ class CORE_EXPORT QgsFeature
      * \see clearGeometry()
      */
     void setGeometry( const QgsGeometry &geometry );
+
+    /**
+     * Set the feature's \a geometry. Ownership of the geometry is transferred to the feature.
+     * The feature will be made valid after calling this method.
+     * \see geometry()
+     * \see clearGeometry()
+     * \since QGIS 3.6
+     */
+#ifndef SIP_RUN
+    void setGeometry( std::unique_ptr< QgsAbstractGeometry > geometry );
+#else
+    void setGeometry( QgsAbstractGeometry *geometry SIP_TRANSFER );
+    % MethodCode
+    sipCpp->setGeometry( std::unique_ptr< QgsAbstractGeometry>( a0 ) );
+    % End
+#endif
 
     /**
      * Removes any geometry associated with the feature.

--- a/tests/src/core/testqgsfeature.cpp
+++ b/tests/src/core/testqgsfeature.cpp
@@ -306,6 +306,13 @@ void TestQgsFeature::geometry()
   QCOMPARE( copy.geometry().asWkb(), geomByRef.asWkb() );
   QCOMPARE( feature.geometry().asWkb(), mGeometry.asWkb() );
 
+  //setGeometry using abstract geom
+  copy = feature;
+  QCOMPARE( copy.geometry().asWkb(), mGeometry.asWkb() );
+  copy.setGeometry( qgis::make_unique< QgsPoint >( 5, 6 ) );
+  QCOMPARE( copy.geometry().asWkt(), QStringLiteral( "Point (5 6)" ) );
+  QCOMPARE( feature.geometry().asWkb(), mGeometry.asWkb() );
+
   //clearGeometry
   QgsFeature geomFeature;
   geomFeature.setGeometry( QgsGeometry( mGeometry2 ) );

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -82,6 +82,7 @@ class TestQgsGeometry : public QObject
     void isEmpty();
     void equality();
     void vertexIterator();
+    void partIterator();
 
 
     // geometry types
@@ -475,6 +476,33 @@ void TestQgsGeometry::vertexIterator()
   QVERIFY( it2.hasNext() );
   QCOMPARE( it2.next(), QgsPoint( 3, 4 ) );
   QVERIFY( !it2.hasNext() );
+}
+
+void TestQgsGeometry::partIterator()
+{
+  QgsGeometry geom;
+  QgsGeometryPartIterator it = geom.parts();
+  QVERIFY( !it.hasNext() );
+
+  geom = QgsGeometry::fromWkt( QStringLiteral( "Point( 1 2 )" ) );
+  QgsGeometryConstPartIterator it2 = geom.constParts();
+  QVERIFY( it2.hasNext() );
+  QCOMPARE( it2.next()->asWkt(), QStringLiteral( "Point (1 2)" ) );
+  QVERIFY( !it2.hasNext() );
+
+  // test that non-const iterator detaches
+  QgsGeometry geom2 = geom;
+  it = geom2.parts();
+  QVERIFY( it.hasNext() );
+  QgsAbstractGeometry *part = it.next();
+  QCOMPARE( part->asWkt(), QStringLiteral( "Point (1 2)" ) );
+  static_cast< QgsPoint * >( part )->setX( 100 );
+  QCOMPARE( geom2.asWkt(), QStringLiteral( "Point (100 2)" ) );
+  QVERIFY( !it.hasNext() );
+  // geom2 should hve adetached, geom should be unaffected by change
+  QCOMPARE( geom.asWkt(), QStringLiteral( "Point (1 2)" ) );
+
+  // See test_qgsgeometry.py for geometry-type specific checks!
 }
 
 void TestQgsGeometry::point()

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -15,7 +15,14 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 import os
-from qgis.core import QgsFeature, QgsGeometry, QgsPointXY, QgsVectorLayer, NULL, QgsFields, QgsField
+from qgis.core import (QgsFeature,
+                       QgsPoint,
+                       QgsGeometry,
+                       QgsPointXY,
+                       QgsVectorLayer,
+                       NULL,
+                       QgsFields,
+                       QgsField)
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
 
@@ -137,6 +144,10 @@ class TestQgsFeature(unittest.TestCase):
         myExpectedGeometry = "!None"
         myMessage = '\nExpected: %s\nGot: %s' % (myExpectedGeometry, myGeometry)
         assert myGeometry is not None, myMessage
+
+        # set from QgsAbstractGeometry
+        feat.setGeometry(QgsPoint(12, 34))
+        self.assertEqual(feat.geometry().asWkt(), 'Point (12 34)')
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -242,6 +242,20 @@ class TestQgsGeometry(unittest.TestCase):
                 result = geom.constGet().perimeter()
                 self.assertAlmostEqual(result, exp, 5, "Perimeter {}: mismatch Expected:\n{}\nGot:\n{}\n".format(i + 1, exp, result))
 
+    def testCollection(self):
+        g = QgsGeometry.fromWkt('MultiLineString()')
+        self.assertEqual(len(g.get()), 0)
+        self.assertTrue(g.get())
+        g = QgsGeometry.fromWkt('MultiLineString((0 0, 1 1),(13 2, 14 1))')
+        self.assertEqual(len(g.get()), 2)
+        self.assertTrue(g.get())
+        self.assertEqual(g.get().geometryN(0).asWkt(), 'LineString (0 0, 1 1)')
+        self.assertEqual(g.get().geometryN(1).asWkt(), 'LineString (13 2, 14 1)')
+        with self.assertRaises(IndexError):
+            g.get().geometryN(-1)
+        with self.assertRaises(IndexError):
+            g.get().geometryN(2)
+
     def testIntersection(self):
         myLine = QgsGeometry.fromPolylineXY([
             QgsPointXY(0, 0),

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -95,6 +95,104 @@ class TestQgsGeometry(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(it)
 
+    def testPartIterator(self):
+        g = QgsGeometry()
+        it = g.parts()
+        with self.assertRaises(StopIteration):
+            next(it)
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # single point geometry
+        g = QgsGeometry.fromWkt('Point (10 10)')
+        it = g.parts()
+        self.assertEqual(next(it).asWkt(), 'Point (10 10)')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        it = g.get().parts()
+        self.assertEqual(next(it).asWkt(), 'Point (10 10)')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # multi point geometry
+        g = QgsGeometry.fromWkt('MultiPoint (10 10, 20 20, 10 20)')
+        it = g.parts()
+        self.assertEqual(next(it).asWkt(), 'Point (10 10)')
+        self.assertEqual(next(it).asWkt(), 'Point (20 20)')
+        self.assertEqual(next(it).asWkt(), 'Point (10 20)')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        it = g.get().parts()
+        self.assertEqual(next(it).asWkt(), 'Point (10 10)')
+        self.assertEqual(next(it).asWkt(), 'Point (20 20)')
+        self.assertEqual(next(it).asWkt(), 'Point (10 20)')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # empty multi point geometry
+        g = QgsGeometry.fromWkt('MultiPoint ()')
+        it = g.parts()
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # single line geometry
+        g = QgsGeometry.fromWkt('LineString (10 10, 20 10, 30 10)')
+        it = g.parts()
+        self.assertEqual(next(it).asWkt(), 'LineString (10 10, 20 10, 30 10)')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # multi line geometry
+        g = QgsGeometry.fromWkt('MultiLineString ((10 10, 20 20, 10 20),(5 7, 8 9))')
+        it = g.parts()
+        self.assertEqual(next(it).asWkt(), 'LineString (10 10, 20 20, 10 20)')
+        self.assertEqual(next(it).asWkt(), 'LineString (5 7, 8 9)')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # empty multi line geometry
+        g = QgsGeometry.fromWkt('MultiLineString ()')
+        it = g.parts()
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # single polygon geometry
+        g = QgsGeometry.fromWkt('Polygon ((10 10, 100 10, 100 100, 10 100, 10 10),(50 50, 55 50, 55 55, 50 55, 50 50))')
+        it = g.parts()
+        self.assertEqual(next(it).asWkt(), 'Polygon ((10 10, 100 10, 100 100, 10 100, 10 10),(50 50, 55 50, 55 55, 50 55, 50 50))')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # multi polygon geometry
+        g = QgsGeometry.fromWkt('MultiPolygon (((10 10, 100 10, 100 100, 10 100, 10 10),(50 50, 55 50, 55 55, 50 55, 50 50)),((20 2, 20 4, 22 4, 22 2, 20 2)))')
+        it = g.parts()
+        self.assertEqual(next(it).asWkt(), 'Polygon ((10 10, 100 10, 100 100, 10 100, 10 10),(50 50, 55 50, 55 55, 50 55, 50 50))')
+        self.assertEqual(next(it).asWkt(), 'Polygon ((20 2, 20 4, 22 4, 22 2, 20 2))')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # empty multi polygon geometry
+        g = QgsGeometry.fromWkt('MultiPolygon ()')
+        it = g.parts()
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # geometry collection
+        g = QgsGeometry.fromWkt('GeometryCollection( Point( 1 2), LineString( 4 5, 8 7 ))')
+        it = g.parts()
+        self.assertEqual(next(it).asWkt(), 'Point (1 2)')
+        self.assertEqual(next(it).asWkt(), 'LineString (4 5, 8 7)')
+        with self.assertRaises(StopIteration):
+            next(it)
+
+        # empty geometry collection
+        g = QgsGeometry.fromWkt('GeometryCollection()')
+        it = g.parts()
+        with self.assertRaises(StopIteration):
+            next(it)
+
     def testWktPointLoading(self):
         myWKT = 'Point (10 10)'
         myGeometry = QgsGeometry.fromWkt(myWKT)


### PR DESCRIPTION
This PR backports the nicer ".parts()" iterator from master API to the 3.4 LTR branch, so that plugins can safely use this API and still be compatible with the LTR version.

As requested by @anitagraser (https://twitter.com/underdarkGIS/status/1067062621906571264)
