### PR TITLE
Locator action filter fixes

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -242,6 +242,7 @@ class ProcessingPlugin:
         self.editInPlaceAction.setObjectName('editInPlaceFeatures')
         self.editInPlaceAction.setCheckable(True)
         self.editInPlaceAction.toggled.connect(self.editSelected)
+        self.menu.addAction(self.editInPlaceAction)
         self.toolbox.processingToolbar.addAction(self.editInPlaceAction)
 
         self.toolbox.processingToolbar.addSeparator()

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -146,6 +146,7 @@ void QgsActionLocatorFilter::searchActions( const QString &string, QWidget *pare
   }
 
   QRegularExpression extractFromTooltip( QStringLiteral( "<b>(.*)</b>" ) );
+  QRegularExpression newLineToSpace( QStringLiteral( "[\\s\\n\\r]+" ) );
 
   Q_FOREACH ( QAction *action, parent->actions() )
   {
@@ -164,6 +165,7 @@ void QgsActionLocatorFilter::searchActions( const QString &string, QWidget *pare
     searchText.replace( '&', QString() );
 
     QString tooltip = action->toolTip();
+    tooltip.replace( newLineToSpace, QStringLiteral( " " ) );
     QRegularExpressionMatch match = extractFromTooltip.match( tooltip );
     if ( match.hasMatch() )
     {

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -173,7 +173,12 @@ void QgsActionLocatorFilter::searchActions( const QString &string, QWidget *pare
     tooltip.replace( QStringLiteral( "…" ), QString() );
     searchText.replace( QStringLiteral( "..." ), QString() );
     searchText.replace( QStringLiteral( "…" ), QString() );
-    if ( searchText.trimmed().compare( tooltip.trimmed(), Qt::CaseInsensitive ) != 0 )
+    bool uniqueTooltip = searchText.trimmed().compare( tooltip.trimmed(), Qt::CaseInsensitive ) != 0;
+    if ( action->isChecked() )
+    {
+      searchText += QStringLiteral( " [%1]" ).arg( tr( "Active" ) );
+    }
+    if ( uniqueTooltip )
     {
       searchText += QStringLiteral( " (%1)" ).arg( tooltip.trimmed() );
     }


### PR DESCRIPTION
## Description
@nyalldawson , I noticed we were missing an important processing menu shortcut: in-place editing. It's useful for folks primarily relying on the locator to run processing algorithms.

While doing so, I fixed an issue with multi-line tooltips, and added an [Active] tag into the locator action item text for checked actions (very useful again).

The result:
![image](https://user-images.githubusercontent.com/1728657/49125057-41378d80-f2f1-11e8-9ec0-63f03988ba9c.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
