### PR TITLE
Rastercalculator memory efficient track

### DIFF
--- a/python/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
@@ -74,6 +74,22 @@ QgsRasterCalcNode cannot be copied
     void setRight( QgsRasterCalcNode *right );
 
 
+    QString toString( bool cStyle = false ) const;
+%Docstring
+Returns a string representation of the expression
+
+:param cStyle: if true operators will follow C syntax
+
+.. versionadded:: 3.6
+%End
+
+    QList<const QgsRasterCalcNode *> findNodes( const QgsRasterCalcNode::Type type ) const;
+%Docstring
+Populates a list of nodes of a specific type.
+
+.. versionadded:: 3.6
+%End
+
     static QgsRasterCalcNode *parseRasterCalcString( const QString &str, QString &parserErrorMsg ) /Factory/;
 
   private:

--- a/python/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalcnode.sip.in
@@ -85,7 +85,7 @@ Returns a string representation of the expression
 
     QList<const QgsRasterCalcNode *> findNodes( const QgsRasterCalcNode::Type type ) const;
 %Docstring
-Populates a list of nodes of a specific type.
+Returns a list of nodes of a specific ``type``
 
 .. versionadded:: 3.6
 %End

--- a/python/plugins/processing/algs/qgis/RasterCalculator.py
+++ b/python/plugins/processing/algs/qgis/RasterCalculator.py
@@ -168,8 +168,8 @@ class RasterCalculator(QgisAlgorithm):
 
         output = self.parameterAsOutputLayer(parameters, self.OUTPUT, context)
 
-        width = math.floor((bbox.xMaximum() - bbox.xMinimum()) / cellsize)
-        height = math.floor((bbox.yMaximum() - bbox.yMinimum()) / cellsize)
+        width = round((bbox.xMaximum() - bbox.xMinimum()) / cellsize)
+        height = round((bbox.yMaximum() - bbox.yMinimum()) / cellsize)
         driverName = GdalUtils.getFormatShortNameFromFilename(output)
 
         calc = QgsRasterCalculator(expression,

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -2563,7 +2563,7 @@ tests:
       EXPRESSION: dem@1
     results:
       OUTPUT:
-        hash: ef97a22ee16e0e28bbdc0341449777b1527e37febc3c4339b2c057c9
+        hash: 525577c05dd999239d9c6f95fd5e70d96355da3a0ea71bfcf021e729
         type: rasterhash
 
   - algorithm: qgis:rastercalculator
@@ -2578,7 +2578,7 @@ tests:
       EXPRESSION: dem@1 * 2
     results:
       OUTPUT:
-        hash: fe6e018be13c5a3c17f3f4d0f0dc7686c628cb440b74c4642aa0c939
+        hash: 98daf025230ec9d031f7502c6a80a3b04dd060808d6b7bcb4328e87c
         type: rasterhash
 
   - algorithm: native:orientedminimumboundingbox

--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -16,6 +16,7 @@
 #include "qgsrasterblock.h"
 #include "qgsrastermatrix.h"
 #include <cfloat>
+#include <QtDebug>
 
 QgsRasterCalcNode::QgsRasterCalcNode( double number )
   : mNumber( number )
@@ -78,6 +79,7 @@ bool QgsRasterCalcNode::calculate( QMap<QString, QgsRasterBlock * > &rasterData,
     {
       for ( int dataCol = 0; dataCol < nCols; ++dataCol )
       {
+        //qDebug() << "Reading value:" << dataRow <<  dataCol << ( *it )->value( dataRow, dataCol );
         data[ dataCol + nCols * outRow] = ( *it )->isNoData( dataRow, dataCol ) ? result.nodataValue() : ( *it )->value( dataRow, dataCol );
       }
     }
@@ -308,14 +310,16 @@ QString QgsRasterCalcNode::toString( bool cStyle ) const
   return result;
 }
 
-void QgsRasterCalcNode::findNodes( const QgsRasterCalcNode::Type type, QList<const QgsRasterCalcNode *> &nodeList ) const
+QList<const QgsRasterCalcNode *> QgsRasterCalcNode::findNodes( const QgsRasterCalcNode::Type type ) const
 {
+  QList<const QgsRasterCalcNode *> nodeList;
   if ( mType == type )
     nodeList.push_back( this );
   if ( mLeft )
-    mLeft->findNodes( type, nodeList );
+    nodeList.append( mLeft->findNodes( type ) );
   if ( mRight )
-    mRight->findNodes( type, nodeList );
+    nodeList.append( mRight->findNodes( type ) );
+  return nodeList;
 }
 
 QgsRasterCalcNode *QgsRasterCalcNode::parseRasterCalcString( const QString &str, QString &parserErrorMsg )

--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -199,6 +199,125 @@ bool QgsRasterCalcNode::calculate( QMap<QString, QgsRasterBlock * > &rasterData,
   return false;
 }
 
+QString QgsRasterCalcNode::toString( bool cStyle ) const
+{
+  QString result;
+  QString left;
+  QString right;
+  if ( mLeft )
+    left = mLeft->toString( cStyle );
+  if ( mRight )
+    right = mRight->toString( cStyle );
+  switch ( mType )
+  {
+    case tOperator:
+      switch ( mOperator )
+      {
+        case opPLUS:
+          result = QStringLiteral( "%1 + %2" ).arg( left ).arg( right );
+          break;
+        case opMINUS:
+        case opSIGN:
+          result = QStringLiteral( "%1 - %2" ).arg( left ).arg( right );
+          break;
+        case opMUL:
+          result = QStringLiteral( "%1 * %2" ).arg( left ).arg( right );
+          break;
+        case opDIV:
+          result = QStringLiteral( "%1 / %2" ).arg( left ).arg( right );
+          break;
+        case opPOW:
+          if ( cStyle )
+            result = QStringLiteral( "pow( %1, %2 )" ).arg( left ).arg( right );
+          else
+            result = QStringLiteral( "%1^%2" ).arg( left ).arg( right );
+          break;
+        case opEQ:
+          if ( cStyle )
+            result = QStringLiteral( "%1 == %2" ).arg( left ).arg( right );
+          else
+            result = QStringLiteral( "%1 = %2" ).arg( left ).arg( right );
+          break;
+        case opNE:
+          result = QStringLiteral( "%1 != %2" ).arg( left ).arg( right );
+          break;
+        case opGT:
+          result = QStringLiteral( "%1 > %2" ).arg( left ).arg( right );
+          break;
+        case opLT:
+          result = QStringLiteral( "%1 < %2" ).arg( left ).arg( right );
+          break;
+        case opGE:
+          result = QStringLiteral( "%1 >= %2" ).arg( left ).arg( right );
+          break;
+        case opLE:
+          result = QStringLiteral( "%1 <= %2" ).arg( left ).arg( right );
+          break;
+        case opAND:
+          if ( cStyle )
+            result = QStringLiteral( "%1 && %2" ).arg( left ).arg( right );
+          else
+            result = QStringLiteral( "%1 AND %2" ).arg( left ).arg( right );
+          break;
+        case opOR:
+          if ( cStyle )
+            result = QStringLiteral( "%1 || %2" ).arg( left ).arg( right );
+          else
+            result = QStringLiteral( "%1 OR%2" ).arg( left ).arg( right );
+          break;
+        case opSQRT:
+          result = QStringLiteral( "sqrt( %1 )" ).arg( left );
+          break;
+        case opSIN:
+          result = QStringLiteral( "sin( %1 )" ).arg( left );
+          break;
+        case opCOS:
+          result = QStringLiteral( "cos( %1 )" ).arg( left );
+          break;
+        case opTAN:
+          result = QStringLiteral( "tan( %1 )" ).arg( left );
+          break;
+        case opASIN:
+          result = QStringLiteral( "asin( %1 )" ).arg( left );
+          break;
+        case opACOS:
+          result = QStringLiteral( "acos( %1 )" ).arg( left );
+          break;
+        case opATAN:
+          result = QStringLiteral( "atan( %1 )" ).arg( left );
+          break;
+        case opLOG:
+          result = QStringLiteral( "log( %1 )" ).arg( left );
+          break;
+        case opLOG10:
+          result = QStringLiteral( "log10( %1 )" ).arg( left );
+          break;
+        case opNONE:
+          break;
+      }
+      break;
+    case tRasterRef:
+      result = QStringLiteral( "\"%1\"" ).arg( mRasterName );
+      break;
+    case tNumber:
+      result = QString::number( mNumber );
+      break;
+    case tMatrix:
+      break;
+  }
+  return result;
+}
+
+void QgsRasterCalcNode::findNodes( const QgsRasterCalcNode::Type type, QList<const QgsRasterCalcNode *> &nodeList ) const
+{
+  if ( mType == type )
+    nodeList.push_back( this );
+  if ( mLeft )
+    mLeft->findNodes( type, nodeList );
+  if ( mRight )
+    mRight->findNodes( type, nodeList );
+}
+
 QgsRasterCalcNode *QgsRasterCalcNode::parseRasterCalcString( const QString &str, QString &parserErrorMsg )
 {
   extern QgsRasterCalcNode *localParseRasterCalcString( const QString & str, QString & parserErrorMsg );

--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -79,7 +79,6 @@ bool QgsRasterCalcNode::calculate( QMap<QString, QgsRasterBlock * > &rasterData,
     {
       for ( int dataCol = 0; dataCol < nCols; ++dataCol )
       {
-        //qDebug() << "Reading value:" << dataRow <<  dataCol << ( *it )->value( dataRow, dataCol );
         data[ dataCol + nCols * outRow] = ( *it )->isNoData( dataRow, dataCol ) ? result.nodataValue() : ( *it )->value( dataRow, dataCol );
       }
     }

--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -264,7 +264,7 @@ QString QgsRasterCalcNode::toString( bool cStyle ) const
           if ( cStyle )
             result = QStringLiteral( "%1 || %2" ).arg( left ).arg( right );
           else
-            result = QStringLiteral( "%1 OR%2" ).arg( left ).arg( right );
+            result = QStringLiteral( "%1 OR %2" ).arg( left ).arg( right );
           break;
         case opSQRT:
           result = QStringLiteral( "sqrt( %1 )" ).arg( left );

--- a/src/analysis/raster/qgsrastercalcnode.h
+++ b/src/analysis/raster/qgsrastercalcnode.h
@@ -117,7 +117,7 @@ class ANALYSIS_EXPORT QgsRasterCalcNode
      * Populates a list of nodes of a specific type.
      * \since QGIS 3.6
      */
-    void findNodes( const QgsRasterCalcNode::Type type, QList<const QgsRasterCalcNode *> &nodeList ) const;
+    QList<const QgsRasterCalcNode *> findNodes( const QgsRasterCalcNode::Type type ) const;
 
     static QgsRasterCalcNode *parseRasterCalcString( const QString &str, QString &parserErrorMsg ) SIP_FACTORY;
 

--- a/src/analysis/raster/qgsrastercalcnode.h
+++ b/src/analysis/raster/qgsrastercalcnode.h
@@ -106,6 +106,19 @@ class ANALYSIS_EXPORT QgsRasterCalcNode
      */
     bool calculate( QMap<QString, QgsRasterBlock * > &rasterData, QgsRasterMatrix &result, int row = -1 ) const SIP_SKIP;
 
+    /**
+     * Returns a string representation of the expression
+     * \param cStyle if true operators will follow C syntax
+     * \since QGIS 3.6
+     */
+    QString toString( bool cStyle = false ) const;
+
+    /**
+     * Populates a list of nodes of a specific type.
+     * \since QGIS 3.6
+     */
+    void findNodes( const QgsRasterCalcNode::Type type, QList<const QgsRasterCalcNode *> &nodeList ) const;
+
     static QgsRasterCalcNode *parseRasterCalcString( const QString &str, QString &parserErrorMsg ) SIP_FACTORY;
 
   private:

--- a/src/analysis/raster/qgsrastercalcnode.h
+++ b/src/analysis/raster/qgsrastercalcnode.h
@@ -114,7 +114,7 @@ class ANALYSIS_EXPORT QgsRasterCalcNode
     QString toString( bool cStyle = false ) const;
 
     /**
-     * Populates a list of nodes of a specific type.
+     * Returns a list of nodes of a specific \a type
      * \since QGIS 3.6
      */
     QList<const QgsRasterCalcNode *> findNodes( const QgsRasterCalcNode::Type type ) const;

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -140,7 +140,7 @@ QgsRasterCalculator::Result QgsRasterCalculator::processCalculation( QgsFeedback
     std::vector<float> castedResult;
     castedResult.reserve( static_cast<size_t>( mNumOutputColumns ) );
     auto rowHeight = mOutputRectangle.height() / mNumOutputRows;
-    for ( size_t row = 0; row < mNumOutputRows; ++row )
+    for ( size_t row = 0; row < static_cast<size_t>( mNumOutputRows ); ++row )
     {
       if ( feedback )
       {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5683,14 +5683,14 @@ void QgisApp::showRasterCalculator()
     //invoke analysis library
     QgsRasterCalculator rc( d.formulaString(), d.outputFile(), d.outputFormat(), d.outputRectangle(), d.outputCrs(), d.numberOfColumns(), d.numberOfRows(), d.rasterEntries() );
 
-    QProgressDialog p( tr( "Calculating…" ), tr( "Abort" ), 0, 0 );
+    QProgressDialog p( tr( "Calculating raster expression…" ), tr( "Abort" ), 0, 0 );
     p.setWindowModality( Qt::WindowModal );
     p.setMaximum( 100.0 );
     QgsFeedback feedback;
     connect( &feedback, &QgsFeedback::progressChanged, &p, &QProgressDialog::setValue );
     connect( &p, &QProgressDialog::canceled, &feedback, &QgsFeedback::cancel );
     p.show();
-    QgsRasterCalculator::Result res = static_cast< QgsRasterCalculator::Result >( rc.processCalculation( &feedback ) );
+    QgsRasterCalculator::Result res = rc.processCalculation( &feedback );
     switch ( res )
     {
       case QgsRasterCalculator::Success:

--- a/src/app/qgsrastercalcdialog.cpp
+++ b/src/app/qgsrastercalcdialog.cpp
@@ -375,12 +375,12 @@ void QgsRasterCalcDialog::mDividePushButton_clicked()
 
 void QgsRasterCalcDialog::mSqrtButton_clicked()
 {
-  mExpressionTextEdit->insertPlainText( QStringLiteral( " std::sqrt ( " ) );
+  mExpressionTextEdit->insertPlainText( QStringLiteral( " sqrt ( " ) );
 }
 
 void QgsRasterCalcDialog::mCosButton_clicked()
 {
-  mExpressionTextEdit->insertPlainText( QStringLiteral( " std::cos ( " ) );
+  mExpressionTextEdit->insertPlainText( QStringLiteral( " cos ( " ) );
 }
 
 void QgsRasterCalcDialog::mSinButton_clicked()

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -538,19 +538,11 @@ void TestQgsRasterCalculator::findNodes()
   std::unique_ptr< QgsRasterCalcNode > calcNode;
 
   auto _test =
-    [ & ]( QString exp, const QgsRasterCalcNode::Type type ) -> QStringList
+    [ & ]( QString exp, const QgsRasterCalcNode::Type type ) -> QList<const QgsRasterCalcNode *>
   {
-    QList<const QgsRasterCalcNode *> nodeList;
     QString error;
     calcNode.reset( QgsRasterCalcNode::parseRasterCalcString( exp, error ) );
-    if ( error.isEmpty() )
-      calcNode->findNodes( type, nodeList );
-    QStringList result;
-    for ( const auto &n : nodeList )
-    {
-      result.push_back( n->toString( true ) );
-    }
-    return result;
+    return calcNode->findNodes( type );
   };
 
   QCOMPARE( _test( QStringLiteral( "atan(\"raster@1\") * cos( 3  +  2 )" ), QgsRasterCalcNode::Type::tOperator ).length(), 4 );
@@ -641,6 +633,25 @@ void TestQgsRasterCalculator::errors( )
   QCOMPARE( static_cast< int >( rc.processCalculation( &feedback ) ), 3 );
   QVERIFY( rc.lastError().isEmpty() );
 }
+
+void TestQgsRasterCalculator::toString()
+{
+  auto _test = [ ]( QString exp, bool cStyle ) -> QString
+  {
+    QString error;
+    std::unique_ptr< QgsRasterCalcNode > calcNode( QgsRasterCalcNode::parseRasterCalcString( exp, error ) );
+    if ( ! error.isEmpty() )
+      return error;
+    return calcNode->toString( cStyle );
+  };
+  QCOMPARE( _test( QStringLiteral( "\"raster@1\"  +  2" ), false ), QString( "\"raster@1\" + 2" ) );
+  QCOMPARE( _test( QStringLiteral( "\"raster@1\"  +  2" ), true ), QString( "\"raster@1\" + 2" ) );
+  QCOMPARE( _test( QStringLiteral( "\"raster@1\" ^ 3  +  2" ), false ), QString( "\"raster@1\"^3 + 2" ) );
+  QCOMPARE( _test( QStringLiteral( "\"raster@1\" ^ 3  +  2" ), true ), QString( "pow( \"raster@1\", 3 ) + 2" ) );
+  QCOMPARE( _test( QStringLiteral( "atan(\"raster@1\") * cos( 3  +  2 )" ), false ), QString( "atan( \"raster@1\" ) * cos( 3 + 2 )" ) );
+  QCOMPARE( _test( QStringLiteral( "atan(\"raster@1\") * cos( 3  +  2 )" ), true ), QString( "atan( \"raster@1\" ) * cos( 3 + 2 )" ) );
+}
+
 
 QGSTEST_MAIN( TestQgsRasterCalculator )
 #include "testqgsrastercalculator.moc"


### PR DESCRIPTION
One of the biggest problems in raster calculator was that the ~~original~~ current implementation was reading ALL input rasters as a whole into memory before even starting the computation.

The code was written many years ago and left more or less untouched since it was written, apparently it was wisely designed to support matrix operations that needed to access to different portions of the raster, this is probably the reason why the rasters were read entirely. If I'm not wrong, the matrix operations have been never implemented (@mhugent can you please confirm if my deductions are correct ?).

This PR adds a memory efficient path in case there are no matrix operations in the expression, this path processes the input rasters by reading them row by row, with a side advantage of allowing the process to be interrupted by the user, which was not possible during the raster reading phase in the original path.




