### PR TITLE
first example deleted, cause it is for combine function

### DIFF
--- a/resources/function_help/json/contains
+++ b/resources/function_help/json/contains
@@ -4,9 +4,7 @@
   "description": "Tests whether a geometry contains another. Returns true if and only if no points of geometry b lie in the exterior of geometry a, and at least one point of the interior of b lies in the interior of a.",
   "arguments": [ {"arg":"geometry a","description":"a geometry"},
                  {"arg":"geometry b","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 2 1)' ) ) )", "returns":"MULTILINESTRING((4 4, 2 1), (3 3, 4 4), (4 4, 5 5))"},
-  { "expression":"contains( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ), geom_from_wkt( 'POINT(0.5 0.5 )' ) )", "returns":"true"},
+  "examples": [ { "expression":"contains( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ), geom_from_wkt( 'POINT(0.5 0.5 )' ) )", "returns":"true"},
   { "expression":"contains( geom_from_wkt( 'POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ) )", "returns":"false"}
   ]
 }
-

--- a/resources/function_help/json/convex_hull
+++ b/resources/function_help/json/convex_hull
@@ -3,8 +3,6 @@
   "type": "function",
   "description": "Returns the convex hull of a geometry. It represents the minimum convex geometry that encloses all geometries within the set.",
   "arguments": [ {"arg":"geometry","description":"a geometry"}],
-  "examples": [ { "expression":"geom_to_wkt( combine( geom_from_wkt( 'LINESTRING(3 3, 4 4, 5 5)' ), geom_from_wkt( 'LINESTRING(3 3, 4 4, 2 1)' ) ) )", "returns":"MULTILINESTRING((4 4, 2 1), (3 3, 4 4), (4 4, 5 5))"},
-  { "expression":"geom_to_wkt( convex_hull( geom_from_wkt( 'LINESTRING(3 3, 4 4, 4 10)' ) ) )", "returns":"POLYGON((3 3,4 10,4 4,3 3))"}
+  "examples": [ { "expression":"geom_to_wkt( convex_hull( geom_from_wkt( 'LINESTRING(3 3, 4 4, 4 10)' ) ) )", "returns":"POLYGON((3 3,4 10,4 4,3 3))"}
   ]
 }
-


### PR DESCRIPTION
deleting the first example in "contains" and "convex-hull" functions, cause they are for "combine" function (and come from there)