### PR TITLE
Fixes for exporting labels/text as text objects, not paths

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutexporter.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutexporter.sip.in
@@ -188,6 +188,8 @@ Constructor for PdfExportSettings
 
       QgsLayoutRenderContext::Flags flags;
 
+      QgsRenderContext::TextRenderFormat textRenderFormat;
+
     };
 
     ExportResult exportToPdf( const QString &filePath, const QgsLayoutExporter::PdfExportSettings &settings );
@@ -285,6 +287,8 @@ Constructor for SvgExportSettings
       bool exportMetadata;
 
       QgsLayoutRenderContext::Flags flags;
+
+      QgsRenderContext::TextRenderFormat textRenderFormat;
 
     };
 

--- a/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -204,6 +204,24 @@ If ``layer`` is -1, all item layers should be rendered.
 .. seealso:: :py:func:`setCurrentExportLayer`
 %End
 
+    QgsRenderContext::TextRenderFormat textRenderFormat() const;
+%Docstring
+Returns the text render format, which dictates how text is rendered (e.g. as paths or real text objects).
+
+.. seealso:: :py:func:`setTextRenderFormat`
+
+.. versionadded:: 3.4.3
+%End
+
+    void setTextRenderFormat( QgsRenderContext::TextRenderFormat format );
+%Docstring
+Sets the text render ``format``, which dictates how text is rendered (e.g. as paths or real text objects).
+
+.. seealso:: :py:func:`textRenderFormat`
+
+.. versionadded:: 3.4.3
+%End
+
   signals:
 
     void flagsChanged( QgsLayoutRenderContext::Flags flags );

--- a/python/core/auto_generated/qgslabelingenginesettings.sip.in
+++ b/python/core/auto_generated/qgslabelingenginesettings.sip.in
@@ -8,7 +8,6 @@
 
 
 
-
 class QgsLabelingEngineSettings
 {
 %Docstring
@@ -25,6 +24,7 @@ Stores global configuration for labeling engine
     {
       UseAllLabels,
       UsePartialCandidates,
+      // TODO QGIS 4.0: remove
       RenderOutlineLabels,
       DrawLabelRectOnly,
       DrawCandidates,
@@ -90,6 +90,25 @@ Read configuration of the labeling engine from a project
     void writeSettingsToProject( QgsProject *project );
 %Docstring
 Write configuration of the labeling engine to a project
+%End
+
+
+    QgsRenderContext::TextRenderFormat defaultTextRenderFormat() const;
+%Docstring
+Returns the default text rendering format for the labels.
+
+.. seealso:: :py:func:`setDefaultTextRenderFormat`
+
+.. versionadded:: 3.4.3
+%End
+
+    void setDefaultTextRenderFormat( QgsRenderContext::TextRenderFormat format );
+%Docstring
+Sets the default text rendering ``format`` for the labels.
+
+.. seealso:: :py:func:`defaultTextRenderFormat`
+
+.. versionadded:: 3.4.3
 %End
 
 };

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -283,6 +283,24 @@ Returns combination of flags used for rendering
 Check whether a particular flag is enabled
 %End
 
+    QgsRenderContext::TextRenderFormat textRenderFormat() const;
+%Docstring
+Returns the text render format, which dictates how text is rendered (e.g. as paths or real text objects).
+
+.. seealso:: :py:func:`setTextRenderFormat`
+
+.. versionadded:: 3.4.3
+%End
+
+    void setTextRenderFormat( QgsRenderContext::TextRenderFormat format );
+%Docstring
+Sets the text render ``format``, which dictates how text is rendered (e.g. as paths or real text objects).
+
+.. seealso:: :py:func:`textRenderFormat`
+
+.. versionadded:: 3.4.3
+%End
+
     void setOutputImageFormat( QImage::Format format );
 %Docstring
 sets format of internal QImage
@@ -499,6 +517,7 @@ Returns global configuration of the labeling engine
 %End
 
   protected:
+
 
 
 

--- a/python/core/auto_generated/qgsmapsettings.sip.in
+++ b/python/core/auto_generated/qgsmapsettings.sip.in
@@ -296,6 +296,11 @@ Returns the text render format, which dictates how text is rendered (e.g. as pat
 %Docstring
 Sets the text render ``format``, which dictates how text is rendered (e.g. as paths or real text objects).
 
+.. warning::
+
+   Calling the setLabelingEngineSettings() method will reset the text render format to match the default
+   text render format from the label engine settings.
+
 .. seealso:: :py:func:`textRenderFormat`
 
 .. versionadded:: 3.4.3
@@ -504,14 +509,24 @@ Gets segmentation tolerance type (maximum angle or maximum difference between cu
 
     void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings );
 %Docstring
-Sets global configuration of the labeling engine
+Sets the global configuration of the labeling engine.
+
+.. note::
+
+   Calling this method will reset the textRenderFormat() to match the default
+   text render format from the label engine ``settings``.
+
+.. seealso:: :py:func:`labelingEngineSettings`
+
 
 .. versionadded:: 3.0
 %End
 
     const QgsLabelingEngineSettings &labelingEngineSettings() const;
 %Docstring
-Returns global configuration of the labeling engine
+Returns the global configuration of the labeling engine.
+
+.. seealso:: :py:func:`setLabelingEngineSettings`
 
 .. versionadded:: 3.0
 %End

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -47,7 +47,11 @@ to be rendered etc.
 
     enum TextRenderFormat
     {
+      // refs for below dox: https://github.com/qgis/QGIS/pull/1286#issuecomment-39806854
+      // https://github.com/qgis/QGIS/pull/8573#issuecomment-445585826
+
       TextFormatAlwaysOutlines,
+
       TextFormatAlwaysText,
     };
 

--- a/python/core/auto_generated/qgsrendercontext.sip.in
+++ b/python/core/auto_generated/qgsrendercontext.sip.in
@@ -45,6 +45,12 @@ to be rendered etc.
     typedef QFlags<QgsRenderContext::Flag> Flags;
 
 
+    enum TextRenderFormat
+    {
+      TextFormatAlwaysOutlines,
+      TextFormatAlwaysText,
+    };
+
     void setFlags( QgsRenderContext::Flags flags );
 %Docstring
 Set combination of flags that will be used for rendering.
@@ -392,6 +398,24 @@ Convert meter distances to active MapUnit values for QgsUnitTypes.RenderMetersIn
 When the sourceCrs() is geographic, the center of the Extent will be used
 
 .. versionadded:: 3.0
+%End
+
+    TextRenderFormat textRenderFormat() const;
+%Docstring
+Returns the text render format, which dictates how text is rendered (e.g. as paths or real text objects).
+
+.. seealso:: :py:func:`setTextRenderFormat`
+
+.. versionadded:: 3.4.3
+%End
+
+    void setTextRenderFormat( TextRenderFormat format );
+%Docstring
+Sets the text render ``format``, which dictates how text is rendered (e.g. as paths or real text objects).
+
+.. seealso:: :py:func:`textRenderFormat`
+
+.. versionadded:: 3.4.3
 %End
 
 };

--- a/python/core/auto_generated/qgstextrenderer.sip.in
+++ b/python/core/auto_generated/qgstextrenderer.sip.in
@@ -1555,6 +1555,7 @@ Calculates pixel size (considering output size should be in pixel or map units, 
 :return: font pixel size
 %End
 
+
     static void drawText( const QRectF &rect, double rotation, HAlignment alignment, const QStringList &textLines,
                           QgsRenderContext &context, const QgsTextFormat &format,
                           bool drawAsOutlines = true );
@@ -1569,7 +1570,8 @@ Draws text within a rectangle using the specified settings.
 :param format: text format
 :param drawAsOutlines: set to false to render text as text. This allows outputs to
                        formats like SVG to maintain text as text objects, but at the cost of degraded
-                       rendering and may result in side effects like misaligned text buffers.
+                       rendering and may result in side effects like misaligned text buffers. This setting is deprecated and has no effect
+                       as of QGIS 3.4.3 and the text format should be set using QgsRenderContext.setTextRenderFormat() instead.
 %End
 
     static void drawText( QPointF point, double rotation, HAlignment alignment, const QStringList &textLines,
@@ -1586,7 +1588,8 @@ Draws text at a point origin using the specified settings.
 :param format: text format
 :param drawAsOutlines: set to false to render text as text. This allows outputs to
                        formats like SVG to maintain text as text objects, but at the cost of degraded
-                       rendering and may result in side effects like misaligned text buffers.
+                       rendering and may result in side effects like misaligned text buffers. This setting is deprecated and has no effect
+                       as of QGIS 3.4.3 and the text format should be set using QgsRenderContext.setTextRenderFormat() instead.
 %End
 
     static void drawPart( const QRectF &rect, double rotation, HAlignment alignment, const QStringList &textLines,
@@ -1606,7 +1609,8 @@ Draws a single component of rendered text using the specified settings.
              with the text or background parts)
 :param drawAsOutlines: set to false to render text as text. This allows outputs to
                        formats like SVG to maintain text as text objects, but at the cost of degraded
-                       rendering and may result in side effects like misaligned text buffers.
+                       rendering and may result in side effects like misaligned text buffers. This setting is deprecated and has no effect
+                       as of QGIS 3.4.3 and the text format should be set using QgsRenderContext.setTextRenderFormat() instead.
 %End
 
     static void drawPart( QPointF origin, double rotation, HAlignment alignment, const QStringList &textLines,
@@ -1626,7 +1630,8 @@ Draws a single component of rendered text using the specified settings.
              with the text or background parts)
 :param drawAsOutlines: set to false to render text as text. This allows outputs to
                        formats like SVG to maintain text as text objects, but at the cost of degraded
-                       rendering and may result in side effects like misaligned text buffers.
+                       rendering and may result in side effects like misaligned text buffers. This setting is deprecated and has no effect
+                       as of QGIS 3.4.3 and the text format should be set using QgsRenderContext.setTextRenderFormat() instead.
 %End
 
     static QFontMetricsF fontMetrics( QgsRenderContext &context, const QgsTextFormat &format );

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2064,12 +2064,12 @@ void QgsLayoutDesignerDialog::exportToPdf()
 
   setLastExportPath( outputFileName );
 
-  mView->setPaintingEnabled( false );
-  QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
-
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   if ( !getPdfExportSettings( pdfSettings ) )
     return;
+
+  mView->setPaintingEnabled( false );
+  QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
 
   QgsProxyProgressTask *proxyTask = new QgsProxyProgressTask( tr( "Exporting “%1”" ).arg( mMasterLayout->name() ) );
   QgsApplication::taskManager()->addTask( proxyTask );
@@ -2967,13 +2967,12 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
     outputFileName = QDir( dir ).filePath( QStringLiteral( "atlas" ) ); // filename is overridden by atlas
   }
 
-  mView->setPaintingEnabled( false );
-  QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
-
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   if ( !getPdfExportSettings( pdfSettings ) )
     return;
 
+  mView->setPaintingEnabled( false );
+  QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
   pdfSettings.rasterizeWholeImage = mLayout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
 
   QString error;
@@ -3345,9 +3344,6 @@ void QgsLayoutDesignerDialog::exportReportToPdf()
   }
   setLastExportPath( outputFileName );
 
-  mView->setPaintingEnabled( false );
-  QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
-
   bool rasterize = false;
   if ( mLayout )
   {
@@ -3356,6 +3352,9 @@ void QgsLayoutDesignerDialog::exportReportToPdf()
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   if ( !getPdfExportSettings( pdfSettings ) )
     return;
+
+  mView->setPaintingEnabled( false );
+  QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
 
   pdfSettings.rasterizeWholeImage = rasterize;
 

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -3969,7 +3969,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   double marginRight = 0.0;
   double marginBottom = 0.0;
   double marginLeft = 0.0;
-  bool previousForceVector = false;
+  bool forceVector = false;
   bool layersAsGroup = false;
   bool cropToContents = false;
   double topMargin = 0.0;
@@ -3979,7 +3979,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   bool includeMetadata = true;
   if ( mLayout )
   {
-    mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
+    forceVector = mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
     layersAsGroup = mLayout->customProperty( QStringLiteral( "svgGroupLayers" ), false ).toBool();
     cropToContents = mLayout->customProperty( QStringLiteral( "svgCropToContents" ), false ).toBool();
     topMargin = mLayout->customProperty( QStringLiteral( "svgCropMarginTop" ), 0 ).toInt();
@@ -4006,7 +4006,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   options.mTextRenderFormatComboBox->setCurrentIndex( options.mTextRenderFormatComboBox->findData( prevTextRenderFormat ) );
   options.chkMapLayersAsGroup->setChecked( layersAsGroup );
   options.mClipToContentGroupBox->setChecked( cropToContents );
-  options.mForceVectorCheckBox->setChecked( previousForceVector );
+  options.mForceVectorCheckBox->setChecked( forceVector );
   options.mTopMarginSpinBox->setValue( topMargin );
   options.mRightMarginSpinBox->setValue( rightMargin );
   options.mBottomMarginSpinBox->setValue( bottomMargin );
@@ -4023,6 +4023,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   marginBottom = options.mBottomMarginSpinBox->value();
   marginLeft = options.mLeftMarginSpinBox->value();
   includeMetadata = options.mIncludeMetadataCheckbox->isChecked();
+  forceVector = options.mForceVectorCheckBox->isChecked();
   QgsRenderContext::TextRenderFormat textRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( options.mTextRenderFormatComboBox->currentData().toInt() );
 
   if ( mLayout )
@@ -4035,12 +4036,13 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
     mLayout->setCustomProperty( QStringLiteral( "svgCropMarginBottom" ), marginBottom );
     mLayout->setCustomProperty( QStringLiteral( "svgCropMarginLeft" ), marginLeft );
     mLayout->setCustomProperty( QStringLiteral( "svgIncludeMetadata" ), includeMetadata ? 1 : 0 );
+    mLayout->setCustomProperty( QStringLiteral( "forceVector" ), forceVector ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "svgTextFormat" ), static_cast< int >( textRenderFormat ) );
   }
 
   settings.cropToContents = clipToContent;
   settings.cropMargins = QgsMargins( marginLeft, marginTop, marginRight, marginBottom );
-  settings.forceVectorOutput = options.mForceVectorCheckBox->isChecked();
+  settings.forceVectorOutput = forceVector;
   settings.exportAsLayers = groupLayers;
   settings.exportMetadata = includeMetadata;
   settings.textRenderFormat = textRenderFormat;
@@ -4051,11 +4053,11 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
 bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExportSettings &settings )
 {
   QgsRenderContext::TextRenderFormat prevTextRenderFormat = mMasterLayout->layoutProject()->labelingEngineSettings().defaultTextRenderFormat();
-  bool previousForceVector = false;
+  bool forceVector = false;
   bool includeMetadata = true;
   if ( mLayout )
   {
-    mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
+    forceVector = mLayout->customProperty( QStringLiteral( "forceVector" ), 0 ).toBool();
     includeMetadata = mLayout->customProperty( QStringLiteral( "pdfIncludeMetadata" ), 1 ).toBool();
     const int prevLayoutSettingLabelsAsOutlines = mLayout->customProperty( QStringLiteral( "pdfTextFormat" ), -1 ).toInt();
     if ( prevLayoutSettingLabelsAsOutlines >= 0 )
@@ -4074,23 +4076,25 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   options.mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Text Objects" ), QgsRenderContext::TextFormatAlwaysText );
 
   options.mTextRenderFormatComboBox->setCurrentIndex( options.mTextRenderFormatComboBox->findData( prevTextRenderFormat ) );
-  options.mForceVectorCheckBox->setChecked( previousForceVector );
+  options.mForceVectorCheckBox->setChecked( forceVector );
   options.mIncludeMetadataCheckbox->setChecked( includeMetadata );
 
   if ( dialog.exec() != QDialog::Accepted )
     return false;
 
   includeMetadata = options.mIncludeMetadataCheckbox->isChecked();
+  forceVector = options.mForceVectorCheckBox->isChecked();
   QgsRenderContext::TextRenderFormat textRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( options.mTextRenderFormatComboBox->currentData().toInt() );
 
   if ( mLayout )
   {
     //save dialog settings
+    mLayout->setCustomProperty( QStringLiteral( "forceVector" ), forceVector ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfIncludeMetadata" ), includeMetadata ? 1 : 0 );
     mLayout->setCustomProperty( QStringLiteral( "pdfTextFormat" ), static_cast< int >( textRenderFormat ) );
   }
 
-  settings.forceVectorOutput = options.mForceVectorCheckBox->isChecked();
+  settings.forceVectorOutput = forceVector;
   settings.exportMetadata = includeMetadata;
   settings.textRenderFormat = textRenderFormat;
 

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -3998,7 +3998,11 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   QDialog dialog;
   Ui::QgsSvgExportOptionsDialog options;
   options.setupUi( &dialog );
-  options.chkTextAsOutline->setChecked( prevTextRenderFormat == QgsRenderContext::TextFormatAlwaysOutlines );
+
+  options.mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Paths (Recommended)" ), QgsRenderContext::TextFormatAlwaysOutlines );
+  options.mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Text Objects" ), QgsRenderContext::TextFormatAlwaysText );
+
+  options.mTextRenderFormatComboBox->setCurrentIndex( options.mTextRenderFormatComboBox->findData( prevTextRenderFormat ) );
   options.chkMapLayersAsGroup->setChecked( layersAsGroup );
   options.mClipToContentGroupBox->setChecked( cropToContents );
   options.mForceVectorCheckBox->setChecked( previousForceVector );
@@ -4018,7 +4022,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   marginBottom = options.mBottomMarginSpinBox->value();
   marginLeft = options.mLeftMarginSpinBox->value();
   includeMetadata = options.mIncludeMetadataCheckbox->isChecked();
-  QgsRenderContext::TextRenderFormat textRenderFormat = options.chkTextAsOutline->isChecked() ? QgsRenderContext::TextFormatAlwaysOutlines : QgsRenderContext::TextFormatAlwaysText;
+  QgsRenderContext::TextRenderFormat textRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( options.mTextRenderFormatComboBox->currentData().toInt() );
 
   if ( mLayout )
   {

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -39,6 +39,7 @@
 #include "qgslayoutitemmap.h"
 #include "qgsprintlayout.h"
 #include "qgsmapcanvas.h"
+#include "qgsrendercontext.h"
 #include "qgsmessagebar.h"
 #include "qgsmessageviewer.h"
 #include "qgsgui.h"
@@ -3961,7 +3962,7 @@ bool QgsLayoutDesignerDialog::getRasterExportSettings( QgsLayoutExporter::ImageE
 bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExportSettings &settings )
 {
   bool groupLayers = false;
-  bool prevSettingLabelsAsOutlines = false;
+  QgsRenderContext::TextRenderFormat prevTextRenderFormat = mMasterLayout->layoutProject()->labelingEngineSettings().defaultTextRenderFormat();
   bool clipToContent = false;
   double marginTop = 0.0;
   double marginRight = 0.0;
@@ -3985,14 +3986,19 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
     bottomMargin = mLayout->customProperty( QStringLiteral( "svgCropMarginBottom" ), 0 ).toInt();
     leftMargin = mLayout->customProperty( QStringLiteral( "svgCropMarginLeft" ), 0 ).toInt();
     includeMetadata = mLayout->customProperty( QStringLiteral( "svgIncludeMetadata" ), 1 ).toBool();
-    prevSettingLabelsAsOutlines = mLayout->customProperty( QStringLiteral( "svgRenderTextAsOutlines" ), 1 ).toBool();
+    const int prevLayoutSettingLabelsAsOutlines = mLayout->customProperty( QStringLiteral( "svgTextFormat" ), -1 ).toInt();
+    if ( prevLayoutSettingLabelsAsOutlines >= 0 )
+    {
+      // previous layout setting takes default over project setting
+      prevTextRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( prevLayoutSettingLabelsAsOutlines );
+    }
   }
 
   // open options dialog
   QDialog dialog;
   Ui::QgsSvgExportOptionsDialog options;
   options.setupUi( &dialog );
-  options.chkTextAsOutline->setChecked( prevSettingLabelsAsOutlines );
+  options.chkTextAsOutline->setChecked( prevTextRenderFormat == QgsRenderContext::TextFormatAlwaysOutlines );
   options.chkMapLayersAsGroup->setChecked( layersAsGroup );
   options.mClipToContentGroupBox->setChecked( cropToContents );
   options.mForceVectorCheckBox->setChecked( previousForceVector );
@@ -4024,7 +4030,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
     mLayout->setCustomProperty( QStringLiteral( "svgCropMarginBottom" ), marginBottom );
     mLayout->setCustomProperty( QStringLiteral( "svgCropMarginLeft" ), marginLeft );
     mLayout->setCustomProperty( QStringLiteral( "svgIncludeMetadata" ), includeMetadata ? 1 : 0 );
-    mLayout->setCustomProperty( QStringLiteral( "svgRenderTextAsOutlines" ), textRenderFormat == QgsRenderContext::TextFormatAlwaysOutlines ? 1 : 0 );
+    mLayout->setCustomProperty( QStringLiteral( "svgTextFormat" ), static_cast< int >( textRenderFormat ) );
   }
 
   settings.cropToContents = clipToContent;

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -3996,7 +3996,7 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   }
 
   // open options dialog
-  QDialog dialog;
+  QDialog dialog( this );
   Ui::QgsSvgExportOptionsDialog options;
   options.setupUi( &dialog );
 
@@ -4066,7 +4066,7 @@ bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExport
   }
 
   // open options dialog
-  QDialog dialog;
+  QDialog dialog( this );
   Ui::QgsPdfExportOptionsDialog options;
   options.setupUi( &dialog );
 

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -65,6 +65,7 @@
 #include "qgsreportorganizerwidget.h"
 #include "qgsreadwritecontext.h"
 #include "ui_qgssvgexportoptions.h"
+#include "ui_qgspdfexportoptions.h"
 #include "qgsproxyprogresstask.h"
 #include "ui_defaults.h"
 
@@ -2065,13 +2066,15 @@ void QgsLayoutDesignerDialog::exportToPdf()
 
   mView->setPaintingEnabled( false );
   QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
+
+  QgsLayoutExporter::PdfExportSettings pdfSettings;
+  if ( !getPdfExportSettings( pdfSettings ) )
+    return;
+
   QgsProxyProgressTask *proxyTask = new QgsProxyProgressTask( tr( "Exporting “%1”" ).arg( mMasterLayout->name() ) );
   QgsApplication::taskManager()->addTask( proxyTask );
 
-  QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = mLayout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
-  pdfSettings.forceVectorOutput = mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
-  pdfSettings.textRenderFormat = mLayout->project()->labelingEngineSettings().defaultTextRenderFormat();
 
   // force a refresh, to e.g. update data defined properties, tables, etc
   mLayout->refresh();
@@ -2968,9 +2971,10 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
   QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
 
   QgsLayoutExporter::PdfExportSettings pdfSettings;
+  if ( !getPdfExportSettings( pdfSettings ) )
+    return;
+
   pdfSettings.rasterizeWholeImage = mLayout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
-  pdfSettings.forceVectorOutput = mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
-  pdfSettings.textRenderFormat = mLayout->project()->labelingEngineSettings().defaultTextRenderFormat();
 
   QString error;
   std::unique_ptr< QgsFeedback > feedback = qgis::make_unique< QgsFeedback >();
@@ -3345,17 +3349,15 @@ void QgsLayoutDesignerDialog::exportReportToPdf()
   QgsTemporaryCursorOverride cursorOverride( Qt::BusyCursor );
 
   bool rasterize = false;
-  bool forceVectorOutput = false;
   if ( mLayout )
   {
     rasterize = mLayout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
-    forceVectorOutput = mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
   }
   QgsLayoutExporter::PdfExportSettings pdfSettings;
-  // TODO - show a dialog allowing users to control these settings on a per-output basis
+  if ( !getPdfExportSettings( pdfSettings ) )
+    return;
+
   pdfSettings.rasterizeWholeImage = rasterize;
-  pdfSettings.forceVectorOutput = forceVectorOutput;
-  pdfSettings.textRenderFormat = mLayout->project()->labelingEngineSettings().defaultTextRenderFormat();
 
   QString error;
   std::unique_ptr< QgsFeedback > feedback = qgis::make_unique< QgsFeedback >();
@@ -4041,6 +4043,55 @@ bool QgsLayoutDesignerDialog::getSvgExportSettings( QgsLayoutExporter::SvgExport
   settings.cropMargins = QgsMargins( marginLeft, marginTop, marginRight, marginBottom );
   settings.forceVectorOutput = options.mForceVectorCheckBox->isChecked();
   settings.exportAsLayers = groupLayers;
+  settings.exportMetadata = includeMetadata;
+  settings.textRenderFormat = textRenderFormat;
+
+  return true;
+}
+
+bool QgsLayoutDesignerDialog::getPdfExportSettings( QgsLayoutExporter::PdfExportSettings &settings )
+{
+  QgsRenderContext::TextRenderFormat prevTextRenderFormat = mMasterLayout->layoutProject()->labelingEngineSettings().defaultTextRenderFormat();
+  bool previousForceVector = false;
+  bool includeMetadata = true;
+  if ( mLayout )
+  {
+    mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
+    includeMetadata = mLayout->customProperty( QStringLiteral( "pdfIncludeMetadata" ), 1 ).toBool();
+    const int prevLayoutSettingLabelsAsOutlines = mLayout->customProperty( QStringLiteral( "pdfTextFormat" ), -1 ).toInt();
+    if ( prevLayoutSettingLabelsAsOutlines >= 0 )
+    {
+      // previous layout setting takes default over project setting
+      prevTextRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( prevLayoutSettingLabelsAsOutlines );
+    }
+  }
+
+  // open options dialog
+  QDialog dialog;
+  Ui::QgsPdfExportOptionsDialog options;
+  options.setupUi( &dialog );
+
+  options.mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Paths (Recommended)" ), QgsRenderContext::TextFormatAlwaysOutlines );
+  options.mTextRenderFormatComboBox->addItem( tr( "Always Export Text as Text Objects" ), QgsRenderContext::TextFormatAlwaysText );
+
+  options.mTextRenderFormatComboBox->setCurrentIndex( options.mTextRenderFormatComboBox->findData( prevTextRenderFormat ) );
+  options.mForceVectorCheckBox->setChecked( previousForceVector );
+  options.mIncludeMetadataCheckbox->setChecked( includeMetadata );
+
+  if ( dialog.exec() != QDialog::Accepted )
+    return false;
+
+  includeMetadata = options.mIncludeMetadataCheckbox->isChecked();
+  QgsRenderContext::TextRenderFormat textRenderFormat = static_cast< QgsRenderContext::TextRenderFormat >( options.mTextRenderFormatComboBox->currentData().toInt() );
+
+  if ( mLayout )
+  {
+    //save dialog settings
+    mLayout->setCustomProperty( QStringLiteral( "pdfIncludeMetadata" ), includeMetadata ? 1 : 0 );
+    mLayout->setCustomProperty( QStringLiteral( "pdfTextFormat" ), static_cast< int >( textRenderFormat ) );
+  }
+
+  settings.forceVectorOutput = options.mForceVectorCheckBox->isChecked();
   settings.exportMetadata = includeMetadata;
   settings.textRenderFormat = textRenderFormat;
 

--- a/src/app/layout/qgslayoutdesignerdialog.cpp
+++ b/src/app/layout/qgslayoutdesignerdialog.cpp
@@ -2070,6 +2070,7 @@ void QgsLayoutDesignerDialog::exportToPdf()
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = mLayout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
   pdfSettings.forceVectorOutput = mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
+  pdfSettings.textRenderFormat = mLayout->project()->labelingEngineSettings().defaultTextRenderFormat();
 
   // force a refresh, to e.g. update data defined properties, tables, etc
   mLayout->refresh();
@@ -2968,6 +2969,7 @@ void QgsLayoutDesignerDialog::exportAtlasToPdf()
   QgsLayoutExporter::PdfExportSettings pdfSettings;
   pdfSettings.rasterizeWholeImage = mLayout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
   pdfSettings.forceVectorOutput = mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
+  pdfSettings.textRenderFormat = mLayout->project()->labelingEngineSettings().defaultTextRenderFormat();
 
   QString error;
   std::unique_ptr< QgsFeedback > feedback = qgis::make_unique< QgsFeedback >();
@@ -3349,8 +3351,10 @@ void QgsLayoutDesignerDialog::exportReportToPdf()
     forceVectorOutput = mLayout->customProperty( QStringLiteral( "forceVector" ), false ).toBool();
   }
   QgsLayoutExporter::PdfExportSettings pdfSettings;
+  // TODO - show a dialog allowing users to control these settings on a per-output basis
   pdfSettings.rasterizeWholeImage = rasterize;
   pdfSettings.forceVectorOutput = forceVectorOutput;
+  pdfSettings.textRenderFormat = mLayout->project()->labelingEngineSettings().defaultTextRenderFormat();
 
   QString error;
   std::unique_ptr< QgsFeedback > feedback = qgis::make_unique< QgsFeedback >();

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -505,6 +505,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
     bool showFileSizeWarning();
     bool getRasterExportSettings( QgsLayoutExporter::ImageExportSettings &settings, QSize &imageSize );
     bool getSvgExportSettings( QgsLayoutExporter::SvgExportSettings &settings );
+    bool getPdfExportSettings( QgsLayoutExporter::PdfExportSettings &settings );
 
     void toggleAtlasActions( bool enabled );
 

--- a/src/app/layout/qgslayoutdesignerdialog.h
+++ b/src/app/layout/qgslayoutdesignerdialog.h
@@ -504,7 +504,7 @@ class QgsLayoutDesignerDialog: public QMainWindow, public Ui::QgsLayoutDesignerB
 
     bool showFileSizeWarning();
     bool getRasterExportSettings( QgsLayoutExporter::ImageExportSettings &settings, QSize &imageSize );
-    bool getSvgExportSettings( QgsLayoutExporter::SvgExportSettings &settings, bool &exportAsText );
+    bool getSvgExportSettings( QgsLayoutExporter::SvgExportSettings &settings );
 
     void toggleAtlasActions( bool enabled );
 

--- a/src/app/qgslabelengineconfigdialog.cpp
+++ b/src/app/qgslabelengineconfigdialog.cpp
@@ -36,6 +36,9 @@ QgsLabelEngineConfigDialog::QgsLabelEngineConfigDialog( QWidget *parent )
   // search method
   cboSearchMethod->setCurrentIndex( engineSettings.searchMethod() );
 
+  mTextRenderFormatComboBox->addItem( tr( "Always Render Labels as Paths (Recommended)" ), QgsRenderContext::TextFormatAlwaysOutlines );
+  mTextRenderFormatComboBox->addItem( tr( "Always Render Labels as Text" ), QgsRenderContext::TextFormatAlwaysText );
+
   // candidate numbers
   int candPoint, candLine, candPolygon;
   engineSettings.numCandidatePositions( candPoint, candLine, candPolygon );
@@ -47,9 +50,9 @@ QgsLabelEngineConfigDialog::QgsLabelEngineConfigDialog( QWidget *parent )
   chkShowAllLabels->setChecked( engineSettings.testFlag( QgsLabelingEngineSettings::UseAllLabels ) );
 
   chkShowPartialsLabels->setChecked( engineSettings.testFlag( QgsLabelingEngineSettings::UsePartialCandidates ) );
-  mDrawOutlinesChkBox->setChecked( engineSettings.testFlag( QgsLabelingEngineSettings::RenderOutlineLabels ) );
-}
 
+  mTextRenderFormatComboBox->setCurrentIndex( mTextRenderFormatComboBox->findData( engineSettings.defaultTextRenderFormat() ) );
+}
 
 void QgsLabelEngineConfigDialog::onOK()
 {
@@ -63,7 +66,8 @@ void QgsLabelEngineConfigDialog::onOK()
   engineSettings.setFlag( QgsLabelingEngineSettings::DrawCandidates, chkShowCandidates->isChecked() );
   engineSettings.setFlag( QgsLabelingEngineSettings::UseAllLabels, chkShowAllLabels->isChecked() );
   engineSettings.setFlag( QgsLabelingEngineSettings::UsePartialCandidates, chkShowPartialsLabels->isChecked() );
-  engineSettings.setFlag( QgsLabelingEngineSettings::RenderOutlineLabels, mDrawOutlinesChkBox->isChecked() );
+
+  engineSettings.setDefaultTextRenderFormat( static_cast< QgsRenderContext::TextRenderFormat >( mTextRenderFormatComboBox->currentData().toInt() ) );
 
   QgsProject::instance()->setLabelingEngineSettings( engineSettings );
 
@@ -80,7 +84,7 @@ void QgsLabelEngineConfigDialog::setDefaults()
   chkShowCandidates->setChecked( false );
   chkShowAllLabels->setChecked( false );
   chkShowPartialsLabels->setChecked( p.getShowPartial() );
-  mDrawOutlinesChkBox->setChecked( true );
+  mTextRenderFormatComboBox->setCurrentIndex( mTextRenderFormatComboBox->findData( QgsRenderContext::TextFormatAlwaysOutlines ) );
 }
 
 void QgsLabelEngineConfigDialog::showHelp()

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -299,6 +299,7 @@ class LayoutContextSettingsRestorer
       : mLayout( layout )
       , mPreviousDpi( layout->renderContext().dpi() )
       , mPreviousFlags( layout->renderContext().flags() )
+      , mPreviousTextFormat( layout->renderContext().textRenderFormat() )
       , mPreviousExportLayer( layout->renderContext().currentExportLayer() )
     {
     }
@@ -307,6 +308,7 @@ class LayoutContextSettingsRestorer
     {
       mLayout->renderContext().setDpi( mPreviousDpi );
       mLayout->renderContext().setFlags( mPreviousFlags );
+      mLayout->renderContext().setTextRenderFormat( mPreviousTextFormat );
       mLayout->renderContext().setCurrentExportLayer( mPreviousExportLayer );
     }
 
@@ -317,6 +319,7 @@ class LayoutContextSettingsRestorer
     QgsLayout *mLayout = nullptr;
     double mPreviousDpi = 0;
     QgsLayoutRenderContext::Flags mPreviousFlags = nullptr;
+    QgsRenderContext::TextRenderFormat mPreviousTextFormat = QgsRenderContext::TextFormatAlwaysOutlines;
     int mPreviousExportLayer = 0;
 };
 ///@endcond PRIVATE
@@ -496,6 +499,8 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
 
   mLayout->renderContext().setFlag( QgsLayoutRenderContext::FlagForceVectorOutput, settings.forceVectorOutput );
 
+  mLayout->renderContext().setTextRenderFormat( settings.textRenderFormat );
+
   QPrinter printer;
   preparePrintAsPdf( mLayout, printer, filePath );
   preparePrint( mLayout, printer, false );
@@ -564,6 +569,8 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( QgsAbstractLayou
     iterator->layout()->renderContext().setFlag( QgsLayoutRenderContext::FlagUseAdvancedEffects, !settings.forceVectorOutput );
 
     iterator->layout()->renderContext().setFlag( QgsLayoutRenderContext::FlagForceVectorOutput, settings.forceVectorOutput );
+
+    iterator->layout()->renderContext().setTextRenderFormat( settings.textRenderFormat );
 
     if ( first )
     {
@@ -780,6 +787,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToSvg( const QString &f
   mLayout->renderContext().setDpi( settings.dpi );
 
   mLayout->renderContext().setFlag( QgsLayoutRenderContext::FlagForceVectorOutput, settings.forceVectorOutput );
+  mLayout->renderContext().setTextRenderFormat( s.textRenderFormat );
 
   QFileInfo fi( filePath );
   PageExportDetails pageDetails;

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1026,7 +1026,8 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToSvg( QgsAbstractLayou
 void QgsLayoutExporter::preparePrintAsPdf( QgsLayout *layout, QPrinter &printer, const QString &filePath )
 {
   printer.setOutputFileName( filePath );
-  // setOutputFormat should come after setOutputFileName, which auto-sets format to QPrinter::PdfFormat.
+  // setOutputFormat MUST come after setOutputFileName, which auto-sets format to QPrinter::PdfFormat.
+
   // [LS] This should be QPrinter::NativeFormat for Mac, otherwise fonts are not embed-able
   // and text is not searchable; however, there are several bugs with <= Qt 4.8.5, 5.1.1, 5.2.0:
   // https://bugreports.qt.io/browse/QTBUG-10094 - PDF font embedding fails

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -1026,13 +1026,6 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToSvg( QgsAbstractLayou
 void QgsLayoutExporter::preparePrintAsPdf( QgsLayout *layout, QPrinter &printer, const QString &filePath )
 {
   printer.setOutputFileName( filePath );
-  // setOutputFormat MUST come after setOutputFileName, which auto-sets format to QPrinter::PdfFormat.
-
-  // [LS] This should be QPrinter::NativeFormat for Mac, otherwise fonts are not embed-able
-  // and text is not searchable; however, there are several bugs with <= Qt 4.8.5, 5.1.1, 5.2.0:
-  // https://bugreports.qt.io/browse/QTBUG-10094 - PDF font embedding fails
-  // https://bugreports.qt.io/browse/QTBUG-33583 - PDF output converts text to outline
-  // Also an issue with PDF paper size using QPrinter::NativeFormat on Mac (always outputs portrait letter-size)
   printer.setOutputFormat( QPrinter::PdfFormat );
 
   updatePrinterPageSize( layout, printer, firstPageToBeExported( layout ) );

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -545,7 +545,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( QgsAbstractLayou
       if ( total > 0 )
         feedback->setProperty( "progress", QObject::tr( "Exporting %1 of %2" ).arg( i + 1 ).arg( total ) );
       else
-        feedback->setProperty( "progress", QObject::tr( "Exporting section %1" ).arg( i + 1 ).arg( total ) );
+        feedback->setProperty( "progress", QObject::tr( "Exporting section %1" ).arg( i + 1 ) );
       feedback->setProgress( step * i );
     }
     if ( feedback && feedback->isCanceled() )

--- a/src/core/layout/qgslayoutexporter.h
+++ b/src/core/layout/qgslayoutexporter.h
@@ -278,6 +278,14 @@ class CORE_EXPORT QgsLayoutExporter
        */
       QgsLayoutRenderContext::Flags flags = nullptr;
 
+      /**
+       * Text rendering format, which controls how text should be rendered in the export (e.g.
+       * as paths or real text objects).
+       *
+       * \since QGIS 3.4.3
+       */
+      QgsRenderContext::TextRenderFormat textRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
+
     };
 
     /**
@@ -416,6 +424,14 @@ class CORE_EXPORT QgsLayoutExporter
        * Layout context flags, which control how the export will be created.
        */
       QgsLayoutRenderContext::Flags flags = nullptr;
+
+      /**
+       * Text rendering format, which controls how text should be rendered in the export (e.g.
+       * as paths or real text objects).
+       *
+       * \since QGIS 3.4.3
+       */
+      QgsRenderContext::TextRenderFormat textRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 
     };
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1113,6 +1113,7 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
   jobMapSettings.setPathResolver( mLayout->project()->pathResolver() );
 
   jobMapSettings.setLabelingEngineSettings( mLayout->project()->labelingEngineSettings() );
+  // override the default text render format inherited from the labeling engine settings using the layout's render context setting
   jobMapSettings.setTextRenderFormat( mLayout->renderContext().textRenderFormat() );
 
   return jobMapSettings;

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1113,6 +1113,7 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
   jobMapSettings.setPathResolver( mLayout->project()->pathResolver() );
 
   jobMapSettings.setLabelingEngineSettings( mLayout->project()->labelingEngineSettings() );
+  jobMapSettings.setTextRenderFormat( mLayout->renderContext().textRenderFormat() );
 
   return jobMapSettings;
 }

--- a/src/core/layout/qgslayoutrendercontext.h
+++ b/src/core/layout/qgslayoutrendercontext.h
@@ -200,6 +200,28 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
      */
     int currentExportLayer() const { return mCurrentExportLayer; }
 
+    /**
+     * Returns the text render format, which dictates how text is rendered (e.g. as paths or real text objects).
+     *
+     * \see setTextRenderFormat()
+     * \since QGIS 3.4.3
+     */
+    QgsRenderContext::TextRenderFormat textRenderFormat() const
+    {
+      return mTextRenderFormat;
+    }
+
+    /**
+     * Sets the text render \a format, which dictates how text is rendered (e.g. as paths or real text objects).
+     *
+     * \see textRenderFormat()
+     * \since QGIS 3.4.3
+     */
+    void setTextRenderFormat( QgsRenderContext::TextRenderFormat format )
+    {
+      mTextRenderFormat = format;
+    }
+
   signals:
 
     /**
@@ -229,6 +251,8 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
     bool mGridVisible = false;
     bool mBoundingBoxesVisible = true;
     bool mPagesVisible = true;
+
+    QgsRenderContext::TextRenderFormat mTextRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 
     friend class QgsLayoutExporter;
     friend class TestQgsLayout;

--- a/src/core/layout/qgslayoututils.cpp
+++ b/src/core/layout/qgslayoututils.cpp
@@ -130,6 +130,7 @@ QgsRenderContext QgsLayoutUtils::createRenderContextForMap( QgsLayoutItemMap *ma
       context.setPainter( painter );
 
     context.setFlags( map->layout()->renderContext().renderContextFlags() );
+    context.setTextRenderFormat( map->layout()->renderContext().textRenderFormat() );
     return context;
   }
 }
@@ -139,7 +140,11 @@ QgsRenderContext QgsLayoutUtils::createRenderContextForLayout( QgsLayout *layout
   QgsLayoutItemMap *referenceMap = layout ? layout->referenceMap() : nullptr;
   QgsRenderContext context = createRenderContextForMap( referenceMap, painter, dpi );
   if ( layout )
+  {
     context.setFlags( layout->renderContext().renderContextFlags() );
+    context.setTextRenderFormat( layout->renderContext().textRenderFormat() );
+  }
+
   return context;
 }
 

--- a/src/core/qgslabelingenginesettings.h
+++ b/src/core/qgslabelingenginesettings.h
@@ -16,7 +16,7 @@
 #define QGSLABELINGENGINESETTINGS_H
 
 #include "qgis_core.h"
-
+#include "qgsrendercontext.h"
 #include <QFlags>
 
 class QgsProject;
@@ -34,7 +34,8 @@ class CORE_EXPORT QgsLabelingEngineSettings
     {
       UseAllLabels          = 1 << 1,  //!< Whether to draw all labels even if there would be collisions
       UsePartialCandidates  = 1 << 2,  //!< Whether to use also label candidates that are partially outside of the map view
-      RenderOutlineLabels   = 1 << 3,  //!< Whether to render labels as text or outlines
+      // TODO QGIS 4.0: remove
+      RenderOutlineLabels   = 1 << 3,  //!< Whether to render labels as text or outlines. Deprecated and of QGIS 3.4.3 - use defaultTextRenderFormat() instead.
       DrawLabelRectOnly     = 1 << 4,  //!< Whether to only draw the label rect and not the actual label text (used for unit tests)
       DrawCandidates        = 1 << 5,  //!< Whether to draw rectangles of generated candidates (good for debugging)
     };
@@ -82,6 +83,32 @@ class CORE_EXPORT QgsLabelingEngineSettings
     //! Write configuration of the labeling engine to a project
     void writeSettingsToProject( QgsProject *project );
 
+    // TODO QGIS 4.0: In reality the text render format settings don't only apply to labels, but also
+    // ANY text rendered using QgsTextRenderer (including some non-label text items in layouts).
+    // These methods should possibly be moved out of here and into the general QgsProject settings.
+
+    /**
+     * Returns the default text rendering format for the labels.
+     *
+     * \see setDefaultTextRenderFormat()
+     * \since QGIS 3.4.3
+     */
+    QgsRenderContext::TextRenderFormat defaultTextRenderFormat() const
+    {
+      return mDefaultTextRenderFormat;
+    }
+
+    /**
+     * Sets the default text rendering \a format for the labels.
+     *
+     * \see defaultTextRenderFormat()
+     * \since QGIS 3.4.3
+     */
+    void setDefaultTextRenderFormat( QgsRenderContext::TextRenderFormat format )
+    {
+      mDefaultTextRenderFormat = format;
+    }
+
   private:
     //! Flags
     Flags mFlags;
@@ -89,6 +116,8 @@ class CORE_EXPORT QgsLabelingEngineSettings
     Search mSearchMethod = Chain;
     //! Number of candedate positions that will be generated for features
     int mCandPoint = 16, mCandLine = 50, mCandPolygon = 30;
+
+    QgsRenderContext::TextRenderFormat mDefaultTextRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 
 };
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -253,6 +253,28 @@ class CORE_EXPORT QgsMapSettings
     //! Check whether a particular flag is enabled
     bool testFlag( Flag flag ) const;
 
+    /**
+     * Returns the text render format, which dictates how text is rendered (e.g. as paths or real text objects).
+     *
+     * \see setTextRenderFormat()
+     * \since QGIS 3.4.3
+     */
+    QgsRenderContext::TextRenderFormat textRenderFormat() const
+    {
+      return mTextRenderFormat;
+    }
+
+    /**
+     * Sets the text render \a format, which dictates how text is rendered (e.g. as paths or real text objects).
+     *
+     * \see textRenderFormat()
+     * \since QGIS 3.4.3
+     */
+    void setTextRenderFormat( QgsRenderContext::TextRenderFormat format )
+    {
+      mTextRenderFormat = format;
+    }
+
     //! sets format of internal QImage
     void setOutputImageFormat( QImage::Format format ) { mImageFormat = format; }
     //! format of internal QImage, default QImage::Format_ARGB32_Premultiplied
@@ -469,6 +491,8 @@ class CORE_EXPORT QgsMapSettings
     QgsCoordinateTransformContext mTransformContext;
 
     QgsPathResolver mPathResolver;
+
+    QgsRenderContext::TextRenderFormat mTextRenderFormat = QgsRenderContext::TextFormatAlwaysOutlines;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -267,12 +267,18 @@ class CORE_EXPORT QgsMapSettings
     /**
      * Sets the text render \a format, which dictates how text is rendered (e.g. as paths or real text objects).
      *
+     * \warning Calling the setLabelingEngineSettings() method will reset the text render format to match the default
+     * text render format from the label engine settings.
+     *
      * \see textRenderFormat()
      * \since QGIS 3.4.3
      */
     void setTextRenderFormat( QgsRenderContext::TextRenderFormat format )
     {
       mTextRenderFormat = format;
+      // ensure labeling engine setting is also kept in sync, just in case anyone accesses QgsMapSettings::labelingEngineSettings().defaultTextRenderFormat()
+      // instead of correctly calling QgsMapSettings::textRenderFormat(). It can't hurt to be consistent!
+      mLabelingEngineSettings.setDefaultTextRenderFormat( format );
     }
 
     //! sets format of internal QImage
@@ -433,13 +439,26 @@ class CORE_EXPORT QgsMapSettings
     QgsAbstractGeometry::SegmentationToleranceType segmentationToleranceType() const { return mSegmentationToleranceType; }
 
     /**
-     * Sets global configuration of the labeling engine
+     * Sets the global configuration of the labeling engine.
+     *
+     * \note Calling this method will reset the textRenderFormat() to match the default
+     * text render format from the label engine \a settings.
+     *
+     * \see labelingEngineSettings()
+     *
      * \since QGIS 3.0
      */
-    void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings ) { mLabelingEngineSettings = settings; }
+    void setLabelingEngineSettings( const QgsLabelingEngineSettings &settings )
+    {
+      mLabelingEngineSettings = settings;
+      mTextRenderFormat = settings.defaultTextRenderFormat();
+    }
 
     /**
-     * Returns global configuration of the labeling engine
+     * Returns the global configuration of the labeling engine.
+     *
+     * \see setLabelingEngineSettings()
+     *
      * \since QGIS 3.0
      */
     const QgsLabelingEngineSettings &labelingEngineSettings() const { return mLabelingEngineSettings; }

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -57,6 +57,7 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mSegmentationToleranceType( rh.mSegmentationToleranceType )
   , mTransformContext( rh.mTransformContext )
   , mPathResolver( rh.mPathResolver )
+  , mTextRenderFormat( rh.mTextRenderFormat )
 #ifdef QGISDEBUG
   , mHasTransformContext( rh.mHasTransformContext )
 #endif
@@ -84,6 +85,7 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mDistanceArea = rh.mDistanceArea;
   mTransformContext = rh.mTransformContext;
   mPathResolver = rh.mPathResolver;
+  mTextRenderFormat = rh.mTextRenderFormat;
 #ifdef QGISDEBUG
   mHasTransformContext = rh.mHasTransformContext;
 #endif
@@ -172,6 +174,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.mDistanceArea.setEllipsoid( mapSettings.ellipsoid() );
   ctx.setTransformContext( mapSettings.transformContext() );
   ctx.setPathResolver( mapSettings.pathResolver() );
+  ctx.setTextRenderFormat( mapSettings.textRenderFormat() );
   //this flag is only for stopping during the current rendering progress,
   //so must be false at every new render operation
   ctx.setRenderingStopped( false );
@@ -446,3 +449,5 @@ double QgsRenderContext::convertMetersToMapUnits( double meters ) const
   }
   return meters;
 }
+
+

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -76,6 +76,16 @@ class CORE_EXPORT QgsRenderContext
     Q_DECLARE_FLAGS( Flags, Flag )
 
     /**
+     * Options for rendering text.
+     * \since QGIS 3.4.3
+     */
+    enum TextRenderFormat
+    {
+      TextFormatAlwaysOutlines, //!< Always render text using path objects (AKA outlines/curves). This always results in the best quality rendering.
+      TextFormatAlwaysText, //!< Always render text as text objects. This may result in rendering artefacts or poor quality rendering, depending on the text format settings.
+    };
+
+    /**
      * Set combination of flags that will be used for rendering.
      * \since QGIS 2.14
      */
@@ -386,6 +396,28 @@ class CORE_EXPORT QgsRenderContext
      */
     double convertMetersToMapUnits( double meters ) const;
 
+    /**
+     * Returns the text render format, which dictates how text is rendered (e.g. as paths or real text objects).
+     *
+     * \see setTextRenderFormat()
+     * \since QGIS 3.4.3
+     */
+    TextRenderFormat textRenderFormat() const
+    {
+      return mTextRenderFormat;
+    }
+
+    /**
+     * Sets the text render \a format, which dictates how text is rendered (e.g. as paths or real text objects).
+     *
+     * \see textRenderFormat()
+     * \since QGIS 3.4.3
+     */
+    void setTextRenderFormat( TextRenderFormat format )
+    {
+      mTextRenderFormat = format;
+    }
+
   private:
 
     Flags mFlags;
@@ -441,6 +473,8 @@ class CORE_EXPORT QgsRenderContext
     QgsCoordinateTransformContext mTransformContext;
 
     QgsPathResolver mPathResolver;
+
+    TextRenderFormat mTextRenderFormat = TextFormatAlwaysOutlines;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsRenderContext
     enum TextRenderFormat
     {
       TextFormatAlwaysOutlines, //!< Always render text using path objects (AKA outlines/curves). This always results in the best quality rendering.
-      TextFormatAlwaysText, //!< Always render text as text objects. This may result in rendering artefacts or poor quality rendering, depending on the text format settings.
+      TextFormatAlwaysText, //!< Always render text as text objects. This may result in rendering artifacts or poor quality rendering, depending on the text format settings.
     };
 
     /**

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -81,8 +81,42 @@ class CORE_EXPORT QgsRenderContext
      */
     enum TextRenderFormat
     {
-      TextFormatAlwaysOutlines, //!< Always render text using path objects (AKA outlines/curves). This always results in the best quality rendering.
-      TextFormatAlwaysText, //!< Always render text as text objects. This may result in rendering artifacts or poor quality rendering, depending on the text format settings.
+      // refs for below dox: https://github.com/qgis/QGIS/pull/1286#issuecomment-39806854
+      // https://github.com/qgis/QGIS/pull/8573#issuecomment-445585826
+
+      /**
+       * Always render text using path objects (AKA outlines/curves).
+       *
+       * This setting guarantees the best quality rendering, even when using a raster paint surface
+       * (where sub-pixel path based text rendering is superior to sub-pixel text-based rendering).
+       * The downside is that text is converted to paths only, so users cannot open created vector
+       * outputs for post-processing in other applications and retain text editability.
+       *
+       * This setting also guarantees complete compatibility with the full range of formatting options available
+       * through QgsTextRenderer and QgsTextFormat, some of which may not be possible to reproduce when using
+       * a vector-based paint surface and TextFormatAlwaysText mode.
+       *
+       * A final benefit to this setting is that vector exports created using text as outlines do
+       * not require all users to have the original fonts installed in order to display the
+       * text in its original style.
+       */
+      TextFormatAlwaysOutlines,
+
+      /**
+       * Always render text as text objects.
+       *
+       * While this mode preserves text objects as text for post-processing in external vector editing applications,
+       * it can result in rendering artifacts or poor quality rendering, depending on the text format settings.
+       *
+       * Even with raster based paint devices, TextFormatAlwaysText can result in inferior rendering quality
+       * to TextFormatAlwaysOutlines.
+       *
+       * When rendering using TextFormatAlwaysText to a vector based device (e.g. PDF or SVG), care must be
+       * taken to ensure that the required fonts are available to users when opening the created files,
+       * or default fallback fonts will be used to display the output instead. (Although PDF exports MAY
+       * automatically embed some fonts when possible, depending on the user's platform).
+       */
+      TextFormatAlwaysText,
     };
 
     /**

--- a/src/core/qgstextrenderer.h
+++ b/src/core/qgstextrenderer.h
@@ -1332,6 +1332,8 @@ class CORE_EXPORT QgsTextRenderer
      */
     static int sizeToPixel( double size, const QgsRenderContext &c, QgsUnitTypes::RenderUnit unit, const QgsMapUnitScale &mapUnitScale = QgsMapUnitScale() );
 
+    // TODO QGIS 4.0 -- remove drawAsOutlines from below methods!
+
     /**
      * Draws text within a rectangle using the specified settings.
      * \param rect destination rectangle for text
@@ -1342,7 +1344,8 @@ class CORE_EXPORT QgsTextRenderer
      * \param format text format
      * \param drawAsOutlines set to false to render text as text. This allows outputs to
      * formats like SVG to maintain text as text objects, but at the cost of degraded
-     * rendering and may result in side effects like misaligned text buffers.
+     * rendering and may result in side effects like misaligned text buffers. This setting is deprecated and has no effect
+     * as of QGIS 3.4.3 and the text format should be set using QgsRenderContext::setTextRenderFormat() instead.
      */
     static void drawText( const QRectF &rect, double rotation, HAlignment alignment, const QStringList &textLines,
                           QgsRenderContext &context, const QgsTextFormat &format,
@@ -1358,7 +1361,8 @@ class CORE_EXPORT QgsTextRenderer
      * \param format text format
      * \param drawAsOutlines set to false to render text as text. This allows outputs to
      * formats like SVG to maintain text as text objects, but at the cost of degraded
-     * rendering and may result in side effects like misaligned text buffers.
+     * rendering and may result in side effects like misaligned text buffers. This setting is deprecated and has no effect
+     * as of QGIS 3.4.3 and the text format should be set using QgsRenderContext::setTextRenderFormat() instead.
      */
     static void drawText( QPointF point, double rotation, HAlignment alignment, const QStringList &textLines,
                           QgsRenderContext &context, const QgsTextFormat &format,
@@ -1377,7 +1381,8 @@ class CORE_EXPORT QgsTextRenderer
      * with the text or background parts)
      * \param drawAsOutlines set to false to render text as text. This allows outputs to
      * formats like SVG to maintain text as text objects, but at the cost of degraded
-     * rendering and may result in side effects like misaligned text buffers.
+     * rendering and may result in side effects like misaligned text buffers. This setting is deprecated and has no effect
+     * as of QGIS 3.4.3 and the text format should be set using QgsRenderContext::setTextRenderFormat() instead.
      */
     static void drawPart( const QRectF &rect, double rotation, HAlignment alignment, const QStringList &textLines,
                           QgsRenderContext &context, const QgsTextFormat &format,
@@ -1396,7 +1401,8 @@ class CORE_EXPORT QgsTextRenderer
      * with the text or background parts)
      * \param drawAsOutlines set to false to render text as text. This allows outputs to
      * formats like SVG to maintain text as text objects, but at the cost of degraded
-     * rendering and may result in side effects like misaligned text buffers.
+     * rendering and may result in side effects like misaligned text buffers. This setting is deprecated and has no effect
+     * as of QGIS 3.4.3 and the text format should be set using QgsRenderContext::setTextRenderFormat() instead.
      */
     static void drawPart( QPointF origin, double rotation, HAlignment alignment, const QStringList &textLines,
                           QgsRenderContext &context, const QgsTextFormat &format,
@@ -1490,7 +1496,6 @@ class CORE_EXPORT QgsTextRenderer
                                   const QStringList &textLines,
                                   const QFontMetricsF *fontMetrics,
                                   HAlignment alignment,
-                                  bool drawAsOutlines,
                                   DrawMode mode = Rect );
 
     friend class QgsVectorLayerLabelProvider;

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -623,8 +623,9 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition *label, Q
     QgsTextRenderer::Component component;
     component.origin = outPt;
     component.rotation = label->getAlpha();
+
     QgsTextRenderer::drawTextInternal( drawType, context, tmpLyr.format(), component, multiLineList, labelfm,
-                                       hAlign, mEngine->engineSettings().testFlag( QgsLabelingEngineSettings::RenderOutlineLabels ), QgsTextRenderer::Label );
+                                       hAlign, QgsTextRenderer::Label );
 
   }
 

--- a/src/ui/layout/qgslayoutimageexportoptions.ui
+++ b/src/ui/layout/qgslayoutimageexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>533</width>
-    <height>394</height>
+    <height>424</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,18 +15,11 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
      <property name="title">
       <string>Export Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>Export resolution</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0" colspan="2">
        <widget class="QLabel" name="label_13">
         <property name="text">
@@ -47,6 +40,13 @@
         </property>
         <property name="showClearButton" stdset="0">
          <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>Export resolution</string>
         </property>
        </widget>
       </item>
@@ -114,6 +114,26 @@
         </property>
        </spacer>
       </item>
+      <item row="4" column="0" colspan="5">
+       <widget class="QCheckBox" name="mGenerateWorldFile">
+        <property name="toolTip">
+         <string>If checked, a separate world file which georeferences exported images will be created</string>
+        </property>
+        <property name="text">
+         <string>Generate world file</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="5">
+       <widget class="QCheckBox" name="mAntialiasingCheckBox">
+        <property name="toolTip">
+         <string>If unchecked, the generated images will not be antialiased</string>
+        </property>
+        <property name="text">
+         <string>Enable antialiasing</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -143,7 +163,7 @@
           <item>
            <widget class="QgsSpinBox" name="mLeftMarginSpinBox">
             <property name="suffix">
-             <string> px</string>
+             <string/>
             </property>
             <property name="maximum">
              <number>1000</number>
@@ -160,7 +180,7 @@
           <item>
            <widget class="QgsSpinBox" name="mRightMarginSpinBox">
             <property name="suffix">
-             <string> px</string>
+             <string/>
             </property>
             <property name="maximum">
              <number>1000</number>
@@ -179,7 +199,7 @@
         <item row="0" column="1">
          <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>Top margin</string>
+           <string>Top margin (px)</string>
           </property>
          </widget>
         </item>
@@ -212,7 +232,7 @@
         <item row="0" column="2">
          <widget class="QgsSpinBox" name="mTopMarginSpinBox">
           <property name="suffix">
-           <string> px</string>
+           <string/>
           </property>
           <property name="maximum">
            <number>1000</number>
@@ -222,7 +242,7 @@
         <item row="2" column="2">
          <widget class="QgsSpinBox" name="mBottomMarginSpinBox">
           <property name="suffix">
-           <string> px</string>
+           <string/>
           </property>
           <property name="maximum">
            <number>1000</number>
@@ -232,26 +252,6 @@
        </layout>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="mGenerateWorldFile">
-     <property name="toolTip">
-      <string>If checked, a separate world file which georeferences exported images will be created</string>
-     </property>
-     <property name="text">
-      <string>Generate world file</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="mAntialiasingCheckBox">
-     <property name="toolTip">
-      <string>If unchecked, the generated images will not be antialiased</string>
-     </property>
-     <property name="text">
-      <string>Enable antialiasing</string>
-     </property>
     </widget>
    </item>
    <item>
@@ -283,7 +283,7 @@
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <header location="global">qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -296,6 +296,8 @@
   <tabstop>mResolutionSpinBox</tabstop>
   <tabstop>mWidthSpinBox</tabstop>
   <tabstop>mHeightSpinBox</tabstop>
+  <tabstop>mAntialiasingCheckBox</tabstop>
+  <tabstop>mGenerateWorldFile</tabstop>
   <tabstop>mClipToContentGroupBox</tabstop>
   <tabstop>mTopMarginSpinBox</tabstop>
   <tabstop>mLeftMarginSpinBox</tabstop>

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>190</height>
+    <height>197</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
      <property name="title">
-      <string>PDF Options</string>
+      <string>Export Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
       <item row="1" column="0" colspan="2">

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsPdfExportOptionsDialog</class>
+ <widget class="QDialog" name="QgsPdfExportOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>489</width>
+    <height>190</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>PDF Export Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
+     <property name="title">
+      <string>PDF Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
+        <property name="text">
+         <string>Export RDF metadata</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Text export</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="mForceVectorCheckBox">
+        <property name="toolTip">
+         <string>If checked, the layout will always be kept as vector objects when exported to a compatible format, even if the appearance of the resultant file does not match the layouts settings. If unchecked, some elements in the layout may be rasterized in order to keep their appearance intact.</string>
+        </property>
+        <property name="text">
+         <string>Always export as vectors</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBoxBasic</class>
+   <extends>QGroupBox</extends>
+   <header location="global">qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>mForceVectorCheckBox</tabstop>
+  <tabstop>mIncludeMetadataCheckbox</tabstop>
+  <tabstop>mTextRenderFormatComboBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsPdfExportOptionsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsPdfExportOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/layout/qgssvgexportoptions.ui
+++ b/src/ui/layout/qgssvgexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>351</height>
+    <height>385</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
      <property name="title">
-      <string>SVG Options</string>
+      <string>Export Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
       <item row="0" column="0" colspan="2">

--- a/src/ui/layout/qgssvgexportoptions.ui
+++ b/src/ui/layout/qgssvgexportoptions.ui
@@ -19,8 +19,8 @@
      <property name="title">
       <string>SVG Options</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
+     <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+      <item row="0" column="0" colspan="2">
        <widget class="QCheckBox" name="chkMapLayersAsGroup">
         <property name="text">
          <string>Export map layers as SVG groups (may affect label placement)</string>
@@ -30,23 +30,17 @@
         </property>
        </widget>
       </item>
-      <item>
-       <widget class="QCheckBox" name="chkTextAsOutline">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="toolTip">
-         <string>Uncheck to render map labels as text objects. This will degrade the quality of the map labels but allow editing in vector illustration software.</string>
-        </property>
+      <item row="3" column="1">
+       <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Render map labels as outlines</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
+         <string>Text export</string>
         </property>
        </widget>
       </item>
-      <item>
+      <item row="1" column="0" colspan="2">
        <widget class="QCheckBox" name="mForceVectorCheckBox">
         <property name="toolTip">
          <string>If checked, the layout will always be kept as vector objects when exported to a compatible format, even if the appearance of the resultant file does not match the layouts settings. If unchecked, some elements in the layout may be rasterized in order to keep their appearance intact.</string>
@@ -56,7 +50,7 @@
         </property>
        </widget>
       </item>
-      <item>
+      <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
         <property name="text">
          <string>Export RDF metadata</string>
@@ -214,9 +208,9 @@
  </customwidgets>
  <tabstops>
   <tabstop>chkMapLayersAsGroup</tabstop>
-  <tabstop>chkTextAsOutline</tabstop>
   <tabstop>mForceVectorCheckBox</tabstop>
   <tabstop>mIncludeMetadataCheckbox</tabstop>
+  <tabstop>mTextRenderFormatComboBox</tabstop>
   <tabstop>mClipToContentGroupBox</tabstop>
   <tabstop>mTopMarginSpinBox</tabstop>
   <tabstop>mLeftMarginSpinBox</tabstop>

--- a/src/ui/qgslabelengineconfigdialog.ui
+++ b/src/ui/qgslabelengineconfigdialog.ui
@@ -205,18 +205,25 @@
     </layout>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout_2">
-     <property name="verticalSpacing">
-      <number>6</number>
-     </property>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="chkShowCandidates">
+    <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_5">
        <property name="text">
-        <string>Show candidates (for debugging)</string>
+        <string>Text rendering</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="0" column="1">
+      <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QCheckBox" name="chkShowPartialsLabels">
+       <property name="text">
+        <string>Allow truncated labels on edges of map</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="2">
       <widget class="QCheckBox" name="chkShowAllLabels">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -232,17 +239,10 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QCheckBox" name="mDrawOutlinesChkBox">
+     <item row="3" column="0" colspan="2">
+      <widget class="QCheckBox" name="chkShowCandidates">
        <property name="text">
-        <string>Draw text as outlines (recommended)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="chkShowPartialsLabels">
-       <property name="text">
-        <string>Show partial labels</string>
+        <string>Show candidates (for debugging)</string>
        </property>
       </widget>
      </item>
@@ -278,11 +278,10 @@
   <tabstop>spinCandPoint</tabstop>
   <tabstop>spinCandLine</tabstop>
   <tabstop>spinCandPolygon</tabstop>
-  <tabstop>mDrawOutlinesChkBox</tabstop>
+  <tabstop>mTextRenderFormatComboBox</tabstop>
   <tabstop>chkShowPartialsLabels</tabstop>
   <tabstop>chkShowAllLabels</tabstop>
   <tabstop>chkShowCandidates</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -40,6 +40,7 @@ class TestQgsLabelingEngine : public QObject
     void cleanupTestCase();
     void init();// will be called before each testfunction is executed.
     void cleanup();// will be called after every testfunction.
+    void testEngineSettings();
     void testBasic();
     void testDiagrams();
     void testRuleBased();
@@ -97,6 +98,42 @@ void TestQgsLabelingEngine::cleanup()
 {
   QgsProject::instance()->removeMapLayer( vl->id() );
   vl = nullptr;
+}
+
+void TestQgsLabelingEngine::testEngineSettings()
+{
+  // test labeling engine settings
+
+  // getters/setters
+  QgsLabelingEngineSettings settings;
+  settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
+  QCOMPARE( settings.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
+  settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
+  QCOMPARE( settings.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+
+  // reading from project
+  QgsProject p;
+  settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
+  settings.writeSettingsToProject( &p );
+  QgsLabelingEngineSettings settings2;
+  settings2.readSettingsFromProject( &p );
+  QCOMPARE( settings2.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
+
+  settings.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
+  settings.writeSettingsToProject( &p );
+  settings2.readSettingsFromProject( &p );
+  QCOMPARE( settings2.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+
+  // test that older setting is still respected as a fallback
+  QgsProject p2;
+  QgsLabelingEngineSettings settings3;
+  p2.writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), false );
+  settings3.readSettingsFromProject( &p2 );
+  QCOMPARE( settings3.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
+
+  p2.writeEntry( QStringLiteral( "PAL" ), QStringLiteral( "/DrawOutlineLabels" ), true );
+  settings3.readSettingsFromProject( &p2 );
+  QCOMPARE( settings3.defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
 }
 
 void TestQgsLabelingEngine::setDefaultLabelParams( QgsPalLayerSettings &settings )

--- a/tests/src/core/testqgslayoutcontext.cpp
+++ b/tests/src/core/testqgslayoutcontext.cpp
@@ -43,6 +43,7 @@ class TestQgsLayoutContext: public QObject
     void layer();
     void dpi();
     void renderContextFlags();
+    void textFormat();
     void boundingBoxes();
     void exportLayer();
     void geometry();
@@ -191,6 +192,15 @@ void TestQgsLayoutContext::renderContextFlags()
   QVERIFY( ( flags & QgsRenderContext::Antialiasing ) );
   QVERIFY( ( flags & QgsRenderContext::UseAdvancedEffects ) );
   QVERIFY( ( flags & QgsRenderContext::ForceVectorOutput ) );
+}
+
+void TestQgsLayoutContext::textFormat()
+{
+  QgsLayoutRenderContext context( nullptr );
+  context.setTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
+  QCOMPARE( context.textRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+  context.setTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
+  QCOMPARE( context.textRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
 }
 
 void TestQgsLayoutContext::boundingBoxes()

--- a/tests/src/core/testqgslayoututils.cpp
+++ b/tests/src/core/testqgslayoututils.cpp
@@ -285,6 +285,14 @@ void TestQgsLayoutUtils::createRenderContextFromLayout()
   QVERIFY( ( rc.flags() & QgsRenderContext::UseAdvancedEffects ) );
   QVERIFY( ( rc.flags() & QgsRenderContext::ForceVectorOutput ) );
 
+  // check text format is correctly set
+  l.renderContext().setTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
+  rc = QgsLayoutUtils::createRenderContextForLayout( &l, nullptr );
+  QCOMPARE( rc.textRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+  l.renderContext().setTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
+  rc = QgsLayoutUtils::createRenderContextForLayout( &l, nullptr );
+  QCOMPARE( rc.textRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
+
   p.end();
 }
 
@@ -340,22 +348,30 @@ void TestQgsLayoutUtils::createRenderContextFromMap()
 
   // check render context flags are correctly set
   l.renderContext().setFlags( nullptr );
-  rc = QgsLayoutUtils::createRenderContextForLayout( &l, nullptr );
+  rc = QgsLayoutUtils::createRenderContextForMap( map2, &p );
   QVERIFY( !( rc.flags() & QgsRenderContext::Antialiasing ) );
   QVERIFY( !( rc.flags() & QgsRenderContext::UseAdvancedEffects ) );
   QVERIFY( ( rc.flags() & QgsRenderContext::ForceVectorOutput ) );
 
   l.renderContext().setFlag( QgsLayoutRenderContext::FlagAntialiasing );
-  rc = QgsLayoutUtils::createRenderContextForLayout( &l, nullptr );
+  rc = QgsLayoutUtils::createRenderContextForMap( map2, &p );
   QVERIFY( ( rc.flags() & QgsRenderContext::Antialiasing ) );
   QVERIFY( !( rc.flags() & QgsRenderContext::UseAdvancedEffects ) );
   QVERIFY( ( rc.flags() & QgsRenderContext::ForceVectorOutput ) );
 
   l.renderContext().setFlag( QgsLayoutRenderContext::FlagUseAdvancedEffects );
-  rc = QgsLayoutUtils::createRenderContextForLayout( &l, nullptr );
+  rc = QgsLayoutUtils::createRenderContextForMap( map2, &p );
   QVERIFY( ( rc.flags() & QgsRenderContext::Antialiasing ) );
   QVERIFY( ( rc.flags() & QgsRenderContext::UseAdvancedEffects ) );
   QVERIFY( ( rc.flags() & QgsRenderContext::ForceVectorOutput ) );
+
+  // check text format is correctly set
+  l.renderContext().setTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
+  rc = QgsLayoutUtils::createRenderContextForMap( map2, &p );
+  QCOMPARE( rc.textRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+  l.renderContext().setTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
+  rc = QgsLayoutUtils::createRenderContextForMap( map2, &p );
+  QCOMPARE( rc.textRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
 
   p.end();
 }

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -35,6 +35,7 @@ class TestQgsMapSettings: public QObject
     void initTestCase();
     void cleanupTestCase();
     void testDefaults();
+    void testGettersSetters();
     void visibleExtent();
     void mapUnitsPerPixel();
     void testDevicePixelRatio();
@@ -80,6 +81,17 @@ void TestQgsMapSettings::testDefaults()
 {
   QgsMapSettings ms;
   QCOMPARE( ms.destinationCrs(), QgsCoordinateReferenceSystem() );
+}
+
+void TestQgsMapSettings::testGettersSetters()
+{
+  // basic getter/setter tests
+  QgsMapSettings ms;
+
+  ms.setTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
+  QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
+  ms.setTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
+  QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
 }
 
 void TestQgsMapSettings::visibleExtent()

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -36,6 +36,7 @@ class TestQgsMapSettings: public QObject
     void cleanupTestCase();
     void testDefaults();
     void testGettersSetters();
+    void testLabelingEngineSettings();
     void visibleExtent();
     void mapUnitsPerPixel();
     void testDevicePixelRatio();
@@ -92,6 +93,32 @@ void TestQgsMapSettings::testGettersSetters()
   QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
   ms.setTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
   QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+}
+
+void TestQgsMapSettings::testLabelingEngineSettings()
+{
+  // test that setting labeling engine settings for QgsMapSettings works
+  QgsMapSettings ms;
+  QgsLabelingEngineSettings les;
+  les.setNumCandidatePositions( 4, 8, 15 ); // 23, 42... ;)
+  ms.setLabelingEngineSettings( les );
+  int c1, c2, c3;
+  ms.labelingEngineSettings().numCandidatePositions( c1, c2, c3 );
+  QCOMPARE( c1, 4 );
+  QCOMPARE( c2, 8 );
+  QCOMPARE( c3, 15 );
+
+  // ensure that setting labeling engine settings also sets text format
+  les.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
+  ms.setLabelingEngineSettings( les );
+  QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
+  les.setDefaultTextRenderFormat( QgsRenderContext::TextFormatAlwaysOutlines );
+  ms.setLabelingEngineSettings( les );
+  QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysOutlines );
+  // but we should be able to override this manually
+  ms.setTextRenderFormat( QgsRenderContext::TextFormatAlwaysText );
+  QCOMPARE( ms.textRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
+  QCOMPARE( ms.labelingEngineSettings().defaultTextRenderFormat(), QgsRenderContext::TextFormatAlwaysText );
 }
 
 void TestQgsMapSettings::visibleExtent()

--- a/tests/src/python/test_qgsrendercontext.py
+++ b/tests/src/python/test_qgsrendercontext.py
@@ -34,6 +34,32 @@ start_app()
 
 class TestQgsRenderContext(unittest.TestCase):
 
+    def testGettersSetters(self):
+        """
+        Basic getter/setter tests
+        """
+        c = QgsRenderContext()
+
+        c.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
+        self.assertEqual(c.textRenderFormat(), QgsRenderContext.TextFormatAlwaysText)
+        c.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
+        self.assertEqual(c.textRenderFormat(), QgsRenderContext.TextFormatAlwaysOutlines)
+
+    def testCopyConstructor(self):
+        """
+        Test the copy constructor
+        """
+        c1 = QgsRenderContext()
+
+        c1.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
+
+        c2 = QgsRenderContext(c1)
+        self.assertEqual(c2.textRenderFormat(), QgsRenderContext.TextFormatAlwaysText)
+
+        c1.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
+        c2 = QgsRenderContext(c1)
+        self.assertEqual(c2.textRenderFormat(), QgsRenderContext.TextFormatAlwaysOutlines)
+
     def testFromQPainter(self):
         """ test QgsRenderContext.fromQPainter """
 
@@ -57,6 +83,20 @@ class TestQgsRenderContext(unittest.TestCase):
         c = QgsRenderContext.fromQPainter(p)
         self.assertEqual(c.painter(), p)
         self.assertAlmostEqual(c.scaleFactor(), dots_per_m / 1000, 3)  # scaleFactor should be pixels/mm
+
+    def testFromMapSettings(self):
+        """
+        test QgsRenderContext.fromMapSettings()
+        """
+        ms = QgsMapSettings()
+
+        ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysText)
+        rc = QgsRenderContext.fromMapSettings(ms)
+        self.assertEqual(rc.textRenderFormat(), QgsRenderContext.TextFormatAlwaysText)
+
+        ms.setTextRenderFormat(QgsRenderContext.TextFormatAlwaysOutlines)
+        rc = QgsRenderContext.fromMapSettings(ms)
+        self.assertEqual(rc.textRenderFormat(), QgsRenderContext.TextFormatAlwaysOutlines)
 
     def testRenderMetersInMapUnits(self):
 


### PR DESCRIPTION
This PR is a bunch of ground work to finally and permanently closing off the long standing https://issues.qgis.org/issues/3975 issue.

In order to properly solve this issue and make sure that the user's desire to either export ALL text (not just labels -- this also applies to things like scale bar text now) is respected EVERYWHERE I've moved the setting for text renderer type into QgsRenderContext. This allows the setting to be controlled on a render by render basis, so it fixes the fragile/buggy layout export override for this setting which previously relied on temporarily changing a project-wide setting.

In order to future proof this I've used an enum for the text format. The current options are `TextFormatAlwaysOutlines` (default) and `TextFormatAlwaysText`. The intention here is that we could potentially add a third option `PreferText` -- which means "use text objects, unless doing so results in inferior rendering"** (and make this the new default).

For consistency and ease of use I've also duplicated the existing dialog which shows on exporting a layout to SVG where users can set export options such as the text format and added it for PDF export. This allows us to fix #8844 and let users easily control text settings at PDF export time. It also brings more consistency -- an export options dialog is now shown for all export types from layouts (pdf/svg/raster).

The final part left is testing that older workarounds around OSX PDF export issues can now be removed due to Qt issues fixed in Qt5 -- @3nids will handle this testing and fix.

* Interestingly, trawling through the archives here and testing on master leads me to believe that the issues which caused us to move from text -> paths as defaults back in QGIS 2.0 have been fixed in Qt. At least, I can't find any regressions in the output quality when using text now (including previously mentioned issues like labels with a buffer/underline combination). But this discussion/change can wait for a future PR/release. (ping @dakcarto )