### PR TITLE
[Backport] Deactivate help button for SAGA algorithms

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
@@ -128,9 +128,6 @@ class SagaAlgorithmProvider(QgsProcessingProvider):
     def id(self):
         return 'saga'
 
-    def helpId(self):
-        return 'saga'
-
     def defaultVectorFileExtension(self, hasGeometry=True):
         return 'shp' if hasGeometry else 'dbf'
 


### PR DESCRIPTION
to avoid user frustration because no help is provided in user manual (simply listing parameters and options already shown in GUI can't be called a help)

(cherry picked from commit 72fdda7)