### PR TITLE
[BUGFIX][Server] WMS: Decode loaded SLD files from SLD parameter

### DIFF
--- a/src/server/qgshttprequesthandler.cpp
+++ b/src/server/qgshttprequesthandler.cpp
@@ -27,6 +27,7 @@
 #include "qgsmapserviceexception.h"
 #include <QBuffer>
 #include <QByteArray>
+#include <QTextCodec>
 #include <QDomDocument>
 #include <QFile>
 #include <QImage>
@@ -602,7 +603,12 @@ void QgsHttpRequestHandler::requestStringToParameterMap( const QString& request,
       {
         continue; //only http and ftp supported at the moment
       }
-      value = QString( fileContents );
+      QTextCodec* codec = QTextCodec::codecForUtfText( fileContents, nullptr );
+      if ( !codec )
+      {
+        codec = QTextCodec::codecForName( "UTF-8" );
+      }
+      value = codec->toUnicode( fileContents );
 #else
       QgsMessageLog::logMessage( "http and ftp methods not supported with Qt5." );
       continue;


### PR DESCRIPTION
## Description
QGIS Server did not decode loaded SLD files from SLD parameter.
The solution was to use QTextCodec to decode to unicode.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
