### PR TITLE
Fix(?) font dialog on OSX

### DIFF
--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -544,9 +544,6 @@ void QgsColorButton::prepareMenu()
   mMenu->addAction( pasteColorAction );
   connect( pasteColorAction, &QAction::triggered, this, &QgsColorButton::pasteColor );
 
-  //disabled for OSX, as it is impossible to grab the mouse under OSX
-  //see note for QWidget::grabMouse() re OSX Cocoa
-  //http://qt-project.org/doc/qt-4.8/qwidget.html#grabMouse
   QAction *pickColorAction = new QAction( tr( "Pick Color" ), this );
   mMenu->addAction( pickColorAction );
   connect( pickColorAction, &QAction::triggered, this, &QgsColorButton::activatePicker );

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -195,12 +195,7 @@ namespace QgsGuiUtils
     // parent is intentionally not set to 'this' as
     // that would make it follow the style sheet font
     // see also #12233 and #4937
-#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
-    // Native Mac dialog works only for Qt Carbon
-    return QFontDialog::getFont( &ok, initial, 0, title, QFontDialog::DontUseNativeDialog );
-#else
     return QFontDialog::getFont( &ok, initial, nullptr, title );
-#endif
   }
 
   void saveGeometry( QWidget *widget, const QString &keyName )


### PR DESCRIPTION
Refs discussion and patch at https://issues.qgis.org/issues/20426

I can't test the original issue or this fix to know if it works. @3nids @PeterPetrik @timlinux @slarosa can you please test and merge if it's correct?