### PR TITLE
[FEATURE] Allow deleting settings from the Advanced tab in options

### DIFF
--- a/python/core/auto_generated/qgssettings.sip.in
+++ b/python/core/auto_generated/qgssettings.sip.in
@@ -142,6 +142,18 @@ are based on the group. By default, no group is set.
 %Docstring
 Resets the group to what it was before the corresponding beginGroup() call.
 %End
+
+    QString group() const;
+%Docstring
+Returns the current group.
+
+.. seealso:: :py:func:`beginGroup`
+
+.. seealso:: :py:func:`endGroup`
+
+.. versionadded:: 3.6
+%End
+
     QStringList allKeys() const;
 %Docstring
 Returns a list of all keys, including subkeys, that can be read using the QSettings object.

--- a/src/app/qgssettingstree.h
+++ b/src/app/qgssettingstree.h
@@ -52,6 +52,22 @@ class QgsSettingsTree : public QTreeWidget
     Q_OBJECT
 
   public:
+
+    //! Model roles
+    enum Roles
+    {
+      TypeRole = Qt::UserRole + 1, //!< Item type role, see Type enum
+      PathRole, //!< Complete setting path, including parent groups
+    };
+
+    //! Item types
+    enum Type
+    {
+      Group = 0, //!< Group item
+      Setting, //!< Setting item
+    };
+    Q_ENUM( Type )
+
     explicit QgsSettingsTree( QWidget *parent = nullptr );
 
     void setSettingsObject( QgsSettings *mSettings );
@@ -70,11 +86,12 @@ class QgsSettingsTree : public QTreeWidget
 
   private slots:
     void updateSetting( QTreeWidgetItem *item );
+    void showContextMenu( QPoint pos );
 
   private:
     void updateChildItems( QTreeWidgetItem *parent );
     QTreeWidgetItem *createItem( const QString &text, QTreeWidgetItem *parent,
-                                 int index );
+                                 int index, bool isGroup );
     QTreeWidgetItem *childAt( QTreeWidgetItem *parent, int index );
     int childCount( QTreeWidgetItem *parent );
     int findChild( QTreeWidgetItem *parent, const QString &text, int startIndex );
@@ -87,6 +104,7 @@ class QgsSettingsTree : public QTreeWidget
     QIcon mKeyIcon;
 
     QMap< QString, QStringList > mSettingsMap;
+    QMenu *mContextMenu = nullptr;
 };
 
 #endif

--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -102,6 +102,10 @@ void QgsSettings::endGroup()
   }
 }
 
+QString QgsSettings::group() const
+{
+  return mUserSettings->group();
+}
 
 QStringList QgsSettings::allKeys() const
 {

--- a/src/core/qgssettings.h
+++ b/src/core/qgssettings.h
@@ -154,6 +154,15 @@ class CORE_EXPORT QgsSettings : public QObject
     void beginGroup( const QString &prefix, QgsSettings::Section section = QgsSettings::NoSection );
     //! Resets the group to what it was before the corresponding beginGroup() call.
     void endGroup();
+
+    /**
+     * Returns the current group.
+     * \see beginGroup()
+     * \see endGroup()
+     * \since QGIS 3.6
+     */
+    QString group() const;
+
     //! Returns a list of all keys, including subkeys, that can be read using the QSettings object.
     QStringList allKeys() const;
     //! Returns a list of all top-level keys that can be read using the QSettings object.

--- a/tests/src/python/test_qgssettings.py
+++ b/tests/src/python/test_qgssettings.py
@@ -181,6 +181,7 @@ class TestQgsSettings(unittest.TestCase):
         self.addToDefaults('testqgissettings/name', 'qgisrocks')
 
         self.settings.beginGroup('testqgissettings')
+        self.assertEqual(self.settings.group(), 'testqgissettings')
         self.assertEqual(['names'], self.settings.childGroups())
 
         self.settings.setValue('surnames/name1', 'qgisrocks-1')
@@ -189,11 +190,14 @@ class TestQgsSettings(unittest.TestCase):
         self.settings.setValue('names/name1', 'qgisrocks-1')
         self.assertEqual('qgisrocks-1', self.settings.value('names/name1'))
         self.settings.endGroup()
+        self.assertEqual(self.settings.group(), '')
         self.settings.beginGroup('testqgissettings/names')
+        self.assertEqual(self.settings.group(), 'testqgissettings/names')
         self.settings.setValue('name4', 'qgisrocks-4')
         keys = sorted(self.settings.childKeys())
         self.assertEqual(keys, ['name1', 'name2', 'name3', 'name4'])
         self.settings.endGroup()
+        self.assertEqual(self.settings.group(), '')
         self.assertEqual('qgisrocks-1', self.settings.value('testqgissettings/names/name1'))
         self.assertEqual('qgisrocks-4', self.settings.value('testqgissettings/names/name4'))
 
@@ -205,9 +209,11 @@ class TestQgsSettings(unittest.TestCase):
         self.addToDefaults('testqgissettings/foo/last', 'rocks')
 
         self.settings.beginGroup('testqgissettings')
+        self.assertEqual(self.settings.group(), 'testqgissettings')
         self.assertEqual(['foo'], self.settings.childGroups())
         self.assertEqual(['foo'], self.settings.globalChildGroups())
         self.settings.endGroup()
+        self.assertEqual(self.settings.group(), '')
 
         self.settings.setValue('testqgissettings/bar/first', 'qgis')
         self.settings.setValue('testqgissettings/bar/last', 'rocks')
@@ -227,6 +233,7 @@ class TestQgsSettings(unittest.TestCase):
     def test_group_section(self):
         # Test group by using Section
         self.settings.beginGroup('firstgroup', section=QgsSettings.Core)
+        self.assertEqual(self.settings.group(), 'core/firstgroup')
         self.assertEqual([], self.settings.childGroups())
         self.settings.setValue('key', 'value')
         self.settings.setValue('key2/subkey1', 'subvalue1')
@@ -237,6 +244,7 @@ class TestQgsSettings(unittest.TestCase):
         self.assertEqual(['key', 'key3'], self.settings.childKeys())
         self.assertEqual(['key2'], self.settings.childGroups())
         self.settings.endGroup()
+        self.assertEqual(self.settings.group(), '')
         # Set value by writing the group manually
         self.settings.setValue('firstgroup/key4', 'value4', section=QgsSettings.Core)
         # Checking the value that have been set


### PR DESCRIPTION
This commit adds a new right click menu to the settings shown in the "Advanced" tab in the settings dialog, which allows users to remove that setting (or group of settings).

For those times when starting a whole new blank profile is overkill, and you can't be a$$ed using the QSettings API to delete a key/group...