### PR TITLE
Offline editing to GPKG attribute order. Fixes #20276

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -763,11 +763,9 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
       // NOTE: SpatiaLite provider ignores position of geometry column
       // fill gap in QgsAttributeMap if geometry column is not last (WORKAROUND)
       QgsAttributes attrs = f.attributes();
-      int column = 0;
       // on GPKG newAttrs has an addition FID attribute, so we have to add a dummy in the original set
-      if ( containerType == GPKG )
-        column++;
-      QgsAttributes newAttrs( attrs.count() + column );
+      QgsAttributes newAttrs( containerType == GPKG ? attrs.count() + 1 : attrs.count() );
+      int column = 0;
       for ( int it = 0; it < attrs.count(); ++it )
       {
         newAttrs[column++] = attrs.at( it );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -762,10 +762,10 @@ QgsVectorLayer *QgsOfflineEditing::copyVectorLayer( QgsVectorLayer *layer, sqlit
 
       // NOTE: SpatiaLite provider ignores position of geometry column
       // fill gap in QgsAttributeMap if geometry column is not last (WORKAROUND)
+      int column = 0;
       QgsAttributes attrs = f.attributes();
       // on GPKG newAttrs has an addition FID attribute, so we have to add a dummy in the original set
       QgsAttributes newAttrs( containerType == GPKG ? attrs.count() + 1 : attrs.count() );
-      int column = 0;
       for ( int it = 0; it < attrs.count(); ++it )
       {
         newAttrs[column++] = attrs.at( it );
@@ -1137,13 +1137,14 @@ void QgsOfflineEditing::updateLayerOrder( QgsVectorLayer *sourceLayer, QgsVector
 QMap<int, int> QgsOfflineEditing::attributeLookup( QgsVectorLayer *offlineLayer, QgsVectorLayer *remoteLayer )
 {
   const QgsAttributeList &offlineAttrs = offlineLayer->attributeList();
-  const QgsAttributeList &remoteAttrs = remoteLayer->attributeList();
 
   QMap < int /*offline attr*/, int /*remote attr*/ > attrLookup;
-  // NOTE: use size of remoteAttrs, as offlineAttrs can have new attributes not yet synced
-  for ( int i = 0; i < remoteAttrs.size(); i++ )
+  // NOTE: though offlineAttrs can have new attributes not yet synced, we take the amount of offlineAttrs
+  // because we anyway only add mapping for the fields existing in remoteLayer (this because it could contain fid on 0)
+  for ( int i = 0; i < offlineAttrs.size(); i++ )
   {
-    attrLookup.insert( offlineAttrs.at( i ), remoteAttrs.at( i ) );
+    if ( remoteLayer->fields().lookupField( offlineLayer->fields().field( i ).name() ) >= 0 )
+      attrLookup.insert( offlineAttrs.at( i ), remoteLayer->fields().indexOf( offlineLayer->fields().field( i ).name() ) );
   }
 
   return attrLookup;

--- a/tests/src/core/testqgsofflineediting.cpp
+++ b/tests/src/core/testqgsofflineediting.cpp
@@ -41,6 +41,7 @@ class TestQgsOfflineEditing : public QObject
     QStringList layerIds;
     long numberOfFeatures;
     int numberOfFields;
+    QTemporaryDir tempDir;
 
   private slots:
     void initTestCase();// will be called before the first testfunction is executed.
@@ -75,8 +76,12 @@ void TestQgsOfflineEditing::cleanupTestCase()
 void TestQgsOfflineEditing::init()
 {
   QString myFileName( TEST_DATA_DIR ); //defined in CmakeLists.txt
-  myFileName = myFileName + "/points.shp";
-  QFileInfo myMapFileInfo( myFileName );
+  QString myTempDirName = tempDir.path();
+  QFile::copy( myFileName + "/points.shp", myTempDirName + "/points.shp" );
+  QFile::copy( myFileName + "/points.shx", myTempDirName + "/points.shx" );
+  QFile::copy( myFileName + "/points.dbf", myTempDirName + "/points.dbf" );
+  QString myTempFileName = myTempDirName + "/points.shp";
+  QFileInfo myMapFileInfo( myTempFileName );
   mpLayer = new QgsVectorLayer( myMapFileInfo.filePath(),
                                 myMapFileInfo.completeBaseName(), QStringLiteral( "ogr" ) );
   QgsProject::instance()->addMapLayer( mpLayer );


### PR DESCRIPTION
Has been messed up, because of the additional fid.

Is fixed now by:
Leaving last attribute empty instead of first on creating the GPKG layer features.
Handling fid attribute in attrLookup mapping on synchronization back.

It fixes #20276