### PR TITLE
[Bugfix] .qgs-translation fix: do not create QgsProject before QgsApplication

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -430,6 +430,9 @@ APP_EXPORT
 #endif
 int main( int argc, char *argv[] )
 {
+  //log messages written before creating QgsApplicatoin
+  QStringList preApplicationLogMessages;
+
 #ifdef Q_OS_MACX
   // Increase file resource limits (i.e., number of allowed open files)
   // (from code provided by Larry Biehl, Purdue University, USA, from 'MultiSpec' project)
@@ -866,11 +869,11 @@ int main( int argc, char *argv[] )
   {
     if ( !QgsSettings::setGlobalSettingsPath( globalsettingsfile ) )
     {
-      QgsMessageLog::logMessage( QObject::tr( "Invalid globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" ) );
+      preApplicationLogMessages << QObject::tr( "Invalid globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" );
     }
     else
     {
-      QgsMessageLog::logMessage( QObject::tr( "Successfully loaded globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" ) );
+      preApplicationLogMessages << QObject::tr( "Successfully loaded globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" );
     }
   }
 
@@ -969,6 +972,10 @@ int main( int argc, char *argv[] )
   }
 
   QgsApplication myApp( argc, argv, myUseGuiFlag );
+
+  //write the log messages written before creating QgsApplicatoin
+  for ( QString const &preApplicationLogMessage : preApplicationLogMessages )
+    QgsMessageLog::logMessage( preApplicationLogMessage );
 
   // Settings migration is only supported on the default profile for now.
   if ( profileName == QLatin1String( "default" ) )

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -430,7 +430,7 @@ APP_EXPORT
 #endif
 int main( int argc, char *argv[] )
 {
-  //log messages written before creating QgsApplicatoin
+  //log messages written before creating QgsApplication
   QStringList preApplicationLogMessages;
 
 #ifdef Q_OS_MACX
@@ -973,8 +973,8 @@ int main( int argc, char *argv[] )
 
   QgsApplication myApp( argc, argv, myUseGuiFlag );
 
-  //write the log messages written before creating QgsApplicatoin
-  for ( QString const &preApplicationLogMessage : preApplicationLogMessages )
+  //write the log messages written before creating QgsApplication
+  for ( const QString &preApplicationLogMessage : qgis::as_const( preApplicationLogMessages ) )
     QgsMessageLog::logMessage( preApplicationLogMessage );
 
   // Settings migration is only supported on the default profile for now.

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -384,8 +384,8 @@ QgsProject::QgsProject( QObject *parent )
   connect( mLayerStore.get(), &QgsMapLayerStore::allLayersRemoved, this, &QgsProject::removeAll );
   connect( mLayerStore.get(), &QgsMapLayerStore::layersAdded, this, &QgsProject::layersAdded );
   connect( mLayerStore.get(), &QgsMapLayerStore::layerWasAdded, this, &QgsProject::layerWasAdded );
-  Q_ASSERT( QgsApplication::instance() );
-  connect( QgsApplication::instance(), &QgsApplication::requestForTranslatableObjects, this, &QgsProject::registerTranslatableObjects );
+  if ( QgsApplication::instance() )
+    connect( QgsApplication::instance(), &QgsApplication::requestForTranslatableObjects, this, &QgsProject::registerTranslatableObjects );
   connect( mLayerStore.get(), static_cast<void ( QgsMapLayerStore::* )( const QList<QgsMapLayer *> & )>( &QgsMapLayerStore::layersWillBeRemoved ),
            [ = ]( const QList<QgsMapLayer *> &layers )
   {

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -384,8 +384,8 @@ QgsProject::QgsProject( QObject *parent )
   connect( mLayerStore.get(), &QgsMapLayerStore::allLayersRemoved, this, &QgsProject::removeAll );
   connect( mLayerStore.get(), &QgsMapLayerStore::layersAdded, this, &QgsProject::layersAdded );
   connect( mLayerStore.get(), &QgsMapLayerStore::layerWasAdded, this, &QgsProject::layerWasAdded );
-  if ( QgsApplication::instance() )
-    connect( QgsApplication::instance(), &QgsApplication::requestForTranslatableObjects, this, &QgsProject::registerTranslatableObjects );
+  Q_ASSERT( QgsApplication::instance() );
+  connect( QgsApplication::instance(), &QgsApplication::requestForTranslatableObjects, this, &QgsProject::registerTranslatableObjects );
   connect( mLayerStore.get(), static_cast<void ( QgsMapLayerStore::* )( const QList<QgsMapLayer *> & )>( &QgsMapLayerStore::layersWillBeRemoved ),
            [ = ]( const QList<QgsMapLayer *> &layers )
   {


### PR DESCRIPTION
Do not write logs before QgsApplication instace, because otherwise it creates a QgsProject without a QgsApplication. This would break the qgs. translation.

fixes #20561