### PR TITLE
Fix font dialog on OSX (https://issues.qgis.org/issues/20426)

### DIFF
--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -544,9 +544,6 @@ void QgsColorButton::prepareMenu()
   mMenu->addAction( pasteColorAction );
   connect( pasteColorAction, &QAction::triggered, this, &QgsColorButton::pasteColor );
 
-  //disabled for OSX, as it is impossible to grab the mouse under OSX
-  //see note for QWidget::grabMouse() re OSX Cocoa
-  //http://qt-project.org/doc/qt-4.8/qwidget.html#grabMouse
   QAction *pickColorAction = new QAction( tr( "Pick Color" ), this );
   mMenu->addAction( pickColorAction );
   connect( pickColorAction, &QAction::triggered, this, &QgsColorButton::activatePicker );

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -195,9 +195,12 @@ namespace QgsGuiUtils
     // parent is intentionally not set to 'this' as
     // that would make it follow the style sheet font
     // see also #12233 and #4937
-#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
-    // Native Mac dialog works only for Qt Carbon
-    return QFontDialog::getFont( &ok, initial, 0, title, QFontDialog::DontUseNativeDialog );
+#if defined(Q_OS_MAC)
+    // Native dialog broken on macOS with Qt5
+    // probably only broken in Qt5.11.1 and .2
+    //    (see https://successfulsoftware.net/2018/11/02/qt-is-broken-on-macos-right-now/ )
+    // possible upstream bug: https://bugreports.qt.io/browse/QTBUG-69878 (fixed in Qt 5.12 ?)
+    return QFontDialog::getFont( &ok, initial, nullptr, title, QFontDialog::DontUseNativeDialog );
 #else
     return QFontDialog::getFont( &ok, initial, nullptr, title );
 #endif


### PR DESCRIPTION
This PR fixes the broken font dialog on macOS in QGIS 3.4

on Qt5 (probably only 5.11.1 and .2) the QFontDialog is broken on macOS. There is already a check in place in QGIS to workaround a similar issue, but this check is also broken.

this PR restores the workaround which also applies here and fixes the bug.

see discussions in
- https://issues.qgis.org/issues/20426
- #8585 

upstream Qt bug:
  - https://bugreports.qt.io/browse/QTBUG-69878
  - https://successfulsoftware.net/2018/11/02/qt-is-broken-on-macos-right-now/