### PR TITLE
Save layer changes on successful repair

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7118,7 +7118,6 @@ void QgisApp::commitError( QgsVectorLayer *vlayer )
   const QStringList commitErrors = vlayer->commitErrors();
   if ( !vlayer->allowCommit() && commitErrors.empty() )
   {
-    QgsMessageLog::logMessage( tr( "Could not save changes. Geometry validation failed." ) );
     return;
   }
 

--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -145,7 +145,7 @@ void QgsGeometryValidationService::onFeatureDeleted( QgsVectorLayer *layer, QgsF
 
 void QgsGeometryValidationService::onBeforeCommitChanges( QgsVectorLayer *layer )
 {
-  if ( !mLayerChecks[layer].topologyChecks.empty() ) // TODO && topologyChecks not fulfilled
+  if ( !mBypassChecks && !mLayerChecks[layer].topologyChecks.empty() )
   {
     if ( !layer->allowCommit() )
     {
@@ -461,7 +461,9 @@ void QgsGeometryValidationService::triggerTopologyChecks( QgsVectorLayer *layer 
     }
     if ( allErrors.empty() && mLayerChecks[layer].singleFeatureCheckErrors.empty() && mLayerChecks[layer].commitPending )
     {
+      mBypassChecks = true;
       layer->commitChanges();
+      mBypassChecks = false;
       mMessageBar->popWidget( mMessageBarItem );
       mMessageBarItem = nullptr;
     }

--- a/src/app/qgsgeometryvalidationservice.h
+++ b/src/app/qgsgeometryvalidationservice.h
@@ -122,6 +122,10 @@ class QgsGeometryValidationService : public QObject
     QgsMessageBar *mMessageBar = nullptr;
     QgsMessageBarItem *mMessageBarItem = nullptr;
 
+    // when checks do complete successfully and changes need to be saved
+    // this variable is used to indicate that it's safe to bypass the checks
+    bool mBypassChecks = false;
+
 };
 
 #endif // QGSGEOMETRYVALIDATIONSERVICE_H


### PR DESCRIPTION
When there are topology errors which are fixed subsequently, make sure that the layer can be saved again.
In this case, beforeCommit is called recursively when we are trying to actually commit the changes. In the nested call, changes should be saved instead of triggering a new round of checks.