### PR TITLE
[fix] wrong padding of QgsFontButton on macOS

### DIFF
--- a/src/gui/qgsfontbutton.cpp
+++ b/src/gui/qgsfontbutton.cpp
@@ -773,6 +773,8 @@ void QgsFontButton::updatePreview( const QColor &color, QgsTextFormat *format, Q
       //make sure height of icon looks good under different platforms
 #ifdef Q_OS_WIN
       mIconSize = QSize( buttonSize.width() - 10, height() - 6 );
+#elif defined(Q_OS_MAC)
+      mIconSize = QSize( buttonSize.width() - 10, height() - 2 );
 #else
       mIconSize = QSize( buttonSize.width() - 10, height() - 12 );
 #endif


### PR DESCRIPTION
this PR removes the visual weird padding of the QgsFontButton under macOS. 

![qgis_fontbutton_3 4 2](https://user-images.githubusercontent.com/10474950/49449828-0b584480-f7dc-11e8-9132-de2b20d445ea.png)

i decided to use a tight fit to the button by subtracting 2. 

![qgis_fontbutton_fix2](https://user-images.githubusercontent.com/10474950/49449992-612cec80-f7dc-11e8-8925-c8f35cb646a5.png)

under windows there is a 1px gap at the button margin, which would correspond to subtracting 4 on macOS but imho does not look as good. 

![qgis_fontbutton_fix4](https://user-images.githubusercontent.com/10474950/49450171-c08afc80-f7dc-11e8-9717-51e06d65aa7d.png)



