### PR TITLE
Some Python console fixes

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -87,6 +87,10 @@ class PythonConsole(QgsDockWidget):
         if iface and not iface.mainWindow().restoreDockWidget(self):
             iface.mainWindow().addDockWidget(Qt.BottomDockWidgetArea, self)
 
+        # closeEvent is not always called for this widget -- so we also trigger a settings
+        # save on application exit
+        QgsApplication.instance().aboutToQuit.connect(self.console.saveSettingsConsole)
+
     def activate(self):
         self.activateWindow()
         self.raise_()

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -18,7 +18,7 @@ email                : lrssvtml (at) gmail (dot) com
  ***************************************************************************/
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
-from qgis.PyQt.QtCore import Qt, QObject, QEvent, QCoreApplication, QFileInfo, QSize
+from qgis.PyQt.QtCore import Qt, QObject, QEvent, QCoreApplication, QFileInfo, QSize, QDir
 from qgis.PyQt.QtGui import QFont, QFontMetrics, QColor, QKeySequence, QCursor, QFontDatabase
 from qgis.PyQt.QtWidgets import QShortcut, QMenu, QApplication, QWidget, QGridLayout, QSpacerItem, QSizePolicy, QFileDialog, QTabWidget, QTreeWidgetItem, QFrame, QLabel, QToolButton, QMessageBox
 from qgis.PyQt.Qsci import QsciScintilla, QsciLexerPython, QsciAPIs, QsciStyle
@@ -831,9 +831,10 @@ class EditorTab(QWidget):
         if self.path is None:
             saveTr = QCoreApplication.translate('PythonConsole',
                                                 'Python Console: Save file')
+            folder = self.pc.settings.value("pythonConsole/lastDirPath", QDir.homePath())
             self.path, filter = QFileDialog().getSaveFileName(self,
                                                               saveTr,
-                                                              self.tw.tabText(index) + '.py',
+                                                              os.path.join(folder, self.tw.tabText(index) + '.py'),
                                                               "Script file (*.py)")
             # If the user didn't select a file, abort the save operation
             if len(self.path) == 0:

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -509,11 +509,6 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         subMenu.addAction(
             QCoreApplication.translate("PythonConsole", "Show"),
             self.showHistory, 'Ctrl+Shift+SPACE')
-        subMenu.addSeparator()
-        subMenu.addAction(
-            QCoreApplication.translate("PythonConsole", "Save"),
-            self.writeHistoryFile)
-        subMenu.addSeparator()
         subMenu.addAction(
             QCoreApplication.translate("PythonConsole", "Clear File"),
             self.clearHistory)


### PR DESCRIPTION
- Fixes scripts sometimes default to saving in QGIS bin folder
- Correctly save settings when exiting app, which was preventing the history from being saved and restored between sessions