### PR TITLE
Geometry collection PyQGIS improvements [FEATURE][API]

### DIFF
--- a/i18n/CMakeLists.txt
+++ b/i18n/CMakeLists.txt
@@ -39,7 +39,7 @@ IF (UNIX AND NOT APPLE AND PYQT5_FOUND)
 
   INSTALL(FILES ${CMAKE_BINARY_DIR}/org.qgis.qgis.desktop DESTINATION share/applications)
   INSTALL(FILES ${CMAKE_BINARY_DIR}/org.qgis.qgis.appdata.xml DESTINATION share/metainfo)
-ENDIF (UNIX AND NOT APPLE)
+ENDIF (UNIX AND NOT APPLE AND PYQT5_FOUND)
 
 # creating a custom target is needed to make the files build
 # "ALL" means that it will be run by default

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -816,7 +816,7 @@ Returns next vertex of the geometry (undefined behavior if hasNext() returns fal
     sipRes = sipCpp;
 %End
 
-    SIP_PYOBJECT __next__();
+    SIP_PYOBJECT __next__() /TypeHint="QgsPoint"/;
 %MethodCode
     if ( sipCpp->hasNext() )
       sipRes = sipConvertFromType( new QgsPoint( sipCpp->next() ), sipType_QgsPoint, Py_None );
@@ -863,7 +863,7 @@ Returns next part of the geometry (undefined behavior if hasNext() returns false
     sipRes = sipCpp;
 %End
 
-    SIP_PYOBJECT __next__();
+    SIP_PYOBJECT __next__() /TypeHint="QgsAbstractGeometry"/;
 %MethodCode
     if ( sipCpp->hasNext() )
       sipRes = sipConvertFromType( sipCpp->next(), sipType_QgsAbstractGeometry, NULL );
@@ -911,7 +911,7 @@ Returns next part of the geometry (undefined behavior if hasNext() returns false
     sipRes = sipCpp;
 %End
 
-    SIP_PYOBJECT __next__();
+    SIP_PYOBJECT __next__() /TypeHint="QgsAbstractGeometry"/;
 %MethodCode
     if ( sipCpp->hasNext() )
       sipRes = sipConvertFromType( const_cast< QgsAbstractGeometry * >( sipCpp->next() ), sipType_QgsAbstractGeometry, NULL );

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -109,13 +109,26 @@ Inserts a geometry before a specified index and takes ownership. Returns true in
 :param index: position to insert geometry before
 %End
 
+
     virtual bool removeGeometry( int nr );
 %Docstring
-Removes a geometry from the collection.
+Removes a geometry from the collection by index.
 
-:param nr: index of geometry to remove
+An IndexError will be raised if no geometry with the specified index exists.
 
 :return: true if removal was successful.
+%End
+%MethodCode
+    const int count = sipCpp->numGeometries();
+    if ( a0 < 0 || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipCpp->removeGeometry( a0 );
+    }
 %End
 
     virtual void transform( const QgsCoordinateTransform &ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform, bool transformZ = false ) throw( QgsCsException );
@@ -206,6 +219,56 @@ Returns a geometry without curves. Caller takes ownership
     virtual QgsGeometryCollection *toCurveType() const /Factory/;
 
 
+
+
+
+    SIP_PYOBJECT __getitem__( int index );
+%Docstring
+Returns the geometry at the specified ``index``. An IndexError will be raised if no geometry with the specified ``index`` exists.
+
+Indexes can be less than 0, in which case they correspond to geometries from the end of the collect. E.g. an index of -1
+corresponds to the last geometry in the collection.
+
+.. versionadded:: 3.6
+%End
+%MethodCode
+    const int count = sipCpp->numGeometries();
+    if ( a0 < -count || a0 >= count )
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+    else if ( a0 >= 0 )
+    {
+      return sipConvertFromType( sipCpp->geometryN( a0 ), sipType_QgsAbstractGeometry, NULL );
+    }
+    else
+    {
+      return sipConvertFromType( sipCpp->geometryN( count + a0 ), sipType_QgsAbstractGeometry, NULL );
+    }
+%End
+
+    void __delitem__( int index );
+%Docstring
+Deletes the geometry at the specified ``index``. A geometry at the ``index`` must already exist or an IndexError will be raised.
+
+Indexes can be less than 0, in which case they correspond to geometries from the end of the collection. E.g. an index of -1
+corresponds to the last geometry in the collection.
+
+.. versionadded:: 3.6
+%End
+%MethodCode
+    const int count = sipCpp->numGeometries();
+    if ( a0 >= 0 && a0 < count )
+      sipCpp->removeGeometry( a0 );
+    else if ( a0 < 0 && a0 >= -count )
+      sipCpp->removeGeometry( count + a0 );
+    else
+    {
+      PyErr_SetString( PyExc_IndexError, QByteArray::number( a0 ) );
+      sipIsErr = 1;
+    }
+%End
 
     virtual QgsGeometryCollection *createEmptyWithSameType() const /Factory/;
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -270,6 +270,16 @@ corresponds to the last geometry in the collection.
     }
 %End
 
+    SIP_PYOBJECT __iter__() /TypeHint="QgsGeometryPartIterator"/;
+%Docstring
+Iterates through all geometries in the collection.
+
+.. versionadded:: 3.6
+%End
+%MethodCode
+    sipRes = sipConvertFromNewType( new QgsGeometryPartIterator( sipCpp ), sipType_QgsGeometryPartIterator, Py_None );
+%End
+
     virtual QgsGeometryCollection *createEmptyWithSameType() const /Factory/;
 
 

--- a/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometrycollection.sip.in
@@ -58,7 +58,7 @@ Returns the number of geometries within the collection.
 
 
 
-    SIP_PYOBJECT geometryN( int n );
+    SIP_PYOBJECT geometryN( int n ) /TypeHint="QgsAbstractGeometry"/;
 %Docstring
 Returns a geometry from within the collection.
 
@@ -222,7 +222,7 @@ Returns a geometry without curves. Caller takes ownership
 
 
 
-    SIP_PYOBJECT __getitem__( int index );
+    SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsAbstractGeometry"/;
 %Docstring
 Returns the geometry at the specified ``index``. An IndexError will be raised if no geometry with the specified ``index`` exists.
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -82,7 +82,7 @@ Construct a linestring from a single 2d line segment.
 
 
 
-    SIP_PYOBJECT pointN( int i ) const;
+    SIP_PYOBJECT pointN( int i ) const /TypeHint="QgsPoint"/;
 %Docstring
 Returns the point at the specified index. An IndexError will be raised if no point with the specified index exists.
 
@@ -505,7 +505,7 @@ of the curve.
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 
-    SIP_PYOBJECT __getitem__( int index );
+    SIP_PYOBJECT __getitem__( int index ) /TypeHint="QgsPoint"/;
 %Docstring
 Returns the point at the specified ``index``. An IndexError will be raised if no point with the specified ``index`` exists.
 

--- a/python/core/auto_generated/qgsfeatureiterator.sip.in
+++ b/python/core/auto_generated/qgsfeatureiterator.sip.in
@@ -206,7 +206,7 @@ Wrapper for iterator of features from vector data provider or vector layer
     sipRes = sipCpp;
 %End
 
-    SIP_PYOBJECT __next__();
+    SIP_PYOBJECT __next__() /TypeHint="QgsFeature"/;
 %MethodCode
     std::unique_ptr< QgsFeature > f = qgis::make_unique< QgsFeature >();
     bool result = false;

--- a/scripts/sipify.pl
+++ b/scripts/sipify.pl
@@ -393,6 +393,7 @@ sub fix_annotations {
     $line =~ s/\bSIP_TRANSFERTHIS\b/\/TransferThis\//;
 
     $line =~ s/SIP_PYNAME\(\s*(\w+)\s*\)/\/PyName=$1\//;
+    $line =~ s/SIP_TYPEHINT\(\s*(\w+)\s*\)/\/TypeHint="$1"\//;
     $line =~ s/SIP_VIRTUALERRORHANDLER\(\s*(\w+)\s*\)/\/VirtualErrorHandler=$1\//;
     $line =~ s/SIP_THROW\(\s*(\w+)\s*\)/throw\( $1 \)/;
 

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -1039,7 +1039,7 @@ class CORE_EXPORT QgsVertexIterator
     sipRes = sipCpp;
     % End
 
-    SIP_PYOBJECT __next__();
+    SIP_PYOBJECT __next__() SIP_TYPEHINT( QgsPoint );
     % MethodCode
     if ( sipCpp->hasNext() )
       sipRes = sipConvertFromType( new QgsPoint( sipCpp->next() ), sipType_QgsPoint, Py_None );
@@ -1088,7 +1088,7 @@ class CORE_EXPORT QgsGeometryPartIterator
     sipRes = sipCpp;
     % End
 
-    SIP_PYOBJECT __next__();
+    SIP_PYOBJECT __next__() SIP_TYPEHINT( QgsAbstractGeometry );
     % MethodCode
     if ( sipCpp->hasNext() )
       sipRes = sipConvertFromType( sipCpp->next(), sipType_QgsAbstractGeometry, NULL );
@@ -1138,7 +1138,7 @@ class CORE_EXPORT QgsGeometryConstPartIterator
     sipRes = sipCpp;
     % End
 
-    SIP_PYOBJECT __next__();
+    SIP_PYOBJECT __next__() SIP_TYPEHINT( QgsAbstractGeometry );
     % MethodCode
     if ( sipCpp->hasNext() )
       sipRes = sipConvertFromType( const_cast< QgsAbstractGeometry * >( sipCpp->next() ), sipType_QgsAbstractGeometry, NULL );

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -277,6 +277,16 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
       sipIsErr = 1;
     }
     % End
+
+    /**
+     * Iterates through all geometries in the collection.
+     *
+     * \since QGIS 3.6
+     */
+    SIP_PYOBJECT __iter__() SIP_TYPEHINT( QgsGeometryPartIterator );
+    % MethodCode
+    sipRes = sipConvertFromNewType( new QgsGeometryPartIterator( sipCpp ), sipType_QgsGeometryPartIterator, Py_None );
+    % End
 #endif
 
     QgsGeometryCollection *createEmptyWithSameType() const override SIP_FACTORY;

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -88,7 +88,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
 #ifndef SIP_RUN
     QgsAbstractGeometry *geometryN( int n );
 #else
-    SIP_PYOBJECT geometryN( int n );
+    SIP_PYOBJECT geometryN( int n ) SIP_TYPEHINT( QgsAbstractGeometry );
     % MethodCode
     if ( a0 < 0 || a0 >= sipCpp->numGeometries() )
     {
@@ -238,7 +238,7 @@ class CORE_EXPORT QgsGeometryCollection: public QgsAbstractGeometry
     *
     * \since QGIS 3.6
     */
-    SIP_PYOBJECT __getitem__( int index );
+    SIP_PYOBJECT __getitem__( int index ) SIP_TYPEHINT( QgsAbstractGeometry );
     % MethodCode
     const int count = sipCpp->numGeometries();
     if ( a0 < -count || a0 >= count )

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -109,7 +109,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
      * Indexes can be less than 0, in which case they correspond to positions from the end of the line. E.g. an index of -1
      * corresponds to the last point in the line.
      */
-    SIP_PYOBJECT pointN( int i ) const;
+    SIP_PYOBJECT pointN( int i ) const SIP_TYPEHINT( QgsPoint );
     % MethodCode
     const int count = sipCpp->numPoints();
     if ( a0 < -count || a0 >= count )
@@ -647,7 +647,7 @@ class CORE_EXPORT QgsLineString: public QgsCurve
     *
     * \since QGIS 3.6
     */
-    SIP_PYOBJECT __getitem__( int index );
+    SIP_PYOBJECT __getitem__( int index ) SIP_TYPEHINT( QgsPoint );
     % MethodCode
     const int count = sipCpp->numPoints();
     if ( a0 < -count || a0 >= count )

--- a/src/core/qgis_sip.h
+++ b/src/core/qgis_sip.h
@@ -198,6 +198,14 @@
 #define SIP_DOC_TEMPLATE
 
 /*
+ * Specifies the type of the value returned by the function as it will appear in any
+ * generated docstrings and PEP 484 type hints. It is usually used with results of type
+ * SIP_PYOBJECT to provide a more specific type.
+ * Available for SIP 4.18+
+ */
+#define SIP_TYPEHINT(type)
+
+/*
  * Sip supports the final keyword since version 4.19.0, earlier than that
  * we will have build issues because it tries to override final methods.
  */

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -270,7 +270,7 @@ class CORE_EXPORT QgsFeatureIterator
     sipRes = sipCpp;
     % End
 
-    SIP_PYOBJECT __next__();
+    SIP_PYOBJECT __next__() SIP_TYPEHINT( QgsFeature );
     % MethodCode
     std::unique_ptr< QgsFeature > f = qgis::make_unique< QgsFeature >();
     bool result = false;

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -433,6 +433,71 @@ class TestQgsGeometry(unittest.TestCase):
         with self.assertRaises(IndexError):
             del ls[-3]
 
+    def testGeometryCollectionPythonAdditions(self):
+        """
+        Tests Python specific additions to the QgsGeometryCollection API
+        """
+        g = QgsGeometryCollection()
+        self.assertTrue(bool(g))
+        self.assertEqual(len(g), 0)
+        g = QgsGeometryCollection()
+        g.fromWkt('GeometryCollection( Point(1  2), Point(11 12))')
+        self.assertTrue(bool(g))
+        self.assertEqual(len(g), 2)
+
+        # pointN
+        with self.assertRaises(IndexError):
+            g.geometryN(-1)
+        with self.assertRaises(IndexError):
+            g.geometryN(2)
+        self.assertEqual(g.geometryN(0), QgsPoint(1, 2))
+        self.assertEqual(g.geometryN(1), QgsPoint(11, 12))
+
+        # removeGeometry
+        g.fromWkt('GeometryCollection( Point(1  2), Point(11 12), Point(33 34))')
+        with self.assertRaises(IndexError):
+            g.removeGeometry(-1)
+        with self.assertRaises(IndexError):
+            g.removeGeometry(3)
+        g.removeGeometry(1)
+        self.assertEqual(len(g), 2)
+        self.assertEqual(g.geometryN(0), QgsPoint(1, 2))
+        self.assertEqual(g.geometryN(1), QgsPoint(33, 34))
+        with self.assertRaises(IndexError):
+            g.removeGeometry(2)
+
+        g.fromWkt('GeometryCollection( Point(25 16 37 58), Point(26 22 47 68))')
+        # get item
+        with self.assertRaises(IndexError):
+            g[-3]
+        with self.assertRaises(IndexError):
+            g[2]
+        self.assertEqual(g[0], QgsPoint(25, 16, 37, 58))
+        self.assertEqual(g[1], QgsPoint(26, 22, 47, 68))
+        self.assertEqual(g[-2], QgsPoint(25, 16, 37, 58))
+        self.assertEqual(g[-1], QgsPoint(26, 22, 47, 68))
+
+        # del item
+        g.fromWkt('GeometryCollection( Point(1  2), Point(11 12), Point(33 34))')
+        with self.assertRaises(IndexError):
+            del g[-4]
+        with self.assertRaises(IndexError):
+            del g[3]
+        del g[1]
+        self.assertEqual(len(g), 2)
+        self.assertEqual(g[0], QgsPoint(1, 2))
+        self.assertEqual(g[1], QgsPoint(33, 34))
+        with self.assertRaises(IndexError):
+            del g[2]
+
+        g.fromWkt('GeometryCollection( Point(1  2), Point(11 12), Point(33 34))')
+        del g[-3]
+        self.assertEqual(len(g), 2)
+        self.assertEqual(g[0], QgsPoint(11, 12))
+        self.assertEqual(g[1], QgsPoint(33, 34))
+        with self.assertRaises(IndexError):
+            del g[-3]
+
     def testReferenceGeometry(self):
         """ Test parsing a whole range of valid reference wkt formats and variants, and checking
         expected values such as length, area, centroids, bounding boxes, etc of the resultant geometry.

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -498,6 +498,12 @@ class TestQgsGeometry(unittest.TestCase):
         with self.assertRaises(IndexError):
             del g[-3]
 
+        # iteration
+        g = QgsGeometryCollection()
+        self.assertFalse([p for p in g])
+        g.fromWkt('GeometryCollection( Point(1 2), Point(11 12), LineString(33 34, 44 45))')
+        self.assertEqual([p.asWkt() for p in g], ['Point (1 2)', 'Point (11 12)', 'LineString (33 34, 44 45)'])
+
     def testReferenceGeometry(self):
         """ Test parsing a whole range of valid reference wkt formats and variants, and checking
         expected values such as length, area, centroids, bounding boxes, etc of the resultant geometry.


### PR DESCRIPTION
Adds some nice PyQGIS API for use with geometry collections:

- Calling removeGeometry with an invalid index will now raise an IndexError
- Calling collection[0] will return the first geometry in the collection,
collection[1] the second, etc. And negative indices return from the end
of the collection, so collection[-1] returns the last geometry in the collection.
- Geometries can be deleted by calling `del collection[1]` (deletes the
second geometry from the collection). Also supports negative indices
to count from the end of the collection.
- Iteration on collections directly causes iteration over the geometries in that collection, i.e.

      gc = QgsGeometryCollection()
      gc.fromWkt('GeometryCollection( Point(1 2), Point(11 12), LineString(33 34, 44 45))')
      for part in gc:
        print(part.asWkt())

@3nids I've also addressed the typehint changes discussed in https://github.com/qgis/pyqgis/issues/25