### PR TITLE
[FEATURE][AFS] Automatically convert ESRI picture fill symbols

### DIFF
--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -54,6 +54,7 @@ class QgsArcGisRestUtils
     static std::unique_ptr< QgsSymbol > parseEsriSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsLineSymbol > parseEsriLineSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsFillSymbol > parseEsriFillSymbolJson( const QVariantMap &symbolData );
+    static std::unique_ptr< QgsFillSymbol > parseEsriPictureFillSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsMarkerSymbol > parseEsriMarkerSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsMarkerSymbol > parseEsriPictureMarkerSymbolJson( const QVariantMap &symbolData );
     static QgsFeatureRenderer *parseEsriRenderer( const QVariantMap &rendererData );

--- a/tests/src/providers/testqgsarcgisrestutils.cpp
+++ b/tests/src/providers/testqgsarcgisrestutils.cpp
@@ -46,6 +46,7 @@ class TestQgsArcGisRestUtils : public QObject
     void testPictureMarkerSymbol();
     void testParseLineSymbol();
     void testParseFillSymbol();
+    void testParsePictureFillSymbol();
     void testParseRendererSimple();
     void testParseRendererCategorized();
 
@@ -297,6 +298,46 @@ void TestQgsArcGisRestUtils::testParseFillSymbol()
   QCOMPARE( fillLayer->strokeWidth(), 5.0 );
   QCOMPARE( fillLayer->strokeWidthUnit(), QgsUnitTypes::RenderPoints );
   QCOMPARE( fillLayer->strokeStyle(), Qt::DashDotLine );
+}
+
+
+void TestQgsArcGisRestUtils::testParsePictureFillSymbol()
+{
+  QVariantMap map = jsonStringToMap( "{"
+                                     "\"type\": \"esriPFS\","
+                                     "\"url\": \"866880A0\","
+                                     "\"imageData\": \"abcdef\","
+                                     "\"contentType\": \"image/png\","
+                                     "\"width\": 20,"
+                                     "\"height\": 25,"
+                                     "\"angle\": 0,"
+                                     "\"outline\": {"
+                                     "\"type\": \"esriSLS\","
+                                     "\"style\": \"esriSLSDashDot\","
+                                     "\"color\": ["
+                                     "110,"
+                                     "120,"
+                                     "130,"
+                                     "215"
+                                     "],"
+                                     "\"width\": 5"
+                                     "}"
+                                     "}" );
+  std::unique_ptr<QgsSymbol> symbol = QgsArcGisRestUtils::parseEsriSymbolJson( map );
+  QgsFillSymbol *fill = dynamic_cast< QgsFillSymbol * >( symbol.get() );
+  QVERIFY( fill );
+  QCOMPARE( fill->symbolLayerCount(), 2 );
+  QgsRasterFillSymbolLayer *fillLayer = dynamic_cast< QgsRasterFillSymbolLayer * >( fill->symbolLayer( 0 ) );
+  QVERIFY( fillLayer );
+  QCOMPARE( fillLayer->imageFilePath(), QString( "base64:abcdef" ) );
+  QCOMPARE( fillLayer->width(), 20.0 );
+  QCOMPARE( fillLayer->widthUnit(), QgsUnitTypes::RenderPixels );
+  QgsSimpleLineSymbolLayer *lineLayer = dynamic_cast< QgsSimpleLineSymbolLayer * >( fill->symbolLayer( 1 ) );
+  QVERIFY( lineLayer );
+  QCOMPARE( lineLayer->color(), QColor( 110, 120, 130, 215 ) );
+  QCOMPARE( lineLayer->width(), 5.0 );
+  QCOMPARE( lineLayer->widthUnit(), QgsUnitTypes::RenderPoints );
+  QCOMPARE( lineLayer->penStyle(), Qt::DashDotLine );
 }
 
 void TestQgsArcGisRestUtils::testParseRendererSimple()


### PR DESCRIPTION
## Description
That'll probably make a few people happy out there:
![image](https://user-images.githubusercontent.com/1728657/49562748-72e2d100-f94f-11e8-9bd5-8a573e10965a.png)

ping @nyalldawson 



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
