### PR TITLE
.qgs-translation fix: do not create QgsProject before QgsApplication

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -432,6 +432,9 @@ APP_EXPORT
 #endif
 int main( int argc, char *argv[] )
 {
+  //log messages written before creating QgsApplicatoin
+  QStringList preApplicationLogMessages;
+
 #ifdef Q_OS_MACX
   // Increase file resource limits (i.e., number of allowed open files)
   // (from code provided by Larry Biehl, Purdue University, USA, from 'MultiSpec' project)
@@ -868,11 +871,11 @@ int main( int argc, char *argv[] )
   {
     if ( !QgsSettings::setGlobalSettingsPath( globalsettingsfile ) )
     {
-      QgsMessageLog::logMessage( QObject::tr( "Invalid globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" ) );
+      preApplicationLogMessages << QObject::tr( "Invalid globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" );
     }
     else
     {
-      QgsMessageLog::logMessage( QObject::tr( "Successfully loaded globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" ) );
+      preApplicationLogMessages << QObject::tr( "Successfully loaded globalsettingsfile path: %1" ).arg( globalsettingsfile ), QStringLiteral( "QGIS" );
     }
   }
 
@@ -971,6 +974,10 @@ int main( int argc, char *argv[] )
   }
 
   QgsApplication myApp( argc, argv, myUseGuiFlag );
+
+  //write the log messages written before creating QgsApplicatoin
+  for ( QString const &preApplicationLogMessage : preApplicationLogMessages )
+    QgsMessageLog::logMessage( preApplicationLogMessage );
 
   // Settings migration is only supported on the default profile for now.
   if ( profileName == QLatin1String( "default" ) )

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -432,7 +432,7 @@ APP_EXPORT
 #endif
 int main( int argc, char *argv[] )
 {
-  //log messages written before creating QgsApplicatoin
+  //log messages written before creating QgsApplication
   QStringList preApplicationLogMessages;
 
 #ifdef Q_OS_MACX
@@ -975,8 +975,8 @@ int main( int argc, char *argv[] )
 
   QgsApplication myApp( argc, argv, myUseGuiFlag );
 
-  //write the log messages written before creating QgsApplicatoin
-  for ( QString const &preApplicationLogMessage : preApplicationLogMessages )
+  //write the log messages written before creating QgsApplication
+  for ( const QString &preApplicationLogMessage : qgis::as_const( preApplicationLogMessages ) )
     QgsMessageLog::logMessage( preApplicationLogMessage );
 
   // Settings migration is only supported on the default profile for now.


### PR DESCRIPTION
Backport of #8601

(removed the changes of `QgsProject`)
