### PR TITLE
Access of QGeoPositionInfoSource from QgsQuickPostionKit

### DIFF
--- a/src/quickgui/qgsquickpositionkit.cpp
+++ b/src/quickgui/qgsquickpositionkit.cpp
@@ -61,7 +61,7 @@ QGeoPositionInfoSource  *QgsQuickPositionKit::simulatedSource( double longitude,
 
 QGeoPositionInfoSource &QgsQuickPositionKit::source() const
 {
-    return *mSource;
+  return *mSource;
 }
 
 void QgsQuickPositionKit::useSimulatedLocation( double longitude, double latitude, double radius )

--- a/src/quickgui/qgsquickpositionkit.cpp
+++ b/src/quickgui/qgsquickpositionkit.cpp
@@ -59,6 +59,11 @@ QGeoPositionInfoSource  *QgsQuickPositionKit::simulatedSource( double longitude,
   return new QgsQuickSimulatedPositionSource( this, longitude, latitude, radius );
 }
 
+QGeoPositionInfoSource &QgsQuickPositionKit::source() const
+{
+    return *mSource;
+}
+
 void QgsQuickPositionKit::useSimulatedLocation( double longitude, double latitude, double radius )
 {
   std::unique_ptr<QGeoPositionInfoSource> source( simulatedSource( longitude, latitude, radius ) );

--- a/src/quickgui/qgsquickpositionkit.cpp
+++ b/src/quickgui/qgsquickpositionkit.cpp
@@ -59,9 +59,9 @@ QGeoPositionInfoSource  *QgsQuickPositionKit::simulatedSource( double longitude,
   return new QgsQuickSimulatedPositionSource( this, longitude, latitude, radius );
 }
 
-QGeoPositionInfoSource &QgsQuickPositionKit::source() const
+QGeoPositionInfoSource *QgsQuickPositionKit::source() const
 {
-  return *mSource;
+  return mSource.get();
 }
 
 void QgsQuickPositionKit::useSimulatedLocation( double longitude, double latitude, double radius )
@@ -115,6 +115,7 @@ void QgsQuickPositionKit::replacePositionSource( QGeoPositionInfoSource *source 
   }
 
   mSource.reset( source );
+  emit sourceChanged();
 
   if ( mSource )
   {

--- a/src/quickgui/qgsquickpositionkit.h
+++ b/src/quickgui/qgsquickpositionkit.h
@@ -115,6 +115,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
     Q_PROPERTY( QVector<double> simulatePositionLongLatRad READ simulatePositionLongLatRad WRITE setSimulatePositionLongLatRad NOTIFY simulatePositionLongLatRadChanged )
 
     /**
+     * Internal source of GPS location data.
      * Allows start/stop of its services or access properties.
      */
     Q_PROPERTY( QGeoPositionInfoSource *source READ source NOTIFY sourceChanged )
@@ -164,7 +165,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
     //! \copydoc QgsQuickPositionKit::simulatePositionLongLatRad
     void setSimulatePositionLongLatRad( const QVector<double> &simulatePositionLongLatRad );
 
-    //! \copydoc QgsQuickPositionKit::source
+    //! Returns pointer to the internal QGeoPositionInfoSource object used to receive GPS location.
     QGeoPositionInfoSource *source() const;
 
     /**
@@ -226,7 +227,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
     //! \copydoc QgsQuickPositionKit::simulatePositionLongLatRad
     void simulatePositionLongLatRadChanged( QVector<double> simulatePositionLongLatRad );
 
-    //! \copydoc QgsQuickPositionKit::source
+    //! Emitted when the internal source of GPS location data has been replaced.
     void sourceChanged();
 
   private slots:

--- a/src/quickgui/qgsquickpositionkit.h
+++ b/src/quickgui/qgsquickpositionkit.h
@@ -114,6 +114,11 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
      */
     Q_PROPERTY( QVector<double> simulatePositionLongLatRad READ simulatePositionLongLatRad WRITE setSimulatePositionLongLatRad NOTIFY simulatePositionLongLatRadChanged )
 
+    /**
+     * Allows start/stop of its services or access properties.
+     */
+    Q_PROPERTY( QGeoPositionInfoSource *source READ source NOTIFY sourceChanged )
+
   public:
     //! Creates new position kit
     explicit QgsQuickPositionKit( QObject *parent = nullptr );
@@ -159,10 +164,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
     //! \copydoc QgsQuickPositionKit::simulatePositionLongLatRad
     void setSimulatePositionLongLatRad( const QVector<double> &simulatePositionLongLatRad );
 
-    /**
-     * Allows start/stop of its services or access properties.
-     */
-    Q_INVOKABLE QGeoPositionInfoSource &source() const;
+    QGeoPositionInfoSource *source() const;
 
     /**
      * Coordinate reference system of position - WGS84 (constant)
@@ -222,6 +224,8 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
 
     //! \copydoc QgsQuickPositionKit::simulatePositionLongLatRad
     void simulatePositionLongLatRadChanged( QVector<double> simulatePositionLongLatRad );
+
+    void sourceChanged();
 
   private slots:
     void onPositionUpdated( const QGeoPositionInfo &info );

--- a/src/quickgui/qgsquickpositionkit.h
+++ b/src/quickgui/qgsquickpositionkit.h
@@ -162,7 +162,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
     /**
      * Allows start/stop of its services or access properties.
      */
-     Q_INVOKABLE QGeoPositionInfoSource &source() const;
+    Q_INVOKABLE QGeoPositionInfoSource &source() const;
 
     /**
      * Coordinate reference system of position - WGS84 (constant)
@@ -189,7 +189,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
      */
     Q_INVOKABLE void useGpsLocation();
 
-signals:
+  signals:
     //! \copydoc QgsQuickPositionKit::position
     void positionChanged();
 

--- a/src/quickgui/qgsquickpositionkit.h
+++ b/src/quickgui/qgsquickpositionkit.h
@@ -160,6 +160,11 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
     void setSimulatePositionLongLatRad( const QVector<double> &simulatePositionLongLatRad );
 
     /**
+     * Allows start/stop of its services or access properties.
+     */
+     Q_INVOKABLE QGeoPositionInfoSource &source() const;
+
+    /**
      * Coordinate reference system of position - WGS84 (constant)
      */
     Q_INVOKABLE QgsCoordinateReferenceSystem positionCRS() const;
@@ -184,7 +189,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
      */
     Q_INVOKABLE void useGpsLocation();
 
-  signals:
+signals:
     //! \copydoc QgsQuickPositionKit::position
     void positionChanged();
 

--- a/src/quickgui/qgsquickpositionkit.h
+++ b/src/quickgui/qgsquickpositionkit.h
@@ -164,6 +164,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
     //! \copydoc QgsQuickPositionKit::simulatePositionLongLatRad
     void setSimulatePositionLongLatRad( const QVector<double> &simulatePositionLongLatRad );
 
+    //! \copydoc QgsQuickPositionKit::source
     QGeoPositionInfoSource *source() const;
 
     /**
@@ -225,6 +226,7 @@ class QUICK_EXPORT QgsQuickPositionKit : public QObject
     //! \copydoc QgsQuickPositionKit::simulatePositionLongLatRad
     void simulatePositionLongLatRadChanged( QVector<double> simulatePositionLongLatRad );
 
+    //! \copydoc QgsQuickPositionKit::source
     void sourceChanged();
 
   private slots:


### PR DESCRIPTION
Added function to access QGeoPositionInfoSource out of QgsQuickPostionKit context.

Now source's update functions or other properties can be used (e.g useful when switching GPS update on/off in case of saving battery or see preferred positioning method).