### PR TITLE
Improve SVG/Image embedding widget behavior

### DIFF
--- a/src/core/mesh/qgsmeshdataprovider.cpp
+++ b/src/core/mesh/qgsmeshdataprovider.cpp
@@ -256,6 +256,7 @@ int QgsMeshDataBlock::count() const
     case Vector2DDouble:
       return static_cast<int>( mDoubleBuffer.size() / 2.0 );
   }
+  return 0; // no warnings
 }
 
 bool QgsMeshDataBlock::isValid() const
@@ -277,6 +278,7 @@ QgsMeshDatasetValue QgsMeshDataBlock::value( int index ) const
                mDoubleBuffer[2 * index + 1]
              );
   }
+  return QgsMeshDatasetValue(); // no warnings
 }
 
 bool QgsMeshDataBlock::active( int index ) const

--- a/src/gui/qgsfilecontentsourcelineedit.h
+++ b/src/gui/qgsfilecontentsourcelineedit.h
@@ -147,6 +147,14 @@ class GUI_EXPORT QgsAbstractFileContentSourceLineEdit : public QWidget SIP_ABSTR
 
   private:
 
+    enum Mode
+    {
+      ModeFile,
+      ModeBase64,
+    };
+
+    Mode mMode = ModeFile;
+
     QgsFilterLineEdit *mFileLineEdit = nullptr;
     QToolButton *mFileToolButton = nullptr;
     QString mLastPathKey;

--- a/src/gui/qgsfilecontentsourcelineedit.h
+++ b/src/gui/qgsfilecontentsourcelineedit.h
@@ -21,7 +21,7 @@
 #include <QWidget>
 #include <QString>
 
-class QLineEdit;
+class QgsFilterLineEdit;
 class QToolButton;
 class QgsMessageBar;
 
@@ -144,11 +144,10 @@ class GUI_EXPORT QgsAbstractFileContentSourceLineEdit : public QWidget SIP_ABSTR
     void embedFile();
     void extractFile();
     void mFileLineEdit_textEdited( const QString &text );
-    void mFileLineEdit_editingFinished();
 
   private:
 
-    QLineEdit *mFileLineEdit = nullptr;
+    QgsFilterLineEdit *mFileLineEdit = nullptr;
     QToolButton *mFileToolButton = nullptr;
     QString mLastPathKey;
     QString mBase64;


### PR DESCRIPTION
Don't show the raw base64 contents and instead show a user friendly "Embedded file" string
