### PR TITLE
fix listing of afs services for saved servers starting in a sub-folder [afs]

### DIFF
--- a/src/providers/arcgisrest/qgsafsdataitems.cpp
+++ b/src/providers/arcgisrest/qgsafsdataitems.cpp
@@ -96,15 +96,14 @@ void addFolderItems( QVector< QgsDataItem * > &items, const QVariantMap &service
   }, serviceData, baseUrl );
 }
 
-void addServiceItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &baseUrl, const QString &authcfg, QgsDataItem *parent,
-                      const QString &parentName )
+void addServiceItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &baseUrl, const QString &authcfg, QgsDataItem *parent )
 {
   QgsArcGisRestUtils::visitServiceItems(
     [&items, parent, authcfg]( const QString & name, const QString & url )
   {
     std::unique_ptr< QgsAfsServiceItem > serviceItem = qgis::make_unique< QgsAfsServiceItem >( parent, name, url, url, authcfg );
     items.append( serviceItem.release() );
-  }, serviceData, baseUrl, parentName );
+  }, serviceData, baseUrl );
 }
 
 void addLayerItems( QVector< QgsDataItem * > &items, const QVariantMap &serviceData, const QString &parentUrl, const QString &authcfg, QgsDataItem *parent )
@@ -176,7 +175,7 @@ QVector<QgsDataItem *> QgsAfsConnectionItem::createChildren()
   }
 
   addFolderItems( items, serviceData, url, authcfg, this );
-  addServiceItems( items, serviceData, url, authcfg, this, QString() );
+  addServiceItems( items, serviceData, url, authcfg, this );
   addLayerItems( items, serviceData, url, authcfg, this );
 
   return items;
@@ -287,7 +286,7 @@ QVector<QgsDataItem *> QgsAfsFolderItem::createChildren()
   }
 
   addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, this );
-  addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, this, mName );
+  addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, this );
   addLayerItems( items, serviceData, mPath, mAuthCfg, this );
   return items;
 }
@@ -328,7 +327,7 @@ QVector<QgsDataItem *> QgsAfsServiceItem::createChildren()
   }
 
   addFolderItems( items, serviceData, mBaseUrl, mAuthCfg, this );
-  addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, this, mName );
+  addServiceItems( items, serviceData, mBaseUrl, mAuthCfg, this );
   addLayerItems( items, serviceData, mPath, mAuthCfg, this );
   return items;
 }

--- a/src/providers/arcgisrest/qgsafssourceselect.cpp
+++ b/src/providers/arcgisrest/qgsafssourceselect.cpp
@@ -41,8 +41,8 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
   const QString authcfg = connection.uri().param( QStringLiteral( "authcfg" ) );
   const QString baseUrl = connection.uri().param( QStringLiteral( "url" ) );
 
-  std::function< bool( const QString &, QStandardItem *, const QString & )> visitItemsRecursive;
-  visitItemsRecursive = [this, &visitItemsRecursive, baseUrl, authcfg, &errorTitle, &errorMessage]( const QString & baseItemUrl, QStandardItem * parentItem, const QString & parentName ) -> bool
+  std::function< bool( const QString &, QStandardItem * )> visitItemsRecursive;
+  visitItemsRecursive = [this, &visitItemsRecursive, baseUrl, authcfg, &errorTitle, &errorMessage]( const QString & baseItemUrl, QStandardItem * parentItem ) -> bool
   {
     const QVariantMap serviceInfoMap = QgsArcGisRestUtils::getServiceInfo( baseItemUrl, authcfg, errorTitle, errorMessage );
 
@@ -62,7 +62,7 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
       else
         mModel->appendRow( QList<QStandardItem *>() << nameItem );
 
-      if ( !visitItemsRecursive( url, nameItem, name ) )
+      if ( !visitItemsRecursive( url, nameItem ) )
         res = false;
     }, serviceInfoMap, baseUrl );
 
@@ -76,9 +76,9 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
       else
         mModel->appendRow( QList<QStandardItem *>() << nameItem );
 
-      if ( !visitItemsRecursive( url, nameItem, name ) )
+      if ( !visitItemsRecursive( url, nameItem ) )
         res = false;
-    }, serviceInfoMap, baseUrl, parentName );
+    }, serviceInfoMap, baseUrl );
 
     QMap< QString, QList<QStandardItem *> > layerItems;
     QMap< QString, QString > parents;
@@ -143,7 +143,7 @@ bool QgsAfsSourceSelect::connectToService( const QgsOwsConnection &connection )
     return res;
   };
 
-  if ( !visitItemsRecursive( baseUrl, nullptr, QString() ) )
+  if ( !visitItemsRecursive( baseUrl, nullptr ) )
     QMessageBox::warning( this, tr( "Error" ), tr( "Failed to retrieve service capabilities:\n%1: %2" ).arg( errorTitle, errorMessage ) );
 
   return true;

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -66,8 +66,9 @@ class QgsArcGisRestUtils
     static QDateTime parseDateTime( const QVariant &value );
 
     static QUrl parseUrl( const QUrl &url );
+    static void adjustBaseUrl( QString &baseUrl, const QString name );
     static void visitFolderItems( const std::function<void ( const QString &folderName, const QString &url )> &visitor, const QVariantMap &serviceData, const QString &baseUrl );
-    static void visitServiceItems( const std::function<void ( const QString &serviceName, const QString &url )> &visitor, const QVariantMap &serviceData, const QString &baseUrl, const QString &parentName );
+    static void visitServiceItems( const std::function<void ( const QString &serviceName, const QString &url )> &visitor, const QVariantMap &serviceData, const QString &baseUrl );
     static void addLayerItems( const std::function<void ( const QString &parentLayerId, const QString &layerId, const QString &name, const QString &description, const QString &url, bool isParentLayer, const QString &authid )> &visitor, const QVariantMap &serviceData, const QString &parentUrl );
 };
 


### PR DESCRIPTION
## Description
@nyalldawson , while fooling around AFS styling, I noticed the browser panel (and the source select) fails to list AFS services and groups when the saved AFS server URL isn't the root service URL.

This PR proposes a working solution.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
