### PR TITLE
Fix help text for color format

### DIFF
--- a/src/core/qgsproperty.cpp
+++ b/src/core/qgsproperty.cpp
@@ -87,7 +87,7 @@ QgsPropertyDefinition::QgsPropertyDefinition( const QString &name, const QString
 
     case ColorWithAlpha:
       mTypes = DataTypeString;
-      mHelpText = QObject::tr( "string [<b>r,g,b,a</b>] as int 0-255 or #<b>RRGGBBAA</b> as hex or <b>color</b> as color's name" );
+      mHelpText = QObject::tr( "string [<b>r,g,b,a</b>] as int 0-255 or #<b>AARRGGBB</b> as hex or <b>color</b> as color's name" );
       break;
 
     case ColorNoAlpha:


### PR DESCRIPTION
I don't really get this one - but from https://gis.stackexchange.com/questions/305287/data-defined-override-for-hex-colour-qgis-3-4-1 there IS a bug here, and indeed the format is AARRGGBB

What I don't get is how things have changed here. The color parser uses http://doc.qt.io/qt-5/qcolor.html#setNamedColor , which according to the Qt docs, only accepts AARRGGBB since Qt 5.2. So really the hex format should never have worked with alpha for 2.x. (Maybe it never did... I haven't checked).

Anyway, either we need to update the help text (done here), or change the parser to match the documentation. I'm 50/50 either way.