### PR TITLE
Create labels when settings provied by server [FEATURE][AFS]

### DIFF
--- a/python/core/auto_generated/qgsvectordataprovider.sip.in
+++ b/python/core/auto_generated/qgsvectordataprovider.sip.in
@@ -52,6 +52,7 @@ of feature and attribute information from a spatial datasource.
       WriteLayerMetadata,
       CancelSupport,
       CreateRenderer,
+      CreateLabeling,
     };
 
     typedef QFlags<QgsVectorDataProvider::Capability> Capabilities;
@@ -518,6 +519,23 @@ Only providers which report the CreateRenderer capability will return a feature 
 providers will return None.
 
 .. versionadded:: 3.2
+%End
+
+    virtual QgsAbstractVectorLayerLabeling *createLabeling( const QVariantMap &configuration = QVariantMap() ) const /Factory/;
+%Docstring
+Creates labeling settings, using provider backend specific information.
+
+The ``configuration`` map can be used to pass provider-specific configuration maps to the provider to
+allow customization of the returned labeling object. Support and format of ``configuration`` varies by provider.
+
+When called with an empty ``configuration`` map the provider's default labeling settings will be returned.
+
+This method returns a new labeling settings and the caller takes ownership of the returned object.
+
+Only providers which report the CreateLabeling capability will return labeling settings. Other
+providers will return None.
+
+.. versionadded:: 3.6
 %End
 
     static QVariant convertValue( QVariant::Type type, const QString &value );

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -699,6 +699,11 @@ QgsFeatureRenderer *QgsVectorDataProvider::createRenderer( const QVariantMap & )
   return nullptr;
 }
 
+QgsAbstractVectorLayerLabeling *QgsVectorDataProvider::createLabeling( const QVariantMap & ) const
+{
+  return nullptr;
+}
+
 void QgsVectorDataProvider::pushError( const QString &msg ) const
 {
   QgsDebugMsg( msg );

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -41,6 +41,7 @@ class QgsFeatureIterator;
 class QgsTransaction;
 class QgsFeedback;
 class QgsFeatureRenderer;
+class QgsAbstractVectorLayerLabeling;
 
 #include "qgsfeaturerequest.h"
 
@@ -93,6 +94,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
       WriteLayerMetadata = 1 << 22, //!< Provider can write layer metadata to the data store. Since QGIS 3.0. See QgsDataProvider::writeLayerMetadata()
       CancelSupport = 1 << 23, //!< Supports interruption of pending queries from a separated thread. Since QGIS 3.2
       CreateRenderer = 1 << 24, //!< Provider can create feature renderers using backend-specific formatting information. Since QGIS 3.2. See QgsVectorDataProvider::createRenderer().
+      CreateLabeling = 1 << 25, //!< Provider can set labeling settings using backend-specific formatting information. Since QGIS 3.6. See QgsVectorDataProvider::createLabeling().
     };
 
     Q_DECLARE_FLAGS( Capabilities, Capability )
@@ -519,6 +521,23 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider, public QgsFeat
      * \since QGIS 3.2
      */
     virtual QgsFeatureRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const SIP_FACTORY;
+
+    /**
+     * Creates labeling settings, using provider backend specific information.
+     *
+     * The \a configuration map can be used to pass provider-specific configuration maps to the provider to
+     * allow customization of the returned labeling object. Support and format of \a configuration varies by provider.
+     *
+     * When called with an empty \a configuration map the provider's default labeling settings will be returned.
+     *
+     * This method returns a new labeling settings and the caller takes ownership of the returned object.
+     *
+     * Only providers which report the CreateLabeling capability will return labeling settings. Other
+     * providers will return nullptr.
+     *
+     * \since QGIS 3.6
+     */
+    virtual QgsAbstractVectorLayerLabeling *createLabeling( const QVariantMap &configuration = QVariantMap() ) const SIP_FACTORY;
 
     static QVariant convertValue( QVariant::Type type, const QString &value );
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1531,6 +1531,16 @@ void QgsVectorLayer::setDataSource( const QString &dataSource, const QString &ba
     }
 
     setLegend( QgsMapLayerLegend::defaultVectorLegend( this ) );
+
+    if ( mDataProvider->capabilities() & QgsVectorDataProvider::CreateLabeling )
+    {
+      std::unique_ptr< QgsAbstractVectorLayerLabeling > defaultLabeling( mDataProvider->createLabeling() );
+      if ( defaultLabeling )
+      {
+        setLabeling( defaultLabeling.release() );
+        setLabelsEnabled( true );
+      }
+    }
   }
 
   emit dataSourceChanged();

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -222,6 +222,7 @@ QgsAfsProvider::QgsAfsProvider( const QString &uri, const ProviderOptions &optio
 
   // renderer
   mRendererDataMap = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "renderer" ) ).toMap();
+  mLabelingDataList = layerData.value( QStringLiteral( "drawingInfo" ) ).toMap().value( QStringLiteral( "labelingInfo" ) ).toList();
 
   mValid = true;
 }
@@ -262,6 +263,10 @@ QgsVectorDataProvider::Capabilities QgsAfsProvider::capabilities() const
   if ( !mRendererDataMap.empty() )
   {
     c = c | QgsVectorDataProvider::CreateRenderer;
+  }
+  if ( !mLabelingDataList.empty() )
+  {
+    c = c | QgsVectorDataProvider::CreateLabeling;
   }
   return c;
 }
@@ -307,6 +312,10 @@ QgsFeatureRenderer *QgsAfsProvider::createRenderer( const QVariantMap & ) const
   return QgsArcGisRestUtils::parseEsriRenderer( mRendererDataMap );
 }
 
+QgsAbstractVectorLayerLabeling *QgsAfsProvider::createLabeling( const QVariantMap & ) const
+{
+  return QgsArcGisRestUtils::parseEsriLabeling( mLabelingDataList );
+}
 
 #ifdef HAVE_GUI
 

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -71,6 +71,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QString dataComment() const override;
     void reloadData() override;
     QgsFeatureRenderer *createRenderer( const QVariantMap &configuration = QVariantMap() ) const override;
+    QgsAbstractVectorLayerLabeling *createLabeling( const QVariantMap &configuration = QVariantMap() ) const override;
 
   private:
     bool mValid = false;
@@ -80,6 +81,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     QString mLayerDescription;
     QgsLayerMetadata mLayerMetadata;
     QVariantMap mRendererDataMap;
+    QVariantList mLabelingDataList;
 };
 
 #endif // QGSAFSPROVIDER_H

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -758,8 +758,8 @@ std::unique_ptr<QgsMarkerSymbol> QgsArcGisRestUtils::parseEsriPictureMarkerSymbo
   markerLayer->setSizeUnit( QgsUnitTypes::RenderPixels );
 
   // only change the default aspect ratio if the server height setting requires this
-  if ( !qgsDoubleNear( static_cast< double >( widthInPixels ) / heightInPixels, markerLayer->defaultAspectRatio() ) )
-    markerLayer->setFixedAspectRatio( static_cast< double >( widthInPixels ) / heightInPixels );
+  if ( !qgsDoubleNear( static_cast< double >( heightInPixels ) / widthInPixels, markerLayer->defaultAspectRatio() ) )
+    markerLayer->setFixedAspectRatio( static_cast< double >( heightInPixels ) / widthInPixels );
 
   markerLayer->setOffset( QPointF( xOffset, yOffset ) );
   markerLayer->setOffsetUnit( QgsUnitTypes::RenderPoints );

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -658,7 +658,7 @@ std::unique_ptr<QgsFillSymbol> QgsArcGisRestUtils::parseEsriPictureFillSymbolJso
   std::unique_ptr< QgsRasterFillSymbolLayer > fillLayer = qgis::make_unique< QgsRasterFillSymbolLayer >( symbolPath );
   fillLayer->setWidth( widthInPixels );
   fillLayer->setAngle( angleCW );
-  fillLayer->setWidthUnit( QgsUnitTypes::RenderPixels );
+  fillLayer->setWidthUnit( QgsUnitTypes::RenderPoints );
   fillLayer->setOffset( QPointF( xOffset, yOffset ) );
   fillLayer->setOffsetUnit( QgsUnitTypes::RenderPoints );
   layers.append( fillLayer.release() );
@@ -755,7 +755,7 @@ std::unique_ptr<QgsMarkerSymbol> QgsArcGisRestUtils::parseEsriPictureMarkerSymbo
 
   QgsSymbolLayerList layers;
   std::unique_ptr< QgsRasterMarkerSymbolLayer > markerLayer = qgis::make_unique< QgsRasterMarkerSymbolLayer >( symbolPath, widthInPixels, angleCW, QgsSymbol::ScaleArea );
-  markerLayer->setSizeUnit( QgsUnitTypes::RenderPixels );
+  markerLayer->setSizeUnit( QgsUnitTypes::RenderPoints );
 
   // only change the default aspect ratio if the server height setting requires this
   if ( !qgsDoubleNear( static_cast< double >( heightInPixels ) / widthInPixels, markerLayer->defaultAspectRatio() ) )

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -24,6 +24,7 @@ class QNetworkReply;
 class QgsNetworkAccessManager;
 class QgsFields;
 class QgsAbstractGeometry;
+class QgsAbstractVectorLayerLabeling;
 class QgsCoordinateReferenceSystem;
 class QgsFeedback;
 class QgsSymbol;
@@ -58,6 +59,7 @@ class QgsArcGisRestUtils
     static std::unique_ptr< QgsMarkerSymbol > parseEsriMarkerSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsMarkerSymbol > parseEsriPictureMarkerSymbolJson( const QVariantMap &symbolData );
     static QgsFeatureRenderer *parseEsriRenderer( const QVariantMap &rendererData );
+    static QgsAbstractVectorLayerLabeling *parseEsriLabeling( const QVariantList &labelingData );
 
     static QColor parseEsriColorJson( const QVariant &colorData );
     static Qt::PenStyle parseEsriLineStyle( const QString &style );

--- a/tests/src/providers/testqgsarcgisrestutils.cpp
+++ b/tests/src/providers/testqgsarcgisrestutils.cpp
@@ -226,7 +226,7 @@ void TestQgsArcGisRestUtils::testPictureMarkerSymbol()
   QCOMPARE( markerLayer->path(), QStringLiteral( "base64:abcdef" ) );
   QCOMPARE( markerLayer->size(), 20.0 );
   QCOMPARE( markerLayer->fixedAspectRatio(), 1.25 );
-  QCOMPARE( markerLayer->sizeUnit(), QgsUnitTypes::RenderPixels );
+  QCOMPARE( markerLayer->sizeUnit(), QgsUnitTypes::RenderPoints );
   QCOMPARE( markerLayer->angle(), -10.0 ); // opposite direction to esri spec!
   QCOMPARE( markerLayer->offset(), QPointF( 7, 17 ) );
   QCOMPARE( markerLayer->offsetUnit(), QgsUnitTypes::RenderPoints );
@@ -333,7 +333,7 @@ void TestQgsArcGisRestUtils::testParsePictureFillSymbol()
   QVERIFY( fillLayer );
   QCOMPARE( fillLayer->imageFilePath(), QString( "base64:abcdef" ) );
   QCOMPARE( fillLayer->width(), 20.0 );
-  QCOMPARE( fillLayer->widthUnit(), QgsUnitTypes::RenderPixels );
+  QCOMPARE( fillLayer->widthUnit(), QgsUnitTypes::RenderPoints );
   QgsSimpleLineSymbolLayer *lineLayer = dynamic_cast< QgsSimpleLineSymbolLayer * >( fill->symbolLayer( 1 ) );
   QVERIFY( lineLayer );
   QCOMPARE( lineLayer->color(), QColor( 110, 120, 130, 215 ) );

--- a/tests/src/providers/testqgsarcgisrestutils.cpp
+++ b/tests/src/providers/testqgsarcgisrestutils.cpp
@@ -225,7 +225,7 @@ void TestQgsArcGisRestUtils::testPictureMarkerSymbol()
   QVERIFY( markerLayer );
   QCOMPARE( markerLayer->path(), QStringLiteral( "base64:abcdef" ) );
   QCOMPARE( markerLayer->size(), 20.0 );
-  QCOMPARE( markerLayer->fixedAspectRatio(), 0.8 );
+  QCOMPARE( markerLayer->fixedAspectRatio(), 1.25 );
   QCOMPARE( markerLayer->sizeUnit(), QgsUnitTypes::RenderPixels );
   QCOMPARE( markerLayer->angle(), -10.0 ); // opposite direction to esri spec!
   QCOMPARE( markerLayer->offset(), QPointF( 7, 17 ) );


### PR DESCRIPTION
## Description
Because QGIS is now great at styling AFS layers, it was only natural we'd add pre-defined labels support:
![peek 2018-12-08 15-54](https://user-images.githubusercontent.com/1728657/49684111-b41ae280-fb01-11e8-8847-7b51403711df.gif)

This PR adds a new vector data provider capability, that of defining labels when settings are passed on  by the provider, with a working implementation for our AFS provider.

@nyalldawson , I'm pretty satisfied with the minimal implementation coverage of AFS labels, it meets my needs of the moment. A review would be most appreciated, I'll come up with additional test cases to cover the new functions.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
