### PR TITLE
Use represention values for classified renderers [FEATURE]

### DIFF
--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -279,6 +279,19 @@ Returns the count of symbols matched.
 .. versionadded:: 3.4
 %End
 
+
+    static QgsCategoryList createCategories( const QVariantList &values, const QgsSymbol *symbol, QgsVectorLayer *layer = 0, const QString &fieldName = QString() );
+%Docstring
+Create categories for a list of ``values``.
+The returned symbols in the category list will be a modification of ``symbol``.
+
+If ``layer`` and ``fieldName`` are specified it will try to find nicer values
+to represent the description for the categories based on the respective field
+configuration.
+
+.. versionadded:: 3.6
+%End
+
   protected:
 
 

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -247,6 +247,19 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
     int matchToSymbols( QgsStyle *style, QgsSymbol::SymbolType type,
                         QVariantList &unmatchedCategories SIP_OUT, QStringList &unmatchedSymbols SIP_OUT, bool caseSensitive = true, bool useTolerantMatch = false );
 
+
+    /**
+     * Create categories for a list of \a values.
+     * The returned symbols in the category list will be a modification of \a symbol.
+     *
+     * If \a layer and \a fieldName are specified it will try to find nicer values
+     * to represent the description for the categories based on the respective field
+     * configuration.
+     *
+     * \since QGIS 3.6
+     */
+    static QgsCategoryList createCategories( const QVariantList &values, const QgsSymbol *symbol, QgsVectorLayer *layer = nullptr, const QString &fieldName = QString() );
+
   protected:
     QString mAttrName;
     QgsCategoryList mCategories;

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -25,9 +25,6 @@
 #include "qgscolorramp.h"
 #include "qgscolorrampbutton.h"
 #include "qgsstyle.h"
-#include "qgsfieldformatter.h"
-#include "qgsfieldformatterregistry.h"
-#include "qgsapplication.h"
 #include "qgslogger.h"
 
 #include "qgssymbolselectordialog.h"

--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -495,5 +495,6 @@ class TestQgsCategorizedSymbolRenderer(unittest.TestCase):
         self.assertEqual(result[1].label(), 'Two')
         self.assertEqual(result[2].label(), '(3)')
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/src/python/test_qgscategorizedsymbolrenderer.py
+++ b/tests/src/python/test_qgscategorizedsymbolrenderer.py
@@ -25,7 +25,9 @@ from qgis.core import (QgsCategorizedSymbolRenderer,
                        QgsFeature,
                        QgsRenderContext,
                        QgsSymbol,
-                       QgsStyle
+                       QgsStyle,
+                       QgsVectorLayer,
+                       QgsEditorWidgetSetup
                        )
 from qgis.PyQt.QtCore import QVariant
 from qgis.PyQt.QtGui import QColor
@@ -483,6 +485,15 @@ class TestQgsCategorizedSymbolRenderer(unittest.TestCase):
         renderer.setClassAttribute("value - $area")
         self.assertTrue(renderer.filterNeedsGeometry())
 
+    def testCategories(self):
+        layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer", "addfeat", "memory")
+        layer.setEditorWidgetSetup(1, QgsEditorWidgetSetup("ValueMap", {'map': [{'One': '1'}, {'Two': '2'}]}))
+
+        result = QgsCategorizedSymbolRenderer.createCategories([1, 2, 3], QgsMarkerSymbol(), layer, 'fldint')
+
+        self.assertEqual(result[0].label(), 'One')
+        self.assertEqual(result[1].label(), 'Two')
+        self.assertEqual(result[2].label(), '(3)')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This provides better default labels for category labels if a field configuration is available.

When a field is configured with a value relation, value map or other "representable value" and the field is used as the source for a classification renderer, the represented values will be taken to label the categories.

![image](https://user-images.githubusercontent.com/588407/49643224-6de85500-fa15-11e8-814f-f2ae3dfa9ba1.png)

![image](https://user-images.githubusercontent.com/588407/49643262-85274280-fa15-11e8-8eaa-16c6d625769f.png)
