### PR TITLE
sqlite accept aliased queries from db manager

### DIFF
--- a/python/plugins/db_manager/dlg_sql_layer_window.py
+++ b/python/plugins/db_manager/dlg_sql_layer_window.py
@@ -147,13 +147,13 @@ class DlgSqlLayerWindow(QWidget, Ui_Dialog):
 
         # Update from layer
         # First the SQL from QgsDataSourceUri table
-        sql = uri.table()
+        sql = uri.table().replace('\n', ' ').strip()
         if uri.keyColumn() == '_uid_':
-            match = re.search(r'^\(SELECT .+ AS _uid_,\* FROM \((.*)\) AS _subq_.+_\s*\)$', sql, re.S | re.X)
+            match = re.search(r'^\(SELECT .+ AS _uid_,\* FROM \((.*)\) AS _subq_.+_\s*\)$', sql, re.S | re.X | re.IGNORECASE)
             if match:
                 sql = match.group(1)
         else:
-            match = re.search(r'^\((SELECT .+ FROM .+)\)$', sql, re.S | re.X)
+            match = re.search(r'^\((SELECT .+ FROM .+)\)$', sql, re.S | re.X | re.IGNORECASE)
             if match:
                 sql = match.group(1)
         # Need to check on table() since the parentheses were removed by the regexp

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -602,7 +602,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
     def _getSqlQuery(self):
         sql = self.editSql.selectedText()
         if len(sql) == 0:
-            sql = self.editSql.text()
+            sql = self.editSql.text().replace('\n', ' ').strip()
         return sql
 
     def uniqueChanged(self):


### PR DESCRIPTION
Fixes #20674 - DB Manager - load sql query as layer with geom column

Well, not sure it really fixes that particular issue because it
is not really well described, but for sure this fixes the general
case of "SELECT * FROM my_table AS my_alias"
