### PR TITLE
fix processing plugin error when grass7 disabled

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -157,7 +157,7 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
         return Grass7Utils.getSupportedOutputRasterExtensions()
 
     def canBeActivated(self):
-        return not bool(Grass7Utils.checkGrass7IsInstalled())
+        return not bool(Grass7Utils.checkGrassIsInstalled())
 
     def tr(self, string, context=''):
         if context == '':


### PR DESCRIPTION
Fixes #20342 - Grass7 processing plugin fails to activate on macOS

When QGIS3 is built with grass7 support and the GRASS algorithm is disabled (Preferences -> Processing -> Providers -> GRASS -> uncheck Activate setting), an error occurs when the "processing" python plugin loads during startup.  It looks like the function in python/plugins/processing/algs/grass7/Grass7Utils.py changed from "checkGrass7IsInstalled" to "checkGrassIsInstalled" and the corresponding reference in Grass7AlgorithmProvider.py was never updated.  This fixes the issue.