### PR TITLE
[afs] Add halo/buffer support to label creation

### DIFF
--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -862,6 +862,16 @@ QgsAbstractVectorLayerLabeling *QgsArcGisRestUtils::parseEsriLabeling( const QVa
 
     QVariantMap symbol = labeling.value( QStringLiteral( "symbol" ) ).toMap();
     format.setColor( parseEsriColorJson( symbol.value( QStringLiteral( "color" ) ) ) );
+    const double haloSize = symbol.value( QStringLiteral( "haloSize" ) ).toDouble();
+    if ( !qgsDoubleNear( haloSize, 0.0 ) )
+    {
+      QgsTextBufferSettings buffer;
+      buffer.setEnabled( true );
+      buffer.setSize( haloSize );
+      buffer.setSizeUnit( QgsUnitTypes::RenderPoints );
+      buffer.setColor( parseEsriColorJson( symbol.value( QStringLiteral( "haloColor" ) ) ) );
+      format.setBuffer( buffer );
+    }
 
     const QString fontFamily = symbol.value( QStringLiteral( "font" ) ).toMap().value( QStringLiteral( "family" ) ).toString();
     const QString fontStyle = symbol.value( QStringLiteral( "font" ) ).toMap().value( QStringLiteral( "style" ) ).toString();

--- a/tests/src/providers/testqgsarcgisrestutils.cpp
+++ b/tests/src/providers/testqgsarcgisrestutils.cpp
@@ -516,8 +516,13 @@ void TestQgsArcGisRestUtils::testParseLabeling()
                                      "\"angle\": 0,"
                                      "\"xoffset\": 0,"
                                      "\"yoffset\": 0,"
-                                     "\"haloColor\": null,"
-                                     "\"haloSize\": null,"
+                                     "\"haloColor\": ["
+                                     "255,"
+                                     "255,"
+                                     "255,"
+                                     "255"
+                                     "],"
+                                     "\"haloSize\": 1,"
                                      "\"font\": {"
                                      "\"family\": \"Arial\","
                                      "\"size\": 8,"
@@ -555,6 +560,15 @@ void TestQgsArcGisRestUtils::testParseLabeling()
   QgsTextFormat textFormat = settings->format();
   QCOMPARE( textFormat.color(), QColor( 255, 0, 0 ) );
   QCOMPARE( textFormat.size(), 8.0 );
+  QCOMPARE( textFormat.buffer().enabled(), false );
+
+  settings = children.at( 1 )->settings();
+  QVERIFY( settings );
+  textFormat = settings->format();
+  QCOMPARE( textFormat.buffer().enabled(), true );
+  QCOMPARE( textFormat.buffer().color(), QColor( 255, 255, 255 ) );
+  QCOMPARE( textFormat.buffer().size(), 1.0 );
+  QCOMPARE( textFormat.buffer().sizeUnit(), QgsUnitTypes::RenderPoints );
 }
 
 QVariantMap TestQgsArcGisRestUtils::jsonStringToMap( const QString &string ) const


### PR DESCRIPTION
## Description
Turns out I had a saved AFS instance that made use of label halos, which I needed to compare QGIS rendering against ArcGIS for implementation.

Done, with additional an test to cover halo settings.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
