### PR TITLE
Fix #20764 duplicate QGIS entries in Ubuntu launcher

### DIFF
--- a/linux/org.qgis.qgis.desktop.in
+++ b/linux/org.qgis.qgis.desktop.in
@@ -10,3 +10,4 @@ StartupNotify=false
 Categories=Qt;Education;Science;Geography;
 MimeType=application/x-qgis-project;application/x-qgis-layer-settings;application/x-qgis-layer-definition;application/x-qgis-composer-template;image/tiff;image/jpeg;image/jp2;application/x-raster-aig;application/x-raster-ecw;application/x-raster-mrsid;application/x-mapinfo-mif;application/x-esri-shape;
 Keywords=map;globe;postgis;wms;wfs;ogc;osgeo;
+StartupWMClass=QGIS3


### PR DESCRIPTION
## Description

In UBUNTU, if the user decides to add QGIS to the launcher favourites, the application goes to the launch bar, as expected.

![qgis - favorite - added](https://user-images.githubusercontent.com/163681/49745240-671c4500-fc96-11e8-9a99-d90829a3d054.png)

**But**, when the user starts the application, two different icons will be at the launcher bar.

![qgis - favorite - duplicated](https://user-images.githubusercontent.com/163681/49745262-769b8e00-fc96-11e8-8c8c-28b8945f4535.png)

To fix this double entrance in the launch bar, we need to add `StartupWMClass=QGIS3`
to the desktop file, so it knows that the applications are the same.

The desired behaviour is a launch bar with just one icon:

![qgis - favorite - fixed](https://user-images.githubusercontent.com/163681/49745311-8c10b800-fc96-11e8-80e3-c0d3791bda4d.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
