### PR TITLE
Renames Avoid intersection to Avoid overlap [needs-docs]

### DIFF
--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -347,7 +347,7 @@ QVariant QgsSnappingLayerTreeModel::headerData( int section, Qt::Orientation ori
         case 3:
           return tr( "Units" );
         case 4:
-          return tr( "Avoid intersection" );
+          return tr( "Avoid overlap" );
         default:
           return QVariant();
       }
@@ -493,7 +493,7 @@ QVariant QgsSnappingLayerTreeModel::data( const QModelIndex &idx, int role ) con
       }
     }
 
-    // avoid intersection
+    // avoid intersection(Overlap)
     if ( idx.column() == AvoidIntersectionColumn )
     {
       if ( role == Qt::CheckStateRole && vl->geometryType() == QgsWkbTypes::PolygonGeometry )


### PR DESCRIPTION
## Description
In a training session one of my students point me to the fact that, in the snapping toolbar, the term intersection is used with two different meanings, making it confusing to understand/use.

I think his comment makes sense. In the main toolbar we have an option called snap on intersection. That seems good, and I don't think there's another word for it.

![image](https://user-images.githubusercontent.com/3607161/49766016-f5f78480-fccb-11e8-8718-26e6de663849.png)

In the advanced options, for polygon layers, theres a "Avoid intersections" option. I think that more than intersections, we want to avoid overlaping polygons.

![image](https://user-images.githubusercontent.com/3607161/49766115-322ae500-fccc-11e8-8c5a-b63d2ece42e7.png)

My proposal is to rename "Avoid intersection" to "Avoid overlap", which seems more accurate (when compared with other tools like the topology checker) and fixes the confusion.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
