### PR TITLE
Fix multi-field unique values renderer when parsing AFS settings & basic label expression parsing

### DIFF
--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -919,8 +919,27 @@ QgsFeatureRenderer *QgsArcGisRestUtils::parseEsriRenderer( const QVariantMap &re
   }
   else if ( type == QLatin1String( "uniqueValue" ) )
   {
-    const QString attribute = rendererData.value( QStringLiteral( "field1" ) ).toString();
-    // TODO - handle field2, field3
+    const QString field1 = rendererData.value( QStringLiteral( "field1" ) ).toString();
+    const QString field2 = rendererData.value( QStringLiteral( "field2" ) ).toString();
+    const QString field3 = rendererData.value( QStringLiteral( "field3" ) ).toString();
+    QString attribute;
+    if ( !field2.isEmpty() || !field3.isEmpty() )
+    {
+      const QString delimiter = rendererData.value( QStringLiteral( "fieldDelimiter" ) ).toString();
+      if ( !field3.isEmpty() )
+      {
+        attribute = QStringLiteral( "concat(\"%1\",'%2',\"%3\",'%4',\"%5\")" ).arg( field1, delimiter, field2, delimiter, field3 );
+      }
+      else
+      {
+        attribute = QStringLiteral( "concat(\"%1\",'%2',\"%3\")" ).arg( field1, delimiter, field2 );
+      }
+    }
+    else
+    {
+      attribute = field1;
+    }
+
     const QVariantList categories = rendererData.value( QStringLiteral( "uniqueValueInfos" ) ).toList();
     QgsCategoryList categoryList;
     for ( const QVariant &category : categories )

--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -61,6 +61,7 @@ class QgsArcGisRestUtils
     static QgsFeatureRenderer *parseEsriRenderer( const QVariantMap &rendererData );
     static QgsAbstractVectorLayerLabeling *parseEsriLabeling( const QVariantList &labelingData );
 
+    static QString parseEsriLabelingExpression( const QString &string );
     static QColor parseEsriColorJson( const QVariant &colorData );
     static Qt::PenStyle parseEsriLineStyle( const QString &style );
     static Qt::BrushStyle parseEsriFillStyle( const QString &style );

--- a/tests/src/providers/testqgsarcgisrestutils.cpp
+++ b/tests/src/providers/testqgsarcgisrestutils.cpp
@@ -497,7 +497,7 @@ void TestQgsArcGisRestUtils::testParseLabeling()
                                      "},{"
                                      "\"labelPlacement\": \"esriServerPointLabelPlacementAboveRight\","
                                      "\"where\": \"1_testing broken where string\","
-                                     "\"labelExpression\": \"[Name]\","
+                                     "\"labelExpression\": \"\\\"Name: \\\" CONCAT [Name] CONCAT NEWLINE CONCAT [Size]\","
                                      "\"useCodedValues\": true,"
                                      "\"symbol\": {"
                                      "\"type\": \"esriTS\","
@@ -556,6 +556,7 @@ void TestQgsArcGisRestUtils::testParseLabeling()
   QVERIFY( settings );
   QCOMPARE( settings->placement, QgsPalLayerSettings::OverPoint );
   QCOMPARE( settings->quadOffset, QgsPalLayerSettings::QuadrantAboveRight );
+  QCOMPARE( settings->fieldName, QStringLiteral( "\"Name\"" ) );
 
   QgsTextFormat textFormat = settings->format();
   QCOMPARE( textFormat.color(), QColor( 255, 0, 0 ) );
@@ -564,6 +565,8 @@ void TestQgsArcGisRestUtils::testParseLabeling()
 
   settings = children.at( 1 )->settings();
   QVERIFY( settings );
+  QCOMPARE( settings->fieldName, QStringLiteral( "'Name: ' || \"Name\" || '\\n' || \"Size\"" ) );
+
   textFormat = settings->format();
   QCOMPARE( textFormat.buffer().enabled(), true );
   QCOMPARE( textFormat.buffer().color(), QColor( 255, 255, 255 ) );


### PR DESCRIPTION
## Description
I swear the upgrade efforts end here, can't find anything else wrong with my AFS severs ;)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
