### PR TITLE
[ui] Better visual queue for non-visible layers in the tree

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -260,6 +260,14 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
     QFont f( QgsLayerTree::isLayer( node ) ? mFontLayer : ( QgsLayerTree::isGroup( node ) ? mFontGroup : QFont() ) );
     if ( index == mCurrentIndex )
       f.setUnderline( true );
+    if ( QgsLayerTree::isLayer( node ) )
+    {
+      const QgsMapLayer *layer = QgsLayerTree::toLayer( node )->layer();
+      if ( ( !node->isVisible() && ( !layer || layer->isSpatial() ) ) || ( layer && !layer->isInScaleRange( mLegendMapViewScale ) ) )
+      {
+        f.setItalic( !f.italic() );
+      }
+    }
     return f;
   }
   else if ( role == Qt::ForegroundRole )
@@ -270,7 +278,7 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
       const QgsMapLayer *layer = QgsLayerTree::toLayer( node )->layer();
       if ( ( !node->isVisible() && ( !layer || layer->isSpatial() ) ) || ( layer && !layer->isInScaleRange( mLegendMapViewScale ) ) )
       {
-        brush.setColor( Qt::lightGray );
+        brush.setColor( Qt::gray );
       }
     }
     return brush;


### PR DESCRIPTION
## Description
This PR addresses the absence of visual queue for selected layers when those are not visible (hidden manually, or via expression, or being out of display scale range):
![image](https://user-images.githubusercontent.com/1728657/49791605-6998a080-fd63-11e8-9927-ce81779e4c6f.png)

In addition to graying out the layer name, the PR toggle the italic state of the font (which is the only way we can see an indication when the text styling is overwritten by the selected item state). A little GIF shows this well:
![peek 2018-12-11 16-36](https://user-images.githubusercontent.com/1728657/49791670-951b8b00-fd63-11e8-85a7-de95712eb683.gif)

As a nice little bonus, the tweaked visual queue is compatible with the night mapping theme:
![image](https://user-images.githubusercontent.com/1728657/49791919-08bd9800-fd64-11e8-97dd-55a24f599d34.png)


Lastly, since the italic toggling is added, I thought it'd be good to darken up the gray a bit, some people have complained (see for e.g. https://gis.stackexchange.com/questions/297023/qgis-i-can-barely-see-the-labels-in-layer-panel/297033)
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
