### PR TITLE
Fix broken select/identify by polygon when layer CRS <> canvas CRS

### DIFF
--- a/src/app/qgsmaptoolselectionhandler.cpp
+++ b/src/app/qgsmaptoolselectionhandler.cpp
@@ -264,8 +264,10 @@ void QgsMapToolSelectionHandler::selectPolygonPressEvent( QgsMapMouseEvent *e )
         auto vectorLayer = static_cast<QgsVectorLayer *>( layer );
         if ( vectorLayer->geometryType() == QgsWkbTypes::PolygonGeometry )
         {
-          QgsRectangle r = mCanvas->mapSettings().mapToLayerCoordinates( layer, QgsRectangle( x - sr, y - sr, x + sr, y + sr ) );
-          QgsFeatureIterator fit = vectorLayer->getFeatures( QgsFeatureRequest().setFilterRect( r ).setFlags( QgsFeatureRequest::ExactIntersect ) );
+          QgsFeatureIterator fit = vectorLayer->getFeatures( QgsFeatureRequest()
+                                   .setDestinationCrs( mCanvas->mapSettings().destinationCrs(), mCanvas->mapSettings().transformContext() )
+                                   .setFilterRect( QgsRectangle( x - sr, y - sr, x + sr, y + sr ) )
+                                   .setFlags( QgsFeatureRequest::ExactIntersect ) );
           QgsFeature f;
           while ( fit.nextFeature( f ) )
           {


### PR DESCRIPTION
This fixes the QGIS 3.4 new feature of right-clicking on an existing polygon to select/identify by intersection with that polygon, when the polygon layer is not the same as the canvas layer.

I can't find any existing unit tests for this functionality unfortunately. :-1: 