### PR TITLE
avoid freeze with multiple layers locator search

### DIFF
--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -363,11 +363,10 @@ void QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const Qg
     if ( !expression.needsGeometry() )
       req.setFlags( QgsFeatureRequest::NoGeometry );
     req.setFilterExpression( QStringLiteral( "%1 ILIKE '%%2%'" )
-                             .arg( layer->displayExpression(),
-                                   string ) );
+                             .arg( layer->displayExpression(), string ) );
     req.setLimit( 30 );
 
-    PreparedLayer *preparedLayer = new PreparedLayer();
+    std::shared_ptr<PreparedLayer> preparedLayer( new PreparedLayer() );
     preparedLayer->expression = expression;
     preparedLayer->context = context;
     preparedLayer->layerId = layer->id();
@@ -376,7 +375,7 @@ void QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const Qg
     preparedLayer->request = req;
     preparedLayer->layerIcon = QgsMapLayerModel::iconForLayer( layer );
 
-    mPreparedLayers.append( std::shared_ptr<PreparedLayer>( preparedLayer ) );
+    mPreparedLayers.append( preparedLayer );
   }
 }
 

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -345,6 +345,7 @@ void QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const Qg
   if ( string.length() < 3 && !context.usingPrefix )
     return;
 
+  mPreparedLayers.clear();
   const QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();
   for ( auto it = layers.constBegin(); it != layers.constEnd(); ++it )
   {
@@ -375,7 +376,7 @@ void QgsAllLayersFeaturesLocatorFilter::prepare( const QString &string, const Qg
     preparedLayer->request = req;
     preparedLayer->layerIcon = QgsMapLayerModel::iconForLayer( layer );
 
-    mPreparedLayers.append( preparedLayer );
+    mPreparedLayers.append( std::shared_ptr<PreparedLayer>( preparedLayer ) );
   }
 }
 

--- a/src/app/locator/qgsinbuiltlocatorfilters.cpp
+++ b/src/app/locator/qgsinbuiltlocatorfilters.cpp
@@ -387,7 +387,7 @@ void QgsAllLayersFeaturesLocatorFilter::fetchResults( const QString &string, con
   QgsFeature f;
 
   // we cannot used const loop since iterator::nextFeature is not const
-  for ( auto preparedLayer : mPreparedLayers )
+  for ( auto preparedLayer : qgis::as_const( mPreparedLayers ) )
   {
     foundInCurrentLayer = 0;
     QgsFeatureIterator it = preparedLayer->featureSource->getFeatures( preparedLayer->request );

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -22,6 +22,8 @@
 #include "qgslocatorfilter.h"
 #include "qgsexpressioncontext.h"
 #include "qgsfeatureiterator.h"
+#include "qgsvectorlayerfeatureiterator.h"
+
 
 class QAction;
 
@@ -130,7 +132,8 @@ class APP_EXPORT QgsAllLayersFeaturesLocatorFilter : public QgsLocatorFilter
       public:
         QgsExpression expression;
         QgsExpressionContext context;
-        QgsFeatureIterator iterator;
+        std::unique_ptr<QgsVectorLayerFeatureSource> featureSource;
+        QgsFeatureRequest request;
         QString layerName;
         QString layerId;
         QIcon layerIcon;
@@ -151,7 +154,7 @@ class APP_EXPORT QgsAllLayersFeaturesLocatorFilter : public QgsLocatorFilter
   private:
     int mMaxResultsPerLayer = 6;
     int mMaxTotalResults = 12;
-    QList<PreparedLayer> mPreparedLayers;
+    QList<PreparedLayer *> mPreparedLayers;
 
 
 };

--- a/src/app/locator/qgsinbuiltlocatorfilters.h
+++ b/src/app/locator/qgsinbuiltlocatorfilters.h
@@ -154,7 +154,7 @@ class APP_EXPORT QgsAllLayersFeaturesLocatorFilter : public QgsLocatorFilter
   private:
     int mMaxResultsPerLayer = 6;
     int mMaxTotalResults = 12;
-    QList<PreparedLayer *> mPreparedLayers;
+    QList<std::shared_ptr<PreparedLayer>> mPreparedLayers;
 
 
 };


### PR DESCRIPTION
if the project had many searchable layers, a freeze occured when running the all features locator filter
the feature iterator was created in prepare (main thread) and the maximum number of connection was reached

