### PR TITLE
[layouts] Fix first background map render can never be canceled and must always complete

### DIFF
--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -778,7 +778,13 @@ void QgsLayoutItemMap::paint( QPainter *painter, const QStyleOptionGraphicsItem 
       painter->setFont( messageFont );
       painter->setPen( QColor( 255, 255, 255, 255 ) );
       painter->drawText( thisPaintRect, Qt::AlignCenter | Qt::AlignHCenter, tr( "Rendering map" ) );
-      if ( !mPainterJob && !mDrawingPreview )
+      if ( mPainterJob && mCacheInvalidated && !mDrawingPreview )
+      {
+        // current job was invalidated - start a new one
+        mPreviewScaleFactor = QgsLayoutUtils::scaleFactorFromItemStyle( style );
+        mBackgroundUpdateTimer->start( 1 );
+      }
+      else if ( !mPainterJob && !mDrawingPreview )
       {
         // this is the map's very first paint - trigger a cache update
         mPreviewScaleFactor = QgsLayoutUtils::scaleFactorFromItemStyle( style );


### PR DESCRIPTION
This fixes an issue where map items appear to get "stuck" showing the "Rendering map" text while the very first render of the map item completes. If the map render is lengthy (e.g. due to complex labeling and an initially too small map scale), then it can appear as if the map item has got stuck.

Instead, we now correctly support cancelation of this initial map render job, just like we do subsequent ones.
