### PR TITLE
Pass on the theme style data directly instead of a file:///...

### DIFF
--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -60,7 +60,7 @@ QAbstractSpinBox {
      subcontrol-position: top right;
 
      width: 16px;
-    image: url(icons/up_arrow.png) 1;
+    image: url(@theme_path/icons/up_arrow.png) 1;
  }
 
  QAbstractSpinBox::down-button {
@@ -68,7 +68,7 @@ QAbstractSpinBox {
      subcontrol-position: bottom right;
 
      width: 16px;
-    image: url(icons/down_arrow.png);
+    image: url(@theme_path/icons/down_arrow.png);
  }
 
 
@@ -159,7 +159,7 @@ QToolButton::hover, QToolButton::menu-button::hover
 }
 QToolButton::menu-arrow 
 {
-    image: url(icons/down_arrow.png);
+    image: url(@theme_path/icons/down_arrow.png);
 }
 QToolBar QToolButton, QToolButton::menu-button
 {
@@ -219,7 +219,7 @@ QComboBox::drop-down {
 
 QComboBox::down-arrow
 {
-    image: url(icons/down_arrow.png);
+    image: url(@theme_path/icons/down_arrow.png);
 }
 
 
@@ -298,7 +298,7 @@ QHeaderView::section
 }
 QDockWidget
 {
-  	titlebar-close-icon: url(icons/cross.svg);
+  	titlebar-close-icon: url(@theme_path/icons/cross.svg);
 }
 
 QDockWidget::separator
@@ -566,13 +566,13 @@ QTreeView::item:selected, QTreeView::branch:selected {
 QTreeView::branch:has-children:!has-siblings:closed,
 QTreeView::branch:closed:has-children:has-siblings {
     border-image: none;
-    image: url(icons/caret-right_ffffff_14.png);
+    image: url(@theme_path/icons/caret-right_ffffff_14.png);
 }
 
 QTreeView::branch:open:has-children:!has-siblings,
 QTreeView::branch:open:has-children:has-siblings {
      border-image: none;
-     image: url(icons/caret-down_ffffff_14.png);
+     image: url(@theme_path/icons/caret-down_ffffff_14.png);
 }
 
 QgsLayerTreeView
@@ -594,7 +594,7 @@ QTreeView#viewGraduated::indicator:unchecked,
 QTreeView#viewCategories::indicator:unchecked,
 QTreeView#viewRules::indicator:unchecked 
 {
-    image: url(icons/eye-blocked.svg);
+    image: url(@theme_path/icons/eye-blocked.svg);
 }
 
 QgsLayerTreeView::indicator:checked,
@@ -602,7 +602,7 @@ QTreeView#viewGraduated::indicator:checked,
 QTreeView#viewCategories::indicator:checked, 
 QTreeView#viewRules::indicator:checked 
 {
-    image: url(icons/eye.svg);
+    image: url(@theme_path/icons/eye.svg);
 }
 
 /* ==================================================================================== */

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -144,7 +144,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   QStringList themes = QgsApplication::uiThemes().keys();
   cmbUITheme->addItems( themes );
 
-#if QT_VERSION < QT_VERSION_CHECK( 5, 12, 0 )
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   lblUITheme->setText( QStringLiteral( "%1 <i>(%2)</i>" ).arg( lblUITheme->text(), tr( "QGIS restart required" ) ) );
 #else
   connect( cmbUITheme, static_cast<void ( QComboBox::* )( const QString & )>( &QComboBox::currentIndexChanged ), this, &QgsOptions::uiThemeChanged );

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -144,7 +144,11 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   QStringList themes = QgsApplication::uiThemes().keys();
   cmbUITheme->addItems( themes );
 
+#if QT_VERSION < QT_VERSION_CHECK( 5, 12, 0 )
+  lblUITheme->setText( QStringLiteral( "%1 <i>(%2)</i>" ).arg( lblUITheme->text(), tr( "QGIS restart required" ) ) );
+#else
   connect( cmbUITheme, static_cast<void ( QComboBox::* )( const QString & )>( &QComboBox::currentIndexChanged ), this, &QgsOptions::uiThemeChanged );
+#endif
 
   mIdentifyHighlightColorButton->setColorDialogTitle( tr( "Identify Highlight Color" ) );
   mIdentifyHighlightColorButton->setAllowOpacity( true );
@@ -564,10 +568,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mMessageTimeoutSpnBx->setValue( mSettings->value( QStringLiteral( "/qgis/messageTimeout" ), 5 ).toInt() );
 
   QString name = mSettings->value( QStringLiteral( "/qgis/style" ) ).toString();
-  cmbStyle->setCurrentIndex( cmbStyle->findText( name, Qt::MatchFixedString ) );
+  whileBlocking( cmbStyle )->setCurrentIndex( cmbStyle->findText( name, Qt::MatchFixedString ) );
 
   QString theme = mSettings->value( QStringLiteral( "UI/UITheme" ), QStringLiteral( "auto" ) ).toString();
-  cmbUITheme->setCurrentIndex( cmbUITheme->findText( theme, Qt::MatchFixedString ) );
+  whileBlocking( cmbUITheme )->setCurrentIndex( cmbUITheme->findText( theme, Qt::MatchFixedString ) );
 
   mNativeColorDialogsChkBx->setChecked( mSettings->value( QStringLiteral( "/qgis/native_color_dialogs" ), false ).toBool() );
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -67,6 +67,7 @@
 #include <QPixmap>
 #include <QThreadPool>
 #include <QLocale>
+#include <QStyle>
 
 #ifndef Q_OS_WIN
 #include <netinet/in.h>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -484,7 +484,7 @@
                      <number>0</number>
                     </property>
                     <item>
-                     <widget class="QLabel" name="label_42">
+                     <widget class="QLabel" name="lblUITheme">
                       <property name="text">
                        <string>UI Theme</string>
                       </property>


### PR DESCRIPTION
## Description
Primary benefit is that it allows applying theme in read-only theme directory, but the original idea was to try and plug in a crasher when switching themes.

It seems passing on the style data directly is helping on the crasher front. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
