### PR TITLE
Decent workaround to dirty a project after bad layer handling

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -105,6 +105,7 @@ class QgsGeometryValidationDock;
 class QgsGeometryValidationModel;
 class QgsUserProfileManagerWidgetFactory;
 class Qgs3DMapCanvasDockWidget;
+class QgsHandleBadLayersHandler;
 
 class QDomDocument;
 class QNetworkReply;
@@ -2310,6 +2311,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     std::unique_ptr<QgsGeometryValidationService> mGeometryValidationService;
     QgsGeometryValidationModel *mGeometryValidationModel = nullptr;
     QgsGeometryValidationDock *mGeometryValidationDock = nullptr;
+    QgsHandleBadLayersHandler *mAppBadLayersHandler = nullptr;
 
     friend class TestQgisAppPython;
     friend class QgisAppInterface;

--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -57,7 +57,12 @@ void QgsHandleBadLayersHandler::handleBadLayers( const QList<QDomNode> &layers )
       Qgis::Warning, QgisApp::instance()->messageTimeout() );
 
   if ( dialog->layerCount() > 0 )
-    dialog->exec();
+  {
+    if ( dialog->exec() == dialog->Accepted )
+    {
+      emit layersChanged();
+    }
+  }
 
   delete dialog;
   QApplication::restoreOverrideCursor();

--- a/src/app/qgshandlebadlayers.h
+++ b/src/app/qgshandlebadlayers.h
@@ -32,6 +32,15 @@ class APP_EXPORT QgsHandleBadLayersHandler
 
     //! Implementation of the handler
     void handleBadLayers( const QList<QDomNode> &layers ) override;
+
+  signals:
+
+    /**
+     * Emitted when layers have changed
+     * \since QGIS 3.6
+     */
+    void layersChanged();
+
 };
 
 


### PR DESCRIPTION
Fixes #20743

@nyalldawson I don't know why https://github.com/qgis/QGIS/blob/master/src/app/qgisapp.cpp#L5809 but that is basically blocking a plain `setDirty` call from within the bad layer handlers.

If you can think of a better/cleaner solution than a timer (and that do not involve an API change in the bad layer handlers), please let me know.