### PR TITLE
Do not crash when zipped project is not a valid zip

### DIFF
--- a/src/core/qgsziputils.cpp
+++ b/src/core/qgsziputils.cpp
@@ -110,7 +110,7 @@ bool QgsZipUtils::unzip( const QString &zipFilename, const QString &dir, QString
   }
   else
   {
-    QString err = QObject::tr( "Error opening zip archive: '%1'" ).arg( zip_strerror( z ) );
+    QString err = QObject::tr( "Error opening zip archive: '%1'" ).arg( z ? zip_strerror( z ) : zipFilename );
     QgsMessageLog::logMessage( err, QStringLiteral( "QgsZipUtils" ) );
     return false;
   }


### PR DESCRIPTION
Fixes #20783 - Crash when opening qgz project
