### PR TITLE
Fix QgsReadWriteLocker changeMode

### DIFF
--- a/src/core/qgsreadwritelocker.cpp
+++ b/src/core/qgsreadwritelocker.cpp
@@ -34,6 +34,8 @@ void QgsReadWriteLocker::changeMode( QgsReadWriteLocker::Mode mode )
 
   unlock();
 
+  mMode = mode;
+
   if ( mMode == Read )
     mLock.lockForRead();
   else if ( mMode == Write )


### PR DESCRIPTION
since mMode was never updated, the lock
was never toggled from read to write or
vice-versa.

This was leading to crashes because the
paths that were meant to be serialized
and thread safe were not.

Fixes #20789 and probably many more
random crashes where QgsFeaturePool
was used.
