### PR TITLE
opencl rastercalc fix int input rasters and cast to float

### DIFF
--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -207,6 +207,12 @@ QString QgsRasterCalcNode::toString( bool cStyle ) const
     left = mLeft->toString( cStyle );
   if ( mRight )
     right = mRight->toString( cStyle );
+
+  auto floatCast = [ ]( const QString s ) -> QString
+  {
+    return QStringLiteral( "(float) ( %1 )" ).arg( s );
+  };
+
   switch ( mType )
   {
     case tOperator:
@@ -227,7 +233,7 @@ QString QgsRasterCalcNode::toString( bool cStyle ) const
           break;
         case opPOW:
           if ( cStyle )
-            result = QStringLiteral( "pow( %1, %2 )" ).arg( left ).arg( right );
+            result = QStringLiteral( "pow( %1, %2 )" ).arg( floatCast( left ) ).arg( floatCast( right ) );
           else
             result = QStringLiteral( "%1^%2" ).arg( left ).arg( right );
           break;
@@ -265,31 +271,58 @@ QString QgsRasterCalcNode::toString( bool cStyle ) const
             result = QStringLiteral( "%1 OR %2" ).arg( left ).arg( right );
           break;
         case opSQRT:
-          result = QStringLiteral( "sqrt( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "sqrt( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "sqrt( %1 )" ).arg( left );
           break;
         case opSIN:
-          result = QStringLiteral( "sin( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "sin( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "sin( %1 )" ).arg( left );
           break;
         case opCOS:
-          result = QStringLiteral( "cos( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "cos( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "cos( %1 )" ).arg( left );
           break;
         case opTAN:
-          result = QStringLiteral( "tan( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "tan( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "tan( %1 )" ).arg( left );
           break;
         case opASIN:
-          result = QStringLiteral( "asin( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "asin( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "asin( %1 )" ).arg( left );
           break;
         case opACOS:
-          result = QStringLiteral( "acos( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "acos( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "acos( %1 )" ).arg( left );
           break;
         case opATAN:
-          result = QStringLiteral( "atan( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "atan( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "atan( %1 )" ).arg( left );
           break;
         case opLOG:
-          result = QStringLiteral( "log( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "log( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "log( %1 )" ).arg( left );
           break;
         case opLOG10:
-          result = QStringLiteral( "log10( %1 )" ).arg( left );
+          if ( cStyle )
+            result = QStringLiteral( "log10( %1 )" ).arg( floatCast( left ) );
+          else
+            result = QStringLiteral( "log10( %1 )" ).arg( left );
           break;
         case opNONE:
           break;

--- a/tests/src/analysis/testqgsrastercalculator.cpp
+++ b/tests/src/analysis/testqgsrastercalculator.cpp
@@ -679,9 +679,9 @@ void TestQgsRasterCalculator::toString()
   QCOMPARE( _test( QStringLiteral( "\"raster@1\"  +  2" ), false ), QString( "\"raster@1\" + 2" ) );
   QCOMPARE( _test( QStringLiteral( "\"raster@1\"  +  2" ), true ), QString( "\"raster@1\" + 2" ) );
   QCOMPARE( _test( QStringLiteral( "\"raster@1\" ^ 3  +  2" ), false ), QString( "\"raster@1\"^3 + 2" ) );
-  QCOMPARE( _test( QStringLiteral( "\"raster@1\" ^ 3  +  2" ), true ), QString( "pow( \"raster@1\", 3 ) + 2" ) );
+  QCOMPARE( _test( QStringLiteral( "\"raster@1\" ^ 3  +  2" ), true ), QString( "pow( (float) ( \"raster@1\" ), (float) ( 3 ) ) + 2" ) );
   QCOMPARE( _test( QStringLiteral( "atan(\"raster@1\") * cos( 3  +  2 )" ), false ), QString( "atan( \"raster@1\" ) * cos( 3 + 2 )" ) );
-  QCOMPARE( _test( QStringLiteral( "atan(\"raster@1\") * cos( 3  +  2 )" ), true ), QString( "atan( \"raster@1\" ) * cos( 3 + 2 )" ) );
+  QCOMPARE( _test( QStringLiteral( "atan(\"raster@1\") * cos( 3  +  2 )" ), true ), QString( "atan( (float) ( \"raster@1\" ) ) * cos( (float) ( 3 + 2 ) )" ) );
 }
 
 


### PR DESCRIPTION
Cast to float all math operations because when the
input is not a float or a double opencl raises
an error regarding which override should pick.

By casting to float we are sure that the right
function will be called.

This patch also fixes the buffer sizes for short (16bit)
and int (32bit) and asserts that size of float is 32bit.

Also fixes the case when there is no input raster at all
and the calculation is only expression based.
