### PR TITLE
[ux] Remove custom group box styling and option for QGIS styled group boxes

### DIFF
--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -78,9 +78,6 @@ QMap<QString, QVariant> QgisAppStyleSheet::defaultOptions()
   QgsDebugMsg( QStringLiteral( "fontFamily: %1" ).arg( fontFamily ) );
   opts.insert( QStringLiteral( "fontFamily" ), QVariant( fontFamily ) );
 
-  bool gbxCustom = ( mMacStyle );
-  opts.insert( QStringLiteral( "groupBoxCustom" ), settings.value( QStringLiteral( "groupBoxCustom" ), QVariant( gbxCustom ) ) );
-
   opts.insert( QStringLiteral( "toolbarSpacing" ), settings.value( QStringLiteral( "toolbarSpacing" ), QString() ) );
 
   settings.endGroup(); // "qgis/stylesheet"
@@ -121,42 +118,7 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
     ss += QLatin1String( "QTabBar::close-button:hover{ image: url(:/images/themes/default/mIconCloseTabHover.svg); }" );
   }
 
-  // QGroupBox and QgsCollapsibleGroupBox, mostly for Ubuntu and Mac
-  bool gbxCustom = opts.value( QStringLiteral( "groupBoxCustom" ) ).toBool();
-  QgsDebugMsg( QStringLiteral( "groupBoxCustom: %1" ).arg( gbxCustom ) );
-
-  ss += QLatin1String( "QGroupBox{" );
-  // doesn't work for QGroupBox::title
-  ss += QStringLiteral( "color: rgb(%1,%1,%1);" ).arg( mMacStyle ? 25 : 60 );
-  ss += QLatin1String( "font-weight: bold;" );
-
-  if ( gbxCustom )
-  {
-    ss += QStringLiteral( "background-color: rgba(0,0,0,%1%);" )
-          .arg( mWinOS && mStyle.startsWith( QLatin1String( "windows" ) ) ? 0 : 3 );
-    ss += QLatin1String( "border: 1px solid rgba(0,0,0,20%);" );
-    ss += QLatin1String( "border-radius: 5px;" );
-    ss += QLatin1String( "margin-top: 2.5ex;" );
-    ss += QStringLiteral( "margin-bottom: %1ex;" ).arg( mMacStyle ? 1.5 : 1 );
-  }
-  ss += QLatin1String( "} " );
-  if ( gbxCustom )
-  {
-    ss += QLatin1String( "QGroupBox:flat{" );
-    ss += QLatin1String( "background-color: rgba(0,0,0,0);" );
-    ss += QLatin1String( "border: rgba(0,0,0,0);" );
-    ss += QLatin1String( "} " );
-
-    ss += QLatin1String( "QGroupBox::title{" );
-    ss += QLatin1String( "subcontrol-origin: margin;" );
-    ss += QLatin1String( "subcontrol-position: top left;" );
-    ss += QLatin1String( "margin-left: 6px;" );
-    if ( !( mWinOS && mStyle.startsWith( QLatin1String( "windows" ) ) ) && !mOxyStyle )
-    {
-      ss += QLatin1String( "background-color: rgba(0,0,0,0);" );
-    }
-    ss += QLatin1String( "} " );
-  }
+  ss += QLatin1String( "QGroupBox{ font-weight: 600; }" );
 
   //sidebar style
   QString style = "QListWidget#mOptionsListWidget {"

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -557,10 +557,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   mFontFamilyRadioCustom->blockSignals( false );
   mFontFamilyComboBox->blockSignals( false );
 
-  // custom group boxes
-  mCustomGroupBoxChkBx->setChecked( mStyleSheetOldOpts.value( QStringLiteral( "groupBoxCustom" ) ).toBool() );
-  connect( mCustomGroupBoxChkBx, &QAbstractButton::clicked, this, &QgsOptions::useCustomGroupBox );
-
   mMessageTimeoutSpnBx->setValue( mSettings->value( QStringLiteral( "/qgis/messageTimeout" ), 5 ).toInt() );
 
   QString name = mSettings->value( QStringLiteral( "/qgis/style" ) ).toString();
@@ -1772,12 +1768,6 @@ void QgsOptions::mFontFamilyComboBox_currentFontChanged( const QFont &font )
     mStyleSheetNewOpts.insert( QStringLiteral( "fontFamily" ), QVariant( font.family() ) );
     mStyleSheetBuilder->buildStyleSheet( mStyleSheetNewOpts );
   }
-}
-
-void QgsOptions::useCustomGroupBox( bool chkd )
-{
-  mStyleSheetNewOpts.insert( QStringLiteral( "groupBoxCustom" ), QVariant( chkd ) );
-  mStyleSheetBuilder->buildStyleSheet( mStyleSheetNewOpts );
 }
 
 void QgsOptions::leProjectGlobalCrs_crsChanged( const QgsCoordinateReferenceSystem &crs )

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -115,9 +115,6 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     //! Slot to select custom font family choice for app
     void mFontFamilyComboBox_currentFontChanged( const QFont &font );
 
-    //! Slot to set whether to use custom group boxes
-    void useCustomGroupBox( bool chkd );
-
     void mProxyTypeComboBox_currentIndexChanged( int idx );
 
     //! Add a new URL to exclude from Proxy

--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -304,8 +304,6 @@ void QgsCollapsibleGroupBoxBasic::updateStyle()
   setUpdatesEnabled( false );
 
   QgsSettings settings;
-  // NOTE: QGIS-Style groupbox styled in app stylesheet
-  bool usingQgsStyle = settings.value( QStringLiteral( "qgis/stylesheet/groupBoxCustom" ), QVariant( false ) ).toBool();
 
   QStyleOptionGroupBox box;
   initStyleOption( &box );
@@ -317,8 +315,8 @@ void QgsCollapsibleGroupBoxBasic::updateStyle()
   int marginLeft = 20;  // title margin for disclosure triangle
   int marginRight = 5;  // a little bit of space on the right, to match space on the left
   int offsetLeft = 0;   // offset for oxygen theme
-  int offsetStyle = QApplication::style()->objectName().contains( QLatin1String( "macintosh" ) ) ? ( usingQgsStyle ? 1 : 8 ) : 0;
-  int topBuffer = ( usingQgsStyle ? 3 : 1 ) + offsetStyle; // space between top of title or triangle and widget above
+  int offsetStyle = QApplication::style()->objectName().contains( QLatin1String( "macintosh" ) ) ? 8 : 0;
+  int topBuffer = 1 + offsetStyle; // space between top of title or triangle and widget above
   int offsetTop = topBuffer;
   int offsetTopTri = topBuffer; // offset for triangle
 
@@ -366,10 +364,10 @@ void QgsCollapsibleGroupBoxBasic::updateStyle()
 
   // customize style sheet for collapse/expand button and force left-aligned title
   QString ss;
-  if ( usingQgsStyle || QApplication::style()->objectName().contains( QLatin1String( "macintosh" ) ) )
+  if ( QApplication::style()->objectName().contains( QLatin1String( "macintosh" ) ) )
   {
     ss += QLatin1String( "QgsCollapsibleGroupBoxBasic, QgsCollapsibleGroupBox {" );
-    ss += QStringLiteral( "  margin-top: %1px;" ).arg( topBuffer + ( usingQgsStyle ? rectTitle.height() + 5 : rectFrame.top() ) );
+    ss += QStringLiteral( "  margin-top: %1px;" ).arg( topBuffer + rectFrame.top() );
     ss += '}';
   }
   ss += QLatin1String( "QgsCollapsibleGroupBoxBasic::title, QgsCollapsibleGroupBox::title {" );

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -332,7 +332,7 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>16</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -695,33 +695,12 @@
                      <number>0</number>
                     </property>
                     <item row="2" column="0">
-                     <widget class="QCheckBox" name="cbxCheckVersion">
-                      <property name="text">
-                       <string>Check QGIS version at startup</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QCheckBox" name="mNativeColorDialogsChkBx">
-                      <property name="text">
-                       <string>Use native color chooser dialogs</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
                      <widget class="QCheckBox" name="mDataSourceManagerNonModal">
                       <property name="toolTip">
                        <string>A modeless dialog allows you to interact with QGIS main window and dialogs.</string>
                       </property>
                       <property name="text">
                        <string>Modeless data source manager dialog</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="1">
-                     <widget class="QCheckBox" name="mCustomGroupBoxChkBx">
-                      <property name="text">
-                       <string>QGIS-styled group boxes</string>
                       </property>
                      </widget>
                     </item>
@@ -737,6 +716,33 @@
                        <string>Hide splash screen at startup</string>
                       </property>
                      </widget>
+                    </item>
+                    <item row="3" column="0">
+                     <widget class="QCheckBox" name="cbxCheckVersion">
+                      <property name="text">
+                       <string>Check QGIS version at startup</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <widget class="QCheckBox" name="mNativeColorDialogsChkBx">
+                      <property name="text">
+                       <string>Use native color chooser dialogs</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="1">
+                     <spacer name="horizontalSpacer_2">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
                     </item>
                    </layout>
                   </item>
@@ -5575,7 +5581,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>cbxHideSplash</tabstop>
   <tabstop>mNativeColorDialogsChkBx</tabstop>
   <tabstop>mDataSourceManagerNonModal</tabstop>
-  <tabstop>mCustomGroupBoxChkBx</tabstop>
   <tabstop>cbxCheckVersion</tabstop>
   <tabstop>mProjectOnLaunchCmbBx</tabstop>
   <tabstop>mProjectOnLaunchLineEdit</tabstop>
@@ -5761,6 +5766,9 @@ p, li { white-space: pre-wrap; }
   <tabstop>mRemoveUrlPushButton</tabstop>
   <tabstop>mExcludeUrlListWidget</tabstop>
   <tabstop>mAdvancedSettingsEnableButton</tabstop>
+  <tabstop>mGPUEnableCheckBox</tabstop>
+  <tabstop>mOpenClDevicesCombo</tabstop>
+  <tabstop>mGPUInfoTextBrowser</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
This setting is causing issues on newer operating systems, e.g. MacOS on dark themes. It's a 6 year old workaround for styling issues which have likely since been fixed in Qt and the DEs themselves.

Plus, it's always less maintenance work to avoid these app-specific workarounds in QGIS, and instead rely on Qt to correctly theme widgets.