### PR TITLE
[processing] Throw error when attempting to use Distance Matrix with multipoint datasets

### DIFF
--- a/python/plugins/processing/algs/qgis/PointDistance.py
+++ b/python/plugins/processing/algs/qgis/PointDistance.py
@@ -116,10 +116,16 @@ class PointDistance(QgisAlgorithm):
         if source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.INPUT))
 
+        if QgsWkbTypes.isMultiType(source.wkbType()):
+            raise QgsProcessingException(self.tr('Input point layer is a MultiPoint layer - first convert to single points before using this algorithm.'))
+
         source_field = self.parameterAsString(parameters, self.INPUT_FIELD, context)
         target_source = self.parameterAsSource(parameters, self.TARGET, context)
         if target_source is None:
             raise QgsProcessingException(self.invalidSourceError(parameters, self.TARGET))
+
+        if QgsWkbTypes.isMultiType(target_source.wkbType()):
+            raise QgsProcessingException(self.tr('Target point layer is a MultiPoint layer - first convert to single points before using this algorithm.'))
 
         target_field = self.parameterAsString(parameters, self.TARGET_FIELD, context)
         same_source_and_target = parameters[self.INPUT] == parameters[self.TARGET]


### PR DESCRIPTION
There's no single approach to use for multi-point inputs, so instead
of overloading this algorithm with extra options to control how these
are handled, we raise a helpful error and push the reponsibility back
to the user to get the data into the right format before running the
tool.

Fixes #20799
