### PR TITLE
allow building WITH_SERVER_PLUGINS=OFF

### DIFF
--- a/src/server/qgsowsserver.h
+++ b/src/server/qgsowsserver.h
@@ -21,6 +21,8 @@
 #include "qgsrequesthandler.h"
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 #include "qgsaccesscontrol.h"
+#else
+#include "qgsfeature.h"
 #endif
 
 #include "qgsfield.h"

--- a/src/server/qgsowsserver.h
+++ b/src/server/qgsowsserver.h
@@ -22,7 +22,7 @@
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 #include "qgsaccesscontrol.h"
 #else
-#include "qgsfeature.h"
+class QgsFeature;
 #endif
 
 #include "qgsfield.h"


### PR DESCRIPTION
## Description
when building using
`cmake /build/QGIS -GNinja -DWITH_STAGED_PLUGINS=OFF -DWITH_SERVER=ON -DWITH_SERVER_PLUGINS=OFF -DCMAKE_INSTALL_PREFIX=/usr -DWITH_GRASS=OFF -DWITH_GRASS7=OFF -DSUPPRESS_QT_WARNINGS=ON -DENABLE_TESTS=OFF -DWITH_QSPATIALITE=OFF -DWITH_QWTPOLAR=OFF -DWITH_APIDOC=OFF -DWITH_ASTYLE=OFF -DWITH_DESKTOP=OFF -DWITH_BINDINGS=OFF -DWITH_QTMOBILITY=OFF -DWITH_QUICK=OFF -DWITH_GUI=OFF -DDISABLE_DEPRECATED=ON  -DSERVER_SKIP_ECW=ON -DWITH_GEOREFERENCER=OFF`

I get 

```FAILED: src/server/CMakeFiles/qgis_mapserv.fcgi.dir/qgsowsserver.cpp.o
/usr/bin/c++  -DQGIS_DISABLE_DEPRECATED -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_SQL_LIB -DQT_SVG_LIB -DQT_WEBKIT_LIB -DQT_XML_LIB -DWITH_QTWEBKIT -isystem /usr/include/qt4 -isystem /usr/include/qt4/QtSvg -isystem /usr/include/qt4/QtWebKit -isystem /usr/include/qt4/QtGui -isystem /usr/include/qt4/QtXml -isystem /usr/include/qt4/QtSql -isystem /usr/include/qt4/QtNetwork -isystem /usr/include/qt4/QtCore -I. -I../src/server/../python -isystem /usr/include/gdal -isystem /usr/include/postgresql -Isrc/server -isystem ../src/server/include/qgis -isystem /usr/include/QtCrypto -I../src/server/../core -I../src/server/../core/auth -I../src/server/../core/dxf -I../src/server/../core/geometry -I../src/server/../core/raster -I../src/server/../core/symbology-ng -I../src/server/../core/composer -I../src/server/../core/layertree -I../src/server/../gui -I../src/server/../gui/editorwidgets -I../src/server/../gui/editorwidgets/core -I../src/server/../analysis/interpolation -I../src/server/../plugins/diagram_overlay -I../src/server/. -DSPATIALITE_VERSION_GE_4_0_0 -DSPATIALITE_VERSION_G_4_1_1 -DSPATIALITE_HAS_INIT_EX -std=c++11 -Wall -Wextra -Wno-long-long -Wformat-security -Wno-strict-aliasing -fvisibility=hidden   -DCORE_EXPORT= -DGUI_EXPORT= -DPYTHON_EXPORT= -DANALYSIS_EXPORT= -DAPP_EXPORT= -DCUSTOMWIDGETS_EXPORT=  "-DSERVER_EXPORT=__attribute__ ((visibility (\"default\")))" -MD -MT src/server/CMakeFiles/qgis_mapserv.fcgi.dir/qgsowsserver.cpp.o -MF src/server/CMakeFiles/qgis_mapserv.fcgi.dir/qgsowsserver.cpp.o.d -o src/server/CMakeFiles/qgis_mapserv.fcgi.dir/qgsowsserver.cpp.o -c ../src/server/qgsowsserver.cpp

In file included from ../src/server/qgsowsserver.cpp:18:0:
../src/server/qgsowsserver.h:84:40: error: 'QgsFeature' does not name a type 
static QString featureGmlId( const QgsFeature* f, const QgsAttributeList& pkAttributes );
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
