### PR TITLE
[api] Raises ValueError and TypeError exceptions when QgsGeometry.asPolyline() is called on non-single-line geometries

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1442,10 +1442,35 @@ is null, a ValueError will be raised.
     }
 %End
 
-    QgsPolylineXY asPolyline() const;
+
+    SIP_PYOBJECT asPolyline() const /TypeHint="QgsPolylineXY"/;
 %Docstring
-Returns contents of the geometry as a polyline
-if wkbType is WKBLineString, otherwise an empty list
+Returns the contents of the geometry as a polyline.
+
+Any z or m values present in the geometry will be discarded. If the geometry is a curved line type
+(such as a CircularString), it will be automatically segmentized.
+
+This method works only with single-line (or single-curve) geometry types. If the geometry
+is not a single-line type, a TypeError will be raised. If the geometry is null, a ValueError
+will be raised.
+%End
+%MethodCode
+    const QgsWkbTypes::Type type = sipCpp->wkbType();
+    if ( sipCpp->isNull() )
+    {
+      PyErr_SetString( PyExc_ValueError, QStringLiteral( "Null geometry cannot be converted to a polyline." ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else if ( QgsWkbTypes::geometryType( type ) != QgsWkbTypes::LineGeometry || QgsWkbTypes::isMultiType( type ) )
+    {
+      PyErr_SetString( PyExc_TypeError, QStringLiteral( "%1 geometry cannot be converted to a polyline. Only single line or curve types are permitted." ).arg( QgsWkbTypes::displayString( type ) ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      const sipMappedType *qvector_type = sipFindMappedType( "QVector< QgsPointXY >" );
+      sipRes = sipConvertFromNewType( new QgsPolylineXY( sipCpp->asPolyline() ), qvector_type, Py_None );
+    }
 %End
 
     QgsPolygonXY asPolygon() const;

--- a/python/plugins/processing/algs/qgis/PointsFromLines.py
+++ b/python/plugins/processing/algs/qgis/PointsFromLines.py
@@ -107,6 +107,10 @@ class PointsFromLines(QgisAlgorithm):
         for current, f in enumerate(features):
             if feedback.isCanceled():
                 break
+
+            if not f.hasGeometry():
+                continue
+
             geom = f.geometry()
             if geom.isMultipart():
                 lines = geom.asMultiPolyline()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -563,6 +563,22 @@ class TestQgsGeometry(unittest.TestCase):
         with self.assertRaises(ValueError):
             QgsGeometry().asPoint()
 
+        # as polyline
+        self.assertEqual(QgsGeometry.fromWkt('LineString(11 13,14 15)').asPolyline(), [QgsPointXY(11, 13), QgsPointXY(14, 15)])
+        self.assertEqual(QgsGeometry.fromWkt('LineStringZ(11 13 1,14 15 2)').asPolyline(), [QgsPointXY(11, 13), QgsPointXY(14, 15)])
+        self.assertEqual(QgsGeometry.fromWkt('LineStringM(11 13 1,14 15 2)').asPolyline(), [QgsPointXY(11, 13), QgsPointXY(14, 15)])
+        self.assertEqual(QgsGeometry.fromWkt('LineStringZM(11 13 1 2,14 15 3 4)').asPolyline(), [QgsPointXY(11, 13), QgsPointXY(14, 15)])
+        with self.assertRaises(TypeError):
+            QgsGeometry.fromWkt('Point(11 13)').asPolyline()
+        with self.assertRaises(TypeError):
+            QgsGeometry.fromWkt('MultiPoint(11 13,14 15)').asPolyline()
+        with self.assertRaises(TypeError):
+            QgsGeometry.fromWkt('MultiLineString((11 13, 14 15),(1 2, 3 4))').asPolyline()
+        with self.assertRaises(TypeError):
+            QgsGeometry.fromWkt('Polygon((11 13,14 15, 14 13, 11 13))').asPolyline()
+        with self.assertRaises(ValueError):
+            QgsGeometry().asPolyline()
+
     def testReferenceGeometry(self):
         """ Test parsing a whole range of valid reference wkt formats and variants, and checking
         expected values such as length, area, centroids, bounding boxes, etc of the resultant geometry.


### PR DESCRIPTION
Previously we would just return an empty list when geometries of invalid type were used, but this is dangerous and we are safer to explicitly raise errors preventing use of asPolyline() with incompatible geometry types.

