### PR TITLE
Improve a few decoration dialog .ui files [backport]

### DIFF
--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>603</width>
-    <height>335</height>
+    <height>365</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -299,6 +299,19 @@
          <string/>
         </property>
        </widget>
+      </item>
+      <item row="10" colspan="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>       
       </item>
      </layout>
      <zorder>mOffsetYEdit</zorder>

--- a/src/ui/qgsdecorationscalebardialog.ui
+++ b/src/ui/qgsdecorationscalebardialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>565</width>
-    <height>279</height>
+    <height>337</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,7 +18,7 @@
     <normaloff>../../../../../.designer/backup</normaloff>../../../../../.designer/backup</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="9" column="0" colspan="3">
+   <item row="1" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -28,7 +28,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="3">
+   <item row="0" column="0">
     <widget class="QGroupBox" name="grpEnable">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -419,6 +419,19 @@
          <bool>true</bool>
         </property>
        </widget>
+      </item>
+      <item row="9" colspan="2">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>       
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
(cherry picked from commit 0b19aab50e06e77d00b566ae0c8d45d18511f497)

Avoids widget expanding with dialog as shown in [this rendering](https://raw.githubusercontent.com/qgis/QGIS-Documentation/617da61930015058d9f9ded39bbcfb525bbaaf31/source/docs/user_manual/introduction/img/scale_bar_dialog.png)