### PR TITLE
[RPM] Improve RPM packaging

### DIFF
--- a/rpm/default.cfg
+++ b/rpm/default.cfg
@@ -10,10 +10,10 @@ OUTDIR="result/"
 
 # Which arches to build for. Check /etc/mock for possible options
 ARCHS=(
-        "fedora-27-i386"
-        "fedora-27-x86_64"
         "fedora-28-i386"
         "fedora-28-x86_64"
+        "fedora-29-i386"
+        "fedora-29-x86_64"
       )
 
 # Which git branch to export. Normally take the current

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -12,15 +12,17 @@
 # py files located under /usr/share/qgis/python/plugins
 %global __python %{__python3}
 
+%define grass grass74
+
 %if %{_timestamp} > 0
 # Epoch is set only when building packages from master
 Epoch: %{_timestamp}
+%define combinedversion %{epoch}:%{version}
 %define builddate %(date -d @%{_timestamp} '+%a %b %d %Y')
 %else
+%define combinedversion %{version}
 %define builddate %(date '+%a %b %d %Y')
 %endif
-
-%define grass grass74
 
 Name:           qgis
 Version:        %{_version}
@@ -33,12 +35,15 @@ URL:            http://www.qgis.org
 Source0:        http://qgis.org/downloads/%{name}-%{version}.tar.bz2
 
 # Sample configuration files for QGIS server
-Source2:        %{name}-server-httpd.conf
-Source4:        %{name}-server-README.fedora
+Source1:        %{name}-server-httpd.conf
+Source2:        %{name}-server-nginx.conf
+Source3:        %{name}-server-fcgi.socket
+Source4:        %{name}-server-fcgi.service
+Source5:        %{name}-server-README.fedora
 
 # MIME definitions
 # Based on debian/qgis.xml but excluding already defined or proprietary types
-Source5:        %{name}-mime.xml
+Source6:        %{name}-mime.xml
 
 # Fix builds on 64-bit machines
 # https://issues.qgis.org/issues/15602
@@ -69,6 +74,8 @@ BuildRequires:  gsl-devel
 BuildRequires:  libzip-devel
 BuildRequires:  postgresql-devel
 BuildRequires:  sqlite-devel
+BuildRequires:  hdf5-devel
+BuildRequires:  netcdf-devel
 BuildRequires:  fcgi-devel
 
 # OpenCL
@@ -131,14 +138,14 @@ and USGS ASCII DEM.
 
 %package devel
 Summary:        Development Libraries for the QGIS
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{combinedversion}-%{release}
 
 %description devel
 Development packages for QGIS including the C header files.
 
 %package grass
 Summary:        GRASS Support Libraries for QGIS
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{combinedversion}-%{release}
 
 # The plug-in requires more than just the grass-libs.
 # This questions the sense of the libs package.
@@ -153,12 +160,12 @@ GRASS plugin for QGIS required to interface with the GRASS system.
 %package -n python3-qgis
 %{?python_provide:%python_provide python3-qgis}
 # Remove before F30
-Provides:       %{name}-python = %{version}-%{release}
-Provides:       %{name}-python%{?_isa} = %{version}-%{release}
+Provides:       %{name}-python = %{combinedversion}-%{release}
+Provides:       %{name}-python%{?_isa} = %{combinedversion}-%{release}
 Obsoletes:      %{name}-python < %{version}-%{release}
 Obsoletes:      python2-%{name} < %{version}-%{release}
 Summary:        Python integration and plug-ins for QGIS
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{combinedversion}-%{release}
 Requires:       gdal-python3
 Requires:       python3-future
 Requires:       python3-jinja2
@@ -176,8 +183,7 @@ Python integration and plug-ins for QGIS.
 
 %package server
 Summary:        FCGI-based OGC web map server
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
-Requires:       mod_fcgid
+Requires:       %{name}%{?_isa} = %{combinedversion}-%{release}
 Provides:       mapserver = %{version}-%{release}
 Obsoletes:      mapserver < 2.8.1-1
 
@@ -185,7 +191,7 @@ Obsoletes:      mapserver < 2.8.1-1
 This FastCGI OGC web map server implements OGC WMS 1.3.0 and 1.1.1.
 The services are prepared as regular projects in QGIS. They're rendered using
 the QGIS libraries. The server also supports SLD (Styled Layer Descriptor)
-for styling. Sample configurations for Httpd and Lighttpd are included.
+for styling. Sample configurations for HTTPD and Nginx are included.
 
 Please refer to %{name}-server-README.fedora for details!
 
@@ -196,8 +202,12 @@ Please refer to %{name}-server-README.fedora for details!
 # Remove executable permissions from source code files
 find . \( -name "*.cpp" -o -name "*.h" \) -type f -perm /111 -execdir chmod -x {} \+
 
-# Readme file for QGIS server configuration and Lighttpd example
+# Readme file for QGIS server configuration HTTPD and Nginx example
+install -pm0644 %{SOURCE1} .
+install -pm0644 %{SOURCE2} .
+install -pm0644 %{SOURCE3} .
 install -pm0644 %{SOURCE4} .
+install -pm0644 %{SOURCE5} .
 
 gzip ChangeLog
 
@@ -228,13 +238,8 @@ make install DESTDIR=%{buildroot}
 
 # Install MIME type definitions
 install -d %{buildroot}%{_datadir}/mime/packages
-install -pm0644 %{SOURCE5} \
+install -pm0644 %{SOURCE6} \
     %{buildroot}%{_datadir}/mime/packages/%{name}.xml
-
-# Install basic QGIS Mapserver configuration for Apache
-install -pd %{buildroot}%{_sysconfdir}/httpd/conf.d
-install -pm0644 %{SOURCE2} \
-    %{buildroot}%{_sysconfdir}/httpd/conf.d/qgis-server.conf
 
 # See qgis-server-README.fedora
 rm -f %{buildroot}%{_libexecdir}/%{name}/wms_metadata.xml
@@ -328,7 +333,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 
 %files server
 %doc src/server/admin.sld src/server/wms_metadata.xml %{name}-server-README.fedora
-%config(noreplace) %{_sysconfdir}/httpd/conf.d/%{name}-server.conf
+%doc %{name}-server-httpd.conf %{name}-server-nginx.conf %{name}-server-fcgi.socket %{name}-server-fcgi.service
 %{_libdir}/%{name}/server/
 %{_libdir}/lib%{name}_server.so.*
 %{_libexecdir}/%{name}/

--- a/rpm/sources/qgis-server-README.fedora
+++ b/rpm/sources/qgis-server-README.fedora
@@ -7,18 +7,21 @@ Services (WMS). Simply layout your map in QGIS. The WMS will look
 exactly the same, because QGIS server uses the same libraries for
 rendering, as the desktop application does.
 
-A sample configuration file for Httpd is installed under
-/etc/httpd/conf.d/qgis-server.conf.
+A sample configuration file for HTTPD is installed under
+/usr/share/doc/qgis-server/qgis-server-httpd.conf.
+Also a sample configuration file for Nginx is available under
+/usr/share/doc/qgis-server/qgis-server-nginx.conf with the corresponding
+systemd socket for the FastCGI daemon.
 
-This configuration expects QGIS project files under /var/www/wms. To
+This configuration expects QGIS project files under /var/www/ows. To
 use it, reload the Httpd configuration and place the files you want to
 publish in this directory.
 
 A getCapabilities request looks like this:
 
-http://localhost/wms/my_qgis_project?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0
+http://localhost/ows/my_qgis_project?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0
 
-QGIS project is "/var/www/wms/my_qgis_project.qgs". The sample
+QGIS project is "/var/www/ows/my_qgis_project.qgs". The sample
 configuration automatically adds the project file extension for you.
 
 The actual data can stay where it is. Make sure QGIS server can
@@ -55,7 +58,8 @@ Both configuration files are included as documentation.
 
 ==================================================
 
-Further information: http://karlinapp.ethz.ch/qgis_wms
-
     Volker Fröhlich
     volker27@gmx.at
+
+    Daniele Viganò
+    daniele@vigano.me

--- a/rpm/sources/qgis-server-fcgi.service
+++ b/rpm/sources/qgis-server-fcgi.service
@@ -1,0 +1,17 @@
+# Adapted from http://www.itopen.it/bulk/qgis3-server/#/step-27
+# Path: /etc/systemd/system/qgis-server-fcgi.service
+# systemctl enable qgis-server-fcgi.service && systemctl start qgis-server-fcgi.service
+
+[Unit]
+Description = QGIS Server Tracker FastCGI backend
+After = network.target qgis-server-fcgi.socket
+
+[Service]
+# An existing user must be set
+User = qgis
+Group = qgis
+ExecStart = /usr/libexec/qgis/qgis_mapserv.fcgi
+StandardInput = socket
+WorkingDirectory = /tmp
+
+Restart = always

--- a/rpm/sources/qgis-server-fcgi.socket
+++ b/rpm/sources/qgis-server-fcgi.socket
@@ -1,0 +1,14 @@
+# Adapted from http://www.itopen.it/bulk/qgis3-server/#/step-26
+# Path: /etc/systemd/system/qgis-server-fcgi.socket
+# systemctl enable qgis-server-fcgi.socket && systemctl start qgis-server-fcgi.socket
+
+[Unit]
+Description = QGIS Server FastCGI Socket
+PartOf = qgis-server-fcgi.service
+
+[Socket]
+ListenStream = 127.0.0.1:9993
+Accept = yes
+
+[Install]
+WantedBy = sockets.target

--- a/rpm/sources/qgis-server-httpd.conf
+++ b/rpm/sources/qgis-server-httpd.conf
@@ -2,7 +2,7 @@
 # It is not meant for productive use.
 
 RewriteEngine on
-RewriteRule ^/wms/(.*)$ /qgis/qgis_mapserv.fcgi?map=/var/www/wms/$1.qgs [QSA,PT]
+RewriteRule ^/ows/(.*)$ /qgis/qgis_mapserv.fcgi?map=/var/www/ows/$1.qgs [QSA,PT]
 
 ScriptAlias /qgis/ "/usr/libexec/qgis/"
 

--- a/rpm/sources/qgis-server-nginx.conf
+++ b/rpm/sources/qgis-server-nginx.conf
@@ -1,0 +1,78 @@
+# Adapted from https://github.com/gem/oq-qgis-server/blob/master/conf/qgis-server-nginx.conf
+# It requires a FCGI processes spawner like spawn-fcgi or systemd (see s-server-fcgi.socket)
+
+user nginx;
+worker_processes auto;
+access_log  /var/log/nginx/access.log;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    # Get 'port' from `$http_host`
+    map $http_host $port {
+        "~*.*:(?<p>.*)" $p;
+        default server_port;
+    }
+    # Get 'proto' from `$scheme` unless 'X-Forwarded-Proto'
+    # is set by the reverse proxy
+    map $http_x_forwarded_proto $qgis_proto {
+        "" $scheme;
+        default $http_x_forwarded_proto;
+    }
+    # Get 'host' from `$host` unless 'X-Forwarded-Host'
+    # is set by the reverse proxy
+    map $http_x_forwarded_host $qgis_host {
+        "" $host;
+        default $http_x_forwarded_host;
+    }
+    # Get 'port' from `$port` unless 'X-Forwarded-Port'
+    # is set by the reverse proxy
+    map $http_x_forwarded_port $qgis_port {
+        "" $port;
+        default $http_x_forwarded_port;
+    }
+
+    server {
+        listen       80 default_server;
+        listen       [::]:80 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        location /ows/ {
+            rewrite ^/ows/(.*)$ /qgis/qgis_mapserv.fcgi?map=/var/www/ows/$1.qgs;
+        }
+        location /qgis/ {
+            internal; # Used only by the OGC rewrite
+            root /var/www/ows;
+            fastcgi_pass  localhost:9993;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_param QUERY_STRING    $query_string;
+            # build links in GetCapabilities based on
+            # the hostname exposed by the reverse proxy
+            fastcgi_param  SERVER_PROTOCOL $qgis_proto;
+            fastcgi_param  SERVER_NAME $qgis_host;
+            fastcgi_param  SERVER_PORT $qgis_port;
+        }
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+    }
+
+}


### PR DESCRIPTION
[RPM] Add support for HDF5
[RPM] Do not make qgis-server depend on httpd
[RPM] Add an Nginx configuration example
[RPM] Update server readme and replace wms with a better ogc
[RPM] More fixes for Epoch directive
[RPM] F27 reached EoL, replace it with F29
[RPM] Add support for netcdf and replace ogc with ows as server endpoint
[RPM] Add sample systemd service file

https://ci.services.vigano.me/#/builders/2/builds/76

## Description
Several improvements and fixes for the RPM packaging. Major topics are:
- `qgis-server` does not depend on `httpd` anymore: `fcgid` can be used with `nginx`, `lighttpd`, `caddy` and many other http server. Configuration for apache/httpd is moved to `/usr/share/doc/qgis-server` and a configuration for nginx+fcgi as systemd service is  provided in the documentation folder too
- support for `hdf5` and `netcdf` has been enabled
- the `qgis-server` http endpoint **in examples** has been changed from `wms` to `ows` (suggested by @mbernasocchi) since it does not provide only `wms` but it can provide `wfs` and `wcs` too

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit

/cc @m-kuhn 
