### PR TITLE
Improve multiline cursor behavior in Python console and expression editor

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -146,6 +146,9 @@ class Editor(QsciScintilla):
         self.setEdgeMode(QsciScintilla.EdgeLine)
         self.setEdgeColumn(80)
 
+        self.SendScintilla(self.SCI_SETADDITIONALSELECTIONTYPING, 1)
+        self.SendScintilla(self.SCI_SETMULTIPASTE, 1)
+
         # self.setWrapMode(QsciScintilla.WrapCharacter)
         self.setWhitespaceVisibility(QsciScintilla.WsVisibleAfterIndent)
         # self.SendScintilla(QsciScintilla.SCI_SETHSCROLLBAR, 0)

--- a/src/gui/qgscodeeditor.cpp
+++ b/src/gui/qgscodeeditor.cpp
@@ -38,6 +38,9 @@ QgsCodeEditor::QgsCodeEditor( QWidget *parent, const QString &title, bool foldin
   }
   setSciWidget();
   setHorizontalScrollBarPolicy( Qt::ScrollBarAsNeeded );
+
+  SendScintilla( SCI_SETADDITIONALSELECTIONTYPING, 1 );
+  SendScintilla( SCI_SETMULTIPASTE, 1 );
 }
 
 // Workaround a bug in QScintilla 2.8.X


### PR DESCRIPTION
Now supports multi-line inserts and pastes!

Unfortunately the modifier for multiline selection is a non-standard Ctrl+drag, whereas I'd have preferred the more-standard Alt+drag behavior. But something prevents

    SendScintilla(SCI_SETRECTANGULARSELECTIONMODIFIER, SCIMOD_ALT) 

from having any effect... (maybe something in QSciscintilla?)
