### PR TITLE
WIP: osx INSTALL docs

### DIFF
--- a/doc/osx.t2t
+++ b/doc/osx.t2t
@@ -3,13 +3,14 @@
 = Building on MacOS X =
 
 In this approach I will try to avoid as much as possible building dependencies
-from source and rather use frameworks wherever possible.
+from source and rather use frameworks wherever possible. Dependencies could be 
+installed from various sources (homebrew, MacPorts or conda).
 
 "Universal", SDK and non-default arch builds require more complex options and
 some fiddling with the system. It is best to stick with a single, default,
 architecture build and follow these instructions for an initial build.
-Included are notes for building on Mac OS X 10.5 (__Leopard__), 10.6
-(__Snow Leopard__), 10.7 (__Lion__), 10.8 (__Mt. Lion__) and 10.9 (__Mavericks__)
+Included are notes for building on Mac OS X 10.13 (__High Sierra__) and 
+Mac OS X 10.14 (__Mojave__).
 (These names will be used throughout the instructions.)
 Make sure to read each section completely before typing the first command you see.
 
@@ -54,718 +55,168 @@ many threads.
 
 == Install Developer Tools ==
 
-Developer tools are not a part of a standard OS X installation.  Up through
-Snow Leopard, the Developer Tools, later called Xcode, were included with the
-system install disks, though it's best to download the latest version compatible
-with your system to get important updates fixing various issues.
-Starting with Lion, Xcode is available as a download and from the App Store.
-
-Downloading Xcode/Developer Tools for up through Snow Leopard requires a free developer account at
-developer.apple.com.  Up through Snow Leopard, get the latest __Xcode__ that is
-supported for your system.  For Lion and above, you can get Xcode from either a
-free developer account or for a minimal fee from the app store.
-When installing Xcode up through Snow Leopard, make sure to
+Developer tools are not a part of a standard OS X installation. Xcode is available
+as a download from the App Store. It's best to download the latest version compatible
+with your system to get important updates fixing various issues. Make sure to
 do a custom install and install the Unix Development or Command Line Tools option.
 
-On Lion, if you have installed Xcode 4.0 - 4.2 and are upgrading to 4.3, it's
-a good idea to uninstall the old version first with:
-
-```
-sudo /Developer/Library/uninstall-devtools
-```
-
-On Lion and Mt. Lion, using Xcode 4.4+, the developer command line tools can be
-installed via the Xcode preferences.
-
-Xcode 4.3+ also introduces the clang frontend to the LLVM compiler as default.
-
-**Note:** In XCODE 4.5 installed from the app store, you need to install the
-command line tools from XCode -> Preferences -> Downloads and choose command line tools.
-
-http://clang.llvm.org/
-
-The supplied clang version 4 can compile QGIS, but presents many warnings
-compared to just using LLVM. You can specifically use LLVM by exporting paths to
-the compilers in Terminal, or shell scripts, prior to building QGIS:
-
-```
-export CC=/usr/bin/llvm-gcc
-export CXX=/usr/bin/llvm-g++
-```
-
-If you have trouble building some of the dependencies listed below with clang
-(e.g. OSG & osgEarth), try using only the LLVM compilers.
-
-== Install Qt4 from disk image ==
-
-You need a minimum of Qt-4.4.0. I suggest getting the latest (Qt 4, not 5).  There is no need
-for the full Qt SDK, so save yourself some download time and get the frameworks
-only.  This is available in the Libraries section of the Qt download page.
-
-__Snow Leopard+ note:__ If you are building on Snow Leopard+, you will need to
-decide between 32-bit support in the older Qt Carbon branch, or 64-bit
-support in the Qt Cocoa branch. Appropriate installers are available for both
-as of Qt-4.5.2, though they stopped making Carbon packages at Qt 4.7.4.
-Qt 4.6+ is recommended for Cocoa.
-Starting with Lion, Carbon may not work properly, if at all.
-Starting with Qt 4.8, only 64bit Cocoa installers are available.
-
-__General note:__ Support for new system versions in any given Qt version may
-not be present and may cause a 'This version of Mac OS X
-is unsupported' error when building QGIS.  Try the next Qt version.
-
-__PPC note:__ The readymade Qt Cocoa installers don't include PPC support, you'd
-have to compile Qt yourself.  But, there appear to be issues with Qt Cocoa on
-PPC Macs anyways.  Qt Carbon is recommended on PPC Macs.
-
-http://qt-project.org/downloads
-
-If you want debug frameworks, Qt also provides a separate download with these.
-These are in addition to the non-debug frameworks.
-
-Earlier OS X systems may need an old Qt version - check the requirements of the
-current Qt version.  To get old Qt downloads, there is an FTP link at the bottom
-of the download page.  Files are in the qt/source (yes, even the binary packages).
-
-Once downloaded open the disk image and run the installer. Note you need admin
-privileges to install.
-
-__Leopard+ note:__ Qt includes a couple non-framework libraries in /usr/lib.
-When using a system SDK these libraries will not be found.  To fix this problem,
-add symlinks to /usr/local:
-
-```
-sudo ln -s /usr/lib/libQtUiTools.a /usr/local/lib/
-sudo ln -s /usr/lib/libQtCLucene.dylib /usr/local/lib/
-```
-
-These should then be found automatically.  Earlier systems
-may need some help by adding '-L/usr/local/lib' to CMAKE_SHARED_LINKER_FLAGS,
-CMAKE_MODULE_LINKER_FLAGS and CMAKE_EXE_LINKER_FLAGS in the cmake build.
-
-
-== Install CMake for OSX ==
-
-Get the latest source release from here:
-
-http://www.cmake.org/cmake/resources/software.html
-
-Binary installers are available for OS X, but they are not recommended
-(2.4 versions install in /usr instead of /usr/local, and 2.6+ versions are a
-strange application). Instead, download the source.
-NOTE: 2.8.5 is broken for detecting part of Qt.  Fixed in 2.8.6.
-Double-click the source tarball to unpack it, then cd to the source folder and:
-
-```
-./bootstrap --docdir=/share/doc/CMake --mandir=/share/man
-make -j [#cpus]
-sudo make install
-```
-
-=== Optional setup: ccache ===
-
-__Xcode 4.4+ note:__ You will probably not need to install ccache if you are using
-the clang frontend to LLVM compiler, a setup that already provides fairly quick
-compile times.
-
-Setup ccache to significantly speed up compile times after initial build.
-(Switching git branches will again cause longer initial build times unless
-separate build directories are used for each branch.)
-
-Get the latest source release from here:
-
-http://ccache.samba.org/
-
-Double-click the source tarball to unpack, then, in Terminal.app, cd to the
-source folder and:
-
-```
-./configure
-make
-sudo make install
-```
-
-After install, symbolically link compilers to /usr/local/bin/ccache.
-(Note: this differs from instructions at http://ccache.samba.org/manual.html
-Changing the /usr/bin:/usr/local/bin order in PATH is not recommended on OS X.
-
-```
-sudo mkdir /usr/local/bin/compilers && cd /usr/local/bin/compilers
-sudo ln -s ../ccache gcc
-sudo ln -s ../ccache g++
-sudo ln -s ../ccache cc
-sudo ln -s ../ccache c++
-```
-
-Add the following to the end of your ~/.bash_profile (and optionally ~/.bashrc)
-to allow your login shell to discover the symbolically linked compilers before
-/usr/bin compilers and to easily toggle using ccache off, by commenting out the
-line and starting a new login session in Terminal.
-
-```
-export PATH=/usr/local/bin/compilers:$PATH
-```
-
-If you have trouble building some of the dependencies listed below (e.g. OSG &
-osgEarth), try bypassing ccache.
-
-== Install development frameworks for QGIS dependencies ==
-
-Download William Kyngesburye's excellent GDAL Complete package that includes
-PROJ, GEOS, GDAL, SQLite3, SpatiaLite, and image libraries, as frameworks.
-There are also GSL and FreeType frameworks.
-
-http://www.kyngchaos.com/software/frameworks
-
-Once downloaded, open and install the frameworks.
-
-William provides an additional installer package for PostgreSQL (for PostGIS
-support).  QGIS just needs the libpq client library, so unless you want to
-setup the full Postgres + PostGIS server, all you need is the client-only
-package.  It's available here:
-
-http://www.kyngchaos.com/software/postgres
-
-Also available is a GRASS application:
-
-http://www.kyngchaos.com/software/grass
-
-Old versions of these packages for older systems are available in the
-software archive section.
-
-=== Additional dependencies: General compatibility note ===
-
-There are some additional dependencies that, at the time of writing, are not
-provided as frameworks or installers so we will need to build these from source.
-If you are wanting to build QGIS as a 64-bit application, you will need to
-provide the appropriate build commands to produce 64-bit support in dependencies.
-Likewise, for 32-bit support on Snow Leopard, you will need to override the
-default system architecture, which is 64-bit, according to instructions for
-individual dependency packages.
-
-Stable release versions are preferred.  Beta and other development versions may
-have problems and you are on your own with those.
-
-=== Additional dependencies: Expat ===
-
-__Snow Leopard+ note:__ Snow Leopard includes a usable expat, so this step is
-not necessary on Snow Leopard or above.
-
-Get the expat sources:
-
-http://sourceforge.net/project/showfiles.php?group_id=10127
-
-Double-click the source tarball to unpack, then, in Terminal.app, cd to the
-source folder and:
-
-```
-./configure
-make
-sudo make install
-```
-
-=== Additional dependencies: Spatialindex ===
-
-Get the libspatialindex sources:
-
-http://download.osgeo.org/libspatialindex/
-
-Double-click the source tarball to unpack, then, in Terminal.app, cd to the
-source folder and:
-
-```
-./configure --disable-dependency-tracking CFLAGS=-Os
-make
-sudo make install
-```
-
-=== Additional dependencies: Python ===
-
-__Leopard+ note:__ Starting with Leopard a usable Python is included
-in the system.  This is Python 2.5, 2.6 and 2.7, respectively for Leo, Snow and Lion+.
-So there is no need to install Python on Leopard and newer.
-You can still install Python from python.org if preferred.
-
-If installing from python.org, make sure you install the latest Python
-2.x from
-
-http://www.python.org/download/
-
-Python 3 is a major change, and may have compatibility issues, so try it at
-your own risk.
-
-=== Additional dependencies: SIP ===
-
-__Mt Lion note:__ SIP 4.15.7 appears to not work on Mt Lion.  Install either
-a prior version to 4.14.6 or a later version 4.16.3+
-
-Retrieve the python bindings toolkit SIP from
-
-http://www.riverbankcomputing.com/software/sip/download
-
-Double-click the source tarball to unpack it, then, in Terminal.app,
-cd to the source folder.  Then for your chosen Python:
-
-__python.org Python__
-
-```
-python configure.py
-make
-sudo make install
-```
-
-__Leopard system Python__
-
-SIP wants to install in the system path -- this is not a good idea.
-More configuration is needed to install outside the system path:
-
-```
-python configure.py -n -d /Library/Python/2.5/site-packages -b /usr/local/bin \
--e /usr/local/include -v /usr/local/share/sip -s MacOSX10.5.sdk
-```
-
-__Snow Leopard system Python__
-
-Similar to Leopard, you should install outside the system Python path.
-Also, you need to specify the architecture you want and make sure to run the
-versioned python binary (this one responds to the 'arch' command, 'python' does
-not).  Substitute '2.7' for python version and 10.7 for SDK version below for
-Lion.
-
-If you are using 32-bit Qt (Qt Carbon):
-
-```
-python2.6 configure.py -n -d /Library/Python/2.6/site-packages -b /usr/local/bin \
--e /usr/local/include -v /usr/local/share/sip --arch=i386 -s MacOSX10.6.sdk
-```
-
-For 64-bit Qt (Qt Cocoa), use this configure line:
-
-```
-python2.6 configure.py -n -d /Library/Python/2.6/site-packages -b /usr/local/bin \
--e /usr/local/include -v /usr/local/share/sip --arch=x86_64 -s MacOSX10.6.sdk
-```
-
-__Lion+ system Python__
-
-Similar to Snow Leopard, you should install outside the system Python path.
-The SDK option should match the system you are compiling on:
-
-for Lion:
-
-```
-python2.7 configure.py -d /Library/Python/2.7/site-packages -b /usr/local/bin \
--e /usr/local/include -v /usr/local/share/sip --arch=x86_64 -s MacOSX10.7.sdk
-```
-
-for Mt. Lion:
-
-```
-python2.7 configure.py -d /Library/Python/2.7/site-packages -b /usr/local/bin \
--e /usr/local/include -v /usr/local/share/sip --arch=x86_64 -s MacOSX10.8.sdk
-```
-
-for Mavericks:
-
-```
-python2.7 configure.py -d /Library/Python/2.7/site-packages -b /usr/local/bin \
--e /usr/local/include -v /usr/local/share/sip --arch=x86_64 -s MacOSX10.9.sdk
-```
-
-
-
-__continue...__
-
-Then continue with compilation and installation:
-
-```
-make
-sudo make install
-```
-
-=== Additional dependencies: QScintilla2 ===
-
-Retrieve the Qt version of the Scintilla-based text editor widget from
-
-http://www.riverbankcomputing.co.uk/software/qscintilla/download
-
-Double-click the tarball to unpack it. Then, cd to the QScintilla2.x.x source
-folder in a Terminal.
-
-QScintilla2 wants to install in the system path -- with libraries going into
-/Library/Frameworks and headers into /usr/include/Qsci -- this is not a good
-idea, and it also basically breaks the QtDesigner plugin. More configuration
-is needed to install outside the system path, in /usr/local/:
-
-```
-cd Qt4Qt5
-```
-
-Edit QScintilla-gpl-2.x.x/Qt4Qt5/qscintilla.pro in the following manner:
-
-```
-current line --> new line
-
-target.path = $$[QT_INSTALL_LIBS]  -->  target.path = /usr/local/lib
-header.path = $$[QT_INSTALL_HEADERS]  -->  header.path = /usr/local/include
-```
-Save the qscintilla.pro file and build the QScintilla2 C++ library:
-
-```
-qmake -spec macx-g++ qscintilla.pro
-make -j [#cpus]
-sudo make install
-```
-
-adjust the install_name_tool command for the version installed of QScintilla installed:
-
-```
-sudo install_name_tool -id /usr/local/lib/libqscintilla2.11.dylib \
-  /usr/local/lib/libqscintilla2.11.dylib
-```
-
-This installs QScintilla2's dylib in /usr/local/lib/ and the header files in
-/usr/local/include/Qsci/, both of which should be automatically found when
-building QGIS.
-
-==== Optional setup: QScintilla2 QtDesigner plugin ====
-
-The plugin allows QScintilla2 widgets to be used within QtDesigner.
-
-```
-cd <QScintilla2 source directory>
-cd designer-Qt4Qt5
-qmake -spec macx-g++ designer.pro
-make
-sudo make install
-```
-
-Installs in /Developer/Applications/Qt/plugins/designer/
-
-=== Additional dependencies: PyQt ===
-
-Retrieve the python bindings toolkit for Qt from
-
-http://www.riverbankcomputing.com/software/pyqt/download
-
-Double-click the source tarball to unpack it, then, in Terminal.app,
-cd to the source folder.  Then for your chosen Python:
-
-__python.org Python__
-
-```
-python configure.py -n /usr/local/Qt4.8/qsci
-yes
-```
-
-__Leopard system Python__
-
-PyQt wants to install in the system path -- this is not a good idea.
-More configuration is needed to install outside the system path:
-
-```
-python configure.py -d /Library/Python/2.5/site-packages -b /usr/local/bin -n /usr/local/Qt4.8/qsci -v /usr/local/share/sip/PyQt4
-```
-
-__Snow Leopard system Python__
-
-Similar to Leopard, you should install outside the system Python path.
-Also, you need to specify the architecture you want (requires at least PyQt 4.6),
-and make sure to run the versioned python binary (this one responds to the
-'arch' command, which is important for pyuic4, 'python' does not).
-Substitute '2.7' for python version and 10.7 for SDK version below for Lion.
-
-If you are using 32-bit Qt (Qt Carbon):
-
-```
-python2.6 configure.py -d /Library/Python/2.6/site-packages -b /usr/local/bin \
--n /usr/local/Qt4.8/qsci -v /usr/local/share/sip/PyQt4 --use-arch i386
-```
-
-For 64-bit Qt (Qt Cocoa), use this configure line:
-
-```
-python2.6 configure.py -d /Library/Python/2.6/site-packages -b /usr/local/bin \
--n /usr/local/Qt4.8/qsci -v /usr/local/share/sip/PyQt4 --use-arch x86_64
-```
-
-__Lion, Mt. Lion, and Mavericks system Python__
-
-Similar to Snow Leopard, you should install outside the system Python path.
-But you don't need the use-arch option:
-
-```
-python2.7 configure.py -d /Library/Python/2.7/site-packages -b /usr/local/bin -n /usr/local/Qt4.8/qsci -v /usr/local/share/sip/PyQt4
-```
-
-__continue...__
-
-```
-make -j [#cpus]
-sudo make install
-```
-
-If there is a problem with undefined symbols in QtOpenGL on Leopard, edit
-QtOpenGL/makefile and add ""-undefined dynamic_lookup"" to LFLAGS.
-Then make again.
-
-=== Additional dependencies: QScintilla2 Python Module ===
-
-This will create the Qsci.so module in /Library/Python/2.x/site-packages/PyQt4.
-Like PyQt, it needs help to not install in system locations.
-
-__Snow Leopard:__ substitute '2.6' for Python version
-
-```
-cd <QScintilla2 source dir>
-cd Python
-python2.7 configure.py -o /usr/local/lib -n /usr/local/include \
--d /Library/Python/2.7/site-packages/PyQt4 -v /usr/local/share/sip/PyQt4 \
---sip-incdir=/usr/local/include --pyqt-sipdir=/usr/local/share/sip/PyQt4
-cat >>Qsci.pro <<EOF
-QMAKE_LFLAGS_PLUGIN -= -dynamiclib
-QMAKE_LFLAGS_PLUGIN += -bundle
-EOF
-qmake -spec macx-g++ Qsci.pro
-make -j [#cpus]
-sudo make install
-```
-
-The -o and -n options should match the QScintilla2 C++ dylib install options.
-
-=== Additional dependencies: Qwt ===
-
-The GPS tracking feature uses Qwt.
-
-NOTE: PyQwt is not compatible with PyQt 4.9, so we will skip that.
-
-Download the latest Qwt 6.0 source (6.1 does not work with the QwtPolar in QGIS) from:
-
-http://sourceforge.net/projects/qwt
-
-Double-click the tarball to unpack it. Now, cd to the qwt source folder in a
-Terminal.
-
-Type these commands to build and install 6.0.x (assumes v6.0.2, adjust commands
-for other version as needed):
-
-```
-cat >> qwtconfig.pri <<EOF
-QWT_CONFIG -= QwtFramework
-EOF
-qmake -spec macx-g++
-make -j [#cpus]
-sudo make install
-
-sudo install_name_tool -id /usr/local/qwt-6.0.2/lib/libqwt.6.dylib \
-  /usr/local/qwt-6.0.2/lib/libqwt.6.dylib
-```
-
-The Qwt shared library is now installed in /usr/local/qwt-6.0.x (x is
-the point version).  Remember this for QGIS configuration.
-
-
-=== Additional dependencies: Bison ===
-
-The version of bison available by default on Mac OS X is too old so you
-need to get a more recent one on your system. Download at least version 2.4 from:
-
-```
-ftp.gnu.org/gnu/bison/
-```
-
-Now build and install it to a prefix of /usr/local. Double-click the source
-tarball to unpack it, then cd to the source folder and:
-
-```
-./configure --disable-dependency-tracking CFLAGS=-Os
-make
-sudo make install
-```
-
-
-=== Additional dependencies: gpsbabel ===
-
-For integrated GPS Tools functions, a gpsbabel executable is required. You can
-find this at:
-
-http://www.gpsbabel.org/
-
-Download the GPSBabel OS X package, and copy GPSBabelFE.app from the disk image to
-/Applications.
-
-
-=== Optional dependencies: libfcgi ===
-
-If you want to use the QGIS Mapserver, you need libfcgi.  This is included on
-systems up through Snow Leopard, but was dropped at Lion.  So, on Lion you need
-to get the source from:
-
-http://www.fastcgi.com/dist/
-
-Grab the latest fcgi SNAP package there. Double-click the source
-tarball to unpack it, then cd to the source folder and:
-
-```
-./configure --disable-dependency-tracking CFLAGS=-Os
-make
-sudo make install
-```
-
-
-=== Optional dependencies: OSG & osgEarth ===
-
-If you want the Globe plugin in QGIS (default OFF), OSG and osgEarth are needed.
-
-First, **OpenSceneGraph**.  The main site is very out of date, just go to
-github:
-
-http://github.com/openscenegraph/osg/tags
-
-Download the latest 3.1 version (you can select a tarball when you hover over
-the entry).  Double-click the source tarball to unpack it.
-(There is a version numbering oddity in the source, but since we'll be
-bundling OSG as it's meant to be, it really doesn't matter).
-
-Installation is a bit out of touch with OS X standards, so we'll stage it to a
-temporary location first.  You could stage it to the folder that the OSG source
-folder is in, or a common staging area like /Users/Shared/unix/osg.  Pick a
-folder not hidden and that doesn't need admin permissions to write to for simplicity.
-
-If you are building on Leopard, its configure forces a old ppc/i386 32bit build.
-If you want 64bit you need to fix CMakeLists.txt - in a text editor, find the
-if-block that starts with:
-
-```
-ELSEIF(${OSG_OSX_SDK_NAME} STREQUAL "macosx10.6" OR ${OSG_OSX_SDK_NAME} STREQUAL "macosx10.5")
-```
-
-In that section before the next ELSEIF, change:
-
-```
-ppc;i386
-```
-
-to:
-
-```
-i386;x86_64
-```
-
-and change:
-
-```
-mmacosx-version-min=10.5
-```
-
-to:
-
-```
-mmacosx-version-min=10.6
-```
-
-In a new Terminal cd to the source folder and:
-
-```
-mkdir build
-cd build
-cmake -D CMAKE_INSTALL_PREFIX=/path/to/some/staging/folder \
--D OSG_COMPILE_FRAMEWORKS=ON \
--D OSG_PLUGIN_SEARCH_INSTALL_DIR_FOR_PLUGINS=OFF \
--D JASPER_LIBRARY=/Library/Frameworks/UnixImageIO.framework \
--D JASPER_INCLUDE_DIR=/Library/Frameworks/UnixImageIO.framework/Headers \
--D TIFF_LIBRARY=/Library/Frameworks/UnixImageIO.framework \
--D TIFF_INCLUDE_DIR=/Library/Frameworks/UnixImageIO.framework/Headers \
-..
-make
-make install
-sudo mkdir -p "/Library/Application Support/OpenSceneGraph/PlugIns"
-```
-
-Open the staging folder you chose for the CMAKE_INSTALL_PREFIX option above.
-
-Now move all .frameworks from the lib/ folder in the staging area to /Library/Frameworks.  Move the files in the osgPlugins folder in the lib/ folder
-to /Library/Application Support/OpenSceneGraph/PlugIns.  The bin/ executables
-can be left where they are.
-
-
-Next up is **libzip**.  Get the latest tarball at:
-
-http://nih.at/libzip/
-
-Double-click the source tarball to unpack it.
-In a new Terminal cd to the source folder and:
-
-```
-./configure --disable-dependency-tracking --disable-shared CFLAGS=-Os
-make
-sudo make install
-```
-
-
-Then it's time for **osgEarth**.  Downloads are also on github:
-
-http://github.com/gwaldron/osgearth/tags
-
-Download a tarball for the latest stable release (sorting can be confusing here).
-Double-click the source tarball to unpack it.
-
-__Note:__ for now stick with version 2.3.  There are compile errors in 2.4 that need attention.
-
-This one also needs an intermediate staging area.  Choose a folder similar to OSG.
-
-In a new Terminal cd to the source folder and:
-
-```
-mkdir build
-cd build
-export PATH="/path/to/osg/staging/folder/bin:$PATH"
-cmake -D CMAKE_INSTALL_PREFIX=/path/to/some/staging/folder \
--D CMAKE_BUILD_TYPE=MinSizeRel \
--D OSGEARTH_BUILD_FRAMEWORKS=true \
-..
-make
-make install
-sudo mkdir -p "/Library/Application Support/OpenSceneGraph/Headers"
-```
-
-Open the staging folder you chose for the CMAKE_INSTALL_PREFIX option above.
-Also open the OSG staging path /bin folder from the OSG build.
-
-Move all the .frameworks from the lib/ folder to /Library/Frameworks.
-Move the files in the osgPlugins folder in the lib/ folder to
-/Library/Application Support/OpenSceneGraph/PlugIns.  Move the osgEarthDrivers
-folder in the include/ folder to /Library/Application Support/OpenSceneGraph/Headers.
-(you may need to create this folder)
-And as for OSG, you can leave the bin/ executables where they are.
-
-== API documentation ==
-
-If you want to build a local copy of the API docs (like those at
-http://doc.qgis.org/api) you will need Graphviz and Doxygen installed:
-
-http://www.graphviz.org/Download_macos.php
-
-http://www.stack.nl/~dimitri/doxygen/download.html
-
-Graphviz is simply installed via a regular Mac package installer. Install it
-first. It will place some of its binaries in /usr/local/bin/.
-
-For Doxygen, compiling the source is recommended over installing the app.
-Double-click the source tarball to unpack it, then cd to the source folder and:
-
-```
-./configure
-make -j [#cpus]
-sudo make install
-```
-
-The documentation will be output to the build directory, and if using more complete
-QGIS.app bundling on install, inside the app in:
-
-QGIS.app/Contents/Resources/doc
-
-== QGIS source ==
+== Install Dependencies via homebrew ==
+
+First, install brew from official repository:
+
+https://brew.sh
+
+add add OSGEO tap:
+
+```
+brew tap osgeo/osgeo4mac
+```
+
+Now install all dependencies
+
+```
+brew install fcgi
+brew install git
+brew install cmake
+brew install ninja
+brew install gsl
+brew install sip
+brew install bison
+brew install flex
+brew install pkg-config
+brew install python
+brew install qt
+brew install pyqt
+pip3 install python-dateutil
+pip3 install cython
+brew install osgeo/osgeo4mac/gdal2
+brew link gdal2 --force
+brew install openvpn
+brew install szip
+brew install hdf5
+brew install scipy
+brew install netcdf
+brew install gsl
+brew install exiv2
+brew install osgeo/osgeo4mac/saga-gis-lts
+brew install osgeo/osgeo4mac/postgis2
+brew install pyqt5-webkit
+brew install qca
+brew install qtkeychain
+brew install qscintilla2
+brew install qwt
+brew install qwtpolar
+brew install qjson
+brew install sqlite
+brew install expat
+brew install proj
+brew install spatialindex
+brew install postgresql
+brew install libpq
+brew install curl
+brew install libzip
+brew install libtasn1
+brew install hicolor-icon-theme
+brew install libiconv
+brew install geos
+brew install libspatialite
+brew install openssl
+brew install poppler
+```
+
+and few packages are optional
+
+```
+brew install gdal2-python
+brew install numpy
+brew install brewsci/bio/matplotlib
+brew cask install XQuartz # requirement of grass7
+brew install grass7
+brew install gettext
+brew install gpsbabel
+brew install pyspatialite
+brew install r
+pip3 install owslib
+pip3 install certifi
+pip3 install chardet
+pip3 install idna
+pip3 install OWSLib
+pip3 install cython
+pip3 install pyproj
+pip3 install python-dateutil
+pip3 install pytz
+pip3 install requests
+pip3 install six
+pip3 install urllib3
+pip3 install coverage
+pip3 install funcsigs
+pip3 install future
+pip3 install mock
+pip3 install nose2
+pip3 install pbr
+pip3 install psycopg2
+pip3 install PyYAML
+pip3 install Jinja2
+pip3 install MarkupSafe
+pip3 install Pygments
+pip3 install termcolor
+pip3 install oauthlib
+pip3 install pyOpenSSL
+pip3 install numpy
+pip3 install certifi
+pip3 install chardet
+pip3 install coverage
+pip3 install cycler
+pip3 install decorator
+pip3 install exifread
+pip3 install future
+pip3 install gdal
+pip3 install h5py
+pip3 install httplib2
+pip3 install idna
+pip3 install ipython-genutils
+pip3 install jinja2
+pip3 install jsonschema
+pip3 install jupyter-core
+pip3 install kiwisolver
+pip3 install markupsafe
+pip3 install matplotlib
+pip3 install mock
+pip3 install mock
+pip3 install nbformat
+pip3 install networkx
+pip3 install nose2
+pip3 install numpy
+pip3 install owslib
+pip3 install pandas
+pip3 install pbr
+pip3 install pip
+pip3 install plotly
+pip3 install ply
+pip3 install psycopg2
+pip3 install pygments
+pip3 install pyodbc
+pip3 install pyparsing
+pip3 install pypubsub
+pip3 install pysal
+pip3 install pytz
+pip3 install pyyaml
+pip3 install requests
+pip3 install retrying
+pip3 install scipy
+pip3 install setuptools
+pip3 install shapely
+pip3 install simplejson
+pip3 install six
+pip3 install test
+pip3 install tools
+pip3 install traitlets
+pip3 install urllib3
+pip3 install xlrd
+pip3 install xlwt
+```
+
+== Download QGIS source code ==
 
 Unzip the QGIS source tarball to a working folder of your choice
 (/usr/somewhere is not a good choice as it's hidden and requires root
@@ -811,12 +262,8 @@ In a Terminal cd to the qgis source folder previously downloaded, then:
 mkdir build
 cd build
 cmake -D CMAKE_INSTALL_PREFIX=~/Applications \
+-D CMAKE_PREFIX_PATH="/usr/local/opt/qt5;/usr/local/opt/qt5-webkit;/usr/local/opt/qscintilla2;/usr/local/opt/qwt;/usr/local/opt/qwtpolar;/usr/local/opt/qca;/usr/local/opt/gdal2;/usr/local/opt/gsl;/usr/local/opt/geos;/usr/local/opt/proj;/usr/local/opt/libspatialite;/usr/local/opt/spatialindex;/usr/local/opt/fcgi;/usr/local/opt/expat;/usr/local/opt/sqlite;/usr/local/opt/flex;/usr/local/opt/bison;/usr/local/opt/libzip;/usr/local/opt/libtash1;/usr/local/opt/grass7" \
 -D CMAKE_BUILD_TYPE=MINSIZEREL -D ENABLE_TESTS=FALSE \
--D SPATIALINDEX_LIBRARY=/usr/local/lib/libspatialindex.dylib \
--D SPATIALINDEX_INCLUDE_DIR=/usr/local/include/spatialindex \
--D QWT_LIBRARY=/usr/local/qwt-6.0.2/lib/libqwt.dylib \
--D QWT_INCLUDE_DIR=/usr/local/qwt-6.0.2/include \
--D BISON_EXECUTABLE=/usr/local/bin/bison \
 ..
 ```
 
@@ -830,82 +277,19 @@ cd build
 ccmake ..
 ```
 
-This will automatically find and use the previously installed frameworks, and
-the GRASS application if installed.  Remember to change the Qwt version if a
-different version was installed, and possibly paths, e.g. for Qwt 6.0.2 installed
-as a framework use:
-
-```
--D QWT_LIBRARY=/usr/local/qwt-6.0.2/lib/qwt.framework/qwt \
--D QWT_INCLUDE_DIR=/usr/local/qwt-6.0.2/lib/qwt.framework/Headers \
-```
-
-If you want to use a newer PostgreSQL client than the default Mac OS X version,
-e.g. install from kyngchaos.com, set the following option to pg_config's path:
-
-```
--D POSTGRES_CONFIG=/usr/local/pgsql/bin/pg_config \
-```
-
 To build a local copy of the API docs (see API documentation section above):
 
 ```
 -D WITH_APIDOC=TRUE \
 ```
 
-__Snow Leopard note:__ To handle 32-bit Qt (Carbon), create a 32bit python wrapper
-script and add arch flags to the configuration:
 
-```
-sudo cat >/usr/local/bin/python32 <<EOF
-#!/bin/sh
-exec arch -i386 /usr/bin/python2.6 \${1+"\$@"}
-EOF
-
-sudo chmod +x /usr/local/bin/python32
-
-cmake -D CMAKE_INSTALL_PREFIX=~/Applications \
--D CMAKE_BUILD_TYPE=MINSIZEREL -D ENABLE_TESTS=FALSE \
--D WITH_INTERNAL_SPATIALITE=FALSE \
--D SPATIALINDEX_LIBRARY=/usr/local/lib/libspatialindex.dylib \
--D SPATIALINDEX_INCLUDE_DIR=/usr/local/include/spatialindex \
--D QWT_LIBRARY=/usr/local/qwt-5.2.2/lib/libqwt.dylib \
--D QWT_INCLUDE_DIR=/usr/local/qwt-5.2.2/include \
--D BISON_EXECUTABLE=/usr/local/bin/bison \
--D CMAKE_OSX_ARCHITECTURES=i386 -D PYTHON_EXECUTABLE=/usr/local/bin/python32 \
-..
-```
-
-__Mapserver note:__ The QGIS Mapserver feature requires fastcgi support.  This is included in
-Leopard and Snow Leopard, but was dropped at Lion.  To build the Mapserver
-component on Leopard and Snow, add the following line before the last line in
+__Mapserver note:__ To build the Mapserver add the following 
+line before the last line in
 the above configuration:
 
 ```
 -D WITH_SERVER=TRUE \
-```
-
-On Lion you are on your own to figure out how to install libfcgi and add fcgi
-support to the system Apache.  Not recommended for the average user.
-
-__Globe plugin note:__ If you want the Globe plugin (and you compiled and installed OSG/osgEarth),
-add the following lines before the last line in the above configuration:
-
-```
--D WITH_GLOBE=true \
--D OSGEARTH_INCLUDE_DIR="/Library/Application Support/OpenSceneGraph/Headers" \
--D OSG_PLUGINS_PATH="/Library/Application Support/OpenSceneGraph/PlugIns" \
-```
-
-__Bundling note:__ Older Qt versions may have problems with some Qt plugins and
-QGIS.  The way to handle this is to bundle Qt inside the QGIS application.  The
-default is to bundle Qt (and osg/osgEarth, if configured).
-
-Even better for distribution purposes, to also bundle any extra non-framework,
-non-standard, libs (ie postgres' libpq) set the bundle value to 2:
-
-```
--D QGIS_MACAPP_BUNDLE=2 \
 ```
 
 == Building ==
@@ -929,27 +313,3 @@ or, for an /Applications build:
 sudo make install
 ```
 
-== Post-Install ==
-
-A couple things to take care of.
-
-**gpsbabel**
-
-For QGIS to //easily// find gpsbabel, you need to copy the gpsbabel executable
-to the QGIS application.  Assuming you installed QGIS in your home folder:
-
-```
-cp -fp /Applications/GPSBabelFE.app/Contents/MacOS/gpsbabel ~/QGIS.app/Contents/MacOS/bin/
-```
-
-If you installed in /Applications, adjust the path accordingly and prefix the
-whole command with 'sudo '.
-
-**QGIS Server**
-
-See the QGIS Server documentation page at:
-
-http://docs.qgis.org/2.18/en/docs/user_manual/working_with_ogc/ogc_server_support.html
-
-for instructions on setting up Apache fastcgi and testing qgis server, including
-installing the mod-fastcgi that is missing on Lion.


### PR DESCRIPTION
OSX docs in INSTALL are for QGIS 2.18 and some old MacOS distributions 

trying to write some docs based on homebrew deps:
https://github.com/lutraconsulting/qgis-mac-packager/blob/master/scripts/install_brew.bash

and build command:
https://github.com/lutraconsulting/qgis-mac-packager/blob/master/qgis-mac-packager/qgis_builder.py#L132

Questions:

1. Should we write also docs for MacPorts/Conda deps (I do not have experience with that)?
2. Any idea how to recreate INSTALL from change in docs/osx.t2t?
3. Anyone willing to test the instructions?

