### PR TITLE
Allow saving a layer after fixing invalid geometries

### DIFF
--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -145,6 +145,10 @@ void QgsGeometryValidationService::onFeatureDeleted( QgsVectorLayer *layer, QgsF
 
 void QgsGeometryValidationService::onBeforeCommitChanges( QgsVectorLayer *layer )
 {
+  if ( mLayerChecks[layer].topologyChecks.empty() && !layer->allowCommit() )
+  {
+    showMessage( tr( "Geometry errors have been found. Please fix the errors before saving the layer." ) );
+  }
   if ( !mBypassChecks && !mLayerChecks[layer].topologyChecks.empty() )
   {
     if ( !layer->allowCommit() )
@@ -359,6 +363,8 @@ void QgsGeometryValidationService::processFeature( QgsVectorLayer *layer, QgsFea
 
   if ( !mLayerChecks[layer].singleFeatureCheckErrors.empty() )
     layer->setAllowCommit( false );
+  else if ( mLayerChecks[layer].topologyChecks.empty() )
+    layer->setAllowCommit( true );
 
   emit geometryCheckCompleted( layer, fid, allErrors );
 }


### PR DESCRIPTION
When invalid geometries are not allowed but no topology checks are activated, QGIS did not let a user save edits even after fixing the issue.