### PR TITLE
Improve Python __repr__ handling for null geometries

### DIFF
--- a/python/core/auto_generated/geometry/qgscircularstring.sip.in
+++ b/python/core/auto_generated/geometry/qgscircularstring.sip.in
@@ -168,7 +168,10 @@ Sets the circular string's points
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsCircularString: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsCircularString: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
+++ b/python/core/auto_generated/geometry/qgscompoundcurve.sip.in
@@ -172,7 +172,10 @@ Appends first point if not already closed.
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsCompoundCurve: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsCompoundCurve: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgscurvepolygon.sip.in
@@ -274,7 +274,10 @@ Returns approximate rotation angle for a vertex. Usually average angle between a
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsCurvePolygon: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsCurvePolygon: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -1391,7 +1391,16 @@ Exports the geometry to WKT
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsGeometry: %1>" ).arg( sipCpp->asWkt() );
+    QString str;
+    if ( sipCpp->isNull() )
+      str = QStringLiteral( "<QgsGeometry: null>" );
+    else
+    {
+      QString wkt = sipCpp->asWkt();
+      if ( wkt.length() > 1000 )
+        wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+      str = QStringLiteral( "<QgsGeometry: %1>" ).arg( wkt );
+    }
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgslinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgslinestring.sip.in
@@ -501,7 +501,10 @@ of the curve.
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsLineString: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsLineString: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgsmulticurve.sip.in
+++ b/python/core/auto_generated/geometry/qgsmulticurve.sip.in
@@ -58,7 +58,10 @@ Returns a copy of the multi curve, where each component curve has had its line d
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsMultiCurve: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsMultiCurve: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgsmultilinestring.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultilinestring.sip.in
@@ -55,7 +55,10 @@ Returns the geometry converted to the more generic curve type :py:class:`QgsMult
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsMultiLineString: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsMultiLineString: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgsmultipoint.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipoint.sip.in
@@ -57,7 +57,10 @@ Multi point geometry collection.
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsMultiPoint: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsMultiPoint: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgsmultipolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipolygon.sip.in
@@ -56,7 +56,10 @@ Returns the geometry converted to the more generic curve type :py:class:`QgsMult
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsMultiPolygon: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsMultiPolygon: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/python/core/auto_generated/geometry/qgspolygon.sip.in
+++ b/python/core/auto_generated/geometry/qgspolygon.sip.in
@@ -67,7 +67,10 @@ negative if the point lies outside the polygon.
 
     SIP_PYOBJECT __repr__();
 %MethodCode
-    QString str = QStringLiteral( "<QgsPolygon: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsPolygon: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
 %End
 

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -152,7 +152,10 @@ class CORE_EXPORT QgsCircularString: public QgsCurve
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsCircularString: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsCircularString: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -152,7 +152,10 @@ class CORE_EXPORT QgsCompoundCurve: public QgsCurve
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsCompoundCurve: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsCompoundCurve: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -286,7 +286,10 @@ class CORE_EXPORT QgsCurvePolygon: public QgsSurface
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsCurvePolygon: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsCurvePolygon: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -1392,7 +1392,16 @@ class CORE_EXPORT QgsGeometry
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsGeometry: %1>" ).arg( sipCpp->asWkt() );
+    QString str;
+    if ( sipCpp->isNull() )
+      str = QStringLiteral( "<QgsGeometry: null>" );
+    else
+    {
+      QString wkt = sipCpp->asWkt();
+      if ( wkt.length() > 1000 )
+        wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+      str = QStringLiteral( "<QgsGeometry: %1>" ).arg( wkt );
+    }
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -635,7 +635,10 @@ class CORE_EXPORT QgsLineString: public QgsCurve
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsLineString: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsLineString: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 

--- a/src/core/geometry/qgsmulticurve.h
+++ b/src/core/geometry/qgsmulticurve.h
@@ -76,7 +76,10 @@ class CORE_EXPORT QgsMultiCurve: public QgsGeometryCollection
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsMultiCurve: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsMultiCurve: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/src/core/geometry/qgsmultilinestring.h
+++ b/src/core/geometry/qgsmultilinestring.h
@@ -68,7 +68,10 @@ class CORE_EXPORT QgsMultiLineString: public QgsMultiCurve
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsMultiLineString: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsMultiLineString: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -69,7 +69,10 @@ class CORE_EXPORT QgsMultiPoint: public QgsGeometryCollection
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsMultiPoint: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsMultiPoint: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/src/core/geometry/qgsmultipolygon.h
+++ b/src/core/geometry/qgsmultipolygon.h
@@ -68,7 +68,10 @@ class CORE_EXPORT QgsMultiPolygon: public QgsMultiSurface
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsMultiPolygon: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsMultiPolygon: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -87,7 +87,10 @@ class CORE_EXPORT QgsPolygon: public QgsCurvePolygon
 #ifdef SIP_RUN
     SIP_PYOBJECT __repr__();
     % MethodCode
-    QString str = QStringLiteral( "<QgsPolygon: %1>" ).arg( sipCpp->asWkt() );
+    QString wkt = sipCpp->asWkt();
+    if ( wkt.length() > 1000 )
+      wkt = wkt.left( 1000 ) + QStringLiteral( "..." );
+    QString str = QStringLiteral( "<QgsPolygon: %1>" ).arg( wkt );
     sipRes = PyUnicode_FromString( str.toUtf8().constData() );
     % End
 #endif

--- a/tests/src/python/test_python_repr.py
+++ b/tests/src/python/test_python_repr.py
@@ -26,9 +26,19 @@ start_app()
 class TestPython__repr__(unittest.TestCase):
 
     def testQgsGeometryRepr(self):
+
+        g = QgsGeometry()
+        self.assertEqual(g.__repr__(), '<QgsGeometry: null>')
         p = QgsPointXY(123.456, 987.654)
         g = QgsGeometry.fromPointXY(p)
         self.assertTrue(g.__repr__().startswith('<QgsGeometry: Point (123.456'))
+        g = QgsGeometry(QgsLineString([QgsPoint(0, 2), QgsPoint(1010, 2)]))
+        g = g.densifyByCount(1000)
+        # long strings must be truncated for performance -- otherwise they flood the console/first aid output
+        self.assertTrue(g.__repr__().startswith('<QgsGeometry: LineString (0 2,'))
+        self.assertTrue(
+            g.__repr__().endswith('...>'))
+        self.assertEqual(len(g.__repr__()), 1018)
 
     def testQgsPointRepr(self):
         p = QgsPoint(123.456, 987.654, 100)


### PR DESCRIPTION
Also avoid massive long __repr__ strings for complex geometries, as these can flood the Python console (and first aid plugin), and aren't useful for debugging anyway.

Refs #14640
