### PR TITLE
Apply featureFilterProvider in QgsVectorLayerDiagramProvider

### DIFF
--- a/python/core/auto_generated/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/qgsmaprendererjob.sip.in
@@ -183,6 +183,7 @@ emitted when asynchronous rendering is finished (or canceled).
 
 
 
+
 };
 
 

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -295,12 +295,12 @@ void QgsMapRendererCustomPainterJob::doRender()
         mLabelJob.img->fill( 0 );
         painter.begin( mLabelJob.img );
         mLabelJob.context.setPainter( &painter );
-        drawLabeling( mSettings, mLabelJob.context, mLabelingEngineV2.get(), &painter );
+        drawLabeling( mLabelJob.context, mLabelingEngineV2.get(), &painter );
         painter.end();
       }
       else
       {
-        drawLabeling( mSettings, mLabelJob.context, mLabelingEngineV2.get(), mPainter );
+        drawLabeling( mLabelJob.context, mLabelingEngineV2.get(), mPainter );
       }
 
       mLabelJob.complete = true;
@@ -318,8 +318,7 @@ void QgsMapRendererCustomPainterJob::doRender()
   QgsDebugMsgLevel( "Rendering completed in (seconds): " + QString( "%1" ).arg( renderTime.elapsed() / 1000.0 ), 2 );
 }
 
-
-void QgsMapRendererJob::drawLabeling( const QgsMapSettings &settings, QgsRenderContext &renderContext, QgsLabelingEngine *labelingEngine2, QPainter *painter )
+void QgsMapRendererJob::drawLabeling( QgsRenderContext &renderContext, QgsLabelingEngine *labelingEngine2, QPainter *painter )
 {
   QgsDebugMsgLevel( QStringLiteral( "Draw labeling start" ), 5 );
 
@@ -329,22 +328,22 @@ void QgsMapRendererJob::drawLabeling( const QgsMapSettings &settings, QgsRenderC
   // Reset the composition mode before rendering the labels
   painter->setCompositionMode( QPainter::CompositionMode_SourceOver );
 
-  // TODO: this is not ideal - we could override rendering stopped flag that has been set in meanwhile
-  renderContext = QgsRenderContext::fromMapSettings( settings );
   renderContext.setPainter( painter );
 
   if ( labelingEngine2 )
   {
-    // set correct extent
-    renderContext.setExtent( settings.visibleExtent() );
-    renderContext.setCoordinateTransform( QgsCoordinateTransform() );
-
     labelingEngine2->run( renderContext );
   }
 
   QgsDebugMsg( QStringLiteral( "Draw labeling took (seconds): %1" ).arg( t.elapsed() / 1000. ) );
 }
 
+void QgsMapRendererJob::drawLabeling( const QgsMapSettings &settings, QgsRenderContext &renderContext, QgsLabelingEngine *labelingEngine2, QPainter *painter )
+{
+  Q_UNUSED( settings );
+
+  drawLabeling( renderContext, labelingEngine2, painter );
+}
 
 bool QgsMapRendererJob::needTemporaryImage( QgsMapLayer *ml )
 {

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -358,6 +358,7 @@ LabelRenderJob QgsMapRendererJob::prepareLabelingJob( QPainter *painter, QgsLabe
   job.context.setPainter( painter );
   job.context.setLabelingEngine( labelingEngine2 );
   job.context.setExtent( mSettings.visibleExtent() );
+  job.context.setFeatureFilterProvider( mFeatureFilterProvider );
 
   // if we can use the cache, let's do it and avoid rendering!
   bool hasCache = canUseLabelCache && mCache && mCache->hasCacheImage( LABEL_CACHE_ID );

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -286,8 +286,14 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
      */
     void cleanupLabelJob( LabelRenderJob &job ) SIP_SKIP;
 
+    /**
+     * \note not available in Python bindings
+     * \deprecated Will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED static void drawLabeling( const QgsMapSettings &settings, QgsRenderContext &renderContext, QgsLabelingEngine *labelingEngine2, QPainter *painter ) SIP_SKIP;
+
     //! \note not available in Python bindings
-    static void drawLabeling( const QgsMapSettings &settings, QgsRenderContext &renderContext, QgsLabelingEngine *labelingEngine2, QPainter *painter ) SIP_SKIP;
+    static void drawLabeling( QgsRenderContext &renderContext, QgsLabelingEngine *labelingEngine2, QPainter *painter ) SIP_SKIP;
 
   private:
 

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -297,7 +297,7 @@ void QgsMapRendererParallelJob::renderLabelsStatic( QgsMapRendererParallelJob *s
     // draw the labels!
     try
     {
-      drawLabeling( self->mSettings, job.context, self->mLabelingEngineV2.get(), &painter );
+      drawLabeling( job.context, self->mLabelingEngineV2.get(), &painter );
     }
     catch ( QgsException &e )
     {

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -78,8 +78,12 @@ QList<QgsLabelFeature *> QgsVectorLayerDiagramProvider::labelFeatures( QgsRender
   QgsFeatureRequest request;
   request.setFilterRect( layerExtent );
   request.setSubsetOfAttributes( attributeNames, mFields );
+  const QgsFeatureFilterProvider *featureFilterProvider = context.featureFilterProvider();
+  if ( featureFilterProvider )
+  {
+    featureFilterProvider->filterFeatures( qobject_cast<QgsVectorLayer *>( mLayer ), request );
+  }
   QgsFeatureIterator fit = mSource->getFeatures( request );
-
 
   QgsFeature fet;
   while ( fit.nextFeature( fet ) )


### PR DESCRIPTION
## Description

Update of #8463 

As QgsVectorLayerDiagramProvider is created with it's "ownFeatureLoop", FILTER parameter was having no effect on diagrams.

Note: It should be possible to create QgsVectorLayerDiagramProvider with `ownFeatureLoop = true` here: https://github.com/qgis/QGIS/blob/9b04a29116156dec48c32dd6a54aafa0ff05eaea/src/core/qgsvectorlayerrenderer.cpp#L540

But this might have side effects.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
