### PR TITLE
Make expression parser output translatable

### DIFF
--- a/scripts/update_ts.sh
+++ b/scripts/update_ts.sh
@@ -79,7 +79,7 @@ files=
 if [ -d "$2" ]; then
 	builddir=$(realpath $2)
 	textcpp=
-	for i in $builddir/src/core/qgsexpression_texts.cpp; do
+	for i in $builddir/src/core/qgsexpression_texts.cpp $builddir/src/core/qgsexpressionparser.cpp; do
 		if [ -f $i ]; then
 			textcpp="$textcpp $i"
 		elif [ "$action" != "pull" ]; then

--- a/scripts/update_ts_files.sh
+++ b/scripts/update_ts_files.sh
@@ -126,7 +126,7 @@ done
 echo Updating GRASS module translations
 perl scripts/qgm2cpp.pl >src/plugins/grass/grasslabels-i18n.cpp
 echo Creating qmake project file
-$QMAKE -project -o qgis_ts.pro -nopwd src python i18n "$builddir/src/core/qgsexpression_texts.cpp"
+$QMAKE -project -o qgis_ts.pro -nopwd src python i18n "$builddir/src/core/qgsexpression_texts.cpp" "$builddir/src/core/qgsexpressionparser.cpp"
 if [ -n "$add" ]; then
 	for i in $add; do
 		echo "Adding translation for $i"

--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -218,7 +218,7 @@ expression:
           {
             QgsExpression::ParserError::ParserErrorType errorType = QgsExpression::ParserError::FunctionUnknown;
             parser_ctx->currentErrorType = errorType;
-            exp_error(&yyloc, parser_ctx, "Function is not known");
+            exp_error(&yyloc, parser_ctx, QObject::tr( "Function is not known" ).toUtf8().constData() );
             delete $3;
             YYERROR;
           }
@@ -241,13 +241,13 @@ expression:
             QString expectedMessage;
             if ( func->params() == func->minParams() )
             {
-               expectedMessage = QStringLiteral( "Expected %1 but got %2." ).arg( QString::number( func->params() ), QString::number( $3->count() ) );
+               expectedMessage = QObject::tr( "Expected %1 but got %2." ).arg( QString::number( func->params() ), QString::number( $3->count() ) );
             }
             else
             {
-               expectedMessage = QStringLiteral( "Expected between %1 and %2 parameters but %3 were provided." ).arg( QString::number( func->minParams() ), QString::number( func->params() ), QString::number( $3->count() ) );
+               expectedMessage = QObject::tr( "Expected between %1 and %2 parameters but %3 were provided." ).arg( QString::number( func->minParams() ), QString::number( func->params() ), QString::number( $3->count() ) );
             }
-            exp_error(&yyloc, parser_ctx, QStringLiteral( "%1 function is called with wrong number of arguments. %2" ).arg( QgsExpression::Functions()[fnIndex]->name(), expectedMessage ).toUtf8().constData() );
+            exp_error(&yyloc, parser_ctx, QObject::tr( "%1 function is called with wrong number of arguments. %2" ).arg( QgsExpression::Functions()[fnIndex]->name(), expectedMessage ).toUtf8().constData() );
             delete $3;
             YYERROR;
           }
@@ -264,7 +264,7 @@ expression:
           {
             QgsExpression::ParserError::ParserErrorType errorType = QgsExpression::ParserError::FunctionUnknown;
             parser_ctx->currentErrorType = errorType;
-            exp_error(&yyloc, parser_ctx, "Function is not known");
+            exp_error(&yyloc, parser_ctx, QObject::tr( "Function is not known" ).toUtf8().constData() );
             YYERROR;
           }
           // 0 parameters is expected, -1 parameters means leave it to the
@@ -273,7 +273,7 @@ expression:
           {
             QgsExpression::ParserError::ParserErrorType errorType = QgsExpression::ParserError::FunctionWrongArgs;
             parser_ctx->currentErrorType = errorType;
-            exp_error(&yyloc, parser_ctx, QString( "%1 function is called with wrong number of arguments" ).arg( QgsExpression::Functions()[fnIndex]->name() ).toLocal8Bit().constData() );
+            exp_error(&yyloc, parser_ctx, QObject::tr( "%1 function is called with wrong number of arguments" ).arg( QgsExpression::Functions()[fnIndex]->name() ).toLocal8Bit().constData() );
             YYERROR;
           }
           $$ = new QgsExpressionNodeFunction(fnIndex, new QgsExpressionNode::NodeList());
@@ -307,7 +307,7 @@ expression:
           {
             QgsExpression::ParserError::ParserErrorType errorType = QgsExpression::ParserError::FunctionUnknown;
             parser_ctx->currentErrorType = errorType;
-            exp_error(&yyloc, parser_ctx, QString("%1 function is not known").arg(*$1).toLocal8Bit().constData());
+            exp_error(&yyloc, parser_ctx, QObject::tr( "%1 function is not known" ).arg( *$1 ).toLocal8Bit().constData());
             YYERROR;
           }
           delete $1;
@@ -318,7 +318,7 @@ expression:
         {
           // @var is equivalent to var( "var" )
           QgsExpressionNode::NodeList* args = new QgsExpressionNode::NodeList();
-          QgsExpressionNodeLiteral* literal = new QgsExpressionNodeLiteral( QString(*$1).mid(1) );
+          QgsExpressionNodeLiteral* literal = new QgsExpressionNodeLiteral( QString( *$1 ).mid( 1 ) );
           args->append( literal );
           $$ = new QgsExpressionNodeFunction( QgsExpression::functionIndex( "var" ), args );
           delete $1;
@@ -343,7 +343,7 @@ exp_list:
          {
            QgsExpression::ParserError::ParserErrorType errorType = QgsExpression::ParserError::FunctionNamedArgsError;
            parser_ctx->currentErrorType = errorType;
-           exp_error(&yyloc, parser_ctx, "All parameters following a named parameter must also be named.");
+           exp_error(&yyloc, parser_ctx, QObject::tr( "All parameters following a named parameter must also be named." ).toUtf8().constData() );
            delete $1;
            YYERROR;
          }


### PR DESCRIPTION
Messages like "Wrong number of arguments provided" etc. appear e.g. in the expression builder.