### PR TITLE
Correct mapFromSource method when reordering columns. fixes #20673

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -247,14 +247,11 @@ void QgsAttributeTableFilterModel::setSelectedOnTop( bool selectedOnTop )
     Qt::SortOrder order = sortOrder();
 
     // set default sort values if they are not correctly set
-    if ( column < 0 )
-      column = 0;
-
-    if ( order != Qt::AscendingOrder && order != Qt::DescendingOrder )
-      order = Qt::AscendingOrder;
-
-    sort( column, order );
-    invalidate();
+    if ( column < 0 || ( order != Qt::AscendingOrder && order != Qt::DescendingOrder ) )
+    {
+      sort( 0, Qt::AscendingOrder );
+      invalidate();
+    }
   }
 }
 
@@ -382,7 +379,6 @@ void QgsAttributeTableFilterModel::selectionChanged()
   }
   else if ( mSelectedOnTop )
   {
-    sort( sortColumn(), sortOrder() );
     invalidate();
   }
 }
@@ -400,6 +396,14 @@ int QgsAttributeTableFilterModel::mapColumnToSource( int column ) const
     return -1;
   else
     return mColumnMapping.at( column );
+}
+
+int QgsAttributeTableFilterModel::mapColumnFromSource( int column ) const
+{
+  if ( mColumnMapping.isEmpty() )
+    return column;
+  else
+    return mColumnMapping.indexOf( column );
 }
 
 void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
@@ -528,7 +532,8 @@ QModelIndex QgsAttributeTableFilterModel::mapFromSource( const QModelIndex &sour
   if ( proxyIndex.column() < 0 )
     return QModelIndex();
 
-  int col = mapColumnToSource( proxyIndex.column() );
+  int col = mapColumnFromSource( proxyIndex.column() );
+
   if ( col == -1 )
     col = 0;
 
@@ -544,4 +549,3 @@ Qt::ItemFlags QgsAttributeTableFilterModel::flags( const QModelIndex &index ) co
   QModelIndex source_index = mapToSource( index );
   return masterModel()->flags( source_index );
 }
-

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -275,6 +275,7 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
     QgsAttributeTableConfig mConfig;
     QVector<int> mColumnMapping;
     int mapColumnToSource( int column ) const;
+    int mapColumnFromSource( int column ) const;
 
 };
 

--- a/tests/src/app/testqgsattributetable.cpp
+++ b/tests/src/app/testqgsattributetable.cpp
@@ -51,6 +51,7 @@ class TestQgsAttributeTable : public QObject
     void testNoGeom();
     void testSelected();
     void testSortByDisplayExpression();
+    void testOrderColumn();
 
   private:
     QgisApp *mQgisApp = nullptr;
@@ -306,6 +307,49 @@ void TestQgsAttributeTable::testRegression15974()
   QCOMPARE( dlg->mMainView->filteredFeatureCount(), 3 );
 }
 
+void TestQgsAttributeTable::testOrderColumn()
+{
+  std::unique_ptr< QgsVectorLayer> tempLayer( new QgsVectorLayer( QStringLiteral( "LineString?crs=epsg:3111&field=pk:int&field=col1:int&field=col2:int" ), QStringLiteral( "vl" ), QStringLiteral( "memory" ) ) );
+  QVERIFY( tempLayer->isValid() );
+
+  QgsFeature f1( tempLayer->dataProvider()->fields(), 1 );
+  f1.setAttribute( 0, 1 );
+  f1.setAttribute( 1, 13 );
+  f1.setAttribute( 2, 7 );
+  QVERIFY( tempLayer->dataProvider()->addFeatures( QgsFeatureList() << f1 ) );
+
+  std::unique_ptr< QgsAttributeTableDialog > dlg( new QgsAttributeTableDialog( tempLayer.get() ) );
+
+  // Issue https://issues.qgis.org/issues/20673
+  // When we reorder column (last column becomes first column), and we select an entire row
+  // the currentIndex is no longer the first column, and consequently it breaks edition
+
+  QgsAttributeTableConfig config = QgsAttributeTableConfig();
+  config.update( tempLayer->dataProvider()->fields() );
+  QVector<QgsAttributeTableConfig::ColumnConfig> columns = config.columns();
+
+  // move last column in first position
+  columns.move( 2, 0 );
+  config.setColumns( columns );
+
+  dlg->mMainView->setAttributeTableConfig( config );
+
+  QgsAttributeTableFilterModel *filterModel = static_cast<QgsAttributeTableFilterModel *>( dlg->mMainView->mTableView->model() );
+  filterModel->sort( 0, Qt::AscendingOrder );
+
+  QModelIndex index = filterModel->mapToSource( filterModel->sourceModel()->index( 0, 0 ) );
+  QCOMPARE( index.row(), 0 );
+  QCOMPARE( index.column(), 2 );
+
+  index = filterModel->mapFromSource( filterModel->sourceModel()->index( 0, 0 ) );
+  QCOMPARE( index.row(), 0 );
+  QCOMPARE( index.column(), 1 );
+
+  qDebug() << filterModel->mapFromSource( filterModel->sourceModel()->index( 0, 0 ) );
+
+  // column 0 is indeed column 2 since we move it
+  QCOMPARE( filterModel->sortColumn(), 2 );
+}
 
 QGSTEST_MAIN( TestQgsAttributeTable )
 #include "testqgsattributetable.moc"


### PR DESCRIPTION
## Description

This PR corrects the issue https://issues.qgis.org/issues/20673
 When we reorder column (last column becomes first column for instance) with select on top activated, and we select an entire row the currentIndex is no longer the first column, and consequently it breaks edition.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
