### PR TITLE
Avoid using default QPalette to improve theme compatibility

### DIFF
--- a/src/gui/qgsexpressionlineedit.cpp
+++ b/src/gui/qgsexpressionlineedit.cpp
@@ -199,7 +199,7 @@ void QgsExpressionLineEdit::updateLineEditStyle( const QString &expression )
   if ( !mLineEdit )
     return;
 
-  QPalette palette;
+  QPalette palette = mLineEdit->palette();
   if ( !isEnabled() )
   {
     palette.setColor( QPalette::Text, Qt::gray );

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -323,7 +323,7 @@ void QgsFieldExpressionWidget::currentFieldChanged()
 
 void QgsFieldExpressionWidget::updateLineEditStyle( const QString &expression )
 {
-  QPalette palette;
+  QPalette palette = mCombo->lineEdit()->palette();
   if ( !isEnabled() )
   {
     palette.setColor( QPalette::Text, Qt::gray );

--- a/src/gui/qgsstatusbar.cpp
+++ b/src/gui/qgsstatusbar.cpp
@@ -34,10 +34,10 @@ QgsStatusBar::QgsStatusBar( QWidget *parent )
   mLineEdit->setDisabled( true );
   mLineEdit->setFrame( false );
   mLineEdit->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum );
-  QPalette palette;
+  QPalette palette = mLineEdit->palette();
   palette.setColor( QPalette::Disabled, QPalette::Text, QPalette::WindowText );
   mLineEdit->setPalette( palette );
-  mLineEdit->setStyleSheet( QStringLiteral( "* { background-color: rgba(0, 0, 0, 0); }" ) );
+  mLineEdit->setStyleSheet( QStringLiteral( "* { border: 0; background-color: rgba(0, 0, 0, 0); }" ) );
   mLayout->addWidget( mLineEdit, 10 );
   setLayout( mLayout );
 }


### PR DESCRIPTION
## Description
This PR improves our use of palette in a couple of widgets, to avoid compatibility issues when using a non-default theme, for e.g.:
![image](https://user-images.githubusercontent.com/1728657/50324169-174c4200-0510-11e9-85b0-0ed602889410.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
