### PR TITLE
Don't hard-code black and gray for layer tree items' text color

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodel.sip.in
@@ -304,7 +304,7 @@ Gets map of map layer style overrides (key: layer ID, value: style name) where a
 
     void setLayerStyleOverrides( const QMap<QString, QString> &overrides );
 %Docstring
-Set map of map layer style overrides (key: layer ID, value: style name) where a different style should be used instead of the current one
+Sets map of map layer style overrides (key: layer ID, value: style name) where a different style should be used instead of the current one
 
 .. versionadded:: 2.10
 %End

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -272,13 +272,15 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
   }
   else if ( role == Qt::ForegroundRole )
   {
-    QBrush brush( Qt::black, Qt::SolidPattern );
+    QBrush brush( qApp->palette().color( QPalette::Text ), Qt::SolidPattern );
     if ( QgsLayerTree::isLayer( node ) )
     {
       const QgsMapLayer *layer = QgsLayerTree::toLayer( node )->layer();
       if ( ( !node->isVisible() && ( !layer || layer->isSpatial() ) ) || ( layer && !layer->isInScaleRange( mLegendMapViewScale ) ) )
       {
-        brush.setColor( Qt::gray );
+        QColor fadedTextColor = brush.color();
+        fadedTextColor.setAlpha( 66 );
+        brush.setColor( fadedTextColor );
       }
     }
     return brush;

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -269,7 +269,7 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
     QMap<QString, QString> layerStyleOverrides() const;
 
     /**
-     * Set map of map layer style overrides (key: layer ID, value: style name) where a different style should be used instead of the current one
+     * Sets map of map layer style overrides (key: layer ID, value: style name) where a different style should be used instead of the current one
      * \since QGIS 2.10
      */
     void setLayerStyleOverrides( const QMap<QString, QString> &overrides );


### PR DESCRIPTION
## Description
@m-kuhn , @3nids , @nyalldawson , here's a way we could avoid hard-coding black (and instead use the proper text color provided by the system/theme) for the layer tree. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
