### PR TITLE
Processing in-place do not check validity when fixing geometries

### DIFF
--- a/python/plugins/processing/gui/AlgorithmExecutor.py
+++ b/python/plugins/processing/gui/AlgorithmExecutor.py
@@ -94,6 +94,10 @@ def execute_in_place_run(alg, parameters, context=None, feedback=None, raise_exc
     if context is None:
         context = dataobjects.createContext(feedback)
 
+    # Ugly hack: the only invalid policy option that makes sense for fixgeometries is to not check
+    if alg.name() in ('fixgeometries', ):
+        context.setInvalidGeometryCheck(QgsFeatureRequest.GeometryNoCheck)
+
     active_layer = parameters['INPUT']
 
     # Run some checks and prepare the layer for in-place execution by:

--- a/python/plugins/processing/gui/AlgorithmExecutor.py
+++ b/python/plugins/processing/gui/AlgorithmExecutor.py
@@ -34,6 +34,7 @@ from qgis.core import (Qgis,
                        QgsMessageLog,
                        QgsProcessingException,
                        QgsProcessingFeatureSourceDefinition,
+                       QgsProcessingFeatureSource,
                        QgsProcessingParameters,
                        QgsProject,
                        QgsFeatureRequest,
@@ -94,9 +95,12 @@ def execute_in_place_run(alg, parameters, context=None, feedback=None, raise_exc
     if context is None:
         context = dataobjects.createContext(feedback)
 
-    # Ugly hack: the only invalid policy option that makes sense for fixgeometries is to not check
-    if alg.name() in ('fixgeometries', ):
-        context.setInvalidGeometryCheck(QgsFeatureRequest.GeometryNoCheck)
+    # Only feature based algs have sourceFlags
+    try:
+        if alg.sourceFlags() & QgsProcessingFeatureSource.FlagSkipGeometryValidityChecks:
+            context.setInvalidGeometryCheck(QgsFeatureRequest.GeometryNoCheck)
+    except AttributeError:
+        pass
 
     active_layer = parameters['INPUT']
 

--- a/tests/src/python/test_qgsprocessinginplace.py
+++ b/tests/src/python/test_qgsprocessinginplace.py
@@ -12,6 +12,7 @@ __copyright__ = 'Copyright 2018, The QGIS Project'
 # This will get replaced with a git SHA1 when you do a git archive
 __revision__ = '$Format:%H$'
 
+import re
 from qgis.PyQt.QtCore import QCoreApplication, QVariant
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsSettings, QgsApplication, QgsMemoryProviderUtils, QgsWkbTypes, QgsField, QgsFields, QgsProcessingFeatureSourceDefinition, QgsProcessingContext, QgsProcessingFeedback, QgsCoordinateReferenceSystem, QgsProject, QgsProcessingException
@@ -23,7 +24,7 @@ from processing.gui.AlgorithmExecutor import execute_in_place_run
 from qgis.testing import start_app, unittest
 from qgis.PyQt.QtTest import QSignalSpy
 from qgis.analysis import QgsNativeAlgorithms
-from qgis.core import QgsVectorLayerUtils
+from qgis.core import QgsVectorLayerUtils, QgsFeatureRequest
 
 start_app()
 
@@ -349,7 +350,7 @@ class TestQgsProcessingInPlace(unittest.TestCase):
         self.assertEqual(len(new_features), 1)
         self.assertEqual(new_features[0].geometry().asWkt(), '')
 
-    def _alg_tester(self, alg_name, input_layer, parameters):
+    def _alg_tester(self, alg_name, input_layer, parameters, invalid_geometry_policy=QgsFeatureRequest.GeometryNoCheck):
 
         alg = self.registry.createAlgorithmById(alg_name)
 
@@ -363,6 +364,7 @@ class TestQgsProcessingInPlace(unittest.TestCase):
         self.assertEqual(input_layer.selectedFeatureIds(), [old_features[0].id()], alg_name)
 
         context = QgsProcessingContext()
+        context.setInvalidGeometryCheck(invalid_geometry_policy)
         context.setProject(QgsProject.instance())
         feedback = ConsoleFeedBack()
 
@@ -611,16 +613,16 @@ class TestQgsProcessingInPlace(unittest.TestCase):
 
         polygon_layer = self._make_layer('Polygon')
         self.assertTrue(polygon_layer.startEditing())
-        f = QgsFeature(polygon_layer.fields())
-        f.setAttributes([1])
+        f1 = QgsFeature(polygon_layer.fields())
+        f1.setAttributes([1])
         # Flake!
-        f.setGeometry(QgsGeometry.fromWkt('POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))'))
-        self.assertTrue(f.isValid())
+        f1.setGeometry(QgsGeometry.fromWkt('POLYGON ((0 0, 2 2, 0 2, 2 0, 0 0))'))
+        self.assertTrue(f1.isValid())
         f2 = QgsFeature(polygon_layer.fields())
         f2.setAttributes([1])
         f2.setGeometry(QgsGeometry.fromWkt('POLYGON((1.1 1.1, 1.1 2.1, 2.1 2.1, 2.1 1.1, 1.1 1.1))'))
         self.assertTrue(f2.isValid())
-        self.assertTrue(polygon_layer.addFeatures([f, f2]))
+        self.assertTrue(polygon_layer.addFeatures([f1, f2]))
         polygon_layer.commitChanges()
         polygon_layer.rollBack()
         self.assertEqual(polygon_layer.featureCount(), 2)
@@ -631,12 +633,14 @@ class TestQgsProcessingInPlace(unittest.TestCase):
             'native:fixgeometries',
             polygon_layer,
             {
-            }
+            },
+            QgsFeatureRequest.GeometrySkipInvalid
         )
         self.assertEqual(polygon_layer.featureCount(), 3)
-        wkt1, wkt2, _ = [f.geometry().asWkt() for f in new_features]
+        wkt1, wkt2, wkt3 = [f.geometry().asWkt() for f in new_features]
         self.assertEqual(wkt1, 'Polygon ((0 0, 1 1, 2 0, 0 0))')
         self.assertEqual(wkt2, 'Polygon ((1 1, 0 2, 2 2, 1 1))')
+        self.assertEqual(re.sub(r'0000\d+', '', wkt3), 'Polygon ((1.1 1.1, 1.1 2.1, 2.1 2.1, 2.1 1.1, 1.1 1.1))')
 
         # Test with Z (interpolated)
         polygonz_layer = self._make_layer('PolygonZ')


### PR DESCRIPTION
Fixes [#20812](https://issues.qgis.org/issues/20812)
