### PR TITLE
Make geometry constraint configuration size fit the contents

### DIFF
--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -408,13 +408,32 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     mGeometryPrecisionLineEdit->setEnabled( true );
     mGeometryPrecisionLineEdit->setValidator( new QDoubleValidator( mGeometryPrecisionLineEdit ) );
 
-    mRemoveDuplicateNodesCheckbox->setChecked( mLayer->geometryOptions()->removeDuplicateNodes() );
     double precision( mLayer->geometryOptions()->geometryPrecision() );
     bool ok = true;
     QString precisionStr( QLocale().toString( precision, ok ) );
     if ( precision == 0.0 || ! ok )
       precisionStr = QString();
     mGeometryPrecisionLineEdit->setText( precisionStr );
+
+    mRemoveDuplicateNodesManuallyActivated = mLayer->geometryOptions()->removeDuplicateNodes();
+    mRemoveDuplicateNodesCheckbox->setChecked( mRemoveDuplicateNodesManuallyActivated );
+    if ( !precisionStr.isNull() )
+      mRemoveDuplicateNodesCheckbox->setEnabled( false );
+    connect( mGeometryPrecisionLineEdit, &QLineEdit::textChanged, this, [this]
+    {
+      if ( !mGeometryPrecisionLineEdit->text().isEmpty() )
+      {
+        if ( mRemoveDuplicateNodesCheckbox->isEnabled() )
+          mRemoveDuplicateNodesManuallyActivated  = mRemoveDuplicateNodesCheckbox->isChecked();
+        mRemoveDuplicateNodesCheckbox->setEnabled( false );
+        mRemoveDuplicateNodesCheckbox->setChecked( true );
+      }
+      else
+      {
+        mRemoveDuplicateNodesCheckbox->setEnabled( true );
+        mRemoveDuplicateNodesCheckbox->setChecked( mRemoveDuplicateNodesManuallyActivated );
+      }
+    } );
 
     mPrecisionUnitsLabel->setText( QStringLiteral( "[%1]" ).arg( QgsUnitTypes::toAbbreviatedString( mLayer->crs().mapUnits() ) ) );
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -429,6 +429,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
       geometryCheckLayout->addWidget( cb );
     }
     mGeometryValidationGroupBox->setLayout( geometryCheckLayout );
+    mGeometryValidationGroupBox->setVisible( !geometryCheckFactories.isEmpty() );
 
     QLayout *topologyCheckLayout = new QVBoxLayout();
     const QList<QgsGeometryCheckFactory *> topologyCheckFactories = QgsAnalysis::instance()->geometryCheckRegistry()->geometryCheckFactories( mLayer, QgsGeometryCheck::LayerCheck, QgsGeometryCheck::Flag::AvailableInValidation );
@@ -441,6 +442,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
       topologyCheckLayout->addWidget( cb );
     }
     mTopologyChecksGroupBox->setLayout( topologyCheckLayout );
+    mTopologyChecksGroupBox->setVisible( !topologyCheckFactories.isEmpty() );
   }
   else
   {

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -245,6 +245,8 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     QHash<QCheckBox *, QString> mGeometryCheckFactoriesGroupBoxes;
 
+    bool mRemoveDuplicateNodesManuallyActivated = false;
+
   private slots:
     void openPanel( QgsPanelWidget *panel );
 

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -433,8 +433,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>325</width>
-                <height>389</height>
+                <width>315</width>
+                <height>403</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -907,8 +907,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>104</width>
-                <height>102</height>
+                <width>185</width>
+                <height>112</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1504,8 +1504,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>685</width>
-                <height>346</height>
+                <width>734</width>
+                <height>372</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1961,8 +1961,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>340</width>
-                <height>630</height>
+                <width>378</width>
+                <height>678</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2367,8 +2367,8 @@ border-radius: 2px;</string>
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>651</width>
-                <height>804</height>
+                <width>658</width>
+                <height>800</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -2377,8 +2377,15 @@ border-radius: 2px;</string>
                  <property name="title">
                   <string>Automatic Fixes</string>
                  </property>
-                 <layout class="QFormLayout" name="formLayout">
-                  <item row="2" column="0">
+                 <layout class="QGridLayout" name="gridLayout">
+                  <item row="0" column="0" colspan="2">
+                   <widget class="QCheckBox" name="mRemoveDuplicateNodesCheckbox">
+                    <property name="text">
+                     <string>Remove duplicate nodes</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
                    <widget class="QLabel" name="label">
                     <property name="toolTip">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The geometry precision defines the maximum precision to of geometry coordinates that should be stored on this layer. A snap to grid algorithm will be applied on every geometry entering this layer, resulting in coordinates being rounded to multiples of this value. The operation is applied in this layer's coordinate reference system.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -2388,14 +2395,7 @@ border-radius: 2px;</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="0" colspan="2">
-                   <widget class="QCheckBox" name="mRemoveDuplicateNodesCheckbox">
-                    <property name="text">
-                     <string>Remove duplicate nodes</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1">
+                  <item row="1" column="1">
                    <layout class="QHBoxLayout" name="horizontalLayout_11" stretch="0,0">
                     <item>
                      <widget class="QLabel" name="mPrecisionUnitsLabel">
@@ -2435,6 +2435,19 @@ border-radius: 2px;</string>
                   <string>Topology checks</string>
                  </property>
                 </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </widget>
@@ -2623,6 +2636,8 @@ border-radius: 2px;</string>
   <tabstop>mRemoveDuplicateNodesCheckbox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
Improved spacing and beavior on the *digitizing* configuration page.

 * Group boxes are only as tall as they need to be
 * Group boxes disappear if they have no content
 * *Remove duplicate nodes* is automatically checked and disabled whenever a geometry precision is set. Because that's what actually happens anyway in the background.

![screenshot from 2018-12-21 15-10-09](https://user-images.githubusercontent.com/588407/50346404-8f2b6400-0532-11e9-8809-4f9b8428167a.png)

![screenshot from 2018-12-21 15-10-51](https://user-images.githubusercontent.com/588407/50346435-a36f6100-0532-11e9-9a49-51db6d0d6843.png)

Sidenote: 12 is probably not a good value for real life, better use 0.001 or so ;)
