### PR TITLE
Add comment option on db_manager pluging postgis tables

### DIFF
--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -39,7 +39,6 @@ from qgis.core import (QgsDataSourceUri,
 from qgis.gui import QgsMessageViewer
 from qgis.utils import OverrideCursor
 
-import psycopg2
 from .ui.ui_DlgImportVector import Ui_DbManagerDlgImportVector as Ui_Dialog
 
 
@@ -52,7 +51,6 @@ class DlgImportVector(QDialog, Ui_Dialog):
         self.db = outDb
         self.outUri = outUri
         self.setupUi(self)
-        print(self.db)
 
         self.default_pk = "id"
         self.default_geom = "geom"
@@ -82,9 +80,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
 
         if mode == self.ASK_FOR_INPUT_MODE:
             self.btnChooseInputFile.clicked.connect(self.chooseInputFile)
-            # self.cboInputLayer.lineEdit().editingFinished.connect(self.updateInputLayer)
-            self.cboInputLayer.editTextChanged.connect(self.inputPathChanged)
-            # self.cboInputLayer.currentIndexChanged.connect(self.updateInputLayer)
+            self.cboInputLayer.currentTextChanged.connect(self.updateInputLayer)
             self.btnUpdateInputLayer.clicked.connect(self.updateInputLayer)
 
             self.editPrimaryKey.setText(self.default_pk)
@@ -162,13 +158,6 @@ class DlgImportVector(QDialog, Ui_Dialog):
 
         self.cboInputLayer.setEditText(filename)
 
-    def inputPathChanged(self, path):
-        if self.cboInputLayer.currentIndex() < 0:
-            return
-        self.cboInputLayer.blockSignals(True)
-        self.cboInputLayer.setCurrentIndex(-1)
-        self.cboInputLayer.setEditText(path)
-        self.cboInputLayer.blockSignals(False)
 
     def reloadInputLayer(self):
         """ create the input layer and update available options """
@@ -383,7 +372,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
         #Add comment on table
         if self.chkCom.isEnabled() and self.chkCom.isChecked():
             #Using connector executing COMMENT ON TABLE query (with editCome.text() value)
-            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}E\' '.format(schema, table ,self.editCom.text()))
+            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}E\''.format(schema, table ,self.editCom.text()))
 
         self.db.connection().reconnect()
         self.db.refresh()

--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -158,7 +158,6 @@ class DlgImportVector(QDialog, Ui_Dialog):
 
         self.cboInputLayer.setEditText(filename)
 
-
     def reloadInputLayer(self):
         """ create the input layer and update available options """
         if self.mode != self.ASK_FOR_INPUT_MODE:
@@ -369,10 +368,10 @@ class DlgImportVector(QDialog, Ui_Dialog):
         if self.chkSpatialIndex.isEnabled() and self.chkSpatialIndex.isChecked():
             self.db.connector.createSpatialIndex((schema, table), geom)
 
-        #Add comment on table
+        # add comment on table
         if self.chkCom.isEnabled() and self.chkCom.isChecked():
-            #Using connector executing COMMENT ON TABLE query (with editCome.text() value)
-            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}E\''.format(schema, table ,self.editCom.text()))
+            # using connector executing COMMENT ON TABLE query (with editCome.text() value)
+            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}E\''.format(schema, table, self.editCom.text()))
 
         self.db.connection().reconnect()
         self.db.refresh()

--- a/python/plugins/db_manager/dlg_table_properties.py
+++ b/python/plugins/db_manager/dlg_table_properties.py
@@ -336,14 +336,13 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         #Function that add a comment to the selected table
         try:
             #Using the db connector, executing de SQL query Comment on table
-            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}\';'.format(self.table.schema().name, self.table.name ,self.viewComment.text()))
+            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}\';'.format(self.table.schema().name, self.table.name, self.viewComment.text()))
         except DbError as e:
             DlgDbError.showError(e, self)
             return
         self.refresh()
         #Display successful message
         QMessageBox.information(self, self.tr("Add comment"), self.tr("Table successfully commented"))
-
 
     def deleteComment(self):
         #Function that drop the comment to the selected table
@@ -358,4 +357,3 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         self.viewComment.setText('')
         #Display successful message
         QMessageBox.information(self, self.tr("Delete comment"), self.tr("Comment deleted"))
-

--- a/python/plugins/db_manager/dlg_table_properties.py
+++ b/python/plugins/db_manager/dlg_table_properties.py
@@ -59,6 +59,10 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         m = TableIndexesModel(self)
         self.viewIndexes.setModel(m)
 
+        #Display comment in line edit
+        m = self.table.comment
+        self.viewComment.setText(m)
+
         self.btnAddColumn.clicked.connect(self.addColumn)
         self.btnAddGeometryColumn.clicked.connect(self.addGeometryColumn)
         self.btnEditColumn.clicked.connect(self.editColumn)
@@ -70,6 +74,11 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         self.btnAddIndex.clicked.connect(self.createIndex)
         self.btnAddSpatialIndex.clicked.connect(self.createSpatialIndex)
         self.btnDeleteIndex.clicked.connect(self.deleteIndex)
+
+        #Connect button add Comment to function
+        self.btnAddComment.clicked.connect(self.createComment)
+        #Connect button delete Comment to function
+        self.btnDeleteComment.clicked.connect(self.deleteComment)
 
         self.refresh()
 
@@ -322,3 +331,31 @@ class DlgTableProperties(QDialog, Ui_Dialog):
                 self.refresh()
             except BaseError as e:
                 DlgDbError.showError(e, self)
+
+    def createComment(self):
+        #Function that add a comment to the selected table
+        try:
+            #Using the db connector, executing de SQL query Comment on table
+            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}\' '.format(self.table.schema().name, self.table.name ,self.viewComment.text()))
+        except DbError as e:
+            DlgDbError.showError(e, self)
+            return
+        self.refresh()
+        #Display successful message
+        QMessageBox.information(self, self.tr("Add comment"), self.tr("Table successfully commented"))
+
+
+    def deleteComment(self):
+        #Function that drop the comment to the selected table
+        try:
+            #Using the db connector, executing de SQL query Comment on table. Comment is void ''
+            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'\' '.format(self.table.schema().name, self.table.name))
+        except DbError as e:
+            DlgDbError.showError(e, self)
+            return
+        self.refresh()
+        #Refresh line edit, put a void comment
+        self.viewComment.setText('')
+        #Display successful message
+        QMessageBox.information(self, self.tr("Delete comment"), self.tr("Comment deleted"))
+

--- a/python/plugins/db_manager/dlg_table_properties.py
+++ b/python/plugins/db_manager/dlg_table_properties.py
@@ -336,7 +336,7 @@ class DlgTableProperties(QDialog, Ui_Dialog):
         #Function that add a comment to the selected table
         try:
             #Using the db connector, executing de SQL query Comment on table
-            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}\' '.format(self.table.schema().name, self.table.name ,self.viewComment.text()))
+            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'{2}\';'.format(self.table.schema().name, self.table.name ,self.viewComment.text()))
         except DbError as e:
             DlgDbError.showError(e, self)
             return
@@ -348,8 +348,8 @@ class DlgTableProperties(QDialog, Ui_Dialog):
     def deleteComment(self):
         #Function that drop the comment to the selected table
         try:
-            #Using the db connector, executing de SQL query Comment on table. Comment is void ''
-            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS E\'\' '.format(self.table.schema().name, self.table.name))
+            #Using the db connector, executing de SQL query Comment on table using the NULL definition
+            self.db.connector._execute(None, 'COMMENT ON TABLE "{0}"."{1}" IS NULL;'.format(self.table.schema().name, self.table.name))
         except DbError as e:
             DlgDbError.showError(e, self)
             return

--- a/python/plugins/db_manager/ui/DlgImportVector.ui
+++ b/python/plugins/db_manager/ui/DlgImportVector.ui
@@ -262,7 +262,7 @@
        </widget>
       </item>
       <item row="10" column="1">
-       <widget class="QLineEdit" name="editComment">
+       <widget class="QLineEdit" name="editCom">
         <property name="enabled">
          <bool>false</bool>
         </property>

--- a/python/plugins/db_manager/ui/DlgImportVector.ui
+++ b/python/plugins/db_manager/ui/DlgImportVector.ui
@@ -262,7 +262,7 @@
        </widget>
       </item>
       <item row="10" column="1">
-       <widget class="QLineEdit" name="editCom">
+       <widget class="QLineEdit" name="editComment">
         <property name="enabled">
          <bool>false</bool>
         </property>
@@ -324,8 +324,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>334</x>
-     <y>486</y>
+     <x>343</x>
+     <y>617</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -340,12 +340,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>129</x>
-     <y>239</y>
+     <x>155</x>
+     <y>268</y>
     </hint>
     <hint type="destinationlabel">
-     <x>460</x>
-     <y>239</y>
+     <x>463</x>
+     <y>272</y>
     </hint>
    </hints>
   </connection>
@@ -356,12 +356,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>141</x>
-     <y>265</y>
+     <x>167</x>
+     <y>306</y>
     </hint>
     <hint type="destinationlabel">
-     <x>442</x>
-     <y>265</y>
+     <x>463</x>
+     <y>310</y>
     </hint>
    </hints>
   </connection>
@@ -372,12 +372,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>119</x>
-     <y>343</y>
+     <x>145</x>
+     <y>404</y>
     </hint>
     <hint type="destinationlabel">
-     <x>455</x>
-     <y>343</y>
+     <x>463</x>
+     <y>406</y>
     </hint>
    </hints>
   </connection>
@@ -388,8 +388,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>461</x>
-     <y>486</y>
+     <x>470</x>
+     <y>617</y>
     </hint>
     <hint type="destinationlabel">
      <x>508</x>
@@ -404,12 +404,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>134</x>
-     <y>281</y>
+     <x>160</x>
+     <y>341</y>
     </hint>
     <hint type="destinationlabel">
-     <x>357</x>
-     <y>281</y>
+     <x>463</x>
+     <y>341</y>
     </hint>
    </hints>
   </connection>
@@ -420,12 +420,28 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>134</x>
-     <y>307</y>
+     <x>160</x>
+     <y>372</y>
     </hint>
     <hint type="destinationlabel">
-     <x>357</x>
-     <y>307</y>
+     <x>463</x>
+     <y>372</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>chkCom</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>editComment</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>64</x>
+     <y>549</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>215</x>
+     <y>552</y>
     </hint>
    </hints>
   </connection>

--- a/python/plugins/db_manager/ui/DlgImportVector.ui
+++ b/python/plugins/db_manager/ui/DlgImportVector.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>482</width>
-    <height>496</height>
+    <height>627</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -251,6 +251,20 @@
        <widget class="QCheckBox" name="chkSourceSrid">
         <property name="text">
          <string>Source SRID</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QCheckBox" name="chkCom">
+        <property name="text">
+         <string>Comment</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QLineEdit" name="editCom">
+        <property name="enabled">
+         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/python/plugins/db_manager/ui/DlgTableProperties.ui
+++ b/python/plugins/db_manager/ui/DlgTableProperties.ui
@@ -17,13 +17,13 @@
    <item>
     <widget class="QTabWidget" name="tabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="tabColumns">
       <attribute name="title">
        <string>Columns</string>
       </attribute>
-      <layout class="QVBoxLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <widget class="QLabel" name="label">
          <property name="text">
@@ -68,8 +68,8 @@
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
-             <height>20</height>
+             <width>13</width>
+             <height>29</height>
             </size>
            </property>
           </spacer>
@@ -89,7 +89,7 @@
       <attribute name="title">
        <string>Constraints</string>
       </attribute>
-      <layout class="QVBoxLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
         <widget class="QLabel" name="label_3">
          <property name="text">
@@ -141,7 +141,7 @@
       <attribute name="title">
        <string>Indexes</string>
       </attribute>
-      <layout class="QVBoxLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <widget class="QLabel" name="label_2">
          <property name="text">
@@ -157,7 +157,7 @@
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout">
+        <layout class="QHBoxLayout" name="_3">
          <item>
           <widget class="QPushButton" name="btnAddIndex">
            <property name="text">
@@ -187,6 +187,57 @@
          </item>
          <item>
           <widget class="QPushButton" name="btnDeleteIndex">
+           <property name="text">
+            <string>Delete index</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tabComment">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <attribute name="title">
+       <string>Comment</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Comment defined for this table:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="viewComment"/>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="_4">
+         <item>
+          <widget class="QPushButton" name="btnAddComment">
+           <property name="text">
+            <string>Add index</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnDeleteComment">
            <property name="text">
             <string>Delete index</string>
            </property>

--- a/python/plugins/db_manager/ui/DlgTableProperties.ui
+++ b/python/plugins/db_manager/ui/DlgTableProperties.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabs">
      <property name="currentIndex">
-      <number>3</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabColumns">
       <attribute name="title">
@@ -219,7 +219,7 @@
          <item>
           <widget class="QPushButton" name="btnAddComment">
            <property name="text">
-            <string>Add index</string>
+            <string>Add comment</string>
            </property>
           </widget>
          </item>
@@ -239,7 +239,7 @@
          <item>
           <widget class="QPushButton" name="btnDeleteComment">
            <property name="text">
-            <string>Delete index</string>
+            <string>Delete comment</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
## Description
Add possibility to create a comment on a postgres table when import or using the alter table button from db_manager.

## Checklist
Adding an item during db_manager postgres import : 
- Checkbox to specify that we want to comment the table after we import it
- LineEdit to specify the comment once we specified that we wanted to

![import_with_comment](https://user-images.githubusercontent.com/10120833/50350072-234ef880-053e-11e9-99c2-e118b0aa23b7.png)

Adding a new tab on the Table properties window:
- Display comment on a line edit
- Modify the comment directly and confirm using the AddComment button
- Delete the comment using the Delete Comment (Adding a None comment has the same effect)

![add_comment](https://user-images.githubusercontent.com/10120833/50350153-71fc9280-053e-11e9-878c-67406ddbe17f.png)

