### PR TITLE
Optimize space on CRS selection tab

### DIFF
--- a/src/gui/qgsprojectionselectiontreewidget.cpp
+++ b/src/gui/qgsprojectionselectiontreewidget.cpp
@@ -277,7 +277,6 @@ void QgsProjectionSelectionTreeWidget::applySelection( int column, QString value
     lstCoordinateSystems->clearSelection();
     lstRecent->clearSelection();
     teProjection->clear();
-    teSelected->clear();
   }
 }
 
@@ -772,7 +771,6 @@ void QgsProjectionSelectionTreeWidget::lstCoordinateSystems_currentItemChanged( 
     // Found a real CRS
     emit crsSelected();
 
-    teSelected->setText( selectedName() );
     updateBoundsPreview();
 
     QList<QTreeWidgetItem *> nodes = lstRecent->findItems( current->text( QgisCrsIdColumn ), Qt::MatchExactly, QgisCrsIdColumn );
@@ -790,10 +788,9 @@ void QgsProjectionSelectionTreeWidget::lstCoordinateSystems_currentItemChanged( 
   }
   else
   {
-    // Not an CRS - remove the highlight so the user doesn't get too confused
+    // Not a CRS - remove the highlight so the user doesn't get too confused
     current->setSelected( false );
     teProjection->clear();
-    teSelected->clear();
     lstRecent->clearSelection();
   }
 }
@@ -872,7 +869,6 @@ void QgsProjectionSelectionTreeWidget::updateFilter()
           {
             ( *itr )->setSelected( false );
             teProjection->clear();
-            teSelected->clear();
           }
         }
         else if ( ( *itr )->text( NameColumn ).contains( re )
@@ -996,6 +992,7 @@ void QgsProjectionSelectionTreeWidget::updateBoundsPreview()
     return;
 
   QgsRectangle rect = currentCrs.bounds();
+  QString extentString = tr( "Extent not known" );
   if ( !qgsDoubleNear( rect.area(), 0.0 ) )
   {
     QgsGeometry geom;
@@ -1017,22 +1014,22 @@ void QgsProjectionSelectionTreeWidget::updateBoundsPreview()
     mAreaCanvas->setExtent( extent );
     mAreaCanvas->refresh();
     mPreviewBand->show();
-    QString extentString = tr( "Extent: %1, %2, %3, %4" )
-                           .arg( rect.xMinimum(), 0, 'f', 2 )
-                           .arg( rect.yMinimum(), 0, 'f', 2 )
-                           .arg( rect.xMaximum(), 0, 'f', 2 )
-                           .arg( rect.yMaximum(), 0, 'f', 2 );
-    QString proj4String = tr( "Proj4: %1" ).arg( selectedProj4String() );
-    teProjection->setText( extentString + "\n" + proj4String );
+    extentString = QStringLiteral( "%1, %2, %3, %4" )
+                   .arg( rect.xMinimum(), 0, 'f', 2 )
+                   .arg( rect.yMinimum(), 0, 'f', 2 )
+                   .arg( rect.xMaximum(), 0, 'f', 2 )
+                   .arg( rect.yMaximum(), 0, 'f', 2 );
+
   }
   else
   {
     mPreviewBand->hide();
     mAreaCanvas->zoomToFullExtent();
-    QString extentString = tr( "Extent: Extent not known" );
-    QString proj4String = tr( "Proj4: %1" ).arg( selectedProj4String() );
-    teProjection->setText( extentString + "\n" + proj4String );
   }
+
+  QString extentHtml = QStringLiteral( "<dt><b>%1</b></dt><dd>%2</dd>" ).arg( tr( "Extent" ), extentString );
+  QString proj4String = tr( "<dt><b>%1</b></dt><dd>%2</dd>" ).arg( tr( "Proj4" ), selectedProj4String() );
+  teProjection->setText( QStringLiteral( "<h3>%1</h3><dl>" ).arg( selectedName() ) + extentHtml + proj4String + QLatin1String( "</dl>" ) );
 }
 
 QStringList QgsProjectionSelectionTreeWidget::authorities()

--- a/src/ui/qgsdatumtransformtablewidgetbase.ui
+++ b/src/ui/qgsdatumtransformtablewidgetbase.ui
@@ -14,6 +14,18 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="0" column="1">
     <widget class="QToolButton" name="mAddButton">
      <property name="text">
@@ -66,6 +78,37 @@
   </layout>
  </widget>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -231,7 +231,7 @@
         <item>
          <widget class="QTextEdit" name="teProjection">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -240,12 +240,6 @@
            <size>
             <width>0</width>
             <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
            </size>
           </property>
           <property name="baseSize">
@@ -270,7 +264,7 @@
           <item>
            <widget class="QgsMapCanvas" name="mAreaCanvas" native="true">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -36,6 +36,16 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="mCheckBoxNoProjection">
+     <property name="toolTip">
+      <string>Use this option to treat all coordinates as Cartesian coordinates in an unknown reference system.</string>
+     </property>
+     <property name="text">
+      <string>No projection (or unknown/non-Earth projection)</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QFrame" name="mFrameProjections">
      <property name="frameShape">
@@ -57,168 +67,7 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item row="3" column="0">
-       <widget class="QSplitter" name="splitter">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="childrenCollapsible">
-         <bool>true</bool>
-        </property>
-        <widget class="QTreeWidget" name="lstRecent">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>105</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>200</height>
-          </size>
-         </property>
-         <property name="alternatingRowColors">
-          <bool>true</bool>
-         </property>
-         <property name="rootIsDecorated">
-          <bool>false</bool>
-         </property>
-         <property name="uniformRowHeights">
-          <bool>true</bool>
-         </property>
-         <property name="columnCount">
-          <number>3</number>
-         </property>
-         <column>
-          <property name="text">
-           <string>Coordinate Reference System</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Authority ID</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>ID</string>
-          </property>
-         </column>
-        </widget>
-        <widget class="QWidget" name="layoutWidget">
-         <layout class="QGridLayout" name="gridLayout">
-          <property name="horizontalSpacing">
-           <number>0</number>
-          </property>
-          <item row="0" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="label_4">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>Coordinate reference systems of the world</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="cbxHideDeprecated">
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Hide deprecated CRSs</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="1" column="0">
-           <widget class="QTreeWidget" name="lstCoordinateSystems">
-            <property name="alternatingRowColors">
-             <bool>true</bool>
-            </property>
-            <property name="uniformRowHeights">
-             <bool>true</bool>
-            </property>
-            <property name="columnCount">
-             <number>3</number>
-            </property>
-            <column>
-             <property name="text">
-              <string>Coordinate Reference System</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>Authority ID</string>
-             </property>
-            </column>
-            <column>
-             <property name="text">
-              <string>ID</string>
-             </property>
-            </column>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string>Selected CRS</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLineEdit" name="teSelected">
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-      </item>
-      <item row="1" column="0">
+      <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label_5">
@@ -232,7 +81,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_3">
         <property name="font">
          <font>
@@ -244,6 +93,135 @@
          <string>Recently used coordinate reference systems</string>
         </property>
        </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QTreeWidget" name="lstRecent">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>105</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>200</height>
+         </size>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <property name="uniformRowHeights">
+         <bool>true</bool>
+        </property>
+        <property name="columnCount">
+         <number>3</number>
+        </property>
+        <column>
+         <property name="text">
+          <string>Coordinate Reference System</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Authority ID</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>ID</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="horizontalSpacing">
+         <number>0</number>
+        </property>
+        <item row="1" column="0">
+         <widget class="QTreeWidget" name="lstCoordinateSystems">
+          <property name="alternatingRowColors">
+           <bool>true</bool>
+          </property>
+          <property name="uniformRowHeights">
+           <bool>true</bool>
+          </property>
+          <property name="columnCount">
+           <number>3</number>
+          </property>
+          <column>
+           <property name="text">
+            <string>Coordinate Reference System</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Authority ID</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>ID</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="label_4">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Coordinate reference systems of the world</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbxHideDeprecated">
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Hide deprecated CRSs</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </item>
       <item row="4" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -318,16 +296,6 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QCheckBox" name="mCheckBoxNoProjection">
-     <property name="toolTip">
-      <string>Use this option to treat all coordinates as Cartesian coordinates in an unknown reference system.</string>
-     </property>
-     <property name="text">
-      <string>No projection (or unknown/non-Earth projection)</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
@@ -349,7 +317,6 @@
   <tabstop>lstRecent</tabstop>
   <tabstop>cbxHideDeprecated</tabstop>
   <tabstop>lstCoordinateSystems</tabstop>
-  <tabstop>teSelected</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -236,7 +236,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>4</number>
+          <number>2</number>
          </property>
          <widget class="QWidget" name="mProjOptsGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -265,8 +265,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>563</width>
-                <height>833</height>
+                <width>680</width>
+                <height>883</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -863,8 +863,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>547</width>
-                <height>152</height>
+                <width>694</width>
+                <height>778</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -884,7 +884,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="mDatumTransformGroupBox">
+                <widget class="QgsCollapsibleGroupBox" name="mDatumTransformGroupBox">
                  <property name="title">
                   <string>Datum Transformations</string>
                  </property>
@@ -938,8 +938,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>271</width>
-                <height>597</height>
+                <width>291</width>
+                <height>615</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1514,8 +1514,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>157</width>
-                <height>59</height>
+                <width>159</width>
+                <height>49</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -1576,8 +1576,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>603</width>
-                <height>2666</height>
+                <width>632</width>
+                <height>2867</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2960,6 +2960,37 @@
   <tabstop>teOWSChecker</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
The CRS selector tab on the project properties is crowded to overloaded.

This patch removes spacing on the datum transformation widget and makes it collapsible.

# Before
![screenshot from 2018-12-22 16-01-39](https://user-images.githubusercontent.com/588407/50375778-3a0b5300-0603-11e9-880c-31dbc0bfd0da.png)

# After 

![screenshot from 2018-12-22 16-03-32](https://user-images.githubusercontent.com/588407/50375779-3c6dad00-0603-11e9-8a11-6b8bb7afb6ac.png)
