### PR TITLE
Use QGIS user manual for GDAL algorithms help files [Backport]

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalAlgorithm.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithm.py
@@ -142,16 +142,6 @@ class GdalAlgorithm(QgsProcessingAlgorithm):
 
         return results
 
-    def helpUrl(self):
-        helpPath = GdalUtils.gdalHelpPath()
-        if helpPath == '':
-            return None
-
-        if os.path.exists(helpPath):
-            return QUrl.fromLocalFile(os.path.join(helpPath, '{}.html'.format(self.commandName()))).toString()
-        else:
-            return helpPath + '{}.html'.format(self.commandName())
-
     def commandName(self):
         parameters = {}
         for param in self.parameterDefinitions():

--- a/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
+++ b/python/plugins/processing/algs/gdal/GdalAlgorithmProvider.py
@@ -103,18 +103,12 @@ class GdalAlgorithmProvider(QgsProcessingProvider):
         ProcessingConfig.settingIcons[self.name()] = self.icon()
         ProcessingConfig.addSetting(Setting(self.name(), 'ACTIVATE_GDAL',
                                             self.tr('Activate'), True))
-        ProcessingConfig.addSetting(Setting(
-            self.name(),
-            GdalUtils.GDAL_HELP_PATH,
-            self.tr('Location of GDAL docs'),
-            GdalUtils.gdalHelpPath()))
         ProcessingConfig.readSettings()
         self.refreshAlgorithms()
         return True
 
     def unload(self):
         ProcessingConfig.removeSetting('ACTIVATE_GDAL')
-        ProcessingConfig.removeSetting(GdalUtils.GDAL_HELP_PATH)
 
     def isActive(self):
         return ProcessingConfig.getSetting('ACTIVATE_GDAL')

--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -157,10 +157,10 @@ class GdalUtils:
                 if extensions:
                     GdalUtils.supportedRasters[shortName] = extensions
                     # Only creatable rasters can be referenced in output rasters
-                    if ((gdal.DCAP_CREATE in metadata
-                         and metadata[gdal.DCAP_CREATE] == 'YES')
-                        or (gdal.DCAP_CREATECOPY in metadata
-                            and metadata[gdal.DCAP_CREATECOPY] == 'YES')):
+                    if ((gdal.DCAP_CREATE in metadata and
+                         metadata[gdal.DCAP_CREATE] == 'YES') or
+                        (gdal.DCAP_CREATECOPY in metadata and
+                            metadata[gdal.DCAP_CREATECOPY] == 'YES')):
                         GdalUtils.supportedOutputRasters[shortName] = extensions
 
         return GdalUtils.supportedRasters
@@ -239,24 +239,6 @@ class GdalUtils:
     @staticmethod
     def readableVersion():
         return gdal.VersionInfo('RELEASE_NAME')
-
-    @staticmethod
-    def gdalHelpPath():
-        helpPath = ProcessingConfig.getSetting(GdalUtils.GDAL_HELP_PATH)
-
-        if helpPath is None:
-            if isWindows():
-                pass
-            elif isMac():
-                pass
-            else:
-                searchPaths = ['/usr/share/doc/libgdal-doc/gdal']
-                for path in searchPaths:
-                    if os.path.exists(path):
-                        helpPath = os.path.abspath(path)
-                        break
-
-        return helpPath if helpPath is not None else 'http://www.gdal.org/'
 
     @staticmethod
     def ogrConnectionStringFromLayer(layer):


### PR DESCRIPTION
because they are available for most of the algs and wouldn't be used otherwise. Also when someone hits algA help button, he should be given the algA help and not the main gdal utility doc.

(cherry picked from commit ea9b09f2dc8f2b11120c46a7b6534c252df6c206)