### PR TITLE
Enforce use of qt's fusion style for non-default themes

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1222,6 +1222,16 @@ int main( int argc, char *argv[] )
   // Set the application style.  If it's not set QT will use the platform style except on Windows
   // as it looks really ugly so we use QPlastiqueStyle.
   QString presetStyle = settings.value( QStringLiteral( "qgis/style" ) ).toString();
+#ifndef Q_OS_MACX
+  QString theme = settings.value( QStringLiteral( "UI/UITheme" ) ).toString();
+  if ( theme != QStringLiteral( "default" ) )
+  {
+    if ( QStyleFactory::keys().contains( QStringLiteral( "fusion" ), Qt::CaseInsensitive ) )
+    {
+      presetStyle = QStringLiteral( "fusion" );
+    }
+  }
+#endif
   QString activeStyleName = presetStyle;
   if ( activeStyleName.isEmpty() ) // not set, using default style
   {
@@ -1238,13 +1248,16 @@ int main( int argc, char *argv[] )
     //style choices can cause Qt apps to crash...
     if ( QStyleFactory::keys().contains( QStringLiteral( "fusion" ), Qt::CaseInsensitive ) )
     {
-      presetStyle = QStringLiteral( "fusion" );
+      activeStyleName = QStringLiteral( "fusion" );
     }
+  }
+  if ( activeStyleName != presetStyle )
+  {
+    settings.setValue( QStringLiteral( "qgis/style" ), QApplication::style()->objectName() );
   }
   if ( !presetStyle.isEmpty() )
   {
     QApplication::setStyle( presetStyle );
-    settings.setValue( QStringLiteral( "qgis/style" ), QApplication::style()->objectName() );
   }
 
   // set authentication database directory

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -135,7 +135,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   }
   if ( filteredStyles.isEmpty() )
   {
-    //oops - none left!.. have to let user use a broken style
+    // oops - none left!.. have to let user use a broken style
     filteredStyles = styles;
   }
 
@@ -144,11 +144,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   QStringList themes = QgsApplication::uiThemes().keys();
   cmbUITheme->addItems( themes );
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+  // non-default themes are best rendered using the Fusion style, therefore changing themes must require a restart to
   lblUITheme->setText( QStringLiteral( "%1 <i>(%2)</i>" ).arg( lblUITheme->text(), tr( "QGIS restart required" ) ) );
-#else
-  connect( cmbUITheme, static_cast<void ( QComboBox::* )( const QString & )>( &QComboBox::currentIndexChanged ), this, &QgsOptions::uiThemeChanged );
-#endif
 
   mIdentifyHighlightColorButton->setColorDialogTitle( tr( "Identify Highlight Color" ) );
   mIdentifyHighlightColorButton->setAllowOpacity( true );
@@ -566,7 +563,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   QString name = mSettings->value( QStringLiteral( "/qgis/style" ) ).toString();
   whileBlocking( cmbStyle )->setCurrentIndex( cmbStyle->findText( name, Qt::MatchFixedString ) );
 
-  QString theme = mSettings->value( QStringLiteral( "UI/UITheme" ), QStringLiteral( "auto" ) ).toString();
+  QString theme = mSettings->value( QStringLiteral( "UI/UITheme" ), QStringLiteral( "default" ) ).toString();
   whileBlocking( cmbUITheme )->setCurrentIndex( cmbUITheme->findText( theme, Qt::MatchFixedString ) );
 
   mNativeColorDialogsChkBx->setChecked( mSettings->value( QStringLiteral( "/qgis/native_color_dialogs" ), false ).toBool() );


### PR DESCRIPTION
## Description
UI themes (i.e. Qt's stylesheets) are best rendered using the fusion style. Other styles (Breeze, windows, etc.) all show artifacts when using custom stylesheets.

This PR enforces the fusion style when a user has set his/her theme to something other than default. That'll be a significant improvement for Windows users (whom by default are served the windows style).

@nyalldawson , ping.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
