### PR TITLE
Rely on app palette colors when painting in color swatch delegate

### DIFF
--- a/src/gui/qgscolorschemelist.cpp
+++ b/src/gui/qgscolorschemelist.cpp
@@ -687,11 +687,11 @@ void QgsColorSwatchDelegate::paint( QPainter *painter, const QStyleOptionViewIte
     painter->setPen( QPen( Qt::NoPen ) );
     if ( option.state & QStyle::State_Active )
     {
-      painter->setBrush( QBrush( QPalette().highlight() ) );
+      painter->setBrush( QBrush( option.widget->palette().highlight() ) );
     }
     else
     {
-      painter->setBrush( QBrush( QPalette().color( QPalette::Inactive,
+      painter->setBrush( QBrush( option.widget->palette().color( QPalette::Inactive,
                                  QPalette::Highlight ) ) );
     }
     painter->drawRect( option.rect );


### PR DESCRIPTION
## Description
Before:
![image](https://user-images.githubusercontent.com/1728657/50505919-c789ef80-0aa8-11e9-8da1-d212b58ac703.png)

PR:
![image](https://user-images.githubusercontent.com/1728657/50505925-cce73a00-0aa8-11e9-9b45-3dbe5f3a085d.png)



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
