### PR TITLE
Refer to layers panel instead of legend

### DIFF
--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -40,7 +40,7 @@ QgsVectorLayer *QgsMapToolSelectUtils::getCurrentVectorLayer( QgsMapCanvas *canv
   {
     QgisApp::instance()->messageBar()->pushMessage(
       QObject::tr( "No active vector layer" ),
-      QObject::tr( "To select features, choose a vector layer in the legend" ),
+      QObject::tr( "To select features, choose a vector layer in the layers panel" ),
       Qgis::Info,
       QgisApp::instance()->messageTimeout() );
   }


### PR DESCRIPTION
## Description

As recently noted by a user (https://twitter.com/aussiewongm/status/1078482052578590720) the term "legend" is inconsistent with the rest of the UI. 


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
