### PR TITLE
Add custom QStyle override to allow more flexibility with theming

### DIFF
--- a/python/gui/auto_generated/qgsproxystyle.sip.in
+++ b/python/gui/auto_generated/qgsproxystyle.sip.in
@@ -31,6 +31,7 @@ The base style for the QProxyStyle will be set to match the current QGIS applica
 %End
 };
 
+
 /************************************************************************
  * This file has been generated automatically from                      *
  *                                                                      *

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -99,6 +99,7 @@ typedef SInt32 SRefCon;
 #include "qgsziputils.h"
 #include "qgsversionmigration.h"
 #include "qgsfirstrundialog.h"
+#include "qgsproxystyle.h"
 
 #include "qgsuserprofilemanager.h"
 #include "qgsuserprofile.h"
@@ -1249,10 +1250,16 @@ int main( int argc, char *argv[] )
   }
   if ( !desiredStyle.isEmpty() )
   {
-    QApplication::setStyle( desiredStyle );
+    QApplication::setStyle( new QgsAppStyle( desiredStyle ) );
 
     if ( activeStyleName != desiredStyle )
       settings.setValue( QStringLiteral( "qgis/style" ), desiredStyle );
+  }
+  else
+  {
+    // even if user has not set a style, we need to override the application style with the QgsAppStyle proxy
+    // based on the default style (or we miss custom style tweaks)
+    QApplication::setStyle( new QgsAppStyle( activeStyleName ) );
   }
 
   // set authentication database directory

--- a/src/gui/qgsproxystyle.h
+++ b/src/gui/qgsproxystyle.h
@@ -41,4 +41,25 @@ class GUI_EXPORT QgsProxyStyle : public QProxyStyle
     explicit QgsProxyStyle( QWidget *parent SIP_TRANSFER );
 };
 
+///@cond PRIVATE
+#ifndef SIP_RUN
+
+/**
+ * Application style, applies custom style overrides for the QGIS application.
+ * \ingroup gui
+ */
+class GUI_EXPORT QgsAppStyle : public QProxyStyle
+{
+    Q_OBJECT
+
+  public:
+
+    explicit QgsAppStyle( const QString &base );
+    QPixmap generatedIconPixmap( QIcon::Mode iconMode, const QPixmap &pixmap, const QStyleOption *opt ) const override;
+
+};
+
+#endif
+///@endcond
+
 #endif // QGSPROXYSTYLE_H


### PR DESCRIPTION
Allows us to apply custom style overrides. Initially, this just
improves the appearance of disabled icons on dark themes.

The default Qt style method of displaying disabled icons only
works well on light backgrounds, on dark backgrounds it makes the
icons stand out due to the extreme contrast between the background
and the lightened icons.

Replace with a custom approach which desaturates icons and reduces
their opacity. This arguably also improves their appearance on
light themes too (I think so).


Some comparisons:


## Default theme

Before:
![image](https://user-images.githubusercontent.com/1829991/50537322-a65cf800-0ba9-11e9-8ea1-781348292aec.png)

After:
![image](https://user-images.githubusercontent.com/1829991/50537380-76fabb00-0baa-11e9-9559-4e825e0c9fbc.png)



## Blend of gray

Before:

![image](https://user-images.githubusercontent.com/1829991/50537336-ce4c5b80-0ba9-11e9-8ae6-d222d09c3196.png)

After:

![image](https://user-images.githubusercontent.com/1829991/50537369-4adf3a00-0baa-11e9-9edc-f9ed91bdd97c.png)


## Night mapping
Before:

![image](https://user-images.githubusercontent.com/1829991/50537340-e0c69500-0ba9-11e9-9183-5cef2def0ab2.png)


After:

![image](https://user-images.githubusercontent.com/1829991/50537362-326f1f80-0baa-11e9-8919-6205bfdcb059.png)
