### PR TITLE
[processing][needs-docs] Add cell size parameter to native interpolation algorithms (fix #18556, #20114)

### DIFF
--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -31,7 +31,6 @@ from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsRectangle,
                        QgsProcessingUtils,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterExtent,
                        QgsProcessingParameterRasterDestination,
@@ -41,46 +40,9 @@ from qgis.analysis import (QgsInterpolator,
                            QgsGridFileWriter)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
+from processing.algs.qgis.ui.InterpolationWidgets import ParameterInterpolationData
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
-
-
-class ParameterInterpolationData(QgsProcessingParameterDefinition):
-
-    def __init__(self, name='', description=''):
-        super().__init__(name, description)
-        self.setMetadata({
-            'widget_wrapper': 'processing.algs.qgis.ui.InterpolationDataWidget.InterpolationDataWidgetWrapper'
-        })
-
-    def type(self):
-        return 'idw_interpolation_data'
-
-    def clone(self):
-        return ParameterInterpolationData(self.name(), self.description())
-
-    @staticmethod
-    def parseValue(value):
-        if value is None:
-            return None
-
-        if value == '':
-            return None
-
-        if isinstance(value, str):
-            return value if value != '' else None
-        else:
-            return ParameterInterpolationData.dataToString(value)
-
-    @staticmethod
-    def dataToString(data):
-        s = ''
-        for c in data:
-            s += '{}::~::{}::~::{:d}::~::{:d};'.format(c[0],
-                                                       c[1],
-                                                       c[2],
-                                                       c[3])
-        return s[:-1]
 
 
 class IdwInterpolation(QgisAlgorithm):

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -31,7 +31,6 @@ from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsProcessingUtils,
                        QgsProcessing,
-                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterNumber,
                        QgsProcessingParameterExtent,
@@ -45,46 +44,9 @@ from qgis.analysis import (QgsInterpolator,
                            QgsGridFileWriter)
 
 from processing.algs.qgis.QgisAlgorithm import QgisAlgorithm
+from processing.algs.qgis.ui.InterpolationWidgets import ParameterInterpolationData
 
 pluginPath = os.path.split(os.path.split(os.path.dirname(__file__))[0])[0]
-
-
-class ParameterInterpolationData(QgsProcessingParameterDefinition):
-
-    def __init__(self, name='', description=''):
-        super().__init__(name, description)
-        self.setMetadata({
-            'widget_wrapper': 'processing.algs.qgis.ui.InterpolationDataWidget.InterpolationDataWidgetWrapper'
-        })
-
-    def type(self):
-        return 'tin_interpolation_data'
-
-    def clone(self):
-        return ParameterInterpolationData(self.name(), self.description())
-
-    @staticmethod
-    def parseValue(value):
-        if value is None:
-            return None
-
-        if value == '':
-            return None
-
-        if isinstance(value, str):
-            return value if value != '' else None
-        else:
-            return ParameterInterpolationData.dataToString(value)
-
-    @staticmethod
-    def dataToString(data):
-        s = ''
-        for c in data:
-            s += '{}::~:: {}::~:: {:d}::~:: {:d};'.format(c[0],
-                                                          c[1],
-                                                          c[2],
-                                                          c[3])
-        return s[:-1]
 
 
 class TinInterpolation(QgisAlgorithm):

--- a/python/plugins/processing/gui/ExtentSelectionPanel.py
+++ b/python/plugins/processing/gui/ExtentSelectionPanel.py
@@ -31,7 +31,7 @@ import warnings
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QMenu, QAction, QInputDialog
 from qgis.PyQt.QtGui import QCursor
-from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication, pyqtSignal
 
 from qgis.gui import QgsMessageBar
 from qgis.utils import iface
@@ -56,9 +56,13 @@ with warnings.catch_warnings():
 
 class ExtentSelectionPanel(BASE, WIDGET):
 
+    hasChanged = pyqtSignal()
+
     def __init__(self, dialog, param):
         super(ExtentSelectionPanel, self).__init__(None)
         self.setupUi(self)
+
+        self.leText.textChanged.connect(lambda: self.hasChanged.emit())
 
         self.dialog = dialog
         self.param = param

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -395,7 +395,9 @@ class ExtentWidgetWrapper(WidgetWrapper):
 
     def createWidget(self):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
-            return ExtentSelectionPanel(self.dialog, self.parameterDefinition())
+            widget = ExtentSelectionPanel(self.dialog, self.parameterDefinition())
+            widget.hasChanged.connect(lambda: self.widgetValueHasChanged.emit(self))
+            return widget
         else:
             widget = QComboBox()
             widget.setEditable(True)

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -1797,7 +1797,7 @@ tests:
       DISTANCE_COEFFICIENT: 2.0
       EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
       INTERPOLATION_DATA:
-        name: pointsz.gml::~::0::~::1::~::0
+        name: pointsz.gml::~::1::~::1::~::0
         type: interpolation
       PIXEL_SIZE: 0.026667
     results:
@@ -1840,6 +1840,80 @@ tests:
         hash:
           - 1e07ea5c90a16f87df812042d3e89dd5b1216defa7714921f306de94
           - 6d2da87e58dfe8fdfb3a1b66543bc68870f7e3292a9ca2674ea3a523
+        type: rasterhash
+      #TRIANULATION_FILE:
+      #  name: expected/triangulation.gml
+      #  type: vector
+
+  - algorithm: qgis:idwinterpolation
+    name: IDW interpolation using attribute (old parameters)
+    params:
+      COLUMNS: 300
+      DISTANCE_COEFFICIENT: 2.0
+      EXTENT: 0, 8, -5, 3
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::0::~::1::~::0
+        type: interpolation
+      ROWS: 300
+    results:
+      OUTPUT:
+        hash:
+        - 56d2671d50444f8571affba3f9e585830b82af5e380394178f521065
+        - 2ae62aca803e6864ac75e47b4357292b0637d811cb510ed19471f422
+        type: rasterhash
+
+  - algorithm: qgis:idwinterpolation
+    name: IDW interpolation using Z value (old parameters)
+    params:
+      COLUMNS: 300
+      DISTANCE_COEFFICIENT: 2.0
+      EXTENT: 0, 8, -5, 3
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::1::~::-1::~::0
+        type: interpolation
+      ROWS: 300
+    results:
+      OUTPUT:
+        hash:
+        - 56d2671d50444f8571affba3f9e585830b82af5e380394178f521065
+        - 2ae62aca803e6864ac75e47b4357292b0637d811cb510ed19471f422
+        type: rasterhash
+
+  - algorithm: qgis:tininterpolation
+    name: TIN interpolation using attribute (old parameters)
+    params:
+      COLUMNS: 300
+      EXTENT: 0, 8, -5, 3
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::0::~::1::~::0
+        type: interpolation
+      METHOD: '0'
+      ROWS: 300
+    results:
+      OUTPUT:
+        hash:
+        - 87f40be6ec08f3fcbb5707762de71f6be35bb265c61f594335562a26
+        - a31f0faf918ebe0902e5c9c5c8cf606d30f52eb4094bf24e4f8ac67a
+        type: rasterhash
+      #TRIANGULATION_FILE:
+      #  name: expected/triangulation.gml
+      #  type: vector
+
+  - algorithm: qgis:tininterpolation
+    name: TIN interpolation using Z value (old parameters)
+    params:
+      COLUMNS: 300
+      EXTENT: 0, 8, -5, 3
+      INTERPOLATION_DATA:
+        name: pointsz.gml::~::1::~::-1::~::0
+        type: interpolation
+      METHOD: '1'
+      ROWS: 300
+    results:
+      OUTPUT:
+        hash:
+        - 5e14dd0b879884b8b8da56c082947dad681feb4e9f1137f5cda126f8
+        - b8389559d6a85e7a672d72254228473fae71af2d89e5a5dd73d1b0d7
         type: rasterhash
       #TRIANULATION_FILE:
       #  name: expected/triangulation.gml

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -1778,52 +1778,49 @@ tests:
   - algorithm: qgis:idwinterpolation
     name: IDW interpolation using attribute
     params:
-      COLUMNS: 300
       DISTANCE_COEFFICIENT: 2.0
-      EXTENT: 0, 8, -5, 3
+      EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
       INTERPOLATION_DATA:
         name: pointsz.gml::~::0::~::1::~::0
         type: interpolation
-      ROWS: 300
+      PIXEL_SIZE: 0.026667
     results:
       OUTPUT:
         hash:
-        - 56d2671d50444f8571affba3f9e585830b82af5e380394178f521065
-        - 2ae62aca803e6864ac75e47b4357292b0637d811cb510ed19471f422
+        - 76d59e1a9905e97fde7da598022d50ec7de15994e61a59e2b6dc952f
+        - 6d2da87e58dfe8fdfb3a1b66543bc68870f7e3292a9ca2674ea3a523
         type: rasterhash
 
   - algorithm: qgis:idwinterpolation
     name: IDW interpolation using Z value
     params:
-      COLUMNS: 300
       DISTANCE_COEFFICIENT: 2.0
-      EXTENT: 0, 8, -5, 3
+      EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
       INTERPOLATION_DATA:
-        name: pointsz.gml::~::1::~::-1::~::0
+        name: pointsz.gml::~::0::~::1::~::0
         type: interpolation
-      ROWS: 300
+      PIXEL_SIZE: 0.026667
     results:
       OUTPUT:
         hash:
-        - 56d2671d50444f8571affba3f9e585830b82af5e380394178f521065
-        - 2ae62aca803e6864ac75e47b4357292b0637d811cb510ed19471f422
+        - 76d59e1a9905e97fde7da598022d50ec7de15994e61a59e2b6dc952f
+        - 6d2da87e58dfe8fdfb3a1b66543bc68870f7e3292a9ca2674ea3a523
         type: rasterhash
 
   - algorithm: qgis:tininterpolation
     name: TIN interpolation using attribute
     params:
-      COLUMNS: 300
-      EXTENT: 0, 8, -5, 3
+      EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
       INTERPOLATION_DATA:
         name: pointsz.gml::~::0::~::1::~::0
         type: interpolation
-      METHOD: '0'
-      ROWS: 300
+      METHOD: 0
+      PIXEL_SIZE: 0.026667
     results:
       OUTPUT:
         hash:
-        - 87f40be6ec08f3fcbb5707762de71f6be35bb265c61f594335562a26
-        - a31f0faf918ebe0902e5c9c5c8cf606d30f52eb4094bf24e4f8ac67a
+        - 1e07ea5c90a16f87df812042d3e89dd5b1216defa7714921f306de94
+        - 6e533a4c2c2e8ef5ca62814a7ad6dd29cb0f0f6eea85baf2a2802870
         type: rasterhash
       #TRIANGULATION_FILE:
       #  name: expected/triangulation.gml
@@ -1832,18 +1829,17 @@ tests:
   - algorithm: qgis:tininterpolation
     name: TIN interpolation using Z value
     params:
-      COLUMNS: 300
-      EXTENT: 0, 8, -5, 3
+      EXTENT: 0.0,8.0,-5.0,3.0 [EPSG:4326]
       INTERPOLATION_DATA:
         name: pointsz.gml::~::1::~::-1::~::0
         type: interpolation
-      METHOD: '1'
-      ROWS: 300
+      METHOD: 0
+      PIXEL_SIZE: 0.026667
     results:
       OUTPUT:
         hash:
-        - 5e14dd0b879884b8b8da56c082947dad681feb4e9f1137f5cda126f8
-        - b8389559d6a85e7a672d72254228473fae71af2d89e5a5dd73d1b0d7
+          - 1e07ea5c90a16f87df812042d3e89dd5b1216defa7714921f306de94
+          - 6d2da87e58dfe8fdfb3a1b66543bc68870f7e3292a9ca2674ea3a523
         type: rasterhash
       #TRIANULATION_FILE:
       #  name: expected/triangulation.gml


### PR DESCRIPTION
## Description
IDW and TIN interpolation algorithms in Processing does not allow to set output raster cell size, only number of columns/rows, this makes them almost not usable.

This PR fixes issue by using custom parameter and corresponding widget wrapper similar to pixel size parameter/wrapper in the Heatmap algorithm. While this changes algorithms parameters and can be considered as API break, IMHO this fix is quite important and makes both algorithms usable again.

Fixes https://issues.qgis.org/issues/18556 and https://issues.qgis.org/issues/20114

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
