### PR TITLE
Avoid Qt warnings thrown on SSL errors from background threads

### DIFF
--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -109,6 +109,30 @@ for the constructor of this class.
 Returns whether the system proxy should be used
 %End
 
+    static void pauseReplyTimeout( QNetworkReply *reply );
+%Docstring
+Pauses the timeout on a network ``reply``.
+
+This must be called from the same thread as ``reply`` was created from. Calling from a different
+thread will have no effect on the timeout.
+
+.. seealso:: :py:func:`restartReplyTimeout`
+
+.. versionadded:: 3.6
+%End
+
+    static void restartReplyTimeout( QNetworkReply *reply );
+%Docstring
+Restarts the timeout on a network ``reply``.
+
+This must be called from the same thread as ``reply`` was created from. Calling from a different
+thread will have no effect on the timeout.
+
+.. seealso:: :py:func:`pauseReplyTimeout`
+
+.. versionadded:: 3.6
+%End
+
   signals:
     void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * );
     void requestCreated( QNetworkReply * );
@@ -119,6 +143,44 @@ Returns whether the system proxy should be used
 
 
 };
+
+
+class QgsNetworkReplyTimeoutBlocker
+{
+%Docstring
+Temporarily blocks QNetworkReply timeouts for the lifetime of the object.
+
+On object destruction the reply timeout will be restarted.
+
+This must be created from the same thread as ``reply`` was created from. Creating from a different
+thread will have no effect on the timeout.
+
+.. versionadded:: 3.6
+%End
+
+%TypeHeaderCode
+#include "qgsnetworkaccessmanager.h"
+%End
+  public:
+
+    QgsNetworkReplyTimeoutBlocker( QNetworkReply *reply );
+%Docstring
+Constructor for QgsNetworkReplyTimeoutBlocker.
+
+This will block network reply timeouts for the specified ``reply`` for the lifetime of this object.
+
+This must be created from the same thread as ``reply`` was created from. Creating from a different
+thread will have no effect on the timeout.
+%End
+
+
+
+    ~QgsNetworkReplyTimeoutBlocker();
+
+  private:
+    QgsNetworkReplyTimeoutBlocker( const QgsNetworkReplyTimeoutBlocker &other );
+};
+
 
 
 /************************************************************************

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -394,3 +394,31 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
     setCache( newcache );
 }
 
+void QgsNetworkAccessManager::pauseReplyTimeout( QNetworkReply *reply )
+{
+  if ( reply->thread() != QThread::currentThread() )
+    return;
+
+  QTimer *timer = reply->findChild<QTimer *>( QStringLiteral( "timeoutTimer" ) );
+  if ( timer && timer->isActive() )
+  {
+    QgsDebugMsg( QStringLiteral( "Stopping network reply timeout" ) );
+    timer->stop();
+  }
+}
+
+void QgsNetworkAccessManager::restartReplyTimeout( QNetworkReply *reply )
+{
+  if ( reply->thread() != QThread::currentThread() )
+    return;
+
+  QgsSettings s;
+  QTimer *timer = reply->findChild<QTimer *>( QStringLiteral( "timeoutTimer" ) );
+  if ( timer )
+  {
+    QgsDebugMsg( QStringLiteral( "Restarting network reply timeout" ) );
+    timer->setSingleShot( true );
+    timer->start( s.value( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), "60000" ).toInt() );
+  }
+}
+


### PR DESCRIPTION
We shouldn't try to start/stop timers from a different thread
(the main thread) when the reply was created in a background
thread. Doing so has no effect, and throws Qt warnings.

HOWEVER

It seems there's many thread safety issues with the ssl error handling. Because if a reply is created in a background thread, it could easily timeout before the main thread is able to process the ssl error and be deleted in the background thread, whilst the main thread is still trying the handle the ssl error.

I'll ponder further on that....