### PR TITLE
[processing][needs-docs] expose resampling and format options in the gdaladdo (fix #20432)

### DIFF
--- a/python/plugins/processing/algs/gdal/gdaladdo.py
+++ b/python/plugins/processing/algs/gdal/gdaladdo.py
@@ -30,6 +30,7 @@ import os
 from qgis.PyQt.QtGui import QIcon
 
 from qgis.core import (QgsProcessingException,
+                       QgsProcessingParameterDefinition,
                        QgsProcessingParameterRasterLayer,
                        QgsProcessingParameterEnum,
                        QgsProcessingParameterString,
@@ -88,6 +89,9 @@ class gdaladdo(GdalAlgorithm):
                                                  options=self.formats,
                                                  allowMultiple=False,
                                                  defaultValue=0))
+        for p in params:
+            p.setFlags(p.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+            self.addParameter(p)
 
         self.addOutput(QgsProcessingOutputRasterLayer(self.OUTPUT, self.tr('Pyramidized')))
 

--- a/python/plugins/processing/algs/gdal/gdaladdo.py
+++ b/python/plugins/processing/algs/gdal/gdaladdo.py
@@ -83,12 +83,14 @@ class gdaladdo(GdalAlgorithm):
                                                  self.tr('Resampling method'),
                                                  options=[i[0] for i in self.methods],
                                                  allowMultiple=False,
-                                                 defaultValue=0))
+                                                 defaultValue=0,
+                                                 optional=True))
         params.append(QgsProcessingParameterEnum(self.FORMAT,
                                                  self.tr('Overviews format'),
                                                  options=self.formats,
                                                  allowMultiple=False,
-                                                 defaultValue=0))
+                                                 defaultValue=0,
+                                                 optional=True))
         for p in params:
             p.setFlags(p.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
             self.addParameter(p)

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -59,6 +59,8 @@ from processing.algs.gdal.translate import translate
 from processing.algs.gdal.warp import warp
 from processing.algs.gdal.fillnodata import fillnodata
 from processing.algs.gdal.rearrange_bands import rearrange_bands
+from processing.algs.gdal.gdaladdo import gdaladdo
+
 from processing.tools.system import isWindows
 
 from qgis.core import (QgsProcessingContext,
@@ -2368,6 +2370,75 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                  source + ' ' +
                  '-dialect sqlite -sql "SELECT ST_Line_Interpolate_Point(geometry, 0.2) AS geometry,* FROM \'polys2\'" ' +
                  '-f "ESRI Shapefile"'])
+
+    def testGdalAddo(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'dem.tif')
+
+        with tempfile.TemporaryDirectory() as outdir:
+            alg = gdaladdo()
+            alg.initAlgorithm()
+
+            # defaults
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'LEVELS': '2 4 8 16',
+                                        'CLEAN': False,
+                                        'RESAMPLING': 0,
+                                        'FORMAT': 0}, context, feedback),
+                ['gdaladdo',
+                 source + ' ' + '-r nearest 2 4 8 16'])
+
+            # with "clean" option
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'LEVELS': '2 4 8 16',
+                                        'CLEAN': True,
+                                        'RESAMPLING': 0,
+                                        'FORMAT': 0}, context, feedback),
+                ['gdaladdo',
+                 source + ' ' + '-r nearest -clean 2 4 8 16'])
+
+            # ovr format
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'LEVELS': '2 4 8 16',
+                                        'CLEAN': False,
+                                        'RESAMPLING': 0,
+                                        'FORMAT': 1}, context, feedback),
+                ['gdaladdo',
+                 source + ' ' + '-r nearest -ro 2 4 8 16'])
+
+            # Erdas format
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'LEVELS': '2 4 8 16',
+                                        'CLEAN': False,
+                                        'RESAMPLING': 0,
+                                        'FORMAT': 2}, context, feedback),
+                ['gdaladdo',
+                 source + ' ' + '-r nearest --config USE_RRD YES 2 4 8 16'])
+
+            # custom resampling method format
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'LEVELS': '2 4 8 16',
+                                        'CLEAN': False,
+                                        'RESAMPLING': 4,
+                                        'FORMAT': 0}, context, feedback),
+                ['gdaladdo',
+                 source + ' ' + '-r cubicspline 2 4 8 16'])
+
+            # more levels
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'LEVELS': '2 4 8 16 32 64',
+                                        'CLEAN': False,
+                                        'RESAMPLING': 0,
+                                        'FORMAT': 0}, context, feedback),
+                ['gdaladdo',
+                 source + ' ' + '-r nearest 2 4 8 16 32 64'])
 
 
 class TestGdalOgrToPostGis(unittest.TestCase):

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -2440,6 +2440,14 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                 ['gdaladdo',
                  source + ' ' + '-r nearest 2 4 8 16 32 64'])
 
+            # without advanced params
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'LEVELS': '2 4 8 16',
+                                        'CLEAN': False}, context, feedback),
+                ['gdaladdo',
+                 source + ' ' + '-r nearest 2 4 8 16'])
+
 
 class TestGdalOgrToPostGis(unittest.TestCase):
 


### PR DESCRIPTION
## Description
Options to choose overview format and resamplign method were not exposed in the UI and alorithm definition while present in the code. Fixes https://issues.qgis.org/issues/20432.

Unittest included.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
