### PR TITLE
Make Blend of Gray theme hidpi-compatible & one tiny fix

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -46,9 +46,9 @@ QMenuBar::item:pressed
 }
 
 QAbstractSpinBox {
-    padding: 3px 0px 3px 3px;
+    padding: 0.1em 0em 0.1em 0.1em;
     border: 1px solid #222;
-    border-radius:4px;
+    border-radius: 0.2em;
     background-color: @darkgradient;
     color:@itembackground;
 }
@@ -56,14 +56,20 @@ QAbstractSpinBox {
 QAbstractSpinBox::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right;
-    width: 16px;
+    padding-top:-0.2em;
+    padding-right:0.05em;
+    width: 0.8em;
+    height: 1.2em;
     image: url(@theme_path/icons/arrow-up.svg);
 }
 
 QAbstractSpinBox::down-button {
     subcontrol-origin: border;
     subcontrol-position: bottom right;
-    width: 16px;
+    padding-top:0.2em;
+    padding-right:0.05em;
+    width: 0.8em;
+    height: 1.2em;
     image: url(@theme_path/icons/arrow-down.svg);
 }
 
@@ -76,21 +82,21 @@ QMenu
 {
     background: #444;
     border: 1px solid #222;
-    padding: 4px;
-    padding-right: 0px;
+    padding: 0.2em;
+    padding-right: 0em;
 }
 
 QMenu::item
 {
     background: transparent;
-    padding: 5px 20px 5px 20px;
+    padding: 0.2em 1.3em 0.2em 1.3em;
 }
 
 QMenu::item:disabled
 {
     color: #555;
     background: transparent;
-    padding: 2px 20px 2px 20px;
+    padding: 0.2em 1.3em 0.2em 1.3em;
 }
 
 
@@ -108,45 +114,45 @@ QWidget:disabled
 
 QLineEdit, QTextEdit, QPlainTextEdit
 {
-    padding: 3px;
+    padding: 0.1em;
     border-width: 1px;
     border-color: @itemdarkbackground;
     border-style: solid;
-    border-radius: 4px;
+    border-radius: 0.2em;
     background-color:@itembackground;
     color:@text;
 }
 
 QPushButton 
 {
-    padding: 3px;
+    padding: 0.1em;
     border-width: 1px;
     border-color: @itemdarkbackground;
     border-style: solid;
-    border-radius: 4px;
+    border-radius: 0.2em;
     background-color:@itembackground;
     color:@text;
 }
 
 QToolButton
 {
-    padding: 2px;
+    padding: 0.1em;
     border-width: 1px;
     border-color: @itemdarkbackground;
     border-style: solid;
-    border-radius: 4px;
+    border-radius: 0.2em;
     background-color:@itembackground;
     color:@text;
 }
 QToolButton[popupMode="1"]
 {
-    padding-right: 18px;
+    padding-right: 0.9em;
 }
 QToolButton::menu-button {
-    width: 14px;
+    width: 0.8em;
     border-width: 1px;
     border-color: none;
-    border-radius: 4px;
+    border-radius: 0.2em;
     background:@itemdarkbackground;
 }
 QToolButton::hover, QToolButton::menu-button::hover
@@ -154,7 +160,7 @@ QToolButton::hover, QToolButton::menu-button::hover
     border-width: 1px;
     border-color: #1e1e1e;
     border-style: solid;
-    border-radius: 4px;
+    border-radius: 0.2em;
     background-color: none;
 }
 QToolButton:checked
@@ -164,6 +170,8 @@ QToolButton:checked
 QToolButton::menu-arrow 
 {
     image: url(@theme_path/icons/arrow-down.svg);
+    width: 0.8em;
+    height: 1.2em;
 }
 QToolBar QToolButton, QToolButton::menu-button
 {
@@ -180,9 +188,9 @@ QComboBox {
     background-color: @darkgradient;
     color:@itembackground;
     border-style: solid;
-    border: 1px solid #1e1e1e; 
-    border-radius:4px;
-    padding: 3px;
+    border: 1px solid #1e1e1e;
+    border-radius: 0.2em;
+    padding: 0.1em;
 }
 
 
@@ -191,8 +199,8 @@ QComboBox:hover,QPushButton:hover,QToolButton:hover,QAbstractSpinBox:hover {
 }
 
 QComboBox:on {
-    padding-top: 1px;
-    padding-left: 3px;
+    padding: 0.1em;
+    padding-left: 0.2em;
     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1,
         stop: 0     #555,
         stop: 0.1   #4C4C4C,
@@ -213,7 +221,7 @@ QComboBox:editable QLineEdit {
 QComboBox QAbstractItemView, QComboBox QListView {
     border: none;
     border-radius: 0;
-    padding: 3px;
+    padding: 0.1em;
     background: @itemdarkbackground;
     color: @itembackground;
     selection-background-color: @selection;
@@ -222,13 +230,15 @@ QComboBox QAbstractItemView, QComboBox QListView {
 QComboBox::drop-down {
      subcontrol-origin: padding;
      subcontrol-position: top right;
-     width: 15px;
+     width: 0.8em;
      border: 0px;
 }
 
 QComboBox::down-arrow
 {
     image: url(@theme_path/icons/arrow-down.svg);
+    width: 0.8em;
+    height: 1.2em;
 }
 
 
@@ -249,7 +259,7 @@ QTextEdit:focus
 
 QScrollBar:horizontal {
     background-color: #333;
-    height: 8px;
+    height: 0.5em;
     margin: 0px;
     padding: 0px;
 }
@@ -267,7 +277,7 @@ QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {
 
 QScrollBar:vertical {
     background-color: #333;
-    width: 8px;
+    width: 0.5em;
     margin: 0;
 }
 
@@ -285,14 +295,14 @@ QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {
 
 QSizeGrip
 {
-  width: 1px;
+    width: 0.1em;
 }
 
 QHeaderView::section
 {
     /*background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #616161, stop: 0.5 #505050, stop: 0.6 #434343, stop:1 #656565);*/
     color: @text;
-    padding-left: 4px;
+    padding-left: 0.5em;
     border: 1px solid #6c6c6c;
 }
 QDockWidget
@@ -308,9 +318,9 @@ QDockWidget::separator
 QDockWidget::title
 {
     text-align: center;
-    spacing: 3px; /* spacing between items in the tool bar */
+    spacing: 0.1em; /* spacing between items in the tool bar */
     background-color: @background;
-	font-weight: bold;
+    font-weight: bold;
 }
 
 QDockWidget::close-button, QDockWidget::float-button
@@ -333,9 +343,9 @@ QMainWindow::separator
 {
     /*background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #161616, stop: 0.5 #151515, stop: 0.6 #212121, stop:1 #343434);*/
     color: white;
-    padding-left: 4px;
+    padding-left: 0.2em;
     border: 0px solid #4c4c4c;
-    spacing: 3px; /* spacing between items in the tool bar */
+    spacing: 0.1em; /* spacing between items in the tool bar */
 }
 
 QMainWindow::separator:hover
@@ -343,9 +353,9 @@ QMainWindow::separator:hover
 
     /*background-color: QLinearGradient(x1:0, y1:0, x2:0, y2:1, stop:0 #d7801a, stop:0.5 #b56c17 stop:1 #ffa02f);*/
     color: white;
-    padding-left: 4px;
+    padding-left: 0.2em;
     border: 1px solid #6c6c6c;
-    spacing: 3px; /* spacing between items in the tool bar */
+    spacing: 0.1em; /* spacing between items in the tool bar */
 }
 
 QToolBar {
@@ -356,21 +366,29 @@ QToolBar {
 QToolBar::handle:horizontal
 {
     image: url(@theme_path/icons/handle-horizontal.svg);
+    width: 0.2em;
+    height: 0.5em;
 }
 
 QToolBar::handle:vertical
 {
     image: url(@theme_path/icons/handle-vertical.svg);
+    width: 0.5em;
+    height: 0.2em;
 }
 
 QToolBar::separator:horizontal
 {
     image: url(@theme_path/icons/separator-horizontal.svg);
+    width: 0.2em;
+    height: 0.5em;
 }
 
 QToolBar::separator:vertical
 {
     image: url(@theme_path/icons/separator-vertical.svg);
+    width: 0.5em;
+    height: 0.2em;
 }
 
 QMenu::separator
@@ -401,11 +419,11 @@ QTabBar::tab {
     border: 1px solid @itemdarkbackground;
     border-bottom: none;
     background-color: @background;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-top: 3px;
-    padding-bottom: 2px;
-    margin-right: -1px;
+    padding-left: 0.8em;
+    padding-right: 0.8em;
+    padding-top: 0.1em;
+    padding-bottom: 0.1em;
+    margin-right: -0.05em;
 }
 
 QTabBar::tab:last
@@ -415,7 +433,7 @@ QTabBar::tab:last
 
 QTabBar::tab:first:!selected
 {
-  margin-left: 0px; /* the last selected tab has nothing to overlap with on the right */
+    margin-left: 0px; /* the last selected tab has nothing to overlap with on the right */
 }
 
 QTabBar::tab:bottom {
@@ -425,7 +443,7 @@ QTabBar::tab:bottom {
 
 QTabBar::tab:!selected
 {
-    margin-top: 5px;
+    margin-top: 0.3em;
 }
 
 QTabBar::tab:selected
@@ -458,11 +476,15 @@ QGroupBox::title {
 QGroupBox::indicator:unchecked {
     border: 1px solid @background;
     image: url(@theme_path/icons/qcheckbox-unchecked.svg);
+    width:0.8em;
+    height:0.8em;
 }
 
 QGroupBox::indicator:checked {
     border: 1px solid @background;
     image: url(@theme_path/icons/qcheckbox-checked.svg);
+    width:0.8em;
+    height:0.8em;
 }
 
 /* ==================================================================================== */
@@ -472,11 +494,15 @@ QGroupBox::indicator:checked {
 QRadioButton::indicator:unchecked {
     border: 1px solid @background;
     image: url(@theme_path/icons/qradiobox-unchecked.svg);
+    width:0.8em;
+    height:0.8em;
 }
 
 QRadioButton::indicator:checked {
     border: 1px solid @background;
     image: url(@theme_path/icons/qradiobox-checked.svg);
+    width:0.8em;
+    height:0.8em;
 }
 
 /* ==================================================================================== */
@@ -486,11 +512,15 @@ QRadioButton::indicator:checked {
 QCheckBox::indicator:unchecked {
     border: 1px solid @background;
     image: url(@theme_path/icons/qcheckbox-unchecked.svg);
+    width:0.8em;
+    height:0.8em;
 }
 
 QCheckBox::indicator:checked {
     border: 1px solid @background;
     image: url(@theme_path/icons/qcheckbox-checked.svg);
+    width:0.8em;
+    height:0.8em;
 }
 
 /* ==================================================================================== */
@@ -500,7 +530,7 @@ QCheckBox::indicator:checked {
 QSlider::groove:horizontal,
 QSlider::groove:vertical  {
     border: 1px solid @itemdarkbackground;
-    height: 8px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
+    height: 0.4em; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */
     background-color: @itembackground;
     margin: 2px 0;
 }
@@ -508,16 +538,16 @@ QSlider::groove:vertical  {
 QSlider::handle:horizontal {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
     border: 1px solid itemdarkbackground;
-    width: 18px;
+    width: 1em;
     margin: -2px 0; /* handle is placed by default on the contents rect of the groove. Expand outside the groove */
-    border-radius: 3px;
+    border-radius: 0.15em;
 }
 QSlider::handle:vertical {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
     border: 1px solid itemdarkbackground;
-    height: 18px;
+    height: 1em;
     margin: -2px 0; /* handle is placed by default on the contents rect of the groove. Expand outside the groove */
-    border-radius: 3px;
+    border-radius: 0.15em;
 }
 
 /* ==================================================================================== */
@@ -530,7 +560,7 @@ QAbstractItemView, QListView
   alternate-background-color: @itemalternativebackground;
   color: @text;
   border: none;
-  border-radius: 3px;
+  border-radius: 0.15em;
   padding: 1px;
   selection-color: @text;
   selection-background-color: @selection;
@@ -583,7 +613,7 @@ QTreeView#viewGraduated::item,
 QTreeView#viewCategories::item,
 QTreeView#viewRules::item
 {
-    padding: 1px 0px 1px 0px;
+    padding: 0.1em 0em 0.1em 0em;
 }
 
 QgsLayerTreeView::indicator:unchecked,
@@ -615,7 +645,7 @@ QHeaderView::section {
     background-color: @background;
     color: @text;
     border-right: 1px solid @itemdarkbackground;
-    padding: 0 0 2px 3px
+    padding: 0 0 0.1em 0.2em;
 }
 
 /* ==================================================================================== */
@@ -642,5 +672,5 @@ QListWidget#mOptionsListWidget {
 }
 
 QListWidget#mOptionsListWidget::item {
-    padding: 3px;
+    padding: 0.1em;
 }

--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -190,7 +190,7 @@ QComboBox {
     border-style: solid;
     border: 1px solid #1e1e1e;
     border-radius: 0.2em;
-    padding: 0.1em;
+    padding: 0.1em 1em 0.1em 0.1em;
 }
 
 
@@ -241,6 +241,18 @@ QComboBox::down-arrow
     height: 1.2em;
 }
 
+QComboBox:item {
+    padding-left: 1.5em;
+    height:1.2em;
+}
+QComboBox:item:selected {
+    padding-left: 1.5em;
+    height:1.2em;
+}
+QComboBox:item:checked {
+    padding-left: 1.5em;
+    height:1.2em;
+}
 
 QLineEdit:focus
 {

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -198,7 +198,7 @@ QComboBox {
     border-style: solid;
     border: 1px solid #1e1e1e; 
     border-radius: 0px;
-    padding: 0.1em;
+    padding: 0.1em 1em 0.1em 0.1em;
 }
 
 
@@ -250,6 +250,18 @@ QComboBox::down-arrow
     height: 1.2em;
 }
 
+QComboBox:item {
+    padding-left: 1.5em;
+    height:1.2em;
+}
+QComboBox:item:selected {
+    padding-left: 1.5em;
+    height:1.2em;
+}
+QComboBox:item:checked {
+    padding-left: 1.5em;
+    height:1.2em;
+}
 
 QLineEdit:focus
 {

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -141,6 +141,18 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
                     "    background-color:palette(Window);"
                     "    padding-right: 0px;"
                     "}";
+
+    QString toolbarSpacing = opts.value( QStringLiteral( "toolbarSpacing" ), QString() ).toString();
+    if ( !toolbarSpacing.isEmpty() )
+    {
+      bool ok = false;
+      int toolbarSpacingInt = toolbarSpacing.toInt( &ok );
+      if ( ok )
+      {
+        style += QStringLiteral( "QToolBar > QToolButton { padding: %1px; } " ).arg( toolbarSpacingInt );
+      }
+    }
+
     ss += style;
   }
 
@@ -153,17 +165,6 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant> &opts )
                  "}" )
         .arg( palette.highlight().color().name(),
               palette.highlightedText().color().name() );
-
-  QString toolbarSpacing = opts.value( QStringLiteral( "toolbarSpacing" ), QString() ).toString();
-  if ( !toolbarSpacing.isEmpty() )
-  {
-    bool ok = false;
-    int toolbarSpacingInt = toolbarSpacing.toInt( &ok );
-    if ( ok )
-    {
-      ss += QStringLiteral( "QToolBar > QToolButton { padding: %1px; } " ).arg( toolbarSpacingInt );
-    }
-  }
 
   QgsDebugMsg( QStringLiteral( "Stylesheet built: %1" ).arg( ss ) );
 


### PR DESCRIPTION
## Description
This empties my to-do list for theme improvements. We got ourselves a new gray theme, and we're now hidpi friendly.

@nyalldawson , as discussed yesterday, I'm moving the toolbar button spacing bit to only be applied for default themes, as it otherwise messes up qss-styled toolbar buttons.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
