### PR TITLE
[processing] cover more GDAL algorithms with unittests

### DIFF
--- a/python/plugins/processing/algs/gdal/polygonize.py
+++ b/python/plugins/processing/algs/gdal/polygonize.py
@@ -111,7 +111,9 @@ class polygonize(GdalAlgorithm):
         if outFormat:
             arguments.append('-f {}'.format(outFormat))
 
-        arguments.append(GdalUtils.ogrLayerName(output))
+        layerName = GdalUtils.ogrLayerName(output)
+        if layerName:
+            arguments.append(layerName)
         arguments.append(self.parameterAsString(parameters, self.FIELD, context))
 
         commands = []

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -61,6 +61,7 @@ from processing.algs.gdal.fillnodata import fillnodata
 from processing.algs.gdal.rearrange_bands import rearrange_bands
 from processing.algs.gdal.gdaladdo import gdaladdo
 from processing.algs.gdal.sieve import sieve
+from processing.algs.gdal.gdal2xyz import gdal2xyz
 
 from processing.tools.system import isWindows
 
@@ -2511,6 +2512,38 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                  '-st 10 -4 -mask ' +
                  mask +
                  ' -of GTiff ' +
+                 source + ' ' +
+                 outsource])
+
+    def testGdal2Xyz(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'dem.tif')
+
+        with tempfile.TemporaryDirectory() as outdir:
+            outsource = outdir + '/check.csv'
+            alg = gdal2xyz()
+            alg.initAlgorithm()
+
+            # defaults
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'BAND': 1,
+                                        'CSV': False,
+                                        'OUTPUT': outsource}, context, feedback),
+                ['gdal2xyz.py',
+                 '-band 1 ' +
+                 source + ' ' +
+                 outsource])
+
+            # csv output
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'BAND': 1,
+                                        'CSV': True,
+                                        'OUTPUT': outsource}, context, feedback),
+                ['gdal2xyz.py',
+                 '-band 1 -csv ' +
                  source + ' ' +
                  outsource])
 

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -62,6 +62,7 @@ from processing.algs.gdal.rearrange_bands import rearrange_bands
 from processing.algs.gdal.gdaladdo import gdaladdo
 from processing.algs.gdal.sieve import sieve
 from processing.algs.gdal.gdal2xyz import gdal2xyz
+from processing.algs.gdal.polygonize import polygonize
 
 from processing.tools.system import isWindows
 
@@ -2546,6 +2547,56 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                  '-band 1 -csv ' +
                  source + ' ' +
                  outsource])
+
+    def testGdalPolygonize(self):
+        context = QgsProcessingContext()
+        feedback = QgsProcessingFeedback()
+        source = os.path.join(testDataPath, 'dem.tif')
+
+        with tempfile.TemporaryDirectory() as outdir:
+            outsource = outdir + '/check.shp'
+            alg = polygonize()
+            alg.initAlgorithm()
+
+            # defaults
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'BAND': 1,
+                                        'FIELD': 'DN',
+                                        'EIGHT_CONNECTEDNESS': False,
+                                        'OUTPUT': outsource}, context, feedback),
+                ['gdal_polygonize.py',
+                 source + ' ' +
+                 outsource + ' ' +
+                 '-b 1 -f "ESRI Shapefile" DN'
+                 ])
+
+            # 8 connectedness
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'BAND': 1,
+                                        'FIELD': 'DN',
+                                        'EIGHT_CONNECTEDNESS': True,
+                                        'OUTPUT': outsource}, context, feedback),
+                ['gdal_polygonize.py',
+                 source + ' ' +
+                 outsource + ' ' +
+                 '-8 -b 1 -f "ESRI Shapefile" DN'
+                 ])
+
+            # custom output format
+            outsource = outdir + '/check.gpkg'
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'BAND': 1,
+                                        'FIELD': 'DN',
+                                        'EIGHT_CONNECTEDNESS': False,
+                                        'OUTPUT': outsource}, context, feedback),
+                ['gdal_polygonize.py',
+                 source + ' ' +
+                 outsource + ' ' +
+                 '-b 1 -f "GPKG" DN'
+                 ])
 
 
 class TestGdalOgrToPostGis(unittest.TestCase):

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -335,41 +335,6 @@ tests:
         hash: fff4a08498e93494f3f2cf1a9074451e6fd68341849aedc9e2c45e6a
         type: rasterhash
 
-# Disabled as gdal_poligonize.py is not available on Travis
-#  - algorithm: gdal:polygonize
-#    name: Polygonize
-#    params:
-#      BAND: 1
-#      EIGHT_CONNECTEDNESS: false
-#      FIELD: DN
-#      INPUT:
-#        name: dem.tif
-#        type: raster
-#    results:
-#      OUTPUT:
-#        name: expected/gdal/polygonize.gml
-#        type: vector
-
-# Disabled as gdal_proximity.py is not available on Travis
-#  - algorithm: gdal:proximity
-#    name: Proximity
-#    params:
-#      BAND: 1
-#      DATA_TYPE: 5
-#      INPUT:
-#        name: dem.tif
-#        type: raster
-#      MAX_DISTANCE: 0.0
-#      NODATA: 0.0
-#      OPTIONS: ''
-#      REPLACE: 0.0
-#      UNITS: 1
-#      VALUES: '90'
-#    results:
-#      OUTPUT:
-#        hash: 32802271d1ce083ca14078bfefaef6300ae8809af11f6a4270583d0c
-#        type: rasterhash
-
   - algorithm: gdal:rasterize
     name: Test (gdal:rasterize)
     params:

--- a/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/gdal_algorithm_tests.yaml
@@ -168,20 +168,6 @@ tests:
           - 'Band 1 Block=373x5 Type=Float32, ColorInterp=Gray'
           - '  NoData Value=-99999'
 
-# Disabled as gdal2xyz.py is not available on Travis
-#  - algorithm: gdal:gdal2xyz
-#    name: gdal2xyz
-#    params:
-#      BAND: 1
-#      CSV: false
-#      INPUT:
-#        name: dem.tif
-#        type: raster
-#    results:
-#      OUTPUT:
-#        name: expected/gdal/xyz.csv
-#        type: file
-
   - algorithm: gdal:tileindex
     name: Tile index (gdaltindex)
     params:


### PR DESCRIPTION
## Description
Protect gdal2xyz and gdal_polygonize algorithms with unittests

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
