### PR TITLE
Implementing Andy Gio's mssql Fix

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -872,7 +872,15 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList &flist, Flags flags )
 
     QString statement;
     QString values;
-    statement = QStringLiteral( "INSERT INTO [%1].[%2] (" ).arg( mSchemaName, mTableName );
+    if ( !( flags & QgsFeatureSink::FastInsert ) )
+    {
+      statement += QStringLiteral( "DECLARE @px TABLE (id INT); " );
+      statement += QStringLiteral( "INSERT INTO [%1].[%2] (" ).arg( mSchemaName, mTableName );
+    }
+    else
+    {
+      statement += QStringLiteral( "INSERT INTO [%1].[%2] (" ).arg( mSchemaName, mTableName );
+    }
 
     bool first = true;
     QSqlQuery query = createQuery();
@@ -947,10 +955,14 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     statement += QStringLiteral( ") " );
     if ( !( flags & QgsFeatureSink::FastInsert ) )
     {
-      statement += QStringLiteral( " OUTPUT inserted." ) + mFidColName;
+      statement += QStringLiteral( " OUTPUT inserted." ) + mFidColName + QStringLiteral( "  INTO @px " );
     }
     statement += QStringLiteral( " VALUES (" ) + values + ')';
 
+    if ( !( flags & QgsFeatureSink::FastInsert ) )
+    {
+      statement += QStringLiteral( "; SELECT id FROM @px;" );
+    }
     // use prepared statement to prevent from sql injection
     if ( !query.prepare( statement ) )
     {

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -955,7 +955,7 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList &flist, Flags flags )
     statement += QStringLiteral( ") " );
     if ( !( flags & QgsFeatureSink::FastInsert ) )
     {
-      statement += QStringLiteral( " OUTPUT inserted." ) + mFidColName + QStringLiteral( "  INTO @px " );
+      statement += QStringLiteral( " OUTPUT inserted." ) + mFidColName + QStringLiteral( " INTO @px " );
     }
     statement += QStringLiteral( " VALUES (" ) + values + ')';
 


### PR DESCRIPTION
Implementing the suggested fix by Andy Gio in https://issues.qgis.org/issues/20592

Description
This fix should allow the use of triggers on INSERT in MSSQL while maintaining the current behaviour.

To do so a temporary table is created in order to return the ID of the modified features instead of directly using OUTPUT to do so.

This fix has not been tested in my fork.
The prepare commit script has not been run since this is a minor change.

All credit should go to Mr. Andy Gio for this code that was provided in : https://issues.qgis.org/issues/20592.

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
