### PR TITLE
Adding QgsRenderContext support to QgsLegendRenderer

### DIFF
--- a/python/core/auto_generated/qgslegendrenderer.sip.in
+++ b/python/core/auto_generated/qgslegendrenderer.sip.in
@@ -59,7 +59,16 @@ Draw the legend with given painter. It will occupy the area reported in legendSi
 %End
 
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );
+%Docstring
+Set the style of a QgsLayerTreeNode,
+This class requires a node and a style to apply to the node
+%End
+
     static QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node, QgsLayerTreeModel *model );
+%Docstring
+Returns the style of a given QgsLayerTreeNode in a given QgsLayerTreeModel
+%End
+
 
 };
 

--- a/python/core/auto_generated/qgslegendrenderer.sip.in
+++ b/python/core/auto_generated/qgslegendrenderer.sip.in
@@ -71,9 +71,11 @@ Draws the legend with given ``painter``. The legend will occupy the area reporte
 The ``painter`` should be scaled beforehand so that units correspond to millimeters.
 %End
 
-    void drawLegend( QgsRenderContext *rendercontext );
+    void drawLegend( QgsRenderContext &context );
 %Docstring
-Draws the legend using a given :py:class:`QgsRenderContext`. The legend will occupy the area reported in legendSize().
+Draws the legend using a given render ``context``. The legend will occupy the area reported in legendSize().
+
+.. versionadded:: 3.6
 %End
 
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );

--- a/python/core/auto_generated/qgslegendrenderer.sip.in
+++ b/python/core/auto_generated/qgslegendrenderer.sip.in
@@ -53,9 +53,9 @@ Draw the legend with given painter. It will occupy the area reported in legendSi
 Painter should be scaled beforehand so that units correspond to millimeters.
 %End
 
-    void drawLegend( QgsRenderContext *rendercontext);
+    void drawLegend( QgsRenderContext *rendercontext );
 %Docstring
-Draw the legend with given painter. It will occupy the area reported in legendSize().
+Draw the legend using a given :py:class:`QgsRenderContext`. It willoccupy the area reported in legendSize().
 %End
 
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );
@@ -66,9 +66,8 @@ This class requires a node and a style to apply to the node
 
     static QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node, QgsLayerTreeModel *model );
 %Docstring
-Returns the style of a given QgsLayerTreeNode in a given QgsLayerTreeModel
+Returns the style of a given QgsLayerTreeNode in a given :py:class:`QgsLayerTreeModel`
 %End
-
 
 };
 

--- a/python/core/auto_generated/qgslegendrenderer.sip.in
+++ b/python/core/auto_generated/qgslegendrenderer.sip.in
@@ -55,7 +55,7 @@ Painter should be scaled beforehand so that units correspond to millimeters.
 
     void drawLegend( QgsRenderContext *rendercontext );
 %Docstring
-Draw the legend using a given :py:class:`QgsRenderContext`. It willoccupy the area reported in legendSize().
+Draw the legend using a given :py:class:`QgsRenderContext`. It will occupy the area reported in legendSize().
 %End
 
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );

--- a/python/core/auto_generated/qgslegendrenderer.sip.in
+++ b/python/core/auto_generated/qgslegendrenderer.sip.in
@@ -53,6 +53,10 @@ Draw the legend with given painter. It will occupy the area reported in legendSi
 Painter should be scaled beforehand so that units correspond to millimeters.
 %End
 
+    void drawLegend( QgsRenderContext *rendercontext);
+%Docstring
+Draw the legend with given painter. It will occupy the area reported in legendSize().
+%End
 
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );
     static QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node, QgsLayerTreeModel *model );

--- a/python/core/auto_generated/qgslegendrenderer.sip.in
+++ b/python/core/auto_generated/qgslegendrenderer.sip.in
@@ -27,46 +27,67 @@ All spacing and sizes are in millimeters.
 #include "qgslegendrenderer.h"
 %End
   public:
+
     QgsLegendRenderer( QgsLayerTreeModel *legendModel, const QgsLegendSettings &settings );
 %Docstring
-Construct legend renderer. The ownership of legend model does not change
+Constructor for QgsLegendRenderer. The ownership of the legend model is not changed,
+and the model must exist for the lifetime of this renderer.
 %End
 
     QSizeF minimumSize();
 %Docstring
-Run the layout algorithm and determine the size required for legend
+Runs the layout algorithm and returns the minimum size required for the legend.
+
+.. seealso:: :py:func:`setLegendSize`
+
+.. seealso:: :py:func:`legendSize`
 %End
 
     void setLegendSize( QSizeF s );
 %Docstring
 Sets the preferred resulting legend size.
+
+If the size is null, the legend will be drawn with the minimum possible size to fit its content.
+
+.. seealso:: :py:func:`legendSize`
+
+.. seealso:: :py:func:`minimumSize`
 %End
 
     QSizeF legendSize() const;
 %Docstring
-Find out preferred legend size set by the client. If null, the legend will be drawn with the minimum size
+Returns the preferred legend size set by the client.
+
+If the returned size is null, the legend will be drawn with the minimum possible size to fit its content.
+
+.. seealso:: :py:func:`minimumSize`
+
+.. seealso:: :py:func:`setLegendSize`
 %End
 
     void drawLegend( QPainter *painter );
 %Docstring
-Draw the legend with given painter. It will occupy the area reported in legendSize().
-Painter should be scaled beforehand so that units correspond to millimeters.
+Draws the legend with given ``painter``. The legend will occupy the area reported in legendSize().
+The ``painter`` should be scaled beforehand so that units correspond to millimeters.
 %End
 
     void drawLegend( QgsRenderContext *rendercontext );
 %Docstring
-Draw the legend using a given :py:class:`QgsRenderContext`. It will occupy the area reported in legendSize().
+Draws the legend using a given :py:class:`QgsRenderContext`. The legend will occupy the area reported in legendSize().
 %End
 
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );
 %Docstring
-Set the style of a QgsLayerTreeNode,
-This class requires a node and a style to apply to the node
+Sets the ``style`` of a ``node``.
+
+.. seealso:: :py:func:`nodeLegendStyle`
 %End
 
     static QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node, QgsLayerTreeModel *model );
 %Docstring
-Returns the style of a given QgsLayerTreeNode in a given :py:class:`QgsLayerTreeModel`
+Returns the style for the given ``node``, within the specified ``model``.
+
+.. seealso:: :py:func:`setNodeLegendStyle`
 %End
 
 };

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -830,12 +830,12 @@ QSizeF QgsLegendRenderer::drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QgsRende
 }
 
 
-void QgsLegendRenderer::drawLegend( QgsRenderContext *rendercontext )
+void QgsLegendRenderer::drawLegend( QgsRenderContext &context )
 {
-  paintAndDetermineSize( rendercontext );
+  paintAndDetermineSize( &context );
 }
 
-QSizeF QgsLegendRenderer::paintAndDetermineSize( QgsRenderContext *rendercontext )
+QSizeF QgsLegendRenderer::paintAndDetermineSize( QgsRenderContext *context )
 {
   QSizeF size( 0, 0 );
   QgsLayerTreeGroup *rootGroup = mLegendModel->rootGroup();
@@ -888,7 +888,7 @@ QSizeF QgsLegendRenderer::paintAndDetermineSize( QgsRenderContext *rendercontext
       point.ry() += spaceAboveAtom( atom );
     }
 
-    QSizeF atomSize = drawAtom( atom, rendercontext, point );
+    QSizeF atomSize = drawAtom( atom, context, point );
     columnWidth = std::max( atomSize.width(), columnWidth );
 
     point.ry() += atom.size.height();
@@ -929,7 +929,7 @@ QSizeF QgsLegendRenderer::paintAndDetermineSize( QgsRenderContext *rendercontext
       point.rx() = size.width() - mSettings.boxSpace();
     }
     point.ry() = mSettings.boxSpace();
-    drawTitle( rendercontext, point, mSettings.titleAlignment(), size.width() );
+    drawTitle( context, point, mSettings.titleAlignment(), size.width() );
   }
 
   return size;

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -630,11 +630,6 @@ void QgsLegendRenderer::setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendSty
     node->removeCustomProperty( QStringLiteral( "legend/title-style" ) );
 }
 
-void QgsLegendRenderer::drawLegend( QPainter *painter )
-{
-  paintAndDetermineSize( painter );
-}
-
 
 //new version of classes using QgsRenderContext
 QSizeF QgsLegendRenderer::drawTitle( QgsRenderContext *rendercontext, QPointF point, Qt::AlignmentFlag halignment, double legendWidth )

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -471,10 +471,10 @@ double QgsLegendRenderer::spaceAboveAtom( const Atom &atom )
 // Draw atom and expand its size (using actual nucleons labelXOffset)
 QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QPainter *painter, QPointF point )
 {
-  return drawAtomInteral( atom, nullptr, painter, point );
+  return drawAtomInternal( atom, nullptr, painter, point );
 }
 
-QSizeF QgsLegendRenderer::drawAtomInteral( const Atom &atom, QgsRenderContext *context, QPainter *painter, QPointF point )
+QSizeF QgsLegendRenderer::drawAtomInternal( const Atom &atom, QgsRenderContext *context, QPainter *painter, QPointF point )
 {
   bool first = true;
   QSizeF size = QSizeF( atom.size );
@@ -693,7 +693,7 @@ QSizeF QgsLegendRenderer::drawTitle( QgsRenderContext *rendercontext, QPointF po
 
 QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QgsRenderContext *rendercontext, QPointF point )
 {
-  return drawAtomInteral( atom, rendercontext, nullptr, point );
+  return drawAtomInternal( atom, rendercontext, nullptr, point );
 }
 
 QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext, QPointF point, double labelXOffset )

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -21,6 +21,7 @@
 #include "qgslegendstyle.h"
 #include "qgsmaplayerlegend.h"
 #include "qgssymbol.h"
+#include "qgsrendercontext.h"
 #include "qgsvectorlayer.h"
 
 #include <QPainter>
@@ -756,7 +757,7 @@ QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QgsRenderContext *renderco
 QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext, QPointF point, double labelXOffset )
 {
   QgsLayerTreeModelLegendNode::ItemContext ctx;
-  ctx.painter=rendercontext->painter();
+  ctx.painter = rendercontext->painter();
   ctx.point = point;
   ctx.labelXOffset = labelXOffset;
 

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -44,12 +44,17 @@ void QgsLegendRenderer::drawLegend( QPainter *painter )
   paintAndDetermineSize( painter );
 }
 
-
 QSizeF QgsLegendRenderer::paintAndDetermineSize( QPainter *painter )
+{
+  return paintAndDetermineSizeInternal( nullptr, painter );
+}
+
+QSizeF QgsLegendRenderer::paintAndDetermineSizeInternal( QgsRenderContext *context, QPainter *painter )
 {
   QSizeF size( 0, 0 );
   QgsLayerTreeGroup *rootGroup = mLegendModel->rootGroup();
-  if ( !rootGroup ) return size;
+  if ( !rootGroup )
+    return size;
 
   QList<Atom> atomList = createAtomList( rootGroup, mSettings.splitLayer() );
 
@@ -98,7 +103,8 @@ QSizeF QgsLegendRenderer::paintAndDetermineSize( QPainter *painter )
       point.ry() += spaceAboveAtom( atom );
     }
 
-    QSizeF atomSize = drawAtom( atom, painter, point );
+    QSizeF atomSize = context ? drawAtom( atom, context, point )
+                      : drawAtom( atom, painter, point );
     columnWidth = std::max( atomSize.width(), columnWidth );
 
     point.ry() += atom.size.height();
@@ -139,7 +145,10 @@ QSizeF QgsLegendRenderer::paintAndDetermineSize( QPainter *painter )
       point.rx() = size.width() - mSettings.boxSpace();
     }
     point.ry() = mSettings.boxSpace();
-    drawTitle( painter, point, mSettings.titleAlignment(), size.width() );
+    if ( context )
+      drawTitle( context, point, mSettings.titleAlignment(), size.width() );
+    else
+      drawTitle( painter, point, mSettings.titleAlignment(), size.width() );
   }
 
   return size;
@@ -355,8 +364,12 @@ void QgsLegendRenderer::setColumns( QList<Atom> &atomList )
   }
 }
 
-
 QSizeF QgsLegendRenderer::drawTitle( QPainter *painter, QPointF point, Qt::AlignmentFlag halignment, double legendWidth )
+{
+  return drawTitleInternal( nullptr, painter, point, halignment, legendWidth );
+}
+
+QSizeF QgsLegendRenderer::drawTitleInternal( QgsRenderContext *context, QPainter *painter, QPointF point, Qt::AlignmentFlag halignment, double legendWidth )
 {
   QSizeF size( 0, 0 );
   if ( mSettings.title().isEmpty() )
@@ -367,7 +380,11 @@ QSizeF QgsLegendRenderer::drawTitle( QPainter *painter, QPointF point, Qt::Align
   QStringList lines = mSettings.splitStringForWrapping( mSettings.title() );
   double y = point.y();
 
-  if ( painter )
+  if ( context )
+  {
+    context->painter()->setPen( mSettings.fontColor() );
+  }
+  else if ( painter )
   {
     painter->setPen( mSettings.fontColor() );
   }
@@ -403,7 +420,11 @@ QSizeF QgsLegendRenderer::drawTitle( QPainter *painter, QPointF point, Qt::Align
 
     QRectF r( textBoxLeft, y, textBoxWidth, height );
 
-    if ( painter )
+    if ( context->painter() )
+    {
+      mSettings.drawText( context->painter(), r, *titlePart, titleFont, halignment, Qt::AlignVCenter, Qt::TextDontClip );
+    }
+    else if ( painter )
     {
       mSettings.drawText( painter, r, *titlePart, titleFont, halignment, Qt::AlignVCenter, Qt::TextDontClip );
     }
@@ -450,6 +471,11 @@ double QgsLegendRenderer::spaceAboveAtom( const Atom &atom )
 // Draw atom and expand its size (using actual nucleons labelXOffset)
 QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QPainter *painter, QPointF point )
 {
+  return drawAtomInteral( atom, nullptr, painter, point );
+}
+
+QSizeF QgsLegendRenderer::drawAtomInteral( const Atom &atom, QgsRenderContext *context, QPainter *painter, QPointF point )
+{
   bool first = true;
   QSizeF size = QSizeF( atom.size );
   Q_FOREACH ( const Nucleon &nucleon, atom.nucleons )
@@ -463,7 +489,10 @@ QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QPainter *painter, QPointF
         {
           point.ry() += mSettings.style( s ).margin( QgsLegendStyle::Top );
         }
-        drawGroupTitle( groupItem, painter, point );
+        if ( context )
+          drawGroupTitle( groupItem, context, point );
+        else
+          drawGroupTitle( groupItem, painter, point );
       }
     }
     else if ( QgsLayerTreeLayer *layerItem = qobject_cast<QgsLayerTreeLayer *>( nucleon.item ) )
@@ -475,7 +504,10 @@ QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QPainter *painter, QPointF
         {
           point.ry() += mSettings.style( s ).margin( QgsLegendStyle::Top );
         }
-        drawLayerTitle( layerItem, painter, point );
+        if ( context )
+          drawLayerTitle( layerItem, context, point );
+        else
+          drawLayerTitle( layerItem, painter, point );
       }
     }
     else if ( QgsLayerTreeModelLegendNode *legendNode = qobject_cast<QgsLayerTreeModelLegendNode *>( nucleon.item ) )
@@ -485,7 +517,8 @@ QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QPainter *painter, QPointF
         point.ry() += mSettings.style( QgsLegendStyle::Symbol ).margin( QgsLegendStyle::Top );
       }
 
-      Nucleon symbolNucleon = drawSymbolItem( legendNode, painter, point, nucleon.labelXOffset );
+      Nucleon symbolNucleon = context ? drawSymbolItem( legendNode, context, point, nucleon.labelXOffset )
+                              : drawSymbolItem( legendNode, painter, point, nucleon.labelXOffset );
       // expand width, it may be wider because of labelXOffset
       size.rwidth() = std::max( symbolNucleon.size.width(), size.width() );
     }
@@ -495,15 +528,20 @@ QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QPainter *painter, QPointF
   return size;
 }
 
-
 QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QPainter *painter, QPointF point, double labelXOffset )
 {
+  return drawSymbolItemInternal( symbolItem, nullptr, painter, point, labelXOffset );
+}
+
+QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItemInternal( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *context, QPainter *painter, QPointF point, double labelXOffset )
+{
   QgsLayerTreeModelLegendNode::ItemContext ctx;
-  ctx.painter = painter;
+  ctx.painter = context ? context->painter() : painter;
   ctx.point = point;
   ctx.labelXOffset = labelXOffset;
 
-  QgsLayerTreeModelLegendNode::ItemMetrics im = symbolItem->draw( mSettings, painter ? &ctx : nullptr );
+  QgsLayerTreeModelLegendNode::ItemMetrics im = symbolItem->draw( mSettings, context ? &ctx
+      : ( painter ? &ctx : nullptr ) );
 
   Nucleon nucleon;
   nucleon.item = symbolItem;
@@ -516,8 +554,12 @@ QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItem( QgsLayerTreeModelL
   return nucleon;
 }
 
-
 QSizeF QgsLegendRenderer::drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QPainter *painter, QPointF point )
+{
+  return drawLayerTitleInternal( nodeLayer, nullptr, painter, point );
+}
+
+QSizeF QgsLegendRenderer::drawLayerTitleInternal( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *context, QPainter *painter, QPointF point )
 {
   QSizeF size( 0, 0 );
   QModelIndex idx = mLegendModel->node2index( nodeLayer );
@@ -527,7 +569,10 @@ QSizeF QgsLegendRenderer::drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QPainter
 
   double y = point.y();
 
-  if ( painter ) painter->setPen( mSettings.fontColor() );
+  if ( context && context->painter() )
+    context->painter()->setPen( mSettings.fontColor() );
+  else if ( painter )
+    painter->setPen( mSettings.fontColor() );
 
   QFont layerFont = mSettings.style( nodeLegendStyle( nodeLayer ) ).font();
 
@@ -535,7 +580,10 @@ QSizeF QgsLegendRenderer::drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QPainter
   for ( QStringList::Iterator layerItemPart = lines.begin(); layerItemPart != lines.end(); ++layerItemPart )
   {
     y += mSettings.fontAscentMillimeters( layerFont );
-    if ( painter ) mSettings.drawText( painter, point.x(), y, *layerItemPart, layerFont );
+    if ( context && context->painter() )
+      mSettings.drawText( context->painter(), point.x(), y, *layerItemPart, layerFont );
+    if ( painter )
+      mSettings.drawText( painter, point.x(), y, *layerItemPart, layerFont );
     qreal width = mSettings.textWidthMillimeters( layerFont, *layerItemPart );
     size.rwidth() = std::max( width, size.width() );
     if ( layerItemPart != ( lines.end() - 1 ) )
@@ -548,15 +596,22 @@ QSizeF QgsLegendRenderer::drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QPainter
   return size;
 }
 
-
 QSizeF QgsLegendRenderer::drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QPainter *painter, QPointF point )
+{
+  return drawGroupTitleInternal( nodeGroup, nullptr, painter, point );
+}
+
+QSizeF QgsLegendRenderer::drawGroupTitleInternal( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *context, QPainter *painter, QPointF point )
 {
   QSizeF size( 0, 0 );
   QModelIndex idx = mLegendModel->node2index( nodeGroup );
 
   double y = point.y();
 
-  if ( painter ) painter->setPen( mSettings.fontColor() );
+  if ( context && context->painter() )
+    context->painter()->setPen( mSettings.fontColor() );
+  else if ( painter )
+    painter->setPen( mSettings.fontColor() );
 
   QFont groupFont = mSettings.style( nodeLegendStyle( nodeGroup ) ).font();
 
@@ -564,7 +619,10 @@ QSizeF QgsLegendRenderer::drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QPainter
   for ( QStringList::Iterator groupPart = lines.begin(); groupPart != lines.end(); ++groupPart )
   {
     y += mSettings.fontAscentMillimeters( groupFont );
-    if ( painter ) mSettings.drawText( painter, point.x(), y, *groupPart, groupFont );
+    if ( context && context->painter() )
+      mSettings.drawText( context->painter(), point.x(), y, *groupPart, groupFont );
+    else if ( painter )
+      mSettings.drawText( painter, point.x(), y, *groupPart, groupFont );
     qreal width = mSettings.textWidthMillimeters( groupFont, *groupPart );
     size.rwidth() = std::max( width, size.width() );
     if ( groupPart != ( lines.end() - 1 ) )
@@ -575,8 +633,6 @@ QSizeF QgsLegendRenderer::drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QPainter
   size.rheight() = y - point.y();
   return size;
 }
-
-
 
 QgsLegendStyle::Style QgsLegendRenderer::nodeLegendStyle( QgsLayerTreeNode *node, QgsLayerTreeModel *model )
 {
@@ -630,205 +686,30 @@ void QgsLegendRenderer::setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendSty
     node->removeCustomProperty( QStringLiteral( "legend/title-style" ) );
 }
 
-
-//new version of classes using QgsRenderContext
 QSizeF QgsLegendRenderer::drawTitle( QgsRenderContext *rendercontext, QPointF point, Qt::AlignmentFlag halignment, double legendWidth )
 {
-  QSizeF size( 0, 0 );
-  if ( mSettings.title().isEmpty() )
-  {
-    return size;
-  }
-
-  QStringList lines = mSettings.splitStringForWrapping( mSettings.title() );
-  double y = point.y();
-
-  if ( rendercontext->painter() )
-  {
-    rendercontext->painter()->setPen( mSettings.fontColor() );
-  }
-
-  //calculate width and left pos of rectangle to draw text into
-  double textBoxWidth;
-  double textBoxLeft;
-  switch ( halignment )
-  {
-    case Qt::AlignHCenter:
-      textBoxWidth = ( std::min( static_cast< double >( point.x() ), legendWidth - point.x() ) - mSettings.boxSpace() ) * 2.0;
-      textBoxLeft = point.x() - textBoxWidth / 2.;
-      break;
-    case Qt::AlignRight:
-      textBoxLeft = mSettings.boxSpace();
-      textBoxWidth = point.x() - mSettings.boxSpace();
-      break;
-    case Qt::AlignLeft:
-    default:
-      textBoxLeft = point.x();
-      textBoxWidth = legendWidth - point.x() - mSettings.boxSpace();
-      break;
-  }
-
-  QFont titleFont = mSettings.style( QgsLegendStyle::Title ).font();
-
-  for ( QStringList::Iterator titlePart = lines.begin(); titlePart != lines.end(); ++titlePart )
-  {
-    //last word is not drawn if rectangle width is exactly text width, so add 1
-    //TODO - correctly calculate size of italicized text, since QFontMetrics does not
-    qreal width = mSettings.textWidthMillimeters( titleFont, *titlePart ) + 1;
-    qreal height = mSettings.fontAscentMillimeters( titleFont ) + mSettings.fontDescentMillimeters( titleFont );
-
-    QRectF r( textBoxLeft, y, textBoxWidth, height );
-
-    if ( rendercontext->painter() )
-    {
-      mSettings.drawText( rendercontext->painter(), r, *titlePart, titleFont, halignment, Qt::AlignVCenter, Qt::TextDontClip );
-    }
-
-    //update max width of title
-    size.rwidth() = std::max( width, size.rwidth() );
-
-    y += height;
-    if ( titlePart != ( lines.end() - 1 ) )
-    {
-      y += mSettings.lineSpacing();
-    }
-  }
-  size.rheight() = y - point.y();
-
-  return size;
+  return drawTitleInternal( rendercontext, nullptr, point, halignment, legendWidth );
 }
 
-
-
-// Draw atom and expand its size (using actual nucleons labelXOffset)
 QSizeF QgsLegendRenderer::drawAtom( const Atom &atom, QgsRenderContext *rendercontext, QPointF point )
 {
-  bool first = true;
-  QSizeF size = QSizeF( atom.size );
-  Q_FOREACH ( const Nucleon &nucleon, atom.nucleons )
-  {
-    if ( QgsLayerTreeGroup *groupItem = qobject_cast<QgsLayerTreeGroup *>( nucleon.item ) )
-    {
-      QgsLegendStyle::Style s = nodeLegendStyle( groupItem );
-      if ( s != QgsLegendStyle::Hidden )
-      {
-        if ( !first )
-        {
-          point.ry() += mSettings.style( s ).margin( QgsLegendStyle::Top );
-        }
-        drawGroupTitle( groupItem, rendercontext, point );
-      }
-    }
-    else if ( QgsLayerTreeLayer *layerItem = qobject_cast<QgsLayerTreeLayer *>( nucleon.item ) )
-    {
-      QgsLegendStyle::Style s = nodeLegendStyle( layerItem );
-      if ( s != QgsLegendStyle::Hidden )
-      {
-        if ( !first )
-        {
-          point.ry() += mSettings.style( s ).margin( QgsLegendStyle::Top );
-        }
-        drawLayerTitle( layerItem, rendercontext, point );
-      }
-    }
-    else if ( QgsLayerTreeModelLegendNode *legendNode = qobject_cast<QgsLayerTreeModelLegendNode *>( nucleon.item ) )
-    {
-      if ( !first )
-      {
-        point.ry() += mSettings.style( QgsLegendStyle::Symbol ).margin( QgsLegendStyle::Top );
-      }
-
-      Nucleon symbolNucleon = drawSymbolItem( legendNode, rendercontext, point, nucleon.labelXOffset );
-      // expand width, it may be wider because of labelXOffset
-      size.rwidth() = std::max( symbolNucleon.size.width(), size.width() );
-    }
-    point.ry() += nucleon.size.height();
-    first = false;
-  }
-  return size;
+  return drawAtomInteral( atom, rendercontext, nullptr, point );
 }
-
 
 QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext, QPointF point, double labelXOffset )
 {
-  QgsLayerTreeModelLegendNode::ItemContext ctx;
-  ctx.painter = rendercontext->painter();
-  ctx.point = point;
-  ctx.labelXOffset = labelXOffset;
-
-  QgsLayerTreeModelLegendNode::ItemMetrics im = symbolItem->draw( mSettings, rendercontext ? &ctx : nullptr );
-
-  Nucleon nucleon;
-  nucleon.item = symbolItem;
-  nucleon.symbolSize = im.symbolSize;
-  nucleon.labelSize = im.labelSize;
-  //QgsDebugMsg( QStringLiteral( "symbol height = %1 label height = %2").arg( symbolSize.height()).arg( labelSize.height() ));
-  double width = std::max( static_cast< double >( im.symbolSize.width() ), labelXOffset ) + im.labelSize.width();
-  double height = std::max( im.symbolSize.height(), im.labelSize.height() );
-  nucleon.size = QSizeF( width, height );
-  return nucleon;
+  return drawSymbolItemInternal( symbolItem, rendercontext, nullptr, point, labelXOffset );
 }
-
 
 QSizeF QgsLegendRenderer::drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *rendercontext, QPointF point )
 {
-  QSizeF size( 0, 0 );
-  QModelIndex idx = mLegendModel->node2index( nodeLayer );
-
-  //Let the user omit the layer title item by having an empty layer title string
-  if ( mLegendModel->data( idx, Qt::DisplayRole ).toString().isEmpty() ) return size;
-
-  double y = point.y();
-
-  if ( rendercontext->painter() ) rendercontext->painter()->setPen( mSettings.fontColor() );
-
-  QFont layerFont = mSettings.style( nodeLegendStyle( nodeLayer ) ).font();
-
-  QStringList lines = mSettings.splitStringForWrapping( mLegendModel->data( idx, Qt::DisplayRole ).toString() );
-  for ( QStringList::Iterator layerItemPart = lines.begin(); layerItemPart != lines.end(); ++layerItemPart )
-  {
-    y += mSettings.fontAscentMillimeters( layerFont );
-    if ( rendercontext->painter() ) mSettings.drawText( rendercontext->painter(), point.x(), y, *layerItemPart, layerFont );
-    qreal width = mSettings.textWidthMillimeters( layerFont, *layerItemPart );
-    size.rwidth() = std::max( width, size.width() );
-    if ( layerItemPart != ( lines.end() - 1 ) )
-    {
-      y += mSettings.lineSpacing();
-    }
-  }
-  size.rheight() = y - point.y();
-
-  return size;
+  return drawLayerTitleInternal( nodeLayer, rendercontext, nullptr, point );
 }
-
 
 QSizeF QgsLegendRenderer::drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *rendercontext, QPointF point )
 {
-  QSizeF size( 0, 0 );
-  QModelIndex idx = mLegendModel->node2index( nodeGroup );
-
-  double y = point.y();
-
-  if ( rendercontext->painter() ) rendercontext->painter()->setPen( mSettings.fontColor() );
-
-  QFont groupFont = mSettings.style( nodeLegendStyle( nodeGroup ) ).font();
-
-  QStringList lines = mSettings.splitStringForWrapping( mLegendModel->data( idx, Qt::DisplayRole ).toString() );
-  for ( QStringList::Iterator groupPart = lines.begin(); groupPart != lines.end(); ++groupPart )
-  {
-    y += mSettings.fontAscentMillimeters( groupFont );
-    if ( rendercontext->painter() ) mSettings.drawText( rendercontext->painter(), point.x(), y, *groupPart, groupFont );
-    qreal width = mSettings.textWidthMillimeters( groupFont, *groupPart );
-    size.rwidth() = std::max( width, size.width() );
-    if ( groupPart != ( lines.end() - 1 ) )
-    {
-      y += mSettings.lineSpacing();
-    }
-  }
-  size.rheight() = y - point.y();
-  return size;
+  return drawGroupTitleInternal( nodeGroup, rendercontext, nullptr, point );
 }
-
 
 void QgsLegendRenderer::drawLegend( QgsRenderContext &context )
 {
@@ -837,100 +718,5 @@ void QgsLegendRenderer::drawLegend( QgsRenderContext &context )
 
 QSizeF QgsLegendRenderer::paintAndDetermineSize( QgsRenderContext *context )
 {
-  QSizeF size( 0, 0 );
-  QgsLayerTreeGroup *rootGroup = mLegendModel->rootGroup();
-  if ( !rootGroup ) return size;
-
-  QList<Atom> atomList = createAtomList( rootGroup, mSettings.splitLayer() );
-
-  setColumns( atomList );
-
-  qreal maxColumnWidth = 0;
-  if ( mSettings.equalColumnWidth() )
-  {
-    Q_FOREACH ( const Atom &atom, atomList )
-    {
-      maxColumnWidth = std::max( atom.size.width(), maxColumnWidth );
-    }
-  }
-
-  //calculate size of title
-  QSizeF titleSize = drawTitle();
-  //add title margin to size of title text
-  titleSize.rwidth() += mSettings.boxSpace() * 2.0;
-  double columnTop = mSettings.boxSpace() + titleSize.height() + mSettings.style( QgsLegendStyle::Title ).margin( QgsLegendStyle::Bottom );
-
-  QPointF point( mSettings.boxSpace(), columnTop );
-  bool firstInColumn = true;
-  double columnMaxHeight = 0;
-  qreal columnWidth = 0;
-  int column = 0;
-  Q_FOREACH ( const Atom &atom, atomList )
-  {
-    if ( atom.column > column )
-    {
-      // Switch to next column
-      if ( mSettings.equalColumnWidth() )
-      {
-        point.rx() += mSettings.columnSpace() + maxColumnWidth;
-      }
-      else
-      {
-        point.rx() += mSettings.columnSpace() + columnWidth;
-      }
-      point.ry() = columnTop;
-      columnWidth = 0;
-      column++;
-      firstInColumn = true;
-    }
-    if ( !firstInColumn )
-    {
-      point.ry() += spaceAboveAtom( atom );
-    }
-
-    QSizeF atomSize = drawAtom( atom, context, point );
-    columnWidth = std::max( atomSize.width(), columnWidth );
-
-    point.ry() += atom.size.height();
-    columnMaxHeight = std::max( point.y() - columnTop, columnMaxHeight );
-
-    firstInColumn = false;
-  }
-  point.rx() += columnWidth + mSettings.boxSpace();
-
-  size.rheight() = columnTop + columnMaxHeight + mSettings.boxSpace();
-  size.rwidth() = point.x();
-  if ( !mSettings.title().isEmpty() )
-  {
-    size.rwidth() = std::max( titleSize.width(), size.width() );
-  }
-
-  // override the size if it was set by the user
-  if ( mLegendSize.isValid() )
-  {
-    qreal w = std::max( size.width(), mLegendSize.width() );
-    qreal h = std::max( size.height(), mLegendSize.height() );
-    size = QSizeF( w, h );
-  }
-
-  // Now we have set the correct total item width and can draw the title centered
-  if ( !mSettings.title().isEmpty() )
-  {
-    if ( mSettings.titleAlignment() == Qt::AlignLeft )
-    {
-      point.rx() = mSettings.boxSpace();
-    }
-    else if ( mSettings.titleAlignment() == Qt::AlignHCenter )
-    {
-      point.rx() = size.width() / 2;
-    }
-    else
-    {
-      point.rx() = size.width() - mSettings.boxSpace();
-    }
-    point.ry() = mSettings.boxSpace();
-    drawTitle( context, point, mSettings.titleAlignment(), size.width() );
-  }
-
-  return size;
+  return paintAndDetermineSizeInternal( context, nullptr );
 }

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -380,7 +380,7 @@ QSizeF QgsLegendRenderer::drawTitleInternal( QgsRenderContext *context, QPainter
   QStringList lines = mSettings.splitStringForWrapping( mSettings.title() );
   double y = point.y();
 
-  if ( context )
+  if ( context && context->painter() )
   {
     context->painter()->setPen( mSettings.fontColor() );
   }
@@ -420,7 +420,7 @@ QSizeF QgsLegendRenderer::drawTitleInternal( QgsRenderContext *context, QPainter
 
     QRectF r( textBoxLeft, y, textBoxWidth, height );
 
-    if ( context->painter() )
+    if ( context && context->painter() )
     {
       mSettings.drawText( context->painter(), r, *titlePart, titleFont, halignment, Qt::AlignVCenter, Qt::TextDontClip );
     }

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -59,12 +59,12 @@ class CORE_EXPORT QgsLegendRenderer
 
     /**
      * Draw the legend with given painter. It will occupy the area reported in legendSize().
-     *  Painter should be scaled beforehand so that units correspond to millimeters.
+     * Painter should be scaled beforehand so that units correspond to millimeters.
      */
     void drawLegend( QPainter *painter );
 
     /**
-     * Draw the legend using a given QgsRenderContext. It willoccupy the area reported in legendSize().
+     * Draw the legend using a given QgsRenderContext. It will occupy the area reported in legendSize().
      */
     void drawLegend( QgsRenderContext *rendercontext );
 

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -160,7 +160,6 @@ class CORE_EXPORT QgsLegendRenderer
     class Atom
     {
       public:
-        Atom();
 
         //! List of child Nucleons belonging to this Atom.
         QList<Nucleon> nucleons;
@@ -294,6 +293,12 @@ class CORE_EXPORT QgsLegendRenderer
     QSizeF mLegendSize;
 
 #endif
+    QSizeF drawTitleInternal( QgsRenderContext *context, QPainter *painter, QPointF point, Qt::AlignmentFlag halignment, double legendWidth );
+    QSizeF drawAtomInteral( const Atom &atom, QgsRenderContext *context, QPainter *painter, QPointF point );
+    QgsLegendRenderer::Nucleon drawSymbolItemInternal( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *context, QPainter *painter, QPointF point, double labelXOffset );
+    QSizeF drawLayerTitleInternal( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *context, QPainter *painter, QPointF point );
+    QSizeF drawGroupTitleInternal( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *context, QPainter *painter, QPointF point );
+    QSizeF paintAndDetermineSizeInternal( QgsRenderContext *context, QPainter *painter );
 };
 
 #endif // QGSLEGENDRENDERER_H

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -152,7 +152,7 @@ class CORE_EXPORT QgsLegendRenderer
      * style top space */
     QSizeF drawAtom( const Atom &atom, QPainter *painter = nullptr, QPointF point = QPointF() );
 
-    /** 
+    /**
      * Displays the symbol of a given QgsLayerTreeModelLegendNode
      */
     Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QPainter *painter = nullptr, QPointF point = QPointF(), double labelXOffset = 0 );
@@ -187,7 +187,7 @@ class CORE_EXPORT QgsLegendRenderer
      * style top space */
     QSizeF drawAtom( const Atom &atom, QgsRenderContext *rendercontext, QPointF point = QPointF() );
 
-    /** 
+    /**
      * Displays the symbol of a given QgsLayerTreeModelLegendNode
      */
     Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext, QPointF point = QPointF(), double labelXOffset = 0 );

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -45,37 +45,62 @@ class QgsRenderContext;
 class CORE_EXPORT QgsLegendRenderer
 {
   public:
-    //! Construct legend renderer. The ownership of legend model does not change
+
+    /**
+     * Constructor for QgsLegendRenderer. The ownership of the legend model is not changed,
+     * and the model must exist for the lifetime of this renderer.
+     */
     QgsLegendRenderer( QgsLayerTreeModel *legendModel, const QgsLegendSettings &settings );
 
-    //! Run the layout algorithm and determine the size required for legend
+    /**
+     * Runs the layout algorithm and returns the minimum size required for the legend.
+     * \see setLegendSize()
+     * \see legendSize()
+     */
     QSizeF minimumSize();
 
-    //! Sets the preferred resulting legend size.
+    /**
+     * Sets the preferred resulting legend size.
+     *
+     * If the size is null, the legend will be drawn with the minimum possible size to fit its content.
+     *
+     * \see legendSize()
+     * \see minimumSize()
+     */
     void setLegendSize( QSizeF s ) { mLegendSize = s; }
 
-    //! Find out preferred legend size set by the client. If null, the legend will be drawn with the minimum size
+    /**
+     * Returns the preferred legend size set by the client.
+     *
+     * If the returned size is null, the legend will be drawn with the minimum possible size to fit its content.
+     *
+     * \see minimumSize()
+     * \see setLegendSize()
+     */
     QSizeF legendSize() const { return mLegendSize; }
 
     /**
-     * Draw the legend with given painter. It will occupy the area reported in legendSize().
-     * Painter should be scaled beforehand so that units correspond to millimeters.
+     * Draws the legend with given \a painter. The legend will occupy the area reported in legendSize().
+     * The \a painter should be scaled beforehand so that units correspond to millimeters.
      */
     void drawLegend( QPainter *painter );
 
     /**
-     * Draw the legend using a given QgsRenderContext. It will occupy the area reported in legendSize().
+     * Draws the legend using a given QgsRenderContext. The legend will occupy the area reported in legendSize().
      */
     void drawLegend( QgsRenderContext *rendercontext );
 
     /**
-     * Set the style of a QgsLayerTreeNode,
-     * This class requires a node and a style to apply to the node
+     * Sets the \a style of a \a node.
+     *
+     * \see nodeLegendStyle()
      */
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );
 
     /**
-     * Returns the style of a given QgsLayerTreeNode in a given QgsLayerTreeModel
+     * Returns the style for the given \a node, within the specified \a model.
+     *
+     * \see setNodeLegendStyle()
      */
     static QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node, QgsLayerTreeModel *model );
 
@@ -84,9 +109,11 @@ class CORE_EXPORT QgsLegendRenderer
 #ifndef SIP_RUN
 
     /**
-     * Nucleon is either group title, layer title or layer child item.
-     *  E.g. layer title nucleon is just title, it does not
-     *  include all layer subitems, the same with groups.
+     * A legend Nucleon is either a group title, a layer title or a layer child item.
+     *
+     * E.g. a layer title nucleon is just the layer's title, it does not
+     * include all of that layer's subitems. Similarly, a group's title nucleon is just
+     * the group title, and does not include the actual content of that group.
      */
     class Nucleon
     {
@@ -95,117 +122,165 @@ class CORE_EXPORT QgsLegendRenderer
         Nucleon() = default;
 
         QObject *item = nullptr;
-        // Symbol size size without any space around for symbol item
+
+        //! Symbol size, not including any preset padding space around the symbol
         QSizeF symbolSize;
-        // Label size without any space around for symbol item
+
+        //! Label size, not including any preset padding space around the label
         QSizeF labelSize;
+
+        //! Nucleon size
         QSizeF size;
-        // Offset of symbol label, this offset is the same for all symbol labels
-        // of the same layer in the same column
+
+        /**
+         * Horizontal offset for the symbol label.
+         *
+         * This offset is the same for all symbol labels belonging to the same layer,
+         * within the same legend column.
+         */
         double labelXOffset = 0.0;
     };
 
     /**
-     * Atom is indivisible set (indivisible into more columns). It may consists
-     *  of one or more Nucleon, depending on layer splitting mode:
+     * An Atom is indivisible set of legend Nucleons (i.e. it is indivisible into more columns).
+     *
+     * An Atom may consist of one or more Nucleon(s), depending on the layer splitting mode:
+     *
      *  1) no layer split: [group_title ...] layer_title layer_item [layer_item ...]
      *  2) layer split:    [group_title ...] layer_title layer_item
      *              or:    layer_item
-     *  It means that group titles must not be split from layer title and layer title
-     *  must not be split from first item, because it would look bad and it would not
-     *  be readable to leave group or layer title at the bottom of column.
+     *
+     * This means that group titles must not be split from layer titles and layer titles
+     * must not be split from the first layer item, because this results in a poor layout
+     * and it would not be logical to leave a group or layer title at the bottom of a column,
+     * separated from the actual content of that group or layer.
      */
     class Atom
     {
       public:
-        Atom(): size( QSizeF( 0, 0 ) ) {}
+        Atom();
+
+        //! List of child Nucleons belonging to this Atom.
         QList<Nucleon> nucleons;
-        // Atom size including nucleons interspaces but without any space around atom.
-        QSizeF size;
+
+        //! Atom size, including internal spacing between Nucleons, but excluding any padding space around the Atom itself.
+        QSizeF size = QSizeF( 0, 0 );
+
+        //! Corresponding column index
         int column = 0;
     };
 
     /**
-     * displays the legend and return the size of said legend.
-     * If the painter is null, only the size will be given,
-     * since a painter is needed to render the legend.
+     * Draws the legend and returns the actual size of the legend.
+     *
+     * If \a painter is nullptr, only the size of the legend will be calculated and no
+     * painting will be attempted.
      */
     QSizeF paintAndDetermineSize( QPainter *painter = nullptr );
 
-    //! Create list of atoms according to current layer splitting mode
+    /**
+     * Returns a list of Atoms for the specified \a parentGroup, respecting the current layer's
+     * splitting settings.
+     */
     QList<Atom> createAtomList( QgsLayerTreeGroup *parentGroup, bool splitLayer );
 
-    //! Divide atoms to columns and set columns on atoms
+    /**
+     * Divides a list of Atoms into columns, and sets the column index for each atom in the list.
+     */
     void setColumns( QList<Atom> &atomList );
 
     /**
-     * Draws title in the legend using the title font and the specified alignment
-     * If no painter is specified, function returns the required width/height to draw the title.
+     * Draws a title in the legend using the title font and the specified alignment settings.
+     *
+     * Returns the size required to draw the complete title.
+     *
+     * If \a painter is nullptr, no painting will be attempted, but the required size will still be calculated and returned.
      */
     QSizeF drawTitle( QPainter *painter = nullptr, QPointF point = QPointF(), Qt::AlignmentFlag halignment = Qt::AlignLeft, double legendWidth = 0 );
 
+    /**
+     * Returns the calculated padding space required above the given \a atom.
+     */
     double spaceAboveAtom( const Atom &atom );
 
     /**
-     * Draw atom and return its actual size, the atom is drawn with the space above it
-     *  so that first atoms in column are all aligned to the same line regardles their
-     * style top space */
+     * Draws an \a atom and return its actual size.
+     *
+     * The \a atom is drawn with the space above it, so that the first atoms in column are all
+     * aligned to the same line regardless of their style top spacing.
+    */
     QSizeF drawAtom( const Atom &atom, QPainter *painter = nullptr, QPointF point = QPointF() );
 
     /**
-     * Displays the symbol of a given QgsLayerTreeModelLegendNode
+     * Draws the symbol of a given symbol QgsLayerTreeModelLegendNode.
      */
     Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QPainter *painter = nullptr, QPointF point = QPointF(), double labelXOffset = 0 );
 
     /**
-     * Displays the title of a layer given the QgsLayerTreeLayer, a painter and QPointF
-     * otherwise return the size the of the title
+     * Draws the title of a layer, given a QgsLayerTreeLayer, and a destination \a painter.
+     *
+     * Returns the size of the title.
+     *
+     * The \a painter may be nullptr, in which case on the size is calculated and no painting is attempted.
      */
     QSizeF drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QPainter *painter = nullptr, QPointF point = QPointF() );
 
     /**
      * Draws a group item.
-     * Returns list of sizes of layers and groups including this group.
+     * Returns the size of the title.
      */
     QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QPainter *painter = nullptr, QPointF point = QPointF() );
 
     /**
-     * displays the legend and return the size of said legend.
-     * If QgsRenderContext is null, only the size will be given.
+     * Draws the legend using the specified render \a context, and returns the actual size of the legend.
+     *
+     * If \a context is nullptr, only the size of the legend will be calculated and no
+     * painting will be attempted.
      */
-    QSizeF paintAndDetermineSize( QgsRenderContext *rendercontext );
+    QSizeF paintAndDetermineSize( QgsRenderContext *context );
 
     /**
-     * Draws title in the legend using the title font and the specified alignment
-     * If no rendercontext is specified, function returns the required width/height to draw the title.
+     * Draws a title in the legend using the specified render \a context, with the title font and the specified alignment settings.
+     *
+     * Returns the size required to draw the complete title.
+     *
+     * If \a context is nullptr, no painting will be attempted, but the required size will still be calculated and returned.
      */
-    QSizeF drawTitle( QgsRenderContext *rendercontext, QPointF point = QPointF(), Qt::AlignmentFlag halignment = Qt::AlignLeft, double legendWidth = 0 );
+    QSizeF drawTitle( QgsRenderContext *context, QPointF point = QPointF(), Qt::AlignmentFlag halignment = Qt::AlignLeft, double legendWidth = 0 );
 
     /**
-     * Draw atom and return its actual size, the atom is drawn with the space above it
-     *  so that first atoms in column are all aligned to the same line regardles their
-     * style top space */
+     * Draws an \a atom and return its actual size, using the specified render \a context.
+     *
+     * The \a atom is drawn with the space above it, so that the first atoms in column are all
+     * aligned to the same line regardless of their style top spacing.
+     *
+     * If \a context is nullptr, no painting will be attempted, but the required size will still be calculated and returned.
+    */
     QSizeF drawAtom( const Atom &atom, QgsRenderContext *rendercontext, QPointF point = QPointF() );
 
     /**
-     * Displays the symbol of a given QgsLayerTreeModelLegendNode
+     * Draws the symbol of a given symbol QgsLayerTreeModelLegendNode, using the specified render \a context.
      */
-    Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext, QPointF point = QPointF(), double labelXOffset = 0 );
+    Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *context, QPointF point = QPointF(), double labelXOffset = 0 );
 
     /**
-     * Displays the title of a layer given the QgsLayerTreeLayer, a rendercontext and QPointF
-     * otherwise return the size the of the title
+     * Draws the title of a layer, given a QgsLayerTreeLayer, and a destination render \a context.
+     *
+     * Returns the size of the title.
+     *
+     * The \a context may be nullptr, in which case on the size is calculated and no painting is attempted.
      */
-    QSizeF drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *rendercontext, QPointF point = QPointF() );
+    QSizeF drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *context, QPointF point = QPointF() );
 
     /**
-     * Draws a group item.
-     * Returns list of sizes of layers and groups including this group.
+     * Draws a group's title, using the specified render \a context.
+     *
+     * Returns the size of the title.
      */
-    QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *rendercontext, QPointF point = QPointF() );
+    QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *context, QPointF point = QPointF() );
 
     /**
-     * Returns the style of a given QgsLayerTreeNode
+     * Returns the style of the given \a node.
      */
     QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node );
 

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -28,6 +28,7 @@ class QgsLayerTreeModel;
 class QgsLayerTreeModelLegendNode;
 class QgsLayerTreeNode;
 class QgsSymbol;
+class QgsRenderContext;
 
 #include "qgslegendsettings.h"
 

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -294,7 +294,7 @@ class CORE_EXPORT QgsLegendRenderer
 
 #endif
     QSizeF drawTitleInternal( QgsRenderContext *context, QPainter *painter, QPointF point, Qt::AlignmentFlag halignment, double legendWidth );
-    QSizeF drawAtomInteral( const Atom &atom, QgsRenderContext *context, QPainter *painter, QPointF point );
+    QSizeF drawAtomInternal( const Atom &atom, QgsRenderContext *context, QPainter *painter, QPointF point );
     QgsLegendRenderer::Nucleon drawSymbolItemInternal( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *context, QPainter *painter, QPointF point, double labelXOffset );
     QSizeF drawLayerTitleInternal( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *context, QPainter *painter, QPointF point );
     QSizeF drawGroupTitleInternal( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *context, QPainter *painter, QPointF point );

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -61,7 +61,8 @@ class CORE_EXPORT QgsLegendRenderer
      *  Painter should be scaled beforehand so that units correspond to millimeters.
      */
     void drawLegend( QPainter *painter );
-
+    
+    void drawLegend( QgsRenderContext *rendercontext );
 
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );
     static QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node, QgsLayerTreeModel *model );
@@ -112,7 +113,7 @@ class CORE_EXPORT QgsLegendRenderer
         int column = 0;
     };
 
-    QSizeF paintAndDetermineSize( QPainter *painter );
+    QSizeF paintAndDetermineSize( QPainter *painter = nullptr );
 
     //! Create list of atoms according to current layer splitting mode
     QList<Atom> createAtomList( QgsLayerTreeGroup *parentGroup, bool splitLayer );
@@ -144,6 +145,24 @@ class CORE_EXPORT QgsLegendRenderer
      * Returns list of sizes of layers and groups including this group.
      */
     QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QPainter *painter = nullptr, QPointF point = QPointF() );
+
+    
+    QSizeF paintAndDetermineSize( QgsRenderContext *rendercontext );
+
+    QSizeF drawTitle( QgsRenderContext *rendercontext , QPointF point = QPointF(), Qt::AlignmentFlag halignment = Qt::AlignLeft, double legendWidth = 0 );
+
+    QSizeF drawAtom( const Atom &atom, QgsRenderContext *rendercontext , QPointF point = QPointF() );
+
+    Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext , QPointF point = QPointF(), double labelXOffset = 0 );
+
+    //! Draws a layer item
+    QSizeF drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *rendercontext , QPointF point = QPointF() );
+
+    /**
+     * Draws a group item.
+     * Returns list of sizes of layers and groups including this group.
+     */
+    QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *rendercontext , QPointF point = QPointF() );
 
     QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node );
 

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -63,9 +63,20 @@ class CORE_EXPORT QgsLegendRenderer
      */
     void drawLegend( QPainter *painter );
 
+    /**
+     * Draw the legend using a given QgsRenderContext. It willoccupy the area reported in legendSize().
+     */
     void drawLegend( QgsRenderContext *rendercontext );
 
+    /**
+     * Set the style of a QgsLayerTreeNode,
+     * This class requires a node and a style to apply to the node
+     */
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );
+
+    /**
+     * Returns the style of a given QgsLayerTreeNode in a given QgsLayerTreeModel
+     */
     static QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node, QgsLayerTreeModel *model );
 
   private:
@@ -114,6 +125,11 @@ class CORE_EXPORT QgsLegendRenderer
         int column = 0;
     };
 
+    /**
+     * displays the legend and return the size of said legend.
+     * If the painter is null, only the size will be given,
+     * since a painter is needed to render the legend.
+     */
     QSizeF paintAndDetermineSize( QPainter *painter = nullptr );
 
     //! Create list of atoms according to current layer splitting mode
@@ -136,9 +152,15 @@ class CORE_EXPORT QgsLegendRenderer
      * style top space */
     QSizeF drawAtom( const Atom &atom, QPainter *painter = nullptr, QPointF point = QPointF() );
 
+    /** 
+     * Displays the symbol of a given QgsLayerTreeModelLegendNode
+     */
     Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QPainter *painter = nullptr, QPointF point = QPointF(), double labelXOffset = 0 );
 
-    //! Draws a layer item
+    /**
+     * Displays the title of a layer given the QgsLayerTreeLayer, a painter and QPointF
+     * otherwise return the size the of the title
+     */
     QSizeF drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QPainter *painter = nullptr, QPointF point = QPointF() );
 
     /**
@@ -147,16 +169,33 @@ class CORE_EXPORT QgsLegendRenderer
      */
     QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QPainter *painter = nullptr, QPointF point = QPointF() );
 
-
+    /**
+     * displays the legend and return the size of said legend.
+     * If QgsRenderContext is null, only the size will be given.
+     */
     QSizeF paintAndDetermineSize( QgsRenderContext *rendercontext );
 
+    /**
+     * Draws title in the legend using the title font and the specified alignment
+     * If no rendercontext is specified, function returns the required width/height to draw the title.
+     */
     QSizeF drawTitle( QgsRenderContext *rendercontext, QPointF point = QPointF(), Qt::AlignmentFlag halignment = Qt::AlignLeft, double legendWidth = 0 );
 
+    /**
+     * Draw atom and return its actual size, the atom is drawn with the space above it
+     *  so that first atoms in column are all aligned to the same line regardles their
+     * style top space */
     QSizeF drawAtom( const Atom &atom, QgsRenderContext *rendercontext, QPointF point = QPointF() );
 
+    /** 
+     * Displays the symbol of a given QgsLayerTreeModelLegendNode
+     */
     Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext, QPointF point = QPointF(), double labelXOffset = 0 );
 
-    //! Draws a layer item
+    /**
+     * Displays the title of a layer given the QgsLayerTreeLayer, a rendercontext and QPointF
+     * otherwise return the size the of the title
+     */
     QSizeF drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *rendercontext, QPointF point = QPointF() );
 
     /**
@@ -165,6 +204,9 @@ class CORE_EXPORT QgsLegendRenderer
      */
     QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *rendercontext, QPointF point = QPointF() );
 
+    /**
+     * Returns the style of a given QgsLayerTreeNode
+     */
     QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node );
 
   private:

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -86,9 +86,11 @@ class CORE_EXPORT QgsLegendRenderer
     void drawLegend( QPainter *painter );
 
     /**
-     * Draws the legend using a given QgsRenderContext. The legend will occupy the area reported in legendSize().
+     * Draws the legend using a given render \a context. The legend will occupy the area reported in legendSize().
+     *
+     * \since QGIS 3.6
      */
-    void drawLegend( QgsRenderContext *rendercontext );
+    void drawLegend( QgsRenderContext &context );
 
     /**
      * Sets the \a style of a \a node.

--- a/src/core/qgslegendrenderer.h
+++ b/src/core/qgslegendrenderer.h
@@ -61,7 +61,7 @@ class CORE_EXPORT QgsLegendRenderer
      *  Painter should be scaled beforehand so that units correspond to millimeters.
      */
     void drawLegend( QPainter *painter );
-    
+
     void drawLegend( QgsRenderContext *rendercontext );
 
     static void setNodeLegendStyle( QgsLayerTreeNode *node, QgsLegendStyle::Style style );
@@ -146,23 +146,23 @@ class CORE_EXPORT QgsLegendRenderer
      */
     QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QPainter *painter = nullptr, QPointF point = QPointF() );
 
-    
+
     QSizeF paintAndDetermineSize( QgsRenderContext *rendercontext );
 
-    QSizeF drawTitle( QgsRenderContext *rendercontext , QPointF point = QPointF(), Qt::AlignmentFlag halignment = Qt::AlignLeft, double legendWidth = 0 );
+    QSizeF drawTitle( QgsRenderContext *rendercontext, QPointF point = QPointF(), Qt::AlignmentFlag halignment = Qt::AlignLeft, double legendWidth = 0 );
 
-    QSizeF drawAtom( const Atom &atom, QgsRenderContext *rendercontext , QPointF point = QPointF() );
+    QSizeF drawAtom( const Atom &atom, QgsRenderContext *rendercontext, QPointF point = QPointF() );
 
-    Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext , QPointF point = QPointF(), double labelXOffset = 0 );
+    Nucleon drawSymbolItem( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *rendercontext, QPointF point = QPointF(), double labelXOffset = 0 );
 
     //! Draws a layer item
-    QSizeF drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *rendercontext , QPointF point = QPointF() );
+    QSizeF drawLayerTitle( QgsLayerTreeLayer *nodeLayer, QgsRenderContext *rendercontext, QPointF point = QPointF() );
 
     /**
      * Draws a group item.
      * Returns list of sizes of layers and groups including this group.
      */
-    QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *rendercontext , QPointF point = QPointF() );
+    QSizeF drawGroupTitle( QgsLayerTreeGroup *nodeGroup, QgsRenderContext *rendercontext, QPointF point = QPointF() );
 
     QgsLegendStyle::Style nodeLegendStyle( QgsLayerTreeNode *node );
 


### PR DESCRIPTION
This overloads functions in QgsLegendRenderer to allow the use of QgsRenderContext.

The minimumSize function and the PaintAndDetermineSize have been slightly altered to prevent conflict with the overloaded of PaintAndDetermineSize.

Otherwise these changes should not affect anything else in the current API, none of theses overloaded functions should be used currently.

This pull is part of a project to implement expression in the legend as an alternative or replacement to the feature counter. That project is done in cooperation with @nyalldawson  .



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
