### PR TITLE
[themes] Adjust Night Mapping and Blend of Gray to improve display on windows

### DIFF
--- a/resources/themes/Blend of Gray/style.qss
+++ b/resources/themes/Blend of Gray/style.qss
@@ -46,7 +46,7 @@ QMenuBar::item:pressed
 }
 
 QAbstractSpinBox {
-    padding: 0.1em 0em 0.1em 0.1em;
+    padding: 0.12em 0em 0.12em 0.12em;
     border: 1px solid #222;
     border-radius: 0.2em;
     background-color: @darkgradient;
@@ -56,10 +56,10 @@ QAbstractSpinBox {
 QAbstractSpinBox::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right;
-    padding-top:-0.2em;
+    padding-top:0em;
     padding-right:0.05em;
     width: 0.8em;
-    height: 1.2em;
+    height: 0.8em;
     image: url(@theme_path/icons/arrow-up.svg);
 }
 
@@ -69,7 +69,7 @@ QAbstractSpinBox::down-button {
     padding-top:0.2em;
     padding-right:0.05em;
     width: 0.8em;
-    height: 1.2em;
+    height: 0.8em;
     image: url(@theme_path/icons/arrow-down.svg);
 }
 
@@ -114,7 +114,7 @@ QWidget:disabled
 
 QLineEdit, QTextEdit, QPlainTextEdit
 {
-    padding: 0.1em;
+    padding: 0.12em;
     border-width: 1px;
     border-color: @itemdarkbackground;
     border-style: solid;
@@ -125,7 +125,7 @@ QLineEdit, QTextEdit, QPlainTextEdit
 
 QPushButton 
 {
-    padding: 0.1em;
+    padding: 0.12em;
     border-width: 1px;
     border-color: @itemdarkbackground;
     border-style: solid;
@@ -136,7 +136,7 @@ QPushButton
 
 QToolButton
 {
-    padding: 0.1em;
+    padding: 0.12em;
     border-width: 1px;
     border-color: @itemdarkbackground;
     border-style: solid;
@@ -190,7 +190,7 @@ QComboBox {
     border-style: solid;
     border: 1px solid #1e1e1e;
     border-radius: 0.2em;
-    padding: 0.1em 1em 0.1em 0.1em;
+    padding: 0.12em 1.2em 0.12em 0.12em;
 }
 
 
@@ -199,7 +199,7 @@ QComboBox:hover,QPushButton:hover,QToolButton:hover,QAbstractSpinBox:hover {
 }
 
 QComboBox:on {
-    padding: 0.1em;
+    padding: 0.12em;
     padding-left: 0.2em;
     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1,
         stop: 0     #555,
@@ -221,7 +221,7 @@ QComboBox:editable QLineEdit {
 QComboBox QAbstractItemView, QComboBox QListView {
     border: none;
     border-radius: 0;
-    padding: 0.1em;
+    padding: 0.12em;
     background: @itemdarkbackground;
     color: @itembackground;
     selection-background-color: @selection;
@@ -242,16 +242,16 @@ QComboBox::down-arrow
 }
 
 QComboBox:item {
-    padding-left: 1.5em;
-    height:1.2em;
+    padding-left: 1.3em;
+    height:1.25em;
 }
 QComboBox:item:selected {
-    padding-left: 1.5em;
-    height:1.2em;
+    padding-left: 1.3em;
+    height:1.25em;
 }
 QComboBox:item:checked {
-    padding-left: 1.5em;
-    height:1.2em;
+    padding-left: 1.3em;
+    height:1.25em;
 }
 
 QLineEdit:focus
@@ -424,6 +424,10 @@ QProgressBar::chunk
     background-color: @selection;
     width: 3px;
     margin: 1px;
+}
+
+QTabWidget::pane {
+    border: 1px solid @itemdarkbackground;
 }
 
 QTabBar::tab {

--- a/resources/themes/Night Mapping/style.qss
+++ b/resources/themes/Night Mapping/style.qss
@@ -46,7 +46,7 @@ QMenuBar::item:pressed
 }
 
 QAbstractSpinBox {
-    padding: 0.1em 0em 0.1em 0.1em;
+    padding: 0.12em 0em 0.12em 0.12em;
     border: 1px solid #222;
     border-radius:0px;
     background-color: @darkgradient;
@@ -56,10 +56,10 @@ QAbstractSpinBox {
 QAbstractSpinBox::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right;
-    padding-top:-0.2em;
+    padding-top:0em;
     padding-right:0.05em;
     width: 0.8em;
-    height: 1.2em;
+    height: 0.8em;
     image: url(@theme_path/icons/arrow-up.svg);
 }
 
@@ -69,7 +69,7 @@ QAbstractSpinBox::down-button {
     padding-top:0.2em;
     padding-right:0.05em;
     width: 0.8em;
-    height: 1.2em;
+    height: 0.8em;
     image: url(@theme_path/icons/arrow-down.svg);
 }
 
@@ -114,7 +114,7 @@ QWidget:disabled
 
 QLineEdit
 {
-    padding: 0.1em;
+    padding: 0.12em;
     border: 1px solid #111;
     background-color: #888;
     color: #111;
@@ -122,7 +122,7 @@ QLineEdit
 
 QTextEdit, QPlainTextEdit
 {
-    padding: 0.1em;
+    padding: 0.12em;
     border-width: 1px;
     border-color: @itemdarkbackground;
     border-style: solid;
@@ -133,7 +133,7 @@ QTextEdit, QPlainTextEdit
 
 QPushButton 
 {
-    padding: 0.1em;
+    padding: 0.12em;
     border-width: 1px;
     border-color: @itembackground;
     border-style: solid;
@@ -144,7 +144,7 @@ QPushButton
 
 QToolButton
 {
-    padding: 0.1em;
+    padding: 0.12em;
     border-width: 1px;
     border-color: @itembackground;
     border-style: solid;
@@ -198,7 +198,7 @@ QComboBox {
     border-style: solid;
     border: 1px solid #1e1e1e; 
     border-radius: 0px;
-    padding: 0.1em 1em 0.1em 0.1em;
+    padding: 0.12em 1.2em 0.12em 0.12em;
 }
 
 
@@ -207,7 +207,7 @@ QComboBox:hover,QPushButton:hover,QToolButton:hover,QAbstractSpinBox:hover {
 }
 
 QComboBox:on {
-    padding: 0.1em;
+    padding: 0.12em;
     padding-left: 0.2em;
     background-color: QLinearGradient( x1: 0, y1: 0, x2: 0, y2: 1,
         stop: 0     #555,
@@ -230,7 +230,7 @@ QComboBox:editable QLineEdit {
 QComboBox QAbstractItemView, QComboBox QListView {
     border: none;
     border-radius: 0px;
-    padding: 0.1em;
+    padding: 0.12em;
     background: @itemdarkbackground;
     color: @text;
     selection-background-color: @selection;
@@ -251,16 +251,16 @@ QComboBox::down-arrow
 }
 
 QComboBox:item {
-    padding-left: 1.5em;
-    height:1.2em;
+    padding-left: 1.3em;
+    height:1.25em;
 }
 QComboBox:item:selected {
-    padding-left: 1.5em;
-    height:1.2em;
+    padding-left: 1.3em;
+    height:1.25em;
 }
 QComboBox:item:checked {
-    padding-left: 1.5em;
-    height:1.2em;
+    padding-left: 1.3em;
+    height:1.25em;
 }
 
 QLineEdit:focus
@@ -433,6 +433,10 @@ QProgressBar::chunk
     background-color: @focus;
     width: 3px;
     margin: 1px;
+}
+
+QTabWidget::pane {
+    border: 1px solid @itemdarkbackground;
 }
 
 QTabBar::tab {


### PR DESCRIPTION
## Description
This PR fixes a couple of issues with our themes on windows, namely the combo box drop down list having its text clipped, as well as the spinbox's up and down arrow overlapping each other.

Turns out having a single theme QSS that looks great across platforms isn't straightforward. For one, windows' default font size - 8pt - is much smaller that linux. I've slightly increased the padding for most widgets to add a tiny bit of spacing on windows when users have such a small font.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
