### PR TITLE
Remove empty action in shortcut configuration list.

### DIFF
--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -83,6 +83,11 @@ void QgsConfigureShortcutsDialog::populateActions()
       continue;
     }
 
+    if ( actionText.length() == 0 )
+    {
+      continue;
+    }
+
     QStringList lst;
     lst << actionText << sequence;
     QTreeWidgetItem *item = new QTreeWidgetItem( lst );


### PR DESCRIPTION
## Description
Remove empty row in the shortcut configuration list
From:
![selection_005](https://user-images.githubusercontent.com/1421861/50735702-51297380-11b3-11e9-8306-2907c9929019.jpg)
 To:
![selection_006](https://user-images.githubusercontent.com/1421861/50735706-58508180-11b3-11e9-88da-a6b3cedf3331.jpg)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
