### PR TITLE
[FEATURE][georefencer] Make minimizing georeferencer when adding points optional

### DIFF
--- a/src/plugins/georeferencer/qgsgeorefconfigdialog.cpp
+++ b/src/plugins/georeferencer/qgsgeorefconfigdialog.cpp
@@ -91,32 +91,9 @@ void QgsGeorefConfigDialog::buttonBox_rejected()
 void QgsGeorefConfigDialog::readSettings()
 {
   QgsSettings s;
-  if ( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowId" ) ).toBool() )
-  {
-    mShowIDsCheckBox->setChecked( true );
-  }
-  else
-  {
-    mShowIDsCheckBox->setChecked( false );
-  }
-
-  if ( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowCoords" ) ).toBool() )
-  {
-    mShowCoordsCheckBox->setChecked( true );
-  }
-  else
-  {
-    mShowCoordsCheckBox->setChecked( false );
-  }
-
-  if ( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowDocked" ) ).toBool() )
-  {
-    mShowDockedCheckBox->setChecked( true );
-  }
-  else
-  {
-    mShowDockedCheckBox->setChecked( false );
-  }
+  mShowIDsCheckBox->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowId" ) ).toBool() );
+  mShowCoordsCheckBox->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowCoords" ) ).toBool() );
+  mShowDockedCheckBox->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ShowDocked" ) ).toBool() );
 
   if ( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/ResidualUnits" ) ).toString() == QLatin1String( "mapUnits" ) )
   {

--- a/src/plugins/georeferencer/qgsgeorefconfigdialogbase.ui
+++ b/src/plugins/georeferencer/qgsgeorefconfigdialogbase.ui
@@ -6,18 +6,31 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>309</width>
-    <height>443</height>
+    <width>478</width>
+    <height>542</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Configure Georeferencer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
+   <item row="5" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="mPointTipGroupBox">
      <property name="title">
-      <string>Point tip</string>
+      <string>Point Tip</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
@@ -37,25 +50,42 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="mResidualUnitsGroupBox">
-     <property name="title">
-      <string>Residual units</string>
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="mShowDockedCheckBox">
+     <property name="text">
+      <string>Show Georeferencer window docked</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3">
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>PDF Map</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="0">
-       <widget class="QRadioButton" name="mPixelsButton">
-        <property name="text">
-         <string>Pixels</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="mMapUnitsButton">
-        <property name="text">
-         <string>Use map units if possible</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Paper size</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="mPaperSizeComboBox"/>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -63,7 +93,7 @@
    <item row="2" column="0">
     <widget class="QGroupBox" name="mPdfReportGroupBox">
      <property name="title">
-      <string>PDF report</string>
+      <string>PDF Report</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
@@ -114,58 +144,28 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QCheckBox" name="mShowDockedCheckBox">
-     <property name="text">
-      <string>Show Georeferencer window docked</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="groupBox">
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="mResidualUnitsGroupBox">
      <property name="title">
-      <string>PDF map</string>
+      <string>Residual Units</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_5">
+     <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Paper size</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="mPaperSizeComboBox"/>
-        </item>
-       </layout>
+       <widget class="QRadioButton" name="mPixelsButton">
+        <property name="text">
+         <string>Pixels</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="mMapUnitsButton">
+        <property name="text">
+         <string>Use map units if possible</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
-   </item>
-   <item row="5" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/plugins/georeferencer/qgsmapcoordsdialog.cpp
+++ b/src/plugins/georeferencer/qgsmapcoordsdialog.cpp
@@ -46,6 +46,8 @@ QgsMapCoordsDialog::QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, const QgsPoint
   mToolEmitPoint = new QgsGeorefMapToolEmitPoint( qgisCanvas );
   mToolEmitPoint->setButton( mPointFromCanvasPushButton );
 
+  mMinimizeWindowCheckBox->setChecked( s.value( QStringLiteral( "/Plugin-GeoReferencer/Config/Minimize" ), QStringLiteral( "1" ) ).toBool() );
+
   connect( mPointFromCanvasPushButton, &QAbstractButton::clicked, this, &QgsMapCoordsDialog::setToolEmitPoint );
 
   connect( mToolEmitPoint, &QgsGeorefMapToolEmitPoint::canvasClicked,
@@ -63,6 +65,7 @@ QgsMapCoordsDialog::~QgsMapCoordsDialog()
 
   QgsSettings settings;
   settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/MapCoordsWindow/geometry" ), saveGeometry() );
+  settings.setValue( QStringLiteral( "/Plugin-GeoReferencer/Config/Minimize" ), mMinimizeWindowCheckBox->isChecked() );
 }
 
 void QgsMapCoordsDialog::updateOK()
@@ -119,7 +122,10 @@ void QgsMapCoordsDialog::setToolEmitPoint( bool isEnable )
 {
   if ( isEnable )
   {
-    parentWidget()->showMinimized();
+    if ( mMinimizeWindowCheckBox->isChecked() )
+    {
+      parentWidget()->showMinimized();
+    }
 
     Q_ASSERT( parentWidget()->parentWidget() );
     parentWidget()->parentWidget()->activateWindow();

--- a/src/plugins/georeferencer/qgsmapcoordsdialog.cpp
+++ b/src/plugins/georeferencer/qgsmapcoordsdialog.cpp
@@ -34,11 +34,11 @@ QgsMapCoordsDialog::QgsMapCoordsDialog( QgsMapCanvas *qgisCanvas, const QgsPoint
 
   setAttribute( Qt::WA_DeleteOnClose );
 
-  mPointFromCanvasPushButton = new QPushButton( QIcon( ":/icons/default/mPushButtonPencil.png" ), tr( "From map canvas" ) );
+  mPointFromCanvasPushButton = new QPushButton( QIcon( ":/icons/default/mPushButtonPencil.png" ), tr( "From Map Canvas" ) );
   mPointFromCanvasPushButton->setCheckable( true );
   buttonBox->addButton( mPointFromCanvasPushButton, QDialogButtonBox::ActionRole );
 
-  // User can input either DD or DMS coords (from QGis mapcanav we take DD coords)
+  // User can input either DD or DMS coords (from QGis mapcanvas we take DD coords)
   QgsDMSAndDDValidator *validator = new QgsDMSAndDDValidator( this );
   leXCoord->setValidator( validator );
   leYCoord->setValidator( validator );

--- a/src/plugins/georeferencer/qgsmapcoordsdialogbase.ui
+++ b/src/plugins/georeferencer/qgsmapcoordsdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>497</width>
-    <height>204</height>
+    <width>531</width>
+    <height>212</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,6 +17,20 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0">
+   <item row="1" column="0">
+    <widget class="QLabel" name="textLabel1">
+     <property name="text">
+      <string>X / East</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="0" colspan="4">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -27,30 +41,10 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
-    <widget class="QLineEdit" name="leYCoord"/>
-   </item>
    <item row="1" column="2">
     <widget class="QLabel" name="textLabel2">
      <property name="text">
       <string>Y / North</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="textLabel1">
-     <property name="text">
-      <string>X / East</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="leXCoord"/>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -66,6 +60,19 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="1" column="3">
+    <widget class="QLineEdit" name="leYCoord"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="leXCoord"/>
+   </item>
+   <item row="4" column="0" colspan="4">
+    <widget class="QCheckBox" name="mMinimizeWindowCheckBox">
+     <property name="text">
+      <string>Automatically hide georeferencer window </string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/plugins/georeferencer/qgstransformsettingsdialogbase.ui
+++ b/src/plugins/georeferencer/qgstransformsettingsdialogbase.ui
@@ -30,7 +30,7 @@
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Output settings</string>
+      <string>Output Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
       <item row="3" column="0" colspan="2">
@@ -54,7 +54,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QgsFileWidget" name="mOutputRaster"/>
+       <widget class="QgsFileWidget" name="mOutputRaster" native="true"/>
       </item>
       <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="cbxZeroAsTrans">
@@ -176,10 +176,10 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
       <item row="0" column="1">
-       <widget class="QgsFileWidget" name="mPdfMap"/>
+       <widget class="QgsFileWidget" name="mPdfMap" native="true"/>
       </item>
       <item row="1" column="1">
-       <widget class="QgsFileWidget" name="mPdfReport"/>
+       <widget class="QgsFileWidget" name="mPdfReport" native="true"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label_6">
@@ -211,7 +211,7 @@
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Transformation parameters</string>
+      <string>Transformation Parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
@@ -286,7 +286,7 @@
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector">
+       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
         </property>


### PR DESCRIPTION
Allows users to disable this option, which is annoying on multi-monitor setups where it can be desirable to have both windows visible while adding points

Fixes #20449
