### PR TITLE
[FEATURE] Add option to merge categories in categorized renderer

### DIFF
--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -39,6 +39,9 @@ The ``render`` argument indicates whether the category should initially be rende
 %End
 
     QgsRendererCategory( const QgsRendererCategory &cat );
+%Docstring
+Copy constructor.
+%End
 
     QVariant value() const;
 %Docstring

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -12,7 +12,7 @@
 class QgsRendererCategory
 {
 %Docstring
-categorized renderer
+Represents an individual category (class) from a QgsCategorizedSymbolRenderer.
 %End
 
 %TypeHeaderCode
@@ -27,22 +27,62 @@ Constructor for QgsRendererCategory.
 
     QgsRendererCategory( const QVariant &value, QgsSymbol *symbol /Transfer/, const QString &label, bool render = true );
 %Docstring
-takes ownership of symbol
+Constructor for a new QgsRendererCategory, with the specified ``value`` and ``symbol``.
+
+The ownership of ``symbol`` is transferred to the category.
+
+The ``label`` argument specifies the label used for this category in legends and the layer tree.
+
+The ``render`` argument indicates whether the category should initially be rendered and appear checked in the layer tree.
 %End
 
     QgsRendererCategory( const QgsRendererCategory &cat );
-%Docstring
-copy constructor
-%End
-
 
     QVariant value() const;
+%Docstring
+Returns the value corresponding to this category.
+
+.. seealso:: :py:func:`setValue`
+%End
+
     QgsSymbol *symbol() const;
+%Docstring
+Returns the symbol which will be used to render this category.
+
+.. seealso:: :py:func:`setSymbol`
+%End
+
     QString label() const;
+%Docstring
+Returns the label for this category, which is used to represent the category within
+legends and the layer tree.
+
+.. seealso:: :py:func:`setLabel`
+%End
 
     void setValue( const QVariant &value );
+%Docstring
+Sets the ``value`` corresponding to this category.
+
+.. seealso:: :py:func:`value`
+%End
+
     void setSymbol( QgsSymbol *s /Transfer/ );
+%Docstring
+Sets the symbol which will be used to render this category.
+
+Ownership of the symbol is transferred to the category.
+
+.. seealso:: :py:func:`symbol`
+%End
+
     void setLabel( const QString &label );
+%Docstring
+Sets the ``label`` for this category, which is used to represent the category within
+legends and the layer tree.
+
+.. seealso:: :py:func:`label`
+%End
 
     bool renderState() const;
 %Docstring
@@ -62,9 +102,16 @@ Sets whether the category is currently enabled and should be rendered.
 .. versionadded:: 2.5
 %End
 
+
     QString dump() const;
+%Docstring
+Returns a string representing the categories settings, used for debugging purposes only.
+%End
 
     void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+%Docstring
+Converts the category to a matching SLD rule, within the specified DOM document and ``element``.
+%End
 
   protected:
 

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -29,6 +29,8 @@ Constructor for QgsRendererCategory.
 %Docstring
 Constructor for a new QgsRendererCategory, with the specified ``value`` and ``symbol``.
 
+If ``value`` is a list, then the category will match any of the values from this list.
+
 The ownership of ``symbol`` is transferred to the category.
 
 The ``label`` argument specifies the label used for this category in legends and the layer tree.
@@ -41,6 +43,8 @@ The ``render`` argument indicates whether the category should initially be rende
     QVariant value() const;
 %Docstring
 Returns the value corresponding to this category.
+
+If the returned value is a list, then the category will match any of the values from this list.
 
 .. seealso:: :py:func:`setValue`
 %End
@@ -63,6 +67,8 @@ legends and the layer tree.
     void setValue( const QVariant &value );
 %Docstring
 Sets the ``value`` corresponding to this category.
+
+If ``value`` is a list, then the category will match any of the values from this list.
 
 .. seealso:: :py:func:`value`
 %End
@@ -179,8 +185,38 @@ Returns index of category with specified label (-1 if not found or not unique)
 %End
 
     bool updateCategoryValue( int catIndex, const QVariant &value );
+%Docstring
+Changes the value for the category with the specified index.
+
+If ``value`` is a list, then the category will match any of the values from this list.
+
+.. seealso:: :py:func:`updateCategorySymbol`
+
+.. seealso:: :py:func:`updateCategoryLabel`
+%End
+
     bool updateCategorySymbol( int catIndex, QgsSymbol *symbol /Transfer/ );
+%Docstring
+Changes the ``symbol`` for the category with the specified index.
+
+Ownership of ``symbol`` is transferred to the renderer.
+
+.. seealso:: :py:func:`updateCategoryValue`
+
+.. seealso:: :py:func:`updateCategoryLabel`
+%End
+
     bool updateCategoryLabel( int catIndex, const QString &label );
+%Docstring
+Changes the ``label`` for the category with the specified index.
+
+A category's label is used to represent the category within
+legends and the layer tree.
+
+.. seealso:: :py:func:`updateCategoryValue`
+
+.. seealso:: :py:func:`updateCategoryLabel`
+%End
 
     bool updateCategoryRenderState( int catIndex, bool render );
 %Docstring

--- a/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
+++ b/python/core/auto_generated/symbology/qgscategorizedsymbolrenderer.sip.in
@@ -135,6 +135,14 @@ class QgsCategorizedSymbolRenderer : QgsFeatureRenderer
   public:
 
     QgsCategorizedSymbolRenderer( const QString &attrName = QString(), const QgsCategoryList &categories = QgsCategoryList() );
+%Docstring
+Constructor for QgsCategorizedSymbolRenderer.
+
+The ``attrName`` argument specifies the layer's field name, or expression, which the categories will be matched against.
+
+A list of renderer ``categories`` can optionally be specified. If no categories are specified in the constructor, they
+can be added later by calling addCategory().
+%End
 
     virtual QgsSymbol *symbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const;
 
@@ -171,15 +179,18 @@ symbol for the renderer.
 %End
 
     const QgsCategoryList &categories() const;
+%Docstring
+Returns a list of all categories recognized by the renderer.
+%End
 
     int categoryIndexForValue( const QVariant &val );
 %Docstring
-Returns index of category with specified value (-1 if not found)
+Returns the index for the category with the specified value (or -1 if not found).
 %End
 
     int categoryIndexForLabel( const QString &val );
 %Docstring
-Returns index of category with specified label (-1 if not found or not unique)
+Returns the index of the category with the specified label (or -1 if the label was not found, or is not unique).
 
 .. versionadded:: 2.5
 %End
@@ -193,6 +204,8 @@ If ``value`` is a list, then the category will match any of the values from this
 .. seealso:: :py:func:`updateCategorySymbol`
 
 .. seealso:: :py:func:`updateCategoryLabel`
+
+.. seealso:: :py:func:`updateCategoryRenderState`
 %End
 
     bool updateCategorySymbol( int catIndex, QgsSymbol *symbol /Transfer/ );
@@ -204,6 +217,8 @@ Ownership of ``symbol`` is transferred to the renderer.
 .. seealso:: :py:func:`updateCategoryValue`
 
 .. seealso:: :py:func:`updateCategoryLabel`
+
+.. seealso:: :py:func:`updateCategoryRenderState`
 %End
 
     bool updateCategoryLabel( int catIndex, const QString &label );
@@ -216,32 +231,87 @@ legends and the layer tree.
 .. seealso:: :py:func:`updateCategoryValue`
 
 .. seealso:: :py:func:`updateCategoryLabel`
+
+.. seealso:: :py:func:`updateCategoryRenderState`
 %End
 
     bool updateCategoryRenderState( int catIndex, bool render );
 %Docstring
+Changes the render state for the category with the specified index.
+
+The render state indicates whether or not the category will be rendered,
+and is reflected in whether the category is checked with the project's layer tree.
+
+.. seealso:: :py:func:`updateCategoryValue`
+
+.. seealso:: :py:func:`updateCategorySymbol`
+
+.. seealso:: :py:func:`updateCategoryLabel`
 
 .. versionadded:: 2.5
 %End
 
     void addCategory( const QgsRendererCategory &category );
+%Docstring
+Adds a new ``category`` to the renderer.
+
+.. seealso:: :py:func:`categories`
+%End
+
     bool deleteCategory( int catIndex );
+%Docstring
+Deletes the category with the specified index from the renderer.
+
+.. seealso:: :py:func:`deleteAllCategories`
+%End
+
     void deleteAllCategories();
+%Docstring
+Deletes all existing categories from the renderer.
+
+.. seealso:: :py:func:`deleteCategory`
+%End
 
     void moveCategory( int from, int to );
 %Docstring
-Moves the category at index position from to index position to.
+Moves an existing category at index position from to index position to.
 %End
 
     void sortByValue( Qt::SortOrder order = Qt::AscendingOrder );
+%Docstring
+Sorts the existing categories by their value.
+
+.. seealso:: :py:func:`sortByLabel`
+%End
+
     void sortByLabel( Qt::SortOrder order = Qt::AscendingOrder );
+%Docstring
+Sorts the existing categories by their label.
+
+.. seealso:: :py:func:`sortByValue`
+%End
 
     QString classAttribute() const;
+%Docstring
+Returns the class attribute for the renderer, which is the field name
+or expression string from the layer which will be matched against the
+renderer categories.
+
+.. seealso:: :py:func:`setClassAttribute`
+%End
+
     void setClassAttribute( const QString &attr );
+%Docstring
+Sets the class attribute for the renderer, which is the field name
+or expression string from the layer which will be matched against the
+renderer categories.
+
+.. seealso:: :py:func:`classAttribute`
+%End
 
     static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) /Factory/;
 %Docstring
-create renderer from XML element
+Creates a categorized renderer from an XML ``element``.
 %End
 
     virtual QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context );

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -150,6 +150,7 @@ QString QgsExpression::quotedValue( const QVariant &value, QVariant::Type type )
     {
       QStringList quotedValues;
       const QVariantList values = value.toList();
+      quotedValues.reserve( values.count() );
       for ( const QVariant &v : values )
       {
         quotedValues += quotedValue( v );

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -165,7 +165,7 @@ QgsCategorizedSymbolRenderer::QgsCategorizedSymbolRenderer( const QString &attrN
   //important - we need a deep copy of the categories list, not a shared copy. This is required because
   //QgsRendererCategory::symbol() is marked const, and so retrieving the symbol via this method does not
   //trigger a detachment and copy of mCategories BUT that same method CAN be used to modify a symbol in place
-  Q_FOREACH ( const QgsRendererCategory &cat, categories )
+  for ( const QgsRendererCategory &cat : categories )
   {
     if ( !cat.symbol() )
     {
@@ -411,7 +411,7 @@ void QgsCategorizedSymbolRenderer::startRender( QgsRenderContext &context, const
     mExpression->prepare( &context.expressionContext() );
   }
 
-  Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
+  for ( const QgsRendererCategory &cat : qgis::as_const( mCategories ) )
   {
     cat.symbol()->startRender( context, fields );
   }
@@ -421,7 +421,7 @@ void QgsCategorizedSymbolRenderer::stopRender( QgsRenderContext &context )
 {
   QgsFeatureRenderer::stopRender( context );
 
-  Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
+  for ( const QgsRendererCategory &cat : qgis::as_const( mCategories ) )
   {
     cat.symbol()->stopRender( context );
   }
@@ -518,7 +518,7 @@ QString QgsCategorizedSymbolRenderer::filter( const QgsFields &fields )
   QString activeValues;
   QString inactiveValues;
 
-  Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
+  for ( const QgsRendererCategory &cat : qgis::as_const( mCategories ) )
   {
     if ( cat.value() == "" )
     {
@@ -579,7 +579,7 @@ QgsSymbolList QgsCategorizedSymbolRenderer::symbols( QgsRenderContext &context )
   Q_UNUSED( context );
   QgsSymbolList lst;
   lst.reserve( mCategories.count() );
-  Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
+  for ( const QgsRendererCategory &cat : mCategories )
   {
     lst.append( cat.symbol() );
   }
@@ -646,7 +646,7 @@ QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, 
   QDomElement rotationElem = element.firstChildElement( QStringLiteral( "rotation" ) );
   if ( !rotationElem.isNull() && !rotationElem.attribute( QStringLiteral( "field" ) ).isEmpty() )
   {
-    Q_FOREACH ( const QgsRendererCategory &cat, r->mCategories )
+    for ( const QgsRendererCategory &cat : r->mCategories )
     {
       convertSymbolRotation( cat.symbol(), rotationElem.attribute( QStringLiteral( "field" ) ) );
     }
@@ -659,7 +659,7 @@ QgsFeatureRenderer *QgsCategorizedSymbolRenderer::create( QDomElement &element, 
   QDomElement sizeScaleElem = element.firstChildElement( QStringLiteral( "sizescale" ) );
   if ( !sizeScaleElem.isNull() && !sizeScaleElem.attribute( QStringLiteral( "field" ) ).isEmpty() )
   {
-    Q_FOREACH ( const QgsRendererCategory &cat, r->mCategories )
+    for ( const QgsRendererCategory &cat : r->mCategories )
     {
       convertSymbolSizeScale( cat.symbol(),
                               QgsSymbolLayerUtils::decodeScaleMethod( sizeScaleElem.attribute( QStringLiteral( "scalemethod" ) ) ),
@@ -769,7 +769,7 @@ QgsLegendSymbolList QgsCategorizedSymbolRenderer::baseLegendSymbolItems() const
 {
   QgsLegendSymbolList lst;
   int i = 0;
-  Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
+  for ( const QgsRendererCategory &cat : mCategories )
   {
     lst << QgsLegendSymbolItem( cat.symbol(), cat.label(), QString::number( i++ ), true );
   }
@@ -782,7 +782,7 @@ QgsLegendSymbolList QgsCategorizedSymbolRenderer::legendSymbolItems() const
   {
     // check that all symbols that have the same size expression
     QgsProperty ddSize;
-    Q_FOREACH ( const QgsRendererCategory &category, mCategories )
+    for ( const QgsRendererCategory &category : mCategories )
     {
       const QgsMarkerSymbol *symbol = static_cast<const QgsMarkerSymbol *>( category.symbol() );
       if ( ddSize )
@@ -821,7 +821,7 @@ QSet<QString> QgsCategorizedSymbolRenderer::legendKeysForFeature( const QgsFeatu
   QString value = valueForFeature( feature, context ).toString();
   int i = 0;
 
-  Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
+  for ( const QgsRendererCategory &cat : mCategories )
   {
     if ( value == cat.value() )
     {
@@ -869,7 +869,7 @@ void QgsCategorizedSymbolRenderer::updateColorRamp( QgsColorRamp *ramp )
     randomRamp->setTotalColorCount( mCategories.count() );
   }
 
-  Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
+  for ( const QgsRendererCategory &cat : mCategories )
   {
     double value = count / num;
     cat.symbol()->setColor( mSourceColorRamp->color( value ) );
@@ -880,7 +880,7 @@ void QgsCategorizedSymbolRenderer::updateColorRamp( QgsColorRamp *ramp )
 void QgsCategorizedSymbolRenderer::updateSymbols( QgsSymbol *sym )
 {
   int i = 0;
-  Q_FOREACH ( const QgsRendererCategory &cat, mCategories )
+  for ( const QgsRendererCategory &cat : mCategories )
   {
     QgsSymbol *symbol = sym->clone();
     symbol->setColor( cat.symbol()->color() );

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -149,6 +149,14 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
 {
   public:
 
+    /**
+     * Constructor for QgsCategorizedSymbolRenderer.
+     *
+     * The \a attrName argument specifies the layer's field name, or expression, which the categories will be matched against.
+     *
+     * A list of renderer \a categories can optionally be specified. If no categories are specified in the constructor, they
+     * can be added later by calling addCategory().
+     */
     QgsCategorizedSymbolRenderer( const QString &attrName = QString(), const QgsCategoryList &categories = QgsCategoryList() );
 
     QgsSymbol *symbolForFeature( const QgsFeature &feature, QgsRenderContext &context ) const override;
@@ -172,13 +180,18 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
      */
     void updateSymbols( QgsSymbol *sym );
 
+    /**
+     * Returns a list of all categories recognized by the renderer.
+     */
     const QgsCategoryList &categories() const { return mCategories; }
 
-    //! Returns index of category with specified value (-1 if not found)
+    /**
+     * Returns the index for the category with the specified value (or -1 if not found).
+     */
     int categoryIndexForValue( const QVariant &val );
 
     /**
-     * Returns index of category with specified label (-1 if not found or not unique)
+     * Returns the index of the category with the specified label (or -1 if the label was not found, or is not unique).
      * \since QGIS 2.5
      */
     int categoryIndexForLabel( const QString &val );
@@ -190,6 +203,7 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
      *
      * \see updateCategorySymbol()
      * \see updateCategoryLabel()
+     * \see updateCategoryRenderState()
      */
     bool updateCategoryValue( int catIndex, const QVariant &value );
 
@@ -200,6 +214,7 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
      *
      * \see updateCategoryValue()
      * \see updateCategoryLabel()
+     * \see updateCategoryRenderState()
      */
     bool updateCategorySymbol( int catIndex, QgsSymbol *symbol SIP_TRANSFER );
 
@@ -211,26 +226,85 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
      *
      * \see updateCategoryValue()
      * \see updateCategoryLabel()
+     * \see updateCategoryRenderState()
      */
     bool updateCategoryLabel( int catIndex, const QString &label );
 
-    //! \since QGIS 2.5
+    /**
+     * Changes the render state for the category with the specified index.
+     *
+     * The render state indicates whether or not the category will be rendered,
+     * and is reflected in whether the category is checked with the project's layer tree.
+     *
+     * \see updateCategoryValue()
+     * \see updateCategorySymbol()
+     * \see updateCategoryLabel()
+     *
+     * \since QGIS 2.5
+     */
     bool updateCategoryRenderState( int catIndex, bool render );
 
+    /**
+     * Adds a new \a category to the renderer.
+     *
+     * \see categories()
+     */
     void addCategory( const QgsRendererCategory &category );
+
+    /**
+     * Deletes the category with the specified index from the renderer.
+     *
+     * \see deleteAllCategories()
+     */
     bool deleteCategory( int catIndex );
+
+    /**
+     * Deletes all existing categories from the renderer.
+     *
+     * \see deleteCategory()
+     */
     void deleteAllCategories();
 
-    //! Moves the category at index position from to index position to.
+    /**
+     * Moves an existing category at index position from to index position to.
+     */
     void moveCategory( int from, int to );
 
+    /**
+     * Sorts the existing categories by their value.
+     *
+     * \see sortByLabel()
+     */
     void sortByValue( Qt::SortOrder order = Qt::AscendingOrder );
+
+    /**
+     * Sorts the existing categories by their label.
+     *
+     * \see sortByValue()
+     */
     void sortByLabel( Qt::SortOrder order = Qt::AscendingOrder );
 
+    /**
+     * Returns the class attribute for the renderer, which is the field name
+     * or expression string from the layer which will be matched against the
+     * renderer categories.
+     *
+     * \see setClassAttribute()
+     */
     QString classAttribute() const { return mAttrName; }
+
+    /**
+     * Sets the class attribute for the renderer, which is the field name
+     * or expression string from the layer which will be matched against the
+     * renderer categories.
+     *
+     * \see classAttribute()
+     */
     void setClassAttribute( const QString &attr ) { mAttrName = attr; }
 
-    //! create renderer from XML element
+    /**
+     * Creates a categorized renderer from an XML \a element.
+     */
     static QgsFeatureRenderer *create( QDomElement &element, const QgsReadWriteContext &context ) SIP_FACTORY;
 
     QDomElement save( QDomDocument &doc, const QgsReadWriteContext &context ) override;

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -54,6 +54,9 @@ class CORE_EXPORT QgsRendererCategory
     */
     QgsRendererCategory( const QVariant &value, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true );
 
+    /**
+     * Copy constructor.
+     */
     QgsRendererCategory( const QgsRendererCategory &cat );
     QgsRendererCategory &operator=( QgsRendererCategory cat );
 

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -44,6 +44,8 @@ class CORE_EXPORT QgsRendererCategory
     /**
     * Constructor for a new QgsRendererCategory, with the specified \a value and \a symbol.
     *
+    * If \a value is a list, then the category will match any of the values from this list.
+    *
     * The ownership of \a symbol is transferred to the category.
     *
     * The \a label argument specifies the label used for this category in legends and the layer tree.
@@ -57,6 +59,9 @@ class CORE_EXPORT QgsRendererCategory
 
     /**
      * Returns the value corresponding to this category.
+     *
+     * If the returned value is a list, then the category will match any of the values from this list.
+     *
      * \see setValue()
      */
     QVariant value() const;
@@ -76,6 +81,9 @@ class CORE_EXPORT QgsRendererCategory
 
     /**
      * Sets the \a value corresponding to this category.
+     *
+     * If \a value is a list, then the category will match any of the values from this list.
+     *
      * \see value()
      */
     void setValue( const QVariant &value );
@@ -175,8 +183,35 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
      */
     int categoryIndexForLabel( const QString &val );
 
+    /**
+     * Changes the value for the category with the specified index.
+     *
+     * If \a value is a list, then the category will match any of the values from this list.
+     *
+     * \see updateCategorySymbol()
+     * \see updateCategoryLabel()
+     */
     bool updateCategoryValue( int catIndex, const QVariant &value );
+
+    /**
+     * Changes the \a symbol for the category with the specified index.
+     *
+     * Ownership of \a symbol is transferred to the renderer.
+     *
+     * \see updateCategoryValue()
+     * \see updateCategoryLabel()
+     */
     bool updateCategorySymbol( int catIndex, QgsSymbol *symbol SIP_TRANSFER );
+
+    /**
+     * Changes the \a label for the category with the specified index.
+     *
+     * A category's label is used to represent the category within
+     * legends and the layer tree.
+     *
+     * \see updateCategoryValue()
+     * \see updateCategoryLabel()
+     */
     bool updateCategoryLabel( int catIndex, const QString &label );
 
     //! \since QGIS 2.5

--- a/src/core/symbology/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.h
@@ -30,7 +30,7 @@ class QgsStyle;
 
 /**
  * \ingroup core
- * \brief categorized renderer
+ * \brief Represents an individual category (class) from a QgsCategorizedSymbolRenderer.
 */
 class CORE_EXPORT QgsRendererCategory
 {
@@ -41,20 +41,59 @@ class CORE_EXPORT QgsRendererCategory
      */
     QgsRendererCategory() = default;
 
-    //! takes ownership of symbol
+    /**
+    * Constructor for a new QgsRendererCategory, with the specified \a value and \a symbol.
+    *
+    * The ownership of \a symbol is transferred to the category.
+    *
+    * The \a label argument specifies the label used for this category in legends and the layer tree.
+    *
+    * The \a render argument indicates whether the category should initially be rendered and appear checked in the layer tree.
+    */
     QgsRendererCategory( const QVariant &value, QgsSymbol *symbol SIP_TRANSFER, const QString &label, bool render = true );
 
-    //! copy constructor
     QgsRendererCategory( const QgsRendererCategory &cat );
-
     QgsRendererCategory &operator=( QgsRendererCategory cat );
 
+    /**
+     * Returns the value corresponding to this category.
+     * \see setValue()
+     */
     QVariant value() const;
+
+    /**
+     * Returns the symbol which will be used to render this category.
+     * \see setSymbol()
+     */
     QgsSymbol *symbol() const;
+
+    /**
+     * Returns the label for this category, which is used to represent the category within
+     * legends and the layer tree.
+     * \see setLabel()
+     */
     QString label() const;
 
+    /**
+     * Sets the \a value corresponding to this category.
+     * \see value()
+     */
     void setValue( const QVariant &value );
+
+    /**
+     * Sets the symbol which will be used to render this category.
+     *
+     * Ownership of the symbol is transferred to the category.
+     *
+     * \see symbol()
+     */
     void setSymbol( QgsSymbol *s SIP_TRANSFER );
+
+    /**
+     * Sets the \a label for this category, which is used to represent the category within
+     * legends and the layer tree.
+     * \see label()
+     */
     void setLabel( const QString &label );
 
     /**
@@ -72,8 +111,15 @@ class CORE_EXPORT QgsRendererCategory
     void setRenderState( bool render );
 
     // debugging
+
+    /**
+     * Returns a string representing the categories settings, used for debugging purposes only.
+     */
     QString dump() const;
 
+    /**
+     * Converts the category to a matching SLD rule, within the specified DOM document and \a element.
+     */
     void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
 
   protected:

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -557,9 +557,9 @@ QgsCategorizedSymbolRendererWidget::QgsCategorizedSymbolRendererWidget( QgsVecto
   mExpressionWidget->registerExpressionContextGenerator( this );
 
   mMergeCategoriesAction = new QAction( tr( "Merge Categories" ), this );
-  connect( mMergeCategoriesAction, &QAction::triggered, this, &QgsCategorizedSymbolRendererWidget::mergeClicked );
+  connect( mMergeCategoriesAction, &QAction::triggered, this, &QgsCategorizedSymbolRendererWidget::mergeSelectedCategories );
   mUnmergeCategoriesAction = new QAction( tr( "Unmerge Categories" ), this );
-  connect( mUnmergeCategoriesAction, &QAction::triggered, this, &QgsCategorizedSymbolRendererWidget::unmerge );
+  connect( mUnmergeCategoriesAction, &QAction::triggered, this, &QgsCategorizedSymbolRendererWidget::unmergeSelectedCategories );
 }
 
 QgsCategorizedSymbolRendererWidget::~QgsCategorizedSymbolRendererWidget()
@@ -1163,7 +1163,7 @@ void QgsCategorizedSymbolRendererWidget::dataDefinedSizeLegend()
   }
 }
 
-void QgsCategorizedSymbolRendererWidget::mergeClicked()
+void QgsCategorizedSymbolRendererWidget::mergeSelectedCategories()
 {
   const QgsCategoryList &categories = mRenderer->categories();
 
@@ -1214,7 +1214,7 @@ void QgsCategorizedSymbolRendererWidget::mergeClicked()
   emit widgetChanged();
 }
 
-void QgsCategorizedSymbolRendererWidget::unmerge()
+void QgsCategorizedSymbolRendererWidget::unmergeSelectedCategories()
 {
   const QList<int> categoryIndexes = selectedCategories();
   if ( categoryIndexes.isEmpty() )

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -159,7 +159,10 @@ QVariant QgsCategorizedSymbolRendererModel::data( const QModelIndex &index, int 
             for ( const QVariant &v : list )
               res << v.toString();
 
-            return res.join( ';' );
+            if ( role == Qt::DisplayRole )
+              return res.join( ';' );
+            else // tooltip
+              return res.join( '\n' );
           }
           else
           {

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -1155,11 +1155,26 @@ void QgsCategorizedSymbolRendererWidget::dataDefinedSizeLegend()
 
 void QgsCategorizedSymbolRendererWidget::mergeClicked()
 {
-  QList<int> categoryIndexes = selectedCategories();
+  const QgsCategoryList &categories = mRenderer->categories();
+
+  QList<int> selectedCategoryIndexes = selectedCategories();
+  QList< int > categoryIndexes;
+
+  // filter out "" entry
+  for ( int i : selectedCategoryIndexes )
+  {
+    QVariant v = categories.at( i ).value();
+
+    if ( !v.isValid() || v == "" )
+    {
+      continue;
+    }
+
+    categoryIndexes.append( i );
+  }
+
   if ( categoryIndexes.count() < 2 )
     return;
-
-  const QgsCategoryList &categories = mRenderer->categories();
 
   QStringList labels;
   QVariantList values;

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.cpp
@@ -164,6 +164,10 @@ QVariant QgsCategorizedSymbolRendererModel::data( const QModelIndex &index, int 
             else // tooltip
               return res.join( '\n' );
           }
+          else if ( !category.value().isValid() || category.value().isNull() || category.value().toString().isEmpty() )
+          {
+            return tr( "all other values" );
+          }
           else
           {
             return category.value().toString();
@@ -173,6 +177,17 @@ QVariant QgsCategorizedSymbolRendererModel::data( const QModelIndex &index, int 
           return category.label();
       }
       break;
+    }
+
+    case Qt::FontRole:
+    {
+      if ( index.column() == 1 && category.value().type() != QVariant::List && ( !category.value().isValid() || category.value().isNull() || category.value().toString().isEmpty() ) )
+      {
+        QFont italicFont;
+        italicFont.setItalic( true );
+        return italicFont;
+      }
+      return QVariant();
     }
 
     case Qt::DecorationRole:
@@ -187,7 +202,8 @@ QVariant QgsCategorizedSymbolRendererModel::data( const QModelIndex &index, int 
     case Qt::ForegroundRole:
     {
       QBrush brush( qApp->palette().color( QPalette::Text ), Qt::SolidPattern );
-      if ( index.column() == 1 && category.value().type() == QVariant::List )
+      if ( index.column() == 1 && ( category.value().type() == QVariant::List
+                                    || !category.value().isValid() || category.value().isNull() || category.value().toString().isEmpty() ) )
       {
         QColor fadedTextColor = brush.color();
         fadedTextColor.setAlpha( 128 );

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -153,8 +153,21 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void cleanUpSymbolSelector( QgsPanelWidget *container );
     void updateSymbolsFromWidget();
     void dataDefinedSizeLegend();
-    void mergeClicked();
-    void unmerge();
+
+    /**
+     * Merges all selected categories into a single multi-value category.
+     *
+     * \see unmergeSelectedCategories()
+     */
+    void mergeSelectedCategories();
+
+    /**
+     * Unmerges all selected multi-value categories into a individual value categories.
+     *
+     * \see mergeSelectedCategories()
+     */
+    void unmergeSelectedCategories();
+
     void showContextMenu( QPoint p );
 
   protected:

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -154,6 +154,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void updateSymbolsFromWidget();
     void dataDefinedSizeLegend();
     void mergeClicked();
+    void unmerge();
     void showContextMenu( QPoint p );
 
   protected:
@@ -195,6 +196,7 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     QgsCategoryList mCopyBuffer;
     QMenu *mContextMenu = nullptr;
     QAction *mMergeCategoriesAction = nullptr;
+    QAction *mUnmergeCategoriesAction = nullptr;
 
     QgsExpressionContext createExpressionContext() const override;
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -153,6 +153,8 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
     void cleanUpSymbolSelector( QgsPanelWidget *container );
     void updateSymbolsFromWidget();
     void dataDefinedSizeLegend();
+    void mergeClicked();
+    void showContextMenu( QPoint p );
 
   protected:
 
@@ -191,8 +193,12 @@ class GUI_EXPORT QgsCategorizedSymbolRendererWidget : public QgsRendererWidget, 
   private:
     QString mOldClassificationAttribute;
     QgsCategoryList mCopyBuffer;
+    QMenu *mContextMenu = nullptr;
+    QAction *mMergeCategoriesAction = nullptr;
 
     QgsExpressionContext createExpressionContext() const override;
+
+    friend class TestQgsCategorizedRendererWidget;
 };
 
 #endif // QGSCATEGORIZEDSYMBOLRENDERERWIDGET_H

--- a/src/ui/qgscategorizedsymbolrendererwidget.ui
+++ b/src/ui/qgscategorizedsymbolrendererwidget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>378</width>
+    <width>424</width>
     <height>368</height>
    </rect>
   </property>
@@ -216,14 +216,46 @@
   <tabstop>mExpressionWidget</tabstop>
   <tabstop>btnChangeCategorizedSymbol</tabstop>
   <tabstop>btnColorRamp</tabstop>
+  <tabstop>viewCategories</tabstop>
   <tabstop>btnAddCategories</tabstop>
   <tabstop>btnAddCategory</tabstop>
   <tabstop>btnDeleteCategories</tabstop>
   <tabstop>btnDeleteAllCategories</tabstop>
   <tabstop>btnAdvanced</tabstop>
-  <tabstop>viewCategories</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections/>

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -121,6 +121,7 @@ ADD_QGIS_TEST(edittooltest testqgsmaptooledit.cpp)
 #ADD_EXECUTABLE(qgis_rendererv2gui ${rendererv2gui_SRCS} ${rendererv2gui_MOC_SRCS})
 
 #ADD_QGIS_TEST(histogramtest testqgsrasterhistogram.cpp)
+ADD_QGIS_TEST(categorizedrendererwidget testqgscategorizedrendererwidget.cpp)
 ADD_QGIS_TEST(doublespinbox testqgsdoublespinbox.cpp)
 ADD_QGIS_TEST(dualviewtest testqgsdualview.cpp)
 ADD_QGIS_TEST(attributeformtest testqgsattributeform.cpp)

--- a/tests/src/gui/testqgscategorizedrendererwidget.cpp
+++ b/tests/src/gui/testqgscategorizedrendererwidget.cpp
@@ -151,17 +151,17 @@ void TestQgsCategorizedRendererWidget::merge()
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 5 ).value().toString(), QString() );
 
   // no selection, should have no effect
-  widget->mergeClicked();
+  widget->mergeSelectedCategories();
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
 
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
   // one selection, should have no effect
-  widget->mergeClicked();
+  widget->mergeSelectedCategories();
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
 
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 3, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 4, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
-  widget->mergeClicked();
+  widget->mergeSelectedCategories();
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 4 );
 
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "a" ) );
@@ -179,7 +179,7 @@ void TestQgsCategorizedRendererWidget::merge()
   // selection should always "merge into" first selected item
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 2, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 0, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
-  widget->mergeClicked();
+  widget->mergeSelectedCategories();
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 3 );
 
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 0 ).toString(), QStringLiteral( "b" ) );
@@ -198,7 +198,7 @@ void TestQgsCategorizedRendererWidget::merge()
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
   //"" entry should be ignored
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 2, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
-  widget->mergeClicked();
+  widget->mergeSelectedCategories();
 
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 2 );
 
@@ -214,15 +214,15 @@ void TestQgsCategorizedRendererWidget::merge()
 
   widget->viewCategories->selectionModel()->clearSelection();
   // unmerge
-  widget->unmerge();
+  widget->unmergeSelectedCategories();
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 2 );
   // not a list
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
-  widget->unmerge();
+  widget->unmergeSelectedCategories();
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 2 );
   // list
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
-  widget->unmerge();
+  widget->unmergeSelectedCategories();
 
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "b" ) );
@@ -240,15 +240,15 @@ void TestQgsCategorizedRendererWidget::merge()
 
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 2, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 3, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
-  widget->mergeClicked();
+  widget->mergeSelectedCategories();
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 3, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 4, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
-  widget->mergeClicked();
+  widget->mergeSelectedCategories();
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 2, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 3, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
-  widget->unmerge();
+  widget->unmergeSelectedCategories();
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "b" ) );
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toString(), QString() );

--- a/tests/src/gui/testqgscategorizedrendererwidget.cpp
+++ b/tests/src/gui/testqgscategorizedrendererwidget.cpp
@@ -248,9 +248,9 @@ void TestQgsCategorizedRendererWidget::model()
   QCOMPARE( model->data( model->index( 1, 2 ), Qt::DisplayRole ).toString(), QStringLiteral( "list" ) );
   QCOMPARE( model->data( model->index( 2, 2 ), Qt::DisplayRole ).toString(), QStringLiteral( "dd" ) );
 
-  QCOMPARE( model->data( model->index( 0, 0 ), Qt::CheckStateRole ).toInt(), Qt::Checked );
-  QCOMPARE( model->data( model->index( 1, 0 ), Qt::CheckStateRole ).toInt(), Qt::Checked );
-  QCOMPARE( model->data( model->index( 2, 0 ), Qt::CheckStateRole ).toInt(), Qt::Unchecked );
+  QCOMPARE( model->data( model->index( 0, 0 ), Qt::CheckStateRole ).toInt(), static_cast< int >( Qt::Checked ) );
+  QCOMPARE( model->data( model->index( 1, 0 ), Qt::CheckStateRole ).toInt(), static_cast< int >( Qt::Checked ) );
+  QCOMPARE( model->data( model->index( 2, 0 ), Qt::CheckStateRole ).toInt(), static_cast< int >( Qt::Unchecked ) );
 }
 
 QGSTEST_MAIN( TestQgsCategorizedRendererWidget )

--- a/tests/src/gui/testqgscategorizedrendererwidget.cpp
+++ b/tests/src/gui/testqgscategorizedrendererwidget.cpp
@@ -211,6 +211,57 @@ void TestQgsCategorizedRendererWidget::merge()
 
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).label(), QStringLiteral( "b,d,e,c,a" ) );
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).label(), QString() );
+
+  widget->viewCategories->selectionModel()->clearSelection();
+  // unmerge
+  widget->unmerge();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 2 );
+  // not a list
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  widget->unmerge();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 2 );
+  // list
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  widget->unmerge();
+
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toString(), QString() );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).value().toString(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).value().toString(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 4 ).value().toString(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 5 ).value().toString(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).label(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).label(), QString() );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).label(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).label(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 4 ).label(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 5 ).label(), QStringLiteral( "a" ) );
+
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 2, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 3, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->mergeClicked();
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 3, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 4, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->mergeClicked();
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 2, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 3, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->unmerge();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toString(), QString() );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).value().toString(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).value().toString(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 4 ).value().toString(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 5 ).value().toString(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).label(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).label(), QString() );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).label(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).label(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 4 ).label(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 5 ).label(), QStringLiteral( "a" ) );
 }
 
 void TestQgsCategorizedRendererWidget::model()

--- a/tests/src/gui/testqgscategorizedrendererwidget.cpp
+++ b/tests/src/gui/testqgscategorizedrendererwidget.cpp
@@ -1,0 +1,255 @@
+/***************************************************************************
+                         testqgscategorizedrendererwidget.cpp
+                         ---------------------------
+    begin                : January 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstest.h"
+
+#include "qgscategorizedsymbolrenderer.h"
+#include "qgscategorizedsymbolrendererwidget.h"
+#include "qgsapplication.h"
+#include "qgsvectorlayer.h"
+#include "qgsfeature.h"
+#include "qgsvectordataprovider.h"
+
+#include <memory>
+
+class TestQgsCategorizedRendererWidget : public QObject
+{
+    Q_OBJECT
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+    void testAddMissingCategories();
+    void merge();
+    void model();
+
+};
+
+void TestQgsCategorizedRendererWidget::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsCategorizedRendererWidget::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsCategorizedRendererWidget::init()
+{
+}
+
+void TestQgsCategorizedRendererWidget::cleanup()
+{
+}
+
+void TestQgsCategorizedRendererWidget::testAddMissingCategories()
+{
+  std::unique_ptr< QgsVectorLayer > vl = qgis::make_unique< QgsVectorLayer >( "Point?crs=EPSG:4326&field=idx:integer&field=name:string", QString(), QStringLiteral( "memory" ) );
+  QVERIFY( vl->isValid() );
+
+  QgsFeature f;
+  f.setAttributes( QgsAttributes() << 1 << "a" );
+  QVERIFY( vl->dataProvider()->addFeature( f ) );
+  f.setAttributes( QgsAttributes() << 2 << "b" );
+  vl->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 3 << "c" );
+  vl->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 4 << "d" );
+  vl->dataProvider()->addFeature( f );
+
+  QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer( QStringLiteral( "name" ) );
+  vl->setRenderer( renderer );
+
+  std::unique_ptr< QgsCategorizedSymbolRendererWidget > widget = qgis::make_unique< QgsCategorizedSymbolRendererWidget >( vl.get(), nullptr, renderer );
+  QVERIFY( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().isEmpty() );
+
+  widget->addCategories();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 5 );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toString(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).value().toString(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).value().toString(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 4 ).value().toString(), QString() );
+
+  // add a new value
+  f.setAttributes( QgsAttributes() << 4 << "e" );
+  vl->dataProvider()->addFeature( f );
+
+  widget->addCategories();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 5 ).value().toString(), QStringLiteral( "e" ) );
+
+  // test with a value list category
+  widget.reset();
+  renderer = new QgsCategorizedSymbolRenderer( QStringLiteral( "name" ) );
+  renderer->addCategory( QgsRendererCategory( QStringLiteral( "b" ), QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry ), QString() ) );
+  renderer->addCategory( QgsRendererCategory( QVariantList() << QStringLiteral( "a" ) << QStringLiteral( "c" ), QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry ), QString() ) );
+
+  vl->setRenderer( renderer );
+
+  widget = qgis::make_unique< QgsCategorizedSymbolRendererWidget >( vl.get(), nullptr, renderer );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 2 );
+
+  // values inside list categories should not be re-added
+  widget->addCategories();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 5 );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toList().at( 0 ).toString(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toList().at( 1 ).toString(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).value().toString(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).value().toString(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 4 ).value().toString(), QString() );
+}
+
+void TestQgsCategorizedRendererWidget::merge()
+{
+  // test merging categories
+
+  std::unique_ptr< QgsVectorLayer > vl = qgis::make_unique< QgsVectorLayer >( "Point?crs=EPSG:4326&field=idx:integer&field=name:string", QString(), QStringLiteral( "memory" ) );
+  QVERIFY( vl->isValid() );
+
+  QgsFeature f;
+  f.setAttributes( QgsAttributes() << 1 << "a" );
+  QVERIFY( vl->dataProvider()->addFeature( f ) );
+  f.setAttributes( QgsAttributes() << 2 << "b" );
+  vl->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 3 << "c" );
+  vl->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 4 << "d" );
+  vl->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 5 << "e" );
+  vl->dataProvider()->addFeature( f );
+
+  QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer( QStringLiteral( "name" ) );
+  vl->setRenderer( renderer );
+
+  std::unique_ptr< QgsCategorizedSymbolRendererWidget > widget = qgis::make_unique< QgsCategorizedSymbolRendererWidget >( vl.get(), nullptr, renderer );
+  widget->addCategories();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toString(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).value().toString(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).value().toString(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 4 ).value().toString(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 5 ).value().toString(), QString() );
+
+  // no selection, should have no effect
+  widget->mergeClicked();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
+
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  // one selection, should have no effect
+  widget->mergeClicked();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 6 );
+
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 3, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 4, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->mergeClicked();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 4 );
+
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toString(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toList().at( 0 ).toString(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toList().at( 1 ).toString(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toList().at( 2 ).toString(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).value().toString(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).value().toString(), QString() );
+
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).label(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).label(), QStringLiteral( "b,d,e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).label(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 3 ).label(), QString() );
+
+  // selection should always "merge into" first selected item
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 2, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 0, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->mergeClicked();
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 3 );
+
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 0 ).toString(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 1 ).toString(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 2 ).toString(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toList().at( 0 ).toString(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toList().at( 1 ).toString(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).value().toString(), QString() );
+
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).label(), QStringLiteral( "b,d,e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).label(), QStringLiteral( "c,a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 2 ).label(), QString() );
+
+  // merging categories which are already lists
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  widget->mergeClicked();
+
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 2 );
+
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 0 ).toString(), QStringLiteral( "b" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 1 ).toString(), QStringLiteral( "d" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 2 ).toString(), QStringLiteral( "e" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 3 ).toString(), QStringLiteral( "c" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).value().toList().at( 4 ).toString(), QStringLiteral( "a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).value().toString(), QString() );
+
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 0 ).label(), QStringLiteral( "b,d,e,c,a" ) );
+  QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().at( 1 ).label(), QString() );
+}
+
+void TestQgsCategorizedRendererWidget::model()
+{
+  std::unique_ptr< QgsVectorLayer > vl = qgis::make_unique< QgsVectorLayer >( "Point?crs=EPSG:4326&field=idx:integer&field=name:string", QString(), QStringLiteral( "memory" ) );
+  QVERIFY( vl->isValid() );
+
+  QgsFeature f;
+  f.setAttributes( QgsAttributes() << 1 << "a" );
+  QVERIFY( vl->dataProvider()->addFeature( f ) );
+  f.setAttributes( QgsAttributes() << 2 << "b" );
+  vl->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 3 << "c" );
+  vl->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 4 << "d" );
+  vl->dataProvider()->addFeature( f );
+  f.setAttributes( QgsAttributes() << 5 << "e" );
+  vl->dataProvider()->addFeature( f );
+
+  QgsCategorizedSymbolRenderer *renderer = new QgsCategorizedSymbolRenderer( QStringLiteral( "name" ) );
+  renderer = new QgsCategorizedSymbolRenderer( QStringLiteral( "name" ) );
+  renderer->addCategory( QgsRendererCategory( QStringLiteral( "b" ), QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry ), QStringLiteral( "aa" ) ) );
+  renderer->addCategory( QgsRendererCategory( QVariantList() << QStringLiteral( "a" ) << QStringLiteral( "c" ), QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry ), QStringLiteral( "list" ) ) );
+  renderer->addCategory( QgsRendererCategory( QStringLiteral( "d" ), QgsSymbol::defaultSymbol( QgsWkbTypes::PointGeometry ), QStringLiteral( "dd" ), false ) );
+
+  vl->setRenderer( renderer );
+
+  std::unique_ptr< QgsCategorizedSymbolRendererWidget > widget = qgis::make_unique< QgsCategorizedSymbolRendererWidget >( vl.get(), nullptr, renderer );
+  QgsCategorizedSymbolRendererModel *model = widget->mModel;
+  QCOMPARE( model->rowCount(), 3 );
+  QCOMPARE( model->data( model->index( 0, 1 ), Qt::DisplayRole ).toString(), QStringLiteral( "b" ) );
+  QCOMPARE( model->data( model->index( 1, 1 ), Qt::DisplayRole ).toString(), QStringLiteral( "a;c" ) );
+  QCOMPARE( model->data( model->index( 2, 1 ), Qt::DisplayRole ).toString(), QStringLiteral( "d" ) );
+  QCOMPARE( model->data( model->index( 0, 2 ), Qt::DisplayRole ).toString(), QStringLiteral( "aa" ) );
+  QCOMPARE( model->data( model->index( 1, 2 ), Qt::DisplayRole ).toString(), QStringLiteral( "list" ) );
+  QCOMPARE( model->data( model->index( 2, 2 ), Qt::DisplayRole ).toString(), QStringLiteral( "dd" ) );
+
+  QCOMPARE( model->data( model->index( 0, 0 ), Qt::CheckStateRole ).toInt(), Qt::Checked );
+  QCOMPARE( model->data( model->index( 1, 0 ), Qt::CheckStateRole ).toInt(), Qt::Checked );
+  QCOMPARE( model->data( model->index( 2, 0 ), Qt::CheckStateRole ).toInt(), Qt::Unchecked );
+}
+
+QGSTEST_MAIN( TestQgsCategorizedRendererWidget )
+#include "testqgscategorizedrendererwidget.moc"

--- a/tests/src/gui/testqgscategorizedrendererwidget.cpp
+++ b/tests/src/gui/testqgscategorizedrendererwidget.cpp
@@ -196,6 +196,8 @@ void TestQgsCategorizedRendererWidget::merge()
   // merging categories which are already lists
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 0, 0 ), QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Rows );
   widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 1, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
+  //"" entry should be ignored
+  widget->viewCategories->selectionModel()->select( widget->viewCategories->model()->index( 2, 0 ), QItemSelectionModel::Select | QItemSelectionModel::Rows );
   widget->mergeClicked();
 
   QCOMPARE( static_cast< QgsCategorizedSymbolRenderer * >( widget->renderer() )->categories().count(), 2 );

--- a/tests/src/python/test_qgsrulebasedrenderer.py
+++ b/tests/src/python/test_qgsrulebasedrenderer.py
@@ -261,35 +261,44 @@ class TestQgsRulebasedRenderer(unittest.TestCase):
         cats.append(QgsRendererCategory('a\nb', QgsMarkerSymbol(), "id a\\nb"))
         cats.append(QgsRendererCategory('a\\b', QgsMarkerSymbol(), "id a\\\\b"))
         cats.append(QgsRendererCategory('a\tb', QgsMarkerSymbol(), "id a\\tb"))
+        cats.append(QgsRendererCategory(['c', 'd'], QgsMarkerSymbol(), "c/d"))
         c = QgsCategorizedSymbolRenderer("id", cats)
 
         r = QgsRuleBasedRenderer.convertFromRenderer(c)
+        self.assertEqual(len(r.rootRule().children()), 7)
         self.assertEqual(r.rootRule().children()[0].filterExpression(), '"id" = 1')
         self.assertEqual(r.rootRule().children()[1].filterExpression(), '"id" = 2')
         self.assertEqual(r.rootRule().children()[2].filterExpression(), '"id" = \'a\'\'b\'')
         self.assertEqual(r.rootRule().children()[3].filterExpression(), '"id" = \'a\\nb\'')
         self.assertEqual(r.rootRule().children()[4].filterExpression(), '"id" = \'a\\\\b\'')
         self.assertEqual(r.rootRule().children()[5].filterExpression(), '"id" = \'a\\tb\'')
+        self.assertEqual(r.rootRule().children()[6].filterExpression(), '"id" IN (\'c\',\'d\')')
 
         # Next try with an expression based category
         cats = []
         cats.append(QgsRendererCategory(1, QgsMarkerSymbol(), "result 1"))
         cats.append(QgsRendererCategory(2, QgsMarkerSymbol(), "result 2"))
+        cats.append(QgsRendererCategory([3, 4], QgsMarkerSymbol(), "result 3/4"))
         c = QgsCategorizedSymbolRenderer("id + 1", cats)
 
         r = QgsRuleBasedRenderer.convertFromRenderer(c)
+        self.assertEqual(len(r.rootRule().children()), 3)
         self.assertEqual(r.rootRule().children()[0].filterExpression(), 'id + 1 = 1')
         self.assertEqual(r.rootRule().children()[1].filterExpression(), 'id + 1 = 2')
+        self.assertEqual(r.rootRule().children()[2].filterExpression(), 'id + 1 IN (3,4)')
 
         # Last try with an expression which is just a quoted field name
         cats = []
         cats.append(QgsRendererCategory(1, QgsMarkerSymbol(), "result 1"))
         cats.append(QgsRendererCategory(2, QgsMarkerSymbol(), "result 2"))
+        cats.append(QgsRendererCategory([3, 4], QgsMarkerSymbol(), "result 3/4"))
         c = QgsCategorizedSymbolRenderer('"id"', cats)
 
         r = QgsRuleBasedRenderer.convertFromRenderer(c)
+        self.assertEqual(len(r.rootRule().children()), 3)
         self.assertEqual(r.rootRule().children()[0].filterExpression(), '"id" = 1')
         self.assertEqual(r.rootRule().children()[1].filterExpression(), '"id" = 2')
+        self.assertEqual(r.rootRule().children()[2].filterExpression(), '"id" IN (3,4)')
 
     def testConvertFromGraduatedRenderer(self):
         # Test converting graduated renderer to rule based


### PR DESCRIPTION
This allows users to select multiple existing categories and group them into a single category, which applies to any of the values from the selection.

This allows simpler styling of layers with a large number of categories, where it may be possible to group numerous distinct categories into a smaller, more managable set of categories which apply to multiple values.

Sponsored by SMEC/SJ

![peek 2019-01-07 16-51](https://user-images.githubusercontent.com/1829991/50753128-78a83b00-129c-11e9-916a-dec2cf847305.gif)
