### PR TITLE
re-add the r.mapcalculator module (as r.mapcalc.simple) and remove the not working r.mapcalc

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.mapcalc.simple.txt
+++ b/python/plugins/processing/algs/grass7/description/r.mapcalc.simple.txt
@@ -1,0 +1,11 @@
+r.mapcalc.simple
+Calculate new raster map from a r.mapcalc expression.
+Raster (r.*)
+ParameterRaster|a|Raster layer A|False
+ParameterRaster|b|Raster layer B|True
+ParameterRaster|c|Raster layer C|True
+ParameterRaster|d|Raster layer D|True
+ParameterRaster|e|Raster layer E|True
+ParameterRaster|f|Raster layer F|True
+ParameterString|expression|Formula|A*2
+OutputRaster|output|Calculated

--- a/python/plugins/processing/algs/grass7/description/r.mapcalc.txt
+++ b/python/plugins/processing/algs/grass7/description/r.mapcalc.txt
@@ -1,9 +1,0 @@
-r.mapcalc
-Raster map calculator. 
-Raster (r.*)
-ParameterMultipleInput|maps|Raster maps used in the calculator|3|True
-ParameterString|expression|Expression to evaluate. The raster names used in expression should be the same than in QGIS|None|True|True
-ParameterFile|file|File containing expression(s) to evaluate (same rule for raster names than above)|True
-ParameterString|seed|Integer seed for rand() function|None|False|True
-*ParameterBoolean|-s|Generate random seed (result is non-deterministic)|False
-OutputDirectory|output_dir|Results Directory


### PR DESCRIPTION
## Description
This is the backport of https://github.com/qgis/QGIS/pull/8444

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
