### PR TITLE
re-add the r.mapcalculator momodule (as r.mapcalc.simple) and remove the not working r.mapcalc

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.mapcalc.simple.txt
+++ b/python/plugins/processing/algs/grass7/description/r.mapcalc.simple.txt
@@ -1,0 +1,11 @@
+r.mapcalc.simple
+Calculate new raster map from a r.mapcalc expression.
+Raster (r.*)
+ParameterRaster|a|Raster layer A|False
+ParameterRaster|b|Raster layer B|True
+ParameterRaster|c|Raster layer C|True
+ParameterRaster|d|Raster layer D|True
+ParameterRaster|e|Raster layer E|True
+ParameterRaster|f|Raster layer F|True
+ParameterString|expression|Formula|A*2
+OutputRaster|output|Calculated

--- a/python/plugins/processing/algs/grass7/description/r.mapcalc.simple.txt
+++ b/python/plugins/processing/algs/grass7/description/r.mapcalc.simple.txt
@@ -1,11 +1,11 @@
 r.mapcalc.simple
 Calculate new raster map from a r.mapcalc expression.
 Raster (r.*)
-ParameterRaster|a|Raster layer A|False
-ParameterRaster|b|Raster layer B|True
-ParameterRaster|c|Raster layer C|True
-ParameterRaster|d|Raster layer D|True
-ParameterRaster|e|Raster layer E|True
-ParameterRaster|f|Raster layer F|True
-ParameterString|expression|Formula|A*2
-OutputRaster|output|Calculated
+QgsProcessingParameterRasterLayer|a|Raster layer A|False
+QgsProcessingParameterRasterLayer|b|Raster layer B|True
+QgsProcessingParameterRasterLayer|c|Raster layer C|True
+QgsProcessingParameterRasterLayer|d|Raster layer D|True
+QgsProcessingParameterRasterLayer|e|Raster layer E|True
+QgsProcessingParameterRasterLayer|f|Raster layer F|True
+QgsProcessingParameterString|expression|Formula|A*2
+QgsProcessingParameterRasterDestination|output|Calculated

--- a/python/plugins/processing/algs/grass7/description/r.mapcalc.txt
+++ b/python/plugins/processing/algs/grass7/description/r.mapcalc.txt
@@ -1,9 +1,0 @@
-r.mapcalc
-Raster map calculator.
-Raster (r.*)
-QgsProcessingParameterMultipleLayers|maps|Raster maps used in the calculator|3|None|True
-QgsProcessingParameterString|expression|Expression to evaluate. Syntax e.g. `raster_out=raster1+raster2`. Use original filenames, without extension|None|True|True
-QgsProcessingParameterFile|file|File containing expression(s) to evaluate (same rule for raster names than above)|QgsProcessingParameterFile.File|txt|None|True
-QgsProcessingParameterString|seed|Integer seed for rand() function|None|False|True
-*QgsProcessingParameterBoolean|-s|Generate random seed (result is non-deterministic)|False
-QgsProcessingParameterFolderDestination|output_dir|Results Directory


### PR DESCRIPTION
## Description
This is the backport of #8444

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
