### PR TITLE
Fix "unexpected geometry type:7" warning thrown by pal geometry handling

### DIFF
--- a/src/core/pal/util.cpp
+++ b/src/core/pal/util.cpp
@@ -106,6 +106,7 @@ QLinkedList<const GEOSGeometry *> *pal::Util::unmulti( const GEOSGeometry *the_g
       case GEOS_MULTIPOINT:
       case GEOS_MULTILINESTRING:
       case GEOS_MULTIPOLYGON:
+      case GEOS_GEOMETRYCOLLECTION:
         nGeom = GEOSGetNumGeometries_r( geosctxt, geom );
         for ( i = 0; i < nGeom; i++ )
         {


### PR DESCRIPTION
If geometry preparation for labeling results in a geometry collection type, pal didn't know how to handle this and threw the warning.