### PR TITLE
Tweak API

### DIFF
--- a/python/core/auto_generated/qgsdistancearea.sip.in
+++ b/python/core/auto_generated/qgsdistancearea.sip.in
@@ -370,7 +370,7 @@ Datum of Australia Technical Manual", Chapter 4.
 .. versionadded:: 3.0
 %End
 
-    QList< QList< QgsPointXY > > geodesicLine( const QgsPointXY &p1, const QgsPointXY &p2, double interval, bool breakLine = false ) const;
+    QVector<QVector<QgsPointXY> > geodesicLine( const QgsPointXY &p1, const QgsPointXY &p2, double interval, bool breakLine = false ) const;
 %Docstring
 Calculates the geodesic line between ``p1`` and ``p2``, which represents the shortest path on the
 ellipsoid between these two points.

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -532,11 +532,11 @@ double QgsDistanceArea::latitudeGeodesicCrossesDateLine( const QgsPointXY &pp1, 
   return lat;
 }
 
-QList< QList<QgsPointXY> > QgsDistanceArea::geodesicLine( const QgsPointXY &p1, const QgsPointXY &p2, const double interval, const bool breakLine ) const
+QVector< QVector<QgsPointXY> > QgsDistanceArea::geodesicLine( const QgsPointXY &p1, const QgsPointXY &p2, const double interval, const bool breakLine ) const
 {
   if ( !willUseEllipsoid() )
   {
-    return QList< QList< QgsPointXY > >() << ( QList< QgsPointXY >() << p1 << p2 );
+    return QVector< QVector< QgsPointXY > >() << ( QVector< QgsPointXY >() << p1 << p2 );
   }
 
   geod_geodesic geod;
@@ -551,15 +551,15 @@ QList< QList<QgsPointXY> > QgsDistanceArea::geodesicLine( const QgsPointXY &p1, 
   catch ( QgsCsException & )
   {
     QgsMessageLog::logMessage( QObject::tr( "Caught a coordinate system exception while trying to transform a point. Unable to calculate geodesic line." ) );
-    return QList< QList< QgsPointXY > >();
+    return QVector< QVector< QgsPointXY > >();
   }
 
   geod_geodesicline line;
   geod_inverseline( &line, &geod, pp1.y(), pp1.x(), pp2.y(), pp2.x(), GEOD_ALL );
   const double totalDist = line.s13;
 
-  QList< QList< QgsPointXY > > res;
-  QList< QgsPointXY > currentPart;
+  QVector< QVector< QgsPointXY > > res;
+  QVector< QgsPointXY > currentPart;
   currentPart << p1;
   double d = interval;
   double prevLon = p1.x();

--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -317,7 +317,7 @@ class CORE_EXPORT QgsDistanceArea
      *
      * \since QGIS 3.6
      */
-    QList< QList< QgsPointXY > > geodesicLine( const QgsPointXY &p1, const QgsPointXY &p2, double interval, bool breakLine = false ) const;
+    QVector<QVector<QgsPointXY> > geodesicLine( const QgsPointXY &p1, const QgsPointXY &p2, double interval, bool breakLine = false ) const;
 
     /**
      * Calculates the latitude at which the geodesic line joining \a p1 and \a p2 crosses


### PR DESCRIPTION
Better to use QVector here, because the QgsLineString/QgsGeometry
methods all use QVector too, and we want to avoid unnecessary
list->vector conversions.
