### PR TITLE
Consider 'print as raster' setting for pdf print in server

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -565,6 +565,9 @@ namespace QgsWms
       }
       // Draw selections
       exportSettings.flags |= QgsLayoutRenderContext::FlagDrawSelection;
+      // Print as raster
+      exportSettings.rasterizeWholeImage = layout->customProperty( QStringLiteral( "rasterize" ), false ).toBool();
+
       // Export all pages
       QgsLayoutExporter exporter( layout.get() );
       if ( atlas )


### PR DESCRIPTION
QGIS Server 3 currently does not consider the 'print as raster' setting in the layout for the pdf print. This PR provides a fix. 
