### PR TITLE
[server] Remove unnecessary #include 

### DIFF
--- a/python/server/auto_generated/qgsaccesscontrol.sip.in
+++ b/python/server/auto_generated/qgsaccesscontrol.sip.in
@@ -12,7 +12,6 @@
 
 
 
-
 class QgsAccessControl : QgsFeatureFilterProvider
 {
 %Docstring

--- a/python/server/auto_generated/qgsbufferserverrequest.sip.in
+++ b/python/server/auto_generated/qgsbufferserverrequest.sip.in
@@ -8,7 +8,6 @@
 
 
 
-
 class QgsBufferServerRequest : QgsServerRequest
 {
 %Docstring

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -19,8 +19,6 @@
 //for CMAKE_INSTALL_PREFIX
 #include "qgsconfig.h"
 #include "qgsserver.h"
-#include "qgslogger.h"
-#include "qgsserverlogger.h"
 #include "qgsfcgiserverresponse.h"
 #include "qgsfcgiserverrequest.h"
 

--- a/src/server/qgsaccesscontrol.cpp
+++ b/src/server/qgsaccesscontrol.cpp
@@ -20,7 +20,6 @@
 #include "qgsmaplayer.h"
 #include "qgsvectorlayer.h"
 
-#include <QStringList>
 
 void QgsAccessControl::resolveFilterFeatures( const QList<QgsMapLayer *> &layers )
 {

--- a/src/server/qgsaccesscontrol.h
+++ b/src/server/qgsaccesscontrol.h
@@ -21,13 +21,10 @@
 #include "qgsfeaturefilterprovider.h"
 #include "qgsaccesscontrolfilter.h"
 
-#include <QMultiMap>
 #include "qgis_server.h"
 #include "qgis_sip.h"
 
 SIP_IF_MODULE( HAVE_SERVER_PYTHON_PLUGINS )
-
-class QgsAccessControlPlugin;
 
 
 /**

--- a/src/server/qgsaccesscontrolfilter.cpp
+++ b/src/server/qgsaccesscontrolfilter.cpp
@@ -22,9 +22,6 @@
 #include "qgsmessagelog.h"
 #include "qgsfeature.h"
 
-#include <QString>
-#include <QStringList>
-
 
 //! Constructor
 QgsAccessControlFilter::QgsAccessControlFilter( const QgsServerInterface *serverInterface ):

--- a/src/server/qgsaccesscontrolfilter.h
+++ b/src/server/qgsaccesscontrolfilter.h
@@ -21,7 +21,6 @@
 #define QGSACCESSCONTROLPLUGIN_H
 
 #include <QMultiMap>
-#include <QList>
 #include <QString>
 #include "qgis_server.h"
 #include "qgis_sip.h"
@@ -31,7 +30,6 @@ SIP_IF_MODULE( HAVE_SERVER_PYTHON_PLUGINS )
 class QgsServerInterface;
 class QgsMapLayer;
 class QgsVectorLayer;
-class QgsExpression;
 class QgsFeature;
 
 

--- a/src/server/qgsbufferserverrequest.cpp
+++ b/src/server/qgsbufferserverrequest.cpp
@@ -18,10 +18,6 @@
  ***************************************************************************/
 
 #include "qgsbufferserverrequest.h"
-#include "qgslogger.h"
-#include "qgsmessagelog.h"
-
-#include <QDebug>
 
 QgsBufferServerRequest::QgsBufferServerRequest( const QString &url, Method method, const QgsServerRequest::Headers &headers, QByteArray *data )
   : QgsServerRequest( url, method, headers )

--- a/src/server/qgsbufferserverrequest.h
+++ b/src/server/qgsbufferserverrequest.h
@@ -22,10 +22,6 @@
 #include "qgis_server.h"
 #include "qgsserverrequest.h"
 
-#include <QBuffer>
-#include <QByteArray>
-#include <QMap>
-
 /**
  * \ingroup server
  * \class QgsBufferServerRequest

--- a/src/server/qgsbufferserverresponse.cpp
+++ b/src/server/qgsbufferserverresponse.cpp
@@ -18,10 +18,7 @@
  ***************************************************************************/
 
 #include "qgsbufferserverresponse.h"
-#include "qgslogger.h"
 #include "qgsmessagelog.h"
-
-#include <QDebug>
 
 //
 // QgsBufferServerResponse

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -17,7 +17,6 @@
 
 #include "qgsconfigcache.h"
 #include "qgsmessagelog.h"
-#include "qgsaccesscontrol.h"
 
 #include <QFile>
 

--- a/src/server/qgsconfigcache.h
+++ b/src/server/qgsconfigcache.h
@@ -22,7 +22,6 @@
 
 #include <QCache>
 #include <QFileSystemWatcher>
-#include <QMap>
 #include <QObject>
 #include <QDomDocument>
 

--- a/src/server/qgsfcgiserverrequest.cpp
+++ b/src/server/qgsfcgiserverrequest.cpp
@@ -19,12 +19,9 @@
 
 #include "qgis.h"
 #include "qgsfcgiserverrequest.h"
-#include "qgslogger.h"
 #include "qgsserverlogger.h"
 #include "qgsmessagelog.h"
 #include <fcgi_stdio.h>
-
-#include <QDebug>
 
 
 QgsFcgiServerRequest::QgsFcgiServerRequest()

--- a/src/server/qgsfcgiserverrequest.h
+++ b/src/server/qgsfcgiserverrequest.h
@@ -24,7 +24,6 @@
 
 #include "qgsserverrequest.h"
 
-#include <QBuffer>
 
 /**
  * \ingroup server

--- a/src/server/qgsfcgiserverresponse.cpp
+++ b/src/server/qgsfcgiserverresponse.cpp
@@ -19,12 +19,8 @@
 
 #include "qgis.h"
 #include "qgsfcgiserverresponse.h"
-#include "qgslogger.h"
-#include "qgsserverlogger.h"
 #include "qgsmessagelog.h"
 #include <fcgi_stdio.h>
-
-#include <QDebug>
 
 //
 // QgsFcgiServerResponse

--- a/src/server/qgsfilterrestorer.cpp
+++ b/src/server/qgsfilterrestorer.cpp
@@ -18,7 +18,6 @@
 #include "qgsfilterrestorer.h"
 #include "qgsmessagelog.h"
 #include "qgsvectorlayer.h"
-#include "qgsvectordataprovider.h"
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 #include "qgsaccesscontrol.h"

--- a/src/server/qgsrequesthandler.cpp
+++ b/src/server/qgsrequesthandler.cpp
@@ -20,16 +20,10 @@
 #include "qgis.h"
 #include "qgsrequesthandler.h"
 #include "qgsmessagelog.h"
-#include "qgsserverexception.h"
 #include "qgsserverrequest.h"
 #include "qgsserverresponse.h"
-#include <QBuffer>
 #include <QByteArray>
 #include <QDomDocument>
-#include <QFile>
-#include <QImage>
-#include <QTextStream>
-#include <QStringList>
 #include <QUrl>
 #include <QUrlQuery>
 

--- a/src/server/qgsrequesthandler.h
+++ b/src/server/qgsrequesthandler.h
@@ -23,15 +23,11 @@
 #include <QMap>
 #include "qgis_sip.h"
 #include <QString>
-#include <QStringList>
 #include <QPair>
 #include <QColor>
-#include <QHash>
 
 #include "qgis_server.h"
 
-class QDomDocument;
-class QImage;
 class QgsServerException;
 class QgsServerRequest;
 class QgsServerResponse;

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -21,7 +21,6 @@
 //for CMAKE_INSTALL_PREFIX
 #include "qgsconfig.h"
 #include "qgsserver.h"
-#include "qgsmapsettings.h"
 #include "qgsauthmanager.h"
 #include "qgscapabilitiescache.h"
 #include "qgsfontutils.h"
@@ -33,16 +32,12 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgsserverlogger.h"
 #include "qgsserverrequest.h"
-#include "qgsbufferserverresponse.h"
-#include "qgsbufferserverrequest.h"
 #include "qgsfilterresponsedecorator.h"
 #include "qgsservice.h"
-#include "qgsserverprojectutils.h"
 #include "qgsserverparameters.h"
 
 #include <QDomDocument>
 #include <QNetworkDiskCache>
-#include <QImage>
 #include <QSettings>
 #include <QDateTime>
 

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -29,15 +29,11 @@
 
 #include <QFileInfo>
 #include "qgsrequesthandler.h"
-#include "qgsapplication.h"
 #include "qgsconfigcache.h"
 #include "qgscapabilitiescache.h"
-#include "qgsmapsettings.h"
-#include "qgsmessagelog.h"
 #include "qgsserviceregistry.h"
 #include "qgsserversettings.h"
 #include "qgsserverplugins.h"
-#include "qgsserverfilter.h"
 #include "qgsserverinterfaceimpl.h"
 #include "qgis_server.h"
 #include "qgsserverrequest.h"

--- a/src/server/qgsservercachefilter.h
+++ b/src/server/qgsservercachefilter.h
@@ -22,7 +22,6 @@
 
 #include <QMultiMap>
 #include <QDomDocument>
-#include <QObject>
 #include "qgsserverrequest.h"
 #include "qgis_server.h"
 #include "qgis_sip.h"

--- a/src/server/qgsservercachemanager.h
+++ b/src/server/qgsservercachemanager.h
@@ -23,7 +23,6 @@
 #include "qgsaccesscontrol.h"
 #include "qgsserverrequest.h"
 
-#include <QMultiMap>
 #include <QDomDocument>
 #include "qgis_server.h"
 #include "qgis_sip.h"

--- a/src/server/qgsserverlogger.cpp
+++ b/src/server/qgsserverlogger.cpp
@@ -16,13 +16,6 @@
  ***************************************************************************/
 
 #include "qgsserverlogger.h"
-#include "qgsapplication.h"
-#include <QCoreApplication>
-#include <QFile>
-#include <QTextStream>
-#include <QTime>
-
-#include <cstdlib>
 
 QgsServerLogger *QgsServerLogger::sInstance = nullptr;
 

--- a/src/server/qgsserverparameters.h
+++ b/src/server/qgsserverparameters.h
@@ -19,7 +19,6 @@
 #define QGSSERVERPARAMETERS_H
 
 #include <QMap>
-#include <QObject>
 #include <QMetaEnum>
 #include <QUrlQuery>
 #include <QColor>

--- a/src/server/qgsserverplugins.cpp
+++ b/src/server/qgsserverplugins.cpp
@@ -17,11 +17,9 @@
 
 
 #include "qgsserverplugins.h"
-#include "qgsmapserviceexception.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgspythonutils.h"
-#include "qgsserverlogger.h"
 
 #include <QLibrary>
 

--- a/src/server/qgsserverplugins.h
+++ b/src/server/qgsserverplugins.h
@@ -21,7 +21,6 @@
 #define SIP_NO_FILE
 
 
-#include "qgsrequesthandler.h"
 #include "qgsserverinterface.h"
 
 // This is needed by SIP otherwise it doesn't find QgsPythonUtils header

--- a/src/server/qgsserversettings.cpp
+++ b/src/server/qgsserversettings.cpp
@@ -21,8 +21,6 @@
 
 #include <QSettings>
 
-#include <iostream>
-
 QgsServerSettings::QgsServerSettings()
 {
   load();

--- a/src/server/qgsservicenativeloader.cpp
+++ b/src/server/qgsservicenativeloader.cpp
@@ -22,9 +22,7 @@
 #include <QDebug>
 
 #include "qgsservicenativeloader.h"
-#include "qgsserviceregistry.h"
 #include "qgsservicemodule.h"
-#include "qgslogger.h"
 #include "qgsmessagelog.h"
 #include "qgis.h"
 

--- a/src/server/qgsserviceregistry.cpp
+++ b/src/server/qgsserviceregistry.cpp
@@ -19,7 +19,6 @@
 
 #include "qgsserviceregistry.h"
 #include "qgsservice.h"
-#include "qgslogger.h"
 #include "qgsmessagelog.h"
 
 #include <algorithm>

--- a/src/server/services/wcs/qgswcsdescribecoverage.cpp
+++ b/src/server/services/wcs/qgswcsdescribecoverage.cpp
@@ -21,11 +21,8 @@
 #include "qgswcsdescribecoverage.h"
 
 #include "qgsproject.h"
-#include "qgsexception.h"
 #include "qgsmaplayer.h"
 #include "qgsrasterlayer.h"
-#include "qgsmapserviceexception.h"
-#include "qgscoordinatereferencesystem.h"
 
 namespace QgsWcs
 {

--- a/src/server/services/wcs/qgswcsdescribecoverage.h
+++ b/src/server/services/wcs/qgswcsdescribecoverage.h
@@ -19,7 +19,6 @@
 #ifndef QGSWCSDESCRIBECOVERAGE_H
 #define QGSWCSDESCRIBECOVERAGE_H
 
-#include "qgsrasterlayer.h"
 
 #include <QDomDocument>
 

--- a/src/server/services/wcs/qgswcsgetcapabilities.cpp
+++ b/src/server/services/wcs/qgswcsgetcapabilities.cpp
@@ -21,12 +21,7 @@
 #include "qgswcsgetcapabilities.h"
 
 #include "qgsproject.h"
-#include "qgsexception.h"
 #include "qgsrasterlayer.h"
-#include "qgsmapserviceexception.h"
-#include "qgscoordinatereferencesystem.h"
-
-#include <QStringList>
 
 namespace QgsWcs
 {

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -25,16 +25,8 @@
 #include "qgswfsparameters.h"
 
 #include "qgsproject.h"
-#include "qgsexception.h"
 #include "qgsvectorlayer.h"
-#include "qgsvectordataprovider.h"
-#include "qgsmapserviceexception.h"
-#include "qgscoordinatereferencesystem.h"
-#include "qgsfieldformatterregistry.h"
-#include "qgsfieldformatter.h"
 #include "qgsdatetimefieldformatter.h"
-
-#include <QStringList>
 
 namespace QgsWfs
 {

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -27,10 +27,7 @@
 #include "qgsexception.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
-#include "qgsmapserviceexception.h"
 #include "qgscoordinatereferencesystem.h"
-
-#include <QStringList>
 
 namespace QgsWfs
 {

--- a/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
@@ -24,13 +24,9 @@
 #include "qgswfsgetcapabilities_1_0_0.h"
 
 #include "qgsproject.h"
-#include "qgsexception.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
-#include "qgsmapserviceexception.h"
 #include "qgscoordinatereferencesystem.h"
-
-#include <QStringList>
 
 namespace QgsWfs
 {

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -22,15 +22,12 @@
 #include "qgswfsutils.h"
 #include "qgsserverprojectutils.h"
 #include "qgsfields.h"
-#include "qgsfieldformatterregistry.h"
-#include "qgsfieldformatter.h"
 #include "qgsdatetimefieldformatter.h"
 #include "qgsexpression.h"
 #include "qgsgeometry.h"
 #include "qgsmaplayer.h"
 #include "qgsfeatureiterator.h"
 #include "qgscoordinatereferencesystem.h"
-#include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgsfilterrestorer.h"
 #include "qgsproject.h"
@@ -38,8 +35,6 @@
 #include "qgsjsonutils.h"
 
 #include "qgswfsgetfeature.h"
-
-#include <QStringList>
 
 namespace QgsWfs
 {

--- a/src/server/services/wfs/qgswfsparameters.cpp
+++ b/src/server/services/wfs/qgswfsparameters.cpp
@@ -17,7 +17,6 @@
 
 #include "qgswfsparameters.h"
 #include "qgsmessagelog.h"
-#include <iostream>
 
 namespace QgsWfs
 {

--- a/src/server/services/wfs/qgswfsparameters.h
+++ b/src/server/services/wfs/qgswfsparameters.h
@@ -19,12 +19,9 @@
 #define QGSWFSPARAMETERS_H
 
 #include <QMap>
-#include <QObject>
 #include <QMetaEnum>
 
 #include "qgsrectangle.h"
-#include "qgswfsserviceexception.h"
-#include "qgsserverrequest.h"
 #include "qgsprojectversion.h"
 #include "qgsserverparameters.h"
 

--- a/src/server/services/wfs/qgswfsutils.cpp
+++ b/src/server/services/wfs/qgswfsutils.cpp
@@ -22,7 +22,6 @@
 
 #include "qgswfsutils.h"
 #include "qgsogcutils.h"
-#include "qgsconfigcache.h"
 #include "qgsserverprojectutils.h"
 #include "qgswfsparameters.h"
 #include "qgsvectorlayer.h"

--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -16,9 +16,6 @@ email                : david dot marteau at 3liz dot com
  ***************************************************************************/
 #include "qgsmodule.h"
 #include "qgsdxfwriter.h"
-#include "qgswmsutils.h"
-#include "qgsmaplayer.h"
-#include "qgsvectorlayer.h"
 #include "qgsdxfexport.h"
 #include "qgswmsrenderer.h"
 

--- a/src/server/services/wms/qgswms.cpp
+++ b/src/server/services/wms/qgswms.cpp
@@ -20,7 +20,6 @@
  ***************************************************************************/
 
 #include "qgsmodule.h"
-#include "qgswmsutils.h"
 #include "qgsdxfwriter.h"
 #include "qgswmsgetcapabilities.h"
 #include "qgswmsgetmap.h"

--- a/src/server/services/wms/qgswmsdescribelayer.cpp
+++ b/src/server/services/wms/qgswmsdescribelayer.cpp
@@ -20,6 +20,7 @@
  ***************************************************************************/
 
 #include "qgswmsutils.h"
+#include "qgswmsserviceexception.h"
 #include "qgswmsdescribelayer.h"
 #include "qgsserverprojectutils.h"
 #include "qgsproject.h"

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -31,11 +31,6 @@
 #include "qgslayoutframe.h"
 #include "qgslayoutpagecollection.h"
 
-#include "qgslayertreenode.h"
-#include "qgslayertreegroup.h"
-#include "qgslayertreelayer.h"
-#include "qgslayertreemodel.h"
-#include "qgslayertree.h"
 #include "qgsmaplayerstylemanager.h"
 
 #include "qgsexception.h"

--- a/src/server/services/wms/qgswmsgetcapabilities.h
+++ b/src/server/services/wms/qgswmsgetcapabilities.h
@@ -24,7 +24,6 @@
 #include "qgslayertreenode.h"
 #include "qgslayertreegroup.h"
 #include "qgslayertreelayer.h"
-#include "qgslayertreemodel.h"
 #include "qgslayertree.h"
 
 namespace QgsWms

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -25,7 +25,6 @@
 #include "qgslayertreenode.h"
 #include "qgslayertreegroup.h"
 #include "qgslayertreelayer.h"
-#include "qgslayertreemodel.h"
 #include "qgslayertree.h"
 #include "qgsmaplayerstylemanager.h"
 

--- a/src/server/services/wms/qgswmsgetstyles.cpp
+++ b/src/server/services/wms/qgswmsgetstyles.cpp
@@ -21,6 +21,7 @@
 
 
 #include "qgswmsutils.h"
+#include "qgswmsserviceexception.h"
 #include "qgswmsgetstyles.h"
 #include "qgsserverprojectutils.h"
 

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -18,8 +18,6 @@
 #include "qgswmsparameters.h"
 #include "qgsdatasourceuri.h"
 #include "qgsmessagelog.h"
-#include <iostream>
-#include <QUrl>
 
 namespace QgsWms
 {

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -19,13 +19,11 @@
 #define QGSWMSPARAMETERS_H
 
 #include <QMap>
-#include <QObject>
 #include <QMetaEnum>
 #include <QColor>
 
 #include "qgsrectangle.h"
 #include "qgswmsserviceexception.h"
-#include "qgsserverrequest.h"
 #include "qgslegendsettings.h"
 #include "qgsprojectversion.h"
 #include "qgsogcutils.h"

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -21,7 +21,6 @@
 #include "qgswmsutils.h"
 #include "qgswmsrenderer.h"
 #include "qgsfilterrestorer.h"
-#include "qgscapabilitiescache.h"
 #include "qgsexception.h"
 #include "qgsfields.h"
 #include "qgsfieldformatter.h"
@@ -44,12 +43,8 @@
 #include "qgscoordinatereferencesystem.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
-#include "qgslogger.h"
 #include "qgsmessagelog.h"
-#include "qgssymbol.h"
 #include "qgsrenderer.h"
-#include "qgspaintenginehack.h"
-#include "qgsogcutils.h"
 #include "qgsfeature.h"
 #include "qgsaccesscontrol.h"
 #include "qgsfeaturerequest.h"
@@ -72,7 +67,6 @@
 #include <QPainter>
 #include <QStringList>
 #include <QTemporaryFile>
-#include <QTextStream>
 #include <QDir>
 
 //for printing
@@ -91,17 +85,10 @@
 #include "qgslayoutitemmapgrid.h"
 #include "qgslayoutframe.h"
 #include "qgslayoutitemhtml.h"
-#include "qgslayoutitempicture.h"
-#include "qgslayoutitemscalebar.h"
-#include "qgslayoutitemshape.h"
 #include "qgsfeaturefilterprovidergroup.h"
 #include "qgsogcutils.h"
 #include "qgsunittypes.h"
-#include <QBuffer>
-#include <QPrinter>
-#include <QSvgGenerator>
 #include <QUrl>
-#include <QPaintEngine>
 
 namespace QgsWms
 {

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -25,38 +25,26 @@
 #include "qgsfeaturefilter.h"
 #include <QDomDocument>
 #include <QMap>
-#include <QPair>
 #include <QString>
-#include <map>
 
-class QgsCapabilitiesCache;
 class QgsCoordinateReferenceSystem;
 class QgsPrintLayout;
-class QgsConfigParser;
 class QgsFeature;
-class QgsFeatureRenderer;
 class QgsMapLayer;
 class QgsMapSettings;
 class QgsPointXY;
 class QgsRasterLayer;
-class QgsRasterRenderer;
 class QgsRectangle;
 class QgsRenderContext;
 class QgsVectorLayer;
-class QgsSymbol;
-class QgsSymbol;
 class QgsAccessControl;
 class QgsDxfExport;
 class QgsLayerTreeModel;
 class QgsLayerTree;
 
-class QColor;
-class QFile;
-class QFont;
 class QImage;
 class QPaintDevice;
 class QPainter;
-class QStandardItem;
 class QgsLayerTreeGroup;
 
 namespace QgsWms

--- a/src/server/services/wms/qgswmsutils.cpp
+++ b/src/server/services/wms/qgswmsutils.cpp
@@ -24,8 +24,8 @@
 #include "qgsmodule.h"
 #include "qgswmsutils.h"
 #include "qgsmediancut.h"
-#include "qgsconfigcache.h"
 #include "qgsserverprojectutils.h"
+#include "qgswmsserviceexception.h"
 
 namespace QgsWms
 {

--- a/src/server/services/wms/qgswmsutils.h
+++ b/src/server/services/wms/qgswmsutils.h
@@ -24,7 +24,6 @@
 #define QGSWMSUTILS_H
 
 #include "qgsmodule.h"
-#include "qgswmsserviceexception.h"
 
 class QgsRectangle;
 

--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -20,13 +20,7 @@
 
 #include "qgsproject.h"
 #include "qgsexception.h"
-#include "qgsmapserviceexception.h"
 #include "qgscoordinatereferencesystem.h"
-#include "qgslayertree.h"
-#include "qgslayertreemodel.h"
-#include "qgslayertreemodellegendnode.h"
-
-#include <QStringList>
 
 namespace QgsWmts
 {

--- a/src/server/services/wmts/qgswmtsgetfeatureinfo.cpp
+++ b/src/server/services/wmts/qgswmtsgetfeatureinfo.cpp
@@ -18,8 +18,6 @@
 #include "qgswmtsparameters.h"
 #include "qgswmtsgetfeatureinfo.h"
 
-#include <QImage>
-
 namespace QgsWmts
 {
 

--- a/src/server/services/wmts/qgswmtsparameters.cpp
+++ b/src/server/services/wmts/qgswmtsparameters.cpp
@@ -17,7 +17,6 @@
 
 #include "qgswmtsparameters.h"
 #include "qgsmessagelog.h"
-#include <iostream>
 
 namespace QgsWmts
 {

--- a/src/server/services/wmts/qgswmtsparameters.h
+++ b/src/server/services/wmts/qgswmtsparameters.h
@@ -22,8 +22,6 @@
 #include <QObject>
 #include <QMetaEnum>
 
-#include "qgswmtsserviceexception.h"
-#include "qgsserverrequest.h"
 #include "qgsprojectversion.h"
 #include "qgsserverparameters.h"
 

--- a/src/server/services/wmts/qgswmtsutils.cpp
+++ b/src/server/services/wmts/qgswmtsutils.cpp
@@ -17,16 +17,12 @@
 
 #include "qgswmtsutils.h"
 #include "qgswmtsparameters.h"
-#include "qgsconfigcache.h"
 #include "qgsserverprojectutils.h"
 
 #include "qgsproject.h"
 #include "qgsexception.h"
-#include "qgsmapserviceexception.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgslayertree.h"
-#include "qgslayertreemodel.h"
-#include "qgslayertreemodellegendnode.h"
 #include "qgssettings.h"
 
 


### PR DESCRIPTION
## Description

I tried [IWYU](https://github.com/include-what-you-use/include-what-you-use) to detect unnecessary `#include`, and its pretty convincing...

A lot of work could be done on core, app, gui, ... too.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
