### PR TITLE
Validity check PyQGIS love

### DIFF
--- a/python/core/__init__.py.in
+++ b/python/core/__init__.py.in
@@ -37,6 +37,7 @@ from .additions.qgsgeometry import _geometryNonZero, mapping_geometry
 from .additions.qgssettings import _qgssettings_enum_value, _qgssettings_set_enum_value, _qgssettings_flag_value
 from .additions.qgstaskwrapper import QgsTaskWrapper
 from .additions.readwritecontextentercategory import ReadWriteContextEnterCategory
+from .additions.validitycheck import check
 
 # Injections into classes
 QgsFeature.__geo_interface__ = property(mapping_feature)

--- a/python/core/additions/validitycheck.py
+++ b/python/core/additions/validitycheck.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    validitycheck.py
+    ---------------------
+    Date                 : January 2019
+    Copyright            : (C) 2019 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+from qgis._core import (
+    QgsAbstractValidityCheck,
+    QgsApplication)
+
+
+class CheckFactory:
+    """
+    Constructs QgsAbstractValidityChecks using a decorator.
+
+    To use, Python based checks should use the decorator syntax:
+
+    .. highlight:: python
+    .. code-block:: python
+        @check.register(type=QgsAbstractValidityCheck.TypeLayoutCheck)
+        def my_layout_check(context, feedback):
+            results = ...
+            return results
+
+    """
+
+    def __init__(self):
+        # unfortunately /Transfer/ annotation isn't working correct on validityCheckRegistry().addCheck(),
+        # so we manually need to store a reference to all checks we register
+        self.checks = []
+
+    def register(self, type, *args, **kwargs):
+        """
+        Implements a decorator for registering Python based checks.
+
+        :param type: check type, e.g. QgsAbstractValidityCheck.TypeLayoutCheck
+        """
+
+        def dec(f):
+            check = CheckWrapper(check_type=type, check_func=f)
+            self.checks.append(check)
+            QgsApplication.validityCheckRegistry().addCheck(check)
+
+        return dec
+
+
+class CheckWrapper(QgsAbstractValidityCheck):
+    """
+    Wrapper object used to create new validity checks from @check.
+    """
+
+    def __init__(self, check_type, check_func):
+        """
+        Initializer for CheckWrapper.
+
+        :param check_type: check type, e.g. QgsAbstractValidityCheck.TypeLayoutCheck
+        :param check_func: test function, should return a list of QgsValidityCheckResult results
+        """
+        super().__init__()
+        self._check_type = check_type
+        self._results = []
+        self._check_func = check_func
+
+    def create(self):
+        return CheckWrapper(check_type=self._check_type, check_func=self._check_func)
+
+    def id(self):
+        return self._check_func.__name__
+
+    def checkType(self):
+        return self._check_type
+
+    def prepareCheck(self, context, feedback):
+        self._results = self._check_func(context, feedback)
+        if self._results is None:
+            self._results = []
+        return True
+
+    def runCheck(self, context, feedback):
+        return self._results
+
+
+check = CheckFactory()

--- a/python/core/auto_generated/validity/qgsabstractvaliditycheck.sip.in
+++ b/python/core/auto_generated/validity/qgsabstractvaliditycheck.sip.in
@@ -41,8 +41,7 @@ result will be communicated to users, but not prevent them from proceeding.
 
 };
 
-
-class QgsAbstractValidityCheck : QObject
+class QgsAbstractValidityCheck
 {
 %Docstring
 Abstract base class for individual validity checks.
@@ -76,6 +75,8 @@ Checks must be registered in the application's :py:class:`QgsValidityCheckRegist
       TypeLayoutCheck,
       TypeUserCheck,
     };
+
+    virtual ~QgsAbstractValidityCheck();
 
     virtual QgsAbstractValidityCheck *create() const = 0 /Factory/;
 %Docstring
@@ -125,9 +126,6 @@ The ``context`` argument gives the wider in which the check is being run.
 %End
 
 };
-
-
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/app/layout/qgslayoutvaliditychecks.cpp
+++ b/src/app/layout/qgslayoutvaliditychecks.cpp
@@ -17,7 +17,12 @@
 #include "qgslayoutvaliditychecks.h"
 #include "qgsvaliditycheckcontext.h"
 #include "qgslayoutitemscalebar.h"
+#include "qgslayoutitemmap.h"
 #include "qgslayout.h"
+
+//
+// QgsLayoutScaleBarValidityCheck
+//
 
 QgsLayoutScaleBarValidityCheck *QgsLayoutScaleBarValidityCheck::create() const
 {
@@ -62,6 +67,62 @@ bool QgsLayoutScaleBarValidityCheck::prepareCheck( const QgsValidityCheckContext
 }
 
 QList<QgsValidityCheckResult> QgsLayoutScaleBarValidityCheck::runCheck( const QgsValidityCheckContext *, QgsFeedback * )
+{
+  return mResults;
+}
+
+
+//
+// QgsLayoutOverviewValidityCheck
+//
+
+QgsLayoutOverviewValidityCheck *QgsLayoutOverviewValidityCheck::create() const
+{
+  return new QgsLayoutOverviewValidityCheck();
+}
+
+QString QgsLayoutOverviewValidityCheck::id() const
+{
+  return QStringLiteral( "layout_overview_check" );
+}
+
+int QgsLayoutOverviewValidityCheck::checkType() const
+{
+  return QgsAbstractValidityCheck::TypeLayoutCheck;
+}
+
+bool QgsLayoutOverviewValidityCheck::prepareCheck( const QgsValidityCheckContext *context, QgsFeedback * )
+{
+  if ( context->type() != QgsValidityCheckContext::TypeLayoutContext )
+    return false;
+
+  const QgsLayoutValidityCheckContext *layoutContext = static_cast< const QgsLayoutValidityCheckContext * >( context );
+  if ( !layoutContext )
+    return false;
+
+  QList< QgsLayoutItemMap * > mapItems;
+  layoutContext->layout->layoutItems( mapItems );
+  for ( QgsLayoutItemMap *map : qgis::as_const( mapItems ) )
+  {
+    for ( int i = 0; i < map->overviews()->size(); ++i )
+    {
+      QgsLayoutItemMapOverview *overview = map->overviews()->overview( i );
+      if ( overview && overview->enabled() && !overview->linkedMap() )
+      {
+        QgsValidityCheckResult res;
+        res.type = QgsValidityCheckResult::Warning;
+        res.title = QObject::tr( "Overview is not linked to a map" );
+        const QString name = map->displayName().toHtmlEscaped();
+        res.detailedDescription = QObject::tr( "The map “%1” includes an overview (“%2”) which is not linked to a map item." ).arg( name, overview->name() );
+        mResults.append( res );
+      }
+    }
+  }
+
+  return true;
+}
+
+QList<QgsValidityCheckResult> QgsLayoutOverviewValidityCheck::runCheck( const QgsValidityCheckContext *, QgsFeedback * )
 {
   return mResults;
 }

--- a/src/app/layout/qgslayoutvaliditychecks.cpp
+++ b/src/app/layout/qgslayoutvaliditychecks.cpp
@@ -51,9 +51,9 @@ bool QgsLayoutScaleBarValidityCheck::prepareCheck( const QgsValidityCheckContext
     {
       QgsValidityCheckResult res;
       res.type = QgsValidityCheckResult::Warning;
-      res.title = tr( "Scalebar is not linked to a map" );
+      res.title = QObject::tr( "Scalebar is not linked to a map" );
       const QString name = bar->displayName().toHtmlEscaped();
-      res.detailedDescription = tr( "The scalebar “%1” is not linked to a map item. This scale will be misleading." ).arg( name );
+      res.detailedDescription = QObject::tr( "The scalebar “%1” is not linked to a map item. This scale will be misleading." ).arg( name );
       mResults.append( res );
     }
   }

--- a/src/app/layout/qgslayoutvaliditychecks.h
+++ b/src/app/layout/qgslayoutvaliditychecks.h
@@ -30,3 +30,17 @@ class APP_EXPORT QgsLayoutScaleBarValidityCheck : public QgsAbstractValidityChec
   private:
     QList<QgsValidityCheckResult> mResults;
 };
+
+class APP_EXPORT QgsLayoutOverviewValidityCheck : public QgsAbstractValidityCheck
+{
+  public:
+
+    QgsLayoutOverviewValidityCheck *create() const override;
+    QString id() const override;
+    int checkType() const override;
+    bool prepareCheck( const QgsValidityCheckContext *context, QgsFeedback *feedback ) override;
+    QList< QgsValidityCheckResult > runCheck( const QgsValidityCheckContext *context, QgsFeedback *feedback ) override;
+
+  private:
+    QList<QgsValidityCheckResult> mResults;
+};

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1238,6 +1238,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   }
 
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutScaleBarValidityCheck() );
+  QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutOverviewValidityCheck() );
 
   mSplash->showMessage( tr( "Initializing file filters" ), Qt::AlignHCenter | Qt::AlignBottom );
   qApp->processEvents();

--- a/src/core/validity/qgsabstractvaliditycheck.h
+++ b/src/core/validity/qgsabstractvaliditycheck.h
@@ -66,9 +66,6 @@ class CORE_EXPORT QgsValidityCheckResult
 
 };
 
-// note -- this is a QObject so that we can store just weak pointers to it -- avoiding crashes
-// if a Python plugin doesn't correctly remove checks on plugin unload
-
 /**
  * \class QgsAbstractValidityCheck
  * \ingroup core
@@ -92,7 +89,7 @@ class CORE_EXPORT QgsValidityCheckResult
  *
  * \since QGIS 3.6
  */
-class CORE_EXPORT QgsAbstractValidityCheck : public QObject
+class CORE_EXPORT QgsAbstractValidityCheck
 {
 
   public:
@@ -103,6 +100,8 @@ class CORE_EXPORT QgsAbstractValidityCheck : public QObject
       TypeLayoutCheck = 0, //!< Print layout validity check, triggered on exporting a print layout
       TypeUserCheck = 10000, //!< Starting point for custom user types
     };
+
+    virtual ~QgsAbstractValidityCheck() = default;
 
     /**
      * Creates a new instance of the check and returns it.
@@ -157,8 +156,5 @@ class CORE_EXPORT QgsAbstractValidityCheck : public QObject
     virtual QList< QgsValidityCheckResult > runCheck( const QgsValidityCheckContext *context, QgsFeedback *feedback ) = 0;
 
 };
-
-
-
 
 #endif // QGSABSTRACTVALIDITYCHECK_H

--- a/src/core/validity/qgsvaliditycheckregistry.cpp
+++ b/src/core/validity/qgsvaliditycheckregistry.cpp
@@ -28,10 +28,10 @@ QgsValidityCheckRegistry::~QgsValidityCheckRegistry()
 QList<const QgsAbstractValidityCheck *> QgsValidityCheckRegistry::checks() const
 {
   QList<const QgsAbstractValidityCheck *> results;
-  for ( const QPointer< QgsAbstractValidityCheck > &check : mChecks )
+  for ( const QgsAbstractValidityCheck *check : mChecks )
   {
     if ( check )
-      results.append( check.data() );
+      results.append( check );
   }
   return results;
 }
@@ -39,10 +39,10 @@ QList<const QgsAbstractValidityCheck *> QgsValidityCheckRegistry::checks() const
 QList<const QgsAbstractValidityCheck *> QgsValidityCheckRegistry::checks( int type ) const
 {
   QList< const QgsAbstractValidityCheck * > results;
-  for ( const QPointer< QgsAbstractValidityCheck > &check : mChecks )
+  for ( const QgsAbstractValidityCheck *check : mChecks )
   {
     if ( check && check->checkType() == type )
-      results << check.data();
+      results << check;
   }
   return results;
 }

--- a/src/core/validity/qgsvaliditycheckregistry.h
+++ b/src/core/validity/qgsvaliditycheckregistry.h
@@ -19,7 +19,6 @@
 #include "qgis_sip.h"
 #include "qgsabstractvaliditycheck.h"
 #include <QList>
-#include <QPointer>
 #include <memory>
 #include <vector>
 


### PR DESCRIPTION
This allows nice and simple, elegant construction of checks for Python.

To use, Python based checks should use the decorator syntax:

```
  from qgis.core import check

  @check.register(type=QgsAbstractValidityCheck.TypeLayoutCheck)
  def my_layout_check(context, feedback):
    results = ...
    return results
```

Or, a more complete example. This one throws a warning when attempting
to export a layout with a map item set to the Web Mercator projection:

```
  @check.register(type=QgsAbstractValidityCheck.TypeLayoutCheck)
  def layout_map_crs_choice_check(context, feedback):
    layout = context.layout
    results = []
    for i in layout.items():
      if isinstance(i, QgsLayoutItemMap) and i.crs().authid() == 'EPSG:3857':
        res = QgsValidityCheckResult()
        res.type = QgsValidityCheckResult.Warning
        res.title='Map projection is misleading'
        res.detailedDescription='The projection for the map item {} is set to <i>Web Mercator (EPSG:3857)</i> which misrepresents areas and shapes. Consider using an appropriate local projection instead.'.format(i.displayName())
        results.append(res)

    return results
```


Or, my current personal favorite -- this one checks each map item in the layout and compares the projection used for the map against the extent shown in the map -- if the extent falls outside the valid area for that projection, you get a warning:

```
@check.register(type=QgsAbstractValidityCheck.TypeLayoutCheck)
def layout_map_crs_area_check(context, feedback):
    layout = context.layout
    results = []
    for i in layout.items():
        if isinstance(i, QgsLayoutItemMap):
            bounds = i.crs().bounds()
            ct = QgsCoordinateTransform(QgsCoordinateReferenceSystem('EPSG:4326'),
            i.crs(), QgsProject.instance())
            bounds_crs = ct.transformBoundingBox(bounds)
            
            if not bounds_crs.contains(i.extent()):
                res = QgsValidityCheckResult()
                res.type = QgsValidityCheckResult.Warning
                res.title='Map projection is incorrect'
                res.detailedDescription='The projection for the map item {} is set to \'{}\', which is not valid for the area displayed within the map.'.format(i.displayName(), i.crs().authid())
                results.append(res)
    
    return results
```
