### PR TITLE
[themes] Force fusion style for non-default UI themes on OS X

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1223,7 +1223,6 @@ int main( int argc, char *argv[] )
   // Set the application style.  If it's not set QT will use the platform style except on Windows
   // as it looks really ugly so we use QPlastiqueStyle.
   QString desiredStyle = settings.value( QStringLiteral( "qgis/style" ) ).toString();
-#ifndef Q_OS_MACX
   const QString theme = settings.value( QStringLiteral( "UI/UITheme" ) ).toString();
   if ( theme != QLatin1String( "default" ) )
   {
@@ -1232,7 +1231,6 @@ int main( int argc, char *argv[] )
       desiredStyle = QStringLiteral( "fusion" );
     }
   }
-#endif
   const QString activeStyleName = QApplication::style()->metaObject()->className();
   if ( desiredStyle.contains( QLatin1String( "adwaita" ), Qt::CaseInsensitive )
        || ( desiredStyle.isEmpty() && activeStyleName.contains( QLatin1String( "adwaita" ), Qt::CaseInsensitive ) ) )


### PR DESCRIPTION
## Description
Thanks to @PeterPetrik for taking the time to send over some screenshots confirming fusion style is also required on OS X to best render non-default themes. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
