### PR TITLE
fixes #20547 : Fix error when using a spatialite layer with a non-int primary key an a spatial index

### DIFF
--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -423,7 +423,7 @@ QString QgsSpatiaLiteFeatureIterator::whereClauseRect()
       mbrFilter += QStringLiteral( "ymax >= %1" ).arg( qgsDoubleToString( mFilterRect.yMinimum() ) );
       QString idxName = QStringLiteral( "idx_%1_%2" ).arg( mSource->mIndexTable, mSource->mIndexGeometry );
       whereClause += QStringLiteral( "%1 IN (SELECT pkid FROM %2 WHERE %3)" )
-                     .arg( quotedPrimaryKey(),
+                     .arg( QStringLiteral( "ROWID" ),
                            QgsSqliteUtils::quotedIdentifier( idxName ),
                            mbrFilter );
     }
@@ -432,7 +432,7 @@ QString QgsSpatiaLiteFeatureIterator::whereClauseRect()
       // using the MbrCache spatial index
       QString idxName = QStringLiteral( "cache_%1_%2" ).arg( mSource->mIndexTable, mSource->mIndexGeometry );
       whereClause += QStringLiteral( "%1 IN (SELECT rowid FROM %2 WHERE mbr = FilterMbrIntersects(%3))" )
-                     .arg( quotedPrimaryKey(),
+                     .arg( QStringLiteral( "ROWID" ),
                            QgsSqliteUtils::quotedIdentifier( idxName ),
                            mbr( mFilterRect ) );
     }
@@ -506,7 +506,7 @@ bool QgsSpatiaLiteFeatureIterator::getFeature( sqlite3_stmt *stmt, QgsFeature &f
   {
     if ( ic == 0 )
     {
-      if ( mHasPrimaryKey )
+      if ( mHasPrimaryKey && sqlite3_column_type( stmt, ic ) == SQLITE_INTEGER )
       {
         // first column always contains the ROWID (or the primary key)
         QgsFeatureId fid = sqlite3_column_int64( stmt, ic );

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -763,7 +763,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         con = spatialite_connect(dbname, isolation_level=None)
         cur = con.cursor()
 
-        # try the two differents types of index creation
+        # try the two different types of index creation
         for index_creation_method in ['CreateSpatialIndex', 'CreateMbrCache']:
 
             table_name = "pk_is_string_{}".format(index_creation_method)

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -757,9 +757,7 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
     def testPKNotInt(self):
         """ Check when primary key is not an integer """
         # create test db
-        dbname = os.path.join(tempfile.gettempdir(), "test_pknotint.sqlite")
-        if os.path.exists(dbname):
-            os.remove(dbname)
+        dbname = os.path.join(tempfile.mkdtemp(), "test_pknotint.sqlite")
         con = spatialite_connect(dbname, isolation_level=None)
         cur = con.cursor()
 
@@ -804,6 +802,9 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
             self.assertEqual(point.y(), 2)
 
         con.close()
+
+        basepath, filename = os.path.split(dbname)
+        shutil.rmtree(basepath)
 
     def testLoadStyle(self):
         """Check that we can store and load a style"""


### PR DESCRIPTION
## Description

This PR fixes the issue https://issues.qgis.org/issues/20547

Issue comes from spatialite that use ROWID to reference table element from index table instead of primary key. When primary key is an integer, ROWID is equals to primary key, so it works. but when it's a string (or anything else) and there is a spatial index no features are returned at all.

See spatialite documentation (Chapter 8. Spatial Index: using SQLite's R*Tree at https://www.gaia-gis.it/gaia-sins/spatialite-tutorial-2.3.1.html) :
*the pkid [from index table] column contains the Primary Key value identifying the corresponding row within the indexed table*

And it's the same with Mbr index.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes

**Still working on unit tests**

- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
