### PR TITLE
[Bugfix][Oracle] Add ESCAPE when compiling LIKE

### DIFF
--- a/src/providers/oracle/qgsoracleexpressioncompiler.cpp
+++ b/src/providers/oracle/qgsoracleexpressioncompiler.cpp
@@ -57,11 +57,11 @@ QgsSqlExpressionCompiler::Result QgsOracleExpressionCompiler::compileNode( const
             return Complete;
 
           case QgsExpression::boILike:
-            result = QString( "lower(%1) LIKE lower(%2)" ).arg( op1, op2 );
+            result = QString( "lower(%1) LIKE lower(%2) ESCAPE '\\'" ).arg( op1, op2 );
             return Complete;
 
           case QgsExpression::boNotILike:
-            result = QString( "NOT lower(%1) LIKE lower(%2)" ).arg( op1, op2 );
+            result = QString( "NOT lower(%1) LIKE lower(%2) ESCAPE '\\'" ).arg( op1, op2 );
             return Complete;
 
           case QgsExpression::boIntDiv:


### PR DESCRIPTION
## Description

The oracle SQL documentation specifies that *there is no default escape character* and *the escape character, if specified, must be a character string of length 1*.
In expression the underscore (_) and the percent sign (%) can be escaped with the backslash (\). So in the Oracle Expression Compiler if the ESCAPE clause is not specified, the pattern is not valid.
To fix it, the Oracle Expression Compiler has to add the ESCAPE clause.

https://docs.oracle.com/cd/B12037_01/server.101/b10759/conditions016.htm

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
