### PR TITLE
Using the new QgsLegender.draw method in Qgslayoutitemlegend

### DIFF
--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -156,12 +156,27 @@ void QgsLayoutItemLegend::refresh()
 
 void QgsLayoutItemLegend::draw( QgsLayoutItemRenderContext &context )
 {
+  QPainter *painter = context.renderContext().painter();
+  painter->save();
+
+  // painter is scaled to dots, so scale back to layout units
+  painter->scale( context.renderContext().scaleFactor(), context.renderContext().scaleFactor() );
+
+  painter->setPen( QPen( QColor( 0, 0, 0 ) ) );
+
+  if ( !mSizeToContents )
+  {
+    // set a clip region to crop out parts of legend which don't fit
+    QRectF thisPaintRect = QRectF( 0, 0, rect().width(), rect().height() );
+    painter->setClipRect( thisPaintRect );
+  }
+
   QgsLegendRenderer legendRenderer( mLegendModel.get(), mSettings );
   legendRenderer.setLegendSize( mSizeToContents ? QSize() : rect().size() );
 
-  legendRenderer.drawLegend( context.renderContext() );
+  legendRenderer.drawLegend( context );
 
-  context.renderContext().painter()->restore();
+  painter->restore();
 }
 
 void QgsLayoutItemLegend::adjustBoxSize()

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -156,27 +156,10 @@ void QgsLayoutItemLegend::refresh()
 
 void QgsLayoutItemLegend::draw( QgsLayoutItemRenderContext &context )
 {
-  QPainter *painter = context.renderContext().painter();
-  painter->save();
-
-  // painter is scaled to dots, so scale back to layout units
-  painter->scale( context.renderContext().scaleFactor(), context.renderContext().scaleFactor() );
-
-  painter->setPen( QPen( QColor( 0, 0, 0 ) ) );
-
-  if ( !mSizeToContents )
-  {
-    // set a clip region to crop out parts of legend which don't fit
-    QRectF thisPaintRect = QRectF( 0, 0, rect().width(), rect().height() );
-    painter->setClipRect( thisPaintRect );
-  }
-
   QgsLegendRenderer legendRenderer( mLegendModel.get(), mSettings );
   legendRenderer.setLegendSize( mSizeToContents ? QSize() : rect().size() );
 
-  legendRenderer.drawLegend( painter );
-
-  painter->restore();
+  legendRenderer.drawLegend( context.renderContext() );
 }
 
 void QgsLayoutItemLegend::adjustBoxSize()

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -174,7 +174,7 @@ void QgsLayoutItemLegend::draw( QgsLayoutItemRenderContext &context )
   QgsLegendRenderer legendRenderer( mLegendModel.get(), mSettings );
   legendRenderer.setLegendSize( mSizeToContents ? QSize() : rect().size() );
 
-  legendRenderer.drawLegend( context );
+  legendRenderer.drawLegend( context.renderContext() );
 
   painter->restore();
 }

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -160,6 +160,8 @@ void QgsLayoutItemLegend::draw( QgsLayoutItemRenderContext &context )
   legendRenderer.setLegendSize( mSizeToContents ? QSize() : rect().size() );
 
   legendRenderer.drawLegend( context.renderContext() );
+
+  context.renderContext().painter()->restore();
 }
 
 void QgsLayoutItemLegend::adjustBoxSize()


### PR DESCRIPTION
## Description
This is the first followup to the changes made to QgsLegendRenderer.

This changes simply aims to make use of the new method in Qgslayoutitemlegend.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
