### PR TITLE
calculate innerTangents for 2 circles

### DIFF
--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -197,9 +197,9 @@ Note that this method is 2D only and does not consider the z-value of the circle
 Calculates the inner tangent points between this circle
 and an ``other`` circle.
 
-The outer tangent points correspond to the points at which the two lines
+The inner tangent points correspond to the points at which the two lines
 which are drawn so that they are tangential to both circles but on
-different sides, touching the circles and crossing eachother.
+different sides, touching the circles and crossing each other.
 
 The first tangent line is described by the points
 stored in ``line1P1`` and ``line1P2``,

--- a/python/core/auto_generated/geometry/qgscircle.sip.in
+++ b/python/core/auto_generated/geometry/qgscircle.sip.in
@@ -190,6 +190,31 @@ Note that this method is 2D only and does not consider the z-value of the circle
 .. versionadded:: 3.2
 %End
 
+    int innerTangents( const QgsCircle &other,
+                       QgsPointXY &line1P1 /Out/, QgsPointXY &line1P2 /Out/,
+                       QgsPointXY &line2P1 /Out/, QgsPointXY &line2P2 /Out/ ) const;
+%Docstring
+Calculates the inner tangent points between this circle
+and an ``other`` circle.
+
+The outer tangent points correspond to the points at which the two lines
+which are drawn so that they are tangential to both circles but on
+different sides, touching the circles and crossing eachother.
+
+The first tangent line is described by the points
+stored in ``line1P1`` and ``line1P2``,
+and the second line is described by the points stored in ``line2P1``
+and ``line2P2``.
+
+Returns the number of tangents (either 0 or 2).
+
+Note that this method is 2D only and does not consider the z-value of the circle.
+
+.. seealso:: :py:func:`tangentToPoint`
+
+.. versionadded:: 3.6
+%End
+
     virtual double area() const;
 
     virtual double perimeter() const;

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -213,9 +213,9 @@ Calculates the inner tangent points for two circles, centered at \a
 center1 and ``center2`` and with radii of ``radius1`` and ``radius2``
 respectively.
 
-The outer tangent points correspond to the points at which the two lines
+The inner tangent points correspond to the points at which the two lines
 which are drawn so that they are tangential to both circles and are
-crossing eachother.
+crossing each other.
 
 The first tangent line is described by the points
 stored in ``line1P1`` and ``line1P2``,

--- a/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometryutils.sip.in
@@ -204,6 +204,29 @@ Returns the number of tangents (either 0 or 2).
 .. versionadded:: 3.2
 %End
 
+    static int circleCircleInnerTangents(
+      const QgsPointXY &center1, double radius1, const QgsPointXY &center2, double radius2,
+      QgsPointXY &line1P1 /Out/, QgsPointXY &line1P2 /Out/,
+      QgsPointXY &line2P1 /Out/, QgsPointXY &line2P2 /Out/ );
+%Docstring
+Calculates the inner tangent points for two circles, centered at \a
+center1 and ``center2`` and with radii of ``radius1`` and ``radius2``
+respectively.
+
+The outer tangent points correspond to the points at which the two lines
+which are drawn so that they are tangential to both circles and are
+crossing eachother.
+
+The first tangent line is described by the points
+stored in ``line1P1`` and ``line1P2``,
+and the second line is described by the points stored in ``line2P1``
+and ``line2P2``.
+
+Returns the number of tangents (either 0 or 2).
+
+.. versionadded:: 3.6
+%End
+
     static QgsPoint projectPointOnSegment( const QgsPoint &p, const QgsPoint &s1, const QgsPoint &s2 );
 %Docstring
 Project the point on a segment

--- a/src/core/geometry/qgscircle.cpp
+++ b/src/core/geometry/qgscircle.cpp
@@ -270,6 +270,12 @@ int QgsCircle::outerTangents( const QgsCircle &other, QgsPointXY &line1P1, QgsPo
          QgsPointXY( other.center() ), other.radius(), line1P1, line1P2, line2P1, line2P2 );
 }
 
+int QgsCircle::innerTangents( const QgsCircle &other, QgsPointXY &line1P1, QgsPointXY &line1P2, QgsPointXY &line2P1, QgsPointXY &line2P2 ) const
+{
+  return QgsGeometryUtils::circleCircleInnerTangents( QgsPointXY( mCenter ), radius(),
+         QgsPointXY( other.center() ), other.radius(), line1P1, line1P2, line2P1, line2P2 );
+}
+
 QgsCircle QgsCircle::fromExtent( const QgsPoint &pt1, const QgsPoint &pt2 )
 {
   double delta_x = std::fabs( pt1.x() - pt2.x() );

--- a/src/core/geometry/qgscircle.h
+++ b/src/core/geometry/qgscircle.h
@@ -166,7 +166,7 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      * \returns true if tangent was found.
      *
      *
-     * \see outerTangents()
+     * \see outerTangents() and innerTangents()
      * \since QGIS 3.2
      */
     bool tangentToPoint( const QgsPointXY &p, QgsPointXY &pt1 SIP_OUT, QgsPointXY &pt2 SIP_OUT ) const;
@@ -189,10 +189,35 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      * Note that this method is 2D only and does not consider the z-value of the circle.
      *
      *
-     * \see tangentToPoint()
+     * \see tangentToPoint() and innerTangents()
      * \since QGIS 3.2
      */
     int outerTangents( const QgsCircle &other,
+                       QgsPointXY &line1P1 SIP_OUT, QgsPointXY &line1P2 SIP_OUT,
+                       QgsPointXY &line2P1 SIP_OUT, QgsPointXY &line2P2 SIP_OUT ) const;
+
+    /**
+     * Calculates the inner tangent points between this circle
+     * and an \a other circle.
+     *
+     * The outer tangent points correspond to the points at which the two lines
+     * which are drawn so that they are tangential to both circles but on
+     * different sides, touching the circles and crossing eachother.
+     *
+     * The first tangent line is described by the points
+     * stored in \a line1P1 and \a line1P2,
+     * and the second line is described by the points stored in \a line2P1
+     * and \a line2P2.
+     *
+     * Returns the number of tangents (either 0 or 2).
+     *
+     * Note that this method is 2D only and does not consider the z-value of the circle.
+     *
+     *
+     * \see tangentToPoint() and outerTangents()
+     * \since QGIS 3.6
+     */
+    int innerTangents( const QgsCircle &other,
                        QgsPointXY &line1P1 SIP_OUT, QgsPointXY &line1P2 SIP_OUT,
                        QgsPointXY &line2P1 SIP_OUT, QgsPointXY &line2P2 SIP_OUT ) const;
 

--- a/src/core/geometry/qgscircle.h
+++ b/src/core/geometry/qgscircle.h
@@ -200,9 +200,9 @@ class CORE_EXPORT QgsCircle : public QgsEllipse
      * Calculates the inner tangent points between this circle
      * and an \a other circle.
      *
-     * The outer tangent points correspond to the points at which the two lines
+     * The inner tangent points correspond to the points at which the two lines
      * which are drawn so that they are tangential to both circles but on
-     * different sides, touching the circles and crossing eachother.
+     * different sides, touching the circles and crossing each other.
      *
      * The first tangent line is described by the points
      * stored in \a line1P1 and \a line1P2,

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -207,9 +207,9 @@ class CORE_EXPORT QgsGeometryUtils
      * center1 and \a center2 and with radii of \a radius1 and \a radius2
      * respectively.
      *
-     * The outer tangent points correspond to the points at which the two lines
+     * The inner tangent points correspond to the points at which the two lines
      * which are drawn so that they are tangential to both circles and are
-     * crossing eachother.
+     * crossing each other.
      *
      * The first tangent line is described by the points
      * stored in \a line1P1 and \a line1P2,

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -203,6 +203,29 @@ class CORE_EXPORT QgsGeometryUtils
       QgsPointXY &line2P1 SIP_OUT, QgsPointXY &line2P2 SIP_OUT );
 
     /**
+     * Calculates the inner tangent points for two circles, centered at \a
+     * center1 and \a center2 and with radii of \a radius1 and \a radius2
+     * respectively.
+     *
+     * The outer tangent points correspond to the points at which the two lines
+     * which are drawn so that they are tangential to both circles and are
+     * crossing eachother.
+     *
+     * The first tangent line is described by the points
+     * stored in \a line1P1 and \a line1P2,
+     * and the second line is described by the points stored in \a line2P1
+     * and \a line2P2.
+     *
+     * Returns the number of tangents (either 0 or 2).
+     *
+     * \since QGIS 3.6
+     */
+    static int circleCircleInnerTangents(
+      const QgsPointXY &center1, double radius1, const QgsPointXY &center2, double radius2,
+      QgsPointXY &line1P1 SIP_OUT, QgsPointXY &line1P2 SIP_OUT,
+      QgsPointXY &line2P1 SIP_OUT, QgsPointXY &line2P2 SIP_OUT );
+
+    /**
      * \brief Project the point on a segment
      * \param p The point
      * \param s1 The segment start point

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -7812,7 +7812,7 @@ void TestQgsGeometry::circle()
   QGSCOMPARENEAR( t2.x(), 2.2, 0.01 );
   QGSCOMPARENEAR( t2.y(), 5.82, 0.01 );
 
-  // two circle tangents
+  // two outer circle tangents
   QgsPointXY l1p1, l1p2, l2p1, l2p2;
   QCOMPARE( QgsCircle( QgsPoint( 1, 2 ), 4 ).outerTangents( QgsCircle( QgsPoint( 2, 3 ), 1 ), l1p1, l1p2, l2p1, l2p2 ), 0 );
   QCOMPARE( QgsCircle( QgsPoint( 1, 2 ), 1 ).outerTangents( QgsCircle( QgsPoint( 10, 3 ), 4 ), l1p1, l1p2, l2p1, l2p2 ), 2 );
@@ -7824,6 +7824,20 @@ void TestQgsGeometry::circle()
   QGSCOMPARENEAR( l2p1.y(), 1.025, 0.01 );
   QGSCOMPARENEAR( l2p2.x(), 9.099, 0.01 );
   QGSCOMPARENEAR( l2p2.y(), -0.897, 0.01 );
+
+  // two inner circle tangents
+  QCOMPARE( QgsCircle( QgsPoint( 1, 2 ), 4 ).innerTangents( QgsCircle( QgsPoint( 2, 3 ), 1 ), l1p1, l1p2, l2p1, l2p2 ), 0 );
+  QCOMPARE( QgsCircle( QgsPoint( 0, 0 ), 4 ).innerTangents( QgsCircle( QgsPoint( 8, 0 ), 5 ), l1p1, l1p2, l2p1, l2p2 ), 0 );
+  QCOMPARE( QgsCircle( QgsPoint( 0, 0 ), 4 ).innerTangents( QgsCircle( QgsPoint( 8, 0 ), 4 ), l1p1, l1p2, l2p1, l2p2 ), 0 );
+  QCOMPARE( QgsCircle( QgsPoint( 1, 2 ), 1 ).innerTangents( QgsCircle( QgsPoint( 10, 3 ), 4 ), l1p1, l1p2, l2p1, l2p2 ), 2 );
+  QGSCOMPARENEAR( l1p1.x(), 7.437, 0.01 );
+  QGSCOMPARENEAR( l1p1.y(), 6.071, 0.01 );
+  QGSCOMPARENEAR( l1p2.x(), 1.641, 0.01 );
+  QGSCOMPARENEAR( l1p2.y(), 1.232, 0.01 );
+  QGSCOMPARENEAR( l2p1.x(), 8.173, 0.01 );
+  QGSCOMPARENEAR( l2p1.y(), -0.558, 0.01 );
+  QGSCOMPARENEAR( l2p2.x(), 1.457, 0.01 );
+  QGSCOMPARENEAR( l2p2.y(), 2.89, 0.01 );
 }
 
 void TestQgsGeometry::regularPolygon()

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -64,6 +64,7 @@ class TestQgsGeometryUtils: public QObject
     void testCircleCircleIntersection();
     void testTangentPointAndCircle();
     void testCircleCircleOuterTangents();
+    void testCircleCircleInnerTangents();
     void testGml();
     void testInterpolatePointOnLineQgsPoint();
     void testInterpolatePointOnLine();
@@ -968,6 +969,45 @@ void TestQgsGeometryUtils::testCircleCircleOuterTangents()
   QGSCOMPARENEAR( l2p1.y(), 1.025, 0.01 );
   QGSCOMPARENEAR( l2p2.x(), 9.099, 0.01 );
   QGSCOMPARENEAR( l2p2.y(), -0.897, 0.01 );
+}
+
+void TestQgsGeometryUtils::testCircleCircleInnerTangents()
+{
+  QgsPointXY l1p1;
+  QgsPointXY l1p2;
+  QgsPointXY l2p1;
+  QgsPointXY l2p2;
+
+  // no tangents, intersecting circles
+  QCOMPARE( QgsGeometryUtils::circleCircleInnerTangents( QgsPointXY( 1, 2 ), 4, QgsPointXY( 2, 3 ), 1, l1p1, l1p2, l2p1, l2p2 ), 0 );
+
+  // no tangents, same circles
+  QCOMPARE( QgsGeometryUtils::circleCircleInnerTangents( QgsPointXY( 1, 2 ), 4, QgsPointXY( 1, 2 ), 4, l1p1, l1p2, l2p1, l2p2 ), 0 );
+
+  // no tangents, touching circles
+  QCOMPARE( QgsGeometryUtils::circleCircleInnerTangents( QgsPointXY( 0, 0 ), 4, QgsPointXY( 0, 8 ), 4, l1p1, l1p2, l2p1, l2p2 ), 0 );
+
+  // tangents
+  QCOMPARE( QgsGeometryUtils::circleCircleInnerTangents( QgsPointXY( 1, 2 ), 1, QgsPointXY( 10, 3 ), 4, l1p1, l1p2, l2p1, l2p2 ), 2 );
+  QGSCOMPARENEAR( l1p1.x(), 7.437, 0.01 );
+  QGSCOMPARENEAR( l1p1.y(), 6.071, 0.01 );
+  QGSCOMPARENEAR( l1p2.x(), 1.641, 0.01 );
+  QGSCOMPARENEAR( l1p2.y(), 1.232, 0.01 );
+  QGSCOMPARENEAR( l2p1.x(), 8.173, 0.01 );
+  QGSCOMPARENEAR( l2p1.y(), -0.558, 0.01 );
+  QGSCOMPARENEAR( l2p2.x(), 1.457, 0.01 );
+  QGSCOMPARENEAR( l2p2.y(), 2.89, 0.01 );
+
+  // tangents, larger circle first
+  QCOMPARE( QgsGeometryUtils::circleCircleInnerTangents( QgsPointXY( 10, 3 ), 4, QgsPointXY( 1, 2 ), 1, l1p1, l1p2, l2p1, l2p2 ), 2 );
+  QGSCOMPARENEAR( l1p1.x(), 7.437, 0.01 );
+  QGSCOMPARENEAR( l1p1.y(), 6.071, 0.01 );
+  QGSCOMPARENEAR( l1p2.x(), 1.641, 0.01 );
+  QGSCOMPARENEAR( l1p2.y(), 1.232, 0.01 );
+  QGSCOMPARENEAR( l2p1.x(), 8.173, 0.01 );
+  QGSCOMPARENEAR( l2p1.y(), -0.558, 0.01 );
+  QGSCOMPARENEAR( l2p2.x(), 1.457, 0.01 );
+  QGSCOMPARENEAR( l2p2.y(), 2.89, 0.01 );
 }
 
 void TestQgsGeometryUtils::testGml()


### PR DESCRIPTION
## Description
Adds the function innerTangents() to the QgsCircle class, which works quite similar to the already existing outerTangents() function. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
