### PR TITLE
Style manager improvements

### DIFF
--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -265,8 +265,17 @@ add a new color ramp to style
     bool editSymbol();
     bool editColorRamp();
 
-    bool removeSymbol();
-    bool removeColorRamp();
+ bool removeSymbol() /Deprecated/;
+%Docstring
+
+.. deprecated:: in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+%End
+
+ bool removeColorRamp() /Deprecated/;
+%Docstring
+
+.. deprecated:: in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+%End
 
     void enableSymbolInputs( bool );
 %Docstring

--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -40,6 +40,7 @@ Opens the add color ramp dialog, returning the new color ramp's name if the ramp
 
   public slots:
 
+
     void activate();
 %Docstring
 Raises, unminimizes and activates this window
@@ -48,32 +49,80 @@ Raises, unminimizes and activates this window
 %End
 
     void addItem();
+%Docstring
+Triggers the dialog for adding a new item, based on the currently
+selected item type tab.
+%End
+
     void editItem();
+%Docstring
+Triggers the dialog for editing the current item.
+%End
+
     void removeItem();
+%Docstring
+Removes the current selected item.
+%End
+
     void exportItemsSVG();
+%Docstring
+Triggers the dialog to export selected items as SVG files.
+
+.. seealso:: :py:func:`exportItemsPNG`
+
+.. seealso:: :py:func:`exportSelectedItemsImages`
+%End
+
     void exportItemsPNG();
+%Docstring
+Triggers the dialog to export selected items as PNG files.
+
+.. seealso:: :py:func:`exportItemsSVG`
+
+.. seealso:: :py:func:`exportSelectedItemsImages`
+%End
+
     void exportSelectedItemsImages( const QString &dir, const QString &format, QSize size );
+%Docstring
+Triggers the dialog to export selected items as images of the specified ``format`` and ``size``.
+
+.. seealso:: :py:func:`exportItemsSVG`
+
+.. seealso:: :py:func:`exportItemsPNG`
+%End
+
     void exportItems();
+%Docstring
+Triggers the dialog to export items.
+
+.. seealso:: :py:func:`importItems`
+%End
+
     void importItems();
+%Docstring
+Triggers the dialog to import items.
+
+.. seealso:: :py:func:`exportItems`
+%End
 
     void populateList();
 %Docstring
-adds symbols of some type to list
+Refreshes the list of items.
 %End
 
     void onFinished();
 %Docstring
-called when the dialog is going to be closed
+Called when the dialog is going to be closed.
 %End
 
     void onClose();
 %Docstring
-Close the dialog
+Closes the dialog
 %End
 
     void showHelp();
 %Docstring
-Open the associated help
+Opens the associated help
 %End
 
  void itemChanged( QStandardItem *item ) /Deprecated/;
@@ -83,38 +132,49 @@ Open the associated help
 %End
 
     void groupChanged( const QModelIndex & );
-    void groupRenamed( QStandardItem * );
+%Docstring
+Trigerred when the current group (or tag) is changed.
+%End
+
+    void groupRenamed( QStandardItem *item );
+%Docstring
+Triggered when a group ``item`` is renamed.
+%End
+
     int addTag();
 %Docstring
-add a tag
+Triggers the dialog to add a new tag.
 %End
+
     int addSmartgroup();
 %Docstring
-add a smartgroup
+Triggers the dialog to add a new smart group.
 %End
+
     void removeGroup();
 %Docstring
-remove a tag or smartgroup
+Removes the selected tag or smartgroup.
 %End
 
     void tagSymbolsAction();
 %Docstring
-carry out symbol tagging using check boxes
+Toggles the interactive item tagging mode.
 %End
 
     void editSmartgroupAction();
 %Docstring
-edit the selected smart group
+Triggers the dialog for editing the selected smart group.
 %End
 
-    void regrouped( QStandardItem * );
+ void regrouped( QStandardItem * ) /Deprecated/;
 %Docstring
-symbol changed from one group
+
+.. deprecated:: in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
 %End
 
-    void filterSymbols( const QString & );
+    void filterSymbols( const QString &filter );
 %Docstring
-filter the symbols based on input search term
+Sets the ``filter`` string to filter symbols by.
 %End
 
     void symbolSelected( const QModelIndex & );

--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsStyleManagerDialog : QDialog
 {
 %Docstring
@@ -75,7 +76,11 @@ Close the dialog
 Open the associated help
 %End
 
-    void itemChanged( QStandardItem *item );
+ void itemChanged( QStandardItem *item ) /Deprecated/;
+%Docstring
+
+.. deprecated:: in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+%End
 
     void groupChanged( const QModelIndex & );
     void groupRenamed( QStandardItem * );
@@ -153,28 +158,36 @@ Remove all tags from selected symbols
 
   protected:
 
-    void populateTypes();
+ void populateTypes() /Deprecated/;
 %Docstring
-populate combo box with known style items (symbols, color ramps)
+Populate combo box with known style items (symbols, color ramps).
+
+.. deprecated:: in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
 %End
 
     void populateGroups();
 %Docstring
 populate the groups
 %End
-    void setSymbolsChecked( const QStringList & );
+
+ void setSymbolsChecked( const QStringList & ) /Deprecated/;
 %Docstring
-to set symbols checked when in editing mode
+
+.. deprecated:: in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
 %End
 
-    void populateSymbols( const QStringList &symbolNames, bool checkable = false );
+ void populateSymbols( const QStringList &symbolNames, bool checkable = false ) /Deprecated/;
 %Docstring
-populate list view with symbols of the current type with the given names
+Populates the list view with symbols of the current type with the given names.
+
+.. deprecated:: No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0
 %End
 
-    void populateColorRamps( const QStringList &colorRamps, bool checkable = false );
+ void populateColorRamps( const QStringList &colorRamps, bool checkable = false ) /Deprecated/;
 %Docstring
-populate list view with color ramps
+Populates the list view with color ramps of the current type with the given names.
+
+.. deprecated:: No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0
 %End
 
     int currentItemType();

--- a/src/core/symbology/qgsstylemodel.cpp
+++ b/src/core/symbology/qgsstylemodel.cpp
@@ -124,15 +124,18 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
               return icon;
 
             std::unique_ptr< QgsSymbol > symbol( mStyle->symbol( name ) );
-            if ( mAdditionalSizes.isEmpty() )
-              icon.addPixmap( QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), QSize( 24, 24 ), 1 ) );
-
-            for ( const QVariant &size : mAdditionalSizes )
+            if ( symbol )
             {
-              QSize s = size.toSize();
-              icon.addPixmap( QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), s, static_cast< int >( s.width() * ICON_PADDING_FACTOR ) ) );
-            }
+              if ( mAdditionalSizes.isEmpty() )
+                icon.addPixmap( QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), QSize( 24, 24 ), 1 ) );
 
+              for ( const QVariant &size : mAdditionalSizes )
+              {
+                QSize s = size.toSize();
+                icon.addPixmap( QgsSymbolLayerUtils::symbolPreviewPixmap( symbol.get(), s, static_cast< int >( s.width() * ICON_PADDING_FACTOR ) ) );
+              }
+
+            }
             mSymbolIconCache.insert( name, icon );
             return icon;
           }
@@ -144,14 +147,17 @@ QVariant QgsStyleModel::data( const QModelIndex &index, int role ) const
               return icon;
 
             std::unique_ptr< QgsColorRamp > ramp( mStyle->colorRamp( name ) );
-            if ( mAdditionalSizes.isEmpty() )
-              icon.addPixmap( QgsSymbolLayerUtils::colorRampPreviewPixmap( ramp.get(), QSize( 24, 24 ), 1 ) );
-            for ( const QVariant &size : mAdditionalSizes )
+            if ( ramp )
             {
-              QSize s = size.toSize();
-              icon.addPixmap( QgsSymbolLayerUtils::colorRampPreviewPixmap( ramp.get(), s, static_cast< int >( s.width() * ICON_PADDING_FACTOR ) ) );
-            }
+              if ( mAdditionalSizes.isEmpty() )
+                icon.addPixmap( QgsSymbolLayerUtils::colorRampPreviewPixmap( ramp.get(), QSize( 24, 24 ), 1 ) );
+              for ( const QVariant &size : mAdditionalSizes )
+              {
+                QSize s = size.toSize();
+                icon.addPixmap( QgsSymbolLayerUtils::colorRampPreviewPixmap( ramp.get(), s, static_cast< int >( s.width() * ICON_PADDING_FACTOR ) ) );
+              }
 
+            }
             mColorRampIconCache.insert( name, icon );
             return icon;
           }

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -132,7 +132,7 @@ bool QgsCheckableStyleModel::setData( const QModelIndex &i, const QVariant &valu
   }
   return QgsStyleProxyModel::setData( i, value, role );
 }
-
+///@endcond
 
 //
 // QgsStyleManagerDialog

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -357,7 +357,7 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
 
   mModel->setEntityFilter( isSymbol  ? QgsStyle::SymbolEntity : QgsStyle::ColorrampEntity );
   mModel->setEntityFilterEnabled( true );
-  mModel->setSymbolTypeFilterEnabled( isSymbol );
+  mModel->setSymbolTypeFilterEnabled( isSymbol && tabItemType->currentIndex() > 0 );
   mModel->setSymbolType( static_cast< QgsSymbol::SymbolType >( currentItemType() ) );
 
   populateList();
@@ -385,13 +385,13 @@ int QgsStyleManagerDialog::currentItemType()
 {
   switch ( tabItemType->currentIndex() )
   {
-    case 0:
-      return QgsSymbol::Marker;
     case 1:
-      return QgsSymbol::Line;
+      return QgsSymbol::Marker;
     case 2:
-      return QgsSymbol::Fill;
+      return QgsSymbol::Line;
     case 3:
+      return QgsSymbol::Fill;
+    case 4:
       return 3;
     default:
       return 0;

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -208,7 +208,6 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
   mSymbolTreeView->setSelectionModel( listItems->selectionModel() );
   mSymbolTreeView->setSelectionMode( listItems->selectionMode() );
 
-  //connect( model, &QStandardItemModel::itemChanged, this, &QgsStyleManagerDialog::itemChanged );
   connect( listItems->selectionModel(), &QItemSelectionModel::currentChanged,
            this, &QgsStyleManagerDialog::symbolSelected );
   connect( listItems->selectionModel(), &QItemSelectionModel::selectionChanged,
@@ -1291,32 +1290,9 @@ void QgsStyleManagerDialog::tagSymbolsAction()
   }
 }
 
-void QgsStyleManagerDialog::regrouped( QStandardItem *item )
+void QgsStyleManagerDialog::regrouped( QStandardItem * )
 {
-  QgsStyle::StyleEntity type = ( currentItemType() < 3 ) ? QgsStyle::SymbolEntity : QgsStyle::ColorrampEntity;
-  if ( currentItemType() > 3 )
-  {
-    QgsDebugMsg( QStringLiteral( "Unknown style entity" ) );
-    return;
-  }
 
-  QStandardItemModel *treeModel = qobject_cast<QStandardItemModel *>( groupTree->model() );
-  QString tag = treeModel->itemFromIndex( groupTree->currentIndex() )->text();
-
-  QString symbolName = item->text();
-  bool regrouped;
-  if ( item->checkState() == Qt::Checked )
-    regrouped = mStyle->tagSymbol( type, symbolName, QStringList( tag ) );
-  else
-    regrouped = mStyle->detagSymbol( type, symbolName, QStringList( tag ) );
-  if ( !regrouped )
-  {
-    int er = QMessageBox::critical( this, tr( "Group Items" ),
-                                    tr( "There was a problem with the symbols database while regrouping." ) );
-    // call the slot again to get back to normal
-    if ( er )
-      tagSymbolsAction();
-  }
 }
 
 void QgsStyleManagerDialog::setSymbolsChecked( const QStringList & )

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -23,9 +23,36 @@
 
 #include "ui_qgsstylemanagerdialogbase.h"
 #include "qgshelp.h"
+#include "qgsstylemodel.h"
 #include "qgis_gui.h"
 
 class QgsStyle;
+
+#ifndef SIP_RUN
+///@cond PRIVATE
+class QgsCheckableStyleModel: public QgsStyleProxyModel
+{
+    Q_OBJECT
+  public:
+
+    explicit QgsCheckableStyleModel( QgsStyle *style, QObject *parent = nullptr );
+
+    void setCheckable( bool checkable );
+    void setCheckTag( const QString &tag );
+
+    Qt::ItemFlags flags( const QModelIndex &index ) const override;
+    QVariant data( const QModelIndex &index, int role ) const override;
+    bool setData( const QModelIndex &index, const QVariant &value, int role = Qt::EditRole ) override;
+
+  private:
+
+    QgsStyle *mStyle = nullptr;
+    bool mCheckable = false;
+    QString mCheckTag;
+
+};
+#endif
+///@endcond
 
 /**
  * \ingroup gui
@@ -83,7 +110,10 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     //! Open the associated help
     void showHelp();
 
-    void itemChanged( QStandardItem *item );
+    /**
+     * \deprecated in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED void itemChanged( QStandardItem *item ) SIP_DEPRECATED;
 
     void groupChanged( const QModelIndex & );
     void groupRenamed( QStandardItem * );
@@ -131,19 +161,34 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
   protected:
 
-    //! populate combo box with known style items (symbols, color ramps)
-    void populateTypes();
+    /**
+     * Populate combo box with known style items (symbols, color ramps).
+     *
+     * \deprecated in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED void populateTypes() SIP_DEPRECATED;
 
     //! populate the groups
     void populateGroups();
-    //! to set symbols checked when in editing mode
-    void setSymbolsChecked( const QStringList & );
 
-    //! populate list view with symbols of the current type with the given names
-    void populateSymbols( const QStringList &symbolNames, bool checkable = false );
+    /**
+     * \deprecated in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED void setSymbolsChecked( const QStringList & ) SIP_DEPRECATED;
 
-    //! populate list view with color ramps
-    void populateColorRamps( const QStringList &colorRamps, bool checkable = false );
+    /**
+     * Populates the list view with symbols of the current type with the given names.
+     *
+     * \deprecated No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED void populateSymbols( const QStringList &symbolNames, bool checkable = false ) SIP_DEPRECATED;
+
+    /**
+     * Populates the list view with color ramps of the current type with the given names.
+     *
+     * \deprecated No longer required in QGIS 3.6, as the model is updated live. Has no effect and will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED void populateColorRamps( const QStringList &colorRamps, bool checkable = false ) SIP_DEPRECATED;
 
     int currentItemType();
     QString currentItemName();
@@ -177,12 +222,14 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     QgsStyle *mStyle = nullptr;
 
+    QgsCheckableStyleModel *mModel = nullptr;
+
     QString mStyleFilename;
 
     bool mModified = false;
 
     //! Mode to display the symbol list
-    bool mGrouppingMode = false;
+    bool mGroupingMode = false;
 
     //! space to store symbol tags
     QStringList mTagList;

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -83,31 +83,82 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
   public slots:
 
+    // TODO QGIS 4.0 -- most of this should be private
+
     /**
      * Raises, unminimizes and activates this window
      * \since QGIS 3.4
      */
     void activate();
 
+    /**
+     * Triggers the dialog for adding a new item, based on the currently
+     * selected item type tab.
+     */
     void addItem();
+
+    /**
+     * Triggers the dialog for editing the current item.
+     */
     void editItem();
+
+    /**
+     * Removes the current selected item.
+     */
     void removeItem();
+
+    /**
+     * Triggers the dialog to export selected items as SVG files.
+     *
+     * \see exportItemsPNG()
+     * \see exportSelectedItemsImages()
+     */
     void exportItemsSVG();
+
+    /**
+     * Triggers the dialog to export selected items as PNG files.
+     *
+     * \see exportItemsSVG()
+     * \see exportSelectedItemsImages()
+     */
     void exportItemsPNG();
+
+    /**
+     * Triggers the dialog to export selected items as images of the specified \a format and \a size.
+     *
+     * \see exportItemsSVG()
+     * \see exportItemsPNG()
+     */
     void exportSelectedItemsImages( const QString &dir, const QString &format, QSize size );
+
+    /**
+     * Triggers the dialog to export items.
+     *
+     * \see importItems()
+     */
     void exportItems();
+
+    /**
+     * Triggers the dialog to import items.
+     *
+     * \see exportItems()
+     */
     void importItems();
 
-    //! adds symbols of some type to list
+    /**
+     * Refreshes the list of items.
+     */
     void populateList();
 
-    //! called when the dialog is going to be closed
+    /**
+     * Called when the dialog is going to be closed.
+     */
     void onFinished();
 
-    //! Close the dialog
+    //! Closes the dialog
     void onClose();
 
-    //! Open the associated help
+    //! Opens the associated help
     void showHelp();
 
     /**
@@ -115,26 +166,50 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
      */
     Q_DECL_DEPRECATED void itemChanged( QStandardItem *item ) SIP_DEPRECATED;
 
+    /**
+     * Trigerred when the current group (or tag) is changed.
+     */
     void groupChanged( const QModelIndex & );
-    void groupRenamed( QStandardItem * );
-    //! add a tag
+
+    /**
+     * Triggered when a group \a item is renamed.
+     */
+    void groupRenamed( QStandardItem *item );
+
+    /**
+     * Triggers the dialog to add a new tag.
+     */
     int addTag();
-    //! add a smartgroup
+
+    /**
+     * Triggers the dialog to add a new smart group.
+     */
     int addSmartgroup();
-    //! remove a tag or smartgroup
+
+    /**
+     * Removes the selected tag or smartgroup.
+     */
     void removeGroup();
 
-    //! carry out symbol tagging using check boxes
+    /**
+     * Toggles the interactive item tagging mode.
+     */
     void tagSymbolsAction();
 
-    //! edit the selected smart group
+    /**
+     * Triggers the dialog for editing the selected smart group.
+     */
     void editSmartgroupAction();
 
-    //! symbol changed from one group
-    void regrouped( QStandardItem * );
+    /**
+     * \deprecated in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED void regrouped( QStandardItem * ) SIP_DEPRECATED;
 
-    //! filter the symbols based on input search term
-    void filterSymbols( const QString & );
+    /**
+     * Sets the \a filter string to filter symbols by.
+     */
+    void filterSymbols( const QString &filter );
 
     //! Perform symbol specific tasks when selected
     void symbolSelected( const QModelIndex & );

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -276,8 +276,15 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     bool editSymbol();
     bool editColorRamp();
 
-    bool removeSymbol();
-    bool removeColorRamp();
+    /**
+     * \deprecated in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED bool removeSymbol() SIP_DEPRECATED;
+
+    /**
+     * \deprecated in QGIS 3.6 - has no effect and will be removed in QGIS 4.0
+     */
+    Q_DECL_DEPRECATED bool removeColorRamp() SIP_DEPRECATED;
 
     //! Enables or disbables the symbol specific inputs
     void enableSymbolInputs( bool );
@@ -294,6 +301,21 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     void tabItemType_currentChanged( int );
 
   private:
+    int selectedItemType();
+
+    /**
+     * Returns true if the "All" tab is selected.
+     */
+    bool allTypesSelected() const;
+
+    struct ItemDetails
+    {
+      QgsStyle::StyleEntity entityType;
+      QgsSymbol::SymbolType symbolType;
+      QString name;
+    };
+
+    QList< ItemDetails > selectedItems();
 
     QgsStyle *mStyle = nullptr;
 

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -203,13 +203,6 @@
           </spacer>
          </item>
          <item>
-          <widget class="QgsFilterLineEdit" name="searchBox">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-         <item>
           <layout class="QHBoxLayout" name="horizontalLayout_7">
            <property name="spacing">
             <number>0</number>
@@ -265,6 +258,13 @@
            </item>
           </layout>
          </item>
+         <item>
+          <widget class="QgsFilterLineEdit" name="searchBox">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="3" column="0">
@@ -274,9 +274,17 @@
          </property>
          <item>
           <widget class="QTabWidget" name="tabItemType">
+           <property name="currentIndex">
+            <number>4</number>
+           </property>
            <property name="documentMode">
             <bool>true</bool>
            </property>
+           <widget class="QWidget" name="tabAll">
+            <attribute name="title">
+             <string>All</string>
+            </attribute>
+           </widget>
            <widget class="QWidget" name="tabMarker">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
@@ -334,7 +342,7 @@
               <normaloff>:/images/themes/default/styleicons/color.svg</normaloff>:/images/themes/default/styleicons/color.svg</iconset>
             </attribute>
             <attribute name="title">
-             <string>Color ramp</string>
+             <string>Color Ramp</string>
             </attribute>
            </widget>
           </widget>
@@ -342,7 +350,7 @@
          <item>
           <widget class="QStackedWidget" name="mSymbolViewStackedWidget">
            <property name="currentIndex">
-            <number>0</number>
+            <number>1</number>
            </property>
            <widget class="QWidget" name="page">
             <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -617,9 +625,9 @@
   <tabstop>btnAddItem</tabstop>
   <tabstop>btnRemoveItem</tabstop>
   <tabstop>btnEditItem</tabstop>
-  <tabstop>searchBox</tabstop>
   <tabstop>mButtonIconView</tabstop>
   <tabstop>mButtonListView</tabstop>
+  <tabstop>searchBox</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -145,123 +145,7 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item row="1" column="0">
-        <widget class="QTabWidget" name="tabItemType">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>20</width>
-           <height>20</height>
-          </size>
-         </property>
-         <widget class="QWidget" name="tabMarker">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <attribute name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mIconPointLayer.svg</normaloff>:/images/themes/default/mIconPointLayer.svg</iconset>
-          </attribute>
-          <attribute name="title">
-           <string>Marker</string>
-          </attribute>
-         </widget>
-         <widget class="QWidget" name="tabLine">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <attribute name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mIconLineLayer.svg</normaloff>:/images/themes/default/mIconLineLayer.svg</iconset>
-          </attribute>
-          <attribute name="title">
-           <string>Line</string>
-          </attribute>
-         </widget>
-         <widget class="QWidget" name="tabFill">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <attribute name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mIconPolygonLayer.svg</normaloff>:/images/themes/default/mIconPolygonLayer.svg</iconset>
-          </attribute>
-          <attribute name="title">
-           <string>Fill</string>
-          </attribute>
-         </widget>
-         <widget class="QWidget" name="tabColorRamp">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <attribute name="icon">
-           <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/styleicons/color.svg</normaloff>:/images/themes/default/styleicons/color.svg</iconset>
-          </attribute>
-          <attribute name="title">
-           <string>Color ramp</string>
-          </attribute>
-         </widget>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QListView" name="listItems">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>3</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="editTriggers">
-          <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>77</width>
-           <height>70</height>
-          </size>
-         </property>
-         <property name="textElideMode">
-          <enum>Qt::ElideNone</enum>
-         </property>
-         <property name="movement">
-          <enum>QListView::Static</enum>
-         </property>
-         <property name="resizeMode">
-          <enum>QListView::Adjust</enum>
-         </property>
-         <property name="spacing">
-          <number>5</number>
-         </property>
-         <property name="viewMode">
-          <enum>QListView::IconMode</enum>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
+       <item row="4" column="0">
         <layout class="QHBoxLayout" name="symbolBtnsLayout">
          <item>
           <widget class="QPushButton" name="btnAddItem">
@@ -322,6 +206,111 @@
           <widget class="QgsFilterLineEdit" name="searchBox">
            <property name="text">
             <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
+        <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QTabWidget" name="tabItemType">
+           <property name="documentMode">
+            <bool>true</bool>
+           </property>
+           <widget class="QWidget" name="tabMarker">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <attribute name="icon">
+             <iconset resource="../../images/images.qrc">
+              <normaloff>:/images/themes/default/mIconPointLayer.svg</normaloff>:/images/themes/default/mIconPointLayer.svg</iconset>
+            </attribute>
+            <attribute name="title">
+             <string>Marker</string>
+            </attribute>
+           </widget>
+           <widget class="QWidget" name="tabLine">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <attribute name="icon">
+             <iconset resource="../../images/images.qrc">
+              <normaloff>:/images/themes/default/mIconLineLayer.svg</normaloff>:/images/themes/default/mIconLineLayer.svg</iconset>
+            </attribute>
+            <attribute name="title">
+             <string>Line</string>
+            </attribute>
+           </widget>
+           <widget class="QWidget" name="tabFill">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <attribute name="icon">
+             <iconset resource="../../images/images.qrc">
+              <normaloff>:/images/themes/default/mIconPolygonLayer.svg</normaloff>:/images/themes/default/mIconPolygonLayer.svg</iconset>
+            </attribute>
+            <attribute name="title">
+             <string>Fill</string>
+            </attribute>
+           </widget>
+           <widget class="QWidget" name="tabColorRamp">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <attribute name="icon">
+             <iconset resource="../../images/images.qrc">
+              <normaloff>:/images/themes/default/styleicons/color.svg</normaloff>:/images/themes/default/styleicons/color.svg</iconset>
+            </attribute>
+            <attribute name="title">
+             <string>Color ramp</string>
+            </attribute>
+           </widget>
+          </widget>
+         </item>
+         <item>
+          <widget class="QListView" name="listItems">
+           <property name="editTriggers">
+            <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>77</width>
+             <height>70</height>
+            </size>
+           </property>
+           <property name="textElideMode">
+            <enum>Qt::ElideNone</enum>
+           </property>
+           <property name="movement">
+            <enum>QListView::Static</enum>
+           </property>
+           <property name="resizeMode">
+            <enum>QListView::Adjust</enum>
+           </property>
+           <property name="spacing">
+            <number>5</number>
+           </property>
+           <property name="viewMode">
+            <enum>QListView::IconMode</enum>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
@@ -523,6 +512,38 @@
   <tabstop>searchBox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -209,6 +209,62 @@
            </property>
           </widget>
          </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QToolButton" name="mButtonIconView">
+             <property name="toolTip">
+              <string>Icon View</string>
+             </property>
+             <property name="text">
+              <string>PushButton</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/mActionIconView.svg</normaloff>:/images/themes/default/mActionIconView.svg</iconset>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="autoRaise">
+              <bool>true</bool>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">buttonGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="mButtonListView">
+             <property name="toolTip">
+              <string>List View</string>
+             </property>
+             <property name="text">
+              <string>PushButton</string>
+             </property>
+             <property name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/mActionOpenTable.svg</normaloff>:/images/themes/default/mActionOpenTable.svg</iconset>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="autoRaise">
+              <bool>true</bool>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">buttonGroup</string>
+             </attribute>
+            </widget>
+           </item>
+          </layout>
+         </item>
         </layout>
        </item>
        <item row="3" column="0">
@@ -284,34 +340,85 @@
           </widget>
          </item>
          <item>
-          <widget class="QListView" name="listItems">
-           <property name="editTriggers">
-            <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+          <widget class="QStackedWidget" name="mSymbolViewStackedWidget">
+           <property name="currentIndex">
+            <number>0</number>
            </property>
-           <property name="iconSize">
-            <size>
-             <width>77</width>
-             <height>70</height>
-            </size>
-           </property>
-           <property name="textElideMode">
-            <enum>Qt::ElideNone</enum>
-           </property>
-           <property name="movement">
-            <enum>QListView::Static</enum>
-           </property>
-           <property name="resizeMode">
-            <enum>QListView::Adjust</enum>
-           </property>
-           <property name="spacing">
-            <number>5</number>
-           </property>
-           <property name="viewMode">
-            <enum>QListView::IconMode</enum>
-           </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
+           <widget class="QWidget" name="page">
+            <layout class="QVBoxLayout" name="verticalLayout_2">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QListView" name="listItems">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>2</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="editTriggers">
+                <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>77</width>
+                 <height>70</height>
+                </size>
+               </property>
+               <property name="textElideMode">
+                <enum>Qt::ElideNone</enum>
+               </property>
+               <property name="flow">
+                <enum>QListView::LeftToRight</enum>
+               </property>
+               <property name="resizeMode">
+                <enum>QListView::Adjust</enum>
+               </property>
+               <property name="spacing">
+                <number>5</number>
+               </property>
+               <property name="viewMode">
+                <enum>QListView::IconMode</enum>
+               </property>
+               <property name="uniformItemSizes">
+                <bool>false</bool>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="page2">
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QTreeView" name="mSymbolTreeView"/>
+             </item>
+            </layout>
+           </widget>
           </widget>
          </item>
         </layout>
@@ -506,10 +613,13 @@
   <tabstop>btnShare</tabstop>
   <tabstop>tabItemType</tabstop>
   <tabstop>listItems</tabstop>
+  <tabstop>mSymbolTreeView</tabstop>
   <tabstop>btnAddItem</tabstop>
   <tabstop>btnRemoveItem</tabstop>
   <tabstop>btnEditItem</tabstop>
   <tabstop>searchBox</tabstop>
+  <tabstop>mButtonIconView</tabstop>
+  <tabstop>mButtonListView</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>
@@ -596,4 +706,7 @@
    </hints>
   </connection>
  </connections>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
This PR finishes off some work started in 3.4, and ports the style manager dialog to QgsStyleModel. The model brings numerous improvements, e.g.
- better hidpi behavior
- nicer tooltips, with thumbnails of the symbols
- lots of fixes to filtering in the dialog (e.g. now filtering by text AND group AND item type work correctly together -- in 3.4 chained filters like this are ignored)
- nicer code-- the style model is well tested and used elsewhere, so now we've got a single code path for style model fixes and improvements.

I've also added two UX improvements:
1. You can now switch the dialog to a list mode, just like in symbol selector
2. There's a new "All" tab, which shows any matching symbol, regardless of if its a marker/line/fill or ramp. This is useful for managing groups of symbols which consist of mixed types.

![image](https://user-images.githubusercontent.com/1829991/51095779-dc81b500-1802-11e9-962e-a966835c6d76.png)
