### PR TITLE
Fix a bunch of tiny icon sizes on hidpi displays

### DIFF
--- a/src/gui/editorwidgets/qgsmultiedittoolbutton.cpp
+++ b/src/gui/editorwidgets/qgsmultiedittoolbutton.cpp
@@ -15,6 +15,8 @@
 
 #include "qgsmultiedittoolbutton.h"
 #include "qgsapplication.h"
+#include "qgsguiutils.h"
+
 #include <QMenu>
 QgsMultiEditToolButton::QgsMultiEditToolButton( QWidget *parent )
   : QToolButton( parent )
@@ -22,9 +24,13 @@ QgsMultiEditToolButton::QgsMultiEditToolButton( QWidget *parent )
   setFocusPolicy( Qt::StrongFocus );
 
   // set default tool button icon properties
-  setFixedSize( 22, 22 );
   setStyleSheet( QStringLiteral( "QToolButton{ background: none; border: 1px solid rgba(0, 0, 0, 0%);} QToolButton:focus { border: 1px solid palette(highlight); }" ) );
-  setIconSize( QSize( 16, 16 ) );
+
+  int iconSize = QgsGuiUtils::scaleIconSize( 24 );
+  setIconSize( QSize( iconSize, iconSize ) );
+  // button width is 1.25 * icon size, height 1.1 * icon size. But we round to ensure even pixel sizes for equal margins
+  setFixedSize( 2 * static_cast< int >( 1.25 * iconSize / 2.0 ), 2 * static_cast< int >( iconSize * 1.1 / 2.0 ) );
+
   setPopupMode( QToolButton::InstantPopup );
 
   mMenu = new QMenu( this );

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -23,6 +23,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
+#include "qgsguiutils.h"
 #include <QLayout>
 #include <QCompleter>
 #include <QMenu>
@@ -72,7 +73,9 @@ QgsLocatorWidget::QgsLocatorWidget( QWidget *parent )
 
   mResultsView->setModel( mModelBridge->proxyModel() );
   mResultsView->setUniformRowHeights( true );
-  mResultsView->setIconSize( QSize( 16, 16 ) );
+
+  int iconSize = QgsGuiUtils::scaleIconSize( 16 );
+  mResultsView->setIconSize( QSize( iconSize, iconSize ) );
   mResultsView->recalculateSize();
   mResultsView->setContextMenuPolicy( Qt::CustomContextMenu );
 

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -22,6 +22,7 @@
 #include "qgsprocessingguiregistry.h"
 #include "models/qgsprocessingmodelalgorithm.h"
 #include "qgsgui.h"
+#include "qgsguiutils.h"
 #include "qgsexpressioncontext.h"
 #include <QHBoxLayout>
 #include <QToolButton>
@@ -43,7 +44,7 @@ QgsProcessingModelerParameterWidget::QgsProcessingModelerParameterWidget( QgsPro
   setFocusPolicy( Qt::StrongFocus );
 
   // icon size is a bit bigger than text, but minimum size of 24 so that we get pixel-aligned rendering on low-dpi screens
-  int iconSize = static_cast< int >( std::floor( std::max( Qgis::UI_SCALE_FACTOR * fontMetrics().height() * 1.1, 24.0 ) ) );
+  int iconSize = QgsGuiUtils::scaleIconSize( 24 );
 
   QHBoxLayout *hLayout = new QHBoxLayout();
 

--- a/src/gui/qgscompoundcolorwidget.cpp
+++ b/src/gui/qgscompoundcolorwidget.cpp
@@ -220,6 +220,9 @@ QgsCompoundColorWidget::QgsCompoundColorWidget( QWidget *parent, const QColor &c
   mAddCustomColorButton->setMinimumWidth( swatchAddSize );
   mAddCustomColorButton->setMaximumWidth( swatchAddSize );
 
+  const int iconSize = QgsGuiUtils::scaleIconSize( 16 );
+  mTabWidget->setIconSize( QSize( iconSize, iconSize ) );
+
   if ( color.isValid() )
   {
     setColor( color );

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -238,6 +238,14 @@ namespace QgsGuiUtils
     QString key = QStringLiteral( "Windows/%1/geometry" ).arg( subKey );
     return key;
   }
+
+  int scaleIconSize( int standardSize )
+  {
+    QFontMetrics fm( ( QFont() ) );
+    const double scale = 1.1 * standardSize / 24;
+    return static_cast< int >( std::floor( std::max( Qgis::UI_SCALE_FACTOR * fm.height() * scale, static_cast< double >( standardSize ) ) ) );
+  }
+
 }
 
 //

--- a/src/gui/qgsguiutils.h
+++ b/src/gui/qgsguiutils.h
@@ -162,6 +162,17 @@ namespace QgsGuiUtils
    * \return A key name that can be used for the widget in settings.
    */
   QString createWidgetKey( QWidget *widget, const QString &keyName = QString() );
+
+  /**
+   * Scales an icon size to compensate for display pixel density, making the icon
+   * size hi-dpi friendly, whilst still resulting in pixel-perfect sizes for low-dpi
+   * displays.
+   *
+   * \a standardSize should be set to a standard icon size, e.g. 16, 24, 48, etc.
+   *
+   * \since QGIS 3.6
+   */
+  int scaleIconSize( int standardSize );
 }
 
 /**

--- a/src/gui/qgspropertyoverridebutton.cpp
+++ b/src/gui/qgspropertyoverridebutton.cpp
@@ -25,6 +25,7 @@
 #include "qgsauxiliarystorage.h"
 #include "qgscolorschemeregistry.h"
 #include "qgscolorbutton.h"
+#include "qgsguiutils.h"
 
 #include <QClipboard>
 #include <QMenu>
@@ -41,8 +42,7 @@ QgsPropertyOverrideButton::QgsPropertyOverrideButton( QWidget *parent,
 {
   setFocusPolicy( Qt::StrongFocus );
 
-  // icon size is a bit bigger than text, but minimum size of 24 so that we get pixel-aligned rendering on low-dpi screens
-  int iconSize = std::floor( std::max( Qgis::UI_SCALE_FACTOR * fontMetrics().height() * 1.1, 24.0 ) );
+  int iconSize = QgsGuiUtils::scaleIconSize( 24 );
 
   // button width is 1.25 * icon size, height 1.1 * icon size. But we round to ensure even pixel sizes for equal margins
   setFixedSize( 2 * static_cast< int >( 1.25 * iconSize / 2.0 ), 2 * static_cast< int >( iconSize * 1.1 / 2.0 ) );

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -80,6 +80,9 @@ void QgsTextFormatWidget::initWidget()
   connect( chkLineOrientationDependent, &QCheckBox::toggled, this, &QgsTextFormatWidget::chkLineOrientationDependent_toggled );
   connect( mToolButtonConfigureSubstitutes, &QToolButton::clicked, this, &QgsTextFormatWidget::mToolButtonConfigureSubstitutes_clicked );
 
+  const int iconSize = QgsGuiUtils::scaleIconSize( 20 );
+  mOptionsTab->setIconSize( QSize( iconSize, iconSize ) );
+
   mPreviewScaleComboBox->setMapCanvas( mMapCanvas );
   mPreviewScaleComboBox->setShowCurrentScaleButton( true );
   connect( mPreviewScaleComboBox, &QgsScaleWidget::scaleChanged, this, &QgsTextFormatWidget::previewScaleChanged );

--- a/src/gui/symbology/qgsbrushstylecombobox.cpp
+++ b/src/gui/symbology/qgsbrushstylecombobox.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsbrushstylecombobox.h"
+#include "qgsguiutils.h"
 
 #include <QList>
 #include <QPair>
@@ -42,7 +43,8 @@ QgsBrushStyleComboBox::QgsBrushStyleComboBox( QWidget *parent )
          << qMakePair( Qt::Dense6Pattern, tr( "Dense 6" ) )
          << qMakePair( Qt::Dense7Pattern, tr( "Dense 7" ) );
 
-  setIconSize( QSize( 32, 16 ) );
+  int iconSize = QgsGuiUtils::scaleIconSize( 16 );
+  setIconSize( QSize( iconSize * 2, iconSize ) );
 
   for ( int i = 0; i < styles.count(); i++ )
   {

--- a/src/gui/symbology/qgspenstylecombobox.cpp
+++ b/src/gui/symbology/qgspenstylecombobox.cpp
@@ -16,6 +16,7 @@
 #include "qgspenstylecombobox.h"
 
 #include "qgsapplication.h"
+#include "qgsguiutils.h"
 
 #include <QList>
 #include <QPair>
@@ -34,7 +35,8 @@ QgsPenStyleComboBox::QgsPenStyleComboBox( QWidget *parent )
          << qMakePair( Qt::DashDotLine, tr( "Dash Dot Line" ) )
          << qMakePair( Qt::DashDotDotLine, tr( "Dash Dot Dot Line" ) );
 
-  setIconSize( QSize( 32, 12 ) );
+  int iconSize = QgsGuiUtils::scaleIconSize( 16 );
+  setIconSize( QSize( iconSize * 2, iconSize ) );
 
   for ( int i = 0; i < styles.count(); i++ )
   {


### PR DESCRIPTION
Fixes the most annoying hidpi issue (for me). 

Adds a new QgsGuiUtils::scaleIconSize method, which should be called whenever setting a widget icon size. scaleIconSize automatically scales the desired low-dpi icon size (eg "24") to an appropriate hi-dpi size, whilst maintaining pixel perfect rendering for low-dpi icons.