### PR TITLE
Fix vertextool's geometry cache invalidation

### DIFF
--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -97,6 +97,8 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
     void onCachedGeometryDeleted( QgsFeatureId fid );
 
+    void clearGeometryCache();
+
     void showVertexEditor();  //#spellok
 
     void deleteVertexEditorSelection();


### PR DESCRIPTION
This a forward port from d79c212e7ba1e5 in PR #8724

Another fix is added here (which will be backported to 3.4): layer'
signal connections must be destroyed when the cache for this layer is
cleared (otherwise I got an "assertion failed" in onCacheGeometryXXXX)
