### PR TITLE
IndexExtent fix

### DIFF
--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -89,9 +89,12 @@ bool QgsSnappingUtils::isIndexPrepared( QgsVectorLayer *vl, const QgsRectangle &
   if ( mStrategy == IndexAlwaysFull && loc->hasIndex() )
     return true;
 
+  if ( mStrategy == IndexExtent && loc->hasIndex() && loc->extent()->intersects( areaOfInterest ) )
+    return true;
+
   QgsRectangle aoi( areaOfInterest );
   aoi.scale( 0.999 );
-  return ( mStrategy == IndexHybrid || mStrategy == IndexExtent ) && loc->hasIndex() && ( !loc->extent() || loc->extent()->contains( aoi ) ); // the index - even if it exists - is not suitable
+  return mStrategy == IndexHybrid && loc->hasIndex() && ( !loc->extent() || loc->extent()->contains( aoi ) ); // the index - even if it exists - is not suitable
 }
 
 static QgsPointLocator::Match _findClosestSegmentIntersection( const QgsPointXY &pt, const QgsPointLocator::MatchList &segments )
@@ -370,7 +373,7 @@ void QgsSnappingUtils::prepareIndex( const QList<LayerAndAreaOfInterest> &layers
 
       if ( mStrategy == IndexExtent )
       {
-        QgsRectangle rect( mMapSettings.extent() );
+        QgsRectangle rect( mMapSettings.visibleExtent() );
         loc->setExtent( &rect );
         loc->init();
       }


### PR DESCRIPTION
This fixes a problem with the "IndexExtent" snapping indexing strategy.
I got a strange behaviour where all indexes were continuously rebuilt
when the mouse was close to the mapcanvas border.

Proposed solution:
- use QgsMapSettings::visibleExtent() instead of
QgsMapSettings::extent() for the definition of the index extent
- do not try to index features that are beyond the current extent
