### PR TITLE
Adding QgsRenderContext to QgsLayerTreeModelLegendNode::ItemContext 

### DIFF
--- a/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
+++ b/python/core/auto_generated/layertree/qgslayertreemodellegendnode.sip.in
@@ -76,6 +76,7 @@ Default implementation does nothing. *
 
     struct ItemContext
     {
+      QgsRenderContext *context;
       QPainter *painter;
       QPointF point;
       double labelXOffset;

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -86,8 +86,8 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
 
     struct ItemContext
     {
-      //!RenderContext
-      QgsRenderConter *context = nullptr;
+      //! Render context, if available
+      QgsRenderContext *context = nullptr;
       //! Painter
       QPainter *painter = nullptr;
       //! Top-left corner of the legend item

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -86,6 +86,8 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
 
     struct ItemContext
     {
+      //!RenderContext
+      QgsRenderConter *context = nullptr;
       //! Painter
       QPainter *painter = nullptr;
       //! Top-left corner of the legend item

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -536,6 +536,7 @@ QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItem( QgsLayerTreeModelL
 QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItemInternal( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *context, QPainter *painter, QPointF point, double labelXOffset )
 {
   QgsLayerTreeModelLegendNode::ItemContext ctx;
+  ctx.context = context ? context : nullptr;
   ctx.painter = context ? context->painter() : painter;
   ctx.point = point;
   ctx.labelXOffset = labelXOffset;

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -536,7 +536,7 @@ QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItem( QgsLayerTreeModelL
 QgsLegendRenderer::Nucleon QgsLegendRenderer::drawSymbolItemInternal( QgsLayerTreeModelLegendNode *symbolItem, QgsRenderContext *context, QPainter *painter, QPointF point, double labelXOffset )
 {
   QgsLayerTreeModelLegendNode::ItemContext ctx;
-  ctx.context = context ? context : nullptr;
+  ctx.context = context;
   ctx.painter = context ? context->painter() : painter;
   ctx.point = point;
   ctx.labelXOffset = labelXOffset;


### PR DESCRIPTION
## Description
This pulls aims to add QgsRenderContext to QgsLayerTreeModelLegendNode::ItemContext and set this member when needed in the QgsLegendRender.

I'm not sure if structure changes need documentation and I wasn't sure if QgsRenderContext needed to be a * or & but I went with a pointer.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
