### PR TITLE
Allow "browsing" styles through the browser panel

### DIFF
--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -53,6 +53,17 @@ Sets whether smart groups should be shown. The default is to show the groups.
 .. versionadded:: 3.6
 %End
 
+    void setBaseStyleName( const QString &name );
+%Docstring
+Sets the base ``name`` for the style, which is used by the dialog to reflect the
+original style/XML file name.
+
+``name`` should be stripped of any extensions and folder information, e.g. "transport_styles",
+not "d:/stuff/transport_styles.xml".
+
+.. versionadded:: 3.6
+%End
+
   public slots:
 
 

--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -23,7 +23,8 @@ A dialog allowing users to customize and populate a QgsStyle.
 %End
   public:
 
-    QgsStyleManagerDialog( QgsStyle *style, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = Qt::WindowFlags() );
+    QgsStyleManagerDialog( QgsStyle *style, QWidget *parent /TransferThis/ = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
+                           bool readOnly = false );
 %Docstring
 Constructor for QgsStyleManagerDialog, with the specified ``parent`` widget and window ``flags``.
 

--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -39,6 +39,20 @@ The ``style`` object must last for the lifetime of the dialog.
 Opens the add color ramp dialog, returning the new color ramp's name if the ramp has been added.
 %End
 
+    void setFavoritesGroupVisible( bool show );
+%Docstring
+Sets whether the favorites group should be shown. The default is to show the group.
+
+.. versionadded:: 3.6
+%End
+
+    void setSmartGroupsVisible( bool show );
+%Docstring
+Sets whether smart groups should be shown. The default is to show the groups.
+
+.. versionadded:: 3.6
+%End
+
   public slots:
 
 

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -343,9 +343,11 @@ void QgsStyleXmlDataItem::browseStyle( const QString &xmlPath )
   if ( s.importXml( xmlPath ) )
   {
     cursorOverride.reset();
+    QFileInfo fi( xmlPath );
     QgsStyleManagerDialog dlg( &s, QgisApp::instance(), Qt::WindowFlags(), true );
     dlg.setSmartGroupsVisible( false );
     dlg.setFavoritesGroupVisible( false );
+    dlg.setBaseStyleName( fi.baseName() );
     dlg.exec();
   }
 }

--- a/src/app/qgsappbrowserproviders.h
+++ b/src/app/qgsappbrowserproviders.h
@@ -163,6 +163,10 @@ class QgsStyleXmlDataItem : public QgsDataItem
     bool handleDoubleClick() override;
     QList< QAction * > actions( QWidget *parent ) override;
 
+  private:
+
+    static void browseStyle( const QString &xmlPath );
+
 };
 
 /**

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -105,7 +105,7 @@ QgsStyleExportImportDialog::QgsStyleExportImportDialog( QgsStyle *style, QWidget
     mFavorite->setHidden( true );
     mIgnoreXMLTags->setHidden( true );
 
-    pb = new QPushButton( tr( "Select by Group" ) );
+    pb = new QPushButton( tr( "Select by Group…" ) );
     buttonBox->addButton( pb, QDialogButtonBox::ActionRole );
     connect( pb, &QAbstractButton::clicked, this, &QgsStyleExportImportDialog::selectByGroup );
     tagLabel->setHidden( true );

--- a/src/gui/symbology/qgsstyleexportimportdialog.cpp
+++ b/src/gui/symbology/qgsstyleexportimportdialog.cpp
@@ -27,6 +27,7 @@
 #include "qgssettings.h"
 #include "qgsgui.h"
 #include "qgsstylemodel.h"
+#include "qgsstylemanagerdialog.h"
 
 #include <QInputDialog>
 #include <QCloseEvent>
@@ -210,158 +211,22 @@ bool QgsStyleExportImportDialog::populateStyles()
 
 void QgsStyleExportImportDialog::moveStyles( QModelIndexList *selection, QgsStyle *src, QgsStyle *dst )
 {
-  QString symbolName;
-  QStringList symbolTags;
-  bool symbolFavorite;
-  QModelIndex index;
-  bool isSymbol = true;
-  bool prompt = true;
-  bool overwrite = true;
-
-  QStringList importTags = mSymbolTags->text().split( ',' );
-
-  QStringList favoriteSymbols = src->symbolsOfFavorite( QgsStyle::SymbolEntity );
-  QStringList favoriteColorramps = src->symbolsOfFavorite( QgsStyle::ColorrampEntity );
-
+  QList< QgsStyleManagerDialog::ItemDetails > items;
+  items.reserve( selection->size() );
   for ( int i = 0; i < selection->size(); ++i )
   {
-    index = selection->at( i );
-    symbolName = mModel->data( mModel->index( index.row(), QgsStyleModel::Name ), Qt::DisplayRole ).toString();
-    std::unique_ptr< QgsSymbol > symbol( src->symbol( symbolName ) );
-    std::unique_ptr< QgsColorRamp > ramp;
+    QModelIndex index = selection->at( i );
 
-    if ( !mIgnoreXMLTags->isChecked() )
-    {
-      symbolTags = src->tagsOfSymbol( !symbol ? QgsStyle::ColorrampEntity : QgsStyle::SymbolEntity, symbolName );
-    }
-    else
-    {
-      symbolTags.clear();
-    }
+    QgsStyleManagerDialog::ItemDetails details;
+    details.entityType = static_cast< QgsStyle::StyleEntity >( mModel->data( index, QgsStyleModel::TypeRole ).toInt() );
+    if ( details.entityType == QgsStyle::SymbolEntity )
+      details.symbolType = static_cast< QgsSymbol::SymbolType >( mModel->data( index, QgsStyleModel::SymbolTypeRole ).toInt() );
+    details.name = mModel->data( mModel->index( index.row(), QgsStyleModel::Name, index.parent() ), Qt::DisplayRole ).toString();
 
-    if ( mDialogMode == Import )
-    {
-      symbolTags << importTags;
-      symbolFavorite = mFavorite->isChecked();
-    }
-    else
-    {
-      symbolFavorite = !symbol ? favoriteColorramps.contains( symbolName ) : favoriteSymbols.contains( symbolName );
-    }
-
-    if ( !symbol )
-    {
-      isSymbol = false;
-      ramp.reset( src->colorRamp( symbolName ) );
-    }
-
-    if ( isSymbol )
-    {
-      if ( dst->symbolNames().contains( symbolName ) && prompt )
-      {
-        mCursorOverride.reset();
-        int res = QMessageBox::warning( this, tr( "Export/import Symbols" ),
-                                        tr( "Symbol with name '%1' already exists.\nOverwrite?" )
-                                        .arg( symbolName ),
-                                        QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
-        mCursorOverride = qgis::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
-        switch ( res )
-        {
-          case QMessageBox::Cancel:
-            return;
-          case QMessageBox::No:
-            continue;
-          case QMessageBox::Yes:
-          {
-            QgsSymbol *newSymbol = symbol.get();
-            dst->addSymbol( symbolName, symbol.release() );
-            dst->saveSymbol( symbolName, newSymbol, symbolFavorite, symbolTags );
-            continue;
-          }
-          case QMessageBox::YesToAll:
-            prompt = false;
-            overwrite = true;
-            break;
-          case QMessageBox::NoToAll:
-            prompt = false;
-            overwrite = false;
-            break;
-        }
-      }
-
-      if ( dst->symbolNames().contains( symbolName ) && overwrite )
-      {
-        QgsSymbol *newSymbol = symbol.get();
-        dst->addSymbol( symbolName, symbol.release() );
-        dst->saveSymbol( symbolName, newSymbol, symbolFavorite, symbolTags );
-        continue;
-      }
-      else if ( dst->symbolNames().contains( symbolName ) && !overwrite )
-      {
-        continue;
-      }
-      else
-      {
-        QgsSymbol *newSymbol = symbol.get();
-        dst->addSymbol( symbolName, symbol.release() );
-        dst->saveSymbol( symbolName, newSymbol, symbolFavorite, symbolTags );
-        continue;
-      }
-    }
-    else
-    {
-      if ( dst->colorRampNames().contains( symbolName ) && prompt )
-      {
-        mCursorOverride.reset();
-        int res = QMessageBox::warning( this, tr( "Export/import Color Ramps" ),
-                                        tr( "Color ramp with name '%1' already exists.\nOverwrite?" )
-                                        .arg( symbolName ),
-                                        QMessageBox::Yes | QMessageBox::YesToAll | QMessageBox::No | QMessageBox::NoToAll | QMessageBox::Cancel );
-        mCursorOverride = qgis::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
-        switch ( res )
-        {
-          case QMessageBox::Cancel:
-            return;
-          case QMessageBox::No:
-            continue;
-          case QMessageBox::Yes:
-          {
-            QgsColorRamp *newRamp = ramp.get();
-            dst->addColorRamp( symbolName, ramp.release() );
-            dst->saveColorRamp( symbolName, newRamp, symbolFavorite, symbolTags );
-            continue;
-          }
-          case QMessageBox::YesToAll:
-            prompt = false;
-            overwrite = true;
-            break;
-          case QMessageBox::NoToAll:
-            prompt = false;
-            overwrite = false;
-            break;
-        }
-      }
-
-      if ( dst->colorRampNames().contains( symbolName ) && overwrite )
-      {
-        QgsColorRamp *newRamp = ramp.get();
-        dst->addColorRamp( symbolName, ramp.release() );
-        dst->saveColorRamp( symbolName, newRamp, symbolFavorite, symbolTags );
-        continue;
-      }
-      else if ( dst->colorRampNames().contains( symbolName ) && !overwrite )
-      {
-        continue;
-      }
-      else
-      {
-        QgsColorRamp *newRamp = ramp.get();
-        dst->addColorRamp( symbolName, ramp.release() );
-        dst->saveColorRamp( symbolName, newRamp, symbolFavorite, symbolTags );
-        continue;
-      }
-    }
+    items << details;
   }
+  QgsStyleManagerDialog::copyItems( items, src, dst, this, mCursorOverride, mDialogMode == Import,
+                                    mSymbolTags->text().split( ',' ), mFavorite->isChecked(), mIgnoreXMLTags->isChecked() );
 }
 
 QgsStyleExportImportDialog::~QgsStyleExportImportDialog()

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -427,12 +427,25 @@ void QgsStyleManagerDialog::copyItemsToDefault()
   const QList< ItemDetails > items = selectedItems();
   if ( !items.empty() )
   {
+    bool ok = false;
+    const QString tags = QInputDialog::getText( this, tr( "Import Items" ),
+                         tr( "Additional tags to add (comma separated)" ), QLineEdit::Normal,
+                         mBaseName, &ok );
+    if ( !ok )
+      return;
+
+    const QStringList parts = tags.split( ',', QString::SkipEmptyParts );
+    QStringList additionalTags;
+    additionalTags.reserve( parts.count() );
+    for ( const QString &tag : parts )
+      additionalTags << tag.trimmed();
+
     auto cursorOverride = qgis::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
-    const int count = copyItems( items, mStyle, QgsStyle::defaultStyle(), this, cursorOverride, true, QStringList(), false, false );
+    const int count = copyItems( items, mStyle, QgsStyle::defaultStyle(), this, cursorOverride, true, additionalTags, false, false );
     cursorOverride.reset();
     if ( count > 0 )
     {
-      QMessageBox::information( this, tr( "Import Symbols" ),
+      QMessageBox::information( this, tr( "Import Items" ),
                                 count > 1 ? tr( "Successfully imported %1 items." ).arg( count )
                                 : tr( "Successfully imported item." ) );
     }
@@ -928,6 +941,11 @@ void QgsStyleManagerDialog::setSmartGroupsVisible( bool show )
 {
   mSmartGroupVisible = show;
   populateGroups();
+}
+
+void QgsStyleManagerDialog::setBaseStyleName( const QString &name )
+{
+  mBaseName = name;
 }
 
 void QgsStyleManagerDialog::activate()

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -205,9 +205,14 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
   }
   if ( mStyle != QgsStyle::defaultStyle() )
   {
-    mActionCopyToDefault = new QAction( tr( "Copy Selection to Default Style" ), this );
+    mActionCopyToDefault = new QAction( tr( "Copy Selection to Default Style…" ), this );
     shareMenu->addAction( mActionCopyToDefault );
     connect( mActionCopyToDefault, &QAction::triggered, this, &QgsStyleManagerDialog::copyItemsToDefault );
+    connect( mCopyToDefaultButton, &QPushButton::clicked, this, &QgsStyleManagerDialog::copyItemsToDefault );
+  }
+  else
+  {
+    mCopyToDefaultButton->hide();
   }
 
   shareMenu->addSeparator();
@@ -386,6 +391,9 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
     // note -- we have to save state here and not in destructor, as new symbol list widgets are created before the previous ones are destroyed
     QgsSettings().setValue( QStringLiteral( "Windows/StyleV2Manager/treeState" ), mSymbolTreeView->header()->saveState(), QgsSettings::Gui );
   } );
+
+  // set initial disabled state for actions requiring a selection
+  selectedSymbolsChanged( QItemSelection(), QItemSelection() );
 }
 
 void QgsStyleManagerDialog::onFinished()
@@ -1596,6 +1604,7 @@ void QgsStyleManagerDialog::selectedSymbolsChanged( const QItemSelection &select
   actnExportAsSVG->setDisabled( nothingSelected );
   if ( mActionCopyToDefault )
     mActionCopyToDefault->setDisabled( nothingSelected );
+  mCopyToDefaultButton->setDisabled( nothingSelected );
   actnEditItem->setDisabled( nothingSelected || mReadOnly );
 }
 

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -203,9 +203,17 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
     shareMenu->addAction( importAction );
     connect( importAction, &QAction::triggered, this, &QgsStyleManagerDialog::importItems );
   }
+  if ( mStyle != QgsStyle::defaultStyle() )
+  {
+    mActionCopyToDefault = new QAction( tr( "Copy Item(s) to Default Style…" ), this );
+    shareMenu->addAction( mActionCopyToDefault );
+    connect( mActionCopyToDefault, &QAction::triggered, this, &QgsStyleManagerDialog::copyItemsToDefault );
+  }
+
   shareMenu->addSeparator();
   shareMenu->addAction( actnExportAsPNG );
   shareMenu->addAction( actnExportAsSVG );
+
   connect( actnExportAsPNG, &QAction::triggered, this, &QgsStyleManagerDialog::exportItemsPNG );
   connect( actnExportAsSVG, &QAction::triggered, this, &QgsStyleManagerDialog::exportItemsSVG );
   connect( exportAction, &QAction::triggered, this, &QgsStyleManagerDialog::exportItems );
@@ -320,6 +328,10 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
     btnAddTag->setVisible( false );
     btnManageGroups->setVisible( false );
   }
+  if ( mActionCopyToDefault )
+  {
+    mGroupMenu->addAction( mActionCopyToDefault );
+  }
   mGroupMenu->addAction( actnExportAsPNG );
   mGroupMenu->addAction( actnExportAsSVG );
 
@@ -408,6 +420,18 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
     mModel->setSymbolType( static_cast< QgsSymbol::SymbolType >( currentItemType() ) );
 
   populateList();
+}
+
+void QgsStyleManagerDialog::copyItemsToDefault()
+{
+  const QList< ItemDetails > items = selectedItems();
+  if ( !items.empty() )
+  {
+    auto cursorOverride = qgis::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
+    copyItems( items, mStyle, QgsStyle::defaultStyle(), this, cursorOverride, true, QStringList(), false, false );
+    QMessageBox::information( this, tr( "Import Symbols" ),
+                              tr( "Symbols successfully imported." ) );
+  }
 }
 
 int QgsStyleManagerDialog::selectedItemType()
@@ -1556,6 +1580,8 @@ void QgsStyleManagerDialog::selectedSymbolsChanged( const QItemSelection &select
   actnDetag->setDisabled( nothingSelected || mReadOnly );
   actnExportAsPNG->setDisabled( nothingSelected );
   actnExportAsSVG->setDisabled( nothingSelected );
+  if ( mActionCopyToDefault )
+    mActionCopyToDefault->setDisabled( nothingSelected );
   actnEditItem->setDisabled( nothingSelected || mReadOnly );
 }
 

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -747,6 +747,18 @@ QString QgsStyleManagerDialog::addColorRampStatic( QWidget *parent, QgsStyle *st
   return name;
 }
 
+void QgsStyleManagerDialog::setFavoritesGroupVisible( bool show )
+{
+  mFavoritesGroupVisible = show;
+  populateGroups();
+}
+
+void QgsStyleManagerDialog::setSmartGroupsVisible( bool show )
+{
+  mSmartGroupVisible = show;
+  populateGroups();
+}
+
 void QgsStyleManagerDialog::activate()
 {
   raise();
@@ -1015,11 +1027,14 @@ void QgsStyleManagerDialog::populateGroups()
   QStandardItemModel *model = qobject_cast<QStandardItemModel *>( groupTree->model() );
   model->clear();
 
-  QStandardItem *favoriteSymbols = new QStandardItem( tr( "Favorites" ) );
-  favoriteSymbols->setData( "favorite" );
-  favoriteSymbols->setEditable( false );
-  setBold( favoriteSymbols );
-  model->appendRow( favoriteSymbols );
+  if ( mFavoritesGroupVisible )
+  {
+    QStandardItem *favoriteSymbols = new QStandardItem( tr( "Favorites" ) );
+    favoriteSymbols->setData( "favorite" );
+    favoriteSymbols->setEditable( false );
+    setBold( favoriteSymbols );
+    model->appendRow( favoriteSymbols );
+  }
 
   QStandardItem *allSymbols = new QStandardItem( tr( "All" ) );
   allSymbols->setData( "all" );
@@ -1036,26 +1051,31 @@ void QgsStyleManagerDialog::populateGroups()
   {
     QStandardItem *item = new QStandardItem( tag );
     item->setData( mStyle->tagId( tag ) );
+    item->setEditable( !mReadOnly );
     taggroup->appendRow( item );
   }
   taggroup->setText( tr( "Tags" ) );//set title later
   setBold( taggroup );
   model->appendRow( taggroup );
 
-  QStandardItem *smart = new QStandardItem( tr( "Smart Groups" ) );
-  smart->setData( "smartgroups" );
-  smart->setEditable( false );
-  setBold( smart );
-  QgsSymbolGroupMap sgMap = mStyle->smartgroupsListMap();
-  QgsSymbolGroupMap::const_iterator i = sgMap.constBegin();
-  while ( i != sgMap.constEnd() )
+  if ( mSmartGroupVisible )
   {
-    QStandardItem *item = new QStandardItem( i.value() );
-    item->setData( i.key() );
-    smart->appendRow( item );
-    ++i;
+    QStandardItem *smart = new QStandardItem( tr( "Smart Groups" ) );
+    smart->setData( "smartgroups" );
+    smart->setEditable( false );
+    setBold( smart );
+    QgsSymbolGroupMap sgMap = mStyle->smartgroupsListMap();
+    QgsSymbolGroupMap::const_iterator i = sgMap.constBegin();
+    while ( i != sgMap.constEnd() )
+    {
+      QStandardItem *item = new QStandardItem( i.value() );
+      item->setData( i.key() );
+      item->setEditable( !mReadOnly );
+      smart->appendRow( item );
+      ++i;
+    }
+    model->appendRow( smart );
   }
-  model->appendRow( smart );
 
   // expand things in the group tree
   int rows = model->rowCount( model->indexFromItem( model->invisibleRootItem() ) );

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -429,6 +429,7 @@ void QgsStyleManagerDialog::copyItemsToDefault()
   {
     auto cursorOverride = qgis::make_unique< QgsTemporaryCursorOverride >( Qt::WaitCursor );
     copyItems( items, mStyle, QgsStyle::defaultStyle(), this, cursorOverride, true, QStringList(), false, false );
+    cursorOverride.reset();
     QMessageBox::information( this, tr( "Import Symbols" ),
                               tr( "Symbols successfully imported." ) );
   }

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -205,7 +205,7 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
   }
   if ( mStyle != QgsStyle::defaultStyle() )
   {
-    mActionCopyToDefault = new QAction( tr( "Copy Item(s) to Default Style…" ), this );
+    mActionCopyToDefault = new QAction( tr( "Copy Selection to Default Style" ), this );
     shareMenu->addAction( mActionCopyToDefault );
     connect( mActionCopyToDefault, &QAction::triggered, this, &QgsStyleManagerDialog::copyItemsToDefault );
   }

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -35,7 +35,7 @@ class QgsCheckableStyleModel: public QgsStyleProxyModel
     Q_OBJECT
   public:
 
-    explicit QgsCheckableStyleModel( QgsStyle *style, QObject *parent = nullptr );
+    explicit QgsCheckableStyleModel( QgsStyle *style, QObject *parent = nullptr, bool readOnly = false );
 
     void setCheckable( bool checkable );
     void setCheckTag( const QString &tag );
@@ -49,6 +49,7 @@ class QgsCheckableStyleModel: public QgsStyleProxyModel
     QgsStyle *mStyle = nullptr;
     bool mCheckable = false;
     QString mCheckTag;
+    bool mReadOnly = false;
 
 };
 #endif
@@ -73,7 +74,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
      * this style will be shown in the dialog, and changes made within the dialog will be applied to \a style.
      * The \a style object must last for the lifetime of the dialog.
      */
-    QgsStyleManagerDialog( QgsStyle *style, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = Qt::WindowFlags() );
+    QgsStyleManagerDialog( QgsStyle *style, QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = Qt::WindowFlags(),
+                           bool readOnly = false );
 
     /**
      * Opens the add color ramp dialog, returning the new color ramp's name if the ramp has been added.
@@ -345,6 +347,9 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     int mBlockGroupUpdates = 0;
 
+    bool mReadOnly = false;
+    bool mFavoritesGroupVisible = true;
+    bool mSmartGroupVisible = true;
 };
 
 #endif

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -27,6 +27,7 @@
 #include "qgis_gui.h"
 
 class QgsStyle;
+class QgsTemporaryCursorOverride;
 
 #ifndef SIP_RUN
 ///@cond PRIVATE
@@ -333,6 +334,11 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     QList< ItemDetails > selectedItems();
 
+    static void copyItems( const QList< ItemDetails > &items, QgsStyle *src, QgsStyle *dst,
+                           QWidget *parentWidget, std::unique_ptr<QgsTemporaryCursorOverride> &cursorOverride,
+                           bool isImport, const QStringList &importTags, bool addToFavorites, bool ignoreSourceTags );
+
+
     QgsStyle *mStyle = nullptr;
 
     QgsCheckableStyleModel *mModel = nullptr;
@@ -364,6 +370,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     bool mReadOnly = false;
     bool mFavoritesGroupVisible = true;
     bool mSmartGroupVisible = true;
+
+    friend class QgsStyleExportImportDialog;
 };
 
 #endif

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -83,6 +83,20 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     static QString addColorRampStatic( QWidget *parent, QgsStyle *style,
                                        QString RampType = QString() );
 
+    /**
+     * Sets whether the favorites group should be shown. The default is to show the group.
+     *
+     * \since QGIS 3.6
+     */
+    void setFavoritesGroupVisible( bool show );
+
+    /**
+     * Sets whether smart groups should be shown. The default is to show the groups.
+     *
+     * \since QGIS 3.6
+     */
+    void setSmartGroupsVisible( bool show );
+
   public slots:
 
     // TODO QGIS 4.0 -- most of this should be private

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -317,6 +317,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     void tabItemType_currentChanged( int );
 
+    void copyItemsToDefault();
+
   private:
     int selectedItemType();
 
@@ -364,6 +366,8 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     //! Menu for the "Add item" toolbutton when in colorramp mode
     QMenu *mMenuBtnAddItemColorRamp = nullptr;
+
+    QAction *mActionCopyToDefault = nullptr;
 
     int mBlockGroupUpdates = 0;
 

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -98,6 +98,17 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
      */
     void setSmartGroupsVisible( bool show );
 
+    /**
+     * Sets the base \a name for the style, which is used by the dialog to reflect the
+     * original style/XML file name.
+     *
+     * \a name should be stripped of any extensions and folder information, e.g. "transport_styles",
+     * not "d:/stuff/transport_styles.xml".
+     *
+     * \since QGIS 3.6
+     */
+    void setBaseStyleName( const QString &name );
+
   public slots:
 
     // TODO QGIS 4.0 -- most of this should be private
@@ -377,6 +388,7 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     bool mReadOnly = false;
     bool mFavoritesGroupVisible = true;
     bool mSmartGroupVisible = true;
+    QString mBaseName;
 
     friend class QgsStyleExportImportDialog;
 };

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -336,9 +336,12 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     QList< ItemDetails > selectedItems();
 
-    static void copyItems( const QList< ItemDetails > &items, QgsStyle *src, QgsStyle *dst,
-                           QWidget *parentWidget, std::unique_ptr<QgsTemporaryCursorOverride> &cursorOverride,
-                           bool isImport, const QStringList &importTags, bool addToFavorites, bool ignoreSourceTags );
+    /**
+     * Returns count of items copied, excluding skipped items.
+     */
+    static int copyItems( const QList< ItemDetails > &items, QgsStyle *src, QgsStyle *dst,
+                          QWidget *parentWidget, std::unique_ptr<QgsTemporaryCursorOverride> &cursorOverride,
+                          bool isImport, const QStringList &importTags, bool addToFavorites, bool ignoreSourceTags );
 
 
     QgsStyle *mStyle = nullptr;

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -190,6 +190,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="mCopyToDefaultButton">
+           <property name="toolTip">
+            <string>Copies the selected items to the default style library</string>
+           </property>
+           <property name="text">
+            <string>Copy to Default Style…</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -625,6 +635,7 @@
   <tabstop>btnAddItem</tabstop>
   <tabstop>btnRemoveItem</tabstop>
   <tabstop>btnEditItem</tabstop>
+  <tabstop>mCopyToDefaultButton</tabstop>
   <tabstop>mButtonIconView</tabstop>
   <tabstop>mButtonListView</tabstop>
   <tabstop>searchBox</tabstop>

--- a/src/ui/qgsstylemanagerdialogbase.ui
+++ b/src/ui/qgsstylemanagerdialogbase.ui
@@ -275,7 +275,7 @@
          <item>
           <widget class="QTabWidget" name="tabItemType">
            <property name="currentIndex">
-            <number>4</number>
+            <number>0</number>
            </property>
            <property name="documentMode">
             <bool>true</bool>


### PR DESCRIPTION
Double clicking a style .xml in the browser now opens the manager dialog, allowing browsing and non-edit actions for the style. Additionally there's a new "copy items to default style" action available, which allows users to easily transfer symbols and ramps from these other .xml files to their own local style database.

![peek 2019-01-15 11-16](https://user-images.githubusercontent.com/1829991/51151548-17ddbb80-18b7-11e9-954c-fd97e196c1e8.gif)
