### PR TITLE
[browser] Don't show gdal/ogr layer items for QGIS style xml files

### DIFF
--- a/python/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyle.sip.in
@@ -461,6 +461,16 @@ Exports the style as a XML file
 Imports the symbols and colorramps into the default style database from the given XML file
 %End
 
+    static bool isXmlStyleFile( const QString &path );
+%Docstring
+Tests if the file at ``path`` is a QGIS style XML file.
+
+This method samples only the first line in the file, so is safe to call on
+large xml files.
+
+.. versionadded:: 3.6
+%End
+
   signals:
 
     void symbolSaved( const QString &name, QgsSymbol *symbol );

--- a/src/app/qgsappbrowserproviders.cpp
+++ b/src/app/qgsappbrowserproviders.cpp
@@ -333,27 +333,6 @@ QList<QAction *> QgsStyleXmlDataItem::actions( QWidget *parent )
 // QgsStyleXmlDataItemProvider
 //
 
-
-bool isStyleFile( const QString &path )
-{
-  QFileInfo fileInfo( path );
-
-  if ( fileInfo.suffix().compare( QLatin1String( "xml" ), Qt::CaseInsensitive ) != 0 )
-    return false;
-
-  // sniff the first line of the file to see if it's a style file
-  if ( !QFile::exists( path ) )
-    return false;
-
-  QFile inputFile( path );
-  if ( !inputFile.open( QIODevice::ReadOnly ) )
-    return false;
-
-  QTextStream stream( &inputFile );
-  const QString line = stream.readLine();
-  return line == QLatin1String( "<!DOCTYPE qgis_style>" );
-}
-
 QString QgsStyleXmlDataItemProvider::name()
 {
   return QStringLiteral( "style_xml" );
@@ -366,7 +345,7 @@ int QgsStyleXmlDataItemProvider::capabilities()
 
 QgsDataItem *QgsStyleXmlDataItemProvider::createDataItem( const QString &path, QgsDataItem *parentItem )
 {
-  if ( isStyleFile( path ) )
+  if ( QgsStyle::isXmlStyleFile( path ) )
   {
     return new QgsStyleXmlDataItem( parentItem, QFileInfo( path ).fileName(), path );
   }
@@ -391,7 +370,7 @@ void QgsStyleXmlDropHandler::handleCustomUriDrop( const QgsMimeDataUtils::Uri &u
 
 bool QgsStyleXmlDropHandler::handleFileDrop( const QString &file )
 {
-  if ( isStyleFile( file ) )
+  if ( QgsStyle::isXmlStyleFile( file ) )
   {
     QgsStyleExportImportDialog dlg( QgsStyle::defaultStyle(), QgisApp::instance(), QgsStyleExportImportDialog::Import );
     dlg.setImportFilePath( file );

--- a/src/core/symbology/qgsstyle.cpp
+++ b/src/core/symbology/qgsstyle.cpp
@@ -1700,6 +1700,26 @@ bool QgsStyle::importXml( const QString &filename )
   return true;
 }
 
+bool QgsStyle::isXmlStyleFile( const QString &path )
+{
+  QFileInfo fileInfo( path );
+
+  if ( fileInfo.suffix().compare( QLatin1String( "xml" ), Qt::CaseInsensitive ) != 0 )
+    return false;
+
+  // sniff the first line of the file to see if it's a style file
+  if ( !QFile::exists( path ) )
+    return false;
+
+  QFile inputFile( path );
+  if ( !inputFile.open( QIODevice::ReadOnly ) )
+    return false;
+
+  QTextStream stream( &inputFile );
+  const QString line = stream.readLine();
+  return line == QLatin1String( "<!DOCTYPE qgis_style>" );
+}
+
 bool QgsStyle::updateSymbol( StyleEntity type, const QString &name )
 {
   QDomDocument doc( QStringLiteral( "dummy" ) );

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -441,6 +441,16 @@ class CORE_EXPORT QgsStyle : public QObject
     //! Imports the symbols and colorramps into the default style database from the given XML file
     bool importXml( const QString &filename );
 
+    /**
+     * Tests if the file at \a path is a QGIS style XML file.
+     *
+     * This method samples only the first line in the file, so is safe to call on
+     * large xml files.
+     *
+     * \since QGIS 3.6
+     */
+    static bool isXmlStyleFile( const QString &path );
+
   signals:
 
     /**

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -20,6 +20,7 @@
 #include "qgsogrutils.h"
 #include "qgsproject.h"
 #include "qgsgdalutils.h"
+#include "symbology/qgsstyle.h"
 
 #include <QFileInfo>
 #include <QAction>
@@ -257,8 +258,8 @@ QgsDataItem *QgsGdalDataItemProvider::createDataItem( const QString &pathIn, Qgs
   std::call_once( initialized, [ = ]
   {
     buildSupportedRasterFileFilterAndExtensions( sFilterString, sExtensions, sWildcards );
-    QgsDebugMsgLevel( "extensions: " + sExtensions.join( " " ), 2 );
-    QgsDebugMsgLevel( "wildcards: " + sWildcards.join( " " ), 2 );
+    QgsDebugMsgLevel( QStringLiteral( "extensions: " ) + sExtensions.join( ' ' ), 2 );
+    QgsDebugMsgLevel( QStringLiteral( "wildcards: " ) + sWildcards.join( ' ' ), 2 );
   } );
 
   // skip *.aux.xml files (GDAL auxiliary metadata files),
@@ -272,6 +273,11 @@ QgsDataItem *QgsGdalDataItemProvider::createDataItem( const QString &pathIn, Qgs
     return nullptr;
   if ( path.endsWith( QLatin1String( ".tif.xml" ), Qt::CaseInsensitive ) &&
        !sExtensions.contains( QStringLiteral( "tif.xml" ) ) )
+    return nullptr;
+
+  // skip QGIS style xml files
+  if ( path.endsWith( QLatin1String( ".xml" ), Qt::CaseInsensitive ) &&
+       QgsStyle::isXmlStyleFile( path ) )
     return nullptr;
 
   // Filter files by extension

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -25,6 +25,7 @@
 #include "qgsgeopackagedataitems.h"
 #include "qgsogrutils.h"
 #include "qgsproviderregistry.h"
+#include "symbology/qgsstyle.h"
 
 #include <QFileInfo>
 #include <QTextStream>
@@ -665,6 +666,11 @@ QgsDataItem *QgsOgrDataItemProvider::createDataItem( const QString &pathIn, QgsD
     return nullptr;
   if ( path.endsWith( QLatin1String( ".tif.xml" ), Qt::CaseInsensitive ) &&
        !myExtensions.contains( QStringLiteral( "tif.xml" ) ) )
+    return nullptr;
+
+  // skip QGIS style xml files
+  if ( path.endsWith( QLatin1String( ".xml" ), Qt::CaseInsensitive ) &&
+       QgsStyle::isXmlStyleFile( path ) )
     return nullptr;
 
   // We have to filter by extensions, otherwise e.g. all Shapefile files are displayed

--- a/tests/src/core/testqgsstyle.cpp
+++ b/tests/src/core/testqgsstyle.cpp
@@ -68,6 +68,7 @@ class TestStyle : public QObject
     void testFavorites();
     void testTags();
     void testSmartGroup();
+    void testIsStyleXml();
 
 };
 
@@ -633,6 +634,14 @@ void TestStyle::testSmartGroup()
   style.remove( QgsStyle::SmartgroupEntity, 4 );
   QCOMPARE( style.smartgroupNames(), QStringList() << QStringLiteral( "tag" ) << QStringLiteral( "tags" ) );
   QCOMPARE( groupModifiedSpy.count(), 8 );
+}
+
+void TestStyle::testIsStyleXml()
+{
+  QVERIFY( !QgsStyle::isXmlStyleFile( QString() ) );
+  QVERIFY( !QgsStyle::isXmlStyleFile( QStringLiteral( "blah" ) ) );
+  QVERIFY( QgsStyle::isXmlStyleFile( mTestDataDir + QStringLiteral( "categorized.xml" ) ) );
+  QVERIFY( !QgsStyle::isXmlStyleFile( mTestDataDir + QStringLiteral( "openstreetmap/testdata.xml" ) ) );
 }
 
 QGSTEST_MAIN( TestStyle )


### PR DESCRIPTION
These aren't layers, so the extra entries are just distracting noise.

