### PR TITLE
Expose snapping indexing strategy [FEATURE]

### DIFF
--- a/src/app/qgssnappingwidget.h
+++ b/src/app/qgssnappingwidget.h
@@ -23,6 +23,7 @@ class QDoubleSpinBox;
 class QFont;
 class QToolButton;
 class QTreeView;
+class QLabel;
 
 class QgsDoubleSpinBox;
 class QgsFloatingWidget;
@@ -102,6 +103,8 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
 
     void changeUnit( int idx );
 
+    void changeStrategy( int idx );
+
     void enableTopologicalEditing( bool enabled );
 
     void enableIntersectionSnapping( bool enabled );
@@ -144,6 +147,8 @@ class APP_EXPORT QgsSnappingWidget : public QWidget
     QDoubleSpinBox *mToleranceSpinBox = nullptr;
     QAction *mToleranceAction = nullptr; // hide widget does not work on toolbar, action needed
     QComboBox *mUnitsComboBox = nullptr;
+    QLabel *mStrategyLabel = nullptr;
+    QComboBox *mStrategyComboBox = nullptr;
     QAction *mUnitAction = nullptr; // hide widget does not work on toolbar, action needed
     QAction *mTopologicalEditingAction = nullptr;
     QAction *mIntersectionSnappingAction = nullptr;

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -79,6 +79,15 @@ QgsPointLocator *QgsSnappingUtils::temporaryLocatorForLayer( QgsVectorLayer *vl,
   return mTemporaryLocators.value( vl );
 }
 
+void QgsSnappingUtils::setIndexingStrategy( IndexingStrategy strategy )
+{
+  if ( strategy != mStrategy )
+  {
+    clearAllLocators();
+    mStrategy = strategy;
+  }
+}
+
 bool QgsSnappingUtils::isIndexPrepared( QgsVectorLayer *vl, const QgsRectangle &areaOfInterest )
 {
   if ( vl->geometryType() == QgsWkbTypes::NullGeometry || mStrategy == IndexNeverFull )

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -92,7 +92,7 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     };
 
     //! Sets a strategy for indexing geometry data - determines how fast and memory consuming the data structures will be
-    void setIndexingStrategy( IndexingStrategy strategy ) { mStrategy = strategy; }
+    void setIndexingStrategy( IndexingStrategy strategy );
     //! Find out which strategy is used for indexing - by default hybrid indexing is used
     IndexingStrategy indexingStrategy() const { return mStrategy; }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -69,6 +69,7 @@ email                : sherman at mrcc.com
 #include "qgscoordinatetransformcontext.h"
 #include "qgssvgcache.h"
 #include "qgsimagecache.h"
+#include "qgssnappingutils.h"
 #include <cmath>
 
 /**
@@ -2063,6 +2064,20 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
       }
     }
 
+    // read snapping utils
+    if ( mSnappingUtils )
+    {
+      QDomNode snappingNode = node.namedItem( QStringLiteral( "snappingUtils" ) );
+      if ( !snappingNode.isNull() )
+      {
+        QDomAttr attr = snappingNode.toElement().attributeNode( QStringLiteral( "strategy" ) );
+        if ( !attr.isNull() )
+        {
+          mSnappingUtils->setIndexingStrategy( static_cast<QgsSnappingUtils::IndexingStrategy>( attr.value().toInt() ) );
+        }
+      }
+    }
+
     QgsMapSettings tmpSettings;
     tmpSettings.readXml( node );
     if ( objectName() != QStringLiteral( "theMapCanvas" ) )
@@ -2110,6 +2125,13 @@ void QgsMapCanvas::writeProject( QDomDocument &doc )
     mapcanvasNode.setAttribute( QStringLiteral( "theme" ), mTheme );
   mapcanvasNode.setAttribute( QStringLiteral( "annotationsVisible" ), mAnnotationsVisible );
   qgisNode.appendChild( mapcanvasNode );
+
+  if ( mSnappingUtils )
+  {
+    QDomElement snappingNode = doc.createElement( QStringLiteral( "snappingUtils" ) );
+    snappingNode.setAttribute( QStringLiteral( "strategy" ), QString::number( static_cast<int>( snappingUtils()->indexingStrategy() ) ) );
+    mapcanvasNode.appendChild( snappingNode );
+  }
 
   mSettings.writeXml( mapcanvasNode, doc );
   // TODO: store only units, extent, projections, dest CRS


### PR DESCRIPTION
This adds a combo box in the snapping widget that allows to choose the
snapping indexing strategy.

![pr_qgis_indexing_strategy](https://user-images.githubusercontent.com/1618556/51176648-c5ec6400-18bd-11e9-8f45-5595ecf5bc0b.png)


When snapping indexes get destroyed frequently (by declaring "data
dependencies" between layers for example), it becomes useful to tune
the strategy used to build snap indexes.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
