### PR TITLE
Fix gdal_rasterize to accept -init with value of 0

### DIFF
--- a/python/plugins/processing/algs/gdal/rasterize.py
+++ b/python/plugins/processing/algs/gdal/rasterize.py
@@ -127,7 +127,6 @@ class rasterize(GdalAlgorithm):
         init_param = QgsProcessingParameterNumber(self.INIT,
                                                   self.tr('Pre-initialize the output image with value'),
                                                   type=QgsProcessingParameterNumber.Double,
-                                                  defaultValue=0.0,
                                                   optional=True)
         init_param.setFlags(init_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(init_param)
@@ -181,8 +180,8 @@ class rasterize(GdalAlgorithm):
         arguments.append(self.parameterAsDouble(parameters, self.WIDTH, context))
         arguments.append(self.parameterAsDouble(parameters, self.HEIGHT, context))
 
-        initValue = self.parameterAsDouble(parameters, self.INIT, context)
-        if initValue:
+        if self.INIT in parameters and parameters[self.INIT] is not None:
+            initValue = self.parameterAsDouble(parameters, self.INIT, context)
             arguments.append('-init')
             arguments.append(initValue)
 

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -2012,6 +2012,16 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
                  '-l polys2 -a id -ts 0.0 0.0 -a_nodata 9999.0 -ot Float32 -of JPEG ' +
                  source + ' ' +
                  outdir + '/check.jpg'])
+            # with "0" INIT value
+            self.assertEqual(
+                alg.getConsoleCommands({'INPUT': source,
+                                        'INIT': 0,
+                                        'FIELD': 'id',
+                                        'OUTPUT': outdir + '/check.jpg'}, context, feedback),
+                ['gdal_rasterize',
+                 '-l polys2 -a id -ts 0.0 0.0 -init 0.0 -ot Float32 -of JPEG ' +
+                 source + ' ' +
+                 outdir + '/check.jpg'])
             # with "0" NODATA value
             self.assertEqual(
                 alg.getConsoleCommands({'INPUT': source,


### PR DESCRIPTION
## Description
Currently, the Rasterize (vector to raster) plugin was not accepting 0 (zero) as value for the `-init` argument of `gdal_rasterize`, because of mistaken if clause. This fix also needed to a changed default value in the dialogue for 'Pre-initialize the output image with value' parameter from 0 to None, to preserve the current behaviour and not introduce breaking change. No document

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
