### PR TITLE
Fix variable editor widget not playing well with dark themes

### DIFF
--- a/src/gui/qgsvariableeditorwidget.cpp
+++ b/src/gui/qgsvariableeditorwidget.cpp
@@ -263,7 +263,6 @@ QgsVariableEditorTree::QgsVariableEditorTree( QWidget *parent )
   setIconSize( QSize( 18, 18 ) );
   setColumnCount( 2 );
   setHeaderLabels( QStringList() << tr( "Variable" ) << tr( "Value" ) );
-  setAlternatingRowColors( true );
   setEditTriggers( QAbstractItemView::AllEditTriggers );
   setRootIsDecorated( false );
   header()->setSectionsMovable( false );
@@ -478,9 +477,19 @@ void QgsVariableEditorTree::drawRow( QPainter *painter, const QStyleOptionViewIt
   if ( index.parent().isValid() )
   {
     //not a top-level item, so shade row background by context
-    const QColor baseColor = item->data( 0, RowBaseColor ).value<QColor>();
+    QColor baseColor = item->data( 0, RowBaseColor ).value<QColor>();
+    if ( index.row() % 2 == 1 )
+    {
+      baseColor = baseColor.lighter( 110 );
+    }
     painter->fillRect( option.rect, baseColor );
-    opt.palette.setColor( QPalette::AlternateBase, baseColor.lighter( 110 ) );
+
+    //declare custom text color since we've overwritten default background color
+    QPalette pal = opt.palette;
+    pal.setColor( QPalette::Active, QPalette::Text, Qt::black );
+    pal.setColor( QPalette::Inactive, QPalette::Text, Qt::black );
+    pal.setColor( QPalette::Disabled, QPalette::Text, Qt::gray );
+    opt.palette = pal;
   }
   QTreeWidget::drawRow( painter, opt, index );
   QColor color = static_cast<QRgb>( QApplication::style()->styleHint( QStyle::SH_Table_GridLineColor, &opt ) );


### PR DESCRIPTION
## Description
This PR fixes the variable editor widget when used against dark themes. Here's the before vs. fixed shot:
![image](https://user-images.githubusercontent.com/1728657/51223333-f4c51180-1973-11e9-8697-b988e7b66178.png)

This fixes not only QGIS under a non default UI theme, I'm pretty sure it'll improve the widget dramatically under OS X macintosh style's dark mode.

Lesson learned out of this fix: custom stylesheet and tree view alternate row color aren't playing well together.

@nyalldawson , all good?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
