### PR TITLE
Fix dual view's feature list not using app palette

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
+++ b/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
@@ -98,7 +98,7 @@ void QgsFeatureListViewDelegate::paint( QPainter *painter, const QStyleOptionVie
   // Text layout options
   QRect textLayoutBounds( iconLayoutBounds.x() + iconLayoutBounds.width(), option.rect.y(), option.rect.width() - ( iconLayoutBounds.x() + iconLayoutBounds.width() ), option.rect.height() );
 
-  QStyleOptionViewItem textOption;
+  QStyleOptionViewItem textOption = option;
   textOption.state |= QStyle::State_Enabled;
   if ( isEditSelection )
   {


### PR DESCRIPTION
## Description
Hunting down last bits of code that's not dark theme compatible. This PR fixes the dual view feature list, which didn't use the application's palette leading to bad rendering on dark themes (again, that'd negatively impact os x macintosh style's dark mode):
![image](https://user-images.githubusercontent.com/1728657/51224884-93547100-197a-11e9-8c63-c7d751792b39.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
