### PR TITLE
[BUGFIX] SLD : Support escapeChar attribute of PropertyIsLike

### DIFF
--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -3206,6 +3206,10 @@ QgsExpressionNodeBinaryOperator *QgsOgcUtilsExpressionFromFilter::nodeBinaryOper
       {
         escape = element.attribute( QStringLiteral( "escape" ) );
       }
+      if ( element.hasAttribute( QStringLiteral( "escapeChar" ) ) )
+      {
+        escape = element.attribute( QStringLiteral( "escapeChar" ) );
+      }
       // replace
       QString oprValue = static_cast<const QgsExpressionNodeLiteral *>( opRight.get() )->value().toString();
       if ( !wildCard.isEmpty() && wildCard != QLatin1String( "%" ) )

--- a/tests/src/core/testqgsogcutils.cpp
+++ b/tests/src/core/testqgsogcutils.cpp
@@ -391,10 +391,17 @@ void TestQgsOgcUtils::testExpressionFromOgcFilter_data()
                                         "<PropertyName>NAME</PropertyName><Literal>._QGIS.\\.</Literal></PropertyIsLike>"
                                         "</Filter>" )
                                       << QStringLiteral( "NAME LIKE '_\\\\_QGIS_.'" );
-  // different single chars
+  // different escape chars
   QTest::newRow( "like escape char" ) << QString(
                                         "<Filter>"
                                         "<PropertyIsLike wildCard=\"*\" singleChar=\".\" escape=\"!\">"
+                                        "<PropertyName>NAME</PropertyName><Literal>_QGIS.!.!!%QGIS*!*</Literal></PropertyIsLike>"
+                                        "</Filter>" )
+                                      << QStringLiteral( "NAME LIKE '\\\\_QGIS_.!\\\\%QGIS%*'" );
+
+  QTest::newRow( "like escape char" ) << QString(
+                                        "<Filter>"
+                                        "<PropertyIsLike wildCard=\"*\" singleChar=\".\" escapeChar=\"!\">"
                                         "<PropertyName>NAME</PropertyName><Literal>_QGIS.!.!!%QGIS*!*</Literal></PropertyIsLike>"
                                         "</Filter>" )
                                       << QStringLiteral( "NAME LIKE '\\\\_QGIS_.!\\\\%QGIS%*'" );


### PR DESCRIPTION
## Description
In OGC FilterEncoding standard, the PropertyIsLike element has an escapeChar attribute in place of escape attribute.

In the QgsOgcUtils class, the attribute escape or escapeChar is added to PropertyIsLike element, but it only checks escape attribute when it decodes it.

The commit fixed it and adds test.

Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

Forwardporting #8874 

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
