### PR TITLE
Add missing api breaking change for setMapTipTemplate() to QgsVectorLayer

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2430,7 +2430,7 @@ displayExpression instead. For the map tip use mapTipTemplate() instead.
 - select() replaced by selectByRect()
 - selectedFeaturesIds() replaced by selectedFeatureIds()
 - selectedFeaturesIterator() was replaced by getSelectedFeatures()
-- setDisplayField() replaced by setMapTipTemplate()
+- setDisplayField() has been removed, and its functionality split between setMapTipTemplate() and setDisplayExpression()
 - setSelectedFeatures() replaced by selectByIds()
 - applyNamedStyle() replaced by importNamedStyle()
 - isReadOnly() use readOnly()

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -2430,6 +2430,7 @@ displayExpression instead. For the map tip use mapTipTemplate() instead.
 - select() replaced by selectByRect()
 - selectedFeaturesIds() replaced by selectedFeatureIds()
 - selectedFeaturesIterator() was replaced by getSelectedFeatures()
+- setDisplayField() replaced by setMapTipTemplate()
 - setSelectedFeatures() replaced by selectByIds()
 - applyNamedStyle() replaced by importNamedStyle()
 - isReadOnly() use readOnly()


### PR DESCRIPTION
## Description
There is no mention in the breaking changes docs that .setDisplayField() in QgsVectorLayer has been replaced with .setMapTipTemplate().  This commit addresses that by adding it.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
