### PR TITLE
Adding createExpressionContext to QgsLayoutItemLegend

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitemlegend.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemlegend.sip.in
@@ -488,6 +488,9 @@ Returns the legend's renderer settings object.
     virtual void finalizeRestoreFromXml();
 
 
+    virtual QgsExpressionContext createExpressionContext() const;
+
+
 
   public slots:
 

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -761,7 +761,7 @@ void QgsExpression::initVariableHelp()
     sVariableHelpTexts.insert( QStringLiteral(  "legend_title" ), QCoreApplication::translate( "variable_help", "Title of the legend." ) );
   sVariableHelpTexts.insert( QStringLiteral(  "legend_column_count" ), QCoreApplication::translate( "variable_help", "Number of column in the legend." ) );
   sVariableHelpTexts.insert( QStringLiteral(  "legend_split_layers" ), QCoreApplication::translate( "variable_help", "Boolean indicating if layers can be split in the legend." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "legend_warp_string" ), QCoreApplication::translate( "variable_help", "Characters used to warp the legend text." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "legend_wrap_string" ), QCoreApplication::translate( "variable_help", "Characters used to wrap the legend text." ) );
   sVariableHelpTexts.insert( QStringLiteral(  "legend_filter_by_map" ), QCoreApplication::translate( "variable_help", "Boolean indicating if the content of the legend is filtered by the map." ) );
   sVariableHelpTexts.insert( QStringLiteral(  "legend_filter_by_atlas" ), QCoreApplication::translate( "variable_help", "Boolean indicationg if the content of the legend is filtered by the Atlas." ) );
 

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -758,12 +758,12 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "canvas_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the project's geographical coordinates." ) );
 
   // legend canvas item variables
-    sVariableHelpTexts.insert( QStringLiteral(  "legend_title" ), QCoreApplication::translate( "variable_help", "Title of the legend." ) );
-  sVariableHelpTexts.insert( QStringLiteral(  "legend_column_count" ), QCoreApplication::translate( "variable_help", "Number of column in the legend." ) );
-  sVariableHelpTexts.insert( QStringLiteral(  "legend_split_layers" ), QCoreApplication::translate( "variable_help", "Boolean indicating if layers can be split in the legend." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "legend_title" ), QCoreApplication::translate( "variable_help", "Title of the legend." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "legend_column_count" ), QCoreApplication::translate( "variable_help", "Number of column in the legend." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "legend_split_layers" ), QCoreApplication::translate( "variable_help", "Boolean indicating if layers can be split in the legend." ) );
   sVariableHelpTexts.insert( QStringLiteral( "legend_wrap_string" ), QCoreApplication::translate( "variable_help", "Characters used to wrap the legend text." ) );
-  sVariableHelpTexts.insert( QStringLiteral(  "legend_filter_by_map" ), QCoreApplication::translate( "variable_help", "Boolean indicating if the content of the legend is filtered by the map." ) );
-  sVariableHelpTexts.insert( QStringLiteral(  "legend_filter_by_atlas" ), QCoreApplication::translate( "variable_help", "Boolean indicationg if the content of the legend is filtered by the Atlas." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "legend_filter_by_map" ), QCoreApplication::translate( "variable_help", "Boolean indicating if the content of the legend is filtered by the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "legend_filter_by_atlas" ), QCoreApplication::translate( "variable_help", "Boolean indicationg if the content of the legend is filtered by the Atlas." ) );
 
 
   // map tool capture variables

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -763,7 +763,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "legend_split_layers" ), QCoreApplication::translate( "variable_help", "Boolean indicating if layers can be split in the legend." ) );
   sVariableHelpTexts.insert( QStringLiteral( "legend_wrap_string" ), QCoreApplication::translate( "variable_help", "Characters used to wrap the legend text." ) );
   sVariableHelpTexts.insert( QStringLiteral( "legend_filter_by_map" ), QCoreApplication::translate( "variable_help", "Boolean indicating if the content of the legend is filtered by the map." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "legend_filter_by_atlas" ), QCoreApplication::translate( "variable_help", "Boolean indicationg if the content of the legend is filtered by the Atlas." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "legend_filter_out_atlas" ), QCoreApplication::translate( "variable_help", "Boolean indicating if the Atlas is filtered out of the legend." ) );
 
 
   // map tool capture variables

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -757,6 +757,15 @@ void QgsExpression::initVariableHelp()
   // map canvas item variables
   sVariableHelpTexts.insert( QStringLiteral( "canvas_cursor_point" ), QCoreApplication::translate( "variable_help", "Last cursor position on the canvas in the project's geographical coordinates." ) );
 
+  // legend canvas item variables
+    sVariableHelpTexts.insert( QStringLiteral(  "legend_title" ), QCoreApplication::translate( "variable_help", "Title of the legend." ) );
+  sVariableHelpTexts.insert( QStringLiteral(  "legend_column_count" ), QCoreApplication::translate( "variable_help", "Number of column in the legend." ) );
+  sVariableHelpTexts.insert( QStringLiteral(  "legend_split_layers" ), QCoreApplication::translate( "variable_help", "Boolean indicating if layers can be split in the legend." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "legend_warp_string" ), QCoreApplication::translate( "variable_help", "Characters used to warp the legend text." ) );
+  sVariableHelpTexts.insert( QStringLiteral(  "legend_filter_by_map" ), QCoreApplication::translate( "variable_help", "Boolean indicating if the content of the legend is filtered by the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral(  "legend_filter_by_atlas" ), QCoreApplication::translate( "variable_help", "Boolean indicationg if the content of the legend is filtered by the Atlas." ) );
+
+
   // map tool capture variables
   sVariableHelpTexts.insert( QStringLiteral( "snapping_results" ), QCoreApplication::translate( "variable_help",
                              "<p>An array with an item for each snapped point.</p>"

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -826,7 +826,10 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
   // the map specific variables. We don't want the rest of the map's context, because that
   // will contain duplicate global, project, layout, etc scopes.
 
-  // context.appendScope( mMap->createExpressionContext().popScope() );
+  if ( mMap )
+  {
+    context.appendScope( mMap->createExpressionContext().popScope() );
+  }
 
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( tr( "Legend Settings" ) );

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -826,7 +826,7 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
   // the map specific variables. We don't want the rest of the map's context, because that
   // will contain duplicate global, project, layout, etc scopes.
 
-  context.appendScope( mMap->createExpressionContext().popScope() );
+  // context.appendScope( mMap->createExpressionContext().popScope() );
 
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( tr( "Legend Settings" ) );

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -831,12 +831,12 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( tr( "Legend Settings" ) );
 
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ), title(), true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ), columnCount(), true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ), splitLayer(), true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_wrap_string" ), wrapString(), true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ), legendFilterByMapEnabled(), true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ), legendFilterOutAtlas(), true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ), title(), true );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ), columnCount(), true );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ), splitLayer(), true );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_wrap_string" ), wrapString(), true );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ), legendFilterByMapEnabled(), true );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ), legendFilterOutAtlas(), true );
 
   context.appendScope( scope );
 

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -818,6 +818,35 @@ void QgsLayoutItemLegend::onAtlasEnded()
   updateFilterByMap();
 }
 
+QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
+{
+  QgsExpressionContext context = QgsLayoutItem::createExpressionContext();
+
+  //Can't utilize QgsExpressionContextUtils::mapSettingsScope as we don't always
+  //have a QgsMapSettings object available when the context is required, so we manually
+  //add the same variables here
+
+  // add the existing context of the linked map
+  if (mMap)
+  {
+    context.appendScope( mMap.createExpressionContext() );
+  }
+
+  QgsExpressionContextScope *scope = new QgsExpressionContextScope( tr( "Legend Settings" ) );
+
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ),title(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_settings" ),legendSettings(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "column_count" ),columnCount(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "split_layers" ),splitLayer(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "warp_string" ),warpString(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ),legendFilterByMapEnabled(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ),legendFilterOutAtlas(),true);
+
+  context.appendScope( scope );
+
+  return context;
+}
+
 // -------------------------------------------------------------------------
 #include "qgslayertreemodellegendnode.h"
 #include "qgsvectorlayer.h"

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -822,23 +822,19 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
 {
   QgsExpressionContext context = QgsLayoutItem::createExpressionContext();
 
-  //Can't utilize QgsExpressionContextUtils::mapSettingsScope as we don't always
-  //have a QgsMapSettings object available when the context is required, so we manually
-  //add the same variables here
+  // We only want the last scope from the map's expression context, as this contains
+  // the map specific variables. We don't want the rest of the map's context, because that
+  // will contain duplicate global, project, layout, etc scopes.
 
-  // add the existing context of the linked map
-  if (mMap)
-  {
-    context.appendScope( mMap.createExpressionContext() );
-  }
+  context.appendScope( mMap->createExpressionContext().popScope() );
+
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( tr( "Legend Settings" ) );
 
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ),title(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_settings" ),legendSettings(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "column_count" ),columnCount(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "split_layers" ),splitLayer(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "warp_string" ),warpString(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ),columnCount(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ),splitLayer(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_warp_string" ),warpString(),true);
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ),legendFilterByMapEnabled(),true);
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ),legendFilterOutAtlas(),true);
 

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -834,7 +834,7 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ), title(), true);
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ), columnCount(), true);
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ), splitLayer(), true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_warp_string" ), warpString(), true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_wrap_string" ), wrapString(), true);
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ), legendFilterByMapEnabled(), true);
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ), legendFilterOutAtlas(), true);
 

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -832,7 +832,7 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( tr( "Legend Settings" ) );
 
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ), title(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ), columnCount(), true  );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ), columnCount(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ), splitLayer(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_wrap_string" ), wrapString(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ), legendFilterByMapEnabled(), true ) );

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -831,12 +831,12 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( tr( "Legend Settings" ) );
 
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ), title(), true );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ), columnCount(), true );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ), splitLayer(), true );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_wrap_string" ), wrapString(), true );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ), legendFilterByMapEnabled(), true );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ), legendFilterOutAtlas(), true );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ), title(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ), columnCount(), true  );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ), splitLayer(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_wrap_string" ), wrapString(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ), legendFilterByMapEnabled(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ), legendFilterOutAtlas(), true ) );
 
   context.appendScope( scope );
 

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -831,12 +831,12 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
 
   QgsExpressionContextScope *scope = new QgsExpressionContextScope( tr( "Legend Settings" ) );
 
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ),title(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ),columnCount(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ),splitLayer(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_warp_string" ),warpString(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ),legendFilterByMapEnabled(),true);
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ),legendFilterOutAtlas(),true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_title" ), title(), true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_column_count" ), columnCount(), true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ), splitLayer(), true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_warp_string" ), warpString(), true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ), legendFilterByMapEnabled(), true);
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ), legendFilterOutAtlas(), true);
 
   context.appendScope( scope );
 

--- a/src/core/layout/qgslayoutitemlegend.cpp
+++ b/src/core/layout/qgslayoutitemlegend.cpp
@@ -839,7 +839,7 @@ QgsExpressionContext QgsLayoutItemLegend::createExpressionContext() const
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_split_layers" ), splitLayer(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_wrap_string" ), wrapString(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_map" ), legendFilterByMapEnabled(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_by_atlas" ), legendFilterOutAtlas(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "legend_filter_out_atlas" ), legendFilterOutAtlas(), true ) );
 
   context.appendScope( scope );
 

--- a/src/core/layout/qgslayoutitemlegend.h
+++ b/src/core/layout/qgslayoutitemlegend.h
@@ -436,6 +436,13 @@ class CORE_EXPORT QgsLayoutItemLegend : public QgsLayoutItem
 
     void finalizeRestoreFromXml() override;
 
+    /**
+     * Returns an expression context containing information about the legend and layout map
+     * 
+     * \since 3.6
+    */  
+    QgsExpressionContext createExpressionContext() const override;
+
 
   public slots:
 

--- a/src/core/layout/qgslayoutitemlegend.h
+++ b/src/core/layout/qgslayoutitemlegend.h
@@ -436,11 +436,6 @@ class CORE_EXPORT QgsLayoutItemLegend : public QgsLayoutItem
 
     void finalizeRestoreFromXml() override;
 
-    /**
-     * Returns an expression context containing information about the legend and layout map
-     * 
-     * \since 3.6
-    */  
     QgsExpressionContext createExpressionContext() const override;
 
 

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -306,8 +306,5 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         self.assertEqual(exp6.evaluate(expc2), 15.2)
 
 
-
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -281,7 +281,7 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         legend.setWrapString('d')
         legend.setLegendFilterOutAtlas(True)
 
-        expc=legend.createExpressionContext()
+        expc = legend.createExpressionContext()
 
         exp1 = QgsExpression("@legend_title")
         self.assertEqual(exp1.evaluate(expc), "Legend")

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -283,15 +283,15 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
 
         expc=legend.createExpressionContext()
 
-        exp1=QgsExpression("@legend_title")
+        exp1 = QgsExpression("@legend_title")
         self.assertEqual(exp1.evaluate(expc), "Legend")
-        exp2=QgsExpression("@legend_column_count")
+        exp2 = QgsExpression("@legend_column_count")
         self.assertEqual(exp2.evaluate(expc), 2)
-        exp3=QgsExpression("@legend_wrap_string")
+        exp3 = QgsExpression("@legend_wrap_string")
         self.assertEqual(exp3.evaluate(expc), 'd')
-        exp4=QgsExpression("@legend_split_layers")
+        exp4 = QgsExpression("@legend_split_layers")
         self.assertEqual(exp4.evaluate(expc), False)
-        exp5=QgsExpression("@legend_filter_out_atlas")
+        exp5 = QgsExpression("@legend_filter_out_atlas")
         self.assertEqual(exp5.evaluate(expc), True)
 
         map = QgsLayoutItemMap(layout)
@@ -300,10 +300,10 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         layout.addLayoutItem(map)
         map.setScale(15.2)
         legend.setLinkedMap(map)
-        expc2=legend.createExpressionContext()
+        expc2 = legend.createExpressionContext()
 
-        exp6=QgsExpression("@map_scale")
-        self.assertEqual(exp6.evaluate(expc2),15.2)
+        exp6 = QgsExpression("@map_scale")
+        self.assertEqual(exp6.evaluate(expc2), 15.2)
 
 
 

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -269,6 +269,30 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         self.assertEqual(legend.columnCount(), 2)
         self.assertEqual(legend.legendSettings().columnCount(), 5)
 
+    def testLegendScopeVariables(self):
+        layout = QgsLayout(QgsProject.instance())
+        layout.initializeDefaults()
+
+        legend = QgsLayoutItemLegend(layout)
+        legend.setTitle("Legend")
+        layout.addLayoutItem(legend)
+
+        legend.setColumnCount(2)
+        legend.setWrapString('d')
+        legend.setLegendFilterOutAtlas(True)
+
+        expc=legend.createExpressionContext()
+
+        exp1=QgsExpression("@legend_title")
+        self.assertEqual(exp1.evaluate(expc), "Legend")
+        exp2=QgsExpression("@legend_column_count")
+        self.assertEqual(exp2.evaluate(expc), 2)
+        exp3=QgsExpression("@legend_wrap_string")
+        self.assertEqual(exp3.evaluate(expc), 'd')
+        exp4=QgsExpression("@legend_split_layers")
+        self.assertEqual(exp4.evaluate(expc), False)
+        exp5=QgsExpression("@legend_filter_out_atlas")
+        self.assertEqual(exp5.evaluate(expc), True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -294,5 +294,20 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         exp5=QgsExpression("@legend_filter_out_atlas")
         self.assertEqual(exp5.evaluate(expc), True)
 
+        map = QgsLayoutItemMap(layout)
+        map.attemptSetSceneRect(QRectF(20, 20, 80, 80))
+        map.setFrameEnabled(True)
+        layout.addLayoutItem(map)
+        map.setScale(15.2)
+        legend.setLinkedMap(map)
+        expc2=legend.createExpressionContext()
+
+        exp6=QgsExpression("@map_scale")
+        self.assertEqual(exp6.evaluate(expc2),15.2)
+
+
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_qgslayoutlegend.py
+++ b/tests/src/python/test_qgslayoutlegend.py
@@ -29,7 +29,8 @@ from qgis.core import (QgsLayoutItemLegend,
                        QgsLayoutMeasurement,
                        QgsLayoutItem,
                        QgsLayoutPoint,
-                       QgsLayoutSize)
+                       QgsLayoutSize,
+                       QgsExpression)
 from qgis.testing import (start_app,
                           unittest
                           )
@@ -282,7 +283,6 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         legend.setLegendFilterOutAtlas(True)
 
         expc = legend.createExpressionContext()
-
         exp1 = QgsExpression("@legend_title")
         self.assertEqual(exp1.evaluate(expc), "Legend")
         exp2 = QgsExpression("@legend_column_count")
@@ -297,13 +297,13 @@ class TestQgsLayoutItemLegend(unittest.TestCase, LayoutItemTestCase):
         map = QgsLayoutItemMap(layout)
         map.attemptSetSceneRect(QRectF(20, 20, 80, 80))
         map.setFrameEnabled(True)
+        map.setExtent(QgsRectangle(781662.375, 3339523.125, 793062.375, 3345223.125))
         layout.addLayoutItem(map)
-        map.setScale(15.2)
+        map.setScale(15000)
         legend.setLinkedMap(map)
         expc2 = legend.createExpressionContext()
-
         exp6 = QgsExpression("@map_scale")
-        self.assertEqual(exp6.evaluate(expc2), 15.2)
+        self.assertAlmostEqual(exp6.evaluate(expc2), 15000, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
This PR implements the createExpressionContext to the QgsLayoutItemLegend.

This is the continuation of the previous PR.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
