### PR TITLE
Symbol list tree fixes

### DIFF
--- a/src/core/symbology/qgssymbollayerutils.cpp
+++ b/src/core/symbology/qgssymbollayerutils.cpp
@@ -736,6 +736,11 @@ QIcon QgsSymbolLayerUtils::symbolLayerPreviewIcon( QgsSymbolLayer *layer, QgsUni
   painter.begin( &pixmap );
   painter.setRenderHint( QPainter::Antialiasing );
   QgsRenderContext renderContext = QgsRenderContext::fromQPainter( &painter );
+  // build a minimal expression context
+  QgsExpressionContext expContext;
+  expContext.appendScopes( QgsExpressionContextUtils::globalProjectLayerScopes( nullptr ) );
+  renderContext.setExpressionContext( expContext );
+
   QgsSymbolRenderContext symbolContext( renderContext, u, 1.0, false, nullptr, nullptr, QgsFields(), scale );
   layer->drawPreviewIcon( symbolContext, size );
   painter.end();

--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -36,6 +36,7 @@
 #include "qgssvgcache.h"
 #include "qgsimagecache.h"
 #include "qgsproject.h"
+#include "qgsguiutils.h"
 
 #include <QColorDialog>
 #include <QPainter>
@@ -147,11 +148,16 @@ class SymbolLayerItem : public QStandardItem
 
     void updatePreview()
     {
+      if ( !mSize.isValid() )
+      {
+        const int size = QgsGuiUtils::scaleIconSize( 16 );
+        mSize = QSize( size, size );
+      }
       QIcon icon;
       if ( mIsLayer )
-        icon = QgsSymbolLayerUtils::symbolLayerPreviewIcon( mLayer, QgsUnitTypes::RenderMillimeters, QSize( 16, 16 ) ); //todo: make unit a parameter
+        icon = QgsSymbolLayerUtils::symbolLayerPreviewIcon( mLayer, QgsUnitTypes::RenderMillimeters, mSize ); //todo: make unit a parameter
       else
-        icon = QgsSymbolLayerUtils::symbolPreviewIcon( mSymbol, QSize( 16, 16 ) );
+        icon = QgsSymbolLayerUtils::symbolPreviewIcon( mSymbol, mSize );
       setIcon( icon );
 
       if ( parent() )
@@ -214,6 +220,7 @@ class SymbolLayerItem : public QStandardItem
     QgsSymbolLayer *mLayer = nullptr;
     QgsSymbol *mSymbol = nullptr;
     bool mIsLayer;
+    QSize mSize;
 };
 
 ///@endcond


### PR DESCRIPTION
Fixes some issues with generation of the layer preview in the symbol layer tree widget, and also makes sure the icon is big enough on hidpi displays.