### PR TITLE
Show actual linked color in color buttons when color has been linked to a project color

### DIFF
--- a/python/gui/auto_generated/qgscolorbutton.sip.in
+++ b/python/gui/auto_generated/qgscolorbutton.sip.in
@@ -305,6 +305,32 @@ that are shown in the button's drop-down menu.
 .. seealso:: :py:func:`setColorSchemeRegistry`
 %End
 
+    void linkToProjectColor( const QString &name );
+%Docstring
+Sets the button to link to an existing project color, by color ``name``.
+
+This changes the behavior of the button to a "linked" mode. Specifically,
+the button will show the linked color and respond to changes in the project
+color scheme by refreshing the displayed color automatically. Additionally,
+the button's menu will show items specific to linked color mode, including
+an option to "unlink" from the project color.
+
+.. seealso:: :py:func:`linkedProjectColorName`
+
+.. seealso:: :py:func:`unlink`
+
+.. versionadded:: 3.6
+%End
+
+    QString linkedProjectColorName() const;
+%Docstring
+Returns the linked project color name, if set.
+
+.. seealso:: :py:func:`linkToProjectColor`
+
+.. versionadded:: 3.6
+%End
+
     static QPixmap createMenuIcon( const QColor &color, bool showChecks = true );
 %Docstring
 Creates an icon for displaying a ``color`` in a drop-down menu.
@@ -392,6 +418,17 @@ Sets color to null.
 .. versionadded:: 2.16
 %End
 
+    void unlink();
+%Docstring
+Unlinks the button from a project color.
+
+.. seealso:: :py:func:`unlinked`
+
+.. seealso:: :py:func:`linkToProjectColor`
+
+.. versionadded:: 3.6
+%End
+
   signals:
 
     void colorChanged( const QColor &color );
@@ -411,6 +448,18 @@ Emitted when the button is clicked, if the button's behavior is set to SignalOnl
 .. seealso:: :py:func:`setBehavior`
 
 .. seealso:: :py:func:`behavior`
+%End
+
+    void unlinked();
+%Docstring
+Emitted when the color is unlinked, e.g. when it was previously set to link
+to a project color and is now no longer linked.
+
+.. seealso:: :py:func:`unlink`
+
+.. seealso:: :py:func:`linkToProjectColor`
+
+.. versionadded:: 3.6
 %End
 
   protected:

--- a/python/gui/auto_generated/qgspropertyoverridebutton.sip.in
+++ b/python/gui/auto_generated/qgspropertyoverridebutton.sip.in
@@ -31,13 +31,6 @@ and layouts.
 %End
   public:
 
-    enum Flag
-    {
-      FlagDisableCheckedWidgetOnlyWhenProjectColorSet,
-    };
-    typedef QFlags<QgsPropertyOverrideButton::Flag> Flags;
-
-
     QgsPropertyOverrideButton( QWidget *parent /TransferThis/ = 0,
                                const QgsVectorLayer *layer = 0 );
 %Docstring
@@ -45,24 +38,6 @@ Constructor for QgsPropertyOverrideButton.
 
 :param parent: parent widget
 :param layer: associated vector layer
-%End
-
-    Flags flags() const;
-%Docstring
-Returns the button's flags, which control the button behavior.
-
-.. seealso:: :py:func:`setFlags`
-
-.. versionadded:: 3.6
-%End
-
-    void setFlags( QgsPropertyOverrideButton::Flags flags );
-%Docstring
-Sets the button's ``flags``, which control the button behavior.
-
-.. seealso:: :py:func:`flags`
-
-.. versionadded:: 3.6
 %End
 
     void init( int propertyKey,
@@ -221,6 +196,17 @@ Register an expression context generator class that will be used to retrieve
 an expression context for the button when required.
 %End
 
+    void registerLinkedWidget( QWidget *widget );
+%Docstring
+Registers a ``widget`` which is linked to this button. The meaning of linked widgets
+depends on the property type, and the type of linked widget.
+
+For color properties, linking a QgsColorButton allows the color button to correctly
+reflect the status of the property when it's set to follow a project color.
+
+.. versionadded:: 3.6
+%End
+
     void updateFieldLists();
 %Docstring
 Updates list of fields.
@@ -264,9 +250,6 @@ Emitted when creating a new auxiliary field
 
 
 };
-
-QFlags<QgsPropertyOverrideButton::Flag> operator|(QgsPropertyOverrideButton::Flag f1, QFlags<QgsPropertyOverrideButton::Flag> f2);
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/src/app/layout/qgslayoutpicturewidget.cpp
+++ b/src/app/layout/qgslayoutpicturewidget.cpp
@@ -61,10 +61,8 @@ QgsLayoutPictureWidget::QgsLayoutPictureWidget( QgsLayoutItemPicture *picture )
   mStrokeColorButton->setColorDialogTitle( tr( "Select Stroke Color" ) );
   mStrokeColorButton->setContext( QStringLiteral( "composer" ) );
 
-  mFillColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFillColorDDBtn->registerEnabledWidget( mFillColorButton, false );
-  mStrokeColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStrokeColorDDBtn->registerEnabledWidget( mStrokeColorButton, false );
+  mFillColorDDBtn->registerLinkedWidget( mFillColorButton );
+  mStrokeColorDDBtn->registerLinkedWidget( mStrokeColorButton );
 
   mNorthTypeComboBox->blockSignals( true );
   mNorthTypeComboBox->addItem( tr( "Grid north" ), QgsLayoutItemPicture::GridNorth );

--- a/src/app/layout/qgslayoutscalebarwidget.cpp
+++ b/src/app/layout/qgslayoutscalebarwidget.cpp
@@ -109,12 +109,9 @@ QgsLayoutScaleBarWidget::QgsLayoutScaleBarWidget( QgsLayoutItemScaleBar *scaleBa
   mStrokeColorButton->setNoColorString( tr( "Transparent Line" ) );
   mStrokeColorButton->setShowNoColor( true );
 
-  mFillColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFillColorDDBtn->registerEnabledWidget( mFillColorButton, false );
-  mFillColor2DDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFillColor2DDBtn->registerEnabledWidget( mFillColor2Button, false );
-  mLineColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mLineColorDDBtn->registerEnabledWidget( mStrokeColorButton, false );
+  mFillColorDDBtn->registerLinkedWidget( mFillColorButton );
+  mFillColor2DDBtn->registerLinkedWidget( mFillColor2Button );
+  mLineColorDDBtn->registerLinkedWidget( mStrokeColorButton );
 
   if ( mScalebar )
   {

--- a/src/gui/layout/qgslayoutitemwidget.cpp
+++ b/src/gui/layout/qgslayoutitemwidget.cpp
@@ -252,10 +252,8 @@ QgsLayoutItemPropertiesWidget::QgsLayoutItemPropertiesWidget( QWidget *parent, Q
   mSizeLockAspectRatio->setWidthSpinBox( mWidthSpin );
   mSizeLockAspectRatio->setHeightSpinBox( mHeightSpin );
 
-  mItemFrameColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mItemFrameColorDDBtn->registerEnabledWidget( mFrameColorButton, false );
-  mItemBackgroundColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mItemBackgroundColorDDBtn->registerEnabledWidget( mBackgroundColorButton, false );
+  mItemFrameColorDDBtn->registerLinkedWidget( mFrameColorButton );
+  mItemBackgroundColorDDBtn->registerLinkedWidget( mBackgroundColorButton );
 
   connect( mFrameColorButton, &QgsColorButton::colorChanged, this, &QgsLayoutItemPropertiesWidget::mFrameColorButton_colorChanged );
   connect( mBackgroundColorButton, &QgsColorButton::colorChanged, this, &QgsLayoutItemPropertiesWidget::mBackgroundColorButton_colorChanged );

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -495,7 +495,7 @@ QPixmap QgsColorButton::createMenuIcon( const QColor &color, const bool showChec
 
 void QgsColorButton::buttonClicked()
 {
-  if ( !mLinkedColorName.isEmpty() )
+  if ( linkedProjectColor().isValid() )
   {
     QToolButton::showMenu();
   }

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -272,6 +272,30 @@ class GUI_EXPORT QgsColorButton : public QToolButton
     QgsColorSchemeRegistry *colorSchemeRegistry() { return mColorSchemeRegistry; }
 
     /**
+     * Sets the button to link to an existing project color, by color \a name.
+     *
+     * This changes the behavior of the button to a "linked" mode. Specifically,
+     * the button will show the linked color and respond to changes in the project
+     * color scheme by refreshing the displayed color automatically. Additionally,
+     * the button's menu will show items specific to linked color mode, including
+     * an option to "unlink" from the project color.
+     *
+     * \see linkedProjectColorName()
+     * \see unlink()
+     *
+     * \since QGIS 3.6
+     */
+    void linkToProjectColor( const QString &name );
+
+    /**
+     * Returns the linked project color name, if set.
+     *
+     * \see linkToProjectColor()
+     * \since QGIS 3.6
+     */
+    QString linkedProjectColorName() const { return mLinkedColorName; }
+
+    /**
      * Creates an icon for displaying a \a color in a drop-down menu.
      *
      * If \a showChecks set to true, then a checkboard pattern will be shown behind
@@ -343,6 +367,16 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      */
     void setToNull();
 
+    /**
+     * Unlinks the button from a project color.
+     *
+     * \see unlinked()
+     * \see linkToProjectColor()
+     *
+     * \since QGIS 3.6
+     */
+    void unlink();
+
   signals:
 
     /**
@@ -359,6 +393,17 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * \see behavior
      */
     void colorClicked( const QColor &color );
+
+    /**
+     * Emitted when the color is unlinked, e.g. when it was previously set to link
+     * to a project color and is now no longer linked.
+     *
+     * \see unlink()
+     * \see linkToProjectColor()
+     *
+     * \since QGIS 3.6
+     */
+    void unlinked();
 
   protected:
 
@@ -439,6 +484,8 @@ class GUI_EXPORT QgsColorButton : public QToolButton
     QMenu *mMenu = nullptr;
 
     QSize mIconSize;
+    QString mLinkedColorName;
+    bool mShowMenu = true;
 
     /**
      * Attempts to parse mimeData as a color, either via the mime data's color data or by
@@ -457,6 +504,8 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      * the color picking operation
      */
     void stopPicking( QPoint eventPos, bool samplingColor = true );
+
+    QColor linkedProjectColor() const;
 
   private slots:
 

--- a/src/gui/qgspropertyoverridebutton.h
+++ b/src/gui/qgspropertyoverridebutton.h
@@ -54,13 +54,6 @@ class GUI_EXPORT QgsPropertyOverrideButton: public QToolButton
 
   public:
 
-    //! Flags controlling button behavior
-    enum Flag
-    {
-      FlagDisableCheckedWidgetOnlyWhenProjectColorSet = 1 << 1, //!< Indicates that registered widgets will only be disabled when the property is set to follow a project color
-    };
-    Q_DECLARE_FLAGS( Flags, Flag )
-
     /**
      * Constructor for QgsPropertyOverrideButton.
      * \param parent parent widget
@@ -68,22 +61,6 @@ class GUI_EXPORT QgsPropertyOverrideButton: public QToolButton
      */
     QgsPropertyOverrideButton( QWidget *parent SIP_TRANSFERTHIS = nullptr,
                                const QgsVectorLayer *layer = nullptr );
-
-    /**
-     * Returns the button's flags, which control the button behavior.
-     *
-     * \see setFlags()
-     * \since QGIS 3.6
-     */
-    Flags flags() const;
-
-    /**
-     * Sets the button's \a flags, which control the button behavior.
-     *
-     * \see flags()
-     * \since QGIS 3.6
-     */
-    void setFlags( QgsPropertyOverrideButton::Flags flags );
 
     /**
      * Initialize a newly constructed property button (useful if button was included in a UI layout).
@@ -222,6 +199,17 @@ class GUI_EXPORT QgsPropertyOverrideButton: public QToolButton
     void registerExpressionContextGenerator( QgsExpressionContextGenerator *generator );
 
     /**
+     * Registers a \a widget which is linked to this button. The meaning of linked widgets
+     * depends on the property type, and the type of linked widget.
+     *
+     * For color properties, linking a QgsColorButton allows the color button to correctly
+     * reflect the status of the property when it's set to follow a project color.
+     *
+     * \since QGIS 3.6
+     */
+    void registerLinkedWidget( QWidget *widget );
+
+    /**
      * Updates list of fields.
      *
      * \since QGIS 3.0
@@ -323,6 +311,7 @@ class GUI_EXPORT QgsPropertyOverrideButton: public QToolButton
       SiblingEnableState,
       SiblingVisibility,
       SiblingExpressionText,
+      SiblingLinkedWidget,
     };
     struct SiblingWidget
     {
@@ -344,14 +333,10 @@ class GUI_EXPORT QgsPropertyOverrideButton: public QToolButton
 
     std::shared_ptr< QgsSymbol > mSymbol;
 
-    Flags mFlags = nullptr;
-
   private slots:
 
     void showHelp();
     void updateSiblingWidgets( bool state );
 };
-
-Q_DECLARE_OPERATORS_FOR_FLAGS( QgsPropertyOverrideButton::Flags )
 
 #endif // QGSPROPERTYOVERRIDEBUTTON_H

--- a/src/gui/qgstextformatwidget.cpp
+++ b/src/gui/qgstextformatwidget.cpp
@@ -167,16 +167,11 @@ void QgsTextFormatWidget::initWidget()
   mShadowColorBtn->setContext( QStringLiteral( "labeling" ) );
   mShadowColorBtn->setDefaultColor( Qt::black );
 
-  mFontColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFontColorDDBtn->registerEnabledWidget( btnTextColor, false );
-  mBufferColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mBufferColorDDBtn->registerEnabledWidget( btnBufferColor, false );
-  mShapeStrokeColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mShapeStrokeColorDDBtn->registerEnabledWidget( mShapeStrokeColorBtn, false );
-  mShapeFillColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mShapeFillColorDDBtn->registerEnabledWidget( mShapeFillColorBtn, false );
-  mShadowColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mShadowColorDDBtn->registerEnabledWidget( mShadowColorBtn, false );
+  mFontColorDDBtn->registerLinkedWidget( btnTextColor );
+  mBufferColorDDBtn->registerLinkedWidget( btnBufferColor );
+  mShapeStrokeColorDDBtn->registerLinkedWidget( mShapeStrokeColorBtn );
+  mShapeFillColorDDBtn->registerLinkedWidget( mShapeFillColorBtn );
+  mShadowColorDDBtn->registerLinkedWidget( mShadowColorBtn );
 
   // set up quadrant offset button group
   mQuadrantBtnGrp = new QButtonGroup( this );

--- a/src/gui/symbology/qgsellipsesymbollayerwidget.cpp
+++ b/src/gui/symbology/qgsellipsesymbollayerwidget.cpp
@@ -57,10 +57,8 @@ QgsEllipseSymbolLayerWidget::QgsEllipseSymbolLayerWidget( QgsVectorLayer *vl, QW
   btnChangeColorStroke->setShowNoColor( true );
   btnChangeColorStroke->setNoColorString( tr( "Transparent Stroke" ) );
 
-  mFillColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFillColorDDBtn->registerEnabledWidget( btnChangeColorFill, false );
-  mStrokeColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStrokeColorDDBtn->registerEnabledWidget( btnChangeColorStroke, false );
+  mFillColorDDBtn->registerLinkedWidget( btnChangeColorFill );
+  mStrokeColorDDBtn->registerLinkedWidget( btnChangeColorStroke );
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );

--- a/src/gui/symbology/qgssymbollayerwidget.cpp
+++ b/src/gui/symbology/qgssymbollayerwidget.cpp
@@ -195,8 +195,7 @@ QgsSimpleLineSymbolLayerWidget::QgsSimpleLineSymbolLayerWidget( QgsVectorLayer *
   btnChangeColor->setColorDialogTitle( tr( "Select Line Color" ) );
   btnChangeColor->setContext( QStringLiteral( "symbology" ) );
 
-  mColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mColorDDBtn->registerEnabledWidget( btnChangeColor, false );
+  mColorDDBtn->registerLinkedWidget( btnChangeColor );
 
   mRingFilterComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "mIconAllRings.svg" ) ), tr( "All Rings" ), QgsLineSymbolLayer::AllRings );
   mRingFilterComboBox->addItem( QgsApplication::getThemeIcon( QStringLiteral( "mIconExteriorRing.svg" ) ), tr( "Exterior Ring Only" ), QgsLineSymbolLayer::ExteriorRingOnly );
@@ -468,10 +467,8 @@ QgsSimpleMarkerSymbolLayerWidget::QgsSimpleMarkerSymbolLayerWidget( QgsVectorLay
   btnChangeColorStroke->setShowNoColor( true );
   btnChangeColorStroke->setNoColorString( tr( "Transparent Stroke" ) );
 
-  mFillColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFillColorDDBtn->registerEnabledWidget( btnChangeColorFill, false );
-  mStrokeColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStrokeColorDDBtn->registerEnabledWidget( btnChangeColorStroke, false );
+  mFillColorDDBtn->registerLinkedWidget( btnChangeColorFill );
+  mStrokeColorDDBtn->registerLinkedWidget( btnChangeColorStroke );
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
@@ -767,10 +764,8 @@ QgsSimpleFillSymbolLayerWidget::QgsSimpleFillSymbolLayerWidget( QgsVectorLayer *
   connect( spinOffsetX, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSimpleFillSymbolLayerWidget::offsetChanged );
   connect( spinOffsetY, static_cast < void ( QDoubleSpinBox::* )( double ) > ( &QDoubleSpinBox::valueChanged ), this, &QgsSimpleFillSymbolLayerWidget::offsetChanged );
 
-  mFillColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFillColorDDBtn->registerEnabledWidget( btnChangeColor, false );
-  mStrokeColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStrokeColorDDBtn->registerEnabledWidget( btnChangeStrokeColor, false );
+  mFillColorDDBtn->registerLinkedWidget( btnChangeColor );
+  mStrokeColorDDBtn->registerLinkedWidget( btnChangeStrokeColor );
 }
 
 void QgsSimpleFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayer *layer )
@@ -1091,10 +1086,8 @@ QgsGradientFillSymbolLayerWidget::QgsGradientFillSymbolLayerWidget( QgsVectorLay
   btnChangeColor2->setShowNoColor( true );
   btnChangeColor2->setNoColorString( tr( "Transparent" ) );
 
-  mStartColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStartColorDDBtn->registerEnabledWidget( btnChangeColor, false );
-  mEndColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mEndColorDDBtn->registerEnabledWidget( btnChangeColor2, false );
+  mStartColorDDBtn->registerLinkedWidget( btnChangeColor );
+  mEndColorDDBtn->registerLinkedWidget( btnChangeColor2 );
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
@@ -1437,10 +1430,8 @@ QgsShapeburstFillSymbolLayerWidget::QgsShapeburstFillSymbolLayerWidget( QgsVecto
   btnChangeColor2->setShowNoColor( true );
   btnChangeColor2->setNoColorString( tr( "Transparent" ) );
 
-  mStartColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStartColorDDBtn->registerEnabledWidget( btnChangeColor, false );
-  mEndColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mEndColorDDBtn->registerEnabledWidget( btnChangeColor2, false );
+  mStartColorDDBtn->registerLinkedWidget( btnChangeColor );
+  mEndColorDDBtn->registerLinkedWidget( btnChangeColor2 );
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
@@ -1892,10 +1883,8 @@ QgsSvgMarkerSymbolLayerWidget::QgsSvgMarkerSymbolLayerWidget( QgsVectorLayer *vl
   mChangeStrokeColorButton->setColorDialogTitle( tr( "Select Stroke Color" ) );
   mChangeStrokeColorButton->setContext( QStringLiteral( "symbology" ) );
 
-  mFillColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFillColorDDBtn->registerEnabledWidget( mChangeColorButton, false );
-  mStrokeColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStrokeColorDDBtn->registerEnabledWidget( mChangeStrokeColorButton, false );
+  mFillColorDDBtn->registerLinkedWidget( mChangeColorButton );
+  mStrokeColorDDBtn->registerLinkedWidget( mChangeStrokeColorButton );
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );
@@ -2340,10 +2329,8 @@ QgsSVGFillSymbolLayerWidget::QgsSVGFillSymbolLayerWidget( QgsVectorLayer *vl, QW
   mChangeStrokeColorButton->setColorDialogTitle( tr( "Select Stroke Color" ) );
   mChangeStrokeColorButton->setContext( QStringLiteral( "symbology" ) );
 
-  mFilColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mFilColorDDBtn->registerEnabledWidget( mChangeColorButton, false );
-  mStrokeColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStrokeColorDDBtn->registerEnabledWidget( mChangeStrokeColorButton, false );
+  mFilColorDDBtn->registerLinkedWidget( mChangeColorButton );
+  mStrokeColorDDBtn->registerLinkedWidget( mChangeStrokeColorButton );
 
   connect( mSvgListView->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsSVGFillSymbolLayerWidget::setFile );
   connect( mSvgTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsSVGFillSymbolLayerWidget::populateIcons );
@@ -2867,10 +2854,8 @@ QgsFontMarkerSymbolLayerWidget::QgsFontMarkerSymbolLayerWidget( QgsVectorLayer *
   btnStrokeColor->setColorDialogTitle( tr( "Select Symbol Stroke Color" ) );
   btnStrokeColor->setContext( QStringLiteral( "symbology" ) );
 
-  mColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mColorDDBtn->registerEnabledWidget( btnColor, false );
-  mStrokeColorDDBtn->setFlags( QgsPropertyOverrideButton::FlagDisableCheckedWidgetOnlyWhenProjectColorSet );
-  mStrokeColorDDBtn->registerEnabledWidget( btnStrokeColor, false );
+  mColorDDBtn->registerLinkedWidget( btnColor );
+  mStrokeColorDDBtn->registerLinkedWidget( btnStrokeColor );
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );

--- a/tests/src/python/test_qgspropertyoverridebutton.py
+++ b/tests/src/python/test_qgspropertyoverridebutton.py
@@ -31,6 +31,9 @@ start_app()
 class TestQgsPropertyOverrideButton(unittest.TestCase):
 
     def testProjectColor(self):
+        scheme = [s for s in QgsApplication.colorSchemeRegistry().schemes() if isinstance(s, QgsProjectColorScheme)][0]
+        scheme.setColors([])
+
         definition = QgsPropertyDefinition('test', 'test', QgsPropertyDefinition.ColorWithAlpha)
         button = QgsPropertyOverrideButton()
         button.init(0, QgsProperty(), definition)
@@ -43,7 +46,6 @@ class TestQgsPropertyOverrideButton(unittest.TestCase):
         self.assertEqual([a.text() for a in color_action.menu().actions()][0], 'No colors set')
 
         # add some project colors
-        scheme = [s for s in QgsApplication.colorSchemeRegistry().schemes() if isinstance(s, QgsProjectColorScheme)][0]
         scheme.setColors([[QColor(255, 0, 0), 'color 1'], [QColor(255, 255, 0), 'burnt marigold']])
 
         button.aboutToShowMenu()
@@ -89,30 +91,29 @@ class TestQgsPropertyOverrideButton(unittest.TestCase):
         button = QgsPropertyOverrideButton()
         button.init(0, QgsProperty(), definition)
         cb = QgsColorButton()
-        button.registerEnabledWidget(cb, False)
+        button.registerLinkedWidget(cb)
 
-        # set button to a non color property
-        button.setToProperty(QgsProperty.fromValue('#ff0000'))
-        self.assertFalse(cb.isEnabled())
-        button.setActive(False)
-        self.assertTrue(cb.isEnabled())
+        project_scheme = [s for s in QgsApplication.colorSchemeRegistry().schemes() if isinstance(s, QgsProjectColorScheme)][0]
+        project_scheme.setColors([[QColor(255, 0, 0), 'col1'], [QColor(0, 255, 0), 'col2']])
 
-        # set button to a color property
-        button.setToProperty(QgsProperty.fromExpression('project_color(\'Cthulhu\'s delight\')'))
-        self.assertFalse(cb.isEnabled())
-        button.setActive(False)
-        self.assertTrue(cb.isEnabled())
-
-        # test with FlagDisableCheckedWidgetOnlyWhenProjectColorSet set
-        button.setFlags(QgsPropertyOverrideButton.FlagDisableCheckedWidgetOnlyWhenProjectColorSet)
         button.setToProperty(QgsProperty.fromValue('#ff0000'))
         self.assertTrue(cb.isEnabled())
+        self.assertFalse(cb.linkedProjectColorName())
         button.setActive(False)
         self.assertTrue(cb.isEnabled())
+        self.assertFalse(cb.linkedProjectColorName())
         button.setToProperty(QgsProperty.fromExpression('project_color(\'Cthulhu\'s delight\')'))
-        self.assertFalse(cb.isEnabled())
+        self.assertTrue(cb.isEnabled())
+        self.assertFalse(cb.linkedProjectColorName())
+        button.setToProperty(QgsProperty.fromExpression('project_color(\'col1\')'))
+        self.assertTrue(cb.isEnabled())
+        self.assertEqual(cb.linkedProjectColorName(), 'col1')
         button.setActive(False)
         self.assertTrue(cb.isEnabled())
+        self.assertFalse(cb.linkedProjectColorName())
+        button.setActive(True)
+        self.assertTrue(cb.isEnabled())
+        self.assertEqual(cb.linkedProjectColorName(), 'col1')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Instead of only showing linked color status in the accompanying
data defined button, we now also show it inside the color button
itself. So now the button color is a live reflection of the
project color it is linked to.

Additionally, when the color is linked, the button only allows
users the choice of "unlinking" the color from the linked
project color. The usual color button options allowing users
to directly change the color are not present. (As linked
colors must be edited in the project colors section from
the project properties dialog)
