### PR TITLE
Ship better default polygon symbols using outline's simple line when appropriate

### DIFF
--- a/resources/symbology-style.xml
+++ b/resources/symbology-style.xml
@@ -1,4267 +1,5821 @@
 <!DOCTYPE qgis_style>
 <qgis_style version="1">
   <symbols>
-    <symbol alpha="1" clip_to_extent="1" tags="Showcase" name="cat trail" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="0.46;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="208,174,214,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.46" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="cat trail" alpha="1" tags="Showcase" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="0.46;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="208,174,214,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="11" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="4.2" k="offset"/>
-        <prop v="5" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@cat trail@1" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SvgMarker">
-            <prop v="86" k="angle"/>
-            <prop v="208,174,214,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="shopping/shopping_pet2.svg" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="117,58,128,255" k="outline_color"/>
-            <prop v="0.4" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="5.6" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="11"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="4.2"/>
+        <prop k="offset_along_line" v="5"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@cat trail@1" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SvgMarker" locked="0" pass="0">
+            <prop k="angle" v="86"/>
+            <prop k="color" v="208,174,214,255"/>
+            <prop k="fixedAspectRatio" v="0"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="name" v="shopping/shopping_pet2.svg"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="117,58,128,255"/>
+            <prop k="outline_width" v="0.4"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="5.6"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="11" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="-4.2" k="offset"/>
-        <prop v="0" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@cat trail@2" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SvgMarker">
-            <prop v="28.5" k="angle"/>
-            <prop v="208,174,214,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="shopping/shopping_pet2.svg" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="117,58,128,255" k="outline_color"/>
-            <prop v="0.4" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="5.6" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="11"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="-4.2"/>
+        <prop k="offset_along_line" v="0"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@cat trail@2" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SvgMarker" locked="0" pass="0">
+            <prop k="angle" v="28.5"/>
+            <prop k="color" v="208,174,214,255"/>
+            <prop k="fixedAspectRatio" v="0"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="name" v="shopping/shopping_pet2.svg"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="117,58,128,255"/>
+            <prop k="outline_width" v="0.4"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="5.6"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful,Grayscale" name="dash  black" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="0.66;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="0,0,0,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="dash  black" alpha="1" tags="Colorful,Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="0.66;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="dash blue" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="0.66;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="72,123,182,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="dash blue" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="0.66;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="72,123,182,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="dash gray 1" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="0.66;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="247,247,247,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="dash gray 1" alpha="1" tags="Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="0.66;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="247,247,247,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="dash gray 2" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="0.66;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="203,203,203,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="dash gray 2" alpha="1" tags="Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="0.66;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="203,203,203,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="dash gray 3" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="0.66;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="149,149,149,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="dash gray 3" alpha="1" tags="Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="0.66;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="149,149,149,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="dash gray 4" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="0.66;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="83,83,83,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="dash gray 4" alpha="1" tags="Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="0.66;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="83,83,83,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="dash green" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="0.66;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="84,176,74,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="dash green" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="0.66;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="84,176,74,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="dash red" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="0.66;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="219,30,42,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="dash red" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="0.66;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="219,30,42,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="diamond blue" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="72,123,182,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="diamond" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="50,87,128,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4.4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="diamond blue" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="72,123,182,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="diamond"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="50,87,128,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4.4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="diamond green" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="84,176,74,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="diamond" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="61,128,53,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4.4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="diamond green" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="84,176,74,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="diamond"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="61,128,53,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4.4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="diamond red" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="219,30,42,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="diamond" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="128,17,25,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4.4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="diamond red" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="219,30,42,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="diamond"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="128,17,25,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4.4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful,Grayscale" name="dot  black" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,255,255,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol favorite="1" force_rhr="0" name="dot  black" alpha="1" tags="Colorful,Grayscale" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="0,0,0,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,255,255,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful,Grayscale" name="dot  white" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="255,255,255,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol favorite="1" force_rhr="0" name="dot  white" alpha="1" tags="Colorful,Grayscale" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,255,255,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="dot blue" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="72,123,182,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="50,87,128,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol favorite="1" force_rhr="0" name="dot blue" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="72,123,182,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="50,87,128,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="dot brown" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="172,91,49,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="128,67,36,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="dot brown" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="172,91,49,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="128,67,36,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="dot green" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="84,176,74,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="61,128,53,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol favorite="1" force_rhr="0" name="dot green" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="84,176,74,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="61,128,53,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="dot orange" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="247,128,30,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="179,92,21,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="dot orange" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="247,128,30,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="179,92,21,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="dot pink" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="242,125,191,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="179,93,142,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="dot pink" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="242,125,191,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="179,93,142,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="dot purple" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="149,74,162,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="117,58,128,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="dot purple" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="149,74,162,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="117,58,128,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="dot red" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="219,30,42,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="128,17,25,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol favorite="1" force_rhr="0" name="dot red" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="219,30,42,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="128,17,25,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="dot yellow" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="250,255,57,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="247,225,55,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="dot yellow" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="250,255,57,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="247,225,55,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Showcase" name="effect drop shadow" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="184,8,8,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="star" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="184,8,8,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.2" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="6.6" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol favorite="1" force_rhr="0" name="effect drop shadow" alpha="1" tags="Showcase" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="184,8,8,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="star"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="184,8,8,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.2"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="6.6"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
         <effect enabled="1" type="effectStack">
           <effect type="dropShadow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="drawSource">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="34" k="angle"/>
-        <prop v="255,0,0,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="star" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.2" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="7.2" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="34"/>
+        <prop k="color" v="255,0,0,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="star"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,0,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.2"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="7.2"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
         <effect enabled="0" type="effectStack">
           <effect type="drawSource">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Showcase" name="effect emboss" type="line">
-      <layer enabled="1" locked="1" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="0,0,0,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="4.06" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="effect emboss" alpha="1" tags="Showcase" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="1" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="4.06"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
         <effect enabled="0" type="effectStack">
           <effect type="dropShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="outerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="227,26,28,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="227,26,28,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
           <effect type="drawSource">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="228,169,169,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="3.6" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="228,169,169,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="3.6"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
         <effect enabled="1" type="effectStack">
           <effect type="dropShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="outerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
           <effect type="drawSource">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="239,47,172,255" k="single_color"/>
-            <prop v="1" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="2"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="239,47,172,255"/>
+            <prop k="spread" v="1"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Showcase" name="effect neon" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="227,26,28,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="1.86" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="effect neon" alpha="1" tags="Showcase" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="227,26,28,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="1.86"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
         <effect enabled="1" type="effectStack">
           <effect type="dropShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="outerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="239,41,41,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="239,41,41,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
           <effect type="drawSource">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0.854" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="0.146"/>
           </effect>
           <effect type="innerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.614" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.386"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Showcase" name="gradient   plasma" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="0,0,255,255" k="color"/>
-        <prop v="13,8,135,255" k="color1"/>
-        <prop v="240,249,33,255" k="color2"/>
-        <prop v="1" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="255,255,255,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="1,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0.0196078;27,6,141,255:0.0392157;38,5,145,255:0.0588235;47,5,150,255:0.0784314;56,4,154,255:0.0980392;65,4,157,255:0.117647;73,3,160,255:0.137255;81,2,163,255:0.156863;89,1,165,255:0.176471;97,0,167,255:0.196078;105,0,168,255:0.215686;113,0,168,255:0.235294;120,1,168,255:0.254902;128,4,168,255:0.27451;135,7,166,255:0.294118;142,12,164,255:0.313725;149,17,161,255:0.333333;156,23,158,255:0.352941;162,29,154,255:0.372549;168,34,150,255:0.392157;174,40,146,255:0.411765;180,46,141,255:0.431373;186,51,136,255:0.45098;191,57,132,255:0.470588;196,62,127,255:0.490196;201,68,122,255:0.509804;205,74,118,255:0.529412;210,79,113,255:0.54902;214,85,109,255:0.568627;218,91,105,255:0.588235;222,97,100,255:0.607843;226,102,96,255:0.627451;230,108,92,255:0.647059;233,114,87,255:0.666667;237,121,83,255:0.686275;240,127,79,255:0.705882;243,133,75,255:0.72549;245,140,70,255:0.745098;247,147,66,255:0.764706;249,154,62,255:0.784314;251,161,57,255:0.803922;252,168,53,255:0.823529;253,175,49,255:0.843137;254,183,45,255:0.862745;254,190,42,255:0.882353;253,198,39,255:0.901961;252,206,37,255:0.921569;251,215,36,255:0.941176;248,223,37,255:0.960784;246,232,38,255:0.980392;243,240,39,255" k="stops"/>
-        <prop v="1" k="type"/>
+    <symbol favorite="1" force_rhr="0" name="gradient   plasma" alpha="1" tags="Showcase" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="0,0,255,255"/>
+        <prop k="color1" v="13,8,135,255"/>
+        <prop k="color2" v="240,249,33,255"/>
+        <prop k="color_type" v="1"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="255,255,255,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="1,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="stops" v="0.0196078;27,6,141,255:0.0392157;38,5,145,255:0.0588235;47,5,150,255:0.0784314;56,4,154,255:0.0980392;65,4,157,255:0.117647;73,3,160,255:0.137255;81,2,163,255:0.156863;89,1,165,255:0.176471;97,0,167,255:0.196078;105,0,168,255:0.215686;113,0,168,255:0.235294;120,1,168,255:0.254902;128,4,168,255:0.27451;135,7,166,255:0.294118;142,12,164,255:0.313725;149,17,161,255:0.333333;156,23,158,255:0.352941;162,29,154,255:0.372549;168,34,150,255:0.392157;174,40,146,255:0.411765;180,46,141,255:0.431373;186,51,136,255:0.45098;191,57,132,255:0.470588;196,62,127,255:0.490196;201,68,122,255:0.509804;205,74,118,255:0.529412;210,79,113,255:0.54902;214,85,109,255:0.568627;218,91,105,255:0.588235;222,97,100,255:0.607843;226,102,96,255:0.627451;230,108,92,255:0.647059;233,114,87,255:0.666667;237,121,83,255:0.686275;240,127,79,255:0.705882;243,133,75,255:0.72549;245,140,70,255:0.745098;247,147,66,255:0.764706;249,154,62,255:0.784314;251,161,57,255:0.803922;252,168,53,255:0.823529;253,175,49,255:0.843137;254,183,45,255:0.862745;254,190,42,255:0.882353;253,198,39,255:0.901961;252,206,37,255:0.921569;251,215,36,255:0.941176;248,223,37,255:0.960784;246,232,38,255:0.980392;243,240,39,255"/>
+        <prop k="type" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="247,247,247,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.36" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gradient  gray fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="82,82,82,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="204,204,204,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="255,255,51,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="153,153,30,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="247,247,247,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.36"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="gradient blue fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="47,110,158,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="72,169,242,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
+    <symbol force_rhr="0" name="gradient  gray fill" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="82,82,82,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="204,204,204,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="38,89,128,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="gradient brown fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="80,40,18,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="179,90,43,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="179,90,42,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="179,90,42,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="255,255,51,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="153,153,30,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="gradient green fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="66,150,63,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="102,230,97,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
+    <symbol force_rhr="0" name="gradient blue fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="47,110,158,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="72,169,242,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="77,175,74,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="56,128,54,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="38,89,128,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="gradient orange fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="194,94,0,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="255,163,0,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
+    <symbol force_rhr="0" name="gradient brown fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="80,40,18,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="179,90,43,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="255,127,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="128,62,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="179,90,42,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="179,90,42,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="gradient green fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="66,150,63,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="102,230,97,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="77,175,74,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="56,128,54,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="gradient orange fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="194,94,0,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="255,163,0,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="255,127,0,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="128,62,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
         <effect enabled="0" type="effectStack">
           <effect type="dropShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="7" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="7"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="outerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
           <effect type="drawSource">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="gradient pink fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="210,109,163,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="247,163,208,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
+    <symbol force_rhr="0" name="gradient pink fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="210,109,163,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="247,163,208,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="247,129,191,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="153,80,119,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="gradient purple fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="93,48,100,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="170,87,183,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="152,78,163,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="119,61,128,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="247,129,191,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="153,80,119,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="gradient red fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="179,20,23,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="255,29,32,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
+    <symbol force_rhr="0" name="gradient purple fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="93,48,100,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="170,87,183,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="228,26,28,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="128,14,16,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="152,78,163,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="119,61,128,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="gradient red fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="179,20,23,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="255,29,32,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="228,26,28,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="128,14,16,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
         <effect enabled="0" type="effectStack">
           <effect type="dropShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="outerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
           <effect type="blur">
-            <prop v="0" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0" k="blur_method"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="blur_method" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="gradient yellow fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="GradientFill">
-        <prop v="0" k="angle"/>
-        <prop v="255,246,0,255" k="color"/>
-        <prop v="0,0,255,255" k="color1"/>
-        <prop v="0,255,0,255" k="color2"/>
-        <prop v="0" k="color_type"/>
-        <prop v="0" k="coordinate_mode"/>
-        <prop v="0" k="discrete"/>
-        <prop v="255,255,185,255" k="gradient_color2"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0.5,0" k="reference_point1"/>
-        <prop v="0" k="reference_point1_iscentroid"/>
-        <prop v="0.5,1" k="reference_point2"/>
-        <prop v="0" k="reference_point2_iscentroid"/>
-        <prop v="0" k="spread"/>
-        <prop v="0" k="type"/>
+    <symbol force_rhr="0" name="gradient yellow fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="GradientFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,246,0,255"/>
+        <prop k="color1" v="0,0,255,255"/>
+        <prop k="color2" v="0,255,0,255"/>
+        <prop k="color_type" v="0"/>
+        <prop k="coordinate_mode" v="0"/>
+        <prop k="discrete" v="0"/>
+        <prop k="gradient_color2" v="255,255,185,255"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="rampType" v="gradient"/>
+        <prop k="reference_point1" v="0.5,0"/>
+        <prop k="reference_point1_iscentroid" v="0"/>
+        <prop k="reference_point2" v="0.5,1"/>
+        <prop k="reference_point2_iscentroid" v="0"/>
+        <prop k="spread" v="0"/>
+        <prop k="type" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="255,255,51,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="247,225,55,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 1 dot" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="247,247,247,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="83,83,83,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="255,255,51,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="247,225,55,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="no"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 1 fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="247,247,247,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="82,82,82,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="gray 1 dot" alpha="1" tags="Grayscale" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="247,247,247,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="83,83,83,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 1 line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="247,247,247,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="gray 1 fill" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="247,247,247,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="82,82,82,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 2 dot" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="203,203,203,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="83,83,83,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="gray 1 line" alpha="1" tags="Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="247,247,247,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 2 fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="204,204,204,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="82,82,82,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="gray 2 dot" alpha="1" tags="Grayscale" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="203,203,203,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="83,83,83,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 2 line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="203,203,203,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="gray 2 fill" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="204,204,204,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="82,82,82,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 3 dot" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="149,149,149,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="247,247,247,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="gray 2 line" alpha="1" tags="Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="203,203,203,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Grayscale" name="gray 3 fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="150,150,150,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="247,247,247,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="gray 3 dot" alpha="1" tags="Grayscale" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="149,149,149,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="247,247,247,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 3 line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="149,149,149,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="gray 3 fill" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="150,150,150,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="247,247,247,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 4 dot" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="83,83,83,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="247,247,247,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="gray 3 line" alpha="1" tags="Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="149,149,149,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 4 fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="82,82,82,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="247,247,247,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="gray 4 dot" alpha="1" tags="Grayscale" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="83,83,83,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="247,247,247,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="gray 4 line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="83,83,83,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="gray 4 fill" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="82,82,82,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="247,247,247,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Grayscale" name="hashed black /" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="45" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed black /@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="0,0,0,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="gray 4 line" alpha="1" tags="Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="83,83,83,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="hashed black /" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="45"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed black /@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="0,0,0,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Grayscale" name="hashed black X" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="45" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed black X@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="0,0,0,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="hashed black X" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="45"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed black X@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="0,0,0,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="135" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed black X@1" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="0,0,0,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="135"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed black X@1" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="0,0,0,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Grayscale" name="hashed black \" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="135" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed black \@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="0,0,0,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="hashed black \" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="135"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed black \@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="0,0,0,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="hashed black |" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="90" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed black |@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="0,0,0,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed black |" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="90"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed black |@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="0,0,0,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="hashed black —" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="0" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed black —@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="0,0,0,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed black —" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed black —@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="0,0,0,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="hashed cblue /" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="45" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed cblue /@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="55,126,184,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed cblue /" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="45"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed cblue /@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="55,126,184,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="55,126,184,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="55,126,184,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="hashed cblue \" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="135" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed cblue \@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="55,126,184,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed cblue \" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="135"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed cblue \@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="55,126,184,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="55,126,184,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="55,126,184,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="hashed cgreen /" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="45" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed cgreen /@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="77,175,74,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed cgreen /" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="45"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed cgreen /@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="77,175,74,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="77,175,74,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="77,175,74,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="hashed cgreen \" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="135" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed cgreen \@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="77,175,74,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed cgreen \" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="135"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed cgreen \@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="77,175,74,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="77,175,74,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="77,175,74,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="hashed cred /" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="45" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed cred /@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="228,26,28,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed cred /" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="45"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed cred /@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="228,26,28,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="228,26,28,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="228,26,28,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="hashed cred \" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="135" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed cred \@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="228,26,28,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed cred \" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="135"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed cred \@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="228,26,28,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="228,26,28,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="228,26,28,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="hashed gray /" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="45" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed gray /@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="204,204,204,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed gray /" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="45"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed gray /@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="204,204,204,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="204,204,204,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="204,204,204,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="hashed gray \" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="LinePatternFill">
-        <prop v="135" k="angle"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="2" k="distance"/>
-        <prop v="0,0,0,0,0,0" k="distance_map_unit_scale"/>
-        <prop v="MM" k="distance_unit"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="0,0,0,0,0,0" k="line_width_map_unit_scale"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@hashed gray \@0" type="line">
-          <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-            <prop v="square" k="capstyle"/>
-            <prop v="5;2" k="customdash"/>
-            <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-            <prop v="MM" k="customdash_unit"/>
-            <prop v="0" k="draw_inside_polygon"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="204,204,204,255" k="line_color"/>
-            <prop v="solid" k="line_style"/>
-            <prop v="0.3" k="line_width"/>
-            <prop v="MM" k="line_width_unit"/>
-            <prop v="0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0" k="use_custom_dash"/>
-            <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="hashed gray \" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="LinePatternFill" locked="0" pass="0">
+        <prop k="angle" v="135"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="distance" v="2"/>
+        <prop k="distance_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_unit" v="MM"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@hashed gray \@0" alpha="1" type="line" clip_to_extent="1">
+          <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+            <prop k="capstyle" v="square"/>
+            <prop k="customdash" v="5;2"/>
+            <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="customdash_unit" v="MM"/>
+            <prop k="draw_inside_polygon" v="0"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="line_color" v="204,204,204,255"/>
+            <prop k="line_style" v="solid"/>
+            <prop k="line_width" v="0.3"/>
+            <prop k="line_width_unit" v="MM"/>
+            <prop k="offset" v="0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="ring_filter" v="0"/>
+            <prop k="use_custom_dash" v="0"/>
+            <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="204,204,204,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.46" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="204,204,204,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Showcase" name="honeycomb faux 3d" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="255,255,255,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="miter" k="joinstyle"/>
-        <prop v="hexagon" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="250,139,57,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="1" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="8.8" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="honeycomb faux 3d" alpha="1" tags="Showcase" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,255,255,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="miter"/>
+        <prop k="name" v="hexagon"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="250,139,57,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="1"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="8.8"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="250,176,124,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="hexagon" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="250,176,124,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.2" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="3.6" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale" name="outline black" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.96" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="outline blue" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="53,121,177,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="53,121,177,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.96" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="250,176,124,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="hexagon"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="250,176,124,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.2"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="3.6"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="outline green" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="77,175,74,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="77,175,74,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.96" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+    <symbol force_rhr="0" name="outline black" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.96"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="outline red" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="228,26,28,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="228,26,28,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.96" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
+    <symbol favorite="1" force_rhr="0" name="outline blue" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="53,121,177,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.96"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="outline green" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="77,175,74,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.96"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="outline red" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="228,26,28,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.96"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="outline xpattern" alpha="1" tags="Showcase" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="247,247,247,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="82,82,82,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="9"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_along_line" v="0"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@outline xpattern@1" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="77,175,74,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="56,128,54,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="2"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="9"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_along_line" v="4.5"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@outline xpattern@2" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="228,26,28,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="128,14,16,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="2"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="pattern circles" alpha="1" tags="Showcase" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="6"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="2"/>
+        <prop k="offset_along_line" v="0"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@pattern circles@1" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="255,255,255,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.4"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="2"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="6"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="-2"/>
+        <prop k="offset_along_line" v="0"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@pattern circles@2" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="255,255,255,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.4"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="2"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="pattern dot  blue" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="PointPatternFill" locked="0" pass="0">
+        <prop k="displacement_x" v="1.2"/>
+        <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_x_unit" v="MM"/>
+        <prop k="displacement_y" v="0"/>
+        <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_y_unit" v="MM"/>
+        <prop k="distance_x" v="2.4"/>
+        <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_x_unit" v="MM"/>
+        <prop k="distance_y" v="2.4"/>
+        <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_y_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@pattern dot  blue@0" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="55,126,184,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="55,126,184,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.2"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="0.6"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="55,126,184,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.36"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="pattern dot  green" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="PointPatternFill" locked="0" pass="0">
+        <prop k="displacement_x" v="1.2"/>
+        <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_x_unit" v="MM"/>
+        <prop k="displacement_y" v="0"/>
+        <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_y_unit" v="MM"/>
+        <prop k="distance_x" v="2.4"/>
+        <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_x_unit" v="MM"/>
+        <prop k="distance_y" v="2.4"/>
+        <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_y_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@pattern dot  green@0" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="77,175,74,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="77,175,74,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.2"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="0.6"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="77,175,74,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.36"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="pattern dot  red" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="PointPatternFill" locked="0" pass="0">
+        <prop k="displacement_x" v="1.2"/>
+        <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_x_unit" v="MM"/>
+        <prop k="displacement_y" v="0"/>
+        <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_y_unit" v="MM"/>
+        <prop k="distance_x" v="2.4"/>
+        <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_x_unit" v="MM"/>
+        <prop k="distance_y" v="2.4"/>
+        <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_y_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@pattern dot  red@0" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="228,26,28,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="228,26,28,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.2"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="0.6"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="228,26,28,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.36"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="pattern dot black" alpha="1" tags="Grayscale" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="PointPatternFill" locked="0" pass="0">
+        <prop k="displacement_x" v="1.2"/>
+        <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_x_unit" v="MM"/>
+        <prop k="displacement_y" v="0"/>
+        <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_y_unit" v="MM"/>
+        <prop k="distance_x" v="2.4"/>
+        <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_x_unit" v="MM"/>
+        <prop k="distance_y" v="2.4"/>
+        <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_y_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@pattern dot black@0" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.2"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="0.6"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.36"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="pattern zelda" alpha="1" tags="Showcase" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="255,96,17,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,96,17,255"/>
+        <prop k="outline_style" v="no"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="PointPatternFill" locked="0" pass="0">
+        <prop k="displacement_x" v="1.2"/>
+        <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_x_unit" v="MM"/>
+        <prop k="displacement_y" v="0"/>
+        <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_y_unit" v="MM"/>
+        <prop k="distance_x" v="4.8"/>
+        <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_x_unit" v="MM"/>
+        <prop k="distance_y" v="4.8"/>
+        <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_y_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@pattern zelda@1" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="255,190,93,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="triangle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="255,190,93,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.2"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="4.6"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="255,96,17,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.36"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="pointing arrow" alpha="1" tags="Showcase" type="line" clip_to_extent="1">
+      <layer enabled="1" class="ArrowLine" locked="0" pass="0">
+        <prop k="arrow_start_width" v="0.6"/>
+        <prop k="arrow_start_width_unit" v="MM"/>
+        <prop k="arrow_start_width_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="arrow_type" v="0"/>
+        <prop k="arrow_width" v="4"/>
+        <prop k="arrow_width_unit" v="MM"/>
+        <prop k="arrow_width_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="head_length" v="5.9"/>
+        <prop k="head_length_unit" v="MM"/>
+        <prop k="head_length_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="head_thickness" v="4.5"/>
+        <prop k="head_thickness_unit" v="MM"/>
+        <prop k="head_thickness_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="head_type" v="0"/>
+        <prop k="is_curved" v="1"/>
+        <prop k="is_repeated" v="1"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="ring_filter" v="0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@pointing arrow@0" alpha="1" type="fill" clip_to_extent="1">
+          <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+            <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="joinstyle" v="round"/>
+            <prop k="offset" v="-1.19999999999999996,1.39999999999999991"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="no"/>
+            <prop k="outline_width" v="0.46"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="style" v="solid"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+          <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+            <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="color" v="255,127,0,255"/>
+            <prop k="joinstyle" v="round"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="no"/>
+            <prop k="outline_width" v="0.46"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="style" v="solid"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
+          </layer>
+        </symbol>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="shield disability" alpha="1" tags="Showcase" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SvgMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="72,123,182,255"/>
+        <prop k="fixedAspectRatio" v="0"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="name" v="backgrounds/background_square_rounded.svg"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,255,255,255"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="6.8"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="SvgMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,255,255,255"/>
+        <prop k="fixedAspectRatio" v="0"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="name" v="symbol/disability_accessibility2.svg"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,255,255,255"/>
+        <prop k="outline_width" v="0.1"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4.8"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="simple  black" alpha="1" tags="Grayscale,Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="0,0,0,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,255,255,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="simple  black line" alpha="1" tags="Colorful,Grayscale" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="simple  white" alpha="1" tags="Grayscale,Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="255,255,255,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="simple blue fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="55,126,184,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="38,89,128,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="simple blue line" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="72,123,182,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="simple brown fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="179,90,42,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="102,51,24,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="simple brown line" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="172,91,49,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="simple green fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="77,175,74,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="56,128,54,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol favorite="1" force_rhr="0" name="simple green line" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="84,176,74,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="simple orange fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="255,127,0,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="128,62,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
         <effect enabled="0" type="effectStack">
           <effect type="dropShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="7"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="outerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
-          </effect>
-          <effect type="blur">
-            <prop v="0" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0" k="blur_method"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
-          </effect>
-          <effect type="innerShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
-          </effect>
-          <effect type="innerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
-          </effect>
-        </effect>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Showcase" name="outline xpattern" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="247,247,247,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="82,82,82,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="9" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@outline xpattern@1" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="77,175,74,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="56,128,54,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="2" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="9" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="4.5" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@outline xpattern@2" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="228,26,28,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="128,14,16,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="2" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Showcase" name="pattern circles" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0,0,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="6" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="2" k="offset"/>
-        <prop v="0" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@pattern circles@1" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="255,255,255,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.4" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="2" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="6" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="-2" k="offset"/>
-        <prop v="0" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@pattern circles@2" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="255,255,255,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.4" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="2" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="pattern dot  blue" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="PointPatternFill">
-        <prop v="1.2" k="displacement_x"/>
-        <prop v="0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-        <prop v="MM" k="displacement_x_unit"/>
-        <prop v="0" k="displacement_y"/>
-        <prop v="0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-        <prop v="MM" k="displacement_y_unit"/>
-        <prop v="2.4" k="distance_x"/>
-        <prop v="0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-        <prop v="MM" k="distance_x_unit"/>
-        <prop v="2.4" k="distance_y"/>
-        <prop v="0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-        <prop v="MM" k="distance_y_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@pattern dot  blue@0" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="55,126,184,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="55,126,184,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.2" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="0.6" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="55,126,184,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.36" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="pattern dot  green" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="PointPatternFill">
-        <prop v="1.2" k="displacement_x"/>
-        <prop v="0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-        <prop v="MM" k="displacement_x_unit"/>
-        <prop v="0" k="displacement_y"/>
-        <prop v="0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-        <prop v="MM" k="displacement_y_unit"/>
-        <prop v="2.4" k="distance_x"/>
-        <prop v="0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-        <prop v="MM" k="distance_x_unit"/>
-        <prop v="2.4" k="distance_y"/>
-        <prop v="0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-        <prop v="MM" k="distance_y_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@pattern dot  green@0" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="77,175,74,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="77,175,74,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.2" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="0.6" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="77,175,74,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.36" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="pattern dot  red" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="PointPatternFill">
-        <prop v="1.2" k="displacement_x"/>
-        <prop v="0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-        <prop v="MM" k="displacement_x_unit"/>
-        <prop v="0" k="displacement_y"/>
-        <prop v="0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-        <prop v="MM" k="displacement_y_unit"/>
-        <prop v="2.4" k="distance_x"/>
-        <prop v="0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-        <prop v="MM" k="distance_x_unit"/>
-        <prop v="2.4" k="distance_y"/>
-        <prop v="0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-        <prop v="MM" k="distance_y_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@pattern dot  red@0" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="228,26,28,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="228,26,28,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.2" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="0.6" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="228,26,28,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.36" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Grayscale" name="pattern dot black" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="PointPatternFill">
-        <prop v="1.2" k="displacement_x"/>
-        <prop v="0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-        <prop v="MM" k="displacement_x_unit"/>
-        <prop v="0" k="displacement_y"/>
-        <prop v="0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-        <prop v="MM" k="displacement_y_unit"/>
-        <prop v="2.4" k="distance_x"/>
-        <prop v="0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-        <prop v="MM" k="distance_x_unit"/>
-        <prop v="2.4" k="distance_y"/>
-        <prop v="0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-        <prop v="MM" k="distance_y_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@pattern dot black@0" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.2" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="0.6" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.36" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Showcase" name="pattern zelda" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="255,96,17,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,96,17,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="PointPatternFill">
-        <prop v="1.2" k="displacement_x"/>
-        <prop v="0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-        <prop v="MM" k="displacement_x_unit"/>
-        <prop v="0" k="displacement_y"/>
-        <prop v="0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-        <prop v="MM" k="displacement_y_unit"/>
-        <prop v="4.8" k="distance_x"/>
-        <prop v="0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-        <prop v="MM" k="distance_x_unit"/>
-        <prop v="4.8" k="distance_y"/>
-        <prop v="0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-        <prop v="MM" k="distance_y_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@pattern zelda@1" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="255,190,93,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="triangle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="255,190,93,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.2" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="4.6" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
-          </layer>
-        </symbol>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,96,17,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.36" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="no" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Showcase" name="pointing arrow" type="line">
-      <layer enabled="1" locked="0" pass="0" class="ArrowLine">
-        <prop v="0.6" k="arrow_start_width"/>
-        <prop v="MM" k="arrow_start_width_unit"/>
-        <prop v="0,0,0,0,0,0" k="arrow_start_width_unit_scale"/>
-        <prop v="0" k="arrow_type"/>
-        <prop v="4" k="arrow_width"/>
-        <prop v="MM" k="arrow_width_unit"/>
-        <prop v="0,0,0,0,0,0" k="arrow_width_unit_scale"/>
-        <prop v="5.9" k="head_length"/>
-        <prop v="MM" k="head_length_unit"/>
-        <prop v="0,0,0,0,0,0" k="head_length_unit_scale"/>
-        <prop v="4.5" k="head_thickness"/>
-        <prop v="MM" k="head_thickness_unit"/>
-        <prop v="0,0,0,0,0,0" k="head_thickness_unit_scale"/>
-        <prop v="0" k="head_type"/>
-        <prop v="1" k="is_curved"/>
-        <prop v="1" k="is_repeated"/>
-        <prop v="0" k="offset"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-        <symbol alpha="1" clip_to_extent="1" name="@pointing arrow@0" type="fill">
-          <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-            <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="round" k="joinstyle"/>
-            <prop v="-1.19999999999999996,1.39999999999999991" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="no" k="outline_style"/>
-            <prop v="0.46" k="outline_width"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="solid" k="style"/>
-          </layer>
-          <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-            <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-            <prop v="255,127,0,255" k="color"/>
-            <prop v="round" k="joinstyle"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="no" k="outline_style"/>
-            <prop v="0.46" k="outline_width"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="solid" k="style"/>
-          </layer>
-        </symbol>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Showcase" name="shield disability" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SvgMarker">
-        <prop v="0" k="angle"/>
-        <prop v="72,123,182,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="backgrounds/background_square_rounded.svg" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,255,255,255" k="outline_color"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="6.8" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SvgMarker">
-        <prop v="0" k="angle"/>
-        <prop v="255,255,255,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="symbol/disability_accessibility2.svg" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,255,255,255" k="outline_color"/>
-        <prop v="0.1" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4.8" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale,Colorful" name="simple  black" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,255,255,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful,Grayscale" name="simple  black line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0,0,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Grayscale,Colorful" name="simple  white" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="255,255,255,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="simple blue fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="55,126,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="38,89,128,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="simple blue line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="72,123,182,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple brown fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="179,90,42,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="102,51,24,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple brown line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="172,91,49,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="simple green fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="77,175,74,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="56,128,54,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="simple green line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="84,176,74,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple orange fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="255,127,0,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="128,62,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-        <effect enabled="0" type="effectStack">
-          <effect type="dropShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="7" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
-          </effect>
-          <effect type="outerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
           <effect type="drawSource">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple orange line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="247,128,30,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="simple orange line" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="247,128,30,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple pink fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="247,129,191,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="153,80,119,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="simple pink fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="247,129,191,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="153,80,119,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple pink line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="242,125,191,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="simple pink line" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="242,125,191,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple purple fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="152,78,163,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="119,61,128,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="simple purple fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="152,78,163,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="119,61,128,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple purple line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="149,74,162,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="simple purple line" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="149,74,162,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="simple red fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="228,26,28,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="128,14,16,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol favorite="1" force_rhr="0" name="simple red fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="228,26,28,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="128,14,16,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
         <effect enabled="0" type="effectStack">
           <effect type="dropShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="outerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
           <effect type="blur">
-            <prop v="0" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0" k="blur_method"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="blur_method" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerShadow">
-            <prop v="13" k="blend_mode"/>
-            <prop v="10" k="blur_level"/>
-            <prop v="0,0,0,255" k="color"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="135" k="offset_angle"/>
-            <prop v="2" k="offset_distance"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,0,0,0" k="offset_unit_scale"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="13"/>
+            <prop k="blur_level" v="10"/>
+            <prop k="color" v="0,0,0,255"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="offset_angle" v="135"/>
+            <prop k="offset_distance" v="2"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="offset_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="opacity" v="1"/>
           </effect>
           <effect type="innerGlow">
-            <prop v="0" k="blend_mode"/>
-            <prop v="3" k="blur_level"/>
-            <prop v="0,0,255,255" k="color1"/>
-            <prop v="0,255,0,255" k="color2"/>
-            <prop v="0" k="color_type"/>
-            <prop v="0" k="discrete"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="0" k="enabled"/>
-            <prop v="255,255,255,255" k="single_color"/>
-            <prop v="2" k="spread"/>
-            <prop v="MM" k="spread_unit"/>
-            <prop v="0,0,0,0,0,0" k="spread_unit_scale"/>
-            <prop v="0.5" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="blur_level" v="3"/>
+            <prop k="color1" v="0,0,255,255"/>
+            <prop k="color2" v="0,255,0,255"/>
+            <prop k="color_type" v="0"/>
+            <prop k="discrete" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="0"/>
+            <prop k="opacity" v="0.5"/>
+            <prop k="rampType" v="gradient"/>
+            <prop k="single_color" v="255,255,255,255"/>
+            <prop k="spread" v="2"/>
+            <prop k="spread_unit" v="MM"/>
+            <prop k="spread_unit_scale" v="3x:0,0,0,0,0,0"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Colorful" name="simple red line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="219,30,42,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="simple red line" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="219,30,42,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple yellow fill" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="255,255,51,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="247,225,55,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="simple yellow fill" alpha="1" tags="Colorful" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="255,255,51,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="247,225,55,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="simple yellow line" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="250,255,57,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="simple yellow line" alpha="1" tags="Colorful" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="250,255,57,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo airport" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SvgMarker">
-        <prop v="0" k="angle"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="transport/transport_airport.svg" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,255,255,255" k="outline_color"/>
-        <prop v="0.6" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="6" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="topo airport" alpha="1" tags="Topology" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SvgMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="0,0,0,255"/>
+        <prop k="fixedAspectRatio" v="0"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="name" v="transport/transport_airport.svg"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,255,255,255"/>
+        <prop k="outline_width" v="0.6"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="6"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SvgMarker">
-        <prop v="0" k="angle"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="transport/transport_airport.svg" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,255,255,255" k="outline_color"/>
-        <prop v="0" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="6" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo building" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="47,47,47,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="134,134,134,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo camp" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SvgMarker">
-        <prop v="0" k="angle"/>
-        <prop v="255,255,255,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="backgrounds/background_square_rounded.svg" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="6.2" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SvgMarker">
-        <prop v="0" k="angle"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="accommodation/accommodation_camping.svg" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="0.1" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+      <layer enabled="1" class="SvgMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="0,0,0,255"/>
+        <prop k="fixedAspectRatio" v="0"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="name" v="transport/transport_airport.svg"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,255,255,255"/>
+        <prop k="outline_width" v="0"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="6"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo foot" type="line">
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="2.2" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@topo foot@0" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="255,0,0,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="circle" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.4" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="0.36" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="topo building" alpha="1" tags="Topology" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="47,47,47,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="134,134,134,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="topo camp" alpha="1" tags="Topology" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SvgMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,255,255,255"/>
+        <prop k="fixedAspectRatio" v="0"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="name" v="backgrounds/background_square_rounded.svg"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="6.2"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="SvgMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="0,0,0,255"/>
+        <prop k="fixedAspectRatio" v="0"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="name" v="accommodation/accommodation_camping.svg"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_width" v="0.1"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="topo foot" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="2.2"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_along_line" v="0"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@topo foot@0" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="255,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="circle"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.4"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="0.36"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo forest" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="148,209,128,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="143,181,131,255" k="outline_color"/>
-        <prop v="no" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="topo forest" alpha="1" tags="Topology" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="148,209,128,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="143,181,131,255"/>
+        <prop k="outline_style" v="no"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Topology" name="topo hospital" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="255,255,255,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="227,26,28,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="5.2" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol favorite="1" force_rhr="0" name="topo hospital" alpha="1" tags="Topology" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,255,255,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="227,26,28,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="5.2"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="227,26,28,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="cross_fill" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="227,26,28,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.2" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="3" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
-      </layer>
-    </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo hydrology" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="100,152,210,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.66" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="227,26,28,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="cross_fill"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="227,26,28,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.2"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="3"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Topology" name="topo main road" type="line">
-      <layer enabled="1" locked="1" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="0,0,0,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="2.06" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="255,96,17,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="1.46" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="topo hydrology" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="100,152,210,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.66"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo path" type="line">
-      <layer enabled="1" locked="0" pass="1" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="3;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0,0,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.36" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="1" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="topo main road" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="1" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="2.06"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="255,96,17,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="1.46"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Topology" name="topo pop capital" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="255,255,255,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.2" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="3.2" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
-      </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="0.7" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="topo path" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="1">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="3;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.36"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="1"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo pop city" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="255,255,255,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="circle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0,0,0,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.2" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="2.4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol favorite="1" force_rhr="0" name="topo pop capital" alpha="1" tags="Topology" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,255,255,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.2"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="3.2"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="0,0,0,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="0.7"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo pop house" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="square" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,255,255,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="1.6" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="topo pop city" alpha="1" tags="Topology" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="255,255,255,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="circle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="0,0,0,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.2"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="2.4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo pop village" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="0,0,0,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="triangle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,255,255,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="area" k="scale_method"/>
-        <prop v="2.8" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="topo pop house" alpha="1" tags="Topology" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="0,0,0,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="square"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,255,255,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="1.6"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+      </layer>
+    </symbol>
+    <symbol force_rhr="0" name="topo pop village" alpha="1" tags="Topology" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="0,0,0,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="triangle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,255,255,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="area"/>
+        <prop k="size" v="2.8"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
         <effect enabled="0" type="effectStack">
           <effect type="drawSource">
-            <prop v="0" k="blend_mode"/>
-            <prop v="2" k="draw_mode"/>
-            <prop v="1" k="enabled"/>
-            <prop v="0" k="transparency"/>
+            <prop k="blend_mode" v="0"/>
+            <prop k="draw_mode" v="2"/>
+            <prop k="enabled" v="1"/>
+            <prop k="opacity" v="1"/>
           </effect>
         </effect>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Topology" name="topo railway" type="line">
-      <layer enabled="1" locked="1" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="0,0,0,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.4" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="topo railway" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="1" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.4"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="3" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@topo railway@1" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="255,0,0,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="line" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="0,0,0,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.2" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="2.4" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="3"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_along_line" v="0"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@topo railway@1" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="255,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="line"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="0,0,0,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.2"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="2.4"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" favorite="1" tags="Topology" name="topo road" type="line">
-      <layer enabled="1" locked="1" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="0,0,0,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="1.06" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol favorite="1" force_rhr="0" name="topo road" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="1" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="0,0,0,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="1.06"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="round" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="255,255,255,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.86" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="round"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="255,255,255,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.86"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo steps" type="line">
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="round" k="joinstyle"/>
-        <prop v="134,134,134,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="-1.4" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+    <symbol force_rhr="0" name="topo steps" alpha="1" tags="Topology" type="line" clip_to_extent="1">
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="round"/>
+        <prop k="line_color" v="134,134,134,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="-1.4"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="SimpleLine">
-        <prop v="square" k="capstyle"/>
-        <prop v="5;2" k="customdash"/>
-        <prop v="0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-        <prop v="MM" k="customdash_unit"/>
-        <prop v="0" k="draw_inside_polygon"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="134,134,134,255" k="line_color"/>
-        <prop v="solid" k="line_style"/>
-        <prop v="0.26" k="line_width"/>
-        <prop v="MM" k="line_width_unit"/>
-        <prop v="1.4" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="0" k="use_custom_dash"/>
-        <prop v="0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <layer enabled="1" class="SimpleLine" locked="0" pass="0">
+        <prop k="capstyle" v="square"/>
+        <prop k="customdash" v="5;2"/>
+        <prop k="customdash_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="customdash_unit" v="MM"/>
+        <prop k="draw_inside_polygon" v="0"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="line_color" v="134,134,134,255"/>
+        <prop k="line_style" v="solid"/>
+        <prop k="line_width" v="0.26"/>
+        <prop k="line_width_unit" v="MM"/>
+        <prop k="offset" v="1.4"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="use_custom_dash" v="0"/>
+        <prop k="width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="MarkerLine">
-        <prop v="1.5" k="interval"/>
-        <prop v="0,0,0,0,0,0" k="interval_map_unit_scale"/>
-        <prop v="MM" k="interval_unit"/>
-        <prop v="0" k="offset"/>
-        <prop v="0" k="offset_along_line"/>
-        <prop v="0,0,0,0,0,0" k="offset_along_line_map_unit_scale"/>
-        <prop v="MM" k="offset_along_line_unit"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="interval" k="placement"/>
-        <prop v="1" k="rotate"/>
-        <symbol alpha="1" clip_to_extent="1" name="@topo steps@2" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="0" k="angle"/>
-            <prop v="255,0,0,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="line" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="69,69,69,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.2" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="area" k="scale_method"/>
-            <prop v="1.1" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+      <layer enabled="1" class="MarkerLine" locked="0" pass="0">
+        <prop k="interval" v="1.5"/>
+        <prop k="interval_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="interval_unit" v="MM"/>
+        <prop k="offset" v="0"/>
+        <prop k="offset_along_line" v="0"/>
+        <prop k="offset_along_line_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_along_line_unit" v="MM"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="placement" v="interval"/>
+        <prop k="ring_filter" v="0"/>
+        <prop k="rotate" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@topo steps@2" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="0"/>
+            <prop k="color" v="255,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="line"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="69,69,69,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.2"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="area"/>
+            <prop k="size" v="1.1"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology,Showcase" name="topo swamp" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="163,205,185,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="114,133,132,255" k="outline_color"/>
-        <prop v="no" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="topo swamp" alpha="1" tags="Topology,Showcase" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="163,205,185,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="114,133,132,255"/>
+        <prop k="outline_style" v="no"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
-      <layer enabled="1" locked="0" pass="0" class="PointPatternFill">
-        <prop v="5" k="displacement_x"/>
-        <prop v="0,0,0,0,0,0" k="displacement_x_map_unit_scale"/>
-        <prop v="MM" k="displacement_x_unit"/>
-        <prop v="1.6" k="displacement_y"/>
-        <prop v="0,0,0,0,0,0" k="displacement_y_map_unit_scale"/>
-        <prop v="MM" k="displacement_y_unit"/>
-        <prop v="11.4" k="distance_x"/>
-        <prop v="0,0,0,0,0,0" k="distance_x_map_unit_scale"/>
-        <prop v="MM" k="distance_x_unit"/>
-        <prop v="6.6" k="distance_y"/>
-        <prop v="0,0,0,0,0,0" k="distance_y_map_unit_scale"/>
-        <prop v="MM" k="distance_y_unit"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <symbol alpha="1" clip_to_extent="1" name="@topo swamp@1" type="marker">
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="90" k="angle"/>
-            <prop v="255,0,0,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="line" k="name"/>
-            <prop v="0.80000000000000004,1.39999999999999991" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="111,155,204,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.4" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="2.2" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+      <layer enabled="1" class="PointPatternFill" locked="0" pass="0">
+        <prop k="displacement_x" v="5"/>
+        <prop k="displacement_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_x_unit" v="MM"/>
+        <prop k="displacement_y" v="1.6"/>
+        <prop k="displacement_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="displacement_y_unit" v="MM"/>
+        <prop k="distance_x" v="11.4"/>
+        <prop k="distance_x_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_x_unit" v="MM"/>
+        <prop k="distance_y" v="6.6"/>
+        <prop k="distance_y_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="distance_y_unit" v="MM"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
+        <symbol force_rhr="0" name="@topo swamp@1" alpha="1" type="marker" clip_to_extent="1">
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="90"/>
+            <prop k="color" v="255,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="line"/>
+            <prop k="offset" v="0.80000000000000004,1.39999999999999991"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="111,155,204,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.4"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="2.2"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="90" k="angle"/>
-            <prop v="255,0,0,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="line" k="name"/>
-            <prop v="0,0" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="111,155,204,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.4" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="3.8" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="90"/>
+            <prop k="color" v="255,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="line"/>
+            <prop k="offset" v="0,0"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="111,155,204,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.4"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="3.8"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
-          <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-            <prop v="90" k="angle"/>
-            <prop v="255,0,0,255" k="color"/>
-            <prop v="1" k="horizontal_anchor_point"/>
-            <prop v="bevel" k="joinstyle"/>
-            <prop v="line" k="name"/>
-            <prop v="-0.80000000000000004,1.79999999999999982" k="offset"/>
-            <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-            <prop v="MM" k="offset_unit"/>
-            <prop v="111,155,204,255" k="outline_color"/>
-            <prop v="solid" k="outline_style"/>
-            <prop v="0.4" k="outline_width"/>
-            <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-            <prop v="MM" k="outline_width_unit"/>
-            <prop v="diameter" k="scale_method"/>
-            <prop v="3.8" k="size"/>
-            <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-            <prop v="MM" k="size_unit"/>
-            <prop v="1" k="vertical_anchor_point"/>
+          <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+            <prop k="angle" v="90"/>
+            <prop k="color" v="255,0,0,255"/>
+            <prop k="horizontal_anchor_point" v="1"/>
+            <prop k="joinstyle" v="bevel"/>
+            <prop k="name" v="line"/>
+            <prop k="offset" v="-0.80000000000000004,1.79999999999999982"/>
+            <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="offset_unit" v="MM"/>
+            <prop k="outline_color" v="111,155,204,255"/>
+            <prop k="outline_style" v="solid"/>
+            <prop k="outline_width" v="0.4"/>
+            <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="outline_width_unit" v="MM"/>
+            <prop k="scale_method" v="diameter"/>
+            <prop k="size" v="3.8"/>
+            <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+            <prop k="size_unit" v="MM"/>
+            <prop k="vertical_anchor_point" v="1"/>
+            <data_defined_properties>
+              <Option type="Map">
+                <Option name="name" value="" type="QString"/>
+                <Option name="properties"/>
+                <Option name="type" value="collection" type="QString"/>
+              </Option>
+            </data_defined_properties>
           </layer>
         </symbol>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo urban" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="255,166,184,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="255,136,162,255" k="outline_color"/>
-        <prop v="no" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="topo urban" alpha="1" tags="Topology" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="255,166,184,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="255,136,162,255"/>
+        <prop k="outline_style" v="no"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Topology" name="topo water" type="fill">
-      <layer enabled="1" locked="0" pass="0" class="SimpleFill">
-        <prop v="0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-        <prop v="165,191,221,255" k="color"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="100,152,210,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.26" k="outline_width"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="solid" k="style"/>
+    <symbol force_rhr="0" name="topo water" alpha="1" tags="Topology" type="fill" clip_to_extent="1">
+      <layer enabled="1" class="SimpleFill" locked="0" pass="0">
+        <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="color" v="165,191,221,255"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="100,152,210,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.26"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="style" v="solid"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="triangle blue" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="72,123,182,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="triangle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="50,87,128,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="triangle blue" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="72,123,182,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="triangle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="50,87,128,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="triangle green" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="84,176,74,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="triangle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="61,128,53,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="triangle green" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="84,176,74,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="triangle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="61,128,53,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
-    <symbol alpha="1" clip_to_extent="1" tags="Colorful" name="triangle red" type="marker">
-      <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-        <prop v="0" k="angle"/>
-        <prop v="219,30,42,255" k="color"/>
-        <prop v="1" k="horizontal_anchor_point"/>
-        <prop v="bevel" k="joinstyle"/>
-        <prop v="triangle" k="name"/>
-        <prop v="0,0" k="offset"/>
-        <prop v="0,0,0,0,0,0" k="offset_map_unit_scale"/>
-        <prop v="MM" k="offset_unit"/>
-        <prop v="128,17,25,255" k="outline_color"/>
-        <prop v="solid" k="outline_style"/>
-        <prop v="0.4" k="outline_width"/>
-        <prop v="0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-        <prop v="MM" k="outline_width_unit"/>
-        <prop v="diameter" k="scale_method"/>
-        <prop v="4" k="size"/>
-        <prop v="0,0,0,0,0,0" k="size_map_unit_scale"/>
-        <prop v="MM" k="size_unit"/>
-        <prop v="1" k="vertical_anchor_point"/>
+    <symbol force_rhr="0" name="triangle red" alpha="1" tags="Colorful" type="marker" clip_to_extent="1">
+      <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+        <prop k="angle" v="0"/>
+        <prop k="color" v="219,30,42,255"/>
+        <prop k="horizontal_anchor_point" v="1"/>
+        <prop k="joinstyle" v="bevel"/>
+        <prop k="name" v="triangle"/>
+        <prop k="offset" v="0,0"/>
+        <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="offset_unit" v="MM"/>
+        <prop k="outline_color" v="128,17,25,255"/>
+        <prop k="outline_style" v="solid"/>
+        <prop k="outline_width" v="0.4"/>
+        <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="outline_width_unit" v="MM"/>
+        <prop k="scale_method" v="diameter"/>
+        <prop k="size" v="4"/>
+        <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+        <prop k="size_unit" v="MM"/>
+        <prop k="vertical_anchor_point" v="1"/>
+        <data_defined_properties>
+          <Option type="Map">
+            <Option name="name" value="" type="QString"/>
+            <Option name="properties"/>
+            <Option name="type" value="collection" type="QString"/>
+          </Option>
+        </data_defined_properties>
       </layer>
     </symbol>
   </symbols>
   <colorramps>
     <colorramp favorite="1" name="Blues" type="gradient">
-      <prop v="247,251,255,255" k="color1"/>
-      <prop v="8,48,107,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.13;222,235,247,255:0.26;198,219,239,255:0.39;158,202,225,255:0.52;107,174,214,255:0.65;66,146,198,255:0.78;33,113,181,255:0.9;8,81,156,255" k="stops"/>
+      <prop k="color1" v="247,251,255,255"/>
+      <prop k="color2" v="8,48,107,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.13;222,235,247,255:0.26;198,219,239,255:0.39;158,202,225,255:0.52;107,174,214,255:0.65;66,146,198,255:0.78;33,113,181,255:0.9;8,81,156,255"/>
     </colorramp>
     <colorramp name="BrBG" type="gradient">
-      <prop v="166,97,26,255" k="color1"/>
-      <prop v="1,133,113,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;223,194,125,255:0.5;245,245,245,255:0.75;128,205,193,255" k="stops"/>
+      <prop k="color1" v="166,97,26,255"/>
+      <prop k="color2" v="1,133,113,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;223,194,125,255:0.5;245,245,245,255:0.75;128,205,193,255"/>
     </colorramp>
     <colorramp name="BuGn" type="gradient">
-      <prop v="237,248,251,255" k="color1"/>
-      <prop v="0,109,44,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;178,226,226,255:0.5;102,194,164,255:0.75;44,162,95,255" k="stops"/>
+      <prop k="color1" v="237,248,251,255"/>
+      <prop k="color2" v="0,109,44,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;178,226,226,255:0.5;102,194,164,255:0.75;44,162,95,255"/>
     </colorramp>
     <colorramp name="BuPu" type="gradient">
-      <prop v="237,248,251,255" k="color1"/>
-      <prop v="129,15,124,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;179,205,227,255:0.5;140,150,198,255:0.75;136,86,167,255" k="stops"/>
+      <prop k="color1" v="237,248,251,255"/>
+      <prop k="color2" v="129,15,124,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;179,205,227,255:0.5;140,150,198,255:0.75;136,86,167,255"/>
     </colorramp>
     <colorramp name="GnBu" type="gradient">
-      <prop v="240,249,232,255" k="color1"/>
-      <prop v="8,104,172,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;186,228,188,255:0.5;123,204,196,255:0.75;67,162,202,255" k="stops"/>
+      <prop k="color1" v="240,249,232,255"/>
+      <prop k="color2" v="8,104,172,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;186,228,188,255:0.5;123,204,196,255:0.75;67,162,202,255"/>
     </colorramp>
     <colorramp favorite="1" name="Greens" type="gradient">
-      <prop v="247,252,245,255" k="color1"/>
-      <prop v="0,68,27,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.13;229,245,224,255:0.26;199,233,192,255:0.39;161,217,155,255:0.52;116,196,118,255:0.65;65,171,93,255:0.78;35,139,69,255:0.9;0,109,44,255" k="stops"/>
+      <prop k="color1" v="247,252,245,255"/>
+      <prop k="color2" v="0,68,27,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.13;229,245,224,255:0.26;199,233,192,255:0.39;161,217,155,255:0.52;116,196,118,255:0.65;65,171,93,255:0.78;35,139,69,255:0.9;0,109,44,255"/>
     </colorramp>
     <colorramp favorite="1" name="Greys" type="gradient">
-      <prop v="250,250,250,255" k="color1"/>
-      <prop v="5,5,5,255" k="color2"/>
-      <prop v="0" k="discrete"/>
+      <prop k="color1" v="250,250,250,255"/>
+      <prop k="color2" v="5,5,5,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
     </colorramp>
     <colorramp name="Inferno" type="gradient">
-      <prop v="0,0,4,255" k="color1"/>
-      <prop v="252,255,164,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.0196078;2,2,12,255:0.0392157;5,4,23,255:0.0588235;10,7,34,255:0.0784314;16,9,45,255:0.0980392;22,11,57,255:0.117647;30,12,69,255:0.137255;38,12,81,255:0.156863;47,10,91,255:0.176471;56,9,98,255:0.196078;64,10,103,255:0.215686;73,11,106,255:0.235294;81,14,108,255:0.254902;89,16,110,255:0.27451;97,19,110,255:0.294118;105,22,110,255:0.313725;113,25,110,255:0.333333;120,28,109,255:0.352941;128,31,108,255:0.372549;136,34,106,255:0.392157;144,37,104,255:0.411765;152,39,102,255:0.431373;160,42,99,255:0.45098;168,46,95,255:0.470588;176,49,91,255:0.490196;183,53,87,255:0.509804;191,57,82,255:0.529412;198,61,77,255:0.54902;204,66,72,255:0.568627;211,71,67,255:0.588235;217,77,61,255:0.607843;223,83,55,255:0.627451;228,90,49,255:0.647059;233,97,43,255:0.666667;237,105,37,255:0.686275;241,113,31,255:0.705882;244,121,24,255:0.72549;247,130,18,255:0.745098;249,139,11,255:0.764706;250,148,7,255:0.784314;251,157,7,255:0.803922;252,166,12,255:0.823529;252,176,20,255:0.843137;251,186,31,255:0.862745;250,196,42,255:0.882353;248,205,55,255:0.901961;246,215,70,255:0.921569;244,225,86,255:0.941176;242,234,105,255:0.960784;242,242,125,255:0.980392;245,249,146,255" k="stops"/>
+      <prop k="color1" v="0,0,4,255"/>
+      <prop k="color2" v="252,255,164,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.0196078;2,2,12,255:0.0392157;5,4,23,255:0.0588235;10,7,34,255:0.0784314;16,9,45,255:0.0980392;22,11,57,255:0.117647;30,12,69,255:0.137255;38,12,81,255:0.156863;47,10,91,255:0.176471;56,9,98,255:0.196078;64,10,103,255:0.215686;73,11,106,255:0.235294;81,14,108,255:0.254902;89,16,110,255:0.27451;97,19,110,255:0.294118;105,22,110,255:0.313725;113,25,110,255:0.333333;120,28,109,255:0.352941;128,31,108,255:0.372549;136,34,106,255:0.392157;144,37,104,255:0.411765;152,39,102,255:0.431373;160,42,99,255:0.45098;168,46,95,255:0.470588;176,49,91,255:0.490196;183,53,87,255:0.509804;191,57,82,255:0.529412;198,61,77,255:0.54902;204,66,72,255:0.568627;211,71,67,255:0.588235;217,77,61,255:0.607843;223,83,55,255:0.627451;228,90,49,255:0.647059;233,97,43,255:0.666667;237,105,37,255:0.686275;241,113,31,255:0.705882;244,121,24,255:0.72549;247,130,18,255:0.745098;249,139,11,255:0.764706;250,148,7,255:0.784314;251,157,7,255:0.803922;252,166,12,255:0.823529;252,176,20,255:0.843137;251,186,31,255:0.862745;250,196,42,255:0.882353;248,205,55,255:0.901961;246,215,70,255:0.921569;244,225,86,255:0.941176;242,234,105,255:0.960784;242,242,125,255:0.980392;245,249,146,255"/>
     </colorramp>
     <colorramp favorite="1" name="Magma" type="gradient">
-      <prop v="0,0,4,255" k="color1"/>
-      <prop v="252,253,191,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.0196078;2,2,11,255:0.0392157;5,4,22,255:0.0588235;9,7,32,255:0.0784314;14,11,43,255:0.0980392;20,14,54,255:0.117647;26,16,66,255:0.137255;33,17,78,255:0.156863;41,17,90,255:0.176471;49,17,101,255:0.196078;57,15,110,255:0.215686;66,15,117,255:0.235294;74,16,121,255:0.254902;82,19,124,255:0.27451;90,22,126,255:0.294118;98,25,128,255:0.313725;106,28,129,255:0.333333;114,31,129,255:0.352941;121,34,130,255:0.372549;129,37,129,255:0.392157;137,40,129,255:0.411765;145,43,129,255:0.431373;153,45,128,255:0.45098;161,48,126,255:0.470588;170,51,125,255:0.490196;178,53,123,255:0.509804;186,56,120,255:0.529412;194,59,117,255:0.54902;202,62,114,255:0.568627;210,66,111,255:0.588235;217,70,107,255:0.607843;224,76,103,255:0.627451;231,82,99,255:0.647059;236,88,96,255:0.666667;241,96,93,255:0.686275;244,105,92,255:0.705882;247,114,92,255:0.72549;249,123,93,255:0.745098;251,133,96,255:0.764706;252,142,100,255:0.784314;253,152,105,255:0.803922;254,161,110,255:0.823529;254,170,116,255:0.843137;254,180,123,255:0.862745;254,189,130,255:0.882353;254,198,138,255:0.901961;254,207,146,255:0.921569;254,216,154,255:0.941176;253,226,163,255:0.960784;253,235,172,255:0.980392;252,244,182,255" k="stops"/>
+      <prop k="color1" v="0,0,4,255"/>
+      <prop k="color2" v="252,253,191,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.0196078;2,2,11,255:0.0392157;5,4,22,255:0.0588235;9,7,32,255:0.0784314;14,11,43,255:0.0980392;20,14,54,255:0.117647;26,16,66,255:0.137255;33,17,78,255:0.156863;41,17,90,255:0.176471;49,17,101,255:0.196078;57,15,110,255:0.215686;66,15,117,255:0.235294;74,16,121,255:0.254902;82,19,124,255:0.27451;90,22,126,255:0.294118;98,25,128,255:0.313725;106,28,129,255:0.333333;114,31,129,255:0.352941;121,34,130,255:0.372549;129,37,129,255:0.392157;137,40,129,255:0.411765;145,43,129,255:0.431373;153,45,128,255:0.45098;161,48,126,255:0.470588;170,51,125,255:0.490196;178,53,123,255:0.509804;186,56,120,255:0.529412;194,59,117,255:0.54902;202,62,114,255:0.568627;210,66,111,255:0.588235;217,70,107,255:0.607843;224,76,103,255:0.627451;231,82,99,255:0.647059;236,88,96,255:0.666667;241,96,93,255:0.686275;244,105,92,255:0.705882;247,114,92,255:0.72549;249,123,93,255:0.745098;251,133,96,255:0.764706;252,142,100,255:0.784314;253,152,105,255:0.803922;254,161,110,255:0.823529;254,170,116,255:0.843137;254,180,123,255:0.862745;254,189,130,255:0.882353;254,198,138,255:0.901961;254,207,146,255:0.921569;254,216,154,255:0.941176;253,226,163,255:0.960784;253,235,172,255:0.980392;252,244,182,255"/>
     </colorramp>
     <colorramp name="OrRd" type="gradient">
-      <prop v="254,240,217,255" k="color1"/>
-      <prop v="179,0,0,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;253,204,138,255:0.5;252,141,89,255:0.75;227,74,51,255" k="stops"/>
+      <prop k="color1" v="254,240,217,255"/>
+      <prop k="color2" v="179,0,0,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;253,204,138,255:0.5;252,141,89,255:0.75;227,74,51,255"/>
     </colorramp>
     <colorramp name="Oranges" type="gradient">
-      <prop v="255,245,235,255" k="color1"/>
-      <prop v="127,39,4,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.13;254,230,206,255:0.26;253,208,162,255:0.39;253,174,107,255:0.52;253,141,60,255:0.65;241,105,19,255:0.78;217,72,1,255:0.9;166,54,3,255" k="stops"/>
+      <prop k="color1" v="255,245,235,255"/>
+      <prop k="color2" v="127,39,4,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.13;254,230,206,255:0.26;253,208,162,255:0.39;253,174,107,255:0.52;253,141,60,255:0.65;241,105,19,255:0.78;217,72,1,255:0.9;166,54,3,255"/>
     </colorramp>
     <colorramp name="PRGn" type="gradient">
-      <prop v="123,50,148,255" k="color1"/>
-      <prop v="0,136,55,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;194,165,207,255:0.5;247,247,247,255:0.75;166,219,160,255" k="stops"/>
+      <prop k="color1" v="123,50,148,255"/>
+      <prop k="color2" v="0,136,55,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;194,165,207,255:0.5;247,247,247,255:0.75;166,219,160,255"/>
     </colorramp>
     <colorramp name="PiYG" type="gradient">
-      <prop v="208,28,139,255" k="color1"/>
-      <prop v="77,172,38,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;241,182,218,255:0.5;247,247,247,255:0.75;184,225,134,255" k="stops"/>
+      <prop k="color1" v="208,28,139,255"/>
+      <prop k="color2" v="77,172,38,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;241,182,218,255:0.5;247,247,247,255:0.75;184,225,134,255"/>
     </colorramp>
     <colorramp name="Plasma" type="gradient">
-      <prop v="13,8,135,255" k="color1"/>
-      <prop v="240,249,33,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.0196078;27,6,141,255:0.0392157;38,5,145,255:0.0588235;47,5,150,255:0.0784314;56,4,154,255:0.0980392;65,4,157,255:0.117647;73,3,160,255:0.137255;81,2,163,255:0.156863;89,1,165,255:0.176471;97,0,167,255:0.196078;105,0,168,255:0.215686;113,0,168,255:0.235294;120,1,168,255:0.254902;128,4,168,255:0.27451;135,7,166,255:0.294118;142,12,164,255:0.313725;149,17,161,255:0.333333;156,23,158,255:0.352941;162,29,154,255:0.372549;168,34,150,255:0.392157;174,40,146,255:0.411765;180,46,141,255:0.431373;186,51,136,255:0.45098;191,57,132,255:0.470588;196,62,127,255:0.490196;201,68,122,255:0.509804;205,74,118,255:0.529412;210,79,113,255:0.54902;214,85,109,255:0.568627;218,91,105,255:0.588235;222,97,100,255:0.607843;226,102,96,255:0.627451;230,108,92,255:0.647059;233,114,87,255:0.666667;237,121,83,255:0.686275;240,127,79,255:0.705882;243,133,75,255:0.72549;245,140,70,255:0.745098;247,147,66,255:0.764706;249,154,62,255:0.784314;251,161,57,255:0.803922;252,168,53,255:0.823529;253,175,49,255:0.843137;254,183,45,255:0.862745;254,190,42,255:0.882353;253,198,39,255:0.901961;252,206,37,255:0.921569;251,215,36,255:0.941176;248,223,37,255:0.960784;246,232,38,255:0.980392;243,240,39,255" k="stops"/>
+      <prop k="color1" v="13,8,135,255"/>
+      <prop k="color2" v="240,249,33,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.0196078;27,6,141,255:0.0392157;38,5,145,255:0.0588235;47,5,150,255:0.0784314;56,4,154,255:0.0980392;65,4,157,255:0.117647;73,3,160,255:0.137255;81,2,163,255:0.156863;89,1,165,255:0.176471;97,0,167,255:0.196078;105,0,168,255:0.215686;113,0,168,255:0.235294;120,1,168,255:0.254902;128,4,168,255:0.27451;135,7,166,255:0.294118;142,12,164,255:0.313725;149,17,161,255:0.333333;156,23,158,255:0.352941;162,29,154,255:0.372549;168,34,150,255:0.392157;174,40,146,255:0.411765;180,46,141,255:0.431373;186,51,136,255:0.45098;191,57,132,255:0.470588;196,62,127,255:0.490196;201,68,122,255:0.509804;205,74,118,255:0.529412;210,79,113,255:0.54902;214,85,109,255:0.568627;218,91,105,255:0.588235;222,97,100,255:0.607843;226,102,96,255:0.627451;230,108,92,255:0.647059;233,114,87,255:0.666667;237,121,83,255:0.686275;240,127,79,255:0.705882;243,133,75,255:0.72549;245,140,70,255:0.745098;247,147,66,255:0.764706;249,154,62,255:0.784314;251,161,57,255:0.803922;252,168,53,255:0.823529;253,175,49,255:0.843137;254,183,45,255:0.862745;254,190,42,255:0.882353;253,198,39,255:0.901961;252,206,37,255:0.921569;251,215,36,255:0.941176;248,223,37,255:0.960784;246,232,38,255:0.980392;243,240,39,255"/>
     </colorramp>
     <colorramp name="PuBu" type="gradient">
-      <prop v="241,238,246,255" k="color1"/>
-      <prop v="4,90,141,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;189,201,225,255:0.5;116,169,207,255:0.75;43,140,190,255" k="stops"/>
+      <prop k="color1" v="241,238,246,255"/>
+      <prop k="color2" v="4,90,141,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;189,201,225,255:0.5;116,169,207,255:0.75;43,140,190,255"/>
     </colorramp>
     <colorramp name="PuBuGn" type="gradient">
-      <prop v="246,239,247,255" k="color1"/>
-      <prop v="1,108,89,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;189,201,225,255:0.5;103,169,207,255:0.75;28,144,153,255" k="stops"/>
+      <prop k="color1" v="246,239,247,255"/>
+      <prop k="color2" v="1,108,89,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;189,201,225,255:0.5;103,169,207,255:0.75;28,144,153,255"/>
     </colorramp>
     <colorramp name="PuOr" type="gradient">
-      <prop v="230,97,1,255" k="color1"/>
-      <prop v="94,60,153,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;253,184,99,255:0.5;247,247,247,255:0.75;178,171,210,255" k="stops"/>
+      <prop k="color1" v="230,97,1,255"/>
+      <prop k="color2" v="94,60,153,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;253,184,99,255:0.5;247,247,247,255:0.75;178,171,210,255"/>
     </colorramp>
     <colorramp name="PuRd" type="gradient">
-      <prop v="241,238,246,255" k="color1"/>
-      <prop v="152,0,67,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;215,181,216,255:0.5;223,101,176,255:0.75;221,28,119,255" k="stops"/>
+      <prop k="color1" v="241,238,246,255"/>
+      <prop k="color2" v="152,0,67,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;215,181,216,255:0.5;223,101,176,255:0.75;221,28,119,255"/>
     </colorramp>
     <colorramp name="Purples" type="gradient">
-      <prop v="252,251,253,255" k="color1"/>
-      <prop v="63,0,125,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.13;239,237,245,255:0.26;218,218,235,255:0.39;188,189,220,255:0.52;158,154,200,255:0.65;128,125,186,255:0.75;106,81,163,255:0.9;84,39,143,255" k="stops"/>
+      <prop k="color1" v="252,251,253,255"/>
+      <prop k="color2" v="63,0,125,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.13;239,237,245,255:0.26;218,218,235,255:0.39;188,189,220,255:0.52;158,154,200,255:0.65;128,125,186,255:0.75;106,81,163,255:0.9;84,39,143,255"/>
     </colorramp>
     <colorramp name="RdBu" type="gradient">
-      <prop v="202,0,32,255" k="color1"/>
-      <prop v="5,113,176,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;244,165,130,255:0.5;247,247,247,255:0.75;146,197,222,255" k="stops"/>
+      <prop k="color1" v="202,0,32,255"/>
+      <prop k="color2" v="5,113,176,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;244,165,130,255:0.5;247,247,247,255:0.75;146,197,222,255"/>
     </colorramp>
     <colorramp favorite="1" name="RdGy" type="gradient">
-      <prop v="202,0,32,255" k="color1"/>
-      <prop v="64,64,64,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;244,165,130,255:0.5;255,255,255,255:0.75;186,186,186,255" k="stops"/>
+      <prop k="color1" v="202,0,32,255"/>
+      <prop k="color2" v="64,64,64,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;244,165,130,255:0.5;255,255,255,255:0.75;186,186,186,255"/>
     </colorramp>
     <colorramp name="RdPu" type="gradient">
-      <prop v="254,235,226,255" k="color1"/>
-      <prop v="122,1,119,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;251,180,185,255:0.5;247,104,161,255:0.75;197,27,138,255" k="stops"/>
+      <prop k="color1" v="254,235,226,255"/>
+      <prop k="color2" v="122,1,119,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;251,180,185,255:0.5;247,104,161,255:0.75;197,27,138,255"/>
     </colorramp>
     <colorramp name="RdYlBu" type="gradient">
-      <prop v="215,25,28,255" k="color1"/>
-      <prop v="44,123,182,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;253,174,97,255:0.5;255,255,191,255:0.75;171,217,233,255" k="stops"/>
+      <prop k="color1" v="215,25,28,255"/>
+      <prop k="color2" v="44,123,182,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;253,174,97,255:0.5;255,255,191,255:0.75;171,217,233,255"/>
     </colorramp>
     <colorramp name="RdYlGn" type="gradient">
-      <prop v="215,25,28,255" k="color1"/>
-      <prop v="26,150,65,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;253,174,97,255:0.5;255,255,192,255:0.75;166,217,106,255" k="stops"/>
+      <prop k="color1" v="215,25,28,255"/>
+      <prop k="color2" v="26,150,65,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;253,174,97,255:0.5;255,255,192,255:0.75;166,217,106,255"/>
     </colorramp>
     <colorramp favorite="1" name="Reds" type="gradient">
-      <prop v="255,245,240,255" k="color1"/>
-      <prop v="103,0,13,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.13;254,224,210,255:0.26;252,187,161,255:0.39;252,146,114,255:0.52;251,106,74,255:0.65;239,59,44,255:0.78;203,24,29,255:0.9;165,15,21,255" k="stops"/>
+      <prop k="color1" v="255,245,240,255"/>
+      <prop k="color2" v="103,0,13,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.13;254,224,210,255:0.26;252,187,161,255:0.39;252,146,114,255:0.52;251,106,74,255:0.65;239,59,44,255:0.78;203,24,29,255:0.9;165,15,21,255"/>
     </colorramp>
     <colorramp favorite="1" name="Spectral" type="gradient">
-      <prop v="215,25,28,255" k="color1"/>
-      <prop v="43,131,186,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;253,174,97,255:0.5;255,255,191,255:0.75;171,221,164,255" k="stops"/>
+      <prop k="color1" v="215,25,28,255"/>
+      <prop k="color2" v="43,131,186,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;253,174,97,255:0.5;255,255,191,255:0.75;171,221,164,255"/>
     </colorramp>
     <colorramp favorite="1" name="Viridis" type="gradient">
-      <prop v="68,1,84,255" k="color1"/>
-      <prop v="253,231,37,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.0196078;70,8,92,255:0.0392157;71,16,99,255:0.0588235;72,23,105,255:0.0784314;72,29,111,255:0.0980392;72,36,117,255:0.117647;71,42,122,255:0.137255;70,48,126,255:0.156863;69,55,129,255:0.176471;67,61,132,255:0.196078;65,66,135,255:0.215686;63,72,137,255:0.235294;61,78,138,255:0.254902;58,83,139,255:0.27451;56,89,140,255:0.294118;53,94,141,255:0.313725;51,99,141,255:0.333333;49,104,142,255:0.352941;46,109,142,255:0.372549;44,113,142,255:0.392157;42,118,142,255:0.411765;41,123,142,255:0.431373;39,128,142,255:0.45098;37,132,142,255:0.470588;35,137,142,255:0.490196;33,142,141,255:0.509804;32,146,140,255:0.529412;31,151,139,255:0.54902;30,156,137,255:0.568627;31,161,136,255:0.588235;33,165,133,255:0.607843;36,170,131,255:0.627451;40,174,128,255:0.647059;46,179,124,255:0.666667;53,183,121,255:0.686275;61,188,116,255:0.705882;70,192,111,255:0.72549;80,196,106,255:0.745098;90,200,100,255:0.764706;101,203,94,255:0.784314;112,207,87,255:0.803922;124,210,80,255:0.823529;137,213,72,255:0.843137;149,216,64,255:0.862745;162,218,55,255:0.882353;176,221,47,255:0.901961;189,223,38,255:0.921569;202,225,31,255:0.941176;216,226,25,255:0.960784;229,228,25,255:0.980392;241,229,29,255" k="stops"/>
+      <prop k="color1" v="68,1,84,255"/>
+      <prop k="color2" v="253,231,37,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.0196078;70,8,92,255:0.0392157;71,16,99,255:0.0588235;72,23,105,255:0.0784314;72,29,111,255:0.0980392;72,36,117,255:0.117647;71,42,122,255:0.137255;70,48,126,255:0.156863;69,55,129,255:0.176471;67,61,132,255:0.196078;65,66,135,255:0.215686;63,72,137,255:0.235294;61,78,138,255:0.254902;58,83,139,255:0.27451;56,89,140,255:0.294118;53,94,141,255:0.313725;51,99,141,255:0.333333;49,104,142,255:0.352941;46,109,142,255:0.372549;44,113,142,255:0.392157;42,118,142,255:0.411765;41,123,142,255:0.431373;39,128,142,255:0.45098;37,132,142,255:0.470588;35,137,142,255:0.490196;33,142,141,255:0.509804;32,146,140,255:0.529412;31,151,139,255:0.54902;30,156,137,255:0.568627;31,161,136,255:0.588235;33,165,133,255:0.607843;36,170,131,255:0.627451;40,174,128,255:0.647059;46,179,124,255:0.666667;53,183,121,255:0.686275;61,188,116,255:0.705882;70,192,111,255:0.72549;80,196,106,255:0.745098;90,200,100,255:0.764706;101,203,94,255:0.784314;112,207,87,255:0.803922;124,210,80,255:0.823529;137,213,72,255:0.843137;149,216,64,255:0.862745;162,218,55,255:0.882353;176,221,47,255:0.901961;189,223,38,255:0.921569;202,225,31,255:0.941176;216,226,25,255:0.960784;229,228,25,255:0.980392;241,229,29,255"/>
     </colorramp>
     <colorramp name="YlGn" type="gradient">
-      <prop v="255,255,204,255" k="color1"/>
-      <prop v="0,104,55,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;194,230,153,255:0.5;120,198,121,255:0.75;49,163,84,255" k="stops"/>
+      <prop k="color1" v="255,255,204,255"/>
+      <prop k="color2" v="0,104,55,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;194,230,153,255:0.5;120,198,121,255:0.75;49,163,84,255"/>
     </colorramp>
     <colorramp name="YlGnBu" type="gradient">
-      <prop v="255,255,204,255" k="color1"/>
-      <prop v="37,52,148,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;161,218,180,255:0.5;65,182,196,255:0.75;44,127,184,255" k="stops"/>
+      <prop k="color1" v="255,255,204,255"/>
+      <prop k="color2" v="37,52,148,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;161,218,180,255:0.5;65,182,196,255:0.75;44,127,184,255"/>
     </colorramp>
     <colorramp name="YlOrBr" type="gradient">
-      <prop v="255,255,212,255" k="color1"/>
-      <prop v="153,52,4,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;254,217,142,255:0.5;254,153,41,255:0.75;217,95,14,255" k="stops"/>
+      <prop k="color1" v="255,255,212,255"/>
+      <prop k="color2" v="153,52,4,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;254,217,142,255:0.5;254,153,41,255:0.75;217,95,14,255"/>
     </colorramp>
     <colorramp name="YlOrRd" type="gradient">
-      <prop v="255,255,178,255" k="color1"/>
-      <prop v="189,0,38,255" k="color2"/>
-      <prop v="0" k="discrete"/>
-      <prop v="0.25;254,204,92,255:0.5;253,141,60,255:0.75;240,59,32,255" k="stops"/>
+      <prop k="color1" v="255,255,178,255"/>
+      <prop k="color2" v="189,0,38,255"/>
+      <prop k="discrete" v="0"/>
+      <prop k="rampType" v="gradient"/>
+      <prop k="stops" v="0.25;254,204,92,255:0.5;253,141,60,255:0.75;240,59,32,255"/>
     </colorramp>
   </colorramps>
 </qgis_style>


### PR DESCRIPTION
## Description
This PR actually doesn't change anything visually when it comes to the default symbols we ship. However, the outline's simple line symbol layer is used for a bunch of polygon symbols when appropriate to make those symbols behave better when used with graduate / categorized renderers.

The default symbols won't be updated for pre-existing profiles (no easy way to do that), but it'll be a nice fix for new users.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
