### PR TITLE
Add better api docs on Property usage

### DIFF
--- a/src/core/layout/qgslayoutobject.h
+++ b/src/core/layout/qgslayoutobject.h
@@ -226,6 +226,7 @@ class CORE_EXPORT QgsLayoutObject: public QObject, public QgsExpressionContextGe
     /**
      * Returns a reference to the object's property collection, used for data defined overrides.
      * \see setDataDefinedProperties()
+     * \see DataDefinedProperty
      */
     const QgsPropertyCollection &dataDefinedProperties() const { return mDataDefinedProperties; } SIP_SKIP
 
@@ -233,6 +234,7 @@ class CORE_EXPORT QgsLayoutObject: public QObject, public QgsExpressionContextGe
      * Sets the objects's property collection, used for data defined overrides.
      * \param collection property collection. Existing properties will be replaced.
      * \see dataDefinedProperties()
+     * \see DataDefinedProperty
      */
     void setDataDefinedProperties( const QgsPropertyCollection &collection ) { mDataDefinedProperties = collection; }
 

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -308,6 +308,7 @@ class CORE_EXPORT QgsDiagramLayerSettings
     /**
      * Returns a reference to the diagram's property collection, used for data defined overrides.
      * \see setDataDefinedProperties()
+     * \see Property
      * \note not available in Python bindings
      * \since QGIS 3.0
      */
@@ -317,6 +318,7 @@ class CORE_EXPORT QgsDiagramLayerSettings
      * Sets the diagram's property collection, used for data defined overrides.
      * \param collection property collection. Existing properties will be replaced.
      * \see dataDefinedProperties()
+     * \see Property
      * \since QGIS 3.0
      */
     void setDataDefinedProperties( const QgsPropertyCollection &collection ) { mDataDefinedProperties = collection; }

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -793,6 +793,7 @@ class CORE_EXPORT QgsPalLayerSettings
     /**
      * Returns a reference to the label's property collection, used for data defined overrides.
      * \see setDataDefinedProperties()
+     * \see Property
      * \note not available in Python bindings
      * \since QGIS 3.0
      */
@@ -802,6 +803,7 @@ class CORE_EXPORT QgsPalLayerSettings
      * Sets the label's property collection, used for data defined overrides.
      * \param collection property collection. Existing properties will be replaced.
      * \see dataDefinedProperties()
+     * \see Property
      * \since QGIS 3.0
      */
     void setDataDefinedProperties( const QgsPropertyCollection &collection ) { mDataDefinedProperties = collection; }

--- a/src/core/qgspropertycollection.h
+++ b/src/core/qgspropertycollection.h
@@ -274,6 +274,14 @@ class CORE_EXPORT QgsAbstractPropertyCollection
  * Properties within a collection are referenced by an integer key. This is done to avoid the cost of
  * string creation and comparisons which would be required by a string key. The intended use case is that
  * a context specific enum is cast to int and used for the key value.
+ * Examples of such enums are :
+ * \see QgsLayoutObject::DataDefinedProperty
+ * \see QgsSymbolLayer::Property
+ * \see QgsPalLabeling::Property
+ * \see QgsAbstract3DSymbol::Property
+ * \see QgsDiagramLayerSettings::Property
+ * \see QgsPalLayerSettings::Property
+ * \see QgsWidgetWrapper::Property
  * \since QGIS 3.0
  */
 

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -319,6 +319,7 @@ class CORE_EXPORT QgsSymbolLayer
      * Sets a data defined property for the layer. Any existing property with the same key
      * will be overwritten.
      * \see dataDefinedProperties()
+     * \see Property
      * \since QGIS 3.0
      */
     virtual void setDataDefinedProperty( Property key, const QgsProperty &property );
@@ -377,6 +378,7 @@ class CORE_EXPORT QgsSymbolLayer
     /**
      * Returns a reference to the symbol layer's property collection, used for data defined overrides.
      * \see setDataDefinedProperties()
+     * \see Property
      * \since QGIS 3.0
      */
     QgsPropertyCollection &dataDefinedProperties() { return mDataDefinedProperties; }

--- a/src/gui/editorwidgets/core/qgswidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgswidgetwrapper.h
@@ -181,6 +181,7 @@ class GUI_EXPORT QgsWidgetWrapper : public QObject
     /**
      * Returns a reference to the editor widget's property collection, used for data defined overrides.
      * \see setDataDefinedProperties()
+     * \see Property
      * \since QGIS 3.0
      */
     const QgsPropertyCollection &dataDefinedProperties() const { return mPropertyCollection; }
@@ -189,6 +190,7 @@ class GUI_EXPORT QgsWidgetWrapper : public QObject
      * Sets the editor widget's property collection, used for data defined overrides.
      * \param collection property collection. Existing properties will be replaced.
      * \see dataDefinedProperties()
+     * \see Property
      * \since QGIS 3.0
      */
     void setDataDefinedProperties( const QgsPropertyCollection &collection ) { mPropertyCollection = collection; }


### PR DESCRIPTION
## Description
Using the Property system via PyQGIS, is not let's say straight forward the first time, so here some slight better apidocs

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
