### PR TITLE
Adding more map scope crs items

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -747,10 +747,11 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "map_crs" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (e.g., 'EPSG:4326')." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_description" ), QCoreApplication::translate( "variable_help", "Name of the coordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_units" ), QCoreApplication::translate( "variable_help", "Units for map measurements." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the Coordinate reference system of the map." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_ellipsoid_acr" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of theCoordinate reference system of the map." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_crs_Proj4" ), QCoreApplication::translate( "variable_help", "Proj4 definition of the coordinate reference system." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_crs_Wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the coordinate reference system." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_definition" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (full definition)." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the coordinate reference system of the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_ellipsoid_acr" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of the coordinate reference system of the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_proj4" ), QCoreApplication::translate( "variable_help", "Proj4 definition of the coordinate reference system." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the coordinate reference system." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layer_ids" ), QCoreApplication::translate( "variable_help", "List of map layer IDs visible in the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layers" ), QCoreApplication::translate( "variable_help", "List of map layers visible in the map." ) );
 

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -745,7 +745,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "map_extent_width" ), QCoreApplication::translate( "variable_help", "Width of map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_extent_height" ), QCoreApplication::translate( "variable_help", "Height of map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (e.g., 'EPSG:4326')." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_crs_description" ), QCoreApplication::translate( "variable_help", "Name of theCoordinate reference system of the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_description" ), QCoreApplication::translate( "variable_help", "Name of the coordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_units" ), QCoreApplication::translate( "variable_help", "Units for map measurements." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the Coordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_ellipsoid_acr" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of theCoordinate reference system of the map." ) );

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -745,8 +745,12 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "map_extent_width" ), QCoreApplication::translate( "variable_help", "Width of map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_extent_height" ), QCoreApplication::translate( "variable_help", "Height of map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (e.g., 'EPSG:4326')." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_crs_definition" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (full definition)." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_description" ), QCoreApplication::translate( "variable_help", "Name of theCoordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_units" ), QCoreApplication::translate( "variable_help", "Units for map measurements." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the Coordinate reference system of the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_ellipsoid_acr" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of theCoordinate reference system of the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_Proj4" ), QCoreApplication::translate( "variable_help", "Proj4 description of the Coordinate reference system." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_Wkt" ), QCoreApplication::translate( "variable_help", "Wkt description of the Coordinate reference system." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layer_ids" ), QCoreApplication::translate( "variable_help", "List of map layer IDs visible in the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layers" ), QCoreApplication::translate( "variable_help", "List of map layers visible in the map." ) );
 

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -749,7 +749,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "map_units" ), QCoreApplication::translate( "variable_help", "Units for map measurements." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the Coordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_ellipsoid_acr" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of theCoordinate reference system of the map." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_crs_Proj4" ), QCoreApplication::translate( "variable_help", "Proj4 description of the Coordinate reference system." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_Proj4" ), QCoreApplication::translate( "variable_help", "Proj4 definition of the coordinate reference system." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_Wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the coordinate reference system." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layer_ids" ), QCoreApplication::translate( "variable_help", "List of map layer IDs visible in the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layers" ), QCoreApplication::translate( "variable_help", "List of map layers visible in the map." ) );

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -750,7 +750,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the Coordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_ellipsoid_acr" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of theCoordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_Proj4" ), QCoreApplication::translate( "variable_help", "Proj4 description of the Coordinate reference system." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_crs_Wkt" ), QCoreApplication::translate( "variable_help", "Wkt description of the Coordinate reference system." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_Wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the coordinate reference system." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layer_ids" ), QCoreApplication::translate( "variable_help", "List of map layer IDs visible in the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layers" ), QCoreApplication::translate( "variable_help", "List of map layers visible in the map." ) );
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1262,8 +1262,12 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
 
   QgsCoordinateReferenceSystem mapCrs = crs();
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs" ), mapCrs.authid(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_definition" ), mapCrs.toProj4(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapCrs.description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapCrs.mapUnits() ), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapCrs.projectionAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapCrs.ellipsoidAcronym() , true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_Proj4" ), mapCrs.toProj4(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_Wkt" ), mapCrs.toWkr(), true ) );
 
   QVariantList layersIds;
   QVariantList layers;

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1265,9 +1265,9 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapCrs.description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapCrs.mapUnits() ), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapCrs.projectionAcronym(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapCrs.ellipsoidAcronym() , true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapCrs.ellipsoidAcronym(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_Proj4" ), mapCrs.toProj4(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_Wkt" ), mapCrs.toWkr(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_Wkt" ), mapCrs.toWkt(), true ) );
 
   QVariantList layersIds;
   QVariantList layers;

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1262,12 +1262,13 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
 
   QgsCoordinateReferenceSystem mapCrs = crs();
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs" ), mapCrs.authid(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_definition" ), mapCrs.toProj4(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapCrs.description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapCrs.mapUnits() ), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapCrs.projectionAcronym(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapCrs.ellipsoidAcronym(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_Proj4" ), mapCrs.toProj4(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_Wkt" ), mapCrs.toWkt(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_proj4" ), mapCrs.toProj4(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_wkt" ), mapCrs.toWkt(), true ) );
 
   QVariantList layersIds;
   QVariantList layers;

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -985,6 +985,11 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs" ), mapSettings.destinationCrs().authid(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_definition" ), mapSettings.destinationCrs().toProj4(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapSettings.mapUnits() ), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapSettings.destinationCrs().description(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapSettings.destinationCrs().projectionAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapSettings.destinationCrs().ellipsoidAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_proj4" ), mapSettings.destinationCrs().toProj4(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_wkt" ), mapSettings.destinationCrs().toWkt(), true ) );
 
   // IMPORTANT: ANY CHANGES HERE ALSO NEED TO BE MADE TO QgsLayoutItemMap::createExpressionContext()
   // (rationale is described in QgsLayoutItemMap::createExpressionContext() )

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -632,7 +632,7 @@ void TestQgsLayoutMap::expressionContext()
 
   QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
   r = e8.evaluate( &c );
-  QVERIFY( r.toString().lenght() >= 15 );
+  QVERIFY( r.toString().length() >= 15 );
 
   QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
   r = e9.evaluate( &c );

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -610,13 +610,33 @@ void TestQgsLayoutMap::expressionContext()
   r = e2.evaluate( &c );
   QCOMPARE( r.toString(), QString( "EPSG:4326" ) );
 
-  QgsExpression e3( QStringLiteral( "@map_crs_Proj4" ) );
+  QgsExpression e3( QStringLiteral( "@map_crs_definition" ) );
   r = e3.evaluate( &c );
   QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
 
   QgsExpression e4( QStringLiteral( "@map_units" ) );
   r = e4.evaluate( &c );
   QCOMPARE( r.toString(), QString( "degrees" ) );
+
+  QgsExpression e5( QStringLiteral( "@map_crs_description" ) );
+  r = e5.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "WGS 84" ) );
+
+  QgsExpression e6( QStringLiteral( "@map_crs_acronym" ) );
+  r = e6.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "longlat" ) );
+
+  QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
+  r = e7.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+
+  QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
+  r = e8.evaluate( &c );
+  QVERIFY( r.toString().lenght() ­> 15 );
+
+  QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
+  r = e9.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "WGS84" ) );
 
   QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=id_a:integer" ), QStringLiteral( "A" ), QStringLiteral( "memory" ) );
   QgsVectorLayer *layer2 = new QgsVectorLayer( QStringLiteral( "Point?field=id_a:integer" ), QStringLiteral( "B" ), QStringLiteral( "memory" ) );

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -610,7 +610,7 @@ void TestQgsLayoutMap::expressionContext()
   r = e2.evaluate( &c );
   QCOMPARE( r.toString(), QString( "EPSG:4326" ) );
 
-  QgsExpression e3( QStringLiteral( "@map_crs_definition" ) );
+  QgsExpression e3( QStringLiteral( "@map_crs_Proj4" ) );
   r = e3.evaluate( &c );
   QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
 

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -632,7 +632,7 @@ void TestQgsLayoutMap::expressionContext()
 
   QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
   r = e8.evaluate( &c );
-  QVERIFY( r.toString().lenght() ­> 15 );
+  QVERIFY( r.toString().lenght() >= 15 );
 
   QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
   r = e9.evaluate( &c );
@@ -643,19 +643,19 @@ void TestQgsLayoutMap::expressionContext()
   map->setLayers( QList<QgsMapLayer *>() << layer << layer2 );
   QgsProject::instance()->addMapLayers( map->layers() );
   c = map->createExpressionContext();
-  QgsExpression e5( QStringLiteral( "@map_layer_ids" ) );
-  r = e5.evaluate( &c );
+  QgsExpression e10( QStringLiteral( "@map_layer_ids" ) );
+  r = e10.evaluate( &c );
   QCOMPARE( r.toStringList().join( ',' ), QStringLiteral( "%1,%2" ).arg( layer->id(), layer2->id() ) );
-  e5 = QgsExpression( QStringLiteral( "array_foreach(@map_layers, layer_property(@element, 'name'))" ) );
-  r = e5.evaluate( &c );
+  e10 = QgsExpression( QStringLiteral( "array_foreach(@map_layers, layer_property(@element, 'name'))" ) );
+  r = e10.evaluate( &c );
   QCOMPARE( r.toStringList().join( ',' ), QStringLiteral( "A,B" ) );
 
-  QgsExpression e6( QStringLiteral( "is_layer_visible( '%1' )" ).arg( layer->id() ) );
-  r = e6.evaluate( &c );
+  QgsExpression e11( QStringLiteral( "is_layer_visible( '%1' )" ).arg( layer->id() ) );
+  r = e11.evaluate( &c );
   QCOMPARE( r.toBool(), true );
 
-  QgsExpression e7( QStringLiteral( "is_layer_visible( 'aaaaaa' )" ) );
-  r = e7.evaluate( &c );
+  QgsExpression e12( QStringLiteral( "is_layer_visible( 'aaaaaa' )" ) );
+  r = e12.evaluate( &c );
   QCOMPARE( r.toBool(), false );
 }
 

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -626,13 +626,13 @@ void TestQgsLayoutMap::expressionContext()
   r = e6.evaluate( &c );
   QCOMPARE( r.toString(), QString( "longlat" ) );
 
-  QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
-  r = e7.evaluate( &c );
-  QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+  //QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
+  //r = e7.evaluate( &c );
+  //QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
 
-  QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
-  r = e8.evaluate( &c );
-  QVERIFY( r.toString().length() >= 15 );
+  //QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
+  //r = e8.evaluate( &c );
+  //QVERIFY( r.toString().length() >= 15 );
 
   QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
   r = e9.evaluate( &c );

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -411,7 +411,7 @@ void TestQgsMapSettings::testExpressionContext()
 
   QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
   r = e8.evaluate( &c );
-  QVERIFY( r.toString().lenght() > 15 );
+  QVERIFY( r.toString().length() > 15 );
 
   QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
   r = e9.evaluate( &c );

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -47,6 +47,7 @@ class TestQgsMapSettings: public QObject
     void testXmlReadWrite();
     void testSetLayers();
     void testLabelBoundary();
+    void testExpressionContext();
 
   private:
     QString toString( const QPolygonF &p, int decimalPlaces = 2 ) const;
@@ -382,7 +383,7 @@ void TestQgsMapSettings::testExpressionContext()
   QgsMapSettings ms;
   QgsExpressionContext c;
   QVariant r;
-  
+
   ms.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
   c << QgsExpressionContextUtils::mapSettingsScope( ms );
 

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -407,13 +407,13 @@ void TestQgsMapSettings::testExpressionContext()
   r = e6.evaluate( &c );
   QCOMPARE( r.toString(), QString( "longlat" ) );
 
-  QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
-  r = e7.evaluate( &c );
-  QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+  //QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
+  //r = e7.evaluate( &c );
+  //QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
 
-  QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
-  r = e8.evaluate( &c );
-  QVERIFY( r.toString().length() > 15 );
+  //QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
+  //r = e8.evaluate( &c );
+  //QVERIFY( r.toString().length() > 15 );
 
   QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
   r = e9.evaluate( &c );

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -381,8 +381,9 @@ void TestQgsMapSettings::testExpressionContext()
 {
   QgsMapSettings ms;
   QgsExpressionContext c;
-
-  ms->setcrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  QVariant r;
+  
+  ms.setDestinationCrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
   c << QgsExpressionContextUtils::mapSettingsScope( ms );
 
   QgsExpression e2( QStringLiteral( "@map_crs" ) );

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -27,6 +27,7 @@
 #include "qgsapplication.h"
 #include "qgsmaplayerlistutils.h"
 #include "qgsvectorlayer.h"
+#include "qgscoordinatereferencesystem.h"
 
 class TestQgsMapSettings: public QObject
 {
@@ -374,6 +375,48 @@ void TestQgsMapSettings::testLabelBoundary()
   QVERIFY( ms.labelBoundaryGeometry().isNull() );
   ms.setLabelBoundaryGeometry( QgsGeometry::fromWkt( QStringLiteral( "Polygon(( 0 0, 1 0, 1 1, 0 1, 0 0 ))" ) ) );
   QCOMPARE( ms.labelBoundaryGeometry().asWkt(), QStringLiteral( "Polygon ((0 0, 1 0, 1 1, 0 1, 0 0))" ) );
+}
+
+void TestQgsMapSettings::testExpressionContext()
+{
+  QgsMapSettings ms;
+  QgsExpressionContext context;
+
+  ms->setcrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  context << QgsExpressionContextUtils::mapSettingsScope( ms );
+
+  QgsExpression e2( QStringLiteral( "@map_crs" ) );
+  r = e2.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "EPSG:4326" ) );
+
+  QgsExpression e3( QStringLiteral( "@map_crs_definition" ) );
+  r = e3.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+
+  QgsExpression e4( QStringLiteral( "@map_units" ) );
+  r = e4.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "degrees" ) );
+
+  QgsExpression e5( QStringLiteral( "@map_crs_description" ) );
+  r = e5.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "WGS 84" ) );
+
+  QgsExpression e6( QStringLiteral( "@map_crs_acronym" ) );
+  r = e6.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "longlat" ) );
+
+  QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
+  r = e7.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+
+  QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
+  r = e8.evaluate( &c );
+  QVERIFY( r.toString().lenght() > 15 );
+
+  QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
+  r = e9.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "WGS84" ) );
+
 }
 
 QGSTEST_MAIN( TestQgsMapSettings )

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -380,10 +380,10 @@ void TestQgsMapSettings::testLabelBoundary()
 void TestQgsMapSettings::testExpressionContext()
 {
   QgsMapSettings ms;
-  QgsExpressionContext context;
+  QgsExpressionContext c;
 
   ms->setcrs( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
-  context << QgsExpressionContextUtils::mapSettingsScope( ms );
+  c << QgsExpressionContextUtils::mapSettingsScope( ms );
 
   QgsExpression e2( QStringLiteral( "@map_crs" ) );
   r = e2.evaluate( &c );


### PR DESCRIPTION
## Description
Often when making maps I find that there is a lack of CRS variables to properly explain the CRS used in the map.

So I decided to add some new variables to the QgsLayoutItemMap ExpressionScope.

This modifies one definition (since there is a duplicate), the name change of map_definition to map_crs_Proj4 could be duplicated to prevent confusion but I think mentioning that the output is Proj4 makes things more clear.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
