### PR TITLE
Add missing headings and remove table captions

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -230,12 +230,20 @@ Renamed Classes        {#qgis_api_break_3_0_renamed_classes}
 <tr><td>vertexData<td>QgsInterpolatorVertexData
 </table>
 
+
+Renamed Enum Values        {#qgis_api_break_3_0_renamed_enum_values}
+-------------------
+
 <table>
 <caption id="renamed_enum_values">Renamed enum values</caption>
 <tr><th>class</th><th>API 2.x<th>API 3.X
 <tr><td>QgsLayerTreeModelLegendNode<td>SymbolV2LegacyRuleKeyRole<td>SymbolLegacyRuleKeyRole
 <tr><td>QgsVectorLayer<td>EditorWidgetV2<td>EditorWidget
 </table>
+
+
+Renamed Methods        {#qgis_api_break_3_0_renamed_methods}
+---------------
 
 <table>
 <caption id="renamed_methods">Renamed method names</caption>

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -61,7 +61,6 @@ Moved Classes        {#qgis_api_break_3_0_moved_classes}
 -------------
 
 <table>
-<caption id="moved_classes">Moved classes</caption>
 <tr><th>class<th>Module 2.X<th>Module 3.x
 <tr><td>QgsMapLayerModel<td>gui<td>core
 <tr><td>QgsMapLayerProxyModel<td>gui<td>core
@@ -72,7 +71,6 @@ Renamed Classes        {#qgis_api_break_3_0_renamed_classes}
 ---------------
 
 <table>
-<caption id="renamed_classes">Renamed classes</caption>
 <tr><th>API 2.x<th>API 3.X
 <tr><td>QgisGui<td>QgsGuiUtils
 <tr><td>QgsAbstractGeometryV2<td>QgsAbstractGeometry
@@ -235,7 +233,6 @@ Renamed Enum Values        {#qgis_api_break_3_0_renamed_enum_values}
 -------------------
 
 <table>
-<caption id="renamed_enum_values">Renamed enum values</caption>
 <tr><th>class</th><th>API 2.x<th>API 3.X
 <tr><td>QgsLayerTreeModelLegendNode<td>SymbolV2LegacyRuleKeyRole<td>SymbolLegacyRuleKeyRole
 <tr><td>QgsVectorLayer<td>EditorWidgetV2<td>EditorWidget
@@ -246,7 +243,6 @@ Renamed Methods        {#qgis_api_break_3_0_renamed_methods}
 ---------------
 
 <table>
-<caption id="renamed_methods">Renamed method names</caption>
 <tr><th>class</th><th>API 2.x<th>API 3.X
 <tr><td>QgsAnnotation<td>mapPositionFixed<td>hasFixedMapPosition
 <tr><td>QgsApplication<td>defaultStyleV2Path<td>defaultStylePath


### PR DESCRIPTION
## Description
The 'Renamed enum values' and 'Renamed method names' tables currently appear under the 'Renamed Classes' heading.  This PR adds missing headings (and table of contents anchors) for these tables.

The table captions have also been removed, as these are made redundant by the headings the tables are immediately under.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
