### PR TITLE
Persist canvas expression context scope variables to project

### DIFF
--- a/python/core/auto_generated/qgsexpressioncontext.sip.in
+++ b/python/core/auto_generated/qgsexpressioncontext.sip.in
@@ -343,6 +343,24 @@ fields set by the scope will be overwritten.
 :param fields: fields for scope
 %End
 
+    void readXml( const QDomElement &element, const QgsReadWriteContext &context );
+%Docstring
+Reads scope variables from an XML element.
+
+.. seealso:: :py:func:`writeXml`
+
+.. versionadded:: 3.6
+%End
+
+    bool writeXml( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const;
+%Docstring
+Writes scope variables to an XML ``element``.
+
+.. seealso:: :py:func:`readXml`
+
+.. versionadded:: 3.6
+%End
+
 };
 
 class QgsExpressionContext

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -349,6 +349,20 @@ class CORE_EXPORT QgsExpressionContextScope
      */
     void setFields( const QgsFields &fields );
 
+    /**
+     * Reads scope variables from an XML element.
+     * \see writeXml()
+     * \since QGIS 3.6
+     */
+    void readXml( const QDomElement &element, const QgsReadWriteContext &context );
+
+    /**
+     * Writes scope variables to an XML \a element.
+     * \see readXml()
+     * \since QGIS 3.6
+     */
+    bool writeXml( QDomElement &element, QDomDocument &document, const QgsReadWriteContext &context ) const;
+
   private:
     QString mName;
     QHash<QString, StaticVariable> mVariables;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2087,6 +2087,14 @@ void QgsMapCanvas::readProject( const QDomDocument &doc )
       }
     }
     setAnnotationsVisible( elem.attribute( QStringLiteral( "annotationsVisible" ), QStringLiteral( "1" ) ).toInt() );
+
+    // restore canvas expression context
+    const QDomNodeList scopeElements = elem.elementsByTagName( QStringLiteral( "expressionContextScope" ) );
+    if ( scopeElements.size() > 0 )
+    {
+      const QDomElement scopeElement = scopeElements.at( 0 ).toElement();
+      mExpressionContextScope.readXml( scopeElement, QgsReadWriteContext() );
+    }
   }
   else
   {
@@ -2114,6 +2122,12 @@ void QgsMapCanvas::writeProject( QDomDocument &doc )
   qgisNode.appendChild( mapcanvasNode );
 
   mSettings.writeXml( mapcanvasNode, doc );
+
+  // store canvas expression context
+  QDomElement scopeElement = doc.createElement( QStringLiteral( "expressionContextScope" ) );
+  mExpressionContextScope.writeXml( scopeElement, doc, QgsReadWriteContext() );
+  mapcanvasNode.appendChild( scopeElement );
+
   // TODO: store only units, extent, projections, dest CRS
 }
 

--- a/tests/src/python/test_qgsmapcanvas.py
+++ b/tests/src/python/test_qgsmapcanvas.py
@@ -355,10 +355,14 @@ class TestQgsMapCanvas(unittest.TestCase):
         c1.setObjectName('c1')
         c1.setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:3111'))
         c1.setRotation(45)
+        c1.expressionContextScope().setVariable('vara', 1111)
+        c1.expressionContextScope().setVariable('varb', 'bb')
         c2 = QgsMapCanvas()
         c2.setObjectName('c2')
         c2.setDestinationCrs(QgsCoordinateReferenceSystem('EPSG:4326'))
         c2.setRotation(65)
+        c2.expressionContextScope().setVariable('vara', 2222)
+        c2.expressionContextScope().setVariable('varc', 'cc')
 
         doc = QDomDocument("testdoc")
         elem = doc.createElement("qgis")
@@ -375,8 +379,14 @@ class TestQgsMapCanvas(unittest.TestCase):
 
         self.assertEqual(c3.mapSettings().destinationCrs().authid(), 'EPSG:3111')
         self.assertEqual(c3.rotation(), 45)
+        self.assertEqual(set(c3.expressionContextScope().variableNames()), {'vara', 'varb'})
+        self.assertEqual(c3.expressionContextScope().variable('vara'), 1111)
+        self.assertEqual(c3.expressionContextScope().variable('varb'), 'bb')
         self.assertEqual(c4.mapSettings().destinationCrs().authid(), 'EPSG:4326')
         self.assertEqual(c4.rotation(), 65)
+        self.assertEqual(set(c4.expressionContextScope().variableNames()), {'vara', 'varc'})
+        self.assertEqual(c4.expressionContextScope().variable('vara'), 2222)
+        self.assertEqual(c4.expressionContextScope().variable('varc'), 'cc')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
and restore individual scope variables for each canvas on project
load.

Use case here is to allow storage of variables inside individual canvases, so that the map renders in multi canvas setups can have slightly different views/visualisations of data which are dependent on expression variables. This is currently possible, but the variables are lost when the project is closed. So this change persists the variables for each individual canvas, meaning that re-opening the project correctly restores the previous setup.