### PR TITLE
Fix/improve visual look of new version notification

### DIFF
--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -21,12 +21,14 @@
 #include "qgssettings.h"
 #include "qgsgui.h"
 #include "qgsnative.h"
+#include "qgsstringutils.h"
 #include "qgsfileutils.h"
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QListView>
 #include <QDesktopServices>
+#include <QTextBrowser>
 
 QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
   : QWidget( parent )
@@ -67,7 +69,15 @@ QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget *parent )
 
   layout->addWidget( recentProjectsContainer );
 
-  mVersionInformation = new QLabel;
+  mVersionInformation = new QTextBrowser;
+  mVersionInformation->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Maximum );
+  mVersionInformation->setReadOnly( true );
+  mVersionInformation->setOpenExternalLinks( true );
+  mVersionInformation->setStyleSheet( "QTextEdit { background-color: #dff0d8; border: 1px solid #8e998a; padding-top: 0.25em; max-height: 1.75em; min-height: 1.75em; } "
+                                      "QScrollBar { background-color: rgba(0,0,0,0); } "
+                                      "QScrollBar::add-page,QScrollBar::sub-page,QScrollBar::handle { background-color: rgba(0,0,0,0); color: rgba(0,0,0,0); } "
+                                      "QScrollBar::up-arrow,QScrollBar::down-arrow { color: rgb(0,0,0); } " );
+
   mainLayout->addWidget( mVersionInformation );
   mVersionInformation->setVisible( false );
 
@@ -105,13 +115,9 @@ void QgsWelcomePage::versionInfoReceived()
   if ( versionInfo->newVersionAvailable() )
   {
     mVersionInformation->setVisible( true );
-    mVersionInformation->setText( QStringLiteral( "<b>%1</b>: %2" )
-                                  .arg( tr( "There is a new QGIS version available" ),
-                                        versionInfo->downloadInfo() ) );
-    mVersionInformation->setStyleSheet( "QLabel{"
-                                        "  background-color: #dddd00;"
-                                        "  padding: 5px;"
-                                        "}" );
+    mVersionInformation->setText( QStringLiteral( "<style> a, a:visited, a:hover { color:#268300; } </style><b>%1</b>: %2" )
+                                  .arg( tr( "New QGIS version available" ),
+                                        QgsStringUtils::insertLinks( versionInfo->downloadInfo() ) ) );
   }
 }
 

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -17,7 +17,7 @@
 #define QGSWELCOMEDIALOG_H
 
 #include <QWidget>
-#include <QLabel>
+#include <QTextBrowser>
 
 #include "qgswelcomepageitemsmodel.h"
 
@@ -47,7 +47,7 @@ class QgsWelcomePage : public QWidget
 
   private:
     QgsWelcomePageItemsModel *mModel = nullptr;
-    QLabel *mVersionInformation = nullptr;
+    QTextBrowser *mVersionInformation = nullptr;
     QgsVersionInfo *mVersionInfo = nullptr;
     QListView *mRecentProjectsListView = nullptr;
 };


### PR DESCRIPTION
## Description
Fix/improve visual look of new version notification
- Set a better background color (yellow feels like a negative warning)
- Set text color to black to play nice with themes
- Make the hyperlink clickable, we want people to update!

Before:
![image](https://user-images.githubusercontent.com/1728657/51361033-b4df6500-1b00-11e9-80c9-e175f088af11.png)

PR:
![image](https://user-images.githubusercontent.com/1728657/51361037-b9a41900-1b00-11e9-8802-a5890595da52.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
