### PR TITLE
Always bubble up the requestAboutToBeCreated signal to the main thread.

### DIFF
--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -286,6 +286,8 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
   mInitialized = true;
   mUseSystemProxy = false;
 
+  qRegisterMetaType<QNetworkAccessManager::Operation>( "QNetworkAccessManager::Operation" );
+
   Q_ASSERT( sMainNAM );
 
   if ( sMainNAM != this )
@@ -300,6 +302,9 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
 
     connect( this, &QgsNetworkAccessManager::requestTimedOut,
              sMainNAM, &QgsNetworkAccessManager::requestTimedOut );
+
+    connect( this, &QgsNetworkAccessManager::requestAboutToBeCreated,
+             sMainNAM, &QgsNetworkAccessManager::requestAboutToBeCreated );
 
 #ifndef QT_NO_SSL
     connect( this, &QNetworkAccessManager::sslErrors,


### PR DESCRIPTION
## Description

This commit (Thanks Alessandro) bubbles up the requestAboutToBeCreated
signal from QgsNetworkAccessManager (nam) instances in other then the
main thread to the main thread.

Without this, code which connects to the requestAboutToBeCreated of
the main NAM do not receive the signals from NAM's which are created
in other parallel threads (like used in OWS providers).

For some context: see this email thread: 
https://lists.osgeo.org/pipermail/qgis-developer/2019-January/055843.html

I think it is good for a QGIS user to be able to see the HTTP requests that QGIS is firing to servers, for example when using online service providers. 
This plugin https://github.com/rduivenvoorde/qgisnetworklogger makes it easy for an average user to see what is happening when he/she connects to a WMS server.
With a Debug build most requests are visible, but hidden in other Debug info.
Most average users do not have a Debug build though.
To give an impression, this is what you see when you log your network stuff with the plugin,
you see QGIS requesting plugins.xml, WMS requests and using the Locator

![image](https://user-images.githubusercontent.com/731673/51432046-b2305d00-1c31-11e9-9e86-b141717d450c.png)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X ] Commit messages are descriptive and explain the rationale for changes
- [ -] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [- ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [- ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
