### PR TITLE
Fix QgsGeometryCollection (and subclasses) `equal`

### DIFF
--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -78,9 +78,19 @@ bool QgsGeometryCollection::operator==( const QgsAbstractGeometry &other ) const
 
   for ( int i = 0; i < mGeometries.count(); ++i )
   {
-    if ( mGeometries.at( i ) != otherCollection->mGeometries.at( i )
-         && mGeometries.at( i )->operator!=( *otherCollection->mGeometries.at( i ) ) )
-      return false;
+    QgsAbstractGeometry *g1 = mGeometries.at( i );
+    QgsAbstractGeometry *g2 = otherCollection->mGeometries.at( i );
+
+    // Quick check if the geometries are exactly the same
+    if ( g1 != g2 )
+    {
+      if ( !g1 || !g2 )
+        return false;
+
+      // Slower check, compare the contents of the geometries
+      if ( *g1 != *g2 )
+        return false;
+    }
   }
 
   return true;

--- a/src/core/geometry/qgsgeometrycollection.cpp
+++ b/src/core/geometry/qgsgeometrycollection.cpp
@@ -78,7 +78,8 @@ bool QgsGeometryCollection::operator==( const QgsAbstractGeometry &other ) const
 
   for ( int i = 0; i < mGeometries.count(); ++i )
   {
-    if ( mGeometries.at( i ) != otherCollection->mGeometries.at( i ) )
+    if ( mGeometries.at( i ) != otherCollection->mGeometries.at( i )
+         && mGeometries.at( i )->operator!=( *otherCollection->mGeometries.at( i ) ) )
       return false;
   }
 

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -14798,17 +14798,21 @@ void TestQgsGeometry::geometryCollection()
   QgsMultiPoint mp;
   QgsMultiLineString ml;
   QVERIFY( mp != ml );
-  QgsMultiLineString ml2;
   part.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 )
                   << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
                   << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
   ml.addGeometry( part.clone() );
+  QgsMultiLineString ml2;
   QVERIFY( ml != ml2 );
   part.setPoints( QgsPointSequence() << QgsPoint( QgsWkbTypes::PointZ, 1, 1, 1 )
                   << QgsPoint( QgsWkbTypes::PointZ, 0, 10, 2 ) << QgsPoint( QgsWkbTypes::PointZ, 10, 10, 3 )
                   << QgsPoint( QgsWkbTypes::PointZ, 10, 0, 4 ) << QgsPoint( QgsWkbTypes::PointZ, 0, 0, 1 ) );
   ml2.addGeometry( part.clone() );
   QVERIFY( ml != ml2 );
+
+  QgsMultiLineString ml3;
+  ml3.addGeometry( part.clone() );
+  QVERIFY( ml2 == ml3 );
 
   //toCurveType
   std::unique_ptr< QgsGeometryCollection > curveType( c12.toCurveType() );


### PR DESCRIPTION
The equality operators of QgsAbstractGeometry and subclasses should not check if they consist of the *same* subgeometries but if they consist of *equal* subgeometries.

The previous behavior was to check if all parts of the collection are exactly the same.
The new check will check if all parts are equal (same vertice count, same vertice order, same vertice values).