### PR TITLE
Use QgsFeature3DHandler in 3D point symbol implementation

### DIFF
--- a/src/3d/qgs3dutils.h
+++ b/src/3d/qgs3dutils.h
@@ -25,6 +25,11 @@ class QgsAbstract3DEngine;
 class QgsAbstract3DSymbol;
 class Qgs3DMapScene;
 
+namespace Qt3DExtras
+{
+  class QPhongMaterial;
+}
+
 #include "qgs3dmapsettings.h"
 #include "qgs3dtypes.h"
 #include "qgsaabb.h"
@@ -82,10 +87,8 @@ class _3D_EXPORT Qgs3DUtils
     //! Convert a string to a 4x4 transform matrix
     static QMatrix4x4 stringToMatrix4x4( const QString &str );
 
-    /**
-     * Calculates (x,y,z) positions of a (multi)point in the Point vector layers
-     */
-    static QList<QVector3D> positions( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsFeatureRequest &req, Qgs3DTypes::AltitudeClamping altClamp );
+    //! Calculates (x,y,z) positions of (multi)point from the given feature
+    static void extractPointPositions( QgsFeature &f, const Qgs3DMapSettings &map, Qgs3DTypes::AltitudeClamping altClamp, QVector<QVector3D> &positions );
 
     /**
         Returns true if bbox is completely outside the current viewing volume.
@@ -107,6 +110,9 @@ class _3D_EXPORT Qgs3DUtils
 
     //! Returns expression context for use in preparation of 3D data of a layer
     static QgsExpressionContext globalProjectLayerExpressionContext( QgsVectorLayer *layer );
+
+    //! Returns phong material object based on the material settings
+    static Qt3DExtras::QPhongMaterial *phongMaterial( const QgsPhongMaterialSettings &settings );
 };
 
 #endif

--- a/src/3d/qgsrulebased3drenderer.cpp
+++ b/src/3d/qgsrulebased3drenderer.cpp
@@ -264,8 +264,7 @@ void QgsRuleBased3DRenderer::Rule::createHandlers( QgsVectorLayer *layer, QgsRul
     }
     else if ( mSymbol->type() == QLatin1String( "point" ) )
     {
-      // TODO: point symbol
-      //handler = Qgs3DSymbolImpl::handlerForPoint3DSymbol( context, layer, *static_cast<QgsPoint3DSymbol *>( mSymbol.get() ) );
+      handler = Qgs3DSymbolImpl::handlerForPoint3DSymbol( layer, *static_cast<QgsPoint3DSymbol *>( mSymbol.get() ) );
     }
     else if ( mSymbol->type() == QLatin1String( "line" ) )
     {

--- a/src/3d/qgsvectorlayer3drenderer.cpp
+++ b/src/3d/qgsvectorlayer3drenderer.cpp
@@ -84,7 +84,7 @@ Qt3DCore::QEntity *QgsVectorLayer3DRenderer::createEntity( const Qgs3DMapSetting
   if ( mSymbol->type() == QLatin1String( "polygon" ) )
     return Qgs3DSymbolImpl::entityForPolygon3DSymbol( map, vl, *static_cast<QgsPolygon3DSymbol *>( mSymbol.get() ) );
   else if ( mSymbol->type() == QLatin1String( "point" ) )
-    return new QgsPoint3DSymbolEntity( map, vl, *static_cast<QgsPoint3DSymbol *>( mSymbol.get() ) );
+    return Qgs3DSymbolImpl::entityForPoint3DSymbol( map, vl, *static_cast<QgsPoint3DSymbol *>( mSymbol.get() ) );
   else if ( mSymbol->type() == QLatin1String( "line" ) )
     return Qgs3DSymbolImpl::entityForLine3DSymbol( map, vl, *static_cast<QgsLine3DSymbol *>( mSymbol.get() ) );
   else

--- a/src/3d/symbols/qgspoint3dsymbol_p.h
+++ b/src/3d/symbols/qgspoint3dsymbol_p.h
@@ -27,59 +27,19 @@
 // version without notice, or even be removed.
 //
 
-#include <Qt3DCore/QEntity>
-#include <Qt3DRender/QMaterial>
-#include <Qt3DRender/QGeometryRenderer>
-#include <Qt3DCore/QTransform>
 
-#include "qgspoint3dsymbol.h"
+#include "qgsfeature3dhandler_p.h"
 
-class Qgs3DMapSettings;
 class QgsPoint3DSymbol;
 
-class QgsVectorLayer;
-class QgsFeatureRequest;
-
-
-//! Entity that handles rendering of points as 3D objects
-class QgsPoint3DSymbolEntity : public Qt3DCore::QEntity
+namespace Qgs3DSymbolImpl
 {
-  public:
-    QgsPoint3DSymbolEntity( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol, Qt3DCore::QNode *parent = nullptr );
-};
+  //! factory method for QgsLine3DSymbol
+  QgsFeature3DHandler *handlerForPoint3DSymbol( QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol );
 
-class QgsPoint3DSymbolInstancedEntityFactory
-{
-  public:
-    static void addEntityForSelectedPoints( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol, QgsPoint3DSymbolEntity *parent );
-    static void addEntityForNotSelectedPoints( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol, QgsPoint3DSymbolEntity *parent );
-
-  private:
-    static Qt3DRender::QMaterial *material( const QgsPoint3DSymbol &symbol );
-};
-
-class QgsPoint3DSymbolInstancedEntityNode : public Qt3DCore::QEntity
-{
-  public:
-    QgsPoint3DSymbolInstancedEntityNode( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol, const QgsFeatureRequest &req, Qt3DCore::QNode *parent = nullptr );
-
-  private:
-    Qt3DRender::QGeometryRenderer *renderer( const QgsPoint3DSymbol &symbol, const QList<QVector3D> &positions ) const;
-    Qt3DRender::QGeometry *symbolGeometry( QgsPoint3DSymbol::Shape shape, const QVariantMap &shapeProperties ) const;
-};
-
-class QgsPoint3DSymbolModelEntityFactory
-{
-  public:
-    static void addEntitiesForSelectedPoints( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol, QgsPoint3DSymbolEntity *parent );
-    static void addEntitiesForNotSelectedPoints( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol, QgsPoint3DSymbolEntity *parent );
-
-  private:
-    static void addSceneEntities( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsFeatureRequest &req, const QgsPoint3DSymbol &symbol, QgsPoint3DSymbolEntity *parent );
-    static void addMeshEntities( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsFeatureRequest &req, const QgsPoint3DSymbol &symbol, QgsPoint3DSymbolEntity *parent, bool are_selected );
-
-    static Qt3DCore::QTransform *transform( QVector3D position, const QgsPoint3DSymbol &symbol );
-};
+  //! convenience function to create a complete entity from QgsPolygon3DSymbol (will run getFeatures() on the layer)
+  Qt3DCore::QEntity *entityForPoint3DSymbol( const Qgs3DMapSettings &map, QgsVectorLayer *layer, const QgsPoint3DSymbol &symbol );
+}
 
 /// @endcond
 


### PR DESCRIPTION
This is a small refactoring of 3D point symbol code, with three goals:

- use the new handler class just like line and polygon symbols already use

- just one feature loop instead of two and avoiding possibly slow query
  that requests all features by their IDs

- make it possible to use point symbols with rule-based renderer
