### PR TITLE
Make URLS in message log clickable

### DIFF
--- a/python/gui/auto_generated/qgsmessagelogviewer.sip.in
+++ b/python/gui/auto_generated/qgsmessagelogviewer.sip.in
@@ -39,6 +39,8 @@ Logs a ``message`` to the viewer.
 
     virtual void reject();
 
+    virtual bool eventFilter( QObject *obj, QEvent *ev );
+
 
 };
 

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -53,9 +53,14 @@ class GUI_EXPORT QgsMessageLogViewer: public QDialog, private Ui::QgsMessageLogV
   protected:
     void closeEvent( QCloseEvent *e ) override;
     void reject() override;
+    bool eventFilter( QObject *obj, QEvent *ev ) override;
 
   private slots:
     void closeTab( int index );
+
+  private:
+
+    QString mClickedAnchor;
 };
 
 #endif


### PR DESCRIPTION
Makes URLS in the message log clickable. This uses the approach from https://stackoverflow.com/questions/33531632/how-to-catch-the-link-click-event-in-qplaintextedit. , avoiding a need to switch to the slow QTextBrowser widget.