### PR TITLE
Use polyline shape instead of bounding box for selection

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
@@ -209,6 +209,22 @@ Returns the pen width in millimeters for the stroke of the arrow head.
 .. seealso:: :py:func:`arrowHeadStrokeColor`
 %End
 
+    virtual QPainterPath shape() const; /*{
+
+%Docstring
+Returns a path representing the outline of the stroked polyline.
+%End
+        QPainterPath path;
+        path.addPolygon( mPolygon );
+
+        QPainterPathStroker ps;
+
+        ps.setWidth( mPolylineStyleSymbol->width() );
+        QPainterPath strokedOutline;
+
+        return strokedOutline;
+    }*/
+
   protected:
 
     virtual bool _addNode( int indexPoint, QPointF newPoint, double radius );

--- a/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
@@ -53,6 +53,8 @@ The caller takes responsibility for deleting the returned object.
 
     virtual QString displayName() const;
 
+    virtual QPainterPath shape() const;
+
 
     QgsLineSymbol *symbol();
 %Docstring
@@ -209,21 +211,6 @@ Returns the pen width in millimeters for the stroke of the arrow head.
 .. seealso:: :py:func:`arrowHeadStrokeColor`
 %End
 
-    virtual QPainterPath shape() const; /*{
-
-%Docstring
-Returns a path representing the outline of the stroked polyline.
-%End
-        QPainterPath path;
-        path.addPolygon( mPolygon );
-
-        QPainterPathStroker ps;
-
-        ps.setWidth( mPolylineStyleSymbol->width() );
-        QPainterPath strokedOutline;
-
-        return strokedOutline;
-    }*/
 
   protected:
 

--- a/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempolyline.sip.in
@@ -211,7 +211,6 @@ Returns the pen width in millimeters for the stroke of the arrow head.
 .. seealso:: :py:func:`arrowHeadStrokeColor`
 %End
 
-
   protected:
 
     virtual bool _addNode( int indexPoint, QPointF newPoint, double radius );

--- a/src/core/layout/qgslayoutitempolyline.cpp
+++ b/src/core/layout/qgslayoutitempolyline.cpp
@@ -320,7 +320,7 @@ QPainterPath QgsLayoutItemPolyline::shape() const
 
   QPainterPathStroker ps;
 
-  ps.setWidth( mPolylineStyleSymbol->width() );
+  ps.setWidth( 2 * mMaxSymbolBleed );
   QPainterPath strokedOutline = ps.createStroke( path );
 
   return strokedOutline;

--- a/src/core/layout/qgslayoutitempolyline.cpp
+++ b/src/core/layout/qgslayoutitempolyline.cpp
@@ -25,6 +25,7 @@
 #include "qgssvgcache.h"
 #include <QSvgRenderer>
 #include <limits>
+#include <QGraphicsPathItem>
 
 QgsLayoutItemPolyline::QgsLayoutItemPolyline( QgsLayout *layout )
   : QgsLayoutNodesItem( layout )
@@ -310,6 +311,19 @@ void QgsLayoutItemPolyline::setArrowHeadWidth( double width )
   mArrowHeadWidth = width;
   updateMarkerSvgSizes();
   update();
+}
+
+QPainterPath QgsLayoutItemPolyline::shape() const
+{
+  QPainterPath path;
+  path.addPolygon( mPolygon );
+
+  QPainterPathStroker ps;
+
+  ps.setWidth( mPolylineStyleSymbol->width() );
+  QPainterPath strokedOutline = ps.createStroke( path );
+
+  return strokedOutline;
 }
 
 void QgsLayoutItemPolyline::setStartSvgMarkerPath( const QString &path )

--- a/src/core/layout/qgslayoutitempolyline.h
+++ b/src/core/layout/qgslayoutitempolyline.h
@@ -20,6 +20,9 @@
 #include "qgis_core.h"
 #include "qgslayoutitemnodeitem.h"
 #include "qgssymbol.h"
+#include <QGraphicsPathItem>
+#include "qgslogger.h"
+#include "qgslayout.h"
 
 /**
  * \ingroup core
@@ -184,6 +187,21 @@ class CORE_EXPORT QgsLayoutItemPolyline: public QgsLayoutNodesItem
      * \see arrowHeadStrokeColor()
      */
     double arrowHeadStrokeWidth() const { return mArrowHeadStrokeWidth; }
+
+    /**
+     * Returns a path representing the outline of the stroked polyline.
+     */
+    QPainterPath shape() const override; /*{
+        QPainterPath path;
+        path.addPolygon( mPolygon );
+
+        QPainterPathStroker ps;
+
+        ps.setWidth( mPolylineStyleSymbol->width() );
+        QPainterPath strokedOutline = ps.createStroke(path);
+
+        return strokedOutline;
+    }*/
 
   protected:
 

--- a/src/core/layout/qgslayoutitempolyline.h
+++ b/src/core/layout/qgslayoutitempolyline.h
@@ -189,7 +189,6 @@ class CORE_EXPORT QgsLayoutItemPolyline: public QgsLayoutNodesItem
      */
     double arrowHeadStrokeWidth() const { return mArrowHeadStrokeWidth; }
 
-
   protected:
 
     bool _addNode( int indexPoint, QPointF newPoint, double radius ) override;

--- a/src/core/layout/qgslayoutitempolyline.h
+++ b/src/core/layout/qgslayoutitempolyline.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsLayoutItemPolyline: public QgsLayoutNodesItem
     int type() const override;
     QIcon icon() const override;
     QString displayName() const override;
+    QPainterPath shape() const override;
 
     /**
      * Returns the line symbol used to draw the shape.
@@ -188,20 +189,6 @@ class CORE_EXPORT QgsLayoutItemPolyline: public QgsLayoutNodesItem
      */
     double arrowHeadStrokeWidth() const { return mArrowHeadStrokeWidth; }
 
-    /**
-     * Returns a path representing the outline of the stroked polyline.
-     */
-    QPainterPath shape() const override; /*{
-        QPainterPath path;
-        path.addPolygon( mPolygon );
-
-        QPainterPathStroker ps;
-
-        ps.setWidth( mPolylineStyleSymbol->width() );
-        QPainterPath strokedOutline = ps.createStroke(path);
-
-        return strokedOutline;
-    }*/
 
   protected:
 


### PR DESCRIPTION

## Description
At the moment, it's not possible to select horizontal or vertical arrows/polylines using a single click because the arrows' bounding boxes are used for determining which object to select. This pull request changes this behavior so the outline of the polyline is used instead.

This addresses issue #20940.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
