### PR TITLE
Add API to QgsRasterBlock to obtain both pixel value AND no data flag in a single call

### DIFF
--- a/python/core/auto_generated/raster/qgsrasterblock.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterblock.sip.in
@@ -153,18 +153,24 @@ returned value is undefined.
 :param row: row index
 :param column: column index
 
-:return: value *
+:return: value
+
+.. seealso:: :py:func:`valueAndNoData`
 %End
+
 
     double value( qgssize index ) const;
 %Docstring
-Read a single value if type of block is numeric. If type is color,
+Reads a single value if type of block is numeric. If type is color,
 returned value is undefined.
 
 :param index: data matrix index (long type in Python)
 
-:return: value *
+:return: value
+
+.. seealso:: :py:func:`valueAndNoData`
 %End
+
 
 
     QRgb color( int row, int column ) const;
@@ -188,12 +194,14 @@ Read a single value
 
     bool isNoData( int row, int column ) const;
 %Docstring
-Check if value at position is no data
+Checks if value at position is no data
 
 :param row: row index
 :param column: column index
 
-:return: true if value is no data *
+:return: true if value is no data
+
+.. seealso:: :py:func:`valueAndNoData`
 %End
 
     bool isNoData( qgssize row, qgssize column ) const;
@@ -203,7 +211,9 @@ Check if value at position is no data
 :param row: row index
 :param column: column index
 
-:return: true if value is no data *
+:return: true if value is no data
+
+.. seealso:: :py:func:`valueAndNoData`
 %End
 
     bool isNoData( qgssize index ) const;
@@ -212,7 +222,9 @@ Check if value at position is no data
 
 :param index: data matrix index (long type in Python)
 
-:return: true if value is no data *
+:return: true if value is no data
+
+.. seealso:: :py:func:`valueAndNoData`
 %End
 
     bool setValue( int row, int column, double value );
@@ -434,6 +446,7 @@ Returns the height (number of rows) of the raster block.
 %End
 
 };
+
 
 
 

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.cpp
@@ -136,6 +136,7 @@ QVariantMap QgsRasterLayerUniqueValuesReportAlgorithm::processAlgorithm( const Q
   int iterTop = 0;
   int iterCols = 0;
   int iterRows = 0;
+  bool isNoData = false;
   std::unique_ptr< QgsRasterBlock > rasterBlock;
   while ( iter.readNextRasterPart( mBand, iterCols, iterRows, rasterBlock, iterLeft, iterTop ) )
   {
@@ -146,13 +147,13 @@ QVariantMap QgsRasterLayerUniqueValuesReportAlgorithm::processAlgorithm( const Q
         break;
       for ( int column = 0; column < iterCols; column++ )
       {
-        if ( mHasNoDataValue && rasterBlock->isNoData( row, column ) )
+        double value = rasterBlock->valueAndNoData( row, column, isNoData );
+        if ( mHasNoDataValue && isNoData )
         {
-          noDataCount += 1;
+          noDataCount++;
         }
         else
         {
-          double value = rasterBlock->value( row, column );
           uniqueValues[ value ]++;
         }
       }

--- a/src/analysis/processing/qgsalgorithmrasterzonalstats.cpp
+++ b/src/analysis/processing/qgsalgorithmrasterzonalstats.cpp
@@ -217,6 +217,7 @@ QVariantMap QgsRasterLayerZonalStatsAlgorithm::processAlgorithm( const QVariantM
   QgsRectangle blockExtent;
   std::unique_ptr< QgsRasterBlock > rasterBlock;
   std::unique_ptr< QgsRasterBlock > zonesRasterBlock;
+  bool isNoData = false;
   while ( true )
   {
     if ( mRefLayer == Source )
@@ -249,17 +250,19 @@ QVariantMap QgsRasterLayerZonalStatsAlgorithm::processAlgorithm( const QVariantM
 
       for ( int column = 0; column < iterCols; column++ )
       {
-        if ( ( mHasNoDataValue && rasterBlock->isNoData( row, column ) ) ||
-             ( mZonesHasNoDataValue && zonesRasterBlock->isNoData( row, column ) ) )
+        double value = rasterBlock->valueAndNoData( row, column, isNoData );
+        if ( mHasNoDataValue && isNoData )
         {
           noDataCount += 1;
+          continue;
         }
-        else
+        double zone = zonesRasterBlock->valueAndNoData( row, column, isNoData );
+        if ( mZonesHasNoDataValue && isNoData )
         {
-          double value = rasterBlock->value( row, column );
-          double zone = zonesRasterBlock->value( row, column );
-          zoneStats[ zone ].s.addValue( value );
+          noDataCount += 1;
+          continue;
         }
+        zoneStats[ zone ].s.addValue( value );
       }
     }
   }

--- a/src/analysis/processing/qgsalgorithmvectorize.cpp
+++ b/src/analysis/processing/qgsalgorithmvectorize.cpp
@@ -93,6 +93,7 @@ QVariantMap QgsVectorizeAlgorithmBase::processAlgorithm( const QVariantMap &para
   int iterRows = 0;
   std::unique_ptr< QgsRasterBlock > rasterBlock;
   QgsRectangle blockExtent;
+  bool isNoData = false;
   while ( iter.readNextRasterPart( mBand, iterCols, iterRows, rasterBlock, iterLeft, iterTop, &blockExtent ) )
   {
     if ( feedback )
@@ -111,10 +112,10 @@ QVariantMap QgsVectorizeAlgorithmBase::processAlgorithm( const QVariantMap &para
 
       for ( int column = 0; column < iterCols; column++ )
       {
-        if ( !rasterBlock->isNoData( row, column ) )
+        const double value = rasterBlock->valueAndNoData( row, column, isNoData );
+        if ( !isNoData )
         {
           QgsGeometry pixelRectGeometry = createGeometryForPixel( currentX, currentY, mRasterUnitsPerPixelX, mRasterUnitsPerPixelY );
-          double value = rasterBlock->value( row, column );
 
           QgsFeature f;
           f.setGeometry( pixelRectGeometry );

--- a/src/analysis/processing/qgsrasteranalysisutils.cpp
+++ b/src/analysis/processing/qgsrasteranalysisutils.cpp
@@ -74,6 +74,7 @@ void QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( QgsRasterInterface *
   int iterCols = 0;
   int iterRows = 0;
   QgsRectangle blockExtent;
+  bool isNoData = false;
   while ( iter.readNextRasterPart( rasterBand, iterCols, iterRows, block, iterLeft, iterTop, &blockExtent ) )
   {
     double cellCenterY = blockExtent.yMaximum() - 0.5 * cellSizeY;
@@ -83,8 +84,8 @@ void QgsRasterAnalysisUtils::statisticsFromMiddlePointTest( QgsRasterInterface *
       double cellCenterX = blockExtent.xMinimum() + 0.5 * cellSizeX;
       for ( int col = 0; col < iterCols; ++col )
       {
-        double pixelValue = block->value( row, col );
-        if ( validPixel( pixelValue ) && ( !skipNodata || !block->isNoData( row, col ) ) )
+        const double pixelValue = block->valueAndNoData( row, col, isNoData );
+        if ( validPixel( pixelValue ) && ( !skipNodata || !isNoData ) )
         {
           QgsPoint cellCenter( cellCenterX, cellCenterY );
           if ( polyEngine->contains( &cellCenter ) )
@@ -124,6 +125,7 @@ void QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( QgsRasterInterfa
   int iterCols = 0;
   int iterRows = 0;
   QgsRectangle blockExtent;
+  bool isNoData = false;
   while ( iter.readNextRasterPart( rasterBand, iterCols, iterRows, block, iterLeft, iterTop, &blockExtent ) )
   {
     double currentY = blockExtent.yMaximum() - 0.5 * cellSizeY;
@@ -132,8 +134,8 @@ void QgsRasterAnalysisUtils::statisticsFromPreciseIntersection( QgsRasterInterfa
       double currentX = blockExtent.xMinimum() + 0.5 * cellSizeX;
       for ( int col = 0; col < iterCols; ++col )
       {
-        double pixelValue = block->value( row, col );
-        if ( validPixel( pixelValue ) && ( !skipNodata || !block->isNoData( row, col ) ) )
+        const double pixelValue = block->valueAndNoData( row, col, isNoData );
+        if ( validPixel( pixelValue ) && ( !skipNodata || !isNoData ) )
         {
           pixelRectGeometry = QgsGeometry::fromRect( QgsRectangle( currentX - hCellSizeX, currentY - hCellSizeY, currentX + hCellSizeX, currentY + hCellSizeY ) );
           // GEOS intersects tests on prepared geometry is MAGNITUDES faster than calculating the intersection itself,

--- a/src/analysis/processing/qgsreclassifyutils.cpp
+++ b/src/analysis/processing/qgsreclassifyutils.cpp
@@ -82,6 +82,7 @@ void QgsReclassifyUtils::reclassify( const QVector<QgsReclassifyUtils::RasterCla
   destinationRaster->setEditable( true );
   std::unique_ptr< QgsRasterBlock > rasterBlock;
   bool reclassed = false;
+  bool isNoData = false;
   while ( iter.readNextRasterPart( band, iterCols, iterRows, rasterBlock, iterLeft, iterTop ) )
   {
     if ( feedback )
@@ -96,11 +97,11 @@ void QgsReclassifyUtils::reclassify( const QVector<QgsReclassifyUtils::RasterCla
         break;
       for ( int column = 0; column < iterCols; column++ )
       {
-        if ( rasterBlock->isNoData( row, column ) )
+        const double value = rasterBlock->valueAndNoData( row, column, isNoData );
+        if ( isNoData )
           reclassifiedBlock->setValue( row, column, destNoDataValue );
         else
         {
-          double value = rasterBlock->value( row, column );
           double newValue = reclassifyValue( classes, value, reclassed );
           if ( reclassed )
             reclassifiedBlock->setValue( row, column, newValue );

--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -73,11 +73,13 @@ bool QgsRasterCalcNode::calculate( QMap<QString, QgsRasterBlock * > &rasterData,
     //convert input raster values to double, also convert input no data to result no data
 
     int outRow = 0;
+    bool isNoData = false;
     for ( int dataRow = startRow; dataRow < endRow ; ++dataRow, ++outRow )
     {
       for ( int dataCol = 0; dataCol < nCols; ++dataCol )
       {
-        data[ dataCol + nCols * outRow] = ( *it )->isNoData( dataRow, dataCol ) ? result.nodataValue() : ( *it )->value( dataRow, dataCol );
+        const double value = ( *it )->valueAndNoData( dataRow, dataCol, isNoData );
+        data[ dataCol + nCols * outRow] = isNoData ? result.nodataValue() : value;
       }
     }
     result.setData( nCols, nRows, data, result.nodataValue() );

--- a/src/core/raster/qgsmultibandcolorrenderer.cpp
+++ b/src/core/raster/qgsmultibandcolorrenderer.cpp
@@ -294,18 +294,15 @@ QgsRasterBlock *QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  cons
     double blueVal = 0;
     if ( mRedBand > 0 )
     {
-      redVal = redBlock->value( i );
-      if ( redBlock->isNoData( i ) ) isNoData = true;
+      redVal = redBlock->valueAndNoData( i, isNoData );
     }
     if ( !isNoData && mGreenBand > 0 )
     {
-      greenVal = greenBlock->value( i );
-      if ( greenBlock->isNoData( i ) ) isNoData = true;
+      greenVal = greenBlock->valueAndNoData( i, isNoData );
     }
     if ( !isNoData && mBlueBand > 0 )
     {
-      blueVal = blueBlock->value( i );
-      if ( blueBlock->isNoData( i ) ) isNoData = true;
+      blueVal = blueBlock->valueAndNoData( i, isNoData );
     }
     if ( isNoData )
     {

--- a/src/core/raster/qgspalettedrasterrenderer.cpp
+++ b/src/core/raster/qgspalettedrasterrenderer.cpp
@@ -167,14 +167,16 @@ QgsRasterBlock *QgsPalettedRasterRenderer::block( int bandNo, QgsRectangle  cons
   unsigned int *outputData = ( unsigned int * )( outputBlock->bits() );
 
   qgssize rasterSize = ( qgssize )width * height;
+  bool isNoData = false;
   for ( qgssize i = 0; i < rasterSize; ++i )
   {
-    if ( inputBlock->isNoData( i ) )
+    const double value = inputBlock->valueAndNoData( i, isNoData );
+    if ( isNoData )
     {
       outputData[i] = myDefaultColor;
       continue;
     }
-    int val = ( int ) inputBlock->value( i );
+    int val = static_cast< int >( value );
     if ( !mColors.contains( val ) )
     {
       outputData[i] = myDefaultColor;

--- a/src/core/raster/qgsrasterblock.h
+++ b/src/core/raster/qgsrasterblock.h
@@ -179,22 +179,57 @@ class CORE_EXPORT QgsRasterBlock
     static QByteArray valueBytes( Qgis::DataType dataType, double value );
 
     /**
-     * \brief Read a single value if type of block is numeric. If type is color,
-     *  returned value is undefined.
-     *  \param row row index
-     *  \param column column index
-     *  \returns value */
+     * Read a single value if type of block is numeric. If type is color,
+     * returned value is undefined.
+     * \param row row index
+     * \param column column index
+     * \returns value
+     * \see valueAndNoData()
+    */
     double value( int row, int column ) const
     {
       return value( static_cast< qgssize >( row ) * mWidth + column );
     }
 
     /**
-     * \brief Read a single value if type of block is numeric. If type is color,
-     *  returned value is undefined.
-     *  \param index data matrix index (long type in Python)
-     *  \returns value */
+     * Reads a single value from the pixel at \a row and \a column, if type of block is numeric. If type is color,
+     * returned value is undefined.
+     *
+     * Additionally, the \a isNoData argument will be set to true if the pixel represents a nodata value. This method
+     * is more efficient then calling isNoData() and value() separately.
+     *
+     * \note Not available in Python bindings
+     * \see value()
+     * \see isNoData()
+     * \since QGIS 3.6
+     */
+    double valueAndNoData( int row, int column, bool &isNoData ) const SIP_SKIP
+    {
+      return valueAndNoData( static_cast< qgssize >( row ) * mWidth + column, isNoData );
+    }
+
+    /**
+     * Reads a single value if type of block is numeric. If type is color,
+     * returned value is undefined.
+     * \param index data matrix index (long type in Python)
+     * \returns value
+     * \see valueAndNoData()
+    */
     double value( qgssize index ) const;
+
+    /**
+     * Reads a single value from the pixel at the specified data matrix \a index, if type of block is numeric. If type is color,
+     * returned value is undefined.
+     *
+     * Additionally, the \a isNoData argument will be set to true if the pixel represents a nodata value. This method
+     * is more efficient then calling isNoData() and value() separately.
+     *
+     * \note Not available in Python bindings
+     * \see value()
+     * \see isNoData()
+     * \since QGIS 3.6
+     */
+    double valueAndNoData( qgssize index, bool &isNoData ) const SIP_SKIP;
 
     /**
      * Gives direct access to the raster block data.
@@ -234,29 +269,35 @@ class CORE_EXPORT QgsRasterBlock
     }
 
     /**
-     * \brief Check if value at position is no data
-     *  \param row row index
-     *  \param column column index
-     *  \returns true if value is no data */
+     * Checks if value at position is no data
+     * \param row row index
+     * \param column column index
+     * \returns true if value is no data
+     * \see valueAndNoData()
+    */
     bool isNoData( int row, int column ) const
     {
       return isNoData( static_cast< qgssize >( row ) * mWidth + column );
     }
 
     /**
-     * \brief Check if value at position is no data
-     *  \param row row index
-     *  \param column column index
-     *  \returns true if value is no data */
+     * Check if value at position is no data
+     * \param row row index
+     * \param column column index
+     * \returns true if value is no data
+     * \see valueAndNoData()
+    */
     bool isNoData( qgssize row, qgssize column ) const
     {
       return isNoData( row * static_cast< qgssize >( mWidth ) + column );
     }
 
     /**
-     * \brief Check if value at position is no data
-     *  \param index data matrix index (long type in Python)
-     *  \returns true if value is no data */
+     * Check if value at position is no data
+     * \param index data matrix index (long type in Python)
+     * \returns true if value is no data
+     * \see valueAndNoData()
+    */
     bool isNoData( qgssize index ) const
     {
       if ( !mHasNoDataValue && !mNoDataBitmap )
@@ -683,25 +724,18 @@ inline double QgsRasterBlock::readValue( void *data, Qgis::DataType type, qgssiz
   {
     case Qgis::Byte:
       return static_cast< double >( ( static_cast< quint8 * >( data ) )[index] );
-      break;
     case Qgis::UInt16:
       return static_cast< double >( ( static_cast< quint16 * >( data ) )[index] );
-      break;
     case Qgis::Int16:
       return static_cast< double >( ( static_cast< qint16 * >( data ) )[index] );
-      break;
     case Qgis::UInt32:
       return static_cast< double >( ( static_cast< quint32 * >( data ) )[index] );
-      break;
     case Qgis::Int32:
       return static_cast< double >( ( static_cast< qint32 * >( data ) )[index] );
-      break;
     case Qgis::Float32:
       return static_cast< double >( ( static_cast< float * >( data ) )[index] );
-      break;
     case Qgis::Float64:
       return static_cast< double >( ( static_cast< double * >( data ) )[index] );
-      break;
     default:
       QgsDebugMsg( QStringLiteral( "Data type %1 is not supported" ).arg( type ) );
       break;
@@ -751,6 +785,47 @@ inline double QgsRasterBlock::value( qgssize index ) const SIP_SKIP
     return std::numeric_limits<double>::quiet_NaN();
   }
   return readValue( mData, mDataType, index );
+}
+
+inline double QgsRasterBlock::valueAndNoData( qgssize index, bool &isNoData ) const SIP_SKIP
+{
+  if ( !mData )
+  {
+    QgsDebugMsg( QStringLiteral( "Data block not allocated" ) );
+    isNoData = true;
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  if ( index >= static_cast< qgssize >( mWidth )*mHeight )
+  {
+    QgsDebugMsg( QStringLiteral( "Index %1 out of range (%2 x %3)" ).arg( index ).arg( mWidth ).arg( mHeight ) );
+    isNoData = true; // we consider no data if outside
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+
+  const double val = readValue( mData, mDataType, index );
+
+  if ( !mHasNoDataValue && !mNoDataBitmap )
+  {
+    isNoData = false;
+    return val;
+  }
+
+  if ( mHasNoDataValue )
+  {
+    isNoData = isNoDataValue( val );
+    return val;
+  }
+  // use no data bitmap
+  if ( !mNoDataBitmap )
+  {
+    // no data are not defined
+    isNoData = false;
+    return val;
+  }
+
+  // no data is a bitmap
+  isNoData = QgsRasterBlock::isNoData( index );
+  return val;
 }
 
 inline bool QgsRasterBlock::isNoDataValue( double value ) const SIP_SKIP

--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -162,6 +162,7 @@ QgsRasterBandStats QgsRasterInterface::bandStatistics( int bandNo,
   double mySumOfSquares = 0;
 
   bool myFirstIterationFlag = true;
+  bool isNoData = false;
   for ( int myYBlock = 0; myYBlock < myNYBlocks; myYBlock++ )
   {
     for ( int myXBlock = 0; myXBlock < myNXBlocks; myXBlock++ )
@@ -185,9 +186,10 @@ QgsRasterBandStats QgsRasterInterface::bandStatistics( int bandNo,
       // Collect the histogram counts.
       for ( qgssize i = 0; i < ( static_cast< qgssize >( myBlockHeight ) ) * myBlockWidth; i++ )
       {
-        if ( blk->isNoData( i ) ) continue; // NULL
+        double myValue = blk->valueAndNoData( i, isNoData );
+        if ( isNoData )
+          continue; // NULL
 
-        double myValue = blk->value( i );
         myRasterBandStats.sum += myValue;
         myRasterBandStats.elementCount++;
 
@@ -448,6 +450,7 @@ QgsRasterHistogram QgsRasterInterface::histogram( int bandNo,
   double myBinSize = ( myMaximum - myMinimum ) / myBinCount;
 
   // TODO: progress signals
+  bool isNoData = false;
   for ( int myYBlock = 0; myYBlock < myNYBlocks; myYBlock++ )
   {
     for ( int myXBlock = 0; myXBlock < myNXBlocks; myXBlock++ )
@@ -470,11 +473,11 @@ QgsRasterHistogram QgsRasterInterface::histogram( int bandNo,
       // Collect the histogram counts.
       for ( qgssize i = 0; i < ( static_cast< qgssize >( myBlockHeight ) ) * myBlockWidth; i++ )
       {
-        if ( blk->isNoData( i ) )
+        double myValue = blk->valueAndNoData( i, isNoData );
+        if ( isNoData )
         {
           continue; // NULL
         }
-        double myValue = blk->value( i );
 
         int myBinIndex = static_cast <int>( std::floor( ( myValue - myMinimum ) /  myBinSize ) );
 

--- a/src/core/raster/qgsrasternuller.cpp
+++ b/src/core/raster/qgsrasternuller.cpp
@@ -100,13 +100,13 @@ QgsRasterBlock *QgsRasterNuller::block( int bandNo, QgsRectangle  const &extent,
     outputBlock->setNoDataValue( noDataValue );
   }
 
+  bool isNoData = false;
   for ( int i = 0; i < height; i++ )
   {
     for ( int j = 0; j < width; j++ )
     {
-      double value = inputBlock->value( i, j );
+      double value = inputBlock->valueAndNoData( i, j, isNoData );
 
-      bool isNoData = inputBlock->isNoData( i, j );
       if ( QgsRasterRange::contains( value, mNoData.value( bandNo - 1 ) ) )
       {
         isNoData = true;

--- a/src/core/raster/qgssinglebandgrayrenderer.cpp
+++ b/src/core/raster/qgssinglebandgrayrenderer.cpp
@@ -117,14 +117,16 @@ QgsRasterBlock *QgsSingleBandGrayRenderer::block( int bandNo, const QgsRectangle
   }
 
   QRgb myDefaultColor = NODATA_COLOR;
+  bool isNoData = false;
   for ( qgssize i = 0; i < ( qgssize )width * height; i++ )
   {
-    if ( inputBlock->isNoData( i ) )
+    double grayVal = inputBlock->valueAndNoData( i, isNoData );
+
+    if ( isNoData )
     {
       outputBlock->setColor( i, myDefaultColor );
       continue;
     }
-    double grayVal = inputBlock->value( i );
 
     double currentAlpha = mOpacity;
     if ( mRasterTransparency )

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -238,14 +238,16 @@ QgsRasterBlock *QgsSingleBandPseudoColorRenderer::block( int bandNo, QgsRectangl
   const QgsRasterShaderFunction *fcn = mShader->rasterShaderFunction();
 
   qgssize count = ( qgssize )width * height;
+  bool isNoData = false;
   for ( qgssize i = 0; i < count; i++ )
   {
-    if ( inputBlock->isNoData( i ) )
+    double val = inputBlock->valueAndNoData( i, isNoData );
+    if ( isNoData )
     {
       outputBlockData[i] = myDefaultColor;
       continue;
     }
-    double val = inputBlock->value( i );
+
     int red, green, blue, alpha;
     if ( !fcn->shade( val, &red, &green, &blue, &alpha ) )
     {

--- a/tests/src/core/testqgsrasterblock.cpp
+++ b/tests/src/core/testqgsrasterblock.cpp
@@ -81,6 +81,8 @@ void TestQgsRasterBlock::testBasic()
 
   QgsRasterBlock *block = provider->block( 1, fullExtent, width, height );
 
+  bool isNoData = false;
+
   QCOMPARE( block->width(), 10 );
   QCOMPARE( block->height(), 10 );
 
@@ -96,16 +98,41 @@ void TestQgsRasterBlock::testBasic()
   QCOMPARE( block->value( 0, 0 ), 2. );
   QCOMPARE( block->value( 0, 1 ), 5. );
   QCOMPARE( block->value( 1, 0 ), 27. );
+  QCOMPARE( block->valueAndNoData( 0, 0, isNoData ), 2. );
+  QVERIFY( !isNoData );
+  QCOMPARE( block->valueAndNoData( 0, 1, isNoData ), 5. );
+  QVERIFY( !isNoData );
+  QCOMPARE( block->valueAndNoData( 1, 0, isNoData ), 27. );
+  QVERIFY( !isNoData );
+  QVERIFY( std::isnan( block->valueAndNoData( mpRasterLayer->width() + 1, 0, isNoData ) ) );
+  QVERIFY( isNoData );
+
   // value() with index
   QCOMPARE( block->value( 0 ), 2. );
   QCOMPARE( block->value( 1 ), 5. );
   QCOMPARE( block->value( 10 ), 27. );
+  QCOMPARE( block->valueAndNoData( 0, isNoData ), 2. );
+  QVERIFY( !isNoData );
+  QCOMPARE( block->valueAndNoData( 1, isNoData ), 5. );
+  QVERIFY( !isNoData );
+  QCOMPARE( block->valueAndNoData( 10, isNoData ), 27. );
+  QVERIFY( !isNoData );
+  QVERIFY( std::isnan( block->valueAndNoData( mpRasterLayer->width() * mpRasterLayer->height(), isNoData ) ) );
+  QVERIFY( isNoData );
 
   // isNoData()
   QCOMPARE( block->isNoData( 0, 1 ), false );
   QCOMPARE( block->isNoData( 0, 2 ), true );
   QCOMPARE( block->isNoData( 1 ), false );
   QCOMPARE( block->isNoData( 2 ), true );
+  QCOMPARE( block->valueAndNoData( 0, 1, isNoData ), 5. );
+  QVERIFY( !isNoData );
+  block->valueAndNoData( 0, 2, isNoData );
+  QVERIFY( isNoData );
+  QCOMPARE( block->valueAndNoData( 1, isNoData ), 5. );
+  QVERIFY( !isNoData );
+  block->valueAndNoData( 2, isNoData );
+  QVERIFY( isNoData );
 
   // data()
   QByteArray data = block->data();


### PR DESCRIPTION
This is much more efficient then making two calls, since the QgsRasterBlock::isNoData() check internally calls QgsRasterBlock::value(). So by requiring API users to make the two separate calls individually,
we double the time this process takes...

Found while optimising a processing alg via KDAB's hotspot.
