### PR TITLE
Enable/disable value relation widget

### DIFF
--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -218,6 +218,7 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
       }
     }
     mComboBox->setCurrentIndex( idx );
+    mComboBox->setEnabled( mEnabled );
   }
   else if ( mLineEdit )
   {
@@ -229,6 +230,7 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
         break;
       }
     }
+    mLineEdit->setEnabled( mEnabled );
   }
 }
 
@@ -387,27 +389,4 @@ void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
     return;
 
   mEnabled = enabled;
-
-  if ( mTableWidget )
-  {
-    auto signalBlockedTableWidget = whileBlocking( mTableWidget );
-    Q_UNUSED( signalBlockedTableWidget )
-
-    for ( int j = 0; j < mTableWidget->rowCount(); j++ )
-    {
-      for ( int i = 0; i < mTableWidget->columnCount(); ++i )
-      {
-        QTableWidgetItem *item = mTableWidget->item( j, i );
-        if ( item )
-        {
-          if ( enabled )
-            item->setFlags( item->flags() | Qt::ItemIsEnabled );
-          else
-            item->setFlags( item->flags() & ~Qt::ItemIsEnabled );
-        }
-      }
-    }
-  }
-  else
-    QgsEditorWidgetWrapper::setEnabled( enabled );
 }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -193,6 +193,7 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
         if ( item )
         {
           item->setCheckState( checkList.contains( item->data( Qt::UserRole ).toString() ) ? Qt::Checked : Qt::Unchecked );
+          item->setFlags( mEnabled ? item->flags() | Qt::ItemIsEnabled : item->flags() & ~Qt::ItemIsEnabled );
           lastChangedItem = item;
         }
       }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -193,6 +193,7 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
         if ( item )
         {
           item->setCheckState( checkList.contains( item->data( Qt::UserRole ).toString() ) ? Qt::Checked : Qt::Unchecked );
+          //re-set enabled state because it's lost after reloading items
           item->setFlags( mEnabled ? item->flags() | Qt::ItemIsEnabled : item->flags() & ~Qt::ItemIsEnabled );
           lastChangedItem = item;
         }
@@ -218,7 +219,6 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
       }
     }
     mComboBox->setCurrentIndex( idx );
-    mComboBox->setEnabled( mEnabled );
   }
   else if ( mLineEdit )
   {
@@ -230,7 +230,6 @@ void QgsValueRelationWidgetWrapper::setValue( const QVariant &value )
         break;
       }
     }
-    mLineEdit->setEnabled( mEnabled );
   }
 }
 
@@ -389,4 +388,24 @@ void QgsValueRelationWidgetWrapper::setEnabled( bool enabled )
     return;
 
   mEnabled = enabled;
+
+  if ( mTableWidget )
+  {
+    auto signalBlockedTableWidget = whileBlocking( mTableWidget );
+    Q_UNUSED( signalBlockedTableWidget )
+
+    for ( int j = 0; j < mTableWidget->rowCount(); j++ )
+    {
+      for ( int i = 0; i < mTableWidget->columnCount(); ++i )
+      {
+        QTableWidgetItem *item = mTableWidget->item( j, i );
+        if ( item )
+        {
+          item->setFlags( enabled ? item->flags() | Qt::ItemIsEnabled : item->flags() & ~Qt::ItemIsEnabled );
+        }
+      }
+    }
+  }
+  else
+    QgsEditorWidgetWrapper::setEnabled( enabled );
 }

--- a/tests/src/python/test_qgseditwidgets.py
+++ b/tests/src/python/test_qgseditwidgets.py
@@ -18,8 +18,8 @@ from qgis.core import (QgsProject, QgsFeature, QgsGeometry, QgsPointXY, QgsVecto
 from qgis.gui import QgsGui
 
 from qgis.testing import start_app, unittest
-from qgis.PyQt.QtCore import QVariant
-from qgis.PyQt.QtWidgets import QTextEdit
+from qgis.PyQt.QtCore import Qt, QVariant
+from qgis.PyQt.QtWidgets import QTextEdit, QTableWidgetItem
 
 start_app()
 
@@ -107,6 +107,24 @@ class TestQgsValueRelationWidget(unittest.TestCase):
         self.assertFalse(widget.isEnabled())
         wrapper.setEnabled(True)
         self.assertTrue(widget.isEnabled())
+
+    def test_enableDisableOnTableWidget(self):
+        reg = QgsGui.editorWidgetRegistry()
+        layer = QgsVectorLayer("none?field=number:integer", "layer", "memory")
+        wrapper = reg.create('ValueRelation', layer, 0, {'AllowMulti': 'True'}, None, None)
+
+        widget = wrapper.widget()
+        item = QTableWidgetItem('first item')
+        widget.setItem(0, 0, item)
+
+        # does not change the state the whole widget but the single items instead
+        wrapper.setEnabled(False)
+        # widget still true, but items false
+        self.assertTrue(widget.isEnabled())
+        self.assertNotEqual(widget.item(0, 0).flags(), widget.item(0, 0).flags() | Qt.ItemIsEnabled)
+        wrapper.setEnabled(True)
+        self.assertTrue(widget.isEnabled())
+        self.assertEqual(widget.item(0, 0).flags(), widget.item(0, 0).flags() | Qt.ItemIsEnabled)
 
 
 class TestQgsValueMapEditWidget(unittest.TestCase):


### PR DESCRIPTION
## Bugfix

![valuerelations_bad](https://user-images.githubusercontent.com/28384354/51487258-25a5ac00-1da3-11e9-9719-92a9f70fdfd6.gif)

Since we still need to be able to use the scroll bar the items has to be set to disabled / enabled individually.

This has been done in the `setEnabled` but on value reload the single items have been recreated and seemed to loose the flags. This leaded to confusion and you entered data even when you have been not in editing-mode.

Since the `setValues` is called on toggle of editing-mode anyway, the enable / disable setting of the widget is done there. To avoid redundant code the setting for the `QLineEdit` and the `QComboBox` are there as well.

![valuerelations_gut](https://user-images.githubusercontent.com/28384354/51487250-21798e80-1da3-11e9-9ddb-44bbcfd127f9.gif)
