### PR TITLE
[processing][needs-docs] add missed "srcnodata" parameter to the buildvrt algorithm (fix #20586)

### DIFF
--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -39,6 +39,7 @@ from qgis.core import (QgsProcessingAlgorithm,
                        QgsProcessingParameterBoolean,
                        QgsProcessingParameterRasterDestination,
                        QgsProcessingParameterCrs,
+                       QgsProcessingParameterString,
                        QgsProcessingOutputLayerDefinition,
                        QgsProcessingUtils)
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
@@ -57,6 +58,7 @@ class buildvrt(GdalAlgorithm):
     ADD_ALPHA = 'ADD_ALPHA'
     ASSIGN_CRS = 'ASSIGN_CRS'
     RESAMPLING = 'RESAMPLING'
+    SRC_NODATA = 'SRC_NODATA'
 
     RESOLUTION_OPTIONS = ['average', 'highest', 'lowest']
     RESAMPLING_OPTIONS = ['nearest', 'bilinear', 'cubic', 'cubicspline', 'lanczos', 'average', 'mode']
@@ -82,37 +84,44 @@ class buildvrt(GdalAlgorithm):
                 return 'vrt'
 
         self.addParameter(QgsProcessingParameterMultipleLayers(self.INPUT,
-                                                               QCoreApplication.translate("ParameterVrtDestination", 'Input layers'),
+                                                               self.tr('Input layers'),
                                                                QgsProcessing.TypeRaster))
         self.addParameter(QgsProcessingParameterEnum(self.RESOLUTION,
-                                                     QCoreApplication.translate("ParameterVrtDestination", 'Resolution'),
+                                                     self.tr('Resolution'),
                                                      options=self.RESOLUTION_OPTIONS,
                                                      defaultValue=0))
         self.addParameter(QgsProcessingParameterBoolean(self.SEPARATE,
-                                                        QCoreApplication.translate("ParameterVrtDestination", 'Place each input file into a separate band'),
+                                                        self.tr('Place each input file into a separate band'),
                                                         defaultValue=True))
         self.addParameter(QgsProcessingParameterBoolean(self.PROJ_DIFFERENCE,
-                                                        QCoreApplication.translate("ParameterVrtDestination", 'Allow projection difference'),
+                                                        self.tr('Allow projection difference'),
                                                         defaultValue=False))
 
         add_alpha_param = QgsProcessingParameterBoolean(self.ADD_ALPHA,
-                                                        QCoreApplication.translate("ParameterVrtDestination", 'Add alpha mask band to VRT when source raster has none'),
+                                                        self.tr('Add alpha mask band to VRT when source raster has none'),
                                                         defaultValue=False)
         add_alpha_param.setFlags(add_alpha_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(add_alpha_param)
 
         assign_crs = QgsProcessingParameterCrs(self.ASSIGN_CRS,
-                                               QCoreApplication.translate("ParameterVrtDestination", 'Override projection for the output file'),
+                                               self.tr('Override projection for the output file'),
                                                defaultValue=None, optional=True)
         assign_crs.setFlags(assign_crs.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(assign_crs)
 
         resampling = QgsProcessingParameterEnum(self.RESAMPLING,
-                                                QCoreApplication.translate("ParameterVrtDestination", 'Resampling algorithm'),
+                                                self.tr('Resampling algorithm'),
                                                 options=self.RESAMPLING_OPTIONS,
                                                 defaultValue=0)
         resampling.setFlags(resampling.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
         self.addParameter(resampling)
+
+        src_nodata_param = QgsProcessingParameterString(self.SRC_NODATA,
+                                                        self.tr('Nodata value(s) for input bands'),
+                                                        defaultValue=None,
+                                                        optional=True)
+        src_nodata_param.setFlags(src_nodata_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+        self.addParameter(src_nodata_param)
 
         self.addParameter(ParameterVrtDestination(self.OUTPUT, QCoreApplication.translate("ParameterVrtDestination", 'Virtual')))
 
@@ -150,6 +159,10 @@ class buildvrt(GdalAlgorithm):
             arguments.append(GdalUtils.gdal_crs_string(crs))
         arguments.append('-r')
         arguments.append(self.RESAMPLING_OPTIONS[self.parameterAsEnum(parameters, self.RESAMPLING, context)])
+
+        if self.SRC_NODATA in parameters and parameters[self.SRC_NODATA] not in (None, ''):
+            nodata = self.parameterAsString(parameters, self.SRC_NODATA, context)
+            arguments.append('-srcnodata "{}"'.format(nodata))
 
         # Always write input files to a text file in case there are many of them and the
         # length of the command will be longer then allowed in command prompt

--- a/python/plugins/processing/algs/gdal/buildvrt.py
+++ b/python/plugins/processing/algs/gdal/buildvrt.py
@@ -117,7 +117,7 @@ class buildvrt(GdalAlgorithm):
         self.addParameter(resampling)
 
         src_nodata_param = QgsProcessingParameterString(self.SRC_NODATA,
-                                                        self.tr('Nodata value(s) for input bands'),
+                                                        self.tr('Nodata value(s) for input bands (space separated)'),
                                                         defaultValue=None,
                                                         optional=True)
         src_nodata_param.setFlags(src_nodata_param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)

--- a/python/plugins/processing/tests/GdalAlgorithmsTest.py
+++ b/python/plugins/processing/tests/GdalAlgorithmsTest.py
@@ -1104,6 +1104,51 @@ class TestGdalAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
             self.assertIn('-input_file_list', commands[1])
             self.assertIn(outdir + '/test.vrt', commands[1])
 
+            commands = alg.getConsoleCommands({'LAYERS': [source],
+                                               'SRC_NODATA': '-9999',
+                                               'OUTPUT': outdir + '/test.vrt'}, context, feedback)
+            self.assertEqual(len(commands), 2)
+            self.assertEqual(commands[0], 'gdalbuildvrt')
+            self.assertIn('-resolution average', commands[1])
+            self.assertIn('-separate', commands[1])
+            self.assertNotIn('-allow_projection_difference', commands[1])
+            self.assertNotIn('-add_alpha', commands[1])
+            self.assertNotIn('-a_srs', commands[1])
+            self.assertIn('-r nearest', commands[1])
+            self.assertIn('-srcnodata "-9999"', commands[1])
+            self.assertIn('-input_file_list', commands[1])
+            self.assertIn(outdir + '/test.vrt', commands[1])
+
+            commands = alg.getConsoleCommands({'LAYERS': [source],
+                                               'SRC_NODATA': '-9999 9999',
+                                               'OUTPUT': outdir + '/test.vrt'}, context, feedback)
+            self.assertEqual(len(commands), 2)
+            self.assertEqual(commands[0], 'gdalbuildvrt')
+            self.assertIn('-resolution average', commands[1])
+            self.assertIn('-separate', commands[1])
+            self.assertNotIn('-allow_projection_difference', commands[1])
+            self.assertNotIn('-add_alpha', commands[1])
+            self.assertNotIn('-a_srs', commands[1])
+            self.assertIn('-r nearest', commands[1])
+            self.assertIn('-srcnodata "-9999 9999"', commands[1])
+            self.assertIn('-input_file_list', commands[1])
+            self.assertIn(outdir + '/test.vrt', commands[1])
+
+            commands = alg.getConsoleCommands({'LAYERS': [source],
+                                               'SRC_NODATA': '',
+                                               'OUTPUT': outdir + '/test.vrt'}, context, feedback)
+            self.assertEqual(len(commands), 2)
+            self.assertEqual(commands[0], 'gdalbuildvrt')
+            self.assertIn('-resolution average', commands[1])
+            self.assertIn('-separate', commands[1])
+            self.assertNotIn('-allow_projection_difference', commands[1])
+            self.assertNotIn('-add_alpha', commands[1])
+            self.assertNotIn('-a_srs', commands[1])
+            self.assertIn('-r nearest', commands[1])
+            self.assertNotIn('-srcnodata', commands[1])
+            self.assertIn('-input_file_list', commands[1])
+            self.assertIn(outdir + '/test.vrt', commands[1])
+
     def testGdalInfo(self):
         context = QgsProcessingContext()
         feedback = QgsProcessingFeedback()


### PR DESCRIPTION
## Description
Without this parameter it is not possible to remove collars surrounding input raster which may overlap with other input rasters. As this is very frequent case algorithm is useless without such parameter. To keep API compatibility new parameter is optional and not used by default. Fixes https://issues.qgis.org/issues/20586

Tests included.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
