### PR TITLE
Rework QgsNetworkAccessManager::requestAboutToBeCreated() to be thread safe

### DIFF
--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -10,6 +10,51 @@
 
 
 
+class QgsNetworkRequestParameters
+{
+%Docstring
+Encapsulates parameters and properties of a network request.
+
+.. versionadded:: 3.6
+%End
+
+%TypeHeaderCode
+#include "qgsnetworkaccessmanager.h"
+%End
+  public:
+
+    QgsNetworkRequestParameters();
+%Docstring
+Default constructor.
+%End
+
+    QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation,
+                                 const QNetworkRequest &request );
+%Docstring
+Constructor for QgsNetworkRequestParameters, with the specified network
+``operation`` and original ``request``.
+%End
+
+    QNetworkAccessManager::Operation operation() const;
+%Docstring
+Returns the request operation, e.g. GET or POST.
+%End
+
+    QNetworkRequest request() const;
+%Docstring
+Returns the network request.
+
+This is the original network request sent to :py:class:`QgsNetworkAccessManager`, but with QGIS specific
+configuration options such as proxy handling and SSL exceptions applied.
+%End
+
+    QString originatingThreadId() const;
+%Docstring
+Returns a string identifying the thread which the request originated from.
+%End
+
+};
+
 class QgsNetworkAccessManager : QNetworkAccessManager
 {
 %Docstring
@@ -111,6 +156,18 @@ Returns whether the system proxy should be used
 
   signals:
     void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * );
+
+    void requestAboutToBeCreated( QgsNetworkRequestParameters request );
+%Docstring
+Emitted when a network request is about to be created.
+
+This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+only to connect to the main thread's signal in order to receive notifications about requests
+created in any thread.
+
+.. versionadded:: 3.6
+%End
+
     void requestCreated( QNetworkReply * );
     void requestTimedOut( QNetworkReply * );
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -206,6 +206,7 @@ void QgsApplication::init( QString profileFolder )
   qRegisterMetaType<QgsStyle::StyleEntity>( "QgsStyle::StyleEntity" );
   qRegisterMetaType<QgsCoordinateReferenceSystem>( "QgsCoordinateReferenceSystem" );
   qRegisterMetaType<QgsAuthManager::MessageLevel>( "QgsAuthManager::MessageLevel" );
+  qRegisterMetaType<QgsNetworkRequestParameters>( "QgsNetworkRequestParameters" );
 
   ( void ) resolvePkgPath();
 

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -203,6 +203,7 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   }
 #endif
 
+  emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, req ) );
   emit requestAboutToBeCreated( op, req, outgoingData );
   QNetworkReply *reply = QNetworkAccessManager::createRequest( op, req, outgoingData );
 
@@ -301,6 +302,9 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
     connect( this, &QgsNetworkAccessManager::requestTimedOut,
              sMainNAM, &QgsNetworkAccessManager::requestTimedOut );
 
+    connect( this, qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ),
+             sMainNAM, qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ) );
+
 #ifndef QT_NO_SSL
     connect( this, &QNetworkAccessManager::sslErrors,
              sMainNAM, &QNetworkAccessManager::sslErrors,
@@ -394,3 +398,13 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
     setCache( newcache );
 }
 
+//
+// QgsNetworkRequestParameters
+//
+
+QgsNetworkRequestParameters::QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation, const QNetworkRequest &request )
+  : mOperation( operation )
+  , mRequest( request )
+  , mOriginatingThreadId( QStringLiteral( "0x%2" ).arg( reinterpret_cast<quintptr>( QThread::currentThread() ), 2 * QT_POINTER_SIZE, 16, QLatin1Char( '0' ) ) )
+{
+}

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -28,6 +28,54 @@
 #include "qgis_core.h"
 
 /**
+ * \class QgsNetworkRequestParameters
+ * \ingroup core
+ * Encapsulates parameters and properties of a network request.
+ * \since QGIS 3.6
+ */
+class CORE_EXPORT QgsNetworkRequestParameters
+{
+  public:
+
+    /**
+     * Default constructor.
+     */
+    QgsNetworkRequestParameters() = default;
+
+    /**
+     * Constructor for QgsNetworkRequestParameters, with the specified network
+     * \a operation and original \a request.
+     */
+    QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation,
+                                 const QNetworkRequest &request );
+
+    /**
+     * Returns the request operation, e.g. GET or POST.
+     */
+    QNetworkAccessManager::Operation operation() const { return mOperation; }
+
+    /**
+     * Returns the network request.
+     *
+     * This is the original network request sent to QgsNetworkAccessManager, but with QGIS specific
+     * configuration options such as proxy handling and SSL exceptions applied.
+     */
+    QNetworkRequest request() const { return mRequest; }
+
+    /**
+     * Returns a string identifying the thread which the request originated from.
+     */
+    QString originatingThreadId() const { return mOriginatingThreadId; }
+
+  private:
+
+    QNetworkAccessManager::Operation mOperation;
+    QNetworkRequest mRequest;
+    QString mOriginatingThreadId;
+
+};
+
+/**
  * \class QgsNetworkAccessManager
  * \brief network access manager for QGIS
  * \ingroup core
@@ -110,6 +158,18 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 
   signals:
     void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * );
+
+    /**
+     * Emitted when a network request is about to be created.
+     *
+     * This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+     * only to connect to the main thread's signal in order to receive notifications about requests
+     * created in any thread.
+     *
+     * \since QGIS 3.6
+     */
+    void requestAboutToBeCreated( QgsNetworkRequestParameters request );
+
     void requestCreated( QNetworkReply * );
     void requestTimedOut( QNetworkReply * );
 


### PR DESCRIPTION
... and encapsulate more useful request information

An alternative approach to #8907