### PR TITLE
 Silently alias old "$scale" expression function to "@map_scale"

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -749,7 +749,7 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "map_units" ), QCoreApplication::translate( "variable_help", "Units for map measurements." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_definition" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (full definition)." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the coordinate reference system of the map." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_ellipsoid_acr" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of the coordinate reference system of the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_ellipsoid" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of the coordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_proj4" ), QCoreApplication::translate( "variable_help", "Proj4 definition of the coordinate reference system." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs_wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the coordinate reference system." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layer_ids" ), QCoreApplication::translate( "variable_help", "List of map layer IDs visible in the map." ) );

--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -745,8 +745,13 @@ void QgsExpression::initVariableHelp()
   sVariableHelpTexts.insert( QStringLiteral( "map_extent_width" ), QCoreApplication::translate( "variable_help", "Width of map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_extent_height" ), QCoreApplication::translate( "variable_help", "Height of map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_crs" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (e.g., 'EPSG:4326')." ) );
-  sVariableHelpTexts.insert( QStringLiteral( "map_crs_definition" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (full definition)." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_description" ), QCoreApplication::translate( "variable_help", "Name of the coordinate reference system of the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_units" ), QCoreApplication::translate( "variable_help", "Units for map measurements." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_definition" ), QCoreApplication::translate( "variable_help", "Coordinate reference system of map (full definition)." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_acronym" ), QCoreApplication::translate( "variable_help", "Acronym of the coordinate reference system of the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_ellipsoid_acr" ), QCoreApplication::translate( "variable_help", "Acronym of the ellipsoid of the coordinate reference system of the map." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_proj4" ), QCoreApplication::translate( "variable_help", "Proj4 definition of the coordinate reference system." ) );
+  sVariableHelpTexts.insert( QStringLiteral( "map_crs_wkt" ), QCoreApplication::translate( "variable_help", "WKT definition of the coordinate reference system." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layer_ids" ), QCoreApplication::translate( "variable_help", "List of map layer IDs visible in the map." ) );
   sVariableHelpTexts.insert( QStringLiteral( "map_layers" ), QCoreApplication::translate( "variable_help", "List of map layers visible in the map." ) );
 

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -889,6 +889,22 @@ static QVariant fcnAggregateArray( const QVariantList &values, const QgsExpressi
   return fcnAggregateGeneric( QgsAggregateCalculator::ArrayAggregate, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
+static QVariant fcnMapScale( const QVariantList &, const QgsExpressionContext *context, QgsExpression *, const QgsExpressionNodeFunction * )
+{
+  if ( !context )
+    return QVariant();
+
+  QVariant scale = context->variable( QStringLiteral( "map_scale" ) );
+  bool ok = false;
+  if ( !scale.isValid() || scale.isNull() )
+    return QVariant();
+
+  const double v = scale.toDouble( &ok );
+  if ( ok )
+    return v;
+  return QVariant();
+}
+
 static QVariant fcnClamp( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   double minValue = QgsExpressionUtils::getDoubleValue( values.at( 0 ), parent );
@@ -4877,7 +4893,10 @@ const QList<QgsExpressionFunction *> &QgsExpression::Functions()
         << new QgsStaticExpressionFunction( QStringLiteral( "color_part" ), 2, fncColorPart, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "darker" ), 2, fncDarker, QStringLiteral( "Color" ) )
         << new QgsStaticExpressionFunction( QStringLiteral( "lighter" ), 2, fncLighter, QStringLiteral( "Color" ) )
-        << new QgsStaticExpressionFunction( QStringLiteral( "set_color_part" ), 3, fncSetColorPart, QStringLiteral( "Color" ) );
+        << new QgsStaticExpressionFunction( QStringLiteral( "set_color_part" ), 3, fncSetColorPart, QStringLiteral( "Color" ) )
+
+        // deprecated stuff - hidden from users
+        << new QgsStaticExpressionFunction( QStringLiteral( "$scale" ), QgsExpressionFunction::ParameterList(), fcnMapScale, QStringLiteral( "deprecated" ) );
 
     QgsStaticExpressionFunction *geomFunc = new QgsStaticExpressionFunction( QStringLiteral( "$geometry" ), 0, fcnGeometry, QStringLiteral( "GeometryGroup" ), QString(), true );
     geomFunc->setIsStatic( false );

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1263,7 +1263,12 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
   QgsCoordinateReferenceSystem mapCrs = crs();
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs" ), mapCrs.authid(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_definition" ), mapCrs.toProj4(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapCrs.description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapCrs.mapUnits() ), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapCrs.projectionAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapCrs.ellipsoidAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_proj4" ), mapCrs.toProj4(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_wkt" ), mapCrs.toWkt(), true ) );
 
   QVariantList layersIds;
   QVariantList layers;

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1266,7 +1266,7 @@ QgsExpressionContext QgsLayoutItemMap::createExpressionContext() const
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapCrs.description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapCrs.mapUnits() ), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapCrs.projectionAcronym(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapCrs.ellipsoidAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_ellipsoid" ), mapCrs.ellipsoidAcronym(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_proj4" ), mapCrs.toProj4(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_wkt" ), mapCrs.toWkt(), true ) );
 

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -1013,7 +1013,7 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapSettings.mapUnits() ), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapSettings.destinationCrs().description(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapSettings.destinationCrs().projectionAcronym(), true ) );
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapSettings.destinationCrs().ellipsoidAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_ellipsoid" ), mapSettings.destinationCrs().ellipsoidAcronym(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_proj4" ), mapSettings.destinationCrs().toProj4(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_wkt" ), mapSettings.destinationCrs().toWkt(), true ) );
 

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -1011,6 +1011,11 @@ QgsExpressionContextScope *QgsExpressionContextUtils::mapSettingsScope( const Qg
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs" ), mapSettings.destinationCrs().authid(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_definition" ), mapSettings.destinationCrs().toProj4(), true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_units" ), QgsUnitTypes::toString( mapSettings.mapUnits() ), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_description" ), mapSettings.destinationCrs().description(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_acronym" ), mapSettings.destinationCrs().projectionAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_ellipsoid_acr" ), mapSettings.destinationCrs().ellipsoidAcronym(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_proj4" ), mapSettings.destinationCrs().toProj4(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "map_crs_wkt" ), mapSettings.destinationCrs().toWkt(), true ) );
 
   // IMPORTANT: ANY CHANGES HERE ALSO NEED TO BE MADE TO QgsLayoutItemMap::createExpressionContext()
   // (rationale is described in QgsLayoutItemMap::createExpressionContext() )

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -626,15 +626,15 @@ void TestQgsLayoutMap::expressionContext()
   r = e6.evaluate( &c );
   QCOMPARE( r.toString(), QString( "longlat" ) );
 
-  //QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
-  //r = e7.evaluate( &c );
-  //QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+  QgsExpression e7( QStringLiteral( "@map_crs_proj4" ) );
+  r = e7.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
 
-  //QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
-  //r = e8.evaluate( &c );
-  //QVERIFY( r.toString().length() >= 15 );
+  QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
+  r = e8.evaluate( &c );
+  QVERIFY( r.toString().length() >= 15 );
 
-  QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
+  QgsExpression e9( QStringLiteral( "@map_crs_ellipsoid" ) );
   r = e9.evaluate( &c );
   QCOMPARE( r.toString(), QString( "WGS84" ) );
 

--- a/tests/src/core/testqgslayoutmap.cpp
+++ b/tests/src/core/testqgslayoutmap.cpp
@@ -618,24 +618,44 @@ void TestQgsLayoutMap::expressionContext()
   r = e4.evaluate( &c );
   QCOMPARE( r.toString(), QString( "degrees" ) );
 
+  QgsExpression e5( QStringLiteral( "@map_crs_description" ) );
+  r = e5.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "WGS 84" ) );
+
+  QgsExpression e6( QStringLiteral( "@map_crs_acronym" ) );
+  r = e6.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "longlat" ) );
+
+  //QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
+  //r = e7.evaluate( &c );
+  //QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+
+  //QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
+  //r = e8.evaluate( &c );
+  //QVERIFY( r.toString().length() >= 15 );
+
+  QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
+  r = e9.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "WGS84" ) );
+
   QgsVectorLayer *layer = new QgsVectorLayer( QStringLiteral( "Point?field=id_a:integer" ), QStringLiteral( "A" ), QStringLiteral( "memory" ) );
   QgsVectorLayer *layer2 = new QgsVectorLayer( QStringLiteral( "Point?field=id_a:integer" ), QStringLiteral( "B" ), QStringLiteral( "memory" ) );
   map->setLayers( QList<QgsMapLayer *>() << layer << layer2 );
   QgsProject::instance()->addMapLayers( map->layers() );
   c = map->createExpressionContext();
-  QgsExpression e5( QStringLiteral( "@map_layer_ids" ) );
-  r = e5.evaluate( &c );
+  QgsExpression e10( QStringLiteral( "@map_layer_ids" ) );
+  r = e10.evaluate( &c );
   QCOMPARE( r.toStringList().join( ',' ), QStringLiteral( "%1,%2" ).arg( layer->id(), layer2->id() ) );
-  e5 = QgsExpression( QStringLiteral( "array_foreach(@map_layers, layer_property(@element, 'name'))" ) );
-  r = e5.evaluate( &c );
+  e10 = QgsExpression( QStringLiteral( "array_foreach(@map_layers, layer_property(@element, 'name'))" ) );
+  r = e10.evaluate( &c );
   QCOMPARE( r.toStringList().join( ',' ), QStringLiteral( "A,B" ) );
 
-  QgsExpression e6( QStringLiteral( "is_layer_visible( '%1' )" ).arg( layer->id() ) );
-  r = e6.evaluate( &c );
+  QgsExpression e11( QStringLiteral( "is_layer_visible( '%1' )" ).arg( layer->id() ) );
+  r = e11.evaluate( &c );
   QCOMPARE( r.toBool(), true );
 
-  QgsExpression e7( QStringLiteral( "is_layer_visible( 'aaaaaa' )" ) );
-  r = e7.evaluate( &c );
+  QgsExpression e12( QStringLiteral( "is_layer_visible( 'aaaaaa' )" ) );
+  r = e12.evaluate( &c );
   QCOMPARE( r.toBool(), false );
 }
 

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -392,12 +392,12 @@ void TestQgsMapSettings::testExpressionContext()
 
   QgsExpression e( QStringLiteral( "@map_scale" ) );
   r = e.evaluate( &c );
-  QGSCOMPARENEAR( r.toDouble(), 247990, 10 );
+  QGSCOMPARENEAR( r.toDouble(), 247990, 10.0 );
 
   // The old $scale function should silently map to @map_scale, so that older projects work without change
   e = QgsExpression( QStringLiteral( "$scale" ) );
   r = e.evaluate( &c );
-  QGSCOMPARENEAR( r.toDouble(), 247990, 10 );
+  QGSCOMPARENEAR( r.toDouble(), 247990, 10.0 );
 
   // no map settings scope -- $scale is meaningless
   e = QgsExpression( QStringLiteral( "$scale" ) );
@@ -421,11 +421,11 @@ void TestQgsMapSettings::testExpressionContext()
 
   e = QgsExpression( QStringLiteral( "@map_extent_width" ) );
   r = e.evaluate( &c );
-  QCOMPARE( r.toDouble(), 3 );
+  QCOMPARE( r.toDouble(), 3.0 );
 
   e = QgsExpression( QStringLiteral( "@map_extent_height" ) );
   r = e.evaluate( &c );
-  QCOMPARE( r.toDouble(), 3 );
+  QCOMPARE( r.toDouble(), 3.0 );
 
   e = QgsExpression( QStringLiteral( "geom_to_wkt( @map_extent_center )" ) );
   r = e.evaluate( &c );

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -27,6 +27,7 @@
 #include "qgsapplication.h"
 #include "qgsmaplayerlistutils.h"
 #include "qgsvectorlayer.h"
+#include "qgscoordinatereferencesystem.h"
 
 class TestQgsMapSettings: public QObject
 {
@@ -440,7 +441,27 @@ void TestQgsMapSettings::testExpressionContext()
 
   e = QgsExpression( QStringLiteral( "@map_units" ) );
   r = e.evaluate( &c );
-  QCOMPARE( r.toString(), QStringLiteral( "degrees" ) );
+  QCOMPARE( r.toString(), QStringLiteral( "degrees" ) );\
+
+  QgsExpression e5( QStringLiteral( "@map_crs_description" ) );
+  r = e5.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "WGS 84" ) );
+
+  QgsExpression e6( QStringLiteral( "@map_crs_acronym" ) );
+  r = e6.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "longlat" ) );
+
+  //QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
+  //r = e7.evaluate( &c );
+  //QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+
+  //QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
+  //r = e8.evaluate( &c );
+  //QVERIFY( r.toString().length() > 15 );
+
+  QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
+  r = e9.evaluate( &c );
+  QCOMPARE( r.toString(), QString( "WGS84" ) );
 }
 
 QGSTEST_MAIN( TestQgsMapSettings )

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -441,27 +441,27 @@ void TestQgsMapSettings::testExpressionContext()
 
   e = QgsExpression( QStringLiteral( "@map_units" ) );
   r = e.evaluate( &c );
-  QCOMPARE( r.toString(), QStringLiteral( "degrees" ) );\
+  QCOMPARE( r.toString(), QStringLiteral( "degrees" ) );
 
-  QgsExpression e5( QStringLiteral( "@map_crs_description" ) );
-  r = e5.evaluate( &c );
-  QCOMPARE( r.toString(), QString( "WGS 84" ) );
+  e = QgsExpression( QStringLiteral( "@map_crs_description" ) );
+  r = e.evaluate( &c );
+  QCOMPARE( r.toString(), QStringLiteral( "WGS 84" ) );
 
-  QgsExpression e6( QStringLiteral( "@map_crs_acronym" ) );
-  r = e6.evaluate( &c );
-  QCOMPARE( r.toString(), QString( "longlat" ) );
+  e = QgsExpression( QStringLiteral( "@map_crs_acronym" ) );
+  r = e.evaluate( &c );
+  QCOMPARE( r.toString(), QStringLiteral( "longlat" ) );
 
-  //QgsExpression e7( QStringLiteral( "@map_crs_pro4" ) );
-  //r = e7.evaluate( &c );
-  //QCOMPARE( r.toString(), QString( "+proj=longlat +datum=WGS84 +no_defs" ) );
+  e = QgsExpression( QStringLiteral( "@map_crs_proj4" ) );
+  r = e.evaluate( &c );
+  QCOMPARE( r.toString(), QStringLiteral( "+proj=longlat +datum=WGS84 +no_defs" ) );
 
-  //QgsExpression e8( QStringLiteral( "@map_crs_wkt" ) );
-  //r = e8.evaluate( &c );
-  //QVERIFY( r.toString().length() > 15 );
+  e = QgsExpression( QStringLiteral( "@map_crs_wkt" ) );
+  r = e.evaluate( &c );
+  QVERIFY( r.toString().length() > 15 );
 
-  QgsExpression e9( QStringLiteral( "@map_ellipsoid_acr" ) );
-  r = e9.evaluate( &c );
-  QCOMPARE( r.toString(), QString( "WGS84" ) );
+  e = QgsExpression( QStringLiteral( "@map_crs_ellipsoid" ) );
+  r = e.evaluate( &c );
+  QCOMPARE( r.toString(), QStringLiteral( "WGS84" ) );
 }
 
 QGSTEST_MAIN( TestQgsMapSettings )


### PR DESCRIPTION
And add tests, extra CRS format variables for map settings scope. Supersedes #8891 