### PR TITLE
Node tool's editor panel UX fixes

### DIFF
--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -333,7 +333,10 @@ QgsVertexEditor::QgsVertexEditor(
 
 void QgsVertexEditor::updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *selectedFeature )
 {
-  delete mVertexModel;
+  if ( mSelectedFeature )
+  {
+    delete mVertexModel;
+  }
 
   mLayer = layer;
   mSelectedFeature = selectedFeature;

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -74,7 +74,7 @@ QgsVertexEditorModel::QgsVertexEditorModel( QgsVectorLayer *layer, QgsSelectedFe
 
 int QgsVertexEditorModel::rowCount( const QModelIndex &parent ) const
 {
-  if ( parent.isValid() )
+  if ( parent.isValid() || !mSelectedFeature )
     return 0;
 
   return mSelectedFeature->vertexMap().count();
@@ -88,7 +88,7 @@ int QgsVertexEditorModel::columnCount( const QModelIndex &parent ) const
 
 QVariant QgsVertexEditorModel::data( const QModelIndex &index, int role ) const
 {
-  if ( !index.isValid() ||
+  if ( !index.isValid() || !mSelectedFeature ||
        ( role != Qt::DisplayRole && role != Qt::EditRole && role != MIN_RADIUS_ROLE && role != Qt::FontRole ) )
     return QVariant();
 
@@ -206,7 +206,7 @@ bool QgsVertexEditorModel::setData( const QModelIndex &index, const QVariant &va
   {
     return false;
   }
-  if ( index.row() >= mSelectedFeature->vertexMap().count() )
+  if ( !mSelectedFeature || index.row() >= mSelectedFeature->vertexMap().count() )
   {
     return false;
   }
@@ -270,7 +270,7 @@ Qt::ItemFlags QgsVertexEditorModel::flags( const QModelIndex &index ) const
 
 bool QgsVertexEditorModel::calcR( int row, double &r, double &minRadius ) const
 {
-  if ( row <= 0 || row >= mSelectedFeature->vertexMap().count() - 1 )
+  if ( row <= 0 || !mSelectedFeature || row >= mSelectedFeature->vertexMap().count() - 1 )
     return false;
 
   const QgsVertexEntry *entry = mSelectedFeature->vertexMap().at( row );
@@ -333,7 +333,7 @@ void QgsVertexEditor::updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *s
 
 void QgsVertexEditor::updateTableSelection()
 {
-  if ( mUpdatingVertexSelection )
+  if ( !mSelectedFeature || mUpdatingVertexSelection )
     return;
 
   mUpdatingTableSelection = true;
@@ -360,7 +360,7 @@ void QgsVertexEditor::updateTableSelection()
 
 void QgsVertexEditor::updateVertexSelection( const QItemSelection &selected, const QItemSelection & )
 {
-  if ( mUpdatingTableSelection )
+  if ( !mSelectedFeature || mUpdatingTableSelection )
     return;
 
   mUpdatingVertexSelection = true;

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -337,6 +337,7 @@ void QgsVertexEditor::updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *s
   if ( mSelectedFeature )
   {
     delete mVertexModel;
+    mVertexModel = nullptr;
   }
 
   mLayer = layer;

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -309,7 +309,8 @@ QgsVertexEditor::QgsVertexEditor(
   layout->setContentsMargins( 0, 0, 0, 0 );
 
   mHintLabel = new QLabel( this );
-  mHintLabel->setText( tr( "Right click on the edge of an editable feature to show its table of vertices" ) );
+  mHintLabel->setText( QStringLiteral( "%1\n\n%2" ).arg( tr( "Right click on the edge of an editable feature to show its table of vertices." ),
+                       tr( "When a feature is bound to this panel, dragging a rectangle to select vertices on the canvas will only select those of the bound feature." ) ) );
   mHintLabel->setWordWrap( true );
   mHintLabel->setAlignment( Qt::AlignHCenter | Qt::AlignVCenter );
 

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -28,6 +28,8 @@ class QgsMapCanvas;
 class QgsRubberBand;
 class QgsSelectedFeature;
 class QgsVectorLayer;
+
+class QLabel;
 class QTableView;
 
 class QgsVertexEditorModel : public QAbstractTableModel
@@ -95,6 +97,8 @@ class QgsVertexEditor : public QgsDockWidget
     void updateVertexSelection( const QItemSelection &selected, const QItemSelection &deselected );
 
   private:
+
+    QLabel *mHintLabel = nullptr;
 
     bool mUpdatingTableSelection = false;
     bool mUpdatingVertexSelection = false;

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1047,6 +1047,9 @@ void QgsVertexTool::onCachedGeometryChanged( QgsFeatureId fid, const QgsGeometry
 
   // re-run validation for the feature
   validateGeometry( layer, fid );
+
+  if ( mVertexEditor && mSelectedFeature && mSelectedFeature->featureId() == fid && mSelectedFeature->layer() == layer )
+    mVertexEditor->updateEditor( mSelectedFeature->layer(), mSelectedFeature.get() );
 }
 
 void QgsVertexTool::onCachedGeometryDeleted( QgsFeatureId fid )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -41,7 +41,7 @@
 
 #include <QMenu>
 #include <QRubberBand>
-
+#include <QTimer>
 
 uint qHash( const Vertex &v )
 {
@@ -1096,8 +1096,7 @@ void QgsVertexTool::showVertexEditor()  //#spellok
     connect( mVertexEditor.get(), &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
     connect( mVertexEditor.get(), &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
 
-    mVertexEditor->show();
-    mVertexEditor->raise();
+    QTimer::singleShot( 100, this, [ = ] { mVertexEditor->show(); mVertexEditor->raise(); } );
   }
   else
   {

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1068,7 +1068,7 @@ void QgsVertexTool::onCachedGeometryDeleted( QgsFeatureId fid )
 void QgsVertexTool::showVertexEditor()  //#spellok
 {
   QgsPointLocator::Match m = mLastMouseMoveMatch;
-  if ( m.isValid() || m.layer() )
+  if ( m.isValid() && m.layer() )
   {
     if ( mSelectedFeature && mSelectedFeature->featureId() == m.featureId() && mSelectedFeature->layer() == m.layer() )
     {
@@ -1099,7 +1099,8 @@ void QgsVertexTool::showVertexEditor()  //#spellok
     connect( mVertexEditor.get(), &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
     connect( mVertexEditor.get(), &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
 
-    QTimer::singleShot( 100, this, [ = ] { mVertexEditor->show(); mVertexEditor->raise(); } );
+    // timer required as showing/raising the vertex editor in the same function following restoreDockWidget fails
+    QTimer::singleShot( 200, this, [ = ] { mVertexEditor->show(); mVertexEditor->raise(); } );
   }
   else
   {

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1078,13 +1078,21 @@ void QgsVertexTool::showVertexEditor()  //#spellok
   if ( !mVertexEditor )
   {
     mVertexEditor.reset( new QgsVertexEditor( m.layer() ? m.layer() : currentVectorLayer(), mSelectedFeature ? mSelectedFeature.get() : nullptr, mCanvas ) );
-    QgisApp::instance()->addDockWidget( Qt::LeftDockWidgetArea, mVertexEditor.get() );
+    if ( !QgisApp::instance()->restoreDockWidget( mVertexEditor.get() ) )
+      QgisApp::instance()->addDockWidget( Qt::LeftDockWidgetArea, mVertexEditor.get() );
+
     connect( mVertexEditor.get(), &QgsVertexEditor::deleteSelectedRequested, this, &QgsVertexTool::deleteVertexEditorSelection );
     connect( mVertexEditor.get(), &QgsVertexEditor::editorClosed, this, &QgsVertexTool::cleanupVertexEditor );
+
+    mVertexEditor->show();
+    mVertexEditor->raise();
   }
   else
   {
     mVertexEditor->updateEditor( m.layer(), mSelectedFeature.get() );
+
+    mVertexEditor->show();
+    mVertexEditor->raise();
   }
 
   if ( mSelectedFeature )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -286,7 +286,7 @@ void QgsVertexTool::activate()
 {
   if ( QgisApp::instance() )
   {
-    showVertexEditor();
+    showVertexEditor();  //#spellok
   }
   QgsMapToolAdvancedDigitizing::activate();
 }
@@ -445,10 +445,7 @@ void QgsVertexTool::cadCanvasPressEvent( QgsMapMouseEvent *e )
       // show popup menu - if we are on top of a feature
       if ( mLastMouseMoveMatch.isValid() && mLastMouseMoveMatch.layer() )
       {
-        QMenu menu;
-        QAction *actionVertexEditor = menu.addAction( tr( "Vertex Editor" ) );
-        connect( actionVertexEditor, &QAction::triggered, this, &QgsVertexTool::showVertexEditor );  //#spellok
-        menu.exec( mCanvas->mapToGlobal( e->pos() ) );
+        showVertexEditor();  //#spellok
       }
     }
   }
@@ -1058,6 +1055,17 @@ void QgsVertexTool::showVertexEditor()  //#spellok
   QgsPointLocator::Match m = mLastMouseMoveMatch;
   if ( m.isValid() || m.layer() )
   {
+    if ( mSelectedFeature && mSelectedFeature->featureId() == m.featureId() && mSelectedFeature->layer() == m.layer() )
+    {
+      // if show feature is called on a feature that's already binded to the vertex editor, toggle it off
+      mSelectedFeature.reset();
+      if ( mVertexEditor )
+      {
+        mVertexEditor->updateEditor( nullptr, nullptr );
+      }
+      return;
+    }
+
     mSelectedFeature.reset( new QgsSelectedFeature( m.featureId(), m.layer(), mCanvas ) );
     for ( int i = 0; i < mSelectedVertices.length(); ++i )
     {

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1968,6 +1968,9 @@ void QgsVertexTool::deleteVertex()
       setHighlightedVertices( vertices_new );
     }
   }
+
+  if ( mVertexEditor && mSelectedFeature )
+    mVertexEditor->updateEditor( mSelectedFeature->layer(), mSelectedFeature.get() );
 }
 
 void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, HighlightMode mode )

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -477,6 +477,7 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     QgsRectangle map_rect( pt0, pt1 );
     QList<Vertex> vertices;
     QList<Vertex> selectedVertices;
+    QList<Vertex> editorVertices;
 
     // for each editable layer, select vertices
     const auto layers = canvas()->layers();
@@ -499,17 +500,28 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
           if ( layerRect.contains( pt ) )
           {
             vertices << Vertex( vlayer, f.id(), i );
+
             if ( isFeatureSelected )
               selectedVertices << Vertex( vlayer, f.id(), i );
+
+            if ( mSelectedFeature && mSelectedFeature->featureId() == f.id() && mSelectedFeature->layer() == vlayer )
+              editorVertices << Vertex( vlayer, f.id(), i );
           }
         }
       }
     }
 
-    // If there were any vertices that come from selected features, use just vertices from selected features.
+    // If there were any vertices that come from a feature currently binded to the node editor, use just verices from
+    // that feature, otherwise if there were any vertices from selected features, use just vertices from those selected features.
     // This allows user to select a bunch of features in complex situations to constrain the selection.
-    if ( !selectedVertices.isEmpty() )
+    if ( !editorVertices.isEmpty() )
+    {
+      vertices = editorVertices;
+    }
+    else if ( !selectedVertices.isEmpty() )
+    {
       vertices = selectedVertices;
+    }
 
     HighlightMode mode = ModeReset;
     if ( e->modifiers() & Qt::ShiftModifier )

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -85,11 +85,16 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     //! Start addition of a new vertex on double-click
     void canvasDoubleClickEvent( QgsMapMouseEvent *e ) override;
 
+    void activate() override;
+
     void deactivate() override;
 
     void keyPressEvent( QKeyEvent *e ) override;
 
     QgsGeometry cachedGeometry( const QgsVectorLayer *layer, QgsFeatureId fid );
+
+    //! Toggle the vertex editor
+    void showVertexEditor();  //#spellok
 
   private slots:
     //! update geometry of our feature
@@ -98,8 +103,6 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     void onCachedGeometryDeleted( QgsFeatureId fid );
 
     void clearGeometryCache();
-
-    void showVertexEditor();  //#spellok
 
     void deleteVertexEditorSelection();
 


### PR DESCRIPTION
## Description
This PR fixes and improves the UX of the QGIS 3 revamped node tool specifically around its node editor panel. The goal is to make the node editor panel more discoverable, and eases its use and access.

The main fixes/improvements are:
- when the node editor tool is activated, the node editor panel shows up
- when the node editor panel isn't bound to a feature, show an hint label to tell users how to edit a feature via the node editor panel's table
- remove the right-click menu in favor of right-click binding a given feature to the node editor panel (faster/simpler workflow)
- when a feature is bound to the node editor panel, selecting nodes by dragging a rectangle on the canvas will only select vertices from that bound feature (much, much faster than using the selection tools, and adds a nice logic to the binding of a feature to the node editor panel)
- right click on a feature that's already bound to the node editor panel unbinds it (essentially, right-click becomes a toggle when used sequentially on a given feature)
- the node editor panel will properly restore its previous state (position, floating/docked/embedded, etc.)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
