### PR TITLE
Fix shortest path algorithm can "shortcut" when using network in geographic coordinates

### DIFF
--- a/src/analysis/network/qgsvectorlayerdirector.cpp
+++ b/src/analysis/network/qgsvectorlayerdirector.cpp
@@ -254,7 +254,7 @@ void QgsVectorLayerDirector::makeGraph( QgsGraphBuilderInterface *builder, const
             else
             {
               thisSegmentClosestDist = additionalPoint.sqrDistToSegment( pt1.x(), pt1.y(),
-                                       pt2.x(), pt2.y(), snappedPoint );
+                                       pt2.x(), pt2.y(), snappedPoint, 0 );
             }
 
             if ( thisSegmentClosestDist < additionalTiePoints[ i ].mLength )


### PR DESCRIPTION
Fixes #20997
