### PR TITLE
Fix MAC build for OSX < 10.14

### DIFF
--- a/src/native/mac/qgsmacnative.mm
+++ b/src/native/mac/qgsmacnative.mm
@@ -121,7 +121,7 @@ QgsNative::NotificationResult QgsMacNative::showDesktopNotification( const QStri
 
 bool QgsMacNative::hasDarkTheme()
 {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
   if ( [NSApp respondsToSelector:@selector( effectiveAppearance )] )
   {
     // compiled on macos 10.14+ AND running on macos 10.14+


### PR DESCRIPTION
## Description
Fix build for OSX < 10.14 (Mojave)

Testing again 10.14 is done by comparing the variable __MAC_OS_X_VERSION_MAX_ALLOWED to the __MAC_10_14 environment variable. 
But, this variable **is not defined** when building on platform < 10.14 and thus the test is always true and compilation fail with the error:

```
FAILED: src/native/CMakeFiles/qgis_native.dir/mac/qgsmacnative.mm.o
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DQT_CORE_LIB -DQT_DISABLE_DEPRECATED_BEFORE=0 -DQT_GUI_LIB -DQT_MACEXTRAS_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DWITH_BINDINGS -DWITH_QTWEBKIT -Dqgis_native_EXPORTS -I. -I../src/native -Isrc/native -iframework /opt/local/libexec/qt5/lib -isystem /opt/local/libexec/qt5/lib/QtCore.framework/Headers -isystem /opt/local/libexec/qt5/./mkspecs/macx-clang -isystem /opt/local/libexec/qt5/lib/QtGui.framework/Headers -isystem /System/Library/Frameworks/OpenGL.framework/Headers -isystem /opt/local/libexec/qt5/lib/QtMacExtras.framework/Headers -Wno-unknown-attributes -Wall -Wextra -Wno-long-long -Wformat-security -Wno-strict-aliasing -Wno-return-type-c-linkage -Wno-overloaded-virtual -Wimplicit-fallthrough -Qunused-arguments -fPIC -fvisibility=hidden   -fPIC -std=gnu++11 -x objective-c++ -MD -MT src/native/CMakeFiles/qgis_native.dir/mac/qgsmacnative.mm.o -MF src/native/CMakeFiles/qgis_native.dir/mac/qgsmacnative.mm.o.d -o src/native/CMakeFiles/qgis_native.dir/mac/qgsmacnative.mm.o -c ../src/native/mac/qgsmacnative.mm
../src/native/mac/qgsmacnative.mm:129:46: error: property 'effectiveAppearance' not found on object of type '__kindof NSApplication *'
    NSAppearanceName appearanceName = [NSApp.effectiveAppearance bestMatchFromAppearancesWithNames:@[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
                                             ^
../src/native/mac/qgsmacnative.mm:130:46: error: use of undeclared identifier 'NSAppearanceNameDarkAqua'; did you mean 'NSAppearanceNameAqua'?
    return ( [appearanceName isEqualToString:NSAppearanceNameDarkAqua] );
                                             ^~~~~~~~~~~~~~~~~~~~~~~~
                                             NSAppearanceNameAqua
/System/Library/Frameworks/AppKit.framework/Headers/NSAppearance.h:56:38: note: 'NSAppearanceNameAqua' declared here
APPKIT_EXTERN NSAppearanceName const NSAppearanceNameAqua NS_AVAILABLE_MAC(10_9);
```

Testing against MAC OSX version must be done with the numeric version value.

This fix must be ported to master.


