### PR TITLE
fixes #20893 : Update virtual layer when referenced layer update its fields

### DIFF
--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -132,7 +132,7 @@ bool QgsVirtualLayerProvider::loadSourceLayers()
       connect( vl, &QgsVectorLayer::featureAdded, this, &QgsVirtualLayerProvider::invalidateStatistics );
       connect( vl, &QgsVectorLayer::featureDeleted, this, &QgsVirtualLayerProvider::invalidateStatistics );
       connect( vl, &QgsVectorLayer::geometryChanged, this, &QgsVirtualLayerProvider::invalidateStatistics );
-      connect( vl, &QgsVectorLayer::updatedFields, this, [ = ] { createVirtualTable( vl ); } );
+      connect( vl, &QgsVectorLayer::updatedFields, this, [ = ] { createVirtualTable( vl, layer.name() ); } );
     }
     else
     {
@@ -303,7 +303,7 @@ bool QgsVirtualLayerProvider::createIt()
     QString vname = mLayers.at( i ).name;
     if ( vlayer )
     {
-      createVirtualTable( vlayer );
+      createVirtualTable( vlayer, vname );
     }
     else
     {
@@ -455,9 +455,9 @@ bool QgsVirtualLayerProvider::createIt()
   return true;
 }
 
-void QgsVirtualLayerProvider::createVirtualTable( QgsVectorLayer *vlayer )
+void QgsVirtualLayerProvider::createVirtualTable( QgsVectorLayer *vlayer, const QString &vname )
 {
-  QString createStr = QStringLiteral( "DROP TABLE IF EXISTS \"%1\"; CREATE VIRTUAL TABLE \"%1\" USING QgsVLayer(%2);" ).arg( vlayer->name(), vlayer->id() );
+  QString createStr = QStringLiteral( "DROP TABLE IF EXISTS \"%1\"; CREATE VIRTUAL TABLE \"%1\" USING QgsVLayer(%2);" ).arg( vname, vlayer->id() );
   Sqlite::Query::exec( mSqlite.get(), createStr );
 }
 

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -132,6 +132,7 @@ bool QgsVirtualLayerProvider::loadSourceLayers()
       connect( vl, &QgsVectorLayer::featureAdded, this, &QgsVirtualLayerProvider::invalidateStatistics );
       connect( vl, &QgsVectorLayer::featureDeleted, this, &QgsVirtualLayerProvider::invalidateStatistics );
       connect( vl, &QgsVectorLayer::geometryChanged, this, &QgsVirtualLayerProvider::invalidateStatistics );
+      connect( vl, &QgsVectorLayer::updatedFields, this, [ = ] { createVirtualTable( qobject_cast<QgsVectorLayer *>( sender() ) ); } );
     }
     else
     {
@@ -302,8 +303,7 @@ bool QgsVirtualLayerProvider::createIt()
     QString vname = mLayers.at( i ).name;
     if ( vlayer )
     {
-      QString createStr = QStringLiteral( "DROP TABLE IF EXISTS \"%1\"; CREATE VIRTUAL TABLE \"%1\" USING QgsVLayer(%2);" ).arg( vname, vlayer->id() );
-      Sqlite::Query::exec( mSqlite.get(), createStr );
+      createVirtualTable( vlayer );
     }
     else
     {
@@ -453,6 +453,12 @@ bool QgsVirtualLayerProvider::createIt()
   }
 
   return true;
+}
+
+void QgsVirtualLayerProvider::createVirtualTable( QgsVectorLayer *vlayer )
+{
+  QString createStr = QStringLiteral( "DROP TABLE IF EXISTS \"%1\"; CREATE VIRTUAL TABLE \"%1\" USING QgsVLayer(%2);" ).arg( vlayer->name(), vlayer->id() );
+  Sqlite::Query::exec( mSqlite.get(), createStr );
 }
 
 bool QgsVirtualLayerProvider::cancelReload()

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -132,7 +132,7 @@ bool QgsVirtualLayerProvider::loadSourceLayers()
       connect( vl, &QgsVectorLayer::featureAdded, this, &QgsVirtualLayerProvider::invalidateStatistics );
       connect( vl, &QgsVectorLayer::featureDeleted, this, &QgsVirtualLayerProvider::invalidateStatistics );
       connect( vl, &QgsVectorLayer::geometryChanged, this, &QgsVirtualLayerProvider::invalidateStatistics );
-      connect( vl, &QgsVectorLayer::updatedFields, this, [ = ] { createVirtualTable( qobject_cast<QgsVectorLayer *>( sender() ) ); } );
+      connect( vl, &QgsVectorLayer::updatedFields, this, [ = ] { createVirtualTable( vl ); } );
     }
     else
     {

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -111,11 +111,13 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     bool openIt();
     bool createIt();
     bool loadSourceLayers();
+    void createVirtualTable( QgsVectorLayer *vlayer );
 
     friend class QgsVirtualLayerFeatureSource;
 
   private slots:
     void invalidateStatistics();
+
 };
 
 // clazy:excludeall=qstring-allocations

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -111,7 +111,7 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     bool openIt();
     bool createIt();
     bool loadSourceLayers();
-    void createVirtualTable( QgsVectorLayer *vlayer );
+    void createVirtualTable( QgsVectorLayer *vlayer, const QString &name );
 
     friend class QgsVirtualLayerFeatureSource;
 

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -1009,7 +1009,7 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(point.x(), 2)
         self.assertEqual(point.y(), 3)
 
-        QgsProject.instance().read()
+        QgsProject.instance().removeMapLayer(ml)
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -977,6 +977,40 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
 
         QgsProject.instance().removeMapLayer(ml)
 
+    def testUpdatedFields(self):
+        """Test when referenced layer update its fields
+        https://issues.qgis.org/issues/20893
+        """
+
+        ml = QgsVectorLayer("Point?srid=EPSG:4326&field=a:int", "mem", "memory")
+        self.assertEqual(ml.isValid(), True)
+        QgsProject.instance().addMapLayer(ml)
+
+        ml.startEditing()
+        f1 = QgsFeature(ml.fields())
+        f1.setGeometry(QgsGeometry.fromWkt('POINT(2 3)'))
+        ml.addFeatures([f1])
+        ml.commitChanges()
+
+        vl = QgsVectorLayer("?query=select a, geometry from mem", "vl", "virtual")
+        self.assertEqual(vl.isValid(), True)
+
+        # add one more field
+        ml.dataProvider().addAttributes([QgsField('newfield', QVariant.Int)])
+        ml.updateFields()
+
+        self.assertEqual(ml.featureCount(), vl.featureCount())
+        self.assertEqual(vl.fields().count(), 1)
+
+        geometry = next(vl.getFeatures()).geometry()
+        self.assertTrue(geometry)
+
+        point = geometry.asPoint()
+        self.assertEqual(point.x(), 2)
+        self.assertEqual(point.y(), 3)
+
+        QgsProject.instance().read()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
Fixes the issue https://issues.qgis.org/issues/20893

The problems comes from the fact that the referenced layer in the virtual layer updates its fields (its a joined layer) when loading project, but the virtual layer provider has to rebuild the virtual table according to these fields modifications.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
