### PR TITLE
[processing] use complex delimiter for interpolation data (fix #20490)

### DIFF
--- a/python/plugins/processing/algs/qgis/IdwInterpolation.py
+++ b/python/plugins/processing/algs/qgis/IdwInterpolation.py
@@ -129,7 +129,7 @@ class IdwInterpolation(QgisAlgorithm):
 
         layerData = []
         layers = []
-        for row in interpolationData.split(';'):
+        for row in interpolationData.split('::|::'):
             v = row.split('::~::')
             data = QgsInterpolator.LayerData()
 

--- a/python/plugins/processing/algs/qgis/TinInterpolation.py
+++ b/python/plugins/processing/algs/qgis/TinInterpolation.py
@@ -145,7 +145,7 @@ class TinInterpolation(QgisAlgorithm):
         layerData = []
         layers = []
         crs = QgsCoordinateReferenceSystem()
-        for row in interpolationData.split(';'):
+        for row in interpolationData.split('::|::'):
             v = row.split('::~::')
             data = QgsInterpolator.LayerData()
 

--- a/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
+++ b/python/plugins/processing/algs/qgis/ui/InterpolationWidgets.py
@@ -203,10 +203,10 @@ class InterpolationDataWidget(BASE, WIDGET):
                 else:
                     inputType = QgsInterpolator.SourceBreakLines
 
-            layers += '{}::~::{:d}::~::{:d}::~::{:d};'.format(layer.source(),
-                                                              interpolationSource,
-                                                              fieldIndex,
-                                                              inputType)
+            layers += '{}::~::{:d}::~::{:d}::~::{:d}::|::'.format(layer.source(),
+                                                                  interpolationSource,
+                                                                  fieldIndex,
+                                                                  inputType)
         return layers[:-1]
 
 


### PR DESCRIPTION
## Description
IDW and TIN interpolation algorithms use semicolon (`;`) as delimiter for layers records. This cause issues when datasource URI als contains semicolon, e.g. with delimited text layers.

Fixes https://issues.qgis.org/issues/20490

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
