### PR TITLE
[processing] use active layer by default in field calculator algorithm (fix #19686)

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsCalculatorDialog.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsCalculatorDialog.py
@@ -41,9 +41,10 @@ from qgis.core import (Qgis,
                        QgsProperty,
                        QgsProject,
                        QgsMessageLog,
+                       QgsMapLayer,
                        QgsProcessingOutputLayerDefinition)
 from qgis.gui import QgsEncodingFileDialog, QgsGui
-from qgis.utils import OverrideCursor
+from qgis.utils import OverrideCursor, iface
 
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.core.ProcessingLog import ProcessingLog
@@ -86,6 +87,12 @@ class FieldsCalculatorDialog(BASE, WIDGET):
         self.layer = None
 
         self.cmbInputLayer.setFilters(QgsMapLayerProxyModel.VectorLayer)
+        try:
+            if iface.activeLayer().type() == QgsMapLayer.VectorLayer:
+                self.cmbInputLayer.setLayer(iface.activeLayer())
+        except:
+            pass
+
         self.cmbInputLayer.layerChanged.connect(self.updateLayer)
         self.btnBrowse.clicked.connect(self.selectFile)
         self.mNewFieldGroupBox.toggled.connect(self.toggleExistingGroup)


### PR DESCRIPTION
## Description
In contrast to all other native algorithms Field Calculator does not use active layer as an input by default. This is a bit inconvenient.

Fixes https://issues.qgis.org/issues/19686

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
