### PR TITLE
Fix server WMS short name (unreported)

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -2548,8 +2548,9 @@ namespace QgsWms
     }
 
     // init groups
+    const QString rootName { QgsServerProjectUtils::wmsRootName( *mProject ) };
     const QgsLayerTreeGroup *root = mProject->layerTreeRoot();
-    initLayerGroupsRecursive( root, mProject->title() );
+    initLayerGroupsRecursive( root, rootName.isEmpty() ? mProject->title() : rootName );
   }
 
   void QgsRenderer::initLayerGroupsRecursive( const QgsLayerTreeGroup *group, const QString &groupName )

--- a/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
@@ -514,6 +514,47 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
         self.assertEqual(-1, h.find(b'Content-Type: text/xml; charset=utf-8'), "Header: %s\nResponse:\n%s" % (h, r))
         self.assertNotEqual(-1, h.find(b'Content-Type: image/png'), "Header: %s\nResponse:\n%s" % (h, r))
 
+    def test_wms_GetLegendGraphic_wmsRootName(self):
+        """Test an unreported issue when a wmsRootName short name is set in the service capabilities"""
+
+        # First test with the project title itself:
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": self.testdata_path + 'test_project_wms_grouped_layers.qgs',
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetLegendGraphic",
+            "LAYER": "QGIS%20Server%20-%20Grouped%20Layer",
+            "FORMAT": "image/png",
+            "HEIGHT": "840",
+            "WIDTH": "1226",
+            "BBOX": "609152,5808188,625492,5814318",
+            "SRS": "EPSG:25832",
+            "SCALE": "38976"
+        }.items())])
+
+        h, r = self._execute_request(qs)
+        self.assertEqual(-1, h.find(b'Content-Type: text/xml; charset=utf-8'), "Header: %s\nResponse:\n%s" % (h, r))
+        self.assertNotEqual(-1, h.find(b'Content-Type: image/png'), "Header: %s\nResponse:\n%s" % (h, r))
+
+        # Then test with the wmsRootName short name:
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": self.testdata_path + 'test_project_wms_grouped_layers_wmsroot.qgs',
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetLegendGraphic",
+            "LAYER": "All_grouped_layers",
+            "FORMAT": "image/png",
+            "HEIGHT": "840",
+            "WIDTH": "1226",
+            "BBOX": "609152,5808188,625492,5814318",
+            "SRS": "EPSG:25832",
+            "SCALE": "38976"
+        }.items())])
+
+        h, r = self._execute_request(qs)
+        self.assertEqual(-1, h.find(b'Content-Type: text/xml; charset=utf-8'), "Header: %s\nResponse:\n%s" % (h, r))
+        self.assertNotEqual(-1, h.find(b'Content-Type: image/png'), "Header: %s\nResponse:\n%s" % (h, r))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/qgis_server/test_project_wms_grouped_layers_wmsroot.qgs
+++ b/tests/testdata/qgis_server/test_project_wms_grouped_layers_wmsroot.qgs
@@ -1,0 +1,1950 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis projectname="QGIS Server - Grouped Layer" version="3.5.0-Master">
+  <homePath path=""/>
+  <title>QGIS Server - Grouped Layer</title>
+  <autotransaction active="0"/>
+  <evaluateDefaultValues active="0"/>
+  <trust active="0"/>
+  <projectCrs>
+    <spatialrefsys>
+      <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+      <srsid>2105</srsid>
+      <srid>25832</srid>
+      <authid>EPSG:25832</authid>
+      <description>ETRS89 / UTM zone 32N</description>
+      <projectionacronym>utm</projectionacronym>
+      <ellipsoidacronym>GRS80</ellipsoidacronym>
+      <geographicflag>false</geographicflag>
+    </spatialrefsys>
+  </projectCrs>
+  <layer-tree-group>
+    <customproperties/>
+    <layer-tree-group checked="Qt::Checked" name="city and district boundaries" expanded="1">
+      <customproperties/>
+      <layer-tree-layer id="cdb_lines_3f5c3c6d_db6d_4681_9291_7109f8d69f8b" providerKey="ogr" checked="Qt::Checked" source="./test_project_wms_grouped_layers.gpkg|layername=cdb_lines" name="cdb_lines" expanded="1">
+        <customproperties/>
+      </layer-tree-layer>
+      <layer-tree-layer id="cdb_labels_8ee74af8_e7ba_4d80_9e0d_5b0b956d3daf" providerKey="ogr" checked="Qt::Checked" source="./test_project_wms_grouped_layers.gpkg|layername=cdb_labels" name="cdb_labels" expanded="1">
+        <customproperties/>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-group checked="Qt::Checked" name="areas and symbols" expanded="1">
+      <customproperties/>
+      <layer-tree-layer id="as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76" providerKey="ogr" checked="Qt::Checked" source="./test_project_wms_grouped_layers.gpkg|layername=as_symbols" name="as_symbols" expanded="1">
+        <customproperties/>
+      </layer-tree-layer>
+      <layer-tree-layer id="as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467" providerKey="ogr" checked="Qt::Checked" source="./test_project_wms_grouped_layers.gpkg|layername=as_areas" name="as_areas" expanded="1">
+        <customproperties/>
+      </layer-tree-layer>
+    </layer-tree-group>
+    <layer-tree-layer id="osm_85c8eb94_b6fa_437b_b91a_7816ef2e2243" providerKey="gdal" checked="Qt::Checked" source="GPKG:/home/ale/dev/QGIS/tests/testdata/qgis_server/test_project_wms_grouped_layers.gpkg:osm" name="osm" expanded="1">
+      <customproperties/>
+    </layer-tree-layer>
+    <custom-order enabled="0">
+      <item>osm_85c8eb94_b6fa_437b_b91a_7816ef2e2243</item>
+      <item>cdb_labels_8ee74af8_e7ba_4d80_9e0d_5b0b956d3daf</item>
+      <item>cdb_lines_3f5c3c6d_db6d_4681_9291_7109f8d69f8b</item>
+      <item>as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467</item>
+      <item>as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76</item>
+    </custom-order>
+  </layer-tree-group>
+  <snapping-settings unit="1" intersection-snapping="0" enabled="0" mode="2" type="1" tolerance="12">
+    <individual-layer-settings>
+      <layer-setting enabled="0" id="cdb_labels_8ee74af8_e7ba_4d80_9e0d_5b0b956d3daf" type="1" units="1" tolerance="12"/>
+      <layer-setting enabled="0" id="cdb_lines_3f5c3c6d_db6d_4681_9291_7109f8d69f8b" type="1" units="1" tolerance="12"/>
+      <layer-setting enabled="0" id="as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76" type="1" units="1" tolerance="12"/>
+      <layer-setting enabled="0" id="as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467" type="1" units="1" tolerance="12"/>
+    </individual-layer-settings>
+  </snapping-settings>
+  <relations/>
+  <mapcanvas annotationsVisible="1" name="theMapCanvas">
+    <units>meters</units>
+    <extent>
+      <xmin>611130.7508374999742955</xmin>
+      <ymin>5808188.16393684130162001</ymin>
+      <xmax>623514.4366625000257045</xmax>
+      <ymax>5814318.83606315869837999</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+        <srsid>2105</srsid>
+        <srid>25832</srid>
+        <authid>EPSG:25832</authid>
+        <description>ETRS89 / UTM zone 32N</description>
+        <projectionacronym>utm</projectionacronym>
+        <ellipsoidacronym>GRS80</ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
+  </mapcanvas>
+  <projectModels/>
+  <legend updateDrawingOrder="true">
+    <legendgroup checked="Qt::Checked" open="true" name="city and district boundaries">
+      <legendlayer drawingOrder="-1" checked="Qt::Checked" open="true" name="cdb_lines" showFeatureCount="0">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" visible="1" layerid="cdb_lines_3f5c3c6d_db6d_4681_9291_7109f8d69f8b"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="-1" checked="Qt::Checked" open="true" name="cdb_labels" showFeatureCount="0">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" visible="1" layerid="cdb_labels_8ee74af8_e7ba_4d80_9e0d_5b0b956d3daf"/>
+        </filegroup>
+      </legendlayer>
+    </legendgroup>
+    <legendgroup checked="Qt::Checked" open="true" name="areas and symbols">
+      <legendlayer drawingOrder="-1" checked="Qt::Checked" open="true" name="as_symbols" showFeatureCount="0">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" visible="1" layerid="as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76"/>
+        </filegroup>
+      </legendlayer>
+      <legendlayer drawingOrder="-1" checked="Qt::Checked" open="true" name="as_areas" showFeatureCount="0">
+        <filegroup open="true" hidden="false">
+          <legendlayerfile isInOverview="0" visible="1" layerid="as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467"/>
+        </filegroup>
+      </legendlayer>
+    </legendgroup>
+    <legendlayer drawingOrder="-1" checked="Qt::Checked" open="true" name="osm" showFeatureCount="0">
+      <filegroup open="true" hidden="false">
+        <legendlayerfile isInOverview="0" visible="1" layerid="osm_85c8eb94_b6fa_437b_b91a_7816ef2e2243"/>
+      </filegroup>
+    </legendlayer>
+  </legend>
+  <mapViewDocks/>
+  <mapcanvas annotationsVisible="1" name="mAreaCanvas">
+    <units>meters</units>
+    <extent>
+      <xmin>613671.31718749995343387</xmin>
+      <ymin>5808474.67499999981373549</ymin>
+      <xmax>620973.87031250004656613</xmax>
+      <ymax>5814032.32500000018626451</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+        <srsid>2105</srsid>
+        <srid>25832</srid>
+        <authid>EPSG:25832</authid>
+        <description>ETRS89 / UTM zone 32N</description>
+        <projectionacronym>utm</projectionacronym>
+        <ellipsoidacronym>GRS80</ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
+  </mapcanvas>
+  <mapcanvas annotationsVisible="1" name="mAreaCanvas">
+    <units>meters</units>
+    <extent>
+      <xmin>613671.31718749995343387</xmin>
+      <ymin>5808474.67499999981373549</ymin>
+      <xmax>620973.87031250004656613</xmax>
+      <ymax>5814032.32500000018626451</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+        <srsid>2105</srsid>
+        <srid>25832</srid>
+        <authid>EPSG:25832</authid>
+        <description>ETRS89 / UTM zone 32N</description>
+        <projectionacronym>utm</projectionacronym>
+        <ellipsoidacronym>GRS80</ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
+  </mapcanvas>
+  <mapcanvas annotationsVisible="1" name="mAreaCanvas">
+    <units>meters</units>
+    <extent>
+      <xmin>613671.31718749995343387</xmin>
+      <ymin>5808474.67499999981373549</ymin>
+      <xmax>620973.87031250004656613</xmax>
+      <ymax>5814032.32500000018626451</ymax>
+    </extent>
+    <rotation>0</rotation>
+    <destinationsrs>
+      <spatialrefsys>
+        <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+        <srsid>2105</srsid>
+        <srid>25832</srid>
+        <authid>EPSG:25832</authid>
+        <description>ETRS89 / UTM zone 32N</description>
+        <projectionacronym>utm</projectionacronym>
+        <ellipsoidacronym>GRS80</ellipsoidacronym>
+        <geographicflag>false</geographicflag>
+      </spatialrefsys>
+    </destinationsrs>
+    <rendermaptile>0</rendermaptile>
+    <expressionContextScope/>
+  </mapcanvas>
+  <projectlayers>
+    <maplayer autoRefreshTime="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" maxScale="0" type="vector" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" simplifyAlgorithm="0" autoRefreshEnabled="0" labelsEnabled="0" readOnly="0" simplifyDrawingHints="1" simplifyMaxScale="1" geometry="Polygon" styleCategories="AllStyleCategories" refreshOnNotifyEnabled="0">
+      <extent>
+        <xmin>614440.5625</xmin>
+        <ymin>5808607</ymin>
+        <xmax>618892</xmax>
+        <ymax>5812990</ymax>
+      </extent>
+      <id>as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467</id>
+      <datasource>./test_project_wms_grouped_layers.gpkg|layername=as_areas</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>as_areas</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+          <srsid>2105</srsid>
+          <srid>25832</srid>
+          <authid>EPSG:25832</authid>
+          <description>ETRS89 / UTM zone 32N</description>
+          <projectionacronym>utm</projectionacronym>
+          <ellipsoidacronym>GRS80</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <legend type="default-vector"/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+        <symbols>
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="183,72,75,255" k="color"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0.26" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="solid" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties/>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
+      <fieldConfiguration>
+        <field name="fid">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="gid">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="datum">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="bearbeiter">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="veranstaltung">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="beschriftung">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="name">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="flaechentyp">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="farbe">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="schraff_width">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="schraff_width_prt">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="schraff_size">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="schraff_size_prt">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="schraff_winkel">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="umrissfarbe">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="umrisstyp">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="umrissstaerke">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="umrissstaerke_prt">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="umfang">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="flaeche">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="bemerkung">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="last_change">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="fid" index="0" name=""/>
+        <alias field="gid" index="1" name=""/>
+        <alias field="datum" index="2" name=""/>
+        <alias field="bearbeiter" index="3" name=""/>
+        <alias field="veranstaltung" index="4" name=""/>
+        <alias field="beschriftung" index="5" name=""/>
+        <alias field="name" index="6" name=""/>
+        <alias field="flaechentyp" index="7" name=""/>
+        <alias field="farbe" index="8" name=""/>
+        <alias field="schraff_width" index="9" name=""/>
+        <alias field="schraff_width_prt" index="10" name=""/>
+        <alias field="schraff_size" index="11" name=""/>
+        <alias field="schraff_size_prt" index="12" name=""/>
+        <alias field="schraff_winkel" index="13" name=""/>
+        <alias field="umrissfarbe" index="14" name=""/>
+        <alias field="umrisstyp" index="15" name=""/>
+        <alias field="umrissstaerke" index="16" name=""/>
+        <alias field="umrissstaerke_prt" index="17" name=""/>
+        <alias field="umfang" index="18" name=""/>
+        <alias field="flaeche" index="19" name=""/>
+        <alias field="bemerkung" index="20" name=""/>
+        <alias field="last_change" index="21" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="fid" expression="" applyOnUpdate="0"/>
+        <default field="gid" expression="" applyOnUpdate="0"/>
+        <default field="datum" expression="" applyOnUpdate="0"/>
+        <default field="bearbeiter" expression="" applyOnUpdate="0"/>
+        <default field="veranstaltung" expression="" applyOnUpdate="0"/>
+        <default field="beschriftung" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
+        <default field="flaechentyp" expression="" applyOnUpdate="0"/>
+        <default field="farbe" expression="" applyOnUpdate="0"/>
+        <default field="schraff_width" expression="" applyOnUpdate="0"/>
+        <default field="schraff_width_prt" expression="" applyOnUpdate="0"/>
+        <default field="schraff_size" expression="" applyOnUpdate="0"/>
+        <default field="schraff_size_prt" expression="" applyOnUpdate="0"/>
+        <default field="schraff_winkel" expression="" applyOnUpdate="0"/>
+        <default field="umrissfarbe" expression="" applyOnUpdate="0"/>
+        <default field="umrisstyp" expression="" applyOnUpdate="0"/>
+        <default field="umrissstaerke" expression="" applyOnUpdate="0"/>
+        <default field="umrissstaerke_prt" expression="" applyOnUpdate="0"/>
+        <default field="umfang" expression="" applyOnUpdate="0"/>
+        <default field="flaeche" expression="" applyOnUpdate="0"/>
+        <default field="bemerkung" expression="" applyOnUpdate="0"/>
+        <default field="last_change" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint field="fid" constraints="3" exp_strength="0" unique_strength="1" notnull_strength="1"/>
+        <constraint field="gid" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="datum" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="bearbeiter" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="veranstaltung" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="beschriftung" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="name" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="flaechentyp" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="farbe" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="schraff_width" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="schraff_width_prt" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="schraff_size" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="schraff_size_prt" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="schraff_winkel" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="umrissfarbe" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="umrisstyp" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="umrissstaerke" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="umrissstaerke_prt" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="umfang" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="flaeche" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="bemerkung" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="last_change" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="fid" desc="" exp=""/>
+        <constraint field="gid" desc="" exp=""/>
+        <constraint field="datum" desc="" exp=""/>
+        <constraint field="bearbeiter" desc="" exp=""/>
+        <constraint field="veranstaltung" desc="" exp=""/>
+        <constraint field="beschriftung" desc="" exp=""/>
+        <constraint field="name" desc="" exp=""/>
+        <constraint field="flaechentyp" desc="" exp=""/>
+        <constraint field="farbe" desc="" exp=""/>
+        <constraint field="schraff_width" desc="" exp=""/>
+        <constraint field="schraff_width_prt" desc="" exp=""/>
+        <constraint field="schraff_size" desc="" exp=""/>
+        <constraint field="schraff_size_prt" desc="" exp=""/>
+        <constraint field="schraff_winkel" desc="" exp=""/>
+        <constraint field="umrissfarbe" desc="" exp=""/>
+        <constraint field="umrisstyp" desc="" exp=""/>
+        <constraint field="umrissstaerke" desc="" exp=""/>
+        <constraint field="umrissstaerke_prt" desc="" exp=""/>
+        <constraint field="umfang" desc="" exp=""/>
+        <constraint field="flaeche" desc="" exp=""/>
+        <constraint field="bemerkung" desc="" exp=""/>
+        <constraint field="last_change" desc="" exp=""/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+        <columns/>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <editform tolerant="1"></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable/>
+      <labelOnTop/>
+      <widgets/>
+      <previewExpression></previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer autoRefreshTime="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" maxScale="0" type="vector" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" simplifyAlgorithm="0" autoRefreshEnabled="0" labelsEnabled="0" readOnly="0" simplifyDrawingHints="1" simplifyMaxScale="1" geometry="Point" styleCategories="AllStyleCategories" refreshOnNotifyEnabled="0">
+      <extent>
+        <xmin>613845.1875</xmin>
+        <ymin>5810420</ymin>
+        <xmax>620800</xmax>
+        <ymax>5813900</ymax>
+      </extent>
+      <id>as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76</id>
+      <datasource>./test_project_wms_grouped_layers.gpkg|layername=as_symbols</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>as_symbols</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+          <srsid>2105</srsid>
+          <srid>25832</srid>
+          <authid>EPSG:25832</authid>
+          <description>ETRS89 / UTM zone 32N</description>
+          <projectionacronym>utm</projectionacronym>
+          <ellipsoidacronym>GRS80</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <legend type="default-vector"/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+        <symbols>
+          <symbol type="marker" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
+              <prop v="0" k="angle"/>
+              <prop v="0,192,0,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="star" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="0,0,0,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="area" k="scale_method"/>
+              <prop v="4" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties/>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
+      <fieldConfiguration>
+        <field name="fid">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="gid">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="datum">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="bearbeiter">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="veranstaltung">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="beschriftung">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="name">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="form">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="groesse">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="groesse_red">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="winkel">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="farbe">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="bemerkung">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="last_change">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="fid" index="0" name=""/>
+        <alias field="gid" index="1" name=""/>
+        <alias field="datum" index="2" name=""/>
+        <alias field="bearbeiter" index="3" name=""/>
+        <alias field="veranstaltung" index="4" name=""/>
+        <alias field="beschriftung" index="5" name=""/>
+        <alias field="name" index="6" name=""/>
+        <alias field="form" index="7" name=""/>
+        <alias field="groesse" index="8" name=""/>
+        <alias field="groesse_red" index="9" name=""/>
+        <alias field="winkel" index="10" name=""/>
+        <alias field="farbe" index="11" name=""/>
+        <alias field="bemerkung" index="12" name=""/>
+        <alias field="last_change" index="13" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="fid" expression="" applyOnUpdate="0"/>
+        <default field="gid" expression="" applyOnUpdate="0"/>
+        <default field="datum" expression="" applyOnUpdate="0"/>
+        <default field="bearbeiter" expression="" applyOnUpdate="0"/>
+        <default field="veranstaltung" expression="" applyOnUpdate="0"/>
+        <default field="beschriftung" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
+        <default field="form" expression="" applyOnUpdate="0"/>
+        <default field="groesse" expression="" applyOnUpdate="0"/>
+        <default field="groesse_red" expression="" applyOnUpdate="0"/>
+        <default field="winkel" expression="" applyOnUpdate="0"/>
+        <default field="farbe" expression="" applyOnUpdate="0"/>
+        <default field="bemerkung" expression="" applyOnUpdate="0"/>
+        <default field="last_change" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint field="fid" constraints="3" exp_strength="0" unique_strength="1" notnull_strength="1"/>
+        <constraint field="gid" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="datum" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="bearbeiter" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="veranstaltung" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="beschriftung" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="name" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="form" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="groesse" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="groesse_red" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="winkel" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="farbe" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="bemerkung" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="last_change" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="fid" desc="" exp=""/>
+        <constraint field="gid" desc="" exp=""/>
+        <constraint field="datum" desc="" exp=""/>
+        <constraint field="bearbeiter" desc="" exp=""/>
+        <constraint field="veranstaltung" desc="" exp=""/>
+        <constraint field="beschriftung" desc="" exp=""/>
+        <constraint field="name" desc="" exp=""/>
+        <constraint field="form" desc="" exp=""/>
+        <constraint field="groesse" desc="" exp=""/>
+        <constraint field="groesse_red" desc="" exp=""/>
+        <constraint field="winkel" desc="" exp=""/>
+        <constraint field="farbe" desc="" exp=""/>
+        <constraint field="bemerkung" desc="" exp=""/>
+        <constraint field="last_change" desc="" exp=""/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+        <columns/>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <editform tolerant="1"></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable/>
+      <labelOnTop/>
+      <widgets/>
+      <previewExpression></previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer autoRefreshTime="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" maxScale="0" type="vector" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" simplifyAlgorithm="0" autoRefreshEnabled="0" labelsEnabled="1" readOnly="0" simplifyDrawingHints="0" simplifyMaxScale="1" geometry="Point" styleCategories="AllStyleCategories" refreshOnNotifyEnabled="0">
+      <extent>
+        <xmin>613794.8125</xmin>
+        <ymin>5800447</ymin>
+        <xmax>626894.25</xmax>
+        <ymax>5815374.5</ymax>
+      </extent>
+      <id>cdb_labels_8ee74af8_e7ba_4d80_9e0d_5b0b956d3daf</id>
+      <datasource>./test_project_wms_grouped_layers.gpkg|layername=cdb_labels</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>cdb_labels</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+          <srsid>2105</srsid>
+          <srid>25832</srid>
+          <authid>EPSG:25832</authid>
+          <description>ETRS89 / UTM zone 32N</description>
+          <projectionacronym>utm</projectionacronym>
+          <ellipsoidacronym>GRS80</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <legend type="default-vector"/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="singleSymbol" forceraster="0" symbollevels="0" enableorderby="0">
+        <symbols>
+          <symbol type="marker" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleMarker" enabled="1" pass="0" locked="0">
+              <prop v="0" k="angle"/>
+              <prop v="225,89,137,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="no" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="0" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <labeling type="simple">
+        <settings>
+          <text-style useSubstitutions="0" fontWeight="75" fontSize="14" textOpacity="1" fontFamily="Noto Sans" fontStrikeout="0" fontLetterSpacing="0" fontItalic="0" fontSizeUnit="Point" isExpression="0" previewBkgrdColor="#ffffff" blendMode="0" textColor="0,0,149,255" fontUnderline="0" fieldName="NAME" fontSizeMapUnitScale="3x:0,0,0,0,0,0" multilineHeight="1" fontWordSpacing="0" fontCapitals="0" namedStyle="Bold">
+            <text-buffer bufferColor="255,255,255,255" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferDraw="1" bufferSizeUnits="MM" bufferNoFill="0" bufferJoinStyle="64" bufferBlendMode="0" bufferOpacity="1" bufferSize="0.75"/>
+            <background shapeType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM" shapeRotation="0" shapeSizeY="0" shapeRadiiUnit="MM" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeBorderColor="128,128,128,255" shapeOffsetX="0" shapeSizeType="0" shapeBorderWidth="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeSVGFile="" shapeOffsetY="0" shapeOffsetUnit="MM" shapeSizeX="0" shapeJoinStyle="64" shapeBlendMode="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRotationType="0" shapeSizeUnit="MM" shapeRadiiY="0" shapeOpacity="1" shapeDraw="0" shapeRadiiX="0"/>
+            <shadow shadowScale="100" shadowRadius="1.5" shadowColor="0,0,0,255" shadowRadiusAlphaOnly="0" shadowUnder="0" shadowOffsetAngle="135" shadowOpacity="0.7" shadowOffsetUnit="MM" shadowBlendMode="6" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusUnit="MM" shadowDraw="0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetDist="1" shadowOffsetGlobal="1"/>
+            <substitutions/>
+          </text-style>
+          <text-format wrapChar="" formatNumbers="0" rightDirectionSymbol=">" reverseDirectionSymbol="0" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" addDirectionSymbol="0" placeDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" multilineAlign="0" plussign="0"/>
+          <placement repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" centroidInside="1" dist="0" quadOffset="4" maxCurvedCharAngleOut="-20" offsetType="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" maxCurvedCharAngleIn="20" distUnits="MM" placementFlags="0" repeatDistanceUnits="MM" placement="1" preserveRotation="1" offsetUnits="MM" yOffset="0" rotationAngle="0" priority="5" xOffset="0" centroidWhole="0" repeatDistance="0" fitInPolygonOnly="0" distMapUnitScale="3x:0,0,0,0,0,0"/>
+          <rendering upsidedownLabels="0" scaleVisibility="0" scaleMax="10000000" scaleMin="1" obstacleType="0" displayAll="1" minFeatureSize="0" mergeLines="0" maxNumLabels="2000" limitNumLabels="0" obstacleFactor="1" fontMaxPixelSize="10000" fontMinPixelSize="3" drawLabels="1" zIndex="0" fontLimitPixelSize="0" obstacle="1" labelPerPart="0"/>
+          <dd_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </dd_properties>
+        </settings>
+      </labeling>
+      <customproperties>
+        <property value="0" key="embeddedWidgets/count"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+        <DiagramCategory labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" maxScaleDenominator="1e+08" enabled="0" backgroundAlpha="255" minScaleDenominator="0" diagramOrientation="Up" penWidth="0" barWidth="5" height="15" penColor="#000000" rotationOffset="270" lineSizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" scaleDependency="Area" width="15" lineSizeType="MM" sizeType="MM" backgroundColor="#ffffff" opacity="1" penAlpha="255" minimumSize="0">
+          <fontProperties style="" description="Noto Sans,9,-1,5,50,0,0,0,0,0"/>
+          <attribute field="" label="" color="#000000"/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings dist="0" placement="0" obstacle="0" linePlacementFlags="18" priority="0" zIndex="0" showAll="1">
+        <properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
+      <fieldConfiguration>
+        <field name="fid">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="AREA">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="PERIMETER">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="STADTTEILE">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="STADTTEI_1">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="S_A_">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="S_A_ID">
+          <editWidget type="Range">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="O_NAME">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ORTSTEIL">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="STADTTEIL">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="OT_SCHL">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="GEM_SCHL">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ZVS">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="NAME">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="PLZ">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="KERNSTADT_">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ORTSRATSBE">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="PLG_KITA">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="PLG_BERATU">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="PLG_JUFOE">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="VERFLECHTU">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="FUNKTIONSB">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="T_DATUM">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Impfbez_Nr">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="Impfzentru">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="fid" index="0" name=""/>
+        <alias field="AREA" index="1" name=""/>
+        <alias field="PERIMETER" index="2" name=""/>
+        <alias field="STADTTEILE" index="3" name=""/>
+        <alias field="STADTTEI_1" index="4" name=""/>
+        <alias field="S_A_" index="5" name=""/>
+        <alias field="S_A_ID" index="6" name=""/>
+        <alias field="O_NAME" index="7" name=""/>
+        <alias field="ORTSTEIL" index="8" name=""/>
+        <alias field="STADTTEIL" index="9" name=""/>
+        <alias field="OT_SCHL" index="10" name=""/>
+        <alias field="GEM_SCHL" index="11" name=""/>
+        <alias field="ZVS" index="12" name=""/>
+        <alias field="NAME" index="13" name=""/>
+        <alias field="PLZ" index="14" name=""/>
+        <alias field="KERNSTADT_" index="15" name=""/>
+        <alias field="ORTSRATSBE" index="16" name=""/>
+        <alias field="PLG_KITA" index="17" name=""/>
+        <alias field="PLG_BERATU" index="18" name=""/>
+        <alias field="PLG_JUFOE" index="19" name=""/>
+        <alias field="VERFLECHTU" index="20" name=""/>
+        <alias field="FUNKTIONSB" index="21" name=""/>
+        <alias field="T_DATUM" index="22" name=""/>
+        <alias field="Impfbez_Nr" index="23" name=""/>
+        <alias field="Impfzentru" index="24" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="fid" expression="" applyOnUpdate="0"/>
+        <default field="AREA" expression="" applyOnUpdate="0"/>
+        <default field="PERIMETER" expression="" applyOnUpdate="0"/>
+        <default field="STADTTEILE" expression="" applyOnUpdate="0"/>
+        <default field="STADTTEI_1" expression="" applyOnUpdate="0"/>
+        <default field="S_A_" expression="" applyOnUpdate="0"/>
+        <default field="S_A_ID" expression="" applyOnUpdate="0"/>
+        <default field="O_NAME" expression="" applyOnUpdate="0"/>
+        <default field="ORTSTEIL" expression="" applyOnUpdate="0"/>
+        <default field="STADTTEIL" expression="" applyOnUpdate="0"/>
+        <default field="OT_SCHL" expression="" applyOnUpdate="0"/>
+        <default field="GEM_SCHL" expression="" applyOnUpdate="0"/>
+        <default field="ZVS" expression="" applyOnUpdate="0"/>
+        <default field="NAME" expression="" applyOnUpdate="0"/>
+        <default field="PLZ" expression="" applyOnUpdate="0"/>
+        <default field="KERNSTADT_" expression="" applyOnUpdate="0"/>
+        <default field="ORTSRATSBE" expression="" applyOnUpdate="0"/>
+        <default field="PLG_KITA" expression="" applyOnUpdate="0"/>
+        <default field="PLG_BERATU" expression="" applyOnUpdate="0"/>
+        <default field="PLG_JUFOE" expression="" applyOnUpdate="0"/>
+        <default field="VERFLECHTU" expression="" applyOnUpdate="0"/>
+        <default field="FUNKTIONSB" expression="" applyOnUpdate="0"/>
+        <default field="T_DATUM" expression="" applyOnUpdate="0"/>
+        <default field="Impfbez_Nr" expression="" applyOnUpdate="0"/>
+        <default field="Impfzentru" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint field="fid" constraints="3" exp_strength="0" unique_strength="1" notnull_strength="1"/>
+        <constraint field="AREA" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="PERIMETER" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="STADTTEILE" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="STADTTEI_1" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="S_A_" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="S_A_ID" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="O_NAME" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="ORTSTEIL" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="STADTTEIL" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="OT_SCHL" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="GEM_SCHL" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="ZVS" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="NAME" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="PLZ" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="KERNSTADT_" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="ORTSRATSBE" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="PLG_KITA" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="PLG_BERATU" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="PLG_JUFOE" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="VERFLECHTU" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="FUNKTIONSB" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="T_DATUM" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="Impfbez_Nr" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="Impfzentru" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="fid" desc="" exp=""/>
+        <constraint field="AREA" desc="" exp=""/>
+        <constraint field="PERIMETER" desc="" exp=""/>
+        <constraint field="STADTTEILE" desc="" exp=""/>
+        <constraint field="STADTTEI_1" desc="" exp=""/>
+        <constraint field="S_A_" desc="" exp=""/>
+        <constraint field="S_A_ID" desc="" exp=""/>
+        <constraint field="O_NAME" desc="" exp=""/>
+        <constraint field="ORTSTEIL" desc="" exp=""/>
+        <constraint field="STADTTEIL" desc="" exp=""/>
+        <constraint field="OT_SCHL" desc="" exp=""/>
+        <constraint field="GEM_SCHL" desc="" exp=""/>
+        <constraint field="ZVS" desc="" exp=""/>
+        <constraint field="NAME" desc="" exp=""/>
+        <constraint field="PLZ" desc="" exp=""/>
+        <constraint field="KERNSTADT_" desc="" exp=""/>
+        <constraint field="ORTSRATSBE" desc="" exp=""/>
+        <constraint field="PLG_KITA" desc="" exp=""/>
+        <constraint field="PLG_BERATU" desc="" exp=""/>
+        <constraint field="PLG_JUFOE" desc="" exp=""/>
+        <constraint field="VERFLECHTU" desc="" exp=""/>
+        <constraint field="FUNKTIONSB" desc="" exp=""/>
+        <constraint field="T_DATUM" desc="" exp=""/>
+        <constraint field="Impfbez_Nr" desc="" exp=""/>
+        <constraint field="Impfzentru" desc="" exp=""/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+        <columns>
+          <column width="-1" type="field" hidden="0" name="fid"/>
+          <column width="-1" type="field" hidden="0" name="AREA"/>
+          <column width="-1" type="field" hidden="0" name="PERIMETER"/>
+          <column width="-1" type="field" hidden="0" name="STADTTEILE"/>
+          <column width="-1" type="field" hidden="0" name="STADTTEI_1"/>
+          <column width="-1" type="field" hidden="0" name="S_A_"/>
+          <column width="-1" type="field" hidden="0" name="S_A_ID"/>
+          <column width="-1" type="field" hidden="0" name="O_NAME"/>
+          <column width="-1" type="field" hidden="0" name="ORTSTEIL"/>
+          <column width="-1" type="field" hidden="0" name="STADTTEIL"/>
+          <column width="-1" type="field" hidden="0" name="OT_SCHL"/>
+          <column width="-1" type="field" hidden="0" name="GEM_SCHL"/>
+          <column width="-1" type="field" hidden="0" name="ZVS"/>
+          <column width="-1" type="field" hidden="0" name="NAME"/>
+          <column width="-1" type="field" hidden="0" name="PLZ"/>
+          <column width="-1" type="field" hidden="0" name="KERNSTADT_"/>
+          <column width="-1" type="field" hidden="0" name="ORTSRATSBE"/>
+          <column width="-1" type="field" hidden="0" name="PLG_KITA"/>
+          <column width="-1" type="field" hidden="0" name="PLG_BERATU"/>
+          <column width="-1" type="field" hidden="0" name="PLG_JUFOE"/>
+          <column width="-1" type="field" hidden="0" name="VERFLECHTU"/>
+          <column width="-1" type="field" hidden="0" name="FUNKTIONSB"/>
+          <column width="-1" type="field" hidden="0" name="T_DATUM"/>
+          <column width="-1" type="field" hidden="0" name="Impfbez_Nr"/>
+          <column width="-1" type="field" hidden="0" name="Impfzentru"/>
+          <column width="-1" type="actions" hidden="1"/>
+        </columns>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <editform tolerant="1"></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable>
+        <field editable="1" name="AREA"/>
+        <field editable="1" name="FUNKTIONSB"/>
+        <field editable="1" name="GEM_SCHL"/>
+        <field editable="1" name="Impfbez_Nr"/>
+        <field editable="1" name="Impfzentru"/>
+        <field editable="1" name="KERNSTADT_"/>
+        <field editable="1" name="NAME"/>
+        <field editable="1" name="ORTSRATSBE"/>
+        <field editable="1" name="ORTSTEIL"/>
+        <field editable="1" name="OT_SCHL"/>
+        <field editable="1" name="O_NAME"/>
+        <field editable="1" name="PERIMETER"/>
+        <field editable="1" name="PLG_BERATU"/>
+        <field editable="1" name="PLG_JUFOE"/>
+        <field editable="1" name="PLG_KITA"/>
+        <field editable="1" name="PLZ"/>
+        <field editable="1" name="STADTTEIL"/>
+        <field editable="1" name="STADTTEILE"/>
+        <field editable="1" name="STADTTEI_1"/>
+        <field editable="1" name="S_A_"/>
+        <field editable="1" name="S_A_ID"/>
+        <field editable="1" name="T_DATUM"/>
+        <field editable="1" name="VERFLECHTU"/>
+        <field editable="1" name="ZVS"/>
+        <field editable="1" name="fid"/>
+      </editable>
+      <labelOnTop>
+        <field labelOnTop="0" name="AREA"/>
+        <field labelOnTop="0" name="FUNKTIONSB"/>
+        <field labelOnTop="0" name="GEM_SCHL"/>
+        <field labelOnTop="0" name="Impfbez_Nr"/>
+        <field labelOnTop="0" name="Impfzentru"/>
+        <field labelOnTop="0" name="KERNSTADT_"/>
+        <field labelOnTop="0" name="NAME"/>
+        <field labelOnTop="0" name="ORTSRATSBE"/>
+        <field labelOnTop="0" name="ORTSTEIL"/>
+        <field labelOnTop="0" name="OT_SCHL"/>
+        <field labelOnTop="0" name="O_NAME"/>
+        <field labelOnTop="0" name="PERIMETER"/>
+        <field labelOnTop="0" name="PLG_BERATU"/>
+        <field labelOnTop="0" name="PLG_JUFOE"/>
+        <field labelOnTop="0" name="PLG_KITA"/>
+        <field labelOnTop="0" name="PLZ"/>
+        <field labelOnTop="0" name="STADTTEIL"/>
+        <field labelOnTop="0" name="STADTTEILE"/>
+        <field labelOnTop="0" name="STADTTEI_1"/>
+        <field labelOnTop="0" name="S_A_"/>
+        <field labelOnTop="0" name="S_A_ID"/>
+        <field labelOnTop="0" name="T_DATUM"/>
+        <field labelOnTop="0" name="VERFLECHTU"/>
+        <field labelOnTop="0" name="ZVS"/>
+        <field labelOnTop="0" name="fid"/>
+      </labelOnTop>
+      <widgets/>
+      <previewExpression>fid</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer autoRefreshTime="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" maxScale="0" type="vector" simplifyDrawingTol="1" simplifyLocal="1" minScale="1e+08" simplifyAlgorithm="0" autoRefreshEnabled="0" labelsEnabled="0" readOnly="0" simplifyDrawingHints="1" simplifyMaxScale="1" geometry="Polygon" styleCategories="AllStyleCategories" refreshOnNotifyEnabled="0">
+      <extent>
+        <xmin>611951</xmin>
+        <ymin>5797784.5</ymin>
+        <xmax>629677.25</xmax>
+        <ymax>5817605</ymax>
+      </extent>
+      <id>cdb_lines_3f5c3c6d_db6d_4681_9291_7109f8d69f8b</id>
+      <datasource>./test_project_wms_grouped_layers.gpkg|layername=cdb_lines</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>cdb_lines</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+          <srsid>2105</srsid>
+          <srid>25832</srid>
+          <authid>EPSG:25832</authid>
+          <description>ETRS89 / UTM zone 32N</description>
+          <projectionacronym>utm</projectionacronym>
+          <ellipsoidacronym>GRS80</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <provider encoding="UTF-8">ogr</provider>
+      <vectorjoins/>
+      <layerDependencies/>
+      <dataDependencies/>
+      <legend type="default-vector"/>
+      <expressionfields/>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <auxiliaryLayer/>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>1</Searchable>
+      </flags>
+      <renderer-v2 type="categorizedSymbol" forceraster="0" symbollevels="0" attr="typ" enableorderby="0">
+        <categories>
+          <category symbol="0" label="Ortsteil" render="true" value="Ortsteil"/>
+          <category symbol="1" label="Stadtteil" render="true" value="Stadtteil"/>
+        </categories>
+        <symbols>
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="207,94,42,255" k="color"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="78,70,255,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0.5" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="no" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="1" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="153,148,255,255" k="color"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="153,148,255,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0.5" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="no" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </symbols>
+        <source-symbol>
+          <symbol type="fill" alpha="1" clip_to_extent="1" name="0" force_rhr="0">
+            <layer class="SimpleFill" enabled="1" pass="0" locked="0">
+              <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
+              <prop v="145,82,45,255" k="color"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0.26" k="outline_width"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="solid" k="style"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </source-symbol>
+        <rotation/>
+        <sizescale/>
+      </renderer-v2>
+      <customproperties>
+        <property value="&quot;id&quot;" key="dualview/previewExpressions"/>
+        <property value="0" key="embeddedWidgets/count"/>
+        <property key="variableNames"/>
+        <property key="variableValues"/>
+      </customproperties>
+      <blendMode>0</blendMode>
+      <featureBlendMode>0</featureBlendMode>
+      <layerOpacity>1</layerOpacity>
+      <SingleCategoryDiagramRenderer diagramType="Histogram" attributeLegend="1">
+        <DiagramCategory labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" maxScaleDenominator="1e+08" enabled="0" backgroundAlpha="255" minScaleDenominator="0" diagramOrientation="Up" penWidth="0" barWidth="5" height="15" penColor="#000000" rotationOffset="270" lineSizeScale="3x:0,0,0,0,0,0" scaleBasedVisibility="0" scaleDependency="Area" width="15" lineSizeType="MM" sizeType="MM" backgroundColor="#ffffff" opacity="1" penAlpha="255" minimumSize="0">
+          <fontProperties style="" description="Noto Sans,9,-1,5,50,0,0,0,0,0"/>
+          <attribute field="" label="" color="#000000"/>
+        </DiagramCategory>
+      </SingleCategoryDiagramRenderer>
+      <DiagramLayerSettings dist="0" placement="1" obstacle="0" linePlacementFlags="18" priority="0" zIndex="0" showAll="1">
+        <properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </properties>
+      </DiagramLayerSettings>
+      <geometryOptions geometryPrecision="0" removeDuplicateNodes="0">
+        <activeChecks/>
+        <checkConfiguration/>
+      </geometryOptions>
+      <fieldConfiguration>
+        <field name="fid">
+          <editWidget type="">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="id">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="typ">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="name">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+        <field name="ortsrat">
+          <editWidget type="TextEdit">
+            <config>
+              <Option/>
+            </config>
+          </editWidget>
+        </field>
+      </fieldConfiguration>
+      <aliases>
+        <alias field="fid" index="0" name=""/>
+        <alias field="id" index="1" name=""/>
+        <alias field="typ" index="2" name=""/>
+        <alias field="name" index="3" name=""/>
+        <alias field="ortsrat" index="4" name=""/>
+      </aliases>
+      <excludeAttributesWMS/>
+      <excludeAttributesWFS/>
+      <defaults>
+        <default field="fid" expression="" applyOnUpdate="0"/>
+        <default field="id" expression="" applyOnUpdate="0"/>
+        <default field="typ" expression="" applyOnUpdate="0"/>
+        <default field="name" expression="" applyOnUpdate="0"/>
+        <default field="ortsrat" expression="" applyOnUpdate="0"/>
+      </defaults>
+      <constraints>
+        <constraint field="fid" constraints="3" exp_strength="0" unique_strength="1" notnull_strength="1"/>
+        <constraint field="id" constraints="3" exp_strength="0" unique_strength="1" notnull_strength="1"/>
+        <constraint field="typ" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="name" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+        <constraint field="ortsrat" constraints="0" exp_strength="0" unique_strength="0" notnull_strength="0"/>
+      </constraints>
+      <constraintExpressions>
+        <constraint field="fid" desc="" exp=""/>
+        <constraint field="id" desc="" exp=""/>
+        <constraint field="typ" desc="" exp=""/>
+        <constraint field="name" desc="" exp=""/>
+        <constraint field="ortsrat" desc="" exp=""/>
+      </constraintExpressions>
+      <expressionfields/>
+      <attributeactions>
+        <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+      </attributeactions>
+      <attributetableconfig actionWidgetStyle="dropDown" sortOrder="0" sortExpression="">
+        <columns>
+          <column width="-1" type="field" hidden="0" name="id"/>
+          <column width="-1" type="field" hidden="0" name="typ"/>
+          <column width="-1" type="field" hidden="0" name="name"/>
+          <column width="-1" type="field" hidden="0" name="ortsrat"/>
+          <column width="-1" type="actions" hidden="1"/>
+        </columns>
+      </attributetableconfig>
+      <conditionalstyles>
+        <rowstyles/>
+        <fieldstyles/>
+      </conditionalstyles>
+      <editform tolerant="1"></editform>
+      <editforminit/>
+      <editforminitcodesource>0</editforminitcodesource>
+      <editforminitfilepath></editforminitfilepath>
+      <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+      <featformsuppress>0</featformsuppress>
+      <editorlayout>generatedlayout</editorlayout>
+      <editable>
+        <field editable="1" name="id"/>
+        <field editable="1" name="name"/>
+        <field editable="1" name="ortsrat"/>
+        <field editable="1" name="typ"/>
+      </editable>
+      <labelOnTop>
+        <field labelOnTop="0" name="id"/>
+        <field labelOnTop="0" name="name"/>
+        <field labelOnTop="0" name="ortsrat"/>
+        <field labelOnTop="0" name="typ"/>
+      </labelOnTop>
+      <widgets/>
+      <previewExpression>id</previewExpression>
+      <mapTip></mapTip>
+    </maplayer>
+    <maplayer autoRefreshTime="0" refreshOnNotifyMessage="" hasScaleBasedVisibilityFlag="0" maxScale="0" type="raster" minScale="1e+08" autoRefreshEnabled="0" styleCategories="AllStyleCategories" refreshOnNotifyEnabled="0">
+      <extent>
+        <xmin>611425.600499999942258</xmin>
+        <ymin>5808334.13232080265879631</ymin>
+        <xmax>623219.587000000057742</xmax>
+        <ymax>5814172.86767920013517141</ymax>
+      </extent>
+      <id>osm_85c8eb94_b6fa_437b_b91a_7816ef2e2243</id>
+      <datasource>GPKG:./test_project_wms_grouped_layers.gpkg:osm</datasource>
+      <keywordList>
+        <value></value>
+      </keywordList>
+      <layername>osm</layername>
+      <srs>
+        <spatialrefsys>
+          <proj4>+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs</proj4>
+          <srsid>2105</srsid>
+          <srid>25832</srid>
+          <authid>EPSG:25832</authid>
+          <description>ETRS89 / UTM zone 32N</description>
+          <projectionacronym>utm</projectionacronym>
+          <ellipsoidacronym>GRS80</ellipsoidacronym>
+          <geographicflag>false</geographicflag>
+        </spatialrefsys>
+      </srs>
+      <resourceMetadata>
+        <identifier></identifier>
+        <parentidentifier></parentidentifier>
+        <language></language>
+        <type></type>
+        <title></title>
+        <abstract></abstract>
+        <links/>
+        <fees></fees>
+        <encoding></encoding>
+        <crs>
+          <spatialrefsys>
+            <proj4></proj4>
+            <srsid>0</srsid>
+            <srid>0</srid>
+            <authid></authid>
+            <description></description>
+            <projectionacronym></projectionacronym>
+            <ellipsoidacronym></ellipsoidacronym>
+            <geographicflag>false</geographicflag>
+          </spatialrefsys>
+        </crs>
+        <extent/>
+      </resourceMetadata>
+      <provider>gdal</provider>
+      <noData>
+        <noDataList bandNo="1" useSrcNoData="0"/>
+        <noDataList bandNo="2" useSrcNoData="0"/>
+        <noDataList bandNo="3" useSrcNoData="0"/>
+        <noDataList bandNo="4" useSrcNoData="0"/>
+      </noData>
+      <map-layer-style-manager current="default">
+        <map-layer-style name="default"/>
+      </map-layer-style-manager>
+      <flags>
+        <Identifiable>1</Identifiable>
+        <Removable>1</Removable>
+        <Searchable>0</Searchable>
+      </flags>
+      <customproperties>
+        <property value="Value" key="identify/format"/>
+      </customproperties>
+      <pipe>
+        <rasterrenderer opacity="1" type="multibandcolor" redBand="1" greenBand="2" blueBand="3" alphaBand="4">
+          <rasterTransparency/>
+          <minMaxOrigin>
+            <limits>MinMax</limits>
+            <extent>WholeRaster</extent>
+            <statAccuracy>Estimated</statAccuracy>
+            <cumulativeCutLower>0.02</cumulativeCutLower>
+            <cumulativeCutUpper>0.98</cumulativeCutUpper>
+            <stdDevFactor>2</stdDevFactor>
+          </minMaxOrigin>
+          <redContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </redContrastEnhancement>
+          <greenContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </greenContrastEnhancement>
+          <blueContrastEnhancement>
+            <minValue>0</minValue>
+            <maxValue>255</maxValue>
+            <algorithm>NoEnhancement</algorithm>
+          </blueContrastEnhancement>
+        </rasterrenderer>
+        <brightnesscontrast contrast="0" brightness="0"/>
+        <huesaturation colorizeStrength="100" colorizeRed="255" colorizeOn="0" colorizeGreen="128" saturation="0" colorizeBlue="128" grayscaleMode="0"/>
+        <rasterresampler maxOversampling="2"/>
+      </pipe>
+      <blendMode>0</blendMode>
+    </maplayer>
+  </projectlayers>
+  <layerorder>
+    <layer id="osm_85c8eb94_b6fa_437b_b91a_7816ef2e2243"/>
+    <layer id="cdb_labels_8ee74af8_e7ba_4d80_9e0d_5b0b956d3daf"/>
+    <layer id="cdb_lines_3f5c3c6d_db6d_4681_9291_7109f8d69f8b"/>
+    <layer id="as_areas_bbe3c71b_356c_49f5_9fc2_ae771bcdd467"/>
+    <layer id="as_symbols_3a1cdeef_9082_4d07_be5c_47c956bd7e76"/>
+  </layerorder>
+  <properties>
+    <WMSMaxAtlasFeatures type="int">1</WMSMaxAtlasFeatures>
+    <Measure>
+      <Ellipsoid type="QString">GRS80</Ellipsoid>
+    </Measure>
+    <WMTSLayers>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+      <Group type="QStringList"/>
+    </WMTSLayers>
+    <WMSContactOrganization type="QString"></WMSContactOrganization>
+    <WMSUrl type="QString"></WMSUrl>
+    <WMTSPngLayers>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+      <Group type="QStringList"/>
+    </WMTSPngLayers>
+    <WMSUseLayerIDs type="bool">false</WMSUseLayerIDs>
+    <WMTSGrids>
+      <CRS type="QStringList"/>
+      <Config type="QStringList"/>
+    </WMTSGrids>
+    <Macros>
+      <pythonCode type="QString"></pythonCode>
+    </Macros>
+    <WMSKeywordList type="QStringList">
+      <value></value>
+    </WMSKeywordList>
+    <DefaultStyles>
+      <ColorRamp type="QString"></ColorRamp>
+      <RandomColors type="bool">true</RandomColors>
+      <Line type="QString"></Line>
+      <Fill type="QString"></Fill>
+      <Opacity type="double">1</Opacity>
+      <Marker type="QString"></Marker>
+    </DefaultStyles>
+    <SpatialRefSys>
+      <ProjectionsEnabled type="int">1</ProjectionsEnabled>
+    </SpatialRefSys>
+    <WMSContactMail type="QString"></WMSContactMail>
+    <WFSUrl type="QString"></WFSUrl>
+    <WMSAccessConstraints type="QString">None</WMSAccessConstraints>
+    <WMSRequestDefinedDataSources type="bool">false</WMSRequestDefinedDataSources>
+    <WMSOnlineResource type="QString"></WMSOnlineResource>
+    <Paths>
+      <Absolute type="bool">false</Absolute>
+    </Paths>
+    <WMSContactPosition type="QString"></WMSContactPosition>
+    <WMTSMinScale type="int">5000</WMTSMinScale>
+    <WMSSegmentizeFeatureInfoGeometry type="bool">false</WMSSegmentizeFeatureInfoGeometry>
+    <WCSLayers type="QStringList"/>
+    <Legend>
+      <filterByMap type="bool">false</filterByMap>
+    </Legend>
+    <PAL>
+      <SearchMethod type="int">0</SearchMethod>
+      <DrawOutlineLabels type="bool">true</DrawOutlineLabels>
+      <TextFormat type="int">0</TextFormat>
+      <CandidatesLine type="int">50</CandidatesLine>
+      <CandidatesPolygon type="int">30</CandidatesPolygon>
+      <DrawRectOnly type="bool">false</DrawRectOnly>
+      <ShowingPartialsLabels type="bool">true</ShowingPartialsLabels>
+      <CandidatesPoint type="int">16</CandidatesPoint>
+      <ShowingCandidates type="bool">false</ShowingCandidates>
+      <ShowingAllLabels type="bool">false</ShowingAllLabels>
+    </PAL>
+    <WMTSUrl type="QString"></WMTSUrl>
+    <WMSPrecision type="QString">8</WMSPrecision>
+    <WMSFees type="QString">conditions unknown</WMSFees>
+    <WMTSJpegLayers>
+      <Layer type="QStringList"/>
+      <Project type="bool">false</Project>
+      <Group type="QStringList"/>
+    </WMTSJpegLayers>
+    <WFSLayers type="QStringList"/>
+    <WMSContactPhone type="QString"></WMSContactPhone>
+    <WMSAddWktGeometry type="bool">false</WMSAddWktGeometry>
+    <WMSImageQuality type="int">90</WMSImageQuality>
+    <PositionPrecision>
+      <DecimalPlaces type="int">2</DecimalPlaces>
+      <DegreeFormat type="QString">MU</DegreeFormat>
+      <Automatic type="bool">true</Automatic>
+    </PositionPrecision>
+    <WCSUrl type="QString"></WCSUrl>
+    <WFSTLayers>
+      <Delete type="QStringList"/>
+      <Update type="QStringList"/>
+      <Insert type="QStringList"/>
+    </WFSTLayers>
+    <WMSRootName type="QString">All_grouped_layers</WMSRootName>
+    <WMSServiceAbstract type="QString"></WMSServiceAbstract>
+    <WMSServiceCapabilities type="bool">true</WMSServiceCapabilities>
+    <Measurement>
+      <AreaUnits type="QString">m2</AreaUnits>
+      <DistanceUnits type="QString">meters</DistanceUnits>
+    </Measurement>
+    <WMSServiceTitle type="QString">A test project with groups and subgroups</WMSServiceTitle>
+    <WMSContactPerson type="QString"></WMSContactPerson>
+    <Gui>
+      <SelectionColorRedPart type="int">255</SelectionColorRedPart>
+      <SelectionColorAlphaPart type="int">255</SelectionColorAlphaPart>
+      <SelectionColorGreenPart type="int">255</SelectionColorGreenPart>
+      <CanvasColorGreenPart type="int">255</CanvasColorGreenPart>
+      <CanvasColorRedPart type="int">255</CanvasColorRedPart>
+      <CanvasColorBluePart type="int">255</CanvasColorBluePart>
+      <SelectionColorBluePart type="int">0</SelectionColorBluePart>
+    </Gui>
+  </properties>
+  <visibility-presets/>
+  <transformContext/>
+  <projectMetadata>
+    <identifier></identifier>
+    <parentidentifier></parentidentifier>
+    <language></language>
+    <type></type>
+    <title>QGIS Server - Grouped Layer</title>
+    <abstract></abstract>
+    <contact>
+      <name></name>
+      <organization></organization>
+      <position></position>
+      <voice></voice>
+      <fax></fax>
+      <email></email>
+      <role></role>
+    </contact>
+    <links/>
+    <author>Burghardt Scholle</author>
+    <creation>2018-12-11T10:39:23</creation>
+  </projectMetadata>
+  <Annotations/>
+  <Layouts/>
+</qgis>


### PR DESCRIPTION
This patch fixes a WMS server bug when "Short name" was
set in project settings for service capabilities.

When the short name was set, it was not possible
to load the whole WMS by selecting the root
layer named after the short name.

With tests for both cases (with and without short name).

Funded by Kanton Zug
