### PR TITLE
Compile time

### DIFF
--- a/python/core/auto_generated/annotations/qgsannotation.sip.in
+++ b/python/core/auto_generated/annotations/qgsannotation.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsAnnotation : QObject
 {
 %Docstring

--- a/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsabstractgeometry.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 typedef QVector< QgsPoint > QgsPointSequence;
 typedef QVector< QVector< QgsPoint > > QgsRingSequence;
 typedef QVector< QVector< QVector< QgsPoint > > > QgsCoordinateSequence;

--- a/python/core/auto_generated/geometry/qgswkbptr.sip.in
+++ b/python/core/auto_generated/geometry/qgswkbptr.sip.in
@@ -38,6 +38,7 @@ class QgsConstWkbPtr
 
 
 
+
   public:
     QgsConstWkbPtr( const unsigned char *p /Array/, int size /ArraySize/ );
 

--- a/python/core/auto_generated/geometry/qgswkbptr.sip.in
+++ b/python/core/auto_generated/geometry/qgswkbptr.sip.in
@@ -38,9 +38,9 @@ class QgsConstWkbPtr
 
 
 
-
   public:
     QgsConstWkbPtr( const unsigned char *p /Array/, int size /ArraySize/ );
+
 
 
 

--- a/python/core/auto_generated/mesh/qgsmeshlayerinterpolator.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayerinterpolator.sip.in
@@ -11,6 +11,7 @@
 
 
 
+
 %ModuleHeaderCode
 #include "qgsmeshlayerinterpolator.h"
 %End

--- a/python/core/auto_generated/metadata/qgsprojectmetadata.sip.in
+++ b/python/core/auto_generated/metadata/qgsprojectmetadata.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsProjectMetadata : QgsAbstractMetadataBase
 {
 %Docstring

--- a/python/core/auto_generated/qgsabstractcontentcache.sip.in
+++ b/python/core/auto_generated/qgsabstractcontentcache.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsAbstractContentCacheEntry
 {
 %Docstring

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -503,7 +503,6 @@ Gets application icon
 Returns whether this machine uses big or little endian
 %End
 
-
     static QString reportStyleSheet();
 %Docstring
 Returns a standard css style sheet for reports.

--- a/python/gui/auto_generated/qgsnewmemorylayerdialog.sip.in
+++ b/python/gui/auto_generated/qgsnewmemorylayerdialog.sip.in
@@ -28,6 +28,9 @@ Runs the dialog and creates a new memory layer
 %End
 
     QgsNewMemoryLayerDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+%Docstring
+New dialog constructor.
+%End
     ~QgsNewMemoryLayerDialog();
 
     QgsWkbTypes::Type selectedType() const;

--- a/python/gui/auto_generated/qgsnewvectorlayerdialog.sip.in
+++ b/python/gui/auto_generated/qgsnewvectorlayerdialog.sip.in
@@ -28,6 +28,9 @@ If the ``initialPath`` argument is specified, then the dialog will default to th
 %End
 
     QgsNewVectorLayerDialog( QWidget *parent /TransferThis/ = 0, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
+%Docstring
+New dialog constructor.
+%End
     ~QgsNewVectorLayerDialog();
     QgsWkbTypes::Type selectedType() const;
 %Docstring

--- a/src/analysis/processing/qgsalgorithmbuffer.h
+++ b/src/analysis/processing/qgsalgorithmbuffer.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmcentroid.h
+++ b/src/analysis/processing/qgsalgorithmcentroid.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmclip.h
+++ b/src/analysis/processing/qgsalgorithmclip.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmconvexhull.h
+++ b/src/analysis/processing/qgsalgorithmconvexhull.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmdifference.h
+++ b/src/analysis/processing/qgsalgorithmdifference.h
@@ -19,6 +19,7 @@
 #define SIP_NO_FILE
 
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmdissolve.h
+++ b/src/analysis/processing/qgsalgorithmdissolve.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmextractbylocation.h
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmextractvertices.h
+++ b/src/analysis/processing/qgsalgorithmextractvertices.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmintersection.h
+++ b/src/analysis/processing/qgsalgorithmintersection.h
@@ -19,6 +19,7 @@
 #define SIP_NO_FILE
 
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmlineintersection.h
+++ b/src/analysis/processing/qgsalgorithmlineintersection.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmloadlayer.h
+++ b/src/analysis/processing/qgsalgorithmloadlayer.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmmeancoordinates.h
+++ b/src/analysis/processing/qgsalgorithmmeancoordinates.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmmergevector.h
+++ b/src/analysis/processing/qgsalgorithmmergevector.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmmultiparttosinglepart.h
+++ b/src/analysis/processing/qgsalgorithmmultiparttosinglepart.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmnetworkanalysisbase.h
+++ b/src/analysis/processing/qgsalgorithmnetworkanalysisbase.h
@@ -26,6 +26,7 @@
 #include "qgsgraph.h"
 #include "qgsgraphbuilder.h"
 #include "qgsvectorlayerdirector.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmpointonsurface.h
+++ b/src/analysis/processing/qgsalgorithmpointonsurface.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmpromotetomultipart.h
+++ b/src/analysis/processing/qgsalgorithmpromotetomultipart.h
@@ -22,6 +22,7 @@
 
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmsimplify.h
+++ b/src/analysis/processing/qgsalgorithmsimplify.h
@@ -23,6 +23,7 @@
 #include "qgis.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsmaptopixelgeometrysimplifier.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmsymmetricaldifference.h
+++ b/src/analysis/processing/qgsalgorithmsymmetricaldifference.h
@@ -19,6 +19,7 @@
 #define SIP_NO_FILE
 
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/analysis/processing/qgsalgorithmunion.h
+++ b/src/analysis/processing/qgsalgorithmunion.h
@@ -20,6 +20,7 @@
 #define SIP_NO_FILE
 
 #include "qgsprocessingalgorithm.h"
+#include "qgsapplication.h"
 
 ///@cond PRIVATE
 

--- a/src/app/3d/qgs3dmapcanvasdockwidget.cpp
+++ b/src/app/3d/qgs3dmapcanvasdockwidget.cpp
@@ -29,6 +29,7 @@
 #include "qgscameracontroller.h"
 #include "qgsmapcanvas.h"
 #include "qgsmessagebar.h"
+#include "qgsapplication.h"
 
 #include "qgs3danimationsettings.h"
 #include "qgs3danimationwidget.h"

--- a/src/app/3d/qgslightswidget.cpp
+++ b/src/app/3d/qgslightswidget.cpp
@@ -16,6 +16,7 @@
 #include "qgslightswidget.h"
 
 #include "qgs3dmapsettings.h"
+#include "qgsapplication.h"
 
 #include <QMessageBox>
 

--- a/src/app/3d/qgsrulebased3drendererwidget.cpp
+++ b/src/app/3d/qgsrulebased3drendererwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgsrulebased3drenderer.h"
 #include "qgsvectorlayer.h"
 #include "qgssymbol3dwidget.h"
+#include "qgsapplication.h"
 
 #include <QAction>
 #include <QClipboard>

--- a/src/app/3d/qgsvectorlayer3drendererwidget.cpp
+++ b/src/app/3d/qgsvectorlayer3drendererwidget.cpp
@@ -21,6 +21,7 @@
 #include "qgssymbol3dwidget.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayer3drenderer.h"
+#include "qgsapplication.h"
 
 #include <QBoxLayout>
 #include <QCheckBox>

--- a/src/app/browser/qgsinbuiltdataitemproviders.cpp
+++ b/src/app/browser/qgsinbuiltdataitemproviders.cpp
@@ -32,6 +32,7 @@
 #include "qgsnewvectorlayerdialog.h"
 #include "qgsnewgeopackagelayerdialog.h"
 #include "qgsfileutils.h"
+#include "qgsapplication.h"
 #include <QMenu>
 #include <QInputDialog>
 #include <QMessageBox>

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -103,6 +103,7 @@ class QgsStatusBar;
 class QgsGeometryValidationService;
 class QgsGeometryValidationDock;
 class QgsGeometryValidationModel;
+class QgsUserProfileManager;
 class QgsUserProfileManagerWidgetFactory;
 class Qgs3DMapCanvasDockWidget;
 class QgsHandleBadLayersHandler;

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -20,6 +20,7 @@
 #include "qgisapp.h"
 #include "qgsfieldcombobox.h"
 #include "qgsqmlwidgetwrapper.h"
+#include "qgsapplication.h"
 
 QgsAttributesFormProperties::QgsAttributesFormProperties( QgsVectorLayer *layer, QWidget *parent )
   : QWidget( parent )

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -28,6 +28,7 @@
 #include "qgseditorwidgetfactory.h"
 #include "qgseditorwidgetregistry.h"
 #include "qgsgui.h"
+#include "qgsapplication.h"
 
 #include <QTableWidgetItem>
 #include <QFile>

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -39,6 +39,7 @@
 #include "qgisapp.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
+#include "qgsapplication.h"
 
 QgsClipboard::QgsClipboard()
 {

--- a/src/app/qgsgeometryvalidationdock.cpp
+++ b/src/app/qgsgeometryvalidationdock.cpp
@@ -29,6 +29,7 @@ email                : matthias@opengis.ch
 #include "qgsgeometryoptions.h"
 #include "qgsgeometrycheckfactory.h"
 #include "qgisapp.h"
+#include "qgsapplication.h"
 
 
 QgsGeometryValidationDock::QgsGeometryValidationDock( const QString &title, QgsMapCanvas *mapCanvas, QgisApp *parent, Qt::WindowFlags flags )

--- a/src/app/qgsgeometryvalidationmodel.cpp
+++ b/src/app/qgsgeometryvalidationmodel.cpp
@@ -18,6 +18,7 @@ email                : matthias@opengis.ch
 #include "qgsvectorlayer.h"
 #include "qgssinglegeometrycheck.h"
 #include "qgsfeatureid.h"
+#include "qgsapplication.h"
 
 #include <QIcon>
 

--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -27,6 +27,7 @@
 #include "qgsmessagebar.h"
 #include "qgssettings.h"
 #include "qgslayertreeregistrybridge.h"
+#include "qgsapplication.h"
 
 #include <QDomDocument>
 #include <QDomElement>

--- a/src/app/qgslayertreeviewembeddedindicator.cpp
+++ b/src/app/qgslayertreeviewembeddedindicator.cpp
@@ -17,6 +17,7 @@
 #include "qgslayertree.h"
 #include "qgslayertreemodel.h"
 #include "qgslayertreeview.h"
+#include "qgsapplication.h"
 
 QgsLayerTreeViewEmbeddedIndicatorProvider::QgsLayerTreeViewEmbeddedIndicatorProvider( QgsLayerTreeView *view )
   : QObject( view )

--- a/src/app/qgslayertreeviewindicatorprovider.cpp
+++ b/src/app/qgslayertreeviewindicatorprovider.cpp
@@ -22,6 +22,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsrasterlayer.h"
 #include "qgisapp.h"
+#include "qgsapplication.h"
 
 QgsLayerTreeViewIndicatorProvider::QgsLayerTreeViewIndicatorProvider( QgsLayerTreeView *view )
   : QObject( view )

--- a/src/app/qgsmapcanvasdockwidget.cpp
+++ b/src/app/qgsmapcanvasdockwidget.cpp
@@ -29,6 +29,7 @@
 #include "qgsvertexmarker.h"
 #include "qgsrubberband.h"
 #include "qgsvectorlayer.h"
+#include "qgsapplication.h"
 #include <QMessageBox>
 #include <QMenu>
 #include <QToolBar>

--- a/src/app/qgsmaplayerstylecategoriesmodel.cpp
+++ b/src/app/qgsmaplayerstylecategoriesmodel.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsmaplayerstylecategoriesmodel.h"
+#include "qgsapplication.h"
 
 QgsMapLayerStyleCategoriesModel::QgsMapLayerStyleCategoriesModel( QObject *parent )
   : QAbstractListModel( parent )

--- a/src/app/qgsmapsavedialog.cpp
+++ b/src/app/qgsmapsavedialog.cpp
@@ -40,6 +40,7 @@
 #include "qgssettings.h"
 #include "qgsmapcanvas.h"
 #include "qgsmessagebar.h"
+#include "qgsapplication.h"
 
 
 Q_GUI_EXPORT extern int qt_defaultDpiX();

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -22,6 +22,7 @@
 #include "qgsgeometry.h"
 #include "qgspointxy.h"
 #include "qgis.h"
+#include "qgsapplication.h"
 
 #include <QMouseEvent>
 #include <QRect>

--- a/src/app/qgssnappinglayertreemodel.cpp
+++ b/src/app/qgssnappinglayertreemodel.cpp
@@ -24,7 +24,7 @@
 #include "qgsproject.h"
 #include "qgssnappingconfig.h"
 #include "qgsvectorlayer.h"
-
+#include "qgsapplication.h"
 
 QgsSnappingLayerDelegate::QgsSnappingLayerDelegate( QgsMapCanvas *canvas, QObject *parent )
   : QItemDelegate( parent )

--- a/src/app/qgssourcefieldsproperties.cpp
+++ b/src/app/qgssourcefieldsproperties.cpp
@@ -17,6 +17,7 @@
 #include "qgssourcefieldsproperties.h"
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
+#include "qgsapplication.h"
 
 QgsSourceFieldsProperties::QgsSourceFieldsProperties( QgsVectorLayer *layer, QWidget *parent )
   : QWidget( parent )

--- a/src/app/qgsstatisticalsummarydockwidget.cpp
+++ b/src/app/qgsstatisticalsummarydockwidget.cpp
@@ -23,6 +23,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsfeedback.h"
 #include "qgsvectorlayerutils.h"
+#include "qgsapplication.h"
 
 #include <QTableWidget>
 #include <QAction>

--- a/src/core/annotations/qgsannotation.h
+++ b/src/core/annotations/qgsannotation.h
@@ -22,10 +22,11 @@
 #include "qgis.h"
 #include "qgspointxy.h"
 #include "qgscoordinatereferencesystem.h"
-#include "qgsrendercontext.h"
 #include "qgssymbol.h"
 #include "qgsmargins.h"
 #include "qgsmaplayer.h"
+
+class QgsRenderContext;
 
 /**
  * \ingroup core

--- a/src/core/annotations/qgsannotationmanager.cpp
+++ b/src/core/annotations/qgsannotationmanager.cpp
@@ -17,6 +17,7 @@
 #include "qgsproject.h"
 #include "qgsannotation.h"
 #include "qgsannotationregistry.h"
+#include "qgsapplication.h"
 
 QgsAnnotationManager::QgsAnnotationManager( QgsProject *project )
   : QObject( project )

--- a/src/core/diagram/qgsdiagram.cpp
+++ b/src/core/diagram/qgsdiagram.cpp
@@ -14,9 +14,6 @@
  ***************************************************************************/
 #include "qgsdiagram.h"
 #include "qgsdiagramrenderer.h"
-#include "qgsrendercontext.h"
-#include "qgsexpression.h"
-#include "qgssymbollayerutils.h"
 
 #include <QPainter>
 

--- a/src/core/effects/qgseffectstack.cpp
+++ b/src/core/effects/qgseffectstack.cpp
@@ -18,6 +18,7 @@
 #include "qgseffectstack.h"
 #include "qgspainteffectregistry.h"
 #include "qgsrendercontext.h"
+#include "qgsapplication.h"
 #include <QPicture>
 
 QgsEffectStack::QgsEffectStack( const QgsEffectStack &other )

--- a/src/core/effects/qgspainteffectregistry.cpp
+++ b/src/core/effects/qgspainteffectregistry.cpp
@@ -20,6 +20,7 @@
 #include "qgsgloweffect.h"
 #include "qgstransformeffect.h"
 #include "qgscoloreffect.h"
+#include "qgsapplication.h"
 
 QgsPaintEffectAbstractMetadata::QgsPaintEffectAbstractMetadata( const QString &name, const QString &visibleName )
   : mName( name )

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -51,6 +51,7 @@
 #include "sqlite3.h"
 #include "qgstransaction.h"
 #include "qgsthreadingutils.h"
+#include "qgsapplication.h"
 
 const QString QgsExpressionFunction::helpText() const
 {

--- a/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsdatetimefieldformatter.cpp
@@ -18,6 +18,7 @@
 #include "qgssettings.h"
 #include "qgsfield.h"
 #include "qgsvectorlayer.h"
+#include "qgsapplication.h"
 
 const QString QgsDateTimeFieldFormatter::DATE_FORMAT = QStringLiteral( "yyyy-MM-dd" );
 const QString QgsDateTimeFieldFormatter::TIME_FORMAT = QStringLiteral( "HH:mm:ss" );

--- a/src/core/fieldformatter/qgsrangefieldformatter.cpp
+++ b/src/core/fieldformatter/qgsrangefieldformatter.cpp
@@ -21,6 +21,7 @@
 #include "qgssettings.h"
 #include "qgsfield.h"
 #include "qgsvectorlayer.h"
+#include "qgsapplication.h"
 
 
 QString QgsRangeFieldFormatter::id() const

--- a/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
+++ b/src/core/fieldformatter/qgsvaluerelationfieldformatter.cpp
@@ -19,6 +19,7 @@
 #include "qgsproject.h"
 #include "qgsvectorlayer.h"
 #include "qgsexpressionnodeimpl.h"
+#include "qgsapplication.h"
 
 #include <QSettings>
 

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -30,7 +30,7 @@ class QgsMapToPixel;
 class QgsCurve;
 class QgsMultiCurve;
 class QgsMultiPoint;
-class QgsPoint;
+
 struct QgsVertexId;
 class QgsVertexIterator;
 class QPainter;
@@ -38,6 +38,7 @@ class QDomDocument;
 class QDomElement;
 class QgsGeometryPartIterator;
 class QgsGeometryConstPartIterator;
+class QgsConstWkbPtr;
 
 typedef QVector< QgsPoint > QgsPointSequence;
 #ifndef SIP_RUN

--- a/src/core/geometry/qgsgeometryfactory.h
+++ b/src/core/geometry/qgsgeometryfactory.h
@@ -21,6 +21,7 @@
 #define SIP_NO_FILE
 
 #include "qgis_core.h"
+#include "qgswkbtypes.h"
 #include <QString>
 #include <memory>
 

--- a/src/core/geometry/qgswkbptr.cpp
+++ b/src/core/geometry/qgswkbptr.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgswkbptr.h"
+#include "qgsapplication.h"
 
 QgsWkbPtr::QgsWkbPtr( QByteArray &wkb )
 {

--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -132,19 +132,6 @@ class CORE_EXPORT QgsConstWkbPtr
     mutable bool mEndianSwap;
     mutable QgsWkbTypes::Type mWkbType;
 
-#ifndef SIP_RUN
-    template<typename T>
-    void endian_swap( T &value ) const
-    {
-      char *data = reinterpret_cast<char *>( &value );
-      std::size_t n = sizeof( value );
-      for ( std::size_t i = 0, m = n / 2; i < m; ++i )
-      {
-        std::swap( data[i], data[n - 1 - i] );
-      }
-    }
-#endif
-
     /**
      * \brief Verify bounds
      * \note note available in Python bindings
@@ -196,6 +183,17 @@ class CORE_EXPORT QgsConstWkbPtr
      * \note note available in Python bindings
      */
     inline int remaining() const { return mEnd - mP; } SIP_SKIP
+
+  private:
+    template<typename T> void endian_swap( T &value ) const SIP_SKIP
+    {
+      char *data = reinterpret_cast<char *>( &value );
+      std::size_t n = sizeof( value );
+      for ( std::size_t i = 0, m = n / 2; i < m; ++i )
+      {
+        std::swap( data[i], data[n - 1 - i] );
+      }
+    }
 };
 
 #endif // QGSWKBPTR_H

--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -17,7 +17,6 @@
 
 #include "qgis_core.h"
 #include "qgswkbtypes.h"
-#include "qgsapplication.h"
 #include "qgis.h"
 #include "qgsexception.h"
 #include "qpolygon.h"
@@ -133,6 +132,19 @@ class CORE_EXPORT QgsConstWkbPtr
     mutable bool mEndianSwap;
     mutable QgsWkbTypes::Type mWkbType;
 
+#ifndef SIP_RUN
+    template<typename T>
+    void endian_swap( T &value ) const
+    {
+      char *data = reinterpret_cast<char *>( &value );
+      std::size_t n = sizeof( value );
+      for ( std::size_t i = 0, m = n / 2; i < m; ++i )
+      {
+        std::swap( data[i], data[n - 1 - i] );
+      }
+    }
+#endif
+
     /**
      * \brief Verify bounds
      * \note note available in Python bindings
@@ -149,7 +161,7 @@ class CORE_EXPORT QgsConstWkbPtr
       memcpy( &v, mP, sizeof( v ) );
       mP += sizeof( v );
       if ( mEndianSwap )
-        QgsApplication::endian_swap( v );
+        endian_swap( v );
     }
 
   public:

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -19,6 +19,7 @@
 #include "qgslayertreeutils.h"
 #include "qgslayertreemodellegendnode.h"
 #include "qgsproject.h"
+#include "qgsapplication.h"
 
 #include <QMimeData>
 #include <QTextStream>

--- a/src/core/layout/qgslayoutitem.h
+++ b/src/core/layout/qgslayoutitem.h
@@ -24,6 +24,7 @@
 #include "qgsrendercontext.h"
 #include "qgslayoutundocommand.h"
 #include "qgslayoutmeasurement.h"
+#include "qgsapplication.h"
 #include <QGraphicsRectItem>
 #include <QIcon>
 #include <QPainter>

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -30,6 +30,7 @@
 #include "qgsmaplayerstylemanager.h"
 #include "qgsvectorlayer.h"
 #include "qgsexpressioncontext.h"
+#include "qgsapplication.h"
 
 #include <QPainter>
 #include <QStyleOptionGraphicsItem>

--- a/src/core/layout/qgslayoutmultiframe.h
+++ b/src/core/layout/qgslayoutmultiframe.h
@@ -20,6 +20,7 @@
 #include "qgis.h"
 #include "qgslayoutobject.h"
 #include "qgslayoutundocommand.h"
+#include "qgsapplication.h"
 #include <QIcon>
 #include <QObject>
 #include <QSizeF>

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -22,7 +22,6 @@
 
 #include "qgis_core.h"
 #include "qgsmaplayer.h"
-#include "qgsrendercontext.h"
 #include "qgsmeshdataprovider.h"
 #include "qgsmeshrenderersettings.h"
 
@@ -30,6 +29,7 @@ class QgsMapLayerRenderer;
 struct QgsMeshLayerRendererCache;
 class QgsSymbol;
 class QgsTriangularMesh;
+class QgsRenderContext;
 struct QgsMesh;
 
 /**

--- a/src/core/mesh/qgsmeshlayerinterpolator.h
+++ b/src/core/mesh/qgsmeshlayerinterpolator.h
@@ -29,11 +29,12 @@ class QgsMeshDatasetIndex;
 
 #include <QSize>
 #include "qgsmaplayerrenderer.h"
-#include "qgsrendercontext.h"
 #include "qgstriangularmesh.h"
 #include "qgsrasterinterface.h"
 #include "qgssinglebandpseudocolorrenderer.h"
 #include "qgsrastershader.h"
+
+class QgsRenderContext;
 
 #ifdef SIP_RUN
 % ModuleHeaderCode

--- a/src/core/mesh/qgsmeshlayerrenderer.h
+++ b/src/core/mesh/qgsmeshlayerrenderer.h
@@ -29,11 +29,12 @@ class QgsMeshLayer;
 
 #include "qgsmaplayerrenderer.h"
 #include "qgsrasterinterface.h"
-#include "qgsrendercontext.h"
 #include "qgstriangularmesh.h"
 #include "qgsmeshlayer.h"
 #include "qgssymbol.h"
 #include "qgsmeshdataprovider.h"
+
+class QgsRenderContext;
 
 ///@cond PRIVATE
 

--- a/src/core/mesh/qgsmeshvectorrenderer.h
+++ b/src/core/mesh/qgsmeshvectorrenderer.h
@@ -26,10 +26,11 @@
 
 #include "qgis_core.h"
 #include "qgsmeshdataprovider.h"
-#include "qgsrendercontext.h"
 #include "qgstriangularmesh.h"
 #include "qgsmeshlayer.h"
 #include "qgspointxy.h"
+
+class QgsRenderContext;
 
 ///@cond PRIVATE
 

--- a/src/core/metadata/qgslayermetadataformatter.cpp
+++ b/src/core/metadata/qgslayermetadataformatter.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 #include <QStringBuilder>
+#include <QDateTime>
 
 #include "qgslayermetadataformatter.h"
 #include "qgslayermetadata.h"

--- a/src/core/metadata/qgsprojectmetadata.h
+++ b/src/core/metadata/qgsprojectmetadata.h
@@ -22,6 +22,8 @@
 #include "qgis_core.h"
 #include "qgsabstractmetadatabase.h"
 
+#include <QDateTime>
+
 /**
  * \ingroup core
  * \class QgsProjectMetadata

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -22,6 +22,7 @@
 #include "qgsxmlutils.h"
 #include "qgsexception.h"
 #include "qgsvectorlayer.h"
+#include "qgsapplication.h"
 
 #include <QFile>
 #include <QTextStream>

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -30,6 +30,7 @@
 #include "qgsrasterfilewriter.h"
 #include "qgsvectorlayer.h"
 #include "qgsmeshlayer.h"
+#include "qgsapplication.h"
 
 #include <functional>
 

--- a/src/core/providers/memory/qgsmemoryproviderutils.h
+++ b/src/core/providers/memory/qgsmemoryproviderutils.h
@@ -19,7 +19,7 @@
 #define QGSMEMORYPROVIDERUTILS_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgswkbtypes.h"
 #include "qgscoordinatereferencesystem.h"
 #include <QString>
 #include <QVariant>

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -18,25 +18,12 @@
 #ifndef QGIS_H
 #define QGIS_H
 
-#include <QEvent>
-#include <QString>
-#include <QMetaType>
-#include <QMap>
 #include <QMetaEnum>
-#include <QVariant>
-#include <QDateTime>
-#include <QDate>
-#include <QTime>
-#include <QHash>
-#include <cstdlib>
 #include <cfloat>
 #include <memory>
-#include <type_traits>
 #include <cmath>
-#include <qnumeric.h>
 
 #include "qgstolerance.h"
-#include "qgswkbtypes.h"
 #include "qgis_core.h"
 #include "qgis_sip.h"
 

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -22,6 +22,8 @@
 #include "qgis_sip.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
+#include "qgsapplication.h"
+
 #include <QObject>
 #include <QMutex>
 #include <QCache>

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -459,23 +459,6 @@ class CORE_EXPORT QgsApplication : public QApplication
     static endian_t endian();
 
     /**
-     * Swap the endianness of the specified value.
-     * \note not available in Python bindings
-     */
-#ifndef SIP_RUN
-    template<typename T>
-    static void endian_swap( T &value )
-    {
-      char *data = reinterpret_cast<char *>( &value );
-      std::size_t n = sizeof( value );
-      for ( std::size_t i = 0, m = n / 2; i < m; ++i )
-      {
-        std::swap( data[i], data[n - 1 - i] );
-      }
-    }
-#endif
-
-    /**
      * Returns a standard css style sheet for reports.
      *
      * Typically you will use this method by doing:

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -27,6 +27,7 @@
 #include <QMap>
 #include <QHash>
 #include <QReadWriteLock>
+#include <QExplicitlySharedDataPointer>
 
 //qgis includes
 #include "qgis.h"

--- a/src/core/qgscoordinatetransformcontext.h
+++ b/src/core/qgscoordinatetransformcontext.h
@@ -22,6 +22,7 @@
 #include "qgis.h"
 #include "qgsdatumtransform.h"
 
+#include <QExplicitlySharedDataPointer>
 class QgsCoordinateReferenceSystem;
 class QgsReadWriteContext;
 class QgsCoordinateTransformContextPrivate;

--- a/src/core/qgsdatasourceuri.h
+++ b/src/core/qgsdatasourceuri.h
@@ -20,7 +20,8 @@
 #define QGSDATASOURCEURI_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
+#include "qgswkbtypes.h"
 
 #include <QMap>
 

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -21,6 +21,7 @@
 #include "qgsrelationmanager.h"
 #include "qgslogger.h"
 #include "qgsxmlutils.h"
+#include "qgsapplication.h"
 
 //#include "qgseditorwidgetregistry.h"
 

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -18,6 +18,7 @@
 
 #include "qgsvectorlayer.h"
 #include "qgsconditionalstyle.h"
+#include "qgsapplication.h"
 
 QgsFeatureFilterModel::QgsFeatureFilterModel( QObject *parent )
   : QAbstractItemModel( parent )

--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -22,6 +22,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgswkbptr.h"
 #include "qgsogrutils.h"
+#include "qgsapplication.h"
 #include <QBuffer>
 #include <QList>
 #include <QNetworkRequest>

--- a/src/core/qgsinterval.cpp
+++ b/src/core/qgsinterval.cpp
@@ -20,6 +20,7 @@
 #include <QMap>
 #include <QObject>
 #include <QDebug>
+#include <QDateTime>
 
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -25,6 +25,7 @@
 #include "qgslogger.h"
 #include "qgsfieldformatterregistry.h"
 #include "qgsfieldformatter.h"
+#include "qgsapplication.h"
 
 #include <QJsonDocument>
 #include <QJsonArray>

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -28,6 +28,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsreadwritecontext.h"
 #include "qgsvectorlayer.h"
+#include "qgsapplication.h"
 
 bool QgsLayerDefinition::loadLayerDefinition( const QString &path, QgsProject *project, QgsLayerTreeGroup *rootGroup, QString &errorMessage )
 {

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -24,7 +24,6 @@
 #include <QSize>
 #include <QStringList>
 
-#include "qgsabstractgeometry.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgslabelingenginesettings.h"
 #include "qgsmaptopixel.h"

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -53,6 +53,7 @@
 #include "qgsziputils.h"
 #include "qgsauxiliarystorage.h"
 #include "qgssymbollayerutils.h"
+#include "qgsapplication.h"
 
 #include <QApplication>
 #include <QFileInfo>

--- a/src/core/qgsproxyprogresstask.cpp
+++ b/src/core/qgsproxyprogresstask.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsproxyprogresstask.h"
+#include "qgsapplication.h"
 
 QgsProxyProgressTask::QgsProxyProgressTask( const QString &description )
   : QgsTask( description, QgsTask::Flags() )

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -23,7 +23,6 @@
 #include <QColor>
 #include <memory>
 
-#include "qgsabstractgeometry.h"
 #include "qgscoordinatetransform.h"
 #include "qgsexpressioncontext.h"
 #include "qgsfeaturefilterprovider.h"

--- a/src/core/qgssnappingconfig.cpp
+++ b/src/core/qgssnappingconfig.cpp
@@ -22,6 +22,7 @@
 #include "qgslogger.h"
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
+#include "qgsapplication.h"
 
 
 QgsSnappingConfig::IndividualLayerSettings::IndividualLayerSettings( bool enabled, SnappingType type, double tolerance, QgsTolerance::UnitType units )

--- a/src/core/qgsvectorsimplifymethod.cpp
+++ b/src/core/qgsvectorsimplifymethod.cpp
@@ -15,7 +15,6 @@
 
 #include "qgis.h"
 #include "qgsvectorsimplifymethod.h"
-#include "qgsvectorlayer.h"
 
 QgsVectorSimplifyMethod::QgsVectorSimplifyMethod()
   : mSimplifyHints( Qgis::DEFAULT_MAPTOPIXEL_THRESHOLD > 1 ? QgsVectorSimplifyMethod::FullSimplification : QgsVectorSimplifyMethod::GeometrySimplification )

--- a/src/core/qgsvirtuallayerdefinition.h
+++ b/src/core/qgsvirtuallayerdefinition.h
@@ -19,7 +19,7 @@ email                : hugo dot mercier at oslandia dot com
 
 #include "qgis_core.h"
 #include "qgsfields.h"
-#include "qgis.h"
+#include "qgswkbtypes.h"
 
 /**
  * \ingroup core

--- a/src/core/symbology/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology/qgscategorizedsymbolrenderer.cpp
@@ -32,6 +32,7 @@
 #include "qgsstyle.h"
 #include "qgsfieldformatter.h"
 #include "qgsfieldformatterregistry.h"
+#include "qgsapplication.h"
 
 #include <QDomDocument>
 #include <QDomElement>

--- a/src/core/symbology/qgsfillsymbollayer.cpp
+++ b/src/core/symbology/qgsfillsymbollayer.cpp
@@ -29,6 +29,7 @@
 #include "qgscolorramp.h"
 #include "qgsunittypes.h"
 #include "qgsmessagelog.h"
+#include "qgsapplication.h"
 
 #include <QPainter>
 #include <QFile>

--- a/src/core/symbology/qgsrenderer.cpp
+++ b/src/core/symbology/qgsrenderer.cpp
@@ -35,6 +35,7 @@
 #include "qgswkbptr.h"
 #include "qgspoint.h"
 #include "qgsproperty.h"
+#include "qgsapplication.h"
 
 #include <QDomElement>
 #include <QDomDocument>

--- a/src/core/symbology/qgsrendererregistry.h
+++ b/src/core/symbology/qgsrendererregistry.h
@@ -22,7 +22,8 @@
 #include <QStringList>
 #include <QDomElement>
 
-#include "qgis.h"
+// #include "qgis.h"
+#include "qgswkbtypes.h"
 
 class QgsFeatureRenderer;
 class QgsReadWriteContext;

--- a/src/core/symbology/qgssymbol.cpp
+++ b/src/core/symbology/qgssymbol.cpp
@@ -47,6 +47,7 @@
 #include "qgsclipper.h"
 #include "qgsproperty.h"
 #include "qgscolorschemeregistry.h"
+#include "qgsapplication.h"
 
 inline
 QgsProperty rotateWholeSymbol( double additionalRotation, const QgsProperty &property )

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -18,6 +18,7 @@
 #include "qgsattributetablemodel.h"
 #include "qgsvectorlayereditbuffer.h"
 #include "qgsattributetablefiltermodel.h"
+#include "qgsapplication.h"
 
 #include <QItemSelection>
 #include <QSettings>

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -21,6 +21,7 @@
 #include "qgsvectorlayer.h"
 #include "qgseditorwidgetwrapper.h"
 #include "qgssearchwidgetwrapper.h"
+#include "qgsapplication.h"
 
 // Editors
 #include "qgsbinarywidgetfactory.h"

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
@@ -17,6 +17,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
 #include "qgsfields.h"
+#include "qgsapplication.h"
 
 #include <QWidget>
 

--- a/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsbinarywidgetwrapper.cpp
@@ -19,6 +19,7 @@
 #include "qgsfileutils.h"
 #include "qgssettings.h"
 #include "qgsmessagebar.h"
+#include "qgsapplication.h"
 #include <QHBoxLayout>
 #include <QFileDialog>
 #include <QLabel>

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -20,6 +20,7 @@
 #include "qgsdatetimeedit.h"
 #include "qgsdatetimeeditconfig.h"
 #include "qgsdatetimefieldformatter.h"
+#include "qgsapplication.h"
 
 #include <QDateTimeEdit>
 #include <QDateEdit>

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -20,6 +20,7 @@
 #include "qgsexpression.h"
 #include "qgsfieldvalueslineedit.h"
 #include "qgssettings.h"
+#include "qgsapplication.h"
 
 #include <QHBoxLayout>
 

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -22,6 +22,7 @@
 #include "qgsproject.h"
 #include "qgsexternalresourcewidget.h"
 #include "qgsfilterlineedit.h"
+#include "qgsapplication.h"
 
 
 QgsExternalResourceWidgetWrapper::QgsExternalResourceWidgetWrapper( QgsVectorLayer *layer, int fieldIdx, QWidget *editor, QWidget *parent )

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -21,6 +21,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsdial.h"
 #include "qgsslider.h"
+#include "qgsapplication.h"
 
 
 

--- a/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencesearchwidgetwrapper.cpp
@@ -22,6 +22,7 @@
 #include "qgsrelationreferencewidget.h"
 #include "qgsrelationmanager.h"
 #include "qgssettings.h"
+#include "qgsapplication.h"
 
 #include <QStringListModel>
 

--- a/src/gui/editorwidgets/qgstexteditwrapper.cpp
+++ b/src/gui/editorwidgets/qgstexteditwrapper.cpp
@@ -18,6 +18,7 @@
 #include "qgsfields.h"
 #include "qgsfieldvalidator.h"
 #include "qgsfilterlineedit.h"
+#include "qgsapplication.h"
 
 #include <QSettings>
 

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetwrapper.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsvectorlayer.h"
 #include "qgsfilterlineedit.h"
+#include "qgsapplication.h"
 
 #include <QCompleter>
 #include <QSettings>

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -21,6 +21,7 @@
 #include "qgsfilterlineedit.h"
 #include "qgsvaluerelationwidgetwrapper.h"
 #include "qgssettings.h"
+#include "qgsapplication.h"
 
 #include <QStringListModel>
 #include <QCompleter>

--- a/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/gui/ogr/qgsvectorlayersaveasdialog.cpp
@@ -25,6 +25,7 @@
 #include "qgssettings.h"
 #include "qgsmapcanvas.h"
 #include "qgsgui.h"
+#include "qgsapplication.h"
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QTextCodec>

--- a/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
+++ b/src/gui/processing/qgsprocessingalgorithmdialogbase.cpp
@@ -23,6 +23,7 @@
 #include "qgstaskmanager.h"
 #include "processing/qgsprocessingalgrunnertask.h"
 #include "qgsstringutils.h"
+#include "qgsapplication.h"
 #include <QToolButton>
 #include <QDesktopServices>
 #include <QScrollBar>

--- a/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
+++ b/src/gui/processing/qgsprocessingmodelerparameterwidget.cpp
@@ -24,6 +24,7 @@
 #include "qgsgui.h"
 #include "qgsguiutils.h"
 #include "qgsexpressioncontext.h"
+#include "qgsapplication.h"
 #include <QHBoxLayout>
 #include <QToolButton>
 #include <QStackedWidget>

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -23,6 +23,7 @@
 #include "qgsdoublespinbox.h"
 #include "qgsprocessingcontext.h"
 #include "qgsauthconfigselect.h"
+#include "qgsapplication.h"
 #include <QLabel>
 #include <QHBoxLayout>
 #include <QCheckBox>

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -38,6 +38,7 @@
 #include "qgsvectorlayerjoinbuffer.h"
 #include "qgsvectorlayerutils.h"
 #include "qgsqmlwidgetwrapper.h"
+#include "qgsapplication.h"
 
 #include <QDir>
 #include <QTextStream>

--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -44,6 +44,7 @@
 #include "qgsvectorlayercache.h"
 #include "qgsattributetablemodel.h"
 #include "qgsattributetablefiltermodel.h"
+#include "qgsapplication.h"
 #include <QDesktopServices>
 
 #include <QDragEnterEvent>

--- a/src/gui/qgsfeaturelistcombobox.cpp
+++ b/src/gui/qgsfeaturelistcombobox.cpp
@@ -19,6 +19,7 @@
 #include "qgsanimatedicon.h"
 #include "qgsfilterlineedit.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 #include <QCompleter>
 #include <QLineEdit>

--- a/src/gui/qgsfeatureselectiondlg.cpp
+++ b/src/gui/qgsfeatureselectiondlg.cpp
@@ -19,6 +19,7 @@
 #include "qgsdistancearea.h"
 #include "qgsfeaturerequest.h"
 #include "qgsattributeeditorcontext.h"
+#include "qgsapplication.h"
 
 #include <QWindow>
 

--- a/src/gui/qgsfontbutton.cpp
+++ b/src/gui/qgsfontbutton.cpp
@@ -25,6 +25,7 @@
 #include "qgsunittypes.h"
 #include "qgsmenuheader.h"
 #include "qgsfontutils.h"
+#include "qgsapplication.h"
 #include <QMenu>
 #include <QClipboard>
 #include <QDrag>

--- a/src/gui/qgsgeometryrubberband.h
+++ b/src/gui/qgsgeometryrubberband.h
@@ -19,7 +19,7 @@
 #define QGSGEOMETRYRUBBERBAND_H
 
 #include "qgsmapcanvasitem.h"
-#include "qgis.h"
+#include "qgswkbtypes.h"
 #include <QBrush>
 #include <QPen>
 #include "qgis_gui.h"

--- a/src/gui/qgsmaplayerstylemanagerwidget.cpp
+++ b/src/gui/qgsmaplayerstylemanagerwidget.cpp
@@ -30,7 +30,7 @@
 #include "qgsrasterdataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgsrasterlayer.h"
-
+#include "qgsapplication.h"
 
 QgsMapLayerStyleManagerWidget::QgsMapLayerStyleManagerWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, QWidget *parent )
   : QgsMapLayerConfigWidget( layer, canvas, parent )

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -22,6 +22,7 @@
 #include "qgssettings.h"
 #include "qgswebview.h"
 #include "qgswebframe.h"
+#include "qgsapplication.h"
 
 // Qt includes
 #include <QPoint>

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -30,6 +30,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvertexmarker.h"
 #include "qgssettings.h"
+#include "qgsapplication.h"
 
 #include <QAction>
 #include <QCursor>

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -16,7 +16,7 @@
 #ifndef QGSMAPTOOLEDIT_H
 #define QGSMAPTOOLEDIT_H
 
-#include "qgis.h"
+#include "qgswkbtypes.h"
 #include "qgsmaptool.h"
 #include "qgis_gui.h"
 

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -25,6 +25,7 @@
 #include "qgsrubberband.h"
 #include "qgslogger.h"
 #include "qgsmapmouseevent.h"
+#include "qgsapplication.h"
 
 
 

--- a/src/gui/qgsnewmemorylayerdialog.h
+++ b/src/gui/qgsnewmemorylayerdialog.h
@@ -19,7 +19,7 @@
 
 #include "ui_qgsnewmemorylayerdialogbase.h"
 #include "qgsguiutils.h"
-#include "qgis.h"
+#include "qgswkbtypes.h"
 #include "qgshelp.h"
 #include "qgis_gui.h"
 

--- a/src/gui/qgsnewmemorylayerdialog.h
+++ b/src/gui/qgsnewmemorylayerdialog.h
@@ -43,6 +43,9 @@ class GUI_EXPORT QgsNewMemoryLayerDialog: public QDialog, private Ui::QgsNewMemo
      */
     static QgsVectorLayer *runAndCreateLayer( QWidget *parent = nullptr, const QgsCoordinateReferenceSystem &defaultCrs = QgsCoordinateReferenceSystem() );
 
+    /**
+     * New dialog constructor.
+     */
     QgsNewMemoryLayerDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
     ~QgsNewMemoryLayerDialog() override;
 

--- a/src/gui/qgsnewvectorlayerdialog.h
+++ b/src/gui/qgsnewvectorlayerdialog.h
@@ -44,6 +44,9 @@ class GUI_EXPORT QgsNewVectorLayerDialog: public QDialog, private Ui::QgsNewVect
     static QString runAndCreateLayer( QWidget *parent = nullptr, QString *enc = nullptr, const QgsCoordinateReferenceSystem &crs = QgsCoordinateReferenceSystem(),
                                       const QString &initialPath = QString() );
 
+    /**
+     * New dialog constructor.
+     */
     QgsNewVectorLayerDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags fl = QgsGuiUtils::ModalDialogFlags );
     ~QgsNewVectorLayerDialog() override;
     //! Returns the selected geometry type

--- a/src/gui/qgsnewvectorlayerdialog.h
+++ b/src/gui/qgsnewvectorlayerdialog.h
@@ -21,7 +21,7 @@
 #include "qgsguiutils.h"
 #include "qgshelp.h"
 
-#include "qgis.h"
+#include "qgswkbtypes.h"
 #include "qgis_gui.h"
 
 /**

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -18,6 +18,7 @@
 #include "qgssettings.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
+#include "qgsapplication.h"
 
 #include <QListView>
 #include <QMessageBox>

--- a/src/gui/qgssymbolbutton.cpp
+++ b/src/gui/qgssymbolbutton.cpp
@@ -24,6 +24,7 @@
 #include "qgscolorschemeregistry.h"
 #include "qgscolorswatchgrid.h"
 #include "qgssymbollayerutils.h"
+#include "qgsapplication.h"
 #include <QMenu>
 #include <QClipboard>
 #include <QDrag>

--- a/src/gui/qgstextpreview.cpp
+++ b/src/gui/qgstextpreview.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgstextpreview.h"
+#include "qgsapplication.h"
 #include <QDesktopWidget>
 #include <QPainter>
 

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -31,6 +31,7 @@
 #include "qgscubicrasterresampler.h"
 #include "qgsmultibandcolorrenderer.h"
 #include "qgssinglebandgrayrenderer.h"
+#include "qgsapplication.h"
 
 
 #include "qgsmessagelog.h"

--- a/src/gui/symbology/qgsinvertedpolygonrendererwidget.cpp
+++ b/src/gui/symbology/qgsinvertedpolygonrendererwidget.cpp
@@ -20,6 +20,7 @@
 
 #include "qgslogger.h"
 #include "qgsvectorlayer.h"
+#include "qgsapplication.h"
 
 QgsRendererWidget *QgsInvertedPolygonRendererWidget::create( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer )
 {

--- a/src/gui/symbology/qgspointclusterrendererwidget.cpp
+++ b/src/gui/symbology/qgspointclusterrendererwidget.cpp
@@ -24,6 +24,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgsvectorlayer.h"
 #include "qgsguiutils.h"
+#include "qgsapplication.h"
 
 QgsRendererWidget *QgsPointClusterRendererWidget::create( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer )
 {

--- a/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology/qgspointdisplacementrendererwidget.cpp
@@ -24,6 +24,7 @@
 #include "qgssymbollayerutils.h"
 #include "qgsvectorlayer.h"
 #include "qgsguiutils.h"
+#include "qgsapplication.h"
 
 QgsRendererWidget *QgsPointDisplacementRendererWidget::create( QgsVectorLayer *layer, QgsStyle *style, QgsFeatureRenderer *renderer )
 {

--- a/src/plugins/coordinate_capture/coordinatecapturemaptool.cpp
+++ b/src/plugins/coordinate_capture/coordinatecapturemaptool.cpp
@@ -23,6 +23,7 @@
 #include "qgsrubberband.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsmapmouseevent.h"
+#include "qgsapplication.h"
 
 
 CoordinateCaptureMapTool::CoordinateCaptureMapTool( QgsMapCanvas *thepCanvas )

--- a/src/plugins/evis/idtool/eviseventidtool.cpp
+++ b/src/plugins/evis/idtool/eviseventidtool.cpp
@@ -38,6 +38,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsfeatureiterator.h"
 #include "qgsmapmouseevent.h"
+#include "qgsapplication.h"
 
 
 /**

--- a/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/qgsgeometrycheckersetuptab.cpp
@@ -31,6 +31,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsvectorfilewriter.h"
 #include "qgsvectordataprovider.h"
+#include "qgsapplication.h"
 
 #include <QAction>
 #include <QEventLoop>

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -26,6 +26,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
+#include "qgsapplication.h"
 
 #include <QFileDialog>
 #include <QMessageBox>

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -24,6 +24,7 @@
 #include "geometry/qgsgeometry.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsdataitemprovider.h"
+#include "qgsapplication.h"
 
 #ifdef HAVE_GUI
 #include "qgsafssourceselect.h"

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -23,6 +23,7 @@
 #include "qgsrasteridentifyresult.h"
 #include "qgsfeaturestore.h"
 #include "qgsgeometry.h"
+#include "qgsapplication.h"
 
 #ifdef HAVE_GUI
 #include "qgsamssourceselect.h"

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -41,6 +41,7 @@
 #include "qgssinglesymbolrenderer.h"
 #include "qgscategorizedsymbolrenderer.h"
 #include "qgsvectorlayerlabeling.h"
+#include "qgsapplication.h"
 
 #include <QEventLoop>
 #include <QNetworkRequest>

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -24,6 +24,7 @@
 #include "qgsvectorlayer.h"
 #include "qgssettings.h"
 #include "qgsmessageoutput.h"
+#include "qgsapplication.h"
 
 #ifdef HAVE_GUI
 #include "qgsdb2newconnection.h"

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -24,6 +24,7 @@
 #include "qgsdataitem.h"
 #include "qgslogger.h"
 #include "qgscredentials.h"
+#include "qgsapplication.h"
 
 #ifdef HAVE_GUI
 #include "qgsdb2sourceselect.h"

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -21,6 +21,7 @@
 #include "qgstriangularmesh.h"
 #include "qgslogger.h"
 #include "qgsmeshmemorydataprovider.h"
+#include "qgsapplication.h"
 
 #ifdef HAVE_GUI
 #include "qgssourceselectprovider.h"

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -28,6 +28,7 @@
 #include "qgssettings.h"
 #include "qgsmessageoutput.h"
 #include "qgsmssqlconnection.h"
+#include "qgsapplication.h"
 
 #ifdef HAVE_GUI
 #include "qgsmssqlsourceselect.h"

--- a/src/providers/mssql/qgsmssqltablemodel.h
+++ b/src/providers/mssql/qgsmssqltablemodel.h
@@ -20,7 +20,7 @@
 
 #include <QStandardItemModel>
 
-#include "qgis.h"
+#include "qgswkbtypes.h"
 
 //! Layer Property structure
 struct QgsMssqlLayerProperty

--- a/src/providers/ogr/qgsgeopackagedataitems.cpp
+++ b/src/providers/ogr/qgsgeopackagedataitems.cpp
@@ -30,6 +30,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsogrprovider.h"
 #include "qgsogrdataitems.h"
+#include "qgsapplication.h"
 #ifdef HAVE_GUI
 #include "qgsnewnamedialog.h"
 #include "qgsnewgeopackagelayerdialog.h"

--- a/src/providers/ogr/qgsogrdbtablemodel.cpp
+++ b/src/providers/ogr/qgsogrdbtablemodel.cpp
@@ -15,6 +15,7 @@
  ***************************************************************************/
 #include "qgsogrdbtablemodel.h"
 #include "qgsdataitem.h"
+#include "qgsapplication.h"
 
 #include <QIcon>
 

--- a/src/providers/postgres/qgspgtablemodel.h
+++ b/src/providers/postgres/qgspgtablemodel.h
@@ -18,7 +18,7 @@
 #define QGSPGTABLEMODEL_H
 #include <QStandardItemModel>
 
-#include "qgis.h"
+#include "qgswkbtypes.h"
 #include "qgspostgresconn.h"
 
 class QIcon;

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 #include "qgsspatialitedataitems.h"
 
+#include "qgsapplication.h"
 #include "qgsspatialiteprovider.h"
 #include "qgsspatialiteconnection.h"
 

--- a/src/providers/spatialite/qgsspatialitetablemodel.h
+++ b/src/providers/spatialite/qgsspatialitetablemodel.h
@@ -17,7 +17,7 @@
 
 #include <QStandardItemModel>
 class QIcon;
-#include "qgis.h"
+#include "qgswkbtypes.h"
 
 /**
  * A model that holds the tables of a database in a hierarchy where the

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -31,6 +31,7 @@ extern "C"
 #include "qgsproject.h"
 #include "qgsdatasourceuri.h"
 #include "qgslogger.h"
+#include "qgsapplication.h"
 
 #include "qgsvirtuallayerprovider.h"
 #include "qgsvirtuallayersqlitemodule.h"

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -32,6 +32,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgsmessageoutput.h"
 #include "qgsmessagelog.h"
+#include "qgsapplication.h"
 
 #include <QNetworkRequest>
 #include <QNetworkReply>

--- a/src/quickgui/qgsquickutils.cpp
+++ b/src/quickgui/qgsquickutils.cpp
@@ -22,6 +22,7 @@
 #include "qgslogger.h"
 #include "qgsvectorlayer.h"
 #include "qgsfeature.h"
+#include "qgsapplication.h"
 
 #include "qgsquickfeaturelayerpair.h"
 #include "qgsquickmapsettings.h"

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -21,9 +21,12 @@
 #include "qgsserver.h"
 #include "qgsfcgiserverresponse.h"
 #include "qgsfcgiserverrequest.h"
+#include "qgsapplication.h"
 
 #include <fcgi_stdio.h>
 #include <cstdlib>
+
+#include <QStringLiteral>
 
 int fcgi_accept()
 {

--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -26,7 +26,7 @@
 #include <fcgi_stdio.h>
 #include <cstdlib>
 
-#include <QStringLiteral>
+#include <QString>
 
 int fcgi_accept()
 {

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -35,6 +35,7 @@
 #include "qgsfilterresponsedecorator.h"
 #include "qgsservice.h"
 #include "qgsserverparameters.h"
+#include "qgsapplication.h"
 
 #include <QDomDocument>
 #include <QNetworkDiskCache>

--- a/src/server/qgsserverparameters.cpp
+++ b/src/server/qgsserverparameters.cpp
@@ -23,6 +23,7 @@
 #include <QUrl>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QEventLoop>
 
 //
 // QgsServerParameterDefinition

--- a/src/server/services/wms/qgsmaprendererjobproxy.cpp
+++ b/src/server/services/wms/qgsmaprendererjobproxy.cpp
@@ -20,6 +20,7 @@
 #include "qgsmessagelog.h"
 #include "qgsmaprendererparalleljob.h"
 #include "qgsmaprenderercustompainterjob.h"
+#include "qgsapplication.h"
 
 namespace QgsWms
 {

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -80,12 +80,10 @@ ENDIF(ENABLE_MODELTEST)
 #  ADD_TEST(qgis_quickprinttest ${CMAKE_INSTALL_PREFIX}/bin/qgis_quickprinttest)
 #ENDIF (APPLE)
 
-SET(IMAGE_RCCS ../../../images/images.qrc)
-
 MACRO (ADD_QGIS_TEST testname testsrc)
   SET(qgis_${testname}_SRCS ${testsrc} ${util_SRCS})
   SET(qgis_${testname}_MOC_CPPS ${testsrc})
-  ADD_EXECUTABLE(qgis_${testname} ${qgis_${testname}_SRCS} ${IMAGE_RCCS})
+  ADD_EXECUTABLE(qgis_${testname} ${qgis_${testname}_SRCS})
   SET_TARGET_PROPERTIES(qgis_${testname} PROPERTIES AUTOMOC TRUE)
   SET_TARGET_PROPERTIES(qgis_${testname} PROPERTIES AUTORCC TRUE)
   TARGET_LINK_LIBRARIES(qgis_${testname}


### PR DESCRIPTION
## Description

This PR includes some changes to reduce compile times and rebuild times.
The proposed changes are:
  - qgis.h #include statements cleanup (1st commit);
```
    Remove unnecessary includes
```
  - avoid unnecessary `qrc` generation/builds (2nd commit)
```
    Do not build images.qrc for tests
    
    Before this commit the qrc_images.cpp was generated for each test listed in
    tests/src/gui/CMakeLists.txt but the content is always the same (~300k lines).
    
    The build time for this file is quite significant too: 15sec on my machine.
    
    This commit removes it from the test build process to avoid all this work.
```
  - limit qgsapplication.h include counts (3rd commit)
```
    Remove include "qgsapplication.h" from qgswkbptr.h
    
    qgswkbptr.h is included indirectly by a large number of source files.
    So this commit does the following:
      - remove #include "qgsapplication.h" from qgswkbptr.h, and moves the swap_endian
        function where it's used (since qgswkbptr was the only user)
      - add the missing #include "qgsapplication.h" in other files
    
    The rationale for this change is:
      - qgswkbptr.h doesn't really needs QgsApplication, since it only used swap_endian.
        We don't need to add a fake dependency on QgsApplication on every (indirect) "includers"
        of qgswkbptr.h
     - qgsapplication.h depends on qgsconfig.h which itself changes quite often (on every git op
       at least). Before this change, a 'git commit' would trigger a rebuild of about 3500 files.
       With this change we're down to ~700.
```

This work is a first step and there are still a  changes that can be made to reduce compile times, e.g:
- the `ABISYM` stuff in `qgsapplication.h` depends on `qgsconfig.h` but I'm not sure why this pattern is used? I'd be tempted to move all the ABISYM stuff in a `pimpl` struct, defined in `qgsapplication.cpp`
- lots of users of `QgsApplication` only use its static `getXXXPath()` methods. These could be move to a different class (`QgsResources`) which doesn't depend on `qgsconfig.h` and would avoid some unnecessary rebuilds



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
