### PR TITLE
More thread safe QgsNetworkAccessManager signals

### DIFF
--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -165,6 +165,24 @@ This signal is propagated to the main thread QgsNetworkAccessManager instance, s
 only to connect to the main thread's signal in order to receive notifications about requests
 created in any thread.
 
+.. seealso:: :py:func:`finished`
+
+.. versionadded:: 3.6
+%End
+
+    void finished( QgsNetworkReplyContent reply );
+%Docstring
+This signal is emitted whenever a pending network reply is finished.
+
+The ``reply`` parameter will contain a QgsNetworkReplyContent object, containing all the useful
+information relating to the reply, including headers and reply content.
+
+This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+only to connect to the main thread's signal in order to receive notifications about requests
+created in any thread.
+
+.. seealso:: :py:func:`requestAboutToBeCreated`
+
 .. versionadded:: 3.6
 %End
 

--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -29,7 +29,8 @@ Default constructor.
 %End
 
     QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation,
-                                 const QNetworkRequest &request );
+                                 const QNetworkRequest &request,
+                                 int requestId );
 %Docstring
 Constructor for QgsNetworkRequestParameters, with the specified network
 ``operation`` and original ``request``.
@@ -51,6 +52,11 @@ configuration options such as proxy handling and SSL exceptions applied.
     QString originatingThreadId() const;
 %Docstring
 Returns a string identifying the thread which the request originated from.
+%End
+
+    int requestId() const;
+%Docstring
+Returns a unique ID identifying the request.
 %End
 
 };

--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -161,7 +161,12 @@ Returns whether the system proxy should be used
 %End
 
   signals:
-    void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * );
+
+ void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * ) /Deprecated/;
+%Docstring
+
+.. deprecated:: Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead.
+%End
 
     void requestAboutToBeCreated( QgsNetworkRequestParameters request );
 %Docstring
@@ -211,7 +216,12 @@ created in any thread.
 .. versionadded:: 3.6
 %End
 
-    void requestCreated( QNetworkReply * );
+ void requestCreated( QNetworkReply * ) /Deprecated/;
+%Docstring
+
+.. deprecated:: Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead.
+%End
+
     void requestTimedOut( QNetworkReply * );
 
   protected:

--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -173,6 +173,8 @@ created in any thread.
 
 .. seealso:: :py:func:`finished`
 
+.. seealso:: :py:func:`requestTimedOut`
+
 .. versionadded:: 3.6
 %End
 
@@ -188,6 +190,23 @@ only to connect to the main thread's signal in order to receive notifications ab
 created in any thread.
 
 .. seealso:: :py:func:`requestAboutToBeCreated`
+
+.. seealso:: :py:func:`requestTimedOut`
+
+.. versionadded:: 3.6
+%End
+
+    void requestTimedOut( QgsNetworkRequestParameters request );
+%Docstring
+Emitted when a network request has timed out.
+
+This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+only to connect to the main thread's signal in order to receive notifications about requests
+created in any thread.
+
+.. seealso:: :py:func:`requestAboutToBeCreated`
+
+.. seealso:: :py:func:`finished`
 
 .. versionadded:: 3.6
 %End

--- a/python/core/auto_generated/qgsnetworkreply.sip.in
+++ b/python/core/auto_generated/qgsnetworkreply.sip.in
@@ -99,6 +99,11 @@ empty QByteArray if the specified header was not found in the reply.
 .. seealso:: :py:func:`rawHeaderList`
 %End
 
+    int requestId() const;
+%Docstring
+Returns the unique ID identifying the original request which this response was formed from.
+%End
+
 };
 
 /************************************************************************

--- a/python/core/auto_generated/qgsnetworkreply.sip.in
+++ b/python/core/auto_generated/qgsnetworkreply.sip.in
@@ -1,0 +1,110 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsnetworkreply.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+class QgsNetworkReplyContent
+{
+%Docstring
+Encapsulates a network reply within a container which is inexpensive to copy and safe to pass between threads.
+
+.. versionadded:: 3.6
+%End
+
+%TypeHeaderCode
+#include "qgsnetworkreply.h"
+%End
+  public:
+
+    QgsNetworkReplyContent();
+%Docstring
+Default constructor for an empty reply.
+%End
+
+    explicit QgsNetworkReplyContent( QNetworkReply *reply );
+%Docstring
+Constructor for QgsNetworkReplyContent, populated from the specified ``reply``.
+%End
+
+    void clear();
+%Docstring
+Clears the reply, resetting it back to a default, empty reply.
+%End
+
+    QVariant attribute( QNetworkRequest::Attribute code ) const;
+%Docstring
+Returns the attribute associated with the ``code``. If the attribute has not been set, it returns an
+invalid QVariant.
+
+You can expect the default values listed in QNetworkRequest.Attribute to be
+applied to the values returned by this function.
+
+.. seealso:: :py:func:`attributes`
+%End
+
+
+    QNetworkReply::NetworkError error() const;
+%Docstring
+Returns the reply's error message, or QNetworkReply.NoError if no
+error was encountered.
+
+.. seealso:: :py:func:`errorString`
+%End
+
+    QString errorString() const;
+%Docstring
+Returns the error text for the reply, or an empty string if no
+error was encountered.
+
+.. seealso:: :py:func:`error`
+%End
+
+
+    bool hasRawHeader( const QByteArray &headerName ) const;
+%Docstring
+Returns true if the reply contains a header with the specified ``headerName``.
+
+.. seealso:: :py:func:`rawHeaderPairs`
+
+.. seealso:: :py:func:`rawHeaderList`
+
+.. seealso:: :py:func:`rawHeader`
+%End
+
+    QList<QByteArray> rawHeaderList() const;
+%Docstring
+Returns a list of raw header names contained within the reply.
+
+.. seealso:: :py:func:`rawHeaderPairs`
+
+.. seealso:: :py:func:`hasRawHeader`
+
+.. seealso:: :py:func:`rawHeader`
+%End
+
+    QByteArray rawHeader( const QByteArray &headerName ) const;
+%Docstring
+Returns the content of the header with the specified ``headerName``, or an
+empty QByteArray if the specified header was not found in the reply.
+
+.. seealso:: :py:func:`rawHeaderPairs`
+
+.. seealso:: :py:func:`hasRawHeader`
+
+.. seealso:: :py:func:`rawHeaderList`
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsnetworkreply.h                                           *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsnetworkreply.sip.in
+++ b/python/core/auto_generated/qgsnetworkreply.sip.in
@@ -104,6 +104,11 @@ empty QByteArray if the specified header was not found in the reply.
 Returns the unique ID identifying the original request which this response was formed from.
 %End
 
+    QNetworkRequest request() const;
+%Docstring
+Returns the original network request.
+%End
+
 };
 
 /************************************************************************

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -80,6 +80,7 @@
 %Include auto_generated/qgsmargins.sip
 %Include auto_generated/qgsmimedatautils.sip
 %Include auto_generated/qgsmultirenderchecker.sip
+%Include auto_generated/qgsnetworkreply.sip
 %Include auto_generated/qgsobjectcustomproperties.sip
 %Include auto_generated/qgsogcutils.sip
 %Include auto_generated/qgsoptional.sip

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13817,7 +13817,7 @@ void QgisApp::namSetup()
   connect( nam, &QNetworkAccessManager::proxyAuthenticationRequired,
            this, &QgisApp::namProxyAuthenticationRequired );
 
-  connect( nam, &QgsNetworkAccessManager::requestTimedOut,
+  connect( nam, qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestTimedOut ),
            this, &QgisApp::namRequestTimedOut );
 
 #ifndef QT_NO_SSL
@@ -14025,10 +14025,9 @@ void QgisApp::namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors
 }
 #endif
 
-void QgisApp::namRequestTimedOut( QNetworkReply *reply )
+void QgisApp::namRequestTimedOut( const QgsNetworkRequestParameters &request )
 {
-  Q_UNUSED( reply );
-  QLabel *msgLabel = new QLabel( tr( "A network request timed out, any data received is likely incomplete." ) +
+  QLabel *msgLabel = new QLabel( tr( "Network request to %1 timed out, any data received is likely incomplete." ).arg( request.request().url().toString() ) +
                                  tr( " Please check the <a href=\"#messageLog\">message log</a> for further info." ), messageBar() );
   msgLabel->setWordWrap( true );
   connect( msgLabel, &QLabel::linkActivated, mLogDock, &QWidget::show );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -133,6 +133,7 @@ class QgsBrowserModel;
 class QgsGeoCmsProviderRegistry;
 class QgsLayoutQptDropHandler;
 class QgsProxyProgressTask;
+class QgsNetworkRequestParameters;
 
 #include <QMainWindow>
 #include <QToolBar>
@@ -881,7 +882,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 #ifndef QT_NO_SSL
     void namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors );
 #endif
-    void namRequestTimedOut( QNetworkReply *reply );
+    void namRequestTimedOut( const QgsNetworkRequestParameters &request );
 
     //! Schedule and erase of the authentication database upon confirmation
     void eraseAuthenticationDatabase();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -257,6 +257,7 @@ SET(QGIS_CORE_SRCS
   qgsnetworkcontentfetcher.cpp
   qgsnetworkcontentfetcherregistry.cpp
   qgsnetworkcontentfetchertask.cpp
+  qgsnetworkreply.cpp
   qgsnetworkreplyparser.cpp
   qgsobjectcustomproperties.cpp
   qgsofflineediting.cpp
@@ -913,6 +914,7 @@ SET(QGIS_CORE_HDRS
   qgsmargins.h
   qgsmimedatautils.h
   qgsmultirenderchecker.h
+  qgsnetworkreply.h
   qgsobjectcustomproperties.h
   qgsogcutils.h
   qgsoptional.h

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -23,6 +23,7 @@
 #include "qgsproject.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsnetworkcontentfetcherregistry.h"
+#include "qgsnetworkreply.h"
 #include "qgsproviderregistry.h"
 #include "qgsexpression.h"
 #include "qgsactionscoperegistry.h"
@@ -207,6 +208,7 @@ void QgsApplication::init( QString profileFolder )
   qRegisterMetaType<QgsCoordinateReferenceSystem>( "QgsCoordinateReferenceSystem" );
   qRegisterMetaType<QgsAuthManager::MessageLevel>( "QgsAuthManager::MessageLevel" );
   qRegisterMetaType<QgsNetworkRequestParameters>( "QgsNetworkRequestParameters" );
+  qRegisterMetaType<QgsNetworkReplyContent>( "QgsNetworkReplyContent" );
 
   ( void ) resolvePkgPath();
 

--- a/src/core/qgsfiledownloader.cpp
+++ b/src/core/qgsfiledownloader.cpp
@@ -74,7 +74,7 @@ void QgsFileDownloader::startDownload()
   connect( mReply, &QNetworkReply::readyRead, this, &QgsFileDownloader::onReadyRead );
   connect( mReply, &QNetworkReply::finished, this, &QgsFileDownloader::onFinished );
   connect( mReply, &QNetworkReply::downloadProgress, this, &QgsFileDownloader::onDownloadProgress );
-  connect( nam, &QgsNetworkAccessManager::requestTimedOut, this, &QgsFileDownloader::onRequestTimedOut, Qt::UniqueConnection );
+  connect( nam, qgis::overload< QNetworkReply *>::of( &QgsNetworkAccessManager::requestTimedOut ), this, &QgsFileDownloader::onRequestTimedOut, Qt::UniqueConnection );
 #ifndef QT_NO_SSL
   connect( nam, &QgsNetworkAccessManager::sslErrors, this, &QgsFileDownloader::onSslErrors, Qt::UniqueConnection );
 #endif
@@ -87,22 +87,26 @@ void QgsFileDownloader::cancelDownload()
   onFinished();
 }
 
-void QgsFileDownloader::onRequestTimedOut()
+void QgsFileDownloader::onRequestTimedOut( QNetworkReply *reply )
 {
-  error( tr( "Network request %1 timed out" ).arg( mUrl.toString() ) );
+  if ( reply == mReply )
+    error( tr( "Network request %1 timed out" ).arg( mUrl.toString() ) );
 }
 
 #ifndef QT_NO_SSL
 void QgsFileDownloader::onSslErrors( QNetworkReply *reply, const QList<QSslError> &errors )
 {
-  Q_UNUSED( reply );
-  QStringList errorMessages;
-  errorMessages <<  QStringLiteral( "SSL Errors: " );
-  for ( auto end = errors.size(), i = 0; i != end; ++i )
+  if ( reply == mReply )
   {
-    errorMessages << errors[i].errorString();
+    QStringList errorMessages;
+    errorMessages.reserve( errors.size() + 1 );
+    errorMessages <<  QStringLiteral( "SSL Errors: " );
+    for ( auto end = errors.size(), i = 0; i != end; ++i )
+    {
+      errorMessages << errors[i].errorString();
+    }
+    error( errorMessages );
   }
-  error( errorMessages );
 }
 #endif
 

--- a/src/core/qgsfiledownloader.h
+++ b/src/core/qgsfiledownloader.h
@@ -94,7 +94,7 @@ class CORE_EXPORT QgsFileDownloader : public QObject
     //! Called on data ready to be processed
     void onDownloadProgress( qint64 bytesReceived, qint64 bytesTotal );
     //! Called when a network request times out
-    void onRequestTimedOut();
+    void onRequestTimedOut( QNetworkReply *reply );
 
 #ifndef QT_NO_SSL
 

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -243,8 +243,8 @@ void QgsNetworkAccessManager::abortRequest()
   QgsDebugMsgLevel( QStringLiteral( "Abort [reply:%1] %2" ).arg( reinterpret_cast< qint64 >( reply ), 0, 16 ).arg( reply->url().toString() ), 3 );
   QgsMessageLog::logMessage( tr( "Network request %1 timed out" ).arg( reply->url().toString() ), tr( "Network" ) );
   // Notify the application
+  emit requestTimedOut( QgsNetworkRequestParameters( reply->operation(), reply->request(), reply->property( "requestId" ).toInt() ) );
   emit requestTimedOut( reply );
-
 }
 
 void QgsNetworkAccessManager::onReplyFinished( QNetworkReply *reply )
@@ -308,8 +308,11 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
              sMainNAM, &QNetworkAccessManager::proxyAuthenticationRequired,
              connectionType );
 
-    connect( this, &QgsNetworkAccessManager::requestTimedOut,
-             sMainNAM, &QgsNetworkAccessManager::requestTimedOut );
+    connect( this, qgis::overload< QNetworkReply *>::of( &QgsNetworkAccessManager::requestTimedOut ),
+             sMainNAM, qgis::overload< QNetworkReply *>::of( &QgsNetworkAccessManager::requestTimedOut ) );
+
+    connect( this, qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestTimedOut ),
+             sMainNAM, qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestTimedOut ) );
 
     connect( this, qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ),
              sMainNAM, qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ) );

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -208,11 +208,15 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   const int requestId = ++sRequestId;
 
   emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, req, requestId ) );
+  Q_NOWARN_DEPRECATED_PUSH
   emit requestAboutToBeCreated( op, req, outgoingData );
+  Q_NOWARN_DEPRECATED_POP
   QNetworkReply *reply = QNetworkAccessManager::createRequest( op, req, outgoingData );
   reply->setProperty( "requestId", requestId );
 
+  Q_NOWARN_DEPRECATED_PUSH
   emit requestCreated( reply );
+  Q_NOWARN_DEPRECATED_POP
 
   // The timer will call abortRequest slot to abort the connection if needed.
   // The timer is stopped by the finished signal and is restarted on downloadProgress and

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -204,9 +204,13 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   }
 #endif
 
-  emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, req ) );
+  static QAtomicInt sRequestId = 0;
+  const int requestId = ++sRequestId;
+
+  emit requestAboutToBeCreated( QgsNetworkRequestParameters( op, req, requestId ) );
   emit requestAboutToBeCreated( op, req, outgoingData );
   QNetworkReply *reply = QNetworkAccessManager::createRequest( op, req, outgoingData );
+  reply->setProperty( "requestId", requestId );
 
   emit requestCreated( reply );
 
@@ -412,9 +416,10 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache( Qt::ConnectionType conn
 // QgsNetworkRequestParameters
 //
 
-QgsNetworkRequestParameters::QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation, const QNetworkRequest &request )
+QgsNetworkRequestParameters::QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation, const QNetworkRequest &request, int requestId )
   : mOperation( operation )
   , mRequest( request )
   , mOriginatingThreadId( QStringLiteral( "0x%2" ).arg( reinterpret_cast<quintptr>( QThread::currentThread() ), 2 * QT_POINTER_SIZE, 16, QLatin1Char( '0' ) ) )
+  , mRequestId( requestId )
 {
 }

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -27,6 +27,7 @@
 #include <QNetworkRequest>
 
 #include "qgis_core.h"
+#include "qgis_sip.h"
 
 /**
  * \class QgsNetworkRequestParameters
@@ -164,7 +165,11 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     bool useSystemProxy() const { return mUseSystemProxy; }
 
   signals:
-    void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * );
+
+    /**
+     * \deprecated Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead.
+     */
+    Q_DECL_DEPRECATED void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * ) SIP_DEPRECATED;
 
     /**
      * Emitted when a network request is about to be created.
@@ -208,7 +213,11 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      */
     void requestTimedOut( QgsNetworkRequestParameters request );
 
-    void requestCreated( QNetworkReply * );
+    /**
+     * \deprecated Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead.
+     */
+    Q_DECL_DEPRECATED void requestCreated( QNetworkReply * ) SIP_DEPRECATED;
+
     void requestTimedOut( QNetworkReply * );
 
   private slots:

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -174,6 +174,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * created in any thread.
      *
      * \see finished( QgsNetworkReplyContent )
+     * \see requestTimedOut( QgsNetworkRequestParameters )
      * \since QGIS 3.6
      */
     void requestAboutToBeCreated( QgsNetworkRequestParameters request );
@@ -189,9 +190,23 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * created in any thread.
      *
      * \see requestAboutToBeCreated( QgsNetworkRequestParameters )
+     * \see requestTimedOut( QgsNetworkRequestParameters )
      * \since QGIS 3.6
      */
     void finished( QgsNetworkReplyContent reply );
+
+    /**
+     * Emitted when a network request has timed out.
+     *
+     * This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+     * only to connect to the main thread's signal in order to receive notifications about requests
+     * created in any thread.
+     *
+     * \see requestAboutToBeCreated( QgsNetworkRequestParameters )
+     * \see finished( QgsNetworkReplyContent )
+     * \since QGIS 3.6
+     */
+    void requestTimedOut( QgsNetworkRequestParameters request );
 
     void requestCreated( QNetworkReply * );
     void requestTimedOut( QNetworkReply * );

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -20,6 +20,7 @@
 
 #include <QList>
 #include "qgis.h"
+#include "qgsnetworkreply.h"
 #include <QStringList>
 #include <QNetworkAccessManager>
 #include <QNetworkProxy>
@@ -166,15 +167,33 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
      * only to connect to the main thread's signal in order to receive notifications about requests
      * created in any thread.
      *
+     * \see finished( QgsNetworkReplyContent )
      * \since QGIS 3.6
      */
     void requestAboutToBeCreated( QgsNetworkRequestParameters request );
+
+    /**
+     * This signal is emitted whenever a pending network reply is finished.
+     *
+     * The \a reply parameter will contain a QgsNetworkReplyContent object, containing all the useful
+     * information relating to the reply, including headers and reply content.
+     *
+     * This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+     * only to connect to the main thread's signal in order to receive notifications about requests
+     * created in any thread.
+     *
+     * \see requestAboutToBeCreated( QgsNetworkRequestParameters )
+     * \since QGIS 3.6
+     */
+    void finished( QgsNetworkReplyContent reply );
 
     void requestCreated( QNetworkReply * );
     void requestTimedOut( QNetworkReply * );
 
   private slots:
     void abortRequest();
+
+    void onReplyFinished( QNetworkReply *reply );
 
   protected:
     QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = nullptr ) override;

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -48,7 +48,8 @@ class CORE_EXPORT QgsNetworkRequestParameters
      * \a operation and original \a request.
      */
     QgsNetworkRequestParameters( QNetworkAccessManager::Operation operation,
-                                 const QNetworkRequest &request );
+                                 const QNetworkRequest &request,
+                                 int requestId );
 
     /**
      * Returns the request operation, e.g. GET or POST.
@@ -68,12 +69,17 @@ class CORE_EXPORT QgsNetworkRequestParameters
      */
     QString originatingThreadId() const { return mOriginatingThreadId; }
 
+    /**
+     * Returns a unique ID identifying the request.
+     */
+    int requestId() const { return mRequestId; }
+
   private:
 
     QNetworkAccessManager::Operation mOperation;
     QNetworkRequest mRequest;
     QString mOriginatingThreadId;
-
+    int mRequestId = 0;
 };
 
 /**

--- a/src/core/qgsnetworkreply.cpp
+++ b/src/core/qgsnetworkreply.cpp
@@ -1,0 +1,74 @@
+/***************************************************************************
+    qgsnetworkreply.cpp
+    -------------------
+    begin                : November 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsnetworkreply.h"
+#include <QNetworkReply>
+
+QgsNetworkReplyContent::QgsNetworkReplyContent( QNetworkReply *reply )
+  : mError( reply->error() )
+  , mErrorString( reply->errorString() )
+  , mRawHeaderPairs( reply->rawHeaderPairs() )
+{
+  int maxAttribute = static_cast< int >( QNetworkRequest::RedirectPolicyAttribute );
+#if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )
+  maxAttribute = static_cast< int >( QNetworkRequest::Http2DirectAttribute );
+#endif
+  for ( int i = 0; i <= maxAttribute; ++i )
+  {
+    if ( reply->attribute( static_cast< QNetworkRequest::Attribute>( i ) ).isValid() )
+      mAttributes[ static_cast< QNetworkRequest::Attribute>( i ) ] = reply->attribute( static_cast< QNetworkRequest::Attribute>( i ) );
+  }
+}
+
+void QgsNetworkReplyContent::clear()
+{
+  *this = QgsNetworkReplyContent();
+}
+
+QVariant QgsNetworkReplyContent::attribute( QNetworkRequest::Attribute code ) const
+{
+  return mAttributes.value( code );
+}
+
+bool QgsNetworkReplyContent::hasRawHeader( const QByteArray &headerName ) const
+{
+  for ( auto &header : mRawHeaderPairs )
+  {
+    if ( header.first == headerName )
+      return true;
+  }
+  return false;
+}
+
+QList<QByteArray> QgsNetworkReplyContent::rawHeaderList() const
+{
+  QList< QByteArray > res;
+  res.reserve( mRawHeaderPairs.length() );
+  for ( auto &header : mRawHeaderPairs )
+  {
+    res << header.first;
+  }
+  return res;
+}
+
+QByteArray QgsNetworkReplyContent::rawHeader( const QByteArray &headerName ) const
+{
+  for ( auto &header : mRawHeaderPairs )
+  {
+    if ( header.first == headerName )
+      return header.second;
+  }
+  return QByteArray();
+}

--- a/src/core/qgsnetworkreply.cpp
+++ b/src/core/qgsnetworkreply.cpp
@@ -30,6 +30,11 @@ QgsNetworkReplyContent::QgsNetworkReplyContent( QNetworkReply *reply )
     if ( reply->attribute( static_cast< QNetworkRequest::Attribute>( i ) ).isValid() )
       mAttributes[ static_cast< QNetworkRequest::Attribute>( i ) ] = reply->attribute( static_cast< QNetworkRequest::Attribute>( i ) );
   }
+
+  bool ok = false;
+  int requestId = reply->property( "requestId" ).toInt( &ok );
+  if ( ok )
+    mRequestId = requestId;
 }
 
 void QgsNetworkReplyContent::clear()

--- a/src/core/qgsnetworkreply.cpp
+++ b/src/core/qgsnetworkreply.cpp
@@ -20,6 +20,7 @@ QgsNetworkReplyContent::QgsNetworkReplyContent( QNetworkReply *reply )
   : mError( reply->error() )
   , mErrorString( reply->errorString() )
   , mRawHeaderPairs( reply->rawHeaderPairs() )
+  , mRequest( reply->request() )
 {
   int maxAttribute = static_cast< int >( QNetworkRequest::RedirectPolicyAttribute );
 #if QT_VERSION >= QT_VERSION_CHECK( 5, 11, 0 )

--- a/src/core/qgsnetworkreply.h
+++ b/src/core/qgsnetworkreply.h
@@ -133,6 +133,11 @@ class CORE_EXPORT QgsNetworkReplyContent
      */
     int requestId() const { return mRequestId; }
 
+    /**
+     * Returns the original network request.
+     */
+    QNetworkRequest request() const { return mRequest; }
+
   private:
 
     QNetworkReply::NetworkError mError = QNetworkReply::NoError;
@@ -140,6 +145,7 @@ class CORE_EXPORT QgsNetworkReplyContent
     QList<RawHeaderPair> mRawHeaderPairs;
     QMap< QNetworkRequest::Attribute, QVariant > mAttributes;
     int mRequestId = -1;
+    QNetworkRequest mRequest;
 };
 
 #endif // QGSNETWORKREPLY_H

--- a/src/core/qgsnetworkreply.h
+++ b/src/core/qgsnetworkreply.h
@@ -1,0 +1,139 @@
+/***************************************************************************
+    qgsnetworkreply.h
+    -----------------
+    begin                : November 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSNETWORKREPLY_H
+#define QGSNETWORKREPLY_H
+
+#include "qgis_core.h"
+
+#include <QNetworkReply>
+
+/**
+ * Encapsulates a network reply within a container which is inexpensive to copy and safe to pass between threads.
+ * \ingroup core
+ * \since QGIS 3.6
+ */
+class CORE_EXPORT QgsNetworkReplyContent
+{
+  public:
+
+    /**
+     * Default constructor for an empty reply.
+     */
+    QgsNetworkReplyContent() = default;
+
+    /**
+     * Constructor for QgsNetworkReplyContent, populated from the specified \a reply.
+     */
+    explicit QgsNetworkReplyContent( QNetworkReply *reply );
+
+    /**
+     * Clears the reply, resetting it back to a default, empty reply.
+     */
+    void clear();
+
+    /**
+     * Returns the attribute associated with the \a code. If the attribute has not been set, it returns an
+     * invalid QVariant.
+     *
+     * You can expect the default values listed in QNetworkRequest::Attribute to be
+     * applied to the values returned by this function.
+     *
+     * \see attributes()
+     */
+    QVariant attribute( QNetworkRequest::Attribute code ) const;
+
+#ifndef SIP_RUN
+
+    /**
+     * Returns a list of valid attributes received in the reply.
+     *
+     * \see attribute()
+     * \note Not available in Python bindings
+     */
+    QMap< QNetworkRequest::Attribute, QVariant > attributes() const { return mAttributes; }
+#endif
+
+    /**
+     * Returns the reply's error message, or QNetworkReply::NoError if no
+     * error was encountered.
+     *
+     * \see errorString()
+     */
+    QNetworkReply::NetworkError error() const
+    {
+      return mError;
+    }
+
+    /**
+     * Returns the error text for the reply, or an empty string if no
+     * error was encountered.
+     *
+     * \see error()
+     */
+    QString errorString() const
+    {
+      return mErrorString;
+    }
+
+#ifndef SIP_RUN
+    typedef QPair<QByteArray, QByteArray> RawHeaderPair;
+
+    /**
+     * Returns the list of raw header pairs in the reply.
+     * \see hasRawHeader()
+     * \see rawHeaderList()
+     * \see rawHeader()
+     * \note Not available in Python bindings
+     */
+    const QList<RawHeaderPair> &rawHeaderPairs() const
+    {
+      return mRawHeaderPairs;
+    }
+#endif
+
+    /**
+     * Returns true if the reply contains a header with the specified \a headerName.
+     * \see rawHeaderPairs()
+     * \see rawHeaderList()
+     * \see rawHeader()
+     */
+    bool hasRawHeader( const QByteArray &headerName ) const;
+
+    /**
+     * Returns a list of raw header names contained within the reply.
+     * \see rawHeaderPairs()
+     * \see hasRawHeader()
+     * \see rawHeader()
+     */
+    QList<QByteArray> rawHeaderList() const;
+
+    /**
+     * Returns the content of the header with the specified \a headerName, or an
+     * empty QByteArray if the specified header was not found in the reply.
+     * \see rawHeaderPairs()
+     * \see hasRawHeader()
+     * \see rawHeaderList()
+     */
+    QByteArray rawHeader( const QByteArray &headerName ) const;
+
+  private:
+
+    QNetworkReply::NetworkError mError = QNetworkReply::NoError;
+    QString mErrorString;
+    QList<RawHeaderPair> mRawHeaderPairs;
+    QMap< QNetworkRequest::Attribute, QVariant > mAttributes;
+};
+
+#endif // QGSNETWORKREPLY_H

--- a/src/core/qgsnetworkreply.h
+++ b/src/core/qgsnetworkreply.h
@@ -128,12 +128,18 @@ class CORE_EXPORT QgsNetworkReplyContent
      */
     QByteArray rawHeader( const QByteArray &headerName ) const;
 
+    /**
+     * Returns the unique ID identifying the original request which this response was formed from.
+     */
+    int requestId() const { return mRequestId; }
+
   private:
 
     QNetworkReply::NetworkError mError = QNetworkReply::NoError;
     QString mErrorString;
     QList<RawHeaderPair> mRawHeaderPairs;
     QMap< QNetworkRequest::Attribute, QVariant > mAttributes;
+    int mRequestId = -1;
 };
 
 #endif // QGSNETWORKREPLY_H

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -38,7 +38,7 @@ QgsWfsRequest::QgsWfsRequest( const QgsWFSDataSourceURI &uri )
   , mGotNonEmptyResponse( false )
 {
   QgsDebugMsgLevel( QStringLiteral( "theUri = " ) + uri.uri( ), 4 );
-  connect( QgsNetworkAccessManager::instance(), &QgsNetworkAccessManager::requestTimedOut, this, &QgsWfsRequest::requestTimedOut );
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QNetworkReply *>::of( &QgsNetworkAccessManager::requestTimedOut ), this, &QgsWfsRequest::requestTimedOut );
 }
 
 QgsWfsRequest::~QgsWfsRequest()

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -162,6 +162,7 @@ SET(TESTS
  testqgsmeshlayer.cpp
  testqgsmeshlayerinterpolator.cpp
  testqgsmeshlayerrenderer.cpp
+ testqgsnetworkaccessmanager.cpp
  testqgsnetworkcontentfetcher.cpp
  testqgsogcutils.cpp
  testqgsogrutils.cpp

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -1,0 +1,158 @@
+/***************************************************************************
+                         testqgsnetworkaccessmanager.cpp
+                         -----------------------
+    begin                : January 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsnetworkcontentfetcher.h"
+#include "qgsnetworkaccessmanager.h"
+#include "qgsapplication.h"
+#include <QObject>
+#include "qgstest.h"
+#include <QNetworkReply>
+
+class TestQgsNetworkAccessManager : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsNetworkAccessManager() = default;
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+    void fetchEmptyUrl(); //test fetching blank url
+    void fetchBadUrl(); //test fetching bad url
+    void fetchEncodedContent(); //test fetching url content encoded as utf-8
+
+};
+
+void TestQgsNetworkAccessManager::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsNetworkAccessManager::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsNetworkAccessManager::init()
+{
+}
+
+void TestQgsNetworkAccessManager::cleanup()
+{
+}
+
+void TestQgsNetworkAccessManager::fetchEmptyUrl()
+{
+  QObject context;
+  //test fetching from a blank url
+  bool loaded = false;
+  bool gotRequestAboutToBeCreatedSignal = false;
+  int requestId = -1;
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( QgsNetworkRequestParameters params )
+  {
+    gotRequestAboutToBeCreatedSignal = true;
+    requestId = params.requestId();
+    QVERIFY( requestId > 0 );
+    QCOMPARE( params.operation(), QNetworkAccessManager::GetOperation );
+    QCOMPARE( params.request().url(), QUrl() );
+  } );
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( QgsNetworkReplyContent reply )
+  {
+    QCOMPARE( reply.errorString(), QStringLiteral( "Protocol \"\" is unknown" ) );
+    QCOMPARE( reply.requestId(), requestId );
+    loaded = true;
+  } );
+  QgsNetworkAccessManager::instance()->get( QNetworkRequest( QUrl() ) );
+
+  while ( !loaded )
+  {
+    qApp->processEvents();
+  }
+
+  QVERIFY( gotRequestAboutToBeCreatedSignal );
+}
+
+void TestQgsNetworkAccessManager::fetchBadUrl()
+{
+  QObject context;
+  //test fetching from a blank url
+  bool loaded = false;
+  bool gotRequestAboutToBeCreatedSignal = false;
+  int requestId = -1;
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( QgsNetworkRequestParameters params )
+  {
+    gotRequestAboutToBeCreatedSignal = true;
+    requestId = params.requestId();
+    QVERIFY( requestId > 0 );
+    QCOMPARE( params.operation(), QNetworkAccessManager::GetOperation );
+    QCOMPARE( params.request().url(), QUrl( QStringLiteral( "http://x" ) ) );
+  } );
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( QgsNetworkReplyContent reply )
+  {
+    QCOMPARE( reply.errorString(), QStringLiteral( "Host x not found" ) );
+    QCOMPARE( reply.requestId(), requestId );
+    loaded = true;
+  } );
+  QgsNetworkAccessManager::instance()->get( QNetworkRequest( QUrl( QStringLiteral( "http://x" ) ) ) );
+
+  while ( !loaded )
+  {
+    qApp->processEvents();
+  }
+
+  QVERIFY( gotRequestAboutToBeCreatedSignal );
+}
+
+
+void TestQgsNetworkAccessManager::fetchEncodedContent()
+{
+  QObject context;
+  //test fetching from a blank url
+  bool loaded = false;
+  bool gotRequestAboutToBeCreatedSignal = false;
+  int requestId = -1;
+  QUrl u =  QUrl::fromLocalFile( QStringLiteral( TEST_DATA_DIR ) + '/' +  "encoded_html.html" );
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( QgsNetworkRequestParameters params )
+  {
+    gotRequestAboutToBeCreatedSignal = true;
+    requestId = params.requestId();
+    QVERIFY( requestId > 0 );
+    QCOMPARE( params.operation(), QNetworkAccessManager::GetOperation );
+    QCOMPARE( params.request().url(), u );
+  } );
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( QgsNetworkReplyContent reply )
+  {
+    QCOMPARE( reply.error(), QNetworkReply::NoError );
+    QCOMPARE( reply.requestId(), requestId );
+    QVERIFY( reply.rawHeaderList().contains( "Content-Length" ) );
+    loaded = true;
+  } );
+  QgsNetworkAccessManager::instance()->get( QNetworkRequest( u ) );
+
+  while ( !loaded )
+  {
+    qApp->processEvents();
+  }
+
+  QVERIFY( gotRequestAboutToBeCreatedSignal );
+}
+
+QGSTEST_MAIN( TestQgsNetworkAccessManager )
+#include "testqgsnetworkaccessmanager.moc"

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -65,7 +65,7 @@ void TestQgsNetworkAccessManager::fetchEmptyUrl()
   bool loaded = false;
   bool gotRequestAboutToBeCreatedSignal = false;
   int requestId = -1;
-  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( QgsNetworkRequestParameters params )
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( const QgsNetworkRequestParameters & params )
   {
     gotRequestAboutToBeCreatedSignal = true;
     requestId = params.requestId();
@@ -73,10 +73,11 @@ void TestQgsNetworkAccessManager::fetchEmptyUrl()
     QCOMPARE( params.operation(), QNetworkAccessManager::GetOperation );
     QCOMPARE( params.request().url(), QUrl() );
   } );
-  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( QgsNetworkReplyContent reply )
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( const QgsNetworkReplyContent & reply )
   {
     QCOMPARE( reply.errorString(), QStringLiteral( "Protocol \"\" is unknown" ) );
     QCOMPARE( reply.requestId(), requestId );
+    QCOMPARE( reply.request().url(), QUrl() );
     loaded = true;
   } );
   QgsNetworkAccessManager::instance()->get( QNetworkRequest( QUrl() ) );
@@ -96,7 +97,7 @@ void TestQgsNetworkAccessManager::fetchBadUrl()
   bool loaded = false;
   bool gotRequestAboutToBeCreatedSignal = false;
   int requestId = -1;
-  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( QgsNetworkRequestParameters params )
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( const QgsNetworkRequestParameters & params )
   {
     gotRequestAboutToBeCreatedSignal = true;
     requestId = params.requestId();
@@ -104,10 +105,12 @@ void TestQgsNetworkAccessManager::fetchBadUrl()
     QCOMPARE( params.operation(), QNetworkAccessManager::GetOperation );
     QCOMPARE( params.request().url(), QUrl( QStringLiteral( "http://x" ) ) );
   } );
-  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( QgsNetworkReplyContent reply )
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( const QgsNetworkReplyContent & reply )
   {
     QCOMPARE( reply.errorString(), QStringLiteral( "Host x not found" ) );
     QCOMPARE( reply.requestId(), requestId );
+    QCOMPARE( reply.request().url(), QUrl( QStringLiteral( "http://x" ) ) );
+
     loaded = true;
   } );
   QgsNetworkAccessManager::instance()->get( QNetworkRequest( QUrl( QStringLiteral( "http://x" ) ) ) );
@@ -129,7 +132,7 @@ void TestQgsNetworkAccessManager::fetchEncodedContent()
   bool gotRequestAboutToBeCreatedSignal = false;
   int requestId = -1;
   QUrl u =  QUrl::fromLocalFile( QStringLiteral( TEST_DATA_DIR ) + '/' +  "encoded_html.html" );
-  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( QgsNetworkRequestParameters params )
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkRequestParameters >::of( &QgsNetworkAccessManager::requestAboutToBeCreated ), &context, [&]( const QgsNetworkRequestParameters & params )
   {
     gotRequestAboutToBeCreatedSignal = true;
     requestId = params.requestId();
@@ -137,11 +140,12 @@ void TestQgsNetworkAccessManager::fetchEncodedContent()
     QCOMPARE( params.operation(), QNetworkAccessManager::GetOperation );
     QCOMPARE( params.request().url(), u );
   } );
-  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( QgsNetworkReplyContent reply )
+  connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( const QgsNetworkReplyContent & reply )
   {
     QCOMPARE( reply.error(), QNetworkReply::NoError );
     QCOMPARE( reply.requestId(), requestId );
     QVERIFY( reply.rawHeaderList().contains( "Content-Length" ) );
+    QCOMPARE( reply.request().url(), u );
     loaded = true;
   } );
   QgsNetworkAccessManager::instance()->get( QNetworkRequest( u ) );


### PR DESCRIPTION
This PR replaces more of the thread-unsafe QgsNetworkAccessManager signals with versions which are completely safe to use across threads, e.g. allowing safe connection from the main thread to background thread network activity.

As part of this I've unreverted earlier work done for the (since reverted) blocking network request, adding a class which encapsulates properties of a QNetworkReply in a safe manner to store and pass between threads. Unfortunately, Qt limitations prevent storing the actual reply body here -- in Qt, a QNetworkReply's content can only be read ONCE. So if we read it for the signal (or indeed, in ANY plugin connecting to exisiting signals or signals added by this PR), the content will not be available for the original calling code. I'd love to find a workaround for this, if anyone has ideas.

I've also deprecated the older unsafe methods, fixed an issue in QgsFileDownloader, and added some tests.