### PR TITLE
Improve mesh rendering speed

### DIFF
--- a/external/mdal/frmts/mdal_2dm.cpp
+++ b/external/mdal/frmts/mdal_2dm.cpp
@@ -148,7 +148,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::Driver2dm::load( const std::string &meshFile, 
   {
     if ( startsWith( line, "E4Q" ) )
     {
-      chunks = split( line,  " ", SplitBehaviour::SkipEmptyParts );
+      chunks = split( line,  ' ' );
       assert( faceIndex < faceCount );
 
       Face &face = faces[faceIndex];
@@ -161,7 +161,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::Driver2dm::load( const std::string &meshFile, 
     }
     else if ( startsWith( line, "E3T" ) )
     {
-      chunks = split( line,  " ", SplitBehaviour::SkipEmptyParts );
+      chunks = split( line,  ' ' );
       assert( faceIndex < faceCount );
 
       Face &face = faces[faceIndex];
@@ -181,7 +181,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::Driver2dm::load( const std::string &meshFile, 
               startsWith( line, "E9Q" ) )
     {
       // We do not yet support these elements
-      chunks = split( line,  " ", SplitBehaviour::SkipEmptyParts );
+      chunks = split( line,  ' ' );
       assert( faceIndex < faceCount );
 
       //size_t elemID = toSizeT( chunks[1] );
@@ -191,7 +191,7 @@ std::unique_ptr<MDAL::Mesh> MDAL::Driver2dm::load( const std::string &meshFile, 
     }
     else if ( startsWith( line, "ND" ) )
     {
-      chunks = split( line,  " ", SplitBehaviour::SkipEmptyParts );
+      chunks = split( line,  ' ' );
       size_t nodeID = toSizeT( chunks[1] ) - 1; // 2dm is numbered from 1
       _parse_vertex_id_gaps( vertexIDtoIndex, vertexIndex, nodeID, status );
       assert( vertexIndex < vertexCount );

--- a/external/mdal/frmts/mdal_ascii_dat.cpp
+++ b/external/mdal/frmts/mdal_ascii_dat.cpp
@@ -95,7 +95,7 @@ void MDAL::DriverAsciiDat::loadOldFormat( std::ifstream &in,
     line = MDAL::trim( line );
 
     // Split to tokens
-    std::vector<std::string> items = split( line,  " ", SplitBehaviour::SkipEmptyParts );
+    std::vector<std::string> items = split( line,  ' ' );
     if ( items.size() < 1 )
       continue; // empty line?? let's skip it
 
@@ -159,7 +159,7 @@ void MDAL::DriverAsciiDat::loadNewFormat( std::ifstream &in,
     line = MDAL::trim( line );
 
     // Split to tokens
-    std::vector<std::string> items = split( line,  " ", SplitBehaviour::SkipEmptyParts );
+    std::vector<std::string> items = split( line,  ' ' );
     if ( items.size() < 1 )
       continue; // empty line?? let's skip it
 
@@ -320,7 +320,7 @@ void MDAL::DriverAsciiDat::readVertexTimestep(
   {
     std::string line;
     std::getline( stream, line );
-    std::vector<std::string> tsItems = split( line,  " ", SplitBehaviour::SkipEmptyParts );
+    std::vector<std::string> tsItems = split( line,  ' ' );
 
     size_t index;
     if ( m2dm )
@@ -374,7 +374,7 @@ void MDAL::DriverAsciiDat::readFaceTimestep(
   {
     std::string line;
     std::getline( stream, line );
-    std::vector<std::string> tsItems = split( line,  " ", SplitBehaviour::SkipEmptyParts );
+    std::vector<std::string> tsItems = split( line, ' ' );
 
     if ( isVector )
     {

--- a/external/mdal/frmts/mdal_flo2d.cpp
+++ b/external/mdal/frmts/mdal_flo2d.cpp
@@ -109,7 +109,7 @@ void MDAL::DriverFlo2D::parseCADPTSFile( const std::string &datFileName, std::ve
   // CADPTS.DAT - COORDINATES OF CELL CENTERS (ELEM NUM, X, Y)
   while ( std::getline( cadptsStream, line ) )
   {
-    std::vector<std::string> lineParts = MDAL::split( line, " ", MDAL::SplitBehaviour::SkipEmptyParts );
+    std::vector<std::string> lineParts = MDAL::split( line, ' ' );
     if ( lineParts.size() != 3 )
     {
       throw MDAL_Status::Err_UnknownFormat;
@@ -140,7 +140,7 @@ void MDAL::DriverFlo2D::parseFPLAINFile( std::vector<double> &elevations,
 
   while ( std::getline( fplainStream, line ) )
   {
-    std::vector<std::string> lineParts = MDAL::split( line, " ", MDAL::SplitBehaviour::SkipEmptyParts );
+    std::vector<std::string> lineParts = MDAL::split( line, ' ' );
     if ( lineParts.size() != 7 )
     {
       throw MDAL_Status::Err_UnknownFormat;
@@ -220,7 +220,7 @@ void MDAL::DriverFlo2D::parseTIMDEPFile( const std::string &datFileName, const s
 
   while ( std::getline( inStream, line ) )
   {
-    std::vector<std::string> lineParts = MDAL::split( line, " ", MDAL::SplitBehaviour::SkipEmptyParts );
+    std::vector<std::string> lineParts = MDAL::split( line, ' ' );
     if ( lineParts.size() == 1 )
     {
       time = MDAL::toDouble( line );
@@ -303,7 +303,7 @@ void MDAL::DriverFlo2D::parseDEPTHFile( const std::string &datFileName, const st
   {
     if ( vertex_idx == nVertices ) throw MDAL_Status::Err_IncompatibleMesh;
 
-    std::vector<std::string> lineParts = MDAL::split( line, " ", MDAL::SplitBehaviour::SkipEmptyParts );
+    std::vector<std::string> lineParts = MDAL::split( line, ' ' );
     if ( lineParts.size() != 4 )
     {
       throw MDAL_Status::Err_UnknownFormat;
@@ -348,7 +348,7 @@ void MDAL::DriverFlo2D::parseVELFPVELOCFile( const std::string &datFileName )
     {
       if ( vertex_idx == nVertices ) throw MDAL_Status::Err_IncompatibleMesh;
 
-      std::vector<std::string> lineParts = MDAL::split( line, " ", MDAL::SplitBehaviour::SkipEmptyParts );
+      std::vector<std::string> lineParts = MDAL::split( line, ' ' );
       if ( lineParts.size() != 4 )
       {
         throw MDAL_Status::Err_UnknownFormat;
@@ -378,7 +378,7 @@ void MDAL::DriverFlo2D::parseVELFPVELOCFile( const std::string &datFileName )
     {
       if ( vertex_idx == nVertices ) throw MDAL_Status::Err_IncompatibleMesh;
 
-      std::vector<std::string> lineParts = MDAL::split( line, " ", MDAL::SplitBehaviour::SkipEmptyParts );
+      std::vector<std::string> lineParts = MDAL::split( line, ' ' );
       if ( lineParts.size() != 4 )
       {
         throw MDAL_Status::Err_UnknownFormat;

--- a/external/mdal/frmts/mdal_gdal.cpp
+++ b/external/mdal/frmts/mdal_gdal.cpp
@@ -166,7 +166,7 @@ std::string MDAL::DriverGdal::GDALFileName( const std::string &fileName )
 double MDAL::DriverGdal::parseMetadataTime( const std::string &time_s )
 {
   std::string time_trimmed = MDAL::trim( time_s );
-  std::vector<std::string> times = MDAL::split( time_trimmed, " ", MDAL::SkipEmptyParts );
+  std::vector<std::string> times = MDAL::split( time_trimmed, ' ' );
   return MDAL::toDouble( times[0] );
 }
 
@@ -181,7 +181,7 @@ MDAL::DriverGdal::metadata_hash MDAL::DriverGdal::parseMetadata( GDALMajorObject
     for ( int j = 0; GDALmetadata[j]; ++j )
     {
       std::string metadata_pair = GDALmetadata[j]; //KEY = VALUE
-      std::vector<std::string> metadata = MDAL::split( metadata_pair, "=", MDAL::SkipEmptyParts );
+      std::vector<std::string> metadata = MDAL::split( metadata_pair, '=' );
       if ( metadata.size() > 1 )
       {
         std::string key = MDAL::toLower( metadata[0] );

--- a/external/mdal/mdal.cpp
+++ b/external/mdal/mdal.cpp
@@ -22,7 +22,7 @@ static MDAL_Status sLastStatus;
 
 const char *MDAL_Version()
 {
-  return "0.1.4";
+  return "0.1.5";
 }
 
 MDAL_Status MDAL_LastStatus()

--- a/external/mdal/mdal_utils.cpp
+++ b/external/mdal/mdal_utils.cpp
@@ -44,27 +44,51 @@ bool MDAL::endsWith( const std::string &str, const std::string &substr, Contains
     return endsWith( toLower( str ), toLower( substr ), ContainsBehaviour::CaseSensitive );
 }
 
-std::vector<std::string> MDAL::split( const std::string &str, const std::string &delimiter, SplitBehaviour behaviour )
+std::vector<std::string> MDAL::split( const std::string &str,
+                                      const char delimiter
+                                    )
 {
-  std::string remaining( str );
   std::vector<std::string> list;
-  size_t pos = 0;
+  std::string::const_iterator start = str.begin();
+  std::string::const_iterator end = str.end();
+  std::string::const_iterator next;
   std::string token;
-  while ( ( pos = remaining.find( delimiter ) ) != std::string::npos )
+  do
   {
-    token = remaining.substr( 0, pos );
-
-    if ( behaviour == SplitBehaviour::SkipEmptyParts )
-    {
-      if ( !token.empty() )
-        list.push_back( token );
-    }
-    else
+    next = std::find( start, end, delimiter );
+    token = std::string( start, next );
+    if ( !token.empty() )
       list.push_back( token );
 
-    remaining.erase( 0, pos + delimiter.length() );
+    if ( next == end )
+      break;
+    else
+      start = next + 1;
   }
-  list.push_back( remaining );
+  while ( true );
+  return list;
+}
+
+
+std::vector<std::string> MDAL::split( const std::string &str,
+                                      const std::string &delimiter )
+{
+  std::vector<std::string> list;
+  std::string::size_type start = 0;
+  std::string::size_type next;
+  std::string token;
+  do
+  {
+    next = str.find( delimiter, start );
+    if ( next == std::string::npos )
+      token = str.substr( start ); // rest of the string
+    else
+      token = str.substr( start, next - start ); // part of the string
+    if ( !token.empty() )
+      list.push_back( token );
+    start = next + delimiter.size();
+  }
+  while ( next != std::string::npos );
   return list;
 }
 
@@ -308,7 +332,7 @@ double MDAL::parseTimeUnits( const std::string &units )
   // "seconds since 2001-05-05 00:00:00"
   // "hours since 1900-01-01 00:00:0.0"
   // "days since 1961-01-01 00:00:00"
-  const std::vector<std::string> units_list = MDAL::split( units, " since ", SkipEmptyParts );
+  const std::vector<std::string> units_list = MDAL::split( units, " since " );
   if ( units_list.size() == 2 )
   {
     // Give me hours

--- a/external/mdal/mdal_utils.hpp
+++ b/external/mdal/mdal_utils.hpp
@@ -6,6 +6,10 @@
 #ifndef MDAL_UTILS_HPP
 #define MDAL_UTILS_HPP
 
+// Macro for exporting symbols
+// for unit tests (on windows)
+#define MDAL_TEST_EXPORT MDAL_EXPORT
+
 #include <string>
 #include <vector>
 #include <stddef.h>
@@ -59,12 +63,15 @@ namespace MDAL
   bool toBool( const std::string &str );
   bool isNumber( const std::string &str );
 
-  enum SplitBehaviour
-  {
-    SkipEmptyParts,
-    KeepEmptyParts
-  };
-  std::vector<std::string> split( const std::string &str, const std::string &delimiter, SplitBehaviour behaviour );
+  /**
+   * Splits by deliminer and skips empty parts.
+   * Faster than version with std::string
+   */
+  MDAL_TEST_EXPORT std::vector<std::string> split( const std::string &str, const char delimiter );
+
+  //! Splits by deliminer and skips empty parts
+  MDAL_TEST_EXPORT std::vector<std::string> split( const std::string &str, const std::string &delimiter );
+
   std::string join( const std::vector<std::string> parts, const std::string &delimiter );
 
   //! Right trim
@@ -87,7 +94,7 @@ namespace MDAL
 
   // time
   //! Returns a delimiter to get time in hours
-  double parseTimeUnits( const std::string &units );
+  MDAL_TEST_EXPORT double parseTimeUnits( const std::string &units );
 
   // statistics
   void combineStatistics( Statistics &main, const Statistics &other );

--- a/python/core/auto_generated/mesh/qgsmeshspatialindex.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshspatialindex.sip.in
@@ -1,0 +1,90 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/mesh/qgsmeshspatialindex.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+class QgsMeshSpatialIndex
+{
+%Docstring
+
+A spatial index for QgsMeshFace objects.
+
+QgsMeshSpatialIndex objects are implicitly shared and can be inexpensively copied.
+
+.. note::
+
+   While the underlying libspatialindex is not thread safe on some platforms, the QgsMeshSpatialIndex
+   class implements its own locks and accordingly, a single QgsMeshSpatialIndex object can safely
+   be used across multiple threads
+
+.. seealso:: :py:class:`QgsSpatialIndex`
+
+
+.. versionadded:: 3.6
+%End
+
+%TypeHeaderCode
+#include "qgsmeshspatialindex.h"
+%End
+  public:
+
+    QgsMeshSpatialIndex();
+%Docstring
+Constructor for :py:class:`QgsSpatialIndex`. Creates an empty R-tree index.
+%End
+
+    explicit QgsMeshSpatialIndex( const QgsMesh &triangularMesh, QgsFeedback *feedback = 0 );
+%Docstring
+Constructor - creates R-tree and bulk loads faces from the specified mesh
+
+The optional ``feedback`` object can be used to allow cancelation of bulk face loading. Ownership
+of ``feedback`` is not transferred, and callers must take care that the lifetime of feedback exceeds
+that of the spatial index construction.
+%End
+
+    QgsMeshSpatialIndex( const QgsMeshSpatialIndex &other );
+%Docstring
+Copy constructor
+%End
+
+    ~QgsMeshSpatialIndex();
+
+
+    QList<int> intersects( const QgsRectangle &rectangle ) const;
+%Docstring
+Returns a list of face ids with a bounding box which intersects the specified ``rectangle``.
+
+.. note::
+
+   The intersection test is performed based on the face bounding boxes only, so it is necessary
+   to manually test the returned faces for exact geometry intersection when required.
+%End
+
+    QList<int> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;
+%Docstring
+Returns nearest neighbors to a ``point``. The number of neighbours returned is specified
+by the ``neighbours`` argument.
+
+.. note::
+
+   The nearest neighbour test is performed based on the face bounding boxes only,
+   so this method is not guaranteed to return the actual closest neighbours.
+%End
+
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/mesh/qgsmeshspatialindex.h                                  *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -29,6 +29,8 @@ QgsSpatialIndex objects are implicitly shared and can be inexpensively copied.
    be used across multiple threads.
 
 .. seealso:: :py:class:`QgsSpatialIndexKDBush`
+
+.. seealso:: :py:class:`QgsMeshSpatialIndex`
 %End
 
 %TypeHeaderCode
@@ -156,7 +158,6 @@ Gets reference count - just for debugging!
 %End
 
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -239,6 +239,7 @@
 %Include auto_generated/raster/qgshillshaderenderer.sip
 %Include auto_generated/mesh/qgsmeshlayerinterpolator.sip
 %Include auto_generated/mesh/qgsmeshrenderersettings.sip
+%Include auto_generated/mesh/qgsmeshspatialindex.sip
 %Include auto_generated/scalebar/qgsdoubleboxscalebarrenderer.sip
 %Include auto_generated/scalebar/qgsnumericscalebarrenderer.sip
 %Include auto_generated/scalebar/qgsscalebarsettings.sip

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -473,13 +473,14 @@ SET(QGIS_CORE_SRCS
 
   mesh/qgsmeshdataprovider.cpp
   mesh/qgsmeshlayer.cpp
+  mesh/qgsmeshlayerinterpolator.cpp
   mesh/qgsmeshlayerrenderer.cpp
   mesh/qgsmeshlayerutils.cpp
   mesh/qgsmeshmemorydataprovider.cpp
-  mesh/qgstriangularmesh.cpp
-  mesh/qgsmeshlayerinterpolator.cpp
-  mesh/qgsmeshvectorrenderer.cpp
   mesh/qgsmeshrenderersettings.cpp
+  mesh/qgsmeshspatialindex.cpp
+  mesh/qgsmeshvectorrenderer.cpp
+  mesh/qgstriangularmesh.cpp
 
   geometry/qgsabstractgeometry.cpp
   geometry/qgsbox3d.cpp
@@ -1104,12 +1105,13 @@ SET(QGIS_CORE_HDRS
   raster/qgssinglebandpseudocolorrenderer.h
   raster/qgshillshaderenderer.h
 
-  mesh/qgstriangularmesh.h
-  mesh/qgsmeshlayerrenderer.h
   mesh/qgsmeshlayerinterpolator.h
+  mesh/qgsmeshlayerrenderer.h
   mesh/qgsmeshlayerutils.h
-  mesh/qgsmeshvectorrenderer.h
   mesh/qgsmeshrenderersettings.h
+  mesh/qgsmeshspatialindex.h
+  mesh/qgsmeshvectorrenderer.h
+  mesh/qgstriangularmesh.h
 
   scalebar/qgsdoubleboxscalebarrenderer.h
   scalebar/qgsnumericscalebarrenderer.h

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -49,15 +49,24 @@ QgsMeshLayer::QgsMeshLayer( const QString &meshLayerPath,
   }
 
   setLegend( QgsMapLayerLegend::defaultMeshLegend( this ) );
-
-  // show at least the mesh by default so we render something
-  QgsMeshRendererMeshSettings meshSettings;
-  meshSettings.setEnabled( true );
-  mRendererSettings.setNativeMeshSettings( meshSettings );
-
+  setDefaultRendererSettings();
 } // QgsMeshLayer ctor
 
-
+void QgsMeshLayer::setDefaultRendererSettings()
+{
+  if ( mDataProvider && mDataProvider->datasetGroupCount() > 0 )
+  {
+    // show data from the first dataset group
+    mRendererSettings.setActiveScalarDataset( QgsMeshDatasetIndex( 0, 0 ) );
+  }
+  else
+  {
+    // show at least the mesh by default
+    QgsMeshRendererMeshSettings meshSettings;
+    meshSettings.setEnabled( true );
+    mRendererSettings.setNativeMeshSettings( meshSettings );
+  }
+}
 
 QgsMeshLayer::~QgsMeshLayer()
 {

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -232,6 +232,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
   private:
     void fillNativeMesh();
     void assignDefaultStyleToDatasetGroup( int groupIndex );
+    void setDefaultRendererSettings();
 
   private slots:
     void onDatasetGroupsAdded( int count );

--- a/src/core/mesh/qgsmeshspatialindex.cpp
+++ b/src/core/mesh/qgsmeshspatialindex.cpp
@@ -1,0 +1,346 @@
+/***************************************************************************
+    qgsmeshspatialindex.cpp
+    -----------------------
+    begin                : January 2019
+    copyright            : (C) 2019 by Peter Petrik
+    email                : zilolv at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+///@cond PRIVATE
+
+#include "qgsmeshspatialindex.h"
+
+#include "qgsmeshdataprovider.h"
+#include "qgsrectangle.h"
+#include "qgslogger.h"
+#include "qgsfeedback.h"
+
+#include <spatialindex/SpatialIndex.h>
+#include <QMutex>
+#include <QMutexLocker>
+#include <memory>
+
+using namespace SpatialIndex;
+
+static Region faceToRegion( const QgsMesh &mesh, int id )
+{
+  const QgsMeshFace face = mesh.face( id );
+  const QVector<QgsMeshVertex> &vertices = mesh.vertices;
+  Q_ASSERT( face.size() > 0 );
+  double xMinimum = vertices[face[0]].x();
+  double yMinimum = vertices[face[0]].y();
+  double xMaximum = vertices[face[0]].x();
+  double yMaximum = vertices[face[0]].y();
+
+  for ( int i = 1; i < face.size(); ++i )
+  {
+    xMinimum = std::min( vertices[face[i]].x(), xMinimum );
+    yMinimum = std::min( vertices[face[i]].y(), yMinimum );
+    xMaximum = std::max( vertices[face[i]].x(), xMaximum );
+    yMaximum = std::max( vertices[face[i]].y(), yMaximum );
+  }
+
+  double pt1[2] = { xMinimum, yMinimum };
+  double pt2[2] = { xMaximum, yMaximum };
+  return SpatialIndex::Region( pt1, pt2, 2 );
+}
+
+static Region rectToRegion( const QgsRectangle &rect )
+{
+  double pt1[2] = { rect.xMinimum(), rect.yMinimum() };
+  double pt2[2] = { rect.xMaximum(), rect.yMaximum() };
+  return SpatialIndex::Region( pt1, pt2, 2 );
+}
+
+/**
+ * \ingroup core
+ * \class QgisMeshVisitor
+ * \brief Custom visitor that adds found faces to list.
+ * \note not available in Python bindings
+ */
+class QgisMeshVisitor : public SpatialIndex::IVisitor
+{
+  public:
+    explicit QgisMeshVisitor( QList<int> &list )
+      : mList( list ) {}
+
+    void visitNode( const INode &n ) override
+    { Q_UNUSED( n ); }
+
+    void visitData( const IData &d ) override
+    {
+      mList.append( static_cast<int>( d.getIdentifier() ) );
+    }
+
+    void visitData( std::vector<const IData *> &v ) override
+    { Q_UNUSED( v ); }
+
+  private:
+    QList<int> &mList;
+};
+
+/**
+ * \ingroup core
+ * \class QgsMeshSpatialIndexCopyVisitor
+ * \note not available in Python bindings
+ */
+class QgsMeshSpatialIndexCopyVisitor : public SpatialIndex::IVisitor
+{
+  public:
+    explicit QgsMeshSpatialIndexCopyVisitor( SpatialIndex::ISpatialIndex *newIndex )
+      : mNewIndex( newIndex ) {}
+
+    void visitNode( const INode &n ) override
+    { Q_UNUSED( n ); }
+
+    void visitData( const IData &d ) override
+    {
+      SpatialIndex::IShape *shape = nullptr;
+      d.getShape( &shape );
+      mNewIndex->insertData( 0, nullptr, *shape, d.getIdentifier() );
+      delete shape;
+    }
+
+    void visitData( std::vector<const IData *> &v ) override
+    { Q_UNUSED( v ); }
+
+  private:
+    SpatialIndex::ISpatialIndex *mNewIndex = nullptr;
+};
+
+
+/**
+ * \ingroup core
+ * \class QgsMeshFaceIteratorDataStream
+ * \brief Utility class for bulk loading of R-trees. Not a part of public API.
+ * \note not available in Python bindings
+*/
+class QgsMeshFaceIteratorDataStream : public IDataStream
+{
+  public:
+    //! constructor - needs to load all data to a vector for later access when bulk loading
+    explicit QgsMeshFaceIteratorDataStream( const QgsMesh &triangularMesh, QgsFeedback *feedback = nullptr )
+      : mMesh( triangularMesh )
+      , mFeedback( feedback )
+    {
+      readNextEntry();
+    }
+
+    ~QgsMeshFaceIteratorDataStream() override
+    {
+      delete mNextData;
+    }
+
+    //! returns a pointer to the next entry in the stream or 0 at the end of the stream.
+    IData *getNext() override
+    {
+      if ( mFeedback && mFeedback->isCanceled() )
+        return nullptr;
+
+      RTree::Data *ret = mNextData;
+      mNextData = nullptr;
+      readNextEntry();
+      return ret;
+    }
+
+    //! returns true if there are more items in the stream.
+    bool hasNext() override
+    {
+      return nullptr != mNextData;
+    }
+
+    //! returns the total number of entries available in the stream.
+    uint32_t size() override
+    {
+      return static_cast<uint32_t>( mMesh.faceCount() );
+    }
+
+    //! sets the stream pointer to the first entry, if possible.
+    void rewind() override
+    {
+      mIterator = 0;
+    }
+
+  protected:
+    void readNextEntry()
+    {
+      SpatialIndex::Region r;
+      const int faceCount = mMesh.faceCount();
+      if ( mIterator < faceCount )
+      {
+        r = faceToRegion( mMesh, mIterator );
+        mNextData = new RTree::Data(
+          0,
+          nullptr,
+          r,
+          mIterator );
+        ++mIterator;
+      }
+    }
+
+  private:
+    int mIterator = 0;
+    const QgsMesh &mMesh;
+    RTree::Data *mNextData = nullptr;
+    QgsFeedback *mFeedback = nullptr;
+};
+
+
+/**
+ * \ingroup core
+ *  \class QgsSpatialIndexData
+ * \brief Data of spatial index that may be implicitly shared
+ * \note not available in Python bindings
+*/
+class QgsMeshSpatialIndexData : public QSharedData
+{
+  public:
+    QgsMeshSpatialIndexData()
+    {
+      initTree();
+    }
+
+    /**
+     * Constructor for QgsSpatialIndexData which bulk loads features from the specified feature iterator
+     * \a fi.
+     *
+     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
+     * that of the spatial index construction.
+     */
+    explicit QgsMeshSpatialIndexData( const QgsMesh &fi, QgsFeedback *feedback = nullptr )
+    {
+      QgsMeshFaceIteratorDataStream fids( fi, feedback );
+      initTree( &fids );
+    }
+
+    QgsMeshSpatialIndexData( const QgsMeshSpatialIndexData &other )
+      : QSharedData( other )
+    {
+      QMutexLocker locker( &other.mMutex );
+
+      initTree();
+
+      // copy R-tree data one by one (is there a faster way??)
+      double low[]  = { std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest() };
+      double high[] = { std::numeric_limits<double>::max(), std::numeric_limits<double>::max() };
+      SpatialIndex::Region query( low, high, 2 );
+      QgsMeshSpatialIndexCopyVisitor visitor( mRTree.get() );
+      other.mRTree->intersectsWithQuery( query, visitor );
+    }
+
+    ~QgsMeshSpatialIndexData() = default;
+
+    QgsMeshSpatialIndexData &operator=( const QgsMeshSpatialIndexData &rh ) = delete;
+
+    void initTree( IDataStream *inputStream = nullptr )
+    {
+      // for now only memory manager
+      mStorage.reset( StorageManager::createNewMemoryStorageManager() );
+
+      // R-Tree parameters
+      double fillFactor = 0.7;
+      unsigned int indexCapacity = 10;
+      unsigned int leafCapacity = 10;
+      unsigned int dimension = 2;
+      RTree::RTreeVariant variant = RTree::RV_RSTAR;
+
+      // create R-tree
+      SpatialIndex::id_type indexId;
+
+      if ( inputStream && inputStream->hasNext() )
+        mRTree.reset(
+          RTree::createAndBulkLoadNewRTree(
+            RTree::BLM_STR,
+            *inputStream,
+            *mStorage, fillFactor,
+            indexCapacity,
+            leafCapacity,
+            dimension,
+            variant,
+            indexId )
+        );
+      else
+        mRTree.reset(
+          RTree::createNewRTree(
+            *mStorage,
+            fillFactor,
+            indexCapacity,
+            leafCapacity,
+            dimension,
+            variant,
+            indexId )
+        );
+    }
+
+    //! Storage manager
+    std::unique_ptr<SpatialIndex::IStorageManager> mStorage;
+
+    //! R-tree containing spatial index
+    std::unique_ptr<SpatialIndex::ISpatialIndex> mRTree;
+
+    mutable QMutex mMutex;
+
+};
+
+// -------------------------------------------------------------------------
+
+QgsMeshSpatialIndex::QgsMeshSpatialIndex()
+{
+  d = new QgsMeshSpatialIndexData;
+}
+
+QgsMeshSpatialIndex::QgsMeshSpatialIndex( const QgsMesh &triangularMesh, QgsFeedback *feedback )
+{
+  d = new QgsMeshSpatialIndexData( triangularMesh, feedback );
+}
+
+QgsMeshSpatialIndex::QgsMeshSpatialIndex( const QgsMeshSpatialIndex &other ) //NOLINT
+  : d( other.d )
+{
+}
+
+QgsMeshSpatialIndex:: ~QgsMeshSpatialIndex() = default; //NOLINT
+
+QgsMeshSpatialIndex &QgsMeshSpatialIndex::operator=( const QgsMeshSpatialIndex &other )
+{
+  if ( this != &other )
+    d = other.d;
+  return *this;
+}
+
+QList<int> QgsMeshSpatialIndex::intersects( const QgsRectangle &rect ) const
+{
+  QList<int> list;
+  QgisMeshVisitor visitor( list );
+
+  SpatialIndex::Region r = rectToRegion( rect );
+
+  QMutexLocker locker( &d->mMutex );
+  d->mRTree->intersectsWithQuery( r, visitor );
+
+  return list;
+}
+
+QList<int> QgsMeshSpatialIndex::nearestNeighbor( const QgsPointXY &point, int neighbors ) const
+{
+  QList<int> list;
+  QgisMeshVisitor visitor( list );
+
+  double pt[2] = { point.x(), point.y() };
+  Point p( pt, 2 );
+
+  QMutexLocker locker( &d->mMutex );
+  d->mRTree->nearestNeighborQuery( static_cast<uint32_t>( neighbors ), p, visitor );
+
+  return list;
+}
+
+///@endcond

--- a/src/core/mesh/qgsmeshspatialindex.cpp
+++ b/src/core/mesh/qgsmeshspatialindex.cpp
@@ -27,6 +27,8 @@
 
 using namespace SpatialIndex;
 
+///@cond PRIVATE
+
 static Region faceToRegion( const QgsMesh &mesh, int id )
 {
   const QgsMeshFace face = mesh.face( id );
@@ -288,7 +290,7 @@ class QgsMeshSpatialIndexData : public QSharedData
 
 };
 
-// -------------------------------------------------------------------------
+///@endcond
 
 QgsMeshSpatialIndex::QgsMeshSpatialIndex()
 {

--- a/src/core/mesh/qgsmeshspatialindex.cpp
+++ b/src/core/mesh/qgsmeshspatialindex.cpp
@@ -13,8 +13,6 @@
  *                                                                         *
  ***************************************************************************/
 
-///@cond PRIVATE
-
 #include "qgsmeshspatialindex.h"
 
 #include "qgsmeshdataprovider.h"
@@ -195,7 +193,7 @@ class QgsMeshFaceIteratorDataStream : public IDataStream
 
 /**
  * \ingroup core
- *  \class QgsSpatialIndexData
+ * \class QgsSpatialIndexData
  * \brief Data of spatial index that may be implicitly shared
  * \note not available in Python bindings
 */
@@ -208,10 +206,10 @@ class QgsMeshSpatialIndexData : public QSharedData
     }
 
     /**
-     * Constructor for QgsSpatialIndexData which bulk loads features from the specified feature iterator
+     * Constructor for QgsSpatialIndexData which bulk loads faces from the specified mesh
      * \a fi.
      *
-     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * The optional \a feedback object can be used to allow cancelation of bulk face loading. Ownership
      * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
      * that of the spatial index construction.
      */
@@ -342,5 +340,3 @@ QList<int> QgsMeshSpatialIndex::nearestNeighbor( const QgsPointXY &point, int ne
 
   return list;
 }
-
-///@endcond

--- a/src/core/mesh/qgsmeshspatialindex.h
+++ b/src/core/mesh/qgsmeshspatialindex.h
@@ -1,0 +1,104 @@
+/***************************************************************************
+    qgsmeshspatialindex.h
+    ---------------------
+    begin                : January 2019
+    copyright            : (C) 2019 by Peter Petrik
+    email                : zilolv at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMESHSPATIALINDEX_H
+#define QGSMESHSPATIALINDEX_H
+
+///@cond PRIVATE
+
+#include "qgis_sip.h"
+
+#define SIP_NO_FILE
+
+class QgsRectangle;
+class QgsPointXY;
+class QgsFeedback;
+struct QgsMesh;
+
+#include "qgis_core.h"
+#include <QList>
+#include <QSharedDataPointer>
+
+class QgsMeshSpatialIndexData;
+
+/**
+ * \ingroup core
+ * \class QgsMeshSpatialIndex
+ *
+ * A spatial index for QgsMeshFace objects.
+ *
+ * QgsMeshSpatialIndex objects are implicitly shared and can be inexpensively copied.
+ *
+ * \note While the underlying libspatialindex is not thread safe on some platforms, the QgsMeshSpatialIndex
+ * class implements its own locks and accordingly, a single QgsMeshSpatialIndex object can safely
+ * be used across multiple threads
+ *
+ * \see QgsSpatialIndex
+ *
+ * \since QGIS 3.6
+ */
+class CORE_NO_EXPORT QgsMeshSpatialIndex
+{
+
+  public:
+
+    /**
+     * Constructor for QgsSpatialIndex. Creates an empty R-tree index.
+     */
+    QgsMeshSpatialIndex();
+
+    /**
+     * Constructor - creates R-tree and bulk loads it with features from the iterator.
+     *
+     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
+     * that of the spatial index construction.
+     */
+    explicit QgsMeshSpatialIndex( const QgsMesh &triangularMesh, QgsFeedback *feedback = nullptr );
+
+    //! Copy constructor
+    QgsMeshSpatialIndex( const QgsMeshSpatialIndex &other );
+
+    //! Destructor finalizes work with spatial index
+    ~QgsMeshSpatialIndex();
+
+    //! Implement assignment operator
+    QgsMeshSpatialIndex &operator=( const QgsMeshSpatialIndex &other );
+
+    /**
+     * Returns a list of face ids with a bounding box which intersects the specified \a rectangle.
+     *
+     * \note The intersection test is performed based on the feature bounding boxes only, so for non-point
+     * geometry features it is necessary to manually test the returned features for exact geometry intersection
+     * when required.
+     */
+    QList<int> intersects( const QgsRectangle &rectangle ) const;
+
+    /**
+     * Returns nearest neighbors to a \a point. The number of neighbours returned is specified
+     * by the \a neighbours argument.
+     *
+     * \note The nearest neighbour test is performed based on the feature bounding boxes only, so for non-point
+     * geometry features this method is not guaranteed to return the actual closest neighbours.
+     */
+    QList<int> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;
+
+  private:
+    QSharedDataPointer<QgsMeshSpatialIndexData> d;
+};
+
+///@endcond
+
+#endif //QGSMESHSPATIALINDEX_H

--- a/src/core/mesh/qgsmeshspatialindex.h
+++ b/src/core/mesh/qgsmeshspatialindex.h
@@ -16,11 +16,7 @@
 #ifndef QGSMESHSPATIALINDEX_H
 #define QGSMESHSPATIALINDEX_H
 
-///@cond PRIVATE
-
 #include "qgis_sip.h"
-
-#define SIP_NO_FILE
 
 class QgsRectangle;
 class QgsPointXY;
@@ -45,13 +41,12 @@ class QgsMeshSpatialIndexData;
  * class implements its own locks and accordingly, a single QgsMeshSpatialIndex object can safely
  * be used across multiple threads
  *
- * \see QgsSpatialIndex
+ * \see QgsSpatialIndex, which is for vector features
  *
  * \since QGIS 3.6
  */
-class CORE_NO_EXPORT QgsMeshSpatialIndex
+class CORE_EXPORT QgsMeshSpatialIndex
 {
-
   public:
 
     /**
@@ -60,9 +55,9 @@ class CORE_NO_EXPORT QgsMeshSpatialIndex
     QgsMeshSpatialIndex();
 
     /**
-     * Constructor - creates R-tree and bulk loads it with features from the iterator.
+     * Constructor - creates R-tree and bulk loads faces from the specified mesh
      *
-     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * The optional \a feedback object can be used to allow cancelation of bulk face loading. Ownership
      * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
      * that of the spatial index construction.
      */
@@ -80,9 +75,8 @@ class CORE_NO_EXPORT QgsMeshSpatialIndex
     /**
      * Returns a list of face ids with a bounding box which intersects the specified \a rectangle.
      *
-     * \note The intersection test is performed based on the feature bounding boxes only, so for non-point
-     * geometry features it is necessary to manually test the returned features for exact geometry intersection
-     * when required.
+     * \note The intersection test is performed based on the face bounding boxes only, so it is necessary
+     * to manually test the returned faces for exact geometry intersection when required.
      */
     QList<int> intersects( const QgsRectangle &rectangle ) const;
 
@@ -90,15 +84,13 @@ class CORE_NO_EXPORT QgsMeshSpatialIndex
      * Returns nearest neighbors to a \a point. The number of neighbours returned is specified
      * by the \a neighbours argument.
      *
-     * \note The nearest neighbour test is performed based on the feature bounding boxes only, so for non-point
-     * geometry features this method is not guaranteed to return the actual closest neighbours.
+     * \note The nearest neighbour test is performed based on the face bounding boxes only,
+     * so this method is not guaranteed to return the actual closest neighbours.
      */
     QList<int> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;
 
   private:
     QSharedDataPointer<QgsMeshSpatialIndexData> d;
 };
-
-///@endcond
 
 #endif //QGSMESHSPATIALINDEX_H

--- a/src/core/mesh/qgstriangularmesh.cpp
+++ b/src/core/mesh/qgstriangularmesh.cpp
@@ -202,7 +202,7 @@ void QgsTriangularMesh::update( QgsMesh *nativeMesh, QgsRenderContext *context )
   }
 
   // CALCULATE SPATIAL INDEX
-  mSpatialIndex = QgsSpatialIndex( new QgsMeshFeatureIterator( &mTriangularMesh ) );
+  mSpatialIndex = QgsMeshSpatialIndex( mTriangularMesh );
 }
 
 const QVector<QgsMeshVertex> &QgsTriangularMesh::vertices() const
@@ -227,10 +227,9 @@ const QVector<int> &QgsTriangularMesh::trianglesToNativeFaces() const
 
 int QgsTriangularMesh::faceIndexForPoint( const QgsPointXY &point ) const
 {
-  const QList<QgsFeatureId> faceIndexes = mSpatialIndex.intersects( QgsRectangle( point, point ) );
-  for ( const QgsFeatureId fid : faceIndexes )
+  const QList<int> faceIndexes = mSpatialIndex.intersects( QgsRectangle( point, point ) );
+  for ( const int faceIndex : faceIndexes )
   {
-    int faceIndex = static_cast<int>( fid );
     const QgsMeshFace &face = mTriangularMesh.faces.at( faceIndex );
     const QgsGeometry geom = QgsMeshUtils::toGeometry( face, mTriangularMesh.vertices );
     if ( geom.contains( &point ) )
@@ -241,14 +240,7 @@ int QgsTriangularMesh::faceIndexForPoint( const QgsPointXY &point ) const
 
 QList<int> QgsTriangularMesh::faceIndexesForRectangle( const QgsRectangle &rectangle ) const
 {
-  const QList<QgsFeatureId> faceIndexes = mSpatialIndex.intersects( rectangle );
-  QList<int> indexes;
-  for ( const QgsFeatureId fid : faceIndexes )
-  {
-    int faceIndex = static_cast<int>( fid );
-    indexes.append( faceIndex );
-  }
-  return indexes;
+  return mSpatialIndex.intersects( rectangle );
 }
 
 std::unique_ptr< QgsPolygon > QgsMeshUtils::toPolygon( const QgsMeshFace &face, const QVector<QgsMeshVertex> &vertices )

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -27,7 +27,7 @@
 #include "qgsmeshdataprovider.h"
 #include "qgsgeometry.h"
 #include "qgsfeatureid.h"
-#include "qgsspatialindex.h"
+#include "qgsmeshspatialindex.h"
 #include "qgsfeatureiterator.h"
 
 class QgsRenderContext;
@@ -150,7 +150,7 @@ class CORE_EXPORT QgsTriangularMesh
     // centroids of the native faces in map CRS
     QVector<QgsMeshVertex> mNativeMeshFaceCentroids;
 
-    QgsSpatialIndex mSpatialIndex;
+    QgsMeshSpatialIndex mSpatialIndex;
     QgsCoordinateTransform mCoordinateTransform; //coordinate transform used to convert native mesh vertices to map vertices
 
     friend class TestQgsTriangularMesh;

--- a/src/core/mesh/qgstriangularmesh.h
+++ b/src/core/mesh/qgstriangularmesh.h
@@ -26,43 +26,11 @@
 #include "qgis_core.h"
 #include "qgsmeshdataprovider.h"
 #include "qgsgeometry.h"
-#include "qgsfeatureid.h"
 #include "qgsmeshspatialindex.h"
-#include "qgsfeatureiterator.h"
 
 class QgsRenderContext;
 class QgsCoordinateTransform;
 class QgsRectangle;
-
-///@cond PRIVATE
-
-/**
- * Delivers mesh faces as features
- */
-class CORE_NO_EXPORT QgsMeshFeatureIterator : public QgsAbstractFeatureIterator
-{
-  public:
-
-    /**
-     * This constructor creates a feature iterator, that delivers all features
-     *
-     * \param mesh The mesh to use
-     */
-    QgsMeshFeatureIterator( QgsMesh *mesh );
-    ~QgsMeshFeatureIterator() override;
-
-    bool rewind() override;
-    bool close() override;
-
-  protected:
-    bool fetchFeature( QgsFeature &f ) override;
-
-  private:
-    QgsMesh *mMesh = nullptr;
-    int it = 0;
-};
-
-///@endcond
 
 /**
  * \ingroup core
@@ -79,9 +47,9 @@ class CORE_EXPORT QgsTriangularMesh
 {
   public:
     //! Ctor
-    QgsTriangularMesh() = default;
+    QgsTriangularMesh();
     //! Dtor
-    ~QgsTriangularMesh() = default;
+    ~QgsTriangularMesh();
 
     /**
      * Constructs triangular mesh from layer's native mesh and context. Populates spatial index.

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -63,6 +63,7 @@ class QgsFeatureSource;
  * be used across multiple threads.
  *
  * \see QgsSpatialIndexKDBush, which is an optimised non-mutable index for point geometries only.
+ * \see QgsMeshSpatialIndex, which is for mesh faces
  */
 class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
 {
@@ -214,5 +215,4 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
 
 };
 
-#endif
-
+#endif //QGSSPATIALINDEX_H

--- a/tests/src/3d/testqgs3drendering.cpp
+++ b/tests/src/3d/testqgs3drendering.cpp
@@ -24,6 +24,7 @@
 #include "qgssinglebandpseudocolorrenderer.h"
 #include "qgsvectorlayer.h"
 #include "qgsmeshlayer.h"
+#include "qgsmeshrenderersettings.h"
 
 #include "qgs3dmapscene.h"
 #include "qgs3dmapsettings.h"
@@ -104,6 +105,11 @@ void TestQgs3DRendering::initTestCase()
   mLayerMesh = new QgsMeshLayer( dataDir + "/mesh/quad_flower.2dm", "mesh", "mdal" );
   QVERIFY( mLayerMesh->isValid() );
   mLayerMesh->setCrs( mLayerDtm->crs() );  // this testing mesh does not have any CRS defined originally
+  // disable rendering of scalar 2d datasets for now
+  QgsMeshRendererSettings settings = mLayerMesh->rendererSettings();
+  settings.setActiveScalarDataset();
+  settings.setActiveVectorDataset();
+  mLayerMesh->setRendererSettings( settings );
   mProject->addMapLayer( mLayerMesh );
 
   QgsPhongMaterialSettings meshMaterial;


### PR DESCRIPTION
Improves rendering speed of meshes. 

- For new layers, render first dataset instead of mesh frame
- Use custom spatial index instead of vector spatial index.
- new spatial index class infrastructure is mostly copy-pasted from QgsSpatialIndex and it is all private, not exposed to API

For my testcase with 3 mil cells the speed is dropped by 50-60% to load & render new mesh layer. There is even bigger improvement for larger models.