### PR TITLE
[processing] do not allow editing model if it's missing algorithms

### DIFF
--- a/python/plugins/processing/modeler/EditModelAction.py
+++ b/python/plugins/processing/modeler/EditModelAction.py
@@ -26,9 +26,11 @@ __copyright__ = '(C) 2012, Victor Olaya'
 __revision__ = '$Format:%H$'
 
 from qgis.PyQt.QtCore import QCoreApplication
-from qgis.core import QgsApplication, QgsProcessingModelAlgorithm
+from qgis.core import QgsApplication, QgsProcessingModelAlgorithm, QgsMessageLog
 from processing.gui.ContextAction import ContextAction
 from processing.modeler.ModelerDialog import ModelerDialog
+from qgis.core import Qgis
+from qgis.utils import iface
 
 
 class EditModelAction(ContextAction):
@@ -41,9 +43,13 @@ class EditModelAction(ContextAction):
 
     def execute(self):
         alg = self.itemData
-        dlg = ModelerDialog(alg)
-        dlg.update_model.connect(self.updateModel)
-        dlg.show()
+        ok, msg = alg.canExecute()
+        if not ok:
+            iface.messageBar().pushMessage("Cannot edit model:", msg, level=Qgis.Warning)
+        else:
+            dlg = ModelerDialog(alg)
+            dlg.update_model.connect(self.updateModel)
+            dlg.show()
 
     def updateModel(self):
         QgsApplication.processingRegistry().providerById('model').refreshAlgorithms()

--- a/python/plugins/processing/modeler/EditModelAction.py
+++ b/python/plugins/processing/modeler/EditModelAction.py
@@ -45,7 +45,7 @@ class EditModelAction(ContextAction):
         alg = self.itemData
         ok, msg = alg.canExecute()
         if not ok:
-            iface.messageBar().pushMessage("Cannot edit model:", msg, level=Qgis.Warning)
+            iface.messageBar().pushMessage(QCoreApplication.translate('EditModelAction', 'Cannot edit model: {}').format(msg), level=Qgis.Warning)
         else:
             dlg = ModelerDialog(alg)
             dlg.update_model.connect(self.updateModel)


### PR DESCRIPTION
fixes #19607

## Description

When editing a model that includes unavailable algorithm, an error trace is shown. With this fix, the exception is captured and a nicer message is shown

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
