### PR TITLE
Include qgis_sip.h instead of qgis.h where possible

### DIFF
--- a/python/core/auto_generated/qgstranslationcontext.sip.in
+++ b/python/core/auto_generated/qgstranslationcontext.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsTranslationContext
 {
 %Docstring

--- a/python/gui/auto_generated/attributetable/qgsfieldconditionalformatwidget.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfieldconditionalformatwidget.sip.in
@@ -24,8 +24,6 @@ A widget for customizing conditional formatting options.
     explicit QgsFieldConditionalFormatWidget( QWidget *parent /TransferThis/ = 0 );
 %Docstring
 Constructor for QgsFieldConditionalFormatWidget.
-
-:param parent: parent widget
 %End
 
     void viewRules();

--- a/python/gui/auto_generated/symbology/qgsstyleexportimportdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstyleexportimportdialog.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsStyleExportImportDialog : QDialog
 {
 

--- a/src/analysis/interpolation/NormVecDecorator.h
+++ b/src/analysis/interpolation/NormVecDecorator.h
@@ -19,7 +19,6 @@
 
 #include "TriDecorator.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "TriangleInterpolator.h"
 #include "MathUtils.h"
 #include "qgslogger.h"

--- a/src/analysis/interpolation/TriDecorator.h
+++ b/src/analysis/interpolation/TriDecorator.h
@@ -18,7 +18,7 @@
 #define TRIDECORATOR_H
 
 #include "Triangulation.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_analysis.h"
 
 #define SIP_NO_FILE

--- a/src/analysis/interpolation/Triangulation.h
+++ b/src/analysis/interpolation/Triangulation.h
@@ -18,7 +18,7 @@
 #define TRIANGULATION_H
 
 #include <QList>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QPainter>
 #include "TriangleInterpolator.h"
 #include "qgis_analysis.h"

--- a/src/analysis/network/qgsgraphanalyzer.h
+++ b/src/analysis/network/qgsgraphanalyzer.h
@@ -18,7 +18,7 @@
 
 #include <QVector>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_analysis.h"
 
 class QgsGraph;

--- a/src/analysis/network/qgsgraphbuilder.h
+++ b/src/analysis/network/qgsgraphbuilder.h
@@ -17,7 +17,7 @@
 #define QGSGRAPHBUILDER_H
 
 #include "qgsgraphbuilderinterface.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgsspatialindex.h"
 #include "qgis_analysis.h"

--- a/src/analysis/network/qgsgraphdirector.h
+++ b/src/analysis/network/qgsgraphdirector.h
@@ -20,7 +20,7 @@
 #include <QVector>
 #include <QList>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeedback.h"
 #include "qgsnetworkstrategy.h"
 #include "qgis_analysis.h"

--- a/src/analysis/processing/qgsalgorithmaddincrementalfield.h
+++ b/src/analysis/processing/qgsalgorithmaddincrementalfield.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmarrayoffsetlines.h
+++ b/src/analysis/processing/qgsalgorithmarrayoffsetlines.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmarraytranslatedfeatures.h
+++ b/src/analysis/processing/qgsalgorithmarraytranslatedfeatures.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmassignprojection.h
+++ b/src/analysis/processing/qgsalgorithmassignprojection.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmboundary.h
+++ b/src/analysis/processing/qgsalgorithmboundary.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmboundingbox.h
+++ b/src/analysis/processing/qgsalgorithmboundingbox.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmbuffer.h
+++ b/src/analysis/processing/qgsalgorithmbuffer.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmcategorizeusingstyle.h
+++ b/src/analysis/processing/qgsalgorithmcategorizeusingstyle.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 class QgsCategorizedSymbolRenderer;

--- a/src/analysis/processing/qgsalgorithmcentroid.h
+++ b/src/analysis/processing/qgsalgorithmcentroid.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmclip.h
+++ b/src/analysis/processing/qgsalgorithmclip.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmconvexhull.h
+++ b/src/analysis/processing/qgsalgorithmconvexhull.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmdbscanclustering.h
+++ b/src/analysis/processing/qgsalgorithmdbscanclustering.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_analysis.h"
 #include "qgsprocessingalgorithm.h"
 #include <unordered_map>

--- a/src/analysis/processing/qgsalgorithmdensifygeometriesbyinterval.h
+++ b/src/analysis/processing/qgsalgorithmdensifygeometriesbyinterval.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmdissolve.h
+++ b/src/analysis/processing/qgsalgorithmdissolve.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmdrape.h
+++ b/src/analysis/processing/qgsalgorithmdrape.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmdropgeometry.h
+++ b/src/analysis/processing/qgsalgorithmdropgeometry.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmdropmzvalues.h
+++ b/src/analysis/processing/qgsalgorithmdropmzvalues.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmexplode.h
+++ b/src/analysis/processing/qgsalgorithmexplode.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmexplodehstore.h
+++ b/src/analysis/processing/qgsalgorithmexplodehstore.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmextendlines.h
+++ b/src/analysis/processing/qgsalgorithmextendlines.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmextenttolayer.h
+++ b/src/analysis/processing/qgsalgorithmextenttolayer.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmextractbinary.h
+++ b/src/analysis/processing/qgsalgorithmextractbinary.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_analysis.h"
 #include "qgsprocessingalgorithm.h"
 

--- a/src/analysis/processing/qgsalgorithmextractbyattribute.h
+++ b/src/analysis/processing/qgsalgorithmextractbyattribute.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmextractbyexpression.h
+++ b/src/analysis/processing/qgsalgorithmextractbyexpression.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmextractbyextent.h
+++ b/src/analysis/processing/qgsalgorithmextractbyextent.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmextractbylocation.h
+++ b/src/analysis/processing/qgsalgorithmextractbylocation.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmextractvertices.h
+++ b/src/analysis/processing/qgsalgorithmextractvertices.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmextractzmvalues.h
+++ b/src/analysis/processing/qgsalgorithmextractzmvalues.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsstatisticalsummary.h"
 #include <functional>

--- a/src/analysis/processing/qgsalgorithmfiledownloader.h
+++ b/src/analysis/processing/qgsalgorithmfiledownloader.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 class QgsProcessingFeedback;

--- a/src/analysis/processing/qgsalgorithmfilter.h
+++ b/src/analysis/processing/qgsalgorithmfilter.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 class QgsProcessingModelAlgorithm;

--- a/src/analysis/processing/qgsalgorithmfiltervertices.h
+++ b/src/analysis/processing/qgsalgorithmfiltervertices.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsmaptopixelgeometrysimplifier.h"
 

--- a/src/analysis/processing/qgsalgorithmfixgeometries.h
+++ b/src/analysis/processing/qgsalgorithmfixgeometries.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmforcerhr.h
+++ b/src/analysis/processing/qgsalgorithmforcerhr.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmimportphotos.h
+++ b/src/analysis/processing/qgsalgorithmimportphotos.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_analysis.h"
 #include "qgsprocessingalgorithm.h"
 

--- a/src/analysis/processing/qgsalgorithminterpolatepoint.h
+++ b/src/analysis/processing/qgsalgorithminterpolatepoint.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmjoinbyattribute.h
+++ b/src/analysis/processing/qgsalgorithmjoinbyattribute.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmjoinwithlines.h
+++ b/src/analysis/processing/qgsalgorithmjoinwithlines.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmkmeansclustering.h
+++ b/src/analysis/processing/qgsalgorithmkmeansclustering.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_analysis.h"
 #include "qgsprocessingalgorithm.h"
 

--- a/src/analysis/processing/qgsalgorithmlineintersection.h
+++ b/src/analysis/processing/qgsalgorithmlineintersection.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmlinesubstring.h
+++ b/src/analysis/processing/qgsalgorithmlinesubstring.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmloadlayer.h
+++ b/src/analysis/processing/qgsalgorithmloadlayer.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmmeancoordinates.h
+++ b/src/analysis/processing/qgsalgorithmmeancoordinates.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmmergelines.h
+++ b/src/analysis/processing/qgsalgorithmmergelines.h
@@ -21,7 +21,7 @@
 #define SIP_NO_FILE
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsprocessingprovider.h"
 #include "qgsprocessingutils.h"

--- a/src/analysis/processing/qgsalgorithmmergevector.h
+++ b/src/analysis/processing/qgsalgorithmmergevector.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmminimumenclosingcircle.h
+++ b/src/analysis/processing/qgsalgorithmminimumenclosingcircle.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmmultiparttosinglepart.h
+++ b/src/analysis/processing/qgsalgorithmmultiparttosinglepart.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmmultiringconstantbuffer.h
+++ b/src/analysis/processing/qgsalgorithmmultiringconstantbuffer.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmnetworkanalysisbase.h
+++ b/src/analysis/processing/qgsalgorithmnetworkanalysisbase.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 #include "qgsgraph.h"

--- a/src/analysis/processing/qgsalgorithmoffsetlines.h
+++ b/src/analysis/processing/qgsalgorithmoffsetlines.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmorderbyexpression.h
+++ b/src/analysis/processing/qgsalgorithmorderbyexpression.h
@@ -22,7 +22,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.h
+++ b/src/analysis/processing/qgsalgorithmorientedminimumboundingbox.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmpackage.h
+++ b/src/analysis/processing/qgsalgorithmpackage.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmpointonsurface.h
+++ b/src/analysis/processing/qgsalgorithmpointonsurface.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmpolygonstolines.h
+++ b/src/analysis/processing/qgsalgorithmpolygonstolines.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmprojectpointcartesian.h
+++ b/src/analysis/processing/qgsalgorithmprojectpointcartesian.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmpromotetomultipart.h
+++ b/src/analysis/processing/qgsalgorithmpromotetomultipart.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsapplication.h"
 

--- a/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.h
+++ b/src/analysis/processing/qgsalgorithmrasterlayeruniquevalues.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmrastersurfacevolume.h
+++ b/src/analysis/processing/qgsalgorithmrastersurfacevolume.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmrasterzonalstats.h
+++ b/src/analysis/processing/qgsalgorithmrasterzonalstats.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsrasterprojector.h"
 

--- a/src/analysis/processing/qgsalgorithmreclassifybylayer.h
+++ b/src/analysis/processing/qgsalgorithmreclassifybylayer.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsreclassifyutils.h"
 

--- a/src/analysis/processing/qgsalgorithmremoveduplicatesbyattribute.h
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatesbyattribute.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmremoveduplicatevertices.h
+++ b/src/analysis/processing/qgsalgorithmremoveduplicatevertices.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmremoveholes.h
+++ b/src/analysis/processing/qgsalgorithmremoveholes.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmremovenullgeometry.h
+++ b/src/analysis/processing/qgsalgorithmremovenullgeometry.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmrenamelayer.h
+++ b/src/analysis/processing/qgsalgorithmrenamelayer.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmreverselinedirection.h
+++ b/src/analysis/processing/qgsalgorithmreverselinedirection.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmrotate.h
+++ b/src/analysis/processing/qgsalgorithmrotate.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsaveselectedfeatures.h
+++ b/src/analysis/processing/qgsalgorithmsaveselectedfeatures.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsegmentize.h
+++ b/src/analysis/processing/qgsalgorithmsegmentize.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsmaptopixelgeometrysimplifier.h"
 

--- a/src/analysis/processing/qgsalgorithmshortestpathlayertopoint.h
+++ b/src/analysis/processing/qgsalgorithmshortestpathlayertopoint.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsalgorithmnetworkanalysisbase.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmshortestpathpointtolayer.h
+++ b/src/analysis/processing/qgsalgorithmshortestpathpointtolayer.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsalgorithmnetworkanalysisbase.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmshortestpathpointtopoint.h
+++ b/src/analysis/processing/qgsalgorithmshortestpathpointtopoint.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsalgorithmnetworkanalysisbase.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsimplify.h
+++ b/src/analysis/processing/qgsalgorithmsimplify.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsmaptopixelgeometrysimplifier.h"
 #include "qgsapplication.h"

--- a/src/analysis/processing/qgsalgorithmsmooth.h
+++ b/src/analysis/processing/qgsalgorithmsmooth.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.h
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsplitlineantimeridian.h
+++ b/src/analysis/processing/qgsalgorithmsplitlineantimeridian.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsplitwithlines.h
+++ b/src/analysis/processing/qgsalgorithmsplitwithlines.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmstringconcatenation.h
+++ b/src/analysis/processing/qgsalgorithmstringconcatenation.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmsubdivide.h
+++ b/src/analysis/processing/qgsalgorithmsubdivide.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmswapxy.h
+++ b/src/analysis/processing/qgsalgorithmswapxy.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmtaperedbuffer.h
+++ b/src/analysis/processing/qgsalgorithmtaperedbuffer.h
@@ -21,7 +21,7 @@
 #define SIP_NO_FILE
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmtransect.h
+++ b/src/analysis/processing/qgsalgorithmtransect.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmtransform.h
+++ b/src/analysis/processing/qgsalgorithmtransform.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmtranslate.h
+++ b/src/analysis/processing/qgsalgorithmtranslate.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmuniquevalueindex.h
+++ b/src/analysis/processing/qgsalgorithmuniquevalueindex.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmvectorize.h
+++ b/src/analysis/processing/qgsalgorithmvectorize.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 #include "qgsreclassifyutils.h"
 

--- a/src/analysis/processing/qgsalgorithmwedgebuffers.h
+++ b/src/analysis/processing/qgsalgorithmwedgebuffers.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsalgorithmzonalhistogram.h
+++ b/src/analysis/processing/qgsalgorithmzonalhistogram.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingalgorithm.h"
 
 ///@cond PRIVATE

--- a/src/analysis/processing/qgsnativealgorithms.h
+++ b/src/analysis/processing/qgsnativealgorithms.h
@@ -19,7 +19,7 @@
 #define QGSNATIVEALGORITHMS_H
 
 #include "qgis_analysis.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprocessingprovider.h"
 
 /**

--- a/src/analysis/processing/qgsreclassifyutils.h
+++ b/src/analysis/processing/qgsreclassifyutils.h
@@ -20,7 +20,7 @@
 
 #define SIP_NO_FILE
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_analysis.h"
 #include "qgsrasterrange.h"
 #include <QVector>

--- a/src/analysis/raster/qgsalignraster.h
+++ b/src/analysis/raster/qgsalignraster.h
@@ -22,7 +22,7 @@
 #include <QString>
 #include <gdal_version.h>
 #include "qgis_analysis.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsogrutils.h"
 
 class QgsRectangle;

--- a/src/app/decorations/qgsdecorationgrid.h
+++ b/src/app/decorations/qgsdecorationgrid.h
@@ -19,7 +19,6 @@
 #define QGSDECORATIONGRID_H
 
 #include "qgsdecorationitem.h"
-#include "qgis.h"
 
 class QPainter;
 class QgsLineSymbol;

--- a/src/app/layout/qgslayoutaddpagesdialog.h
+++ b/src/app/layout/qgslayoutaddpagesdialog.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTADDPAGESDIALOG_H
 #define QGSLAYOUTADDPAGESDIALOG_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "ui_qgslayoutnewpagedialog.h"
 

--- a/src/app/layout/qgslayoutappmenuprovider.h
+++ b/src/app/layout/qgslayoutappmenuprovider.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTAPPMENUPROVIDER_H
 #define QGSLAYOUTAPPMENUPROVIDER_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayoutview.h"
 #include <QObject>
 

--- a/src/app/layout/qgslayoutapputils.h
+++ b/src/app/layout/qgslayoutapputils.h
@@ -16,8 +16,6 @@
 #ifndef QGSLAYOUTAPPUTILS_H
 #define QGSLAYOUTAPPUTILS_H
 
-#include "qgis.h"
-
 /**
  * Utils for layout handling from app.
  */

--- a/src/app/layout/qgslayoutattributeselectiondialog.h
+++ b/src/app/layout/qgslayoutattributeselectiondialog.h
@@ -24,7 +24,7 @@
 #include <QItemDelegate>
 #include <QAbstractTableModel>
 #include <QSortFilterProxyModel>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "ui_qgslayoutattributeselectiondialogbase.h"
 #include "qgsexpressioncontextgenerator.h"
 

--- a/src/app/layout/qgslayoutitemslistview.h
+++ b/src/app/layout/qgslayoutitemslistview.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTITEMSLISTVIEW_H
 #define QGSLAYOUTITEMSLISTVIEW_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QTreeView>
 #include <QSortFilterProxyModel>
 

--- a/src/app/layout/qgslayoutpagepropertieswidget.h
+++ b/src/app/layout/qgslayoutpagepropertieswidget.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTPAGEPROPERTIESWIDGET_H
 #define QGSLAYOUTPAGEPROPERTIESWIDGET_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "ui_qgslayoutpagepropertieswidget.h"
 
 #include "qgslayoutsize.h"

--- a/src/app/layout/qgsreportsectionmodel.h
+++ b/src/app/layout/qgsreportsectionmodel.h
@@ -16,7 +16,7 @@
 #ifndef QGSREPORTSECTIONMODEL_H
 #define QGSREPORTSECTIONMODEL_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsreport.h"
 #include <QAbstractItemModel>
 

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -27,6 +27,7 @@
 #include "qgsoptionsdialogbase.h"
 #include "qgsguiutils.h"
 #include "qgshelp.h"
+#include "qgis.h"
 
 class QgsPluginSortFilterProxyModel;
 class QgsPythonUtils;

--- a/src/app/qgscrashhandler.h
+++ b/src/app/qgscrashhandler.h
@@ -16,7 +16,6 @@
 #ifndef QGSCRASHHANDLER_H
 #define QGSCRASHHANDLER_H
 
-#include "qgis.h"
 #include "qgis_app.h"
 
 #ifdef WIN32

--- a/src/core/effects/qgsblureffect.h
+++ b/src/core/effects/qgsblureffect.h
@@ -19,7 +19,7 @@
 
 #include "qgis_core.h"
 #include "qgspainteffect.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QPainter>
 
 /**

--- a/src/core/effects/qgscoloreffect.h
+++ b/src/core/effects/qgscoloreffect.h
@@ -20,7 +20,7 @@
 #include "qgis_core.h"
 #include "qgspainteffect.h"
 #include "qgsimageoperation.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QPainter>
 
 /**

--- a/src/core/effects/qgseffectstack.h
+++ b/src/core/effects/qgseffectstack.h
@@ -18,7 +18,7 @@
 #define QGSEFFECTSTACK_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspainteffect.h"
 
 /**

--- a/src/core/effects/qgsimageoperation.h
+++ b/src/core/effects/qgsimageoperation.h
@@ -19,10 +19,11 @@
 #define QGSIMAGEOPERATION_H
 
 #include <QImage>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QColor>
 
 #include "qgis_core.h"
+#include <cmath>
 
 class QgsColorRamp;
 

--- a/src/core/effects/qgspainteffect.h
+++ b/src/core/effects/qgspainteffect.h
@@ -18,7 +18,8 @@
 #define QGSPAINTEFFECT_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
+#include "qgssymbollayer.h"
 #include <QPainter>
 #include <QDomDocument>
 #include <QDomElement>

--- a/src/core/effects/qgspainteffectregistry.h
+++ b/src/core/effects/qgspainteffectregistry.h
@@ -17,7 +17,8 @@
 #define QGSPAINTEFFECTREGISTRY_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
+#include "qgssymbollayer.h"
 #include <QDomElement>
 #include <QDomDocument>
 

--- a/src/core/effects/qgsshadoweffect.h
+++ b/src/core/effects/qgsshadoweffect.h
@@ -19,7 +19,7 @@
 
 #include "qgis_core.h"
 #include "qgspainteffect.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgssymbol.h"
 #include <QPainter>
 

--- a/src/core/effects/qgstransformeffect.h
+++ b/src/core/effects/qgstransformeffect.h
@@ -19,7 +19,7 @@
 
 #include "qgis_core.h"
 #include "qgspainteffect.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmapunitscale.h"
 #include "qgsunittypes.h"
 #include <QPainter>

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -52,6 +52,7 @@
 #include "qgstransaction.h"
 #include "qgsthreadingutils.h"
 #include "qgsapplication.h"
+#include "qgis.h"
 
 const QString QgsExpressionFunction::helpText() const
 {

--- a/src/core/geometry/qgsabstractgeometry.h
+++ b/src/core/geometry/qgsabstractgeometry.h
@@ -21,7 +21,6 @@ email                : marco.hugentobler at sourcepole dot com
 #include <QString>
 
 #include "qgis_core.h"
-#include "qgis.h"
 #include "qgscoordinatetransform.h"
 #include "qgswkbtypes.h"
 #include "qgswkbptr.h"

--- a/src/core/geometry/qgscircularstring.h
+++ b/src/core/geometry/qgscircularstring.h
@@ -21,7 +21,7 @@
 #include <QVector>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgscurve.h"
 
 

--- a/src/core/geometry/qgscompoundcurve.h
+++ b/src/core/geometry/qgscompoundcurve.h
@@ -19,7 +19,7 @@
 #define QGSCOMPOUNDCURVE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgscurve.h"
 
 /**

--- a/src/core/geometry/qgscurve.h
+++ b/src/core/geometry/qgscurve.h
@@ -19,7 +19,7 @@
 #define QGSCURVE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
 #include "qgsrectangle.h"
 

--- a/src/core/geometry/qgscurvepolygon.h
+++ b/src/core/geometry/qgscurvepolygon.h
@@ -19,7 +19,7 @@
 #define QGSCURVEPOLYGON_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgssurface.h"
 #include <memory>
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -28,7 +28,7 @@ email                : morb at ozemail dot com dot au
 #include <memory>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgsabstractgeometry.h"
 #include "qgspointxy.h"

--- a/src/core/geometry/qgsgeometrycollection.h
+++ b/src/core/geometry/qgsgeometrycollection.h
@@ -20,7 +20,7 @@ email                : marco.hugentobler at sourcepole dot com
 
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
 
 class QgsPoint;

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -19,7 +19,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include <limits>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspoint.h"
 #include "qgsabstractgeometry.h"
 #include "qgsvector3d.h"

--- a/src/core/geometry/qgslinestring.h
+++ b/src/core/geometry/qgslinestring.h
@@ -22,7 +22,7 @@
 #include <QPolygonF>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgscurve.h"
 #include "qgscompoundcurve.h"
 

--- a/src/core/geometry/qgsmulticurve.h
+++ b/src/core/geometry/qgsmulticurve.h
@@ -17,7 +17,7 @@ email                : marco.hugentobler at sourcepole dot com
 #define QGSMULTICURVE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsgeometrycollection.h"
 
 /**

--- a/src/core/geometry/qgsmultilinestring.h
+++ b/src/core/geometry/qgsmultilinestring.h
@@ -17,7 +17,7 @@ email                : marco.hugentobler at sourcepole dot com
 #define QGSMULTILINESTRING_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmulticurve.h"
 
 /**

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -17,7 +17,7 @@ email                : marco.hugentobler at sourcepole dot com
 #define QGSMULTIPOINT_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsgeometrycollection.h"
 
 /**

--- a/src/core/geometry/qgsmultipolygon.h
+++ b/src/core/geometry/qgsmultipolygon.h
@@ -17,7 +17,7 @@ email                : marco.hugentobler at sourcepole dot com
 #define QGSMULTIPOLYGON_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmultisurface.h"
 
 /**

--- a/src/core/geometry/qgsmultisurface.h
+++ b/src/core/geometry/qgsmultisurface.h
@@ -17,7 +17,7 @@ email                : marco.hugentobler at sourcepole dot com
 #define QGSMULTISURFACE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsgeometrycollection.h"
 
 /**

--- a/src/core/geometry/qgspoint.h
+++ b/src/core/geometry/qgspoint.h
@@ -19,7 +19,7 @@
 #define QGSPOINT_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
 #include "qgsrectangle.h"
 

--- a/src/core/geometry/qgspolygon.h
+++ b/src/core/geometry/qgspolygon.h
@@ -19,7 +19,7 @@
 #define QGSPOLYGON_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgscurvepolygon.h"
 
 /**

--- a/src/core/geometry/qgsrectangle.h
+++ b/src/core/geometry/qgsrectangle.h
@@ -19,6 +19,7 @@
 #define QGSRECTANGLE_H
 
 #include "qgis_core.h"
+#include "qgis.h"
 #include <iosfwd>
 #include <QDomDocument>
 #include <QRectF>

--- a/src/core/geometry/qgsreferencedgeometry.h
+++ b/src/core/geometry/qgsreferencedgeometry.h
@@ -18,7 +18,6 @@
 #ifndef QGSREFERENCEDGEOMETRY_H
 #define QGSREFERENCEDGEOMETRY_H
 
-#include "qgis.h"
 #include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgscoordinatereferencesystem.h"

--- a/src/core/geometry/qgssurface.h
+++ b/src/core/geometry/qgssurface.h
@@ -19,7 +19,7 @@
 #define QGSSURFACE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsabstractgeometry.h"
 #include "qgsrectangle.h"
 

--- a/src/core/geometry/qgstriangle.h
+++ b/src/core/geometry/qgstriangle.h
@@ -19,7 +19,7 @@
 #define QGSTRIANGLE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspolygon.h"
 #include "qgscircle.h"
 #include "qgslinestring.h"

--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -17,7 +17,7 @@
 
 #include "qgis_core.h"
 #include "qgswkbtypes.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsexception.h"
 #include "qpolygon.h"
 

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -17,7 +17,7 @@
 #define QGSLAYERTREEGROUP_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayertreenode.h"
 
 class QgsMapLayer;

--- a/src/core/layertree/qgslayertreelayer.h
+++ b/src/core/layertree/qgslayertreelayer.h
@@ -17,7 +17,7 @@
 #define QGSLAYERTREELAYER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayertreenode.h"
 #include "qgsmaplayerref.h"
 #include "qgsreadwritecontext.h"

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -24,7 +24,7 @@
 
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgsrasterdataprovider.h" // for QgsImageFetcher dtor visibility
 

--- a/src/core/layertree/qgslayertreenode.h
+++ b/src/core/layertree/qgslayertreenode.h
@@ -21,7 +21,7 @@
 
 #include "qgsobjectcustomproperties.h"
 #include "qgsreadwritecontext.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QDomElement;
 

--- a/src/core/layertree/qgslayertreeregistrybridge.h
+++ b/src/core/layertree/qgslayertreeregistrybridge.h
@@ -20,7 +20,7 @@
 #include <QStringList>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsLayerTreeGroup;
 class QgsLayerTreeNode;

--- a/src/core/layout/qgscompositionconverter.h
+++ b/src/core/layout/qgscompositionconverter.h
@@ -20,7 +20,6 @@
 #include <QDomDocument>
 #include <QDomElement>
 
-#include "qgis.h"
 #include "qgis_sip.h"
 
 #define SIP_NO_FILE

--- a/src/core/layout/qgslayoutframe.h
+++ b/src/core/layout/qgslayoutframe.h
@@ -17,7 +17,7 @@
 #define QGSLAYOUTFRAME_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayoutitem.h"
 
 class QgsLayout;

--- a/src/core/layout/qgslayoutitemattributetable.h
+++ b/src/core/layout/qgslayoutitemattributetable.h
@@ -20,7 +20,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "qgslayouttable.h"
 #include "qgsvectorlayerref.h"
 

--- a/src/core/layout/qgslayoutitemhtml.h
+++ b/src/core/layout/qgslayoutitemhtml.h
@@ -17,7 +17,7 @@
 #define QGSLAYOUTITEMHTML_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayoutmultiframe.h"
 #include "qgsfeature.h"
 #include "qgsdistancearea.h"

--- a/src/core/layout/qgslayoutitemlegend.h
+++ b/src/core/layout/qgslayoutitemlegend.h
@@ -19,7 +19,7 @@
 #define QGSLAYOUTITEMLEGEND_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayoutitem.h"
 #include "qgslayertreemodel.h"
 #include "qgslegendsettings.h"

--- a/src/core/layout/qgslayoutitemmapgrid.h
+++ b/src/core/layout/qgslayoutitemmapgrid.h
@@ -20,7 +20,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "qgslayoutitemmapitem.h"
 #include "qgssymbol.h"
 #include <QPainter>

--- a/src/core/layout/qgslayoutitemmapoverview.h
+++ b/src/core/layout/qgslayoutitemmapoverview.h
@@ -20,7 +20,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "qgslayoutitemmapitem.h"
 #include "qgssymbol.h"
 #include <QString>

--- a/src/core/layout/qgslayoutitemscalebar.h
+++ b/src/core/layout/qgslayoutitemscalebar.h
@@ -17,7 +17,7 @@
 #define QGSLAYOUTITEMSCALEBAR_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayoutitem.h"
 #include "scalebar/qgsscalebarsettings.h"
 #include "scalebar/qgsscalebarrenderer.h"

--- a/src/core/layout/qgslayoutitemtexttable.h
+++ b/src/core/layout/qgslayoutitemtexttable.h
@@ -19,7 +19,7 @@
 #define QGSLAYOUTTEXTTABLE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayouttable.h"
 
 /**

--- a/src/core/layout/qgslayoutmanager.h
+++ b/src/core/layout/qgslayoutmanager.h
@@ -17,7 +17,7 @@
 #define QGSLAYOUTMANAGER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmasterlayoutinterface.h"
 #include <QObject>
 

--- a/src/core/layout/qgslayoutmeasurement.cpp
+++ b/src/core/layout/qgslayoutmeasurement.cpp
@@ -16,7 +16,7 @@
  ***************************************************************************/
 
 #include "qgslayoutmeasurement.h"
-
+#include "qgis.h"
 #include <QStringList>
 
 QgsLayoutMeasurement::QgsLayoutMeasurement( const double length, const QgsUnitTypes::LayoutUnit units )

--- a/src/core/layout/qgslayoutmodel.h
+++ b/src/core/layout/qgslayoutmodel.h
@@ -19,7 +19,7 @@
 #define QGSLAYOUTMODEL_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayoutitemregistry.h"
 
 #include <QAbstractItemModel>

--- a/src/core/layout/qgslayoutmultiframe.h
+++ b/src/core/layout/qgslayoutmultiframe.h
@@ -17,7 +17,7 @@
 #define QGSLAYOUTMULTIFRAME_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayoutobject.h"
 #include "qgslayoutundocommand.h"
 #include "qgsapplication.h"

--- a/src/core/layout/qgslayoutserializableobject.h
+++ b/src/core/layout/qgslayoutserializableobject.h
@@ -18,7 +18,7 @@
 #ifndef QGSLAYOUTSERIALIZABLEOBJECT_H
 #define QGSLAYOUTSERIALIZABLEOBJECT_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgslayoutundocommand.h"
 

--- a/src/core/layout/qgslayouttable.h
+++ b/src/core/layout/qgslayouttable.h
@@ -20,7 +20,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "qgslayoutmultiframe.h"
 #include <QFont>
 #include <QColor>

--- a/src/core/layout/qgslayoutundocommand.h
+++ b/src/core/layout/qgslayoutundocommand.h
@@ -19,7 +19,7 @@
 #define QGSLAYOUTUNDOCOMMAND_H
 
 #include <QUndoCommand>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QDomDocument>
 
 #include "qgis_core.h"

--- a/src/core/layout/qgslayoutundostack.h
+++ b/src/core/layout/qgslayoutundostack.h
@@ -18,7 +18,7 @@
 #ifndef QGSLAYOUTUNDOSTACK_H
 #define QGSLAYOUTUNDOSTACK_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgslayoutundocommand.h"
 #include "qgslayoutitem.h"

--- a/src/core/layout/qgspagesizeregistry.cpp
+++ b/src/core/layout/qgspagesizeregistry.cpp
@@ -16,6 +16,7 @@
 
 #include "qgspagesizeregistry.h"
 #include "qgslayoutmeasurementconverter.h"
+#include "qgis.h"
 
 //
 // QgsPageSizeRegistry

--- a/src/core/metadata/qgsabstractmetadatabase.h
+++ b/src/core/metadata/qgsabstractmetadatabase.h
@@ -18,8 +18,11 @@
 #ifndef QGSABSTRACTMETADATABASE_H
 #define QGSABSTRACTMETADATABASE_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
+#include <QMap>
+#include <QString>
+#include <QMetaType>
 
 class QDomElement;
 class QDomDocument;

--- a/src/core/metadata/qgslayermetadata.h
+++ b/src/core/metadata/qgslayermetadata.h
@@ -18,7 +18,7 @@
 #ifndef QGSLAYERMETADATA_H
 #define QGSLAYERMETADATA_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsbox3d.h"

--- a/src/core/metadata/qgslayermetadataformatter.h
+++ b/src/core/metadata/qgslayermetadataformatter.h
@@ -20,7 +20,7 @@
 
 #include <QCoreApplication>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgslayermetadata.h"
 

--- a/src/core/metadata/qgslayermetadatavalidator.h
+++ b/src/core/metadata/qgslayermetadatavalidator.h
@@ -18,8 +18,10 @@
 #ifndef QGSLAYERMETADATAVALIDATOR_H
 #define QGSLAYERMETADATAVALIDATOR_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
+#include <QString>
+#include <QVariant>
 
 class QgsAbstractMetadataBase;
 class QgsLayerMetadata;

--- a/src/core/metadata/qgsprojectmetadata.h
+++ b/src/core/metadata/qgsprojectmetadata.h
@@ -18,7 +18,7 @@
 #ifndef QGSPROJECTMETADATA_H
 #define QGSPROJECTMETADATA_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgsabstractmetadatabase.h"
 

--- a/src/core/processing/qgsprocessing.h
+++ b/src/core/processing/qgsprocessing.h
@@ -19,7 +19,6 @@
 #define QGSPROCESSING_H
 
 #include "qgis_core.h"
-#include "qgis.h"
 
 //
 // Output definitions

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -20,7 +20,7 @@
 #include <QEvent>
 #include <QStringList>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsconfig.h"
 #include "qgstranslationcontext.h"
 

--- a/src/core/qgsattributes.cpp
+++ b/src/core/qgsattributes.cpp
@@ -15,7 +15,7 @@
  ***************************************************************************/
 
 #include "qgsattributes.h"
-
+#include "qgis.h"
 
 
 QgsAttributeMap QgsAttributes::toMap() const

--- a/src/core/qgsattributes.h
+++ b/src/core/qgsattributes.h
@@ -19,7 +19,7 @@
 #define QGSATTRIBUTES_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include <QMap>
 #include <QString>

--- a/src/core/qgsattributetableconfig.h
+++ b/src/core/qgsattributetableconfig.h
@@ -21,7 +21,7 @@
 #include <QDomNode>
 #include <QVariant>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 
 class QgsFields;

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -20,7 +20,7 @@
 #define QGSCLIPPER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspointxy.h"
 #include "qgsrectangle.h"
 

--- a/src/core/qgscolorscheme.h
+++ b/src/core/qgscolorscheme.h
@@ -24,7 +24,7 @@
 #include <QObject>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup core

--- a/src/core/qgscoordinateformatter.h
+++ b/src/core/qgscoordinateformatter.h
@@ -19,7 +19,7 @@
 #define QGSCOORDINATEFORMATTER_H
 
 #include <QString>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspointxy.h"
 
 /**

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -28,9 +28,10 @@
 #include <QHash>
 #include <QReadWriteLock>
 #include <QExplicitlySharedDataPointer>
+#include <QObject>
 
 //qgis includes
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsunittypes.h"
 #include "qgsrectangle.h"
 #include "qgssqliteutils.h"

--- a/src/core/qgscoordinatetransformcontext.h
+++ b/src/core/qgscoordinatetransformcontext.h
@@ -19,7 +19,7 @@
 #define QGSCOORDINATETRANSFORMCONTEXT_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsdatumtransform.h"
 
 #include <QExplicitlySharedDataPointer>

--- a/src/core/qgscredentials.h
+++ b/src/core/qgscredentials.h
@@ -24,7 +24,7 @@
 #include <QString>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup core

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -17,7 +17,7 @@
 #ifndef QGSDATAITEM_H
 #define QGSDATAITEM_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include <QFileSystemWatcher>
 #include <QFutureWatcher>

--- a/src/core/qgsdataitemprovider.h
+++ b/src/core/qgsdataitemprovider.h
@@ -17,7 +17,7 @@
 #define QGSDATAITEMPROVIDER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsdataitem.h"
 
 class QgsDataItem;

--- a/src/core/qgsdataitemproviderregistry.h
+++ b/src/core/qgsdataitemproviderregistry.h
@@ -17,7 +17,7 @@
 #define QGSDATAITEMPROVIDERREGISTRY_H
 
 #include <QList>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgis_core.h"
 

--- a/src/core/qgsdatetimestatisticalsummary.h
+++ b/src/core/qgsdatetimestatisticalsummary.h
@@ -17,7 +17,7 @@
 #define QGSDATETIMESTATISTICALSUMMARY_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsinterval.h"
 #include <QSet>
 #include <QDateTime>

--- a/src/core/qgsdbfilterproxymodel.h
+++ b/src/core/qgsdbfilterproxymodel.h
@@ -19,7 +19,7 @@
 #define QGSDBFILTERPROXYMODEL_H
 
 #include <QSortFilterProxyModel>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgis_core.h"
 

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -16,7 +16,7 @@
 #define QGSDIAGRAMRENDERER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QColor>
 #include <QFont>
 #include <QList>

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -19,7 +19,7 @@
 #define QGSEDITFORMCONFIG_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QMap>
 #include <QDomElement>
 #include <QDomDocument>

--- a/src/core/qgsellipsoidutils.h
+++ b/src/core/qgsellipsoidutils.h
@@ -17,7 +17,7 @@
 #define QGSELLIPSOIDUTILS_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgscoordinatereferencesystem.h"
 #include <QStringList>
 

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -17,7 +17,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <QVariant>
 #include <QHash>
 #include <QString>

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -17,7 +17,7 @@ email                : sherman at mrcc.com
 #define QGSFEATURE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include <QExplicitlySharedDataPointer>
 #include <QList>

--- a/src/core/qgsfeaturefilterprovider.h
+++ b/src/core/qgsfeaturefilterprovider.h
@@ -19,7 +19,7 @@
 #define QGSFEATUREFILTERPROVIDER_H
 
 #include <QtGlobal>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgis_core.h"
 

--- a/src/core/qgsfeaturesink.h
+++ b/src/core/qgsfeaturesink.h
@@ -19,7 +19,7 @@
 #define QGSFEATURESINK_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeature.h"
 #include "qgsfeatureiterator.h"
 

--- a/src/core/qgsfeaturesource.h
+++ b/src/core/qgsfeaturesource.h
@@ -19,7 +19,7 @@
 #define QGSFEATURESOURCE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeaturerequest.h"
 
 class QgsFeatureIterator;

--- a/src/core/qgsfeaturestore.h
+++ b/src/core/qgsfeaturestore.h
@@ -16,7 +16,7 @@
 #define QGSFEATURESTORE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeature.h"
 #include "qgsfields.h"
 #include "qgsfeaturesink.h"

--- a/src/core/qgsfeedback.h
+++ b/src/core/qgsfeedback.h
@@ -19,7 +19,7 @@
 #include <QObject>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup core

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -22,7 +22,7 @@
 #include <QSharedDataPointer>
 #include "qgsfield_p.h"
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 typedef QList<int> QgsAttributeList SIP_SKIP;
 

--- a/src/core/qgsfieldformatterregistry.h
+++ b/src/core/qgsfieldformatterregistry.h
@@ -20,7 +20,7 @@
 #include <QString>
 #include <QObject>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 
 class QgsFieldFormatter;

--- a/src/core/qgsfieldmodel.h
+++ b/src/core/qgsfieldmodel.h
@@ -23,7 +23,7 @@
 #include "qgsfields.h"
 #include "qgis_core.h"
 
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsVectorLayer;
 

--- a/src/core/qgsfieldproxymodel.h
+++ b/src/core/qgsfieldproxymodel.h
@@ -20,7 +20,7 @@
 
 #include "qgis_core.h"
 
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsFieldModel;
 

--- a/src/core/qgsfields.h
+++ b/src/core/qgsfields.h
@@ -17,7 +17,7 @@
 #define QGSFIELDS_H
 
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgsfield.h"
 

--- a/src/core/qgsfileutils.cpp
+++ b/src/core/qgsfileutils.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgsfileutils.h"
+#include "qgis.h"
 #include <QObject>
 #include <QRegularExpression>
 #include <QFileInfo>

--- a/src/core/qgsfileutils.h
+++ b/src/core/qgsfileutils.h
@@ -18,7 +18,8 @@
 #ifndef QGSFILEUTILS_H
 #define QGSFILEUTILS_H
 
-#include "qgis.h"
+#include "qgis_core.h"
+#include <QString>
 
 /**
  * \ingroup core

--- a/src/core/qgsfontutils.cpp
+++ b/src/core/qgsfontutils.cpp
@@ -18,6 +18,7 @@
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgssettings.h"
+#include "qgis.h"
 
 #include <QApplication>
 #include <QFile>

--- a/src/core/qgsgeometryvalidator.h
+++ b/src/core/qgsgeometryvalidator.h
@@ -17,7 +17,7 @@ email                : jef at norbit dot de
 #define QGSGEOMETRYVALIDATOR_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QThread>
 #include "qgsgeometry.h"
 

--- a/src/core/qgsgml.h
+++ b/src/core/qgsgml.h
@@ -17,7 +17,7 @@
 
 #include "qgis_core.h"
 #include <expat.h>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfields.h"
 #include "qgsrectangle.h"
 #include "qgswkbptr.h"

--- a/src/core/qgsgmlschema.h
+++ b/src/core/qgsgmlschema.h
@@ -17,7 +17,7 @@
 
 #include "qgis_core.h"
 #include <expat.h>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgserror.h"
 #include "qgsfields.h"
 #include <list>

--- a/src/core/qgshtmlutils.cpp
+++ b/src/core/qgshtmlutils.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 #include "qgshtmlutils.h"
+#include <QStringList>
 
 QString QgsHtmlUtils::buildBulletList( const QStringList &values )
 {

--- a/src/core/qgshtmlutils.h
+++ b/src/core/qgshtmlutils.h
@@ -18,7 +18,9 @@
 #ifndef QGSHTMLUTILS_H
 #define QGSHTMLUTILS_H
 
-#include "qgis.h"
+#include "qgis_core.h"
+#include "qgis_sip.h"
+#include <QString>
 
 /**
  * \ingroup core

--- a/src/core/qgsimagecache.h
+++ b/src/core/qgsimagecache.h
@@ -19,7 +19,7 @@
 #define QGSIMAGECACHE_H
 
 #include "qgsabstractcontentcache.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 
 #include <QElapsedTimer>

--- a/src/core/qgsinterval.h
+++ b/src/core/qgsinterval.h
@@ -24,7 +24,7 @@
 
 #include <QVariant>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 
 class QString;

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -17,7 +17,7 @@
 
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include <QString>
 #include <QVector>

--- a/src/core/qgslegendstyle.cpp
+++ b/src/core/qgslegendstyle.cpp
@@ -18,6 +18,7 @@
 #include "qgslegendstyle.h"
 #include "qgsfontutils.h"
 #include "qgssettings.h"
+#include "qgis.h"
 
 #include <QFont>
 #include <QMap>

--- a/src/core/qgslegendstyle.h
+++ b/src/core/qgslegendstyle.h
@@ -25,7 +25,7 @@
 #include <QDomDocument>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup core

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -28,7 +28,7 @@
 #include <QVariant>
 #include <QIcon>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgserror.h"
 #include "qgsobjectcustomproperties.h"
 #include "qgsrectangle.h"

--- a/src/core/qgsmaplayerlegend.h
+++ b/src/core/qgsmaplayerlegend.h
@@ -17,7 +17,7 @@
 #define QGSMAPLAYERLEGEND_H
 
 #include <QObject>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QDomDocument;
 class QDomElement;

--- a/src/core/qgsmaplayermodel.h
+++ b/src/core/qgsmaplayermodel.h
@@ -21,7 +21,7 @@
 #include <QStringList>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsMapLayer;
 

--- a/src/core/qgsmaplayerproxymodel.h
+++ b/src/core/qgsmaplayerproxymodel.h
@@ -20,7 +20,7 @@
 #include <QStringList>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsMapLayerModel;
 class QgsMapLayer;

--- a/src/core/qgsmaplayerstore.h
+++ b/src/core/qgsmaplayerstore.h
@@ -20,7 +20,7 @@
 #define QGSMAPLAYERSTORE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmaplayer.h"
 #include <QObject>
 

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -18,7 +18,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <QFutureWatcher>
 #include <QImage>
 #include <QPainter>

--- a/src/core/qgsmaprenderertask.h
+++ b/src/core/qgsmaprenderertask.h
@@ -18,7 +18,7 @@
 #ifndef QGSMAPRENDERERTASK_H
 #define QGSMAPRENDERERTASK_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgsannotation.h"
 #include "qgsannotationmanager.h"

--- a/src/core/qgsmaptopixel.h
+++ b/src/core/qgsmaptopixel.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include "qgsunittypes.h"
 #include <cassert>
+#include <memory>
 
 class QgsPointXY;
 class QPoint;

--- a/src/core/qgsmaptopixelgeometrysimplifier.h
+++ b/src/core/qgsmaptopixelgeometrysimplifier.h
@@ -18,9 +18,10 @@
 #define QGSMAPTOPIXELGEOMETRYSIMPLIFIER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsgeometrysimplifier.h"
 #include <QPolygonF>
+#include <memory>
 
 class QgsAbstractGeometry;
 class QgsWkbPtr;

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -19,8 +19,8 @@
 #define QGSNETWORKACCESSMANAGER_H
 
 #include <QList>
-#include "qgis.h"
 #include "qgsnetworkreply.h"
+#include "qgis_sip.h"
 #include <QStringList>
 #include <QNetworkAccessManager>
 #include <QNetworkProxy>

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -23,7 +23,6 @@ class QString;
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <list>
 #include <QVector>
 

--- a/src/core/qgsopenclutils.cpp
+++ b/src/core/qgsopenclutils.cpp
@@ -18,7 +18,6 @@
 #include "qgsmessagelog.h"
 #include "qgslogger.h"
 
-
 #include <QTextStream>
 #include <QFile>
 #include <QDebug>

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -23,7 +23,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <QString>
 #include <QFont>
 #include <QFontDatabase>

--- a/src/core/qgspluginlayerregistry.h
+++ b/src/core/qgspluginlayerregistry.h
@@ -20,7 +20,7 @@
 #define QGSPLUGINLAYERREGSITRY_H
 
 #include <QMap>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QDomNode>
 
 #include "qgis_core.h"

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -23,7 +23,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <memory>
 #include <QHash>
 #include <QList>

--- a/src/core/qgsprojecttranslator.h
+++ b/src/core/qgsprojecttranslator.h
@@ -18,7 +18,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <QString>
 
 /**

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -16,7 +16,7 @@
 #define QGSPROPERTY_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsproperty_p.h"
 #include "qgsexpression.h"
 #include "qgsexpressioncontext.h"

--- a/src/core/qgspropertycollection.h
+++ b/src/core/qgspropertycollection.h
@@ -16,7 +16,7 @@
 #define QGSPROPERTYCOLLECTION_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QString>
 #include <QVariant>
 #include <QColor>

--- a/src/core/qgsprovidermetadata.h
+++ b/src/core/qgsprovidermetadata.h
@@ -21,7 +21,7 @@
 
 
 #include <QString>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsdataprovider.h"
 #include "qgis_core.h"
 #include <functional>

--- a/src/core/qgspythonrunner.h
+++ b/src/core/qgspythonrunner.h
@@ -16,7 +16,7 @@
 #define QGSPYTHONRUNNER_H
 
 #include <QString>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgis_core.h"
 

--- a/src/core/qgsrange.h
+++ b/src/core/qgsrange.h
@@ -18,7 +18,6 @@
 #ifndef QGSRANGE_H
 #define QGSRANGE_H
 
-#include "qgis.h"
 #include "qgis_sip.h"
 #include "qgis_core.h"
 

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -24,7 +24,7 @@
 #include "qgsfields.h"
 #include "qgsreadwritecontext.h"
 
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsFeatureIterator;
 class QgsFeature;

--- a/src/core/qgsrenderchecker.h
+++ b/src/core/qgsrenderchecker.h
@@ -17,7 +17,7 @@
 #define QGSRENDERCHECKER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QDir>
 #include <QString>
 #include <QRegExp>

--- a/src/core/qgsscalecalculator.h
+++ b/src/core/qgsscalecalculator.h
@@ -20,7 +20,7 @@
 #define QGSSCALECALCULATOR_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsunittypes.h"
 
 class QString;

--- a/src/core/qgssettings.h
+++ b/src/core/qgssettings.h
@@ -21,7 +21,7 @@
 #include <QMetaEnum>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslogger.h"
 
 /**

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -18,7 +18,7 @@
 
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmapsettings.h"
 #include "qgstolerance.h"
 #include "qgspointlocator.h"

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -39,7 +39,6 @@ class QgsRectangle;
 class QgsPointXY;
 
 #include "qgis_core.h"
-#include "qgis_sip.h"
 #include "qgsfeaturesink.h"
 #include <QList>
 #include <QSharedDataPointer>

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -19,7 +19,6 @@
 
 #include <QCoreApplication>
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <QMetaType>
 #include <QStringList>
 #include <QVariant>

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -20,7 +20,6 @@
 
 #include <QObject>
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <QMap>
 #include <QFuture>
 #include <QReadWriteLock>

--- a/src/core/qgstessellator.h
+++ b/src/core/qgstessellator.h
@@ -17,7 +17,7 @@
 #define QGSTESSELLATOR_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsPolygon;
 class QgsMultiPolygon;

--- a/src/core/qgstestutils.h
+++ b/src/core/qgstestutils.h
@@ -17,7 +17,7 @@
 #define QGSTESTUTILS_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeaturerequest.h"
 
 class QgsVectorDataProvider;

--- a/src/core/qgstextrenderer.h
+++ b/src/core/qgstextrenderer.h
@@ -17,7 +17,7 @@
 #ifndef QGSTEXTRENDERER_H
 #define QGSTEXTRENDERER_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgsmapunitscale.h"
 #include "qgsunittypes.h"

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -19,7 +19,7 @@
 #define QGSTRANSACTION_H
 
 #include <QSet>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QString>
 #include <QObject>
 #include <QStack>

--- a/src/core/qgstranslationcontext.h
+++ b/src/core/qgstranslationcontext.h
@@ -18,7 +18,9 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
+#include <QList>
+#include <QString>
+
 
 class QgsProject;
 

--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -19,7 +19,8 @@
 #define QGSUNITTYPES_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
+#include <QObject>
 
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with

--- a/src/core/qgsuserprofilemanager.h
+++ b/src/core/qgsuserprofilemanager.h
@@ -19,7 +19,7 @@
 #include <QFileSystemWatcher>
 
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_core.h"
 #include "qgserror.h"
 #include "qgsuserprofile.h"

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -24,7 +24,7 @@ class QTextCodec;
 #include <QHash>
 
 //QGIS Includes
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsdataprovider.h"
 #include "qgsfeature.h"
 #include "qgsaggregatecalculator.h"

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -27,7 +27,7 @@
 #include <QFont>
 #include <QMutex>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmaplayer.h"
 #include "qgsfeature.h"
 #include "qgsfeaturerequest.h"

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -21,7 +21,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "qgsfield.h"
 #include "qgsfeaturerequest.h"
 #include "qgsfeatureiterator.h"

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -17,7 +17,7 @@
 
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsgeometry.h"
 #include "qgsfeatureid.h"
 #include "qgsvectorlayer.h"

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -19,7 +19,7 @@
 #define QGSVECTORLAYEREXPORTER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeature.h"
 #include "qgsfeaturesink.h"
 #include "qgstaskmanager.h"

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -19,7 +19,7 @@
 #define QGSVECTORLAYERJOINBUFFER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsvectorlayerjoininfo.h"
 #include "qgsfeaturesink.h"
 

--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -34,7 +34,7 @@ class QgsSingleSymbolRenderer;
 
 typedef QList<int> QgsAttributeList;
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfields.h"  // QgsFields
 #include "qgsfeatureiterator.h"
 #include "qgsvectorsimplifymethod.h"

--- a/src/core/qgsvectorlayertools.h
+++ b/src/core/qgsvectorlayertools.h
@@ -17,7 +17,7 @@
 #define QGSVECTORLAYERTOOLS_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QObject>
 
 #include "qgsfeature.h"

--- a/src/core/qgsvectorlayerundocommand.h
+++ b/src/core/qgsvectorlayerundocommand.h
@@ -17,7 +17,7 @@
 #define QGSVECTORLAYERUNDOCOMMAND_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QUndoCommand>
 
 #include <QVariant>

--- a/src/core/qgsxmlutils.h
+++ b/src/core/qgsxmlutils.h
@@ -20,9 +20,10 @@ class QDomDocument;
 class QgsRectangle;
 
 #include <QDomElement>
+#include <QMetaEnum>
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsunittypes.h"
 
 

--- a/src/core/qgsziputils.h
+++ b/src/core/qgsziputils.h
@@ -17,7 +17,7 @@
 #define QGSZIPUTILS_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QStringList>
 
 #ifdef SIP_RUN

--- a/src/core/raster/qgsbrightnesscontrastfilter.h
+++ b/src/core/raster/qgsbrightnesscontrastfilter.h
@@ -19,7 +19,7 @@
 #define QGSBRIGHTNESSCONTRASTFILTER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrasterinterface.h"
 
 class QDomElement;

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -22,7 +22,7 @@ originally part of the larger QgsRasterLayer class
 #define QGSCOLORRAMPSHADER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QColor>
 #include <QVector>
 #include <memory>

--- a/src/core/raster/qgscontrastenhancement.h
+++ b/src/core/raster/qgscontrastenhancement.h
@@ -24,7 +24,7 @@ class originally created circa 2004 by T.Sutton, Gary E.Sherman, Steve Halasz
 #include "qgis_core.h"
 #include <limits>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsraster.h"
 #include <memory>
 

--- a/src/core/raster/qgscubicrasterresampler.cpp
+++ b/src/core/raster/qgscubicrasterresampler.cpp
@@ -17,6 +17,7 @@
 
 #include "qgscubicrasterresampler.h"
 #include <QImage>
+#include <cmath>
 
 QgsCubicRasterResampler *QgsCubicRasterResampler::clone() const
 {

--- a/src/core/raster/qgshillshaderenderer.h
+++ b/src/core/raster/qgshillshaderenderer.h
@@ -20,7 +20,7 @@
 
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrasterrenderer.h"
 
 class QgsRasterBlock;

--- a/src/core/raster/qgshuesaturationfilter.h
+++ b/src/core/raster/qgshuesaturationfilter.h
@@ -19,7 +19,7 @@
 #define QGSHUESATURATIONFILTER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrasterinterface.h"
 
 class QDomElement;

--- a/src/core/raster/qgsmultibandcolorrenderer.h
+++ b/src/core/raster/qgsmultibandcolorrenderer.h
@@ -19,7 +19,7 @@
 #define QGSMULTIBANDCOLORRENDERER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrasterrenderer.h"
 
 class QgsContrastEnhancement;

--- a/src/core/raster/qgspalettedrasterrenderer.h
+++ b/src/core/raster/qgspalettedrasterrenderer.h
@@ -19,7 +19,7 @@
 #define QGSPALETTEDRASTERRENDERER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QVector>
 
 #include "qgsrasterrenderer.h"

--- a/src/core/raster/qgsrasteridentifyresult.h
+++ b/src/core/raster/qgsrasteridentifyresult.h
@@ -19,7 +19,7 @@
 #define QGSRASTERIDENTIFYRESULT_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsraster.h"
 #include "qgserror.h"
 

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -19,7 +19,6 @@
 #define QGSRASTERINTERFACE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
 #include "qgis_sip.h"
 #include <limits>
 

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -30,7 +30,7 @@
 #include <QPair>
 #include <QVector>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmaplayer.h"
 #include "qgsraster.h"
 #include "qgsrasterdataprovider.h"

--- a/src/core/raster/qgsrasterminmaxorigin.cpp
+++ b/src/core/raster/qgsrasterminmaxorigin.cpp
@@ -20,6 +20,7 @@
 
 #include <QDomDocument>
 #include <QDomElement>
+#include <cmath>
 
 QgsRasterMinMaxOrigin::QgsRasterMinMaxOrigin()
   : mCumulativeCutLower( CUMULATIVE_CUT_LOWER )

--- a/src/core/raster/qgsrasterminmaxorigin.h
+++ b/src/core/raster/qgsrasterminmaxorigin.h
@@ -19,7 +19,7 @@
 #define QGSRASTERMINMAXORIGIN_H
 
 #include <QDomDocument>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QDomElement>
 
 #include "qgis_core.h"

--- a/src/core/raster/qgsrasterpipe.h
+++ b/src/core/raster/qgsrasterpipe.h
@@ -19,7 +19,7 @@
 #define QGSRASTERPIPE_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QImage>
 #include <QMap>
 #include <QObject>

--- a/src/core/raster/qgsrasterresamplefilter.h
+++ b/src/core/raster/qgsrasterresamplefilter.h
@@ -19,7 +19,7 @@
 #define QGSRASTERRESAMPLEFILTER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrasterinterface.h"
 #include "qgsrasterresampler.h"
 

--- a/src/core/raster/qgsrasterresampler.h
+++ b/src/core/raster/qgsrasterresampler.h
@@ -19,8 +19,10 @@
 #define QGSRASTERRESAMPLER_H
 
 #include <QString>
-#include "qgis.h"
+#include "qgis_core.h"
+#include "qgis_sip.h"
 
+class QString;
 class QImage;
 
 /**

--- a/src/core/raster/qgssinglebandgrayrenderer.h
+++ b/src/core/raster/qgssinglebandgrayrenderer.h
@@ -19,7 +19,7 @@
 #define QGSSINGLEBANDGRAYRENDERER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrasterrenderer.h"
 #include <memory>
 

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.h
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.h
@@ -19,7 +19,7 @@
 #define QGSSINGLEBANDPSEUDOCOLORRENDERER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgscolorramp.h"
 #include "qgscolorrampshader.h"
 #include "qgsrasterrenderer.h"

--- a/src/core/symbology/qgsheatmaprenderer.h
+++ b/src/core/symbology/qgsheatmaprenderer.h
@@ -16,7 +16,7 @@
 #define QGSHEATMAPRENDERER_H
 
 #include "qgis_core.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrenderer.h"
 #include "qgssymbol.h"
 #include "qgsexpression.h"

--- a/src/core/symbology/qgsmarkersymbollayer.h
+++ b/src/core/symbology/qgsmarkersymbollayer.h
@@ -18,7 +18,6 @@
 
 #include "qgis_core.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "qgssymbollayer.h"
 
 #define DEFAULT_SIMPLEMARKER_NAME         "circle"

--- a/src/core/symbology/qgssvgcache.h
+++ b/src/core/symbology/qgssvgcache.h
@@ -20,7 +20,6 @@
 
 #include "qgsabstractcontentcache.h"
 #include "qgis.h"
-#include "qgis_core.h"
 
 #include <QPicture>
 

--- a/src/core/symbology/qgssymbollayer.h
+++ b/src/core/symbology/qgssymbollayer.h
@@ -19,7 +19,7 @@
 #define DEFAULT_SCALE_METHOD              QgsSymbol::ScaleDiameter
 
 #include "qgis_core.h"
-#include "qgis.h"
+// #include "qgis.h"
 #include <QColor>
 #include <QMap>
 #include <QPointF>

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -18,7 +18,6 @@
 #define QGSATTRIBUTETABLEFILTERMODEL_H
 
 #include <QSortFilterProxyModel>
-#include "qgis.h"
 #include <QModelIndex>
 
 #include "qgsattributetablemodel.h"

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -17,7 +17,6 @@
 #define QGSATTRIBUTETABLEVIEW_H
 
 #include <QTableView>
-#include "qgis.h"
 #include <QAction>
 #include "qgsfeatureid.h"
 

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -17,7 +17,6 @@
 #define QGSDUALVIEW_H
 
 #include <QStackedWidget>
-#include "qgis.h"
 
 #include "ui_qgsdualviewbase.h"
 

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -16,7 +16,6 @@
 #define QGSATTRIBUTEEDITORMODEL_H
 
 #include "qgsexpression.h"
-#include "qgis.h"
 
 #include <QSortFilterProxyModel>
 #include <QVariant>

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -18,7 +18,6 @@
 
 #include <QListView>
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <qdebug.h>
 #include "qgsactionmenu.h"
 

--- a/src/gui/attributetable/qgsfeatureselectionmodel.h
+++ b/src/gui/attributetable/qgsfeatureselectionmodel.h
@@ -16,7 +16,6 @@
 #define QGSFEATURESELECTIONMODEL_H
 
 #include <QItemSelectionModel>
-#include "qgis.h"
 #include "qgsfeatureid.h"
 
 #include "qgis_gui.h"

--- a/src/gui/attributetable/qgsfieldconditionalformatwidget.h
+++ b/src/gui/attributetable/qgsfieldconditionalformatwidget.h
@@ -16,7 +16,6 @@
 #define QGSFIELDCONDITIONALFORMATWIDGET_H
 
 #include <QWidget>
-#include "qgis.h"
 #include <QStandardItemModel>
 #include <QStandardItem>
 
@@ -37,7 +36,6 @@ class GUI_EXPORT QgsFieldConditionalFormatWidget : public QWidget, private Ui::Q
 
     /**
      * Constructor for QgsFieldConditionalFormatWidget.
-     * \param parent parent widget
      */
     explicit QgsFieldConditionalFormatWidget( QWidget *parent SIP_TRANSFERTHIS = nullptr );
 

--- a/src/gui/auth/qgsauthauthoritieseditor.h
+++ b/src/gui/auth/qgsauthauthoritieseditor.h
@@ -18,7 +18,7 @@
 #define QGSAUTHAUTHORITIESEDITOR_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QSslCertificate>
 
 #include "ui_qgsauthauthoritieseditor.h"

--- a/src/gui/auth/qgsauthcertificateinfo.h
+++ b/src/gui/auth/qgsauthcertificateinfo.h
@@ -19,7 +19,7 @@
 #define QGSAUTHCERTIFICATEINFO_H
 
 #include <QFile>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #ifndef QT_NO_SSL
 #include <QtCrypto>

--- a/src/gui/auth/qgsauthcertificatemanager.h
+++ b/src/gui/auth/qgsauthcertificatemanager.h
@@ -18,7 +18,7 @@
 #define QGSAUTHCERTIFICATEMANAGER_H
 
 #include "ui_qgsauthcertificatemanager.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include <QWidget>
 #include <QDialog>

--- a/src/gui/auth/qgsauthcerttrustpolicycombobox.h
+++ b/src/gui/auth/qgsauthcerttrustpolicycombobox.h
@@ -18,7 +18,7 @@
 #define QGSAUTHCERTTRUSTPOLICYCOMBOBOX_H
 
 #include <QComboBox>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsauthcertutils.h"
 #include "qgis_gui.h"
 

--- a/src/gui/auth/qgsauthconfigeditor.h
+++ b/src/gui/auth/qgsauthconfigeditor.h
@@ -18,7 +18,7 @@
 #define QGSAUTHCONFIGEDITOR_H
 
 #include <QSqlTableModel>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QWidget>
 
 #include "ui_qgsauthconfigeditor.h"

--- a/src/gui/auth/qgsauthconfigselect.h
+++ b/src/gui/auth/qgsauthconfigselect.h
@@ -19,7 +19,7 @@
 
 #include <QWidget>
 #include <QLabel>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "ui_qgsauthconfigselect.h"
 #include "qgsauthconfig.h"

--- a/src/gui/auth/qgsautheditorwidgets.h
+++ b/src/gui/auth/qgsautheditorwidgets.h
@@ -18,7 +18,7 @@
 #define QGSAUTHEDITORWIDGETS_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "ui_qgsautheditorwidgets.h"
 #include "ui_qgsauthmethodplugins.h"
 #include "qgis_gui.h"

--- a/src/gui/auth/qgsauthidentitieseditor.h
+++ b/src/gui/auth/qgsauthidentitieseditor.h
@@ -18,7 +18,7 @@
 #define QGSAUTHIDENTITIESEDITOR_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QSslCertificate>
 
 #include "ui_qgsauthidentitieseditor.h"

--- a/src/gui/auth/qgsauthimportcertdialog.h
+++ b/src/gui/auth/qgsauthimportcertdialog.h
@@ -18,7 +18,7 @@
 #define QGSAUTHIMPORTCERTDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "ui_qgsauthimportcertdialog.h"
 
 #include <QSslCertificate>

--- a/src/gui/auth/qgsauthimportidentitydialog.h
+++ b/src/gui/auth/qgsauthimportidentitydialog.h
@@ -19,7 +19,6 @@
 
 #include <QDialog>
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "ui_qgsauthimportidentitydialog.h"
 
 #include <QSslCertificate>

--- a/src/gui/auth/qgsauthserverseditor.h
+++ b/src/gui/auth/qgsauthserverseditor.h
@@ -18,7 +18,7 @@
 #define QGSAUTHSERVERSEDITOR_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "ui_qgsauthserverseditor.h"
 #include "qgsauthmanager.h"

--- a/src/gui/auth/qgsauthsettingswidget.h
+++ b/src/gui/auth/qgsauthsettingswidget.h
@@ -17,7 +17,7 @@
 #define QGSAUTHSETTINGSWIDGET_H
 
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "ui_qgsauthsettingswidget.h"
 

--- a/src/gui/auth/qgsauthsslconfigwidget.h
+++ b/src/gui/auth/qgsauthsslconfigwidget.h
@@ -18,7 +18,7 @@
 #define QGSAUTHSSLCONFIGWIDGET_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QWidget>
 #include "ui_qgsauthsslconfigwidget.h"
 

--- a/src/gui/auth/qgsauthsslimportdialog.h
+++ b/src/gui/auth/qgsauthsslimportdialog.h
@@ -63,7 +63,7 @@
 #define QGSAUTHSSLIMPORTDIALOG_H
 
 #include "ui_qgsauthsslimportdialog.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include <QDialog>
 #include <QAbstractSocket>

--- a/src/gui/auth/qgsauthtrustedcasdialog.h
+++ b/src/gui/auth/qgsauthtrustedcasdialog.h
@@ -18,7 +18,7 @@
 #define QGSAUTHTRUSTEDCASDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "ui_qgsauthtrustedcasdialog.h"
 
 #include <QSslCertificate>

--- a/src/gui/editorwidgets/core/qgseditorconfigwidget.h
+++ b/src/gui/editorwidgets/core/qgseditorconfigwidget.h
@@ -17,7 +17,7 @@
 #define QGSEDITORCONFIGWIDGET_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 #include "qgseditorwidgetwrapper.h"

--- a/src/gui/editorwidgets/core/qgseditorwidgetautoconf.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetautoconf.h
@@ -16,7 +16,7 @@
 #define QGSEDITORWIDGETAUTOCONF_H
 
 #include <QList>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include <memory>
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetfactory.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetfactory.h
@@ -18,7 +18,6 @@
 
 #include <QDomNode>
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <QMap>
 #include <QString>
 #include <QVariant>

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.h
@@ -18,7 +18,6 @@
 
 #include <QObject>
 #include "qgis_sip.h"
-#include "qgis.h"
 #include <QMap>
 #include "qgseditorwidgetfactory.h"
 #include "qgsattributeeditorcontext.h"

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSEDITORWIDGETWRAPPER_H
 
 #include <QObject>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QMap>
 #include <QVariant>
 

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSSEARCHWIDGETWRAPPER_H
 
 #include <QObject>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QMap>
 #include <QVariant>
 

--- a/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscheckboxsearchwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSCHECKBOXSEARCHWIDGETWRAPPER_H
 
 #include "qgssearchwidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include <QComboBox>
 #include <QListWidget>

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -17,7 +17,7 @@
 #define QGSDATETIMEEDIT_H
 
 #include <QDateTimeEdit>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 /**

--- a/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSDATETIMESEARCHWIDGETWRAPPER_H
 
 #include "qgssearchwidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include <QComboBox>
 #include <QListWidget>

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSDEFAULTSEARCHWIDGETWRAPPER_H
 
 #include "qgssearchwidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfilterlineedit.h"
 
 #include <QCheckBox>

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -17,7 +17,7 @@
 #define QGSDOUBLESPINBOX_H
 
 #include <QDoubleSpinBox>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsSpinBoxLineEdit;

--- a/src/gui/editorwidgets/qgsmultiedittoolbutton.h
+++ b/src/gui/editorwidgets/qgsmultiedittoolbutton.h
@@ -17,7 +17,7 @@
 #define QGSMULTIEDITTOOLBUTTON_H
 
 #include "qgsfields.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QToolButton>
 #include "qgis_gui.h"
 

--- a/src/gui/editorwidgets/qgsqmlwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsqmlwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSQMLWIDGETWRAPPER_H
 
 #include "qgswidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include <QtQuickWidgets/QQuickWidget>
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -17,7 +17,7 @@
 #define QGSRELATIONREFERENCEWIDGET_H
 
 #include "qgsattributeeditorcontext.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeature.h"
 
 #include <QComboBox>

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSRELATIONREFERENCEWIDGETWRAPPER_H
 
 #include "qgseditorwidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsRelationReferenceWidget;

--- a/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSRELATIONWIDGETWRAPPER_H
 
 #include "qgswidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsRelationEditorWidget;

--- a/src/gui/editorwidgets/qgssearchwidgettoolbutton.h
+++ b/src/gui/editorwidgets/qgssearchwidgettoolbutton.h
@@ -17,7 +17,7 @@
 #define QGSSEARCHWIDGETTOOLBUTTON_H
 
 #include "editorwidgets/core/qgssearchwidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QToolButton>
 #include "qgis_gui.h"
 

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -17,7 +17,7 @@
 #define QGSSPINBOX_H
 
 #include <QSpinBox>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsSpinBoxLineEdit;

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSVALUEMAPSEARCHWIDGETWRAPPER_H
 
 #include "qgssearchwidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QComboBox>
 #include "qgis_gui.h"
 

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.h
@@ -17,7 +17,7 @@
 #define QGSVALUERELATIONSEARCHWIDGETWRAPPER_H
 
 #include "qgssearchwidgetwrapper.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsvaluerelationfieldformatter.h"
 
 #include <QComboBox>

--- a/src/gui/layout/qgslayoutitemcombobox.h
+++ b/src/gui/layout/qgslayoutitemcombobox.h
@@ -17,7 +17,7 @@
 #define QGSLAYOUTITEMCOMBOBOX_H
 
 #include <QComboBox>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgslayoutitem.h"
 #include "qgslayoutitemregistry.h"
 #include "qgis_gui.h"

--- a/src/gui/layout/qgslayoutnewitempropertiesdialog.h
+++ b/src/gui/layout/qgslayoutnewitempropertiesdialog.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTNEWITEMPROPERTIESDIALOG_H
 #define QGSLAYOUTNEWITEMPROPERTIESDIALOG_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "ui_qgslayoutnewitemproperties.h"
 

--- a/src/gui/layout/qgslayoutunitscombobox.cpp
+++ b/src/gui/layout/qgslayoutunitscombobox.cpp
@@ -15,6 +15,7 @@
 
 #include "qgslayoutunitscombobox.h"
 #include "qgslayoutmeasurementconverter.h"
+#include "qgis.h"
 
 QgsLayoutUnitsComboBox::QgsLayoutUnitsComboBox( QWidget *parent )
   : QComboBox( parent )

--- a/src/gui/layout/qgslayoutview.h
+++ b/src/gui/layout/qgslayoutview.h
@@ -17,7 +17,7 @@
 #ifndef QGSLAYOUTVIEW_H
 #define QGSLAYOUTVIEW_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsprevieweffect.h" // for QgsPreviewEffect::PreviewMode
 #include "qgis_gui.h"
 #include "qgslayoutitempage.h"

--- a/src/gui/layout/qgslayoutviewtool.h
+++ b/src/gui/layout/qgslayoutviewtool.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOL_H
 #define QGSLAYOUTVIEWTOOL_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include <QCursor>
 #include <QAction>

--- a/src/gui/layout/qgslayoutviewtooladditem.h
+++ b/src/gui/layout/qgslayoutviewtooladditem.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLADDITEM_H
 #define QGSLAYOUTVIEWTOOLADDITEM_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 #include "qgslayoutviewrubberband.h"

--- a/src/gui/layout/qgslayoutviewtooladdnodeitem.h
+++ b/src/gui/layout/qgslayoutviewtooladdnodeitem.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLADDNODEITEM_H
 #define QGSLAYOUTVIEWTOOLADDNODEITEM_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 #include <memory>

--- a/src/gui/layout/qgslayoutviewtooleditnodes.h
+++ b/src/gui/layout/qgslayoutviewtooleditnodes.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLEDITNODES_H
 #define QGSLAYOUTVIEWTOOLEDITNODES_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 

--- a/src/gui/layout/qgslayoutviewtoolmoveitemcontent.h
+++ b/src/gui/layout/qgslayoutviewtoolmoveitemcontent.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLMOVEITEMCONTENT_H
 #define QGSLAYOUTVIEWTOOLMOVEITEMCONTENT_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 

--- a/src/gui/layout/qgslayoutviewtoolpan.h
+++ b/src/gui/layout/qgslayoutviewtoolpan.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLPAN_H
 #define QGSLAYOUTVIEWTOOLPAN_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 

--- a/src/gui/layout/qgslayoutviewtoolselect.h
+++ b/src/gui/layout/qgslayoutviewtoolselect.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLSELECT_H
 #define QGSLAYOUTVIEWTOOLSELECT_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 #include "qgslayoutviewrubberband.h"

--- a/src/gui/layout/qgslayoutviewtooltemporarykeypan.h
+++ b/src/gui/layout/qgslayoutviewtooltemporarykeypan.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLTEMPORARYKEYPAN_H
 #define QGSLAYOUTVIEWTOOLTEMPORARYKEYPAN_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 

--- a/src/gui/layout/qgslayoutviewtooltemporarykeyzoom.h
+++ b/src/gui/layout/qgslayoutviewtooltemporarykeyzoom.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLTEMPORARYKEYZOOM_H
 #define QGSLAYOUTVIEWTOOLTEMPORARYKEYZOOM_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtoolzoom.h"
 #include "qgslayoutviewrubberband.h"

--- a/src/gui/layout/qgslayoutviewtooltemporarymousepan.h
+++ b/src/gui/layout/qgslayoutviewtooltemporarymousepan.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLTEMPORARYMOUSEPAN_H
 #define QGSLAYOUTVIEWTOOLTEMPORARYMOUSEPAN_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 

--- a/src/gui/layout/qgslayoutviewtoolzoom.h
+++ b/src/gui/layout/qgslayoutviewtoolzoom.h
@@ -16,7 +16,7 @@
 #ifndef QGSLAYOUTVIEWTOOLZOOM_H
 #define QGSLAYOUTVIEWTOOLZOOM_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgslayoutviewtool.h"
 #include "qgslayoutviewrubberband.h"

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -55,7 +55,7 @@ class QgsBrowserModel;
 #include <QPair>
 #include <map>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsmaplayer.h"
 #include "qgis_gui.h"
 

--- a/src/gui/qgsabstractdatasourcewidget.h
+++ b/src/gui/qgsabstractdatasourcewidget.h
@@ -20,7 +20,6 @@
 #define QGSABSTRACTDATASOURCEWIDGET_H
 
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "qgis_gui.h"
 
 #include "qgsproviderregistry.h"

--- a/src/gui/qgsactionmenu.h
+++ b/src/gui/qgsactionmenu.h
@@ -17,7 +17,7 @@
 #define QGSACTIONMENU_H
 
 #include <QMenu>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QSignalMapper>
 
 #include "qgsfeature.h"

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -22,7 +22,7 @@
 
 #include "ui_qgsadvanceddigitizingdockwidgetbase.h"
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsdockwidget.h"
 #include "qgsmessagebaritem.h"
 #include "qgspointxy.h"

--- a/src/gui/qgsaggregatetoolbutton.cpp
+++ b/src/gui/qgsaggregatetoolbutton.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsaggregatetoolbutton.h"
 #include "qgsaggregatecalculator.h"
+#include "qgis.h"
 
 #include <QMenu>
 

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -18,7 +18,7 @@
 #define QGSATTRIBUTEDIALOG_H
 
 #include "qgsattributeeditorcontext.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsattributeform.h"
 #include "qgstrackedvectorlayertools.h"
 #include "qgsactionmenu.h"

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -17,7 +17,7 @@
 #define QGSATTRIBUTEFORM_H
 
 #include "qgsfeature.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsattributeeditorcontext.h"
 #include "qgseditorwidgetwrapper.h"
 

--- a/src/gui/qgsattributeformwidget.h
+++ b/src/gui/qgsattributeformwidget.h
@@ -15,7 +15,7 @@
 #ifndef QGSATTRIBUTEFORMWIDGET_H
 #define QGSATTRIBUTEFORMWIDGET_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgsattributeeditorcontext.h"
 #include "qgssearchwidgetwrapper.h"

--- a/src/gui/qgsblendmodecombobox.h
+++ b/src/gui/qgsblendmodecombobox.h
@@ -19,7 +19,7 @@
 #define QGSBLENDMODECOMBOBOX_H
 
 #include <QComboBox>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QPainter> // For QPainter::CompositionMode enum
 #include "qgis_gui.h"
 

--- a/src/gui/qgsbrowsertreeview.h
+++ b/src/gui/qgsbrowsertreeview.h
@@ -17,7 +17,7 @@
 #define QGSBROWSERTREEVIEW_H
 
 #include <QTreeView>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsBrowserModel;

--- a/src/gui/qgscheckablecombobox.h
+++ b/src/gui/qgscheckablecombobox.h
@@ -23,7 +23,7 @@
 #include <QStandardItemModel>
 #include <QStyledItemDelegate>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QEvent;

--- a/src/gui/qgscodeeditor.h
+++ b/src/gui/qgscodeeditor.h
@@ -20,7 +20,7 @@
 #include <QString>
 // qscintilla includes
 #include <Qsci/qsciapis.h>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 

--- a/src/gui/qgscollapsiblegroupbox.h
+++ b/src/gui/qgscollapsiblegroupbox.h
@@ -22,7 +22,7 @@
 #include <QPointer>
 #include <QToolButton>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgssettings.h"
 #include "qgis_gui.h"
 

--- a/src/gui/qgscolorbrewercolorrampdialog.h
+++ b/src/gui/qgscolorbrewercolorrampdialog.h
@@ -21,7 +21,7 @@
 #include "qgscolorramp.h"
 #include "ui_qgscolorbrewercolorrampwidgetbase.h"
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsColorBrewerColorRamp;
 

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -19,7 +19,7 @@
 #include <QToolButton>
 #include <QTemporaryFile>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QMimeData;
 class QgsColorSchemeRegistry;

--- a/src/gui/qgscolordialog.h
+++ b/src/gui/qgscolordialog.h
@@ -20,7 +20,7 @@
 #include <QColorDialog>
 #include "ui_qgscolordialog.h"
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgshelp.h"
 
 class QColor;

--- a/src/gui/qgscolorrampbutton.h
+++ b/src/gui/qgscolorrampbutton.h
@@ -22,7 +22,7 @@
 
 #include <QToolButton>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsPanelWidget;
 

--- a/src/gui/qgscolorschemelist.h
+++ b/src/gui/qgscolorschemelist.h
@@ -21,7 +21,7 @@
 #include <QItemDelegate>
 #include <QFile>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QMimeData;
 class QgsPanelWidget;

--- a/src/gui/qgscolorswatchgrid.h
+++ b/src/gui/qgscolorswatchgrid.h
@@ -19,7 +19,7 @@
 #include <QWidget>
 #include <QWidgetAction>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup gui

--- a/src/gui/qgscolorwidgets.h
+++ b/src/gui/qgscolorwidgets.h
@@ -19,7 +19,7 @@
 #include <QWidgetAction>
 #include <QWidget>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QColor;
 class QSpinBox;

--- a/src/gui/qgscompoundcolorwidget.h
+++ b/src/gui/qgscompoundcolorwidget.h
@@ -17,7 +17,7 @@
 #define QGSCOMPOUNDCOLORWIDGET_H
 
 #include "qgsguiutils.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspanelwidget.h"
 #include "ui_qgscompoundcolorwidget.h"
 #include "qgis_gui.h"

--- a/src/gui/qgsconfigureshortcutsdialog.h
+++ b/src/gui/qgsconfigureshortcutsdialog.h
@@ -17,7 +17,7 @@
 #define QGSCONFIGURESHORTCUTSDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "ui_qgsconfigureshortcutsdialog.h"
 #include "qgshelp.h"

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -22,7 +22,7 @@
 #include "qgscredentials.h"
 
 #include <QString>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QPushButton;

--- a/src/gui/qgscurveeditorwidget.h
+++ b/src/gui/qgscurveeditorwidget.h
@@ -17,7 +17,7 @@
 #define QGSCURVEEDITORWIDGET_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QThread>
 #include <QMutex>
 #include <QPen>

--- a/src/gui/qgsdetaileditemdelegate.h
+++ b/src/gui/qgsdetaileditemdelegate.h
@@ -18,7 +18,7 @@
 #define QGSDETAILEDITEMDELEGATE_H
 
 #include <QAbstractItemDelegate>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QString>
 #include "qgis_gui.h"
 

--- a/src/gui/qgsdetaileditemwidget.h
+++ b/src/gui/qgsdetaileditemwidget.h
@@ -18,7 +18,7 @@
 #define QGSDETAILEDITEMWIDGET_H
 
 #include "ui_qgsdetaileditemwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsdetaileditemdata.h"
 #include "qgis_gui.h"
 

--- a/src/gui/qgsdial.cpp
+++ b/src/gui/qgsdial.cpp
@@ -21,6 +21,7 @@
 #include <QPaintEvent>
 #include <QPainter>
 #include <QRect>
+#include <cmath>
 
 QgsDial::QgsDial( QWidget *parent ) : QDial( parent )
 {

--- a/src/gui/qgsdial.h
+++ b/src/gui/qgsdial.h
@@ -18,7 +18,7 @@
 #include <QDial>
 #include <QVariant>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QPaintEvent;
 

--- a/src/gui/qgsdialog.h
+++ b/src/gui/qgsdialog.h
@@ -24,7 +24,7 @@
 #include <QDialogButtonBox>
 #include <QLayout>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup gui

--- a/src/gui/qgsdockwidget.h
+++ b/src/gui/qgsdockwidget.h
@@ -19,7 +19,7 @@
 
 #include <QDockWidget>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup gui

--- a/src/gui/qgsencodingfiledialog.h
+++ b/src/gui/qgsencodingfiledialog.h
@@ -18,7 +18,7 @@
 
 #include <QFileDialog>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QComboBox;
 class QPushButton;

--- a/src/gui/qgserrordialog.h
+++ b/src/gui/qgserrordialog.h
@@ -23,7 +23,7 @@
 #include "qgsguiutils.h"
 #include "qgserror.h"
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup gui

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -17,7 +17,7 @@
 #define QGSEXPRESSIONBUILDER_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "ui_qgsexpressionbuilder.h"
 #include "qgsdistancearea.h"
 #include "qgsexpressioncontext.h"

--- a/src/gui/qgsexpressionlineedit.h
+++ b/src/gui/qgsexpressionlineedit.h
@@ -17,7 +17,7 @@
 #define QGSEXPRESSIONLINEEDIT_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsexpressioncontext.h"
 #include "qgsdistancearea.h"
 #include "qgis_gui.h"

--- a/src/gui/qgsexpressionselectiondialog.h
+++ b/src/gui/qgsexpressionselectiondialog.h
@@ -17,7 +17,7 @@
 #define QGSEXPRESSIONSELECTIONDIALOG_H
 
 #include "ui_qgsexpressionselectiondialogbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgshelp.h"
 
 #include <QDialog>

--- a/src/gui/qgsextentgroupbox.h
+++ b/src/gui/qgsextentgroupbox.h
@@ -19,7 +19,7 @@
 #include "qgscollapsiblegroupbox.h"
 #include "qgsmaptool.h"
 #include "qgsmaptoolextent.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "ui_qgsextentgroupboxwidget.h"
 

--- a/src/gui/qgsexternalresourcewidget.h
+++ b/src/gui/qgsexternalresourcewidget.h
@@ -25,7 +25,7 @@ class QgsPixmapLabel;
 
 #include "qgsfilewidget.h"
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 
 #ifdef SIP_RUN

--- a/src/gui/qgsfeatureselectiondlg.h
+++ b/src/gui/qgsfeatureselectiondlg.h
@@ -19,7 +19,7 @@
 class QgsGenericFeatureSelectionManager;
 
 #include "ui_qgsfeatureselectiondlg.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 #ifdef SIP_RUN

--- a/src/gui/qgsfieldcombobox.h
+++ b/src/gui/qgsfieldcombobox.h
@@ -21,7 +21,7 @@
 #include "qgsfieldproxymodel.h"
 #include "qgis_gui.h"
 
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsMapLayer;
 class QgsVectorLayer;

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -23,7 +23,7 @@
 #include <memory>
 
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsdistancearea.h"
 #include "qgsexpressioncontextgenerator.h"
 #include "qgsexpressioncontext.h"

--- a/src/gui/qgsfieldvalueslineedit.h
+++ b/src/gui/qgsfieldvalueslineedit.h
@@ -16,7 +16,7 @@
 #define QGSFIELDVALUESLINEEDIT_H
 
 #include "qgsfilterlineedit.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeedback.h"
 
 #include <QStringListModel>

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -25,7 +25,7 @@ class QHBoxLayout;
 #include <QWidget>
 
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfilterlineedit.h"
 
 /**

--- a/src/gui/qgsfilterlineedit.cpp
+++ b/src/gui/qgsfilterlineedit.cpp
@@ -18,6 +18,7 @@
 #include "qgsfilterlineedit.h"
 #include "qgsapplication.h"
 #include "qgsanimatedicon.h"
+#include "qgis.h"
 
 #include <QAction>
 #include <QToolButton>

--- a/src/gui/qgsfilterlineedit.h
+++ b/src/gui/qgsfilterlineedit.h
@@ -20,7 +20,7 @@
 
 #include <QLineEdit>
 #include <QIcon>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QToolButton;

--- a/src/gui/qgsfloatingwidget.h
+++ b/src/gui/qgsfloatingwidget.h
@@ -16,7 +16,7 @@
 #define QGSFLOATINGWIDGET_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsFloatingWidgetEventFilter;

--- a/src/gui/qgsfocuswatcher.h
+++ b/src/gui/qgsfocuswatcher.h
@@ -17,7 +17,7 @@
 #define QGSFOCUSWATCHER_H
 
 #include <QObject>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 /**

--- a/src/gui/qgsfontbutton.h
+++ b/src/gui/qgsfontbutton.h
@@ -16,7 +16,7 @@
 #define QGSFONTBUTTON_H
 
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgstextrenderer.h"
 
 #include <QToolButton>

--- a/src/gui/qgsformannotation.h
+++ b/src/gui/qgsformannotation.h
@@ -19,7 +19,7 @@
 #define QGSFORMANNOTATION_H
 
 #include "qgsannotation.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsfeature.h"
 #include <QWidget>
 #include "qgis_gui.h"

--- a/src/gui/qgsgradientcolorrampdialog.h
+++ b/src/gui/qgsgradientcolorrampdialog.h
@@ -17,7 +17,7 @@
 #define QGSGRADIENTCOLORRAMPDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "ui_qgsgradientcolorrampdialogbase.h"
 #include "qgshelp.h"

--- a/src/gui/qgsgradientstopeditor.h
+++ b/src/gui/qgsgradientstopeditor.h
@@ -17,7 +17,7 @@
 #define QGSGRADIENTSTOPEDITOR_H
 
 #include "qgscolorramp.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QWidget>
 #include "qgis_gui.h"
 

--- a/src/gui/qgsgroupwmsdatadialog.h
+++ b/src/gui/qgsgroupwmsdatadialog.h
@@ -18,7 +18,7 @@
 
 #include "ui_qgsgroupwmsdatadialogbase.h"
 #include "qgsguiutils.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 /**

--- a/src/gui/qgsguiutils.cpp
+++ b/src/gui/qgsguiutils.cpp
@@ -18,6 +18,7 @@
 #include "qgsencodingfiledialog.h"
 #include "qgslogger.h"
 #include "qgis_gui.h"
+#include "qgis.h"
 
 #include <QImageWriter>
 #include <QFontDialog>

--- a/src/gui/qgshistogramwidget.h
+++ b/src/gui/qgshistogramwidget.h
@@ -18,7 +18,7 @@
 #define QGSHISTOGRAMWIDGET_H
 
 #include "ui_qgshistogramwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgshistogram.h"
 #include "qgsstatisticalsummary.h"

--- a/src/gui/qgsidentifymenu.h
+++ b/src/gui/qgsidentifymenu.h
@@ -21,7 +21,7 @@
 #include "qgsmaplayeractionregistry.h"
 #include "qgsmaptoolidentify.h"
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #ifndef SIP_RUN
 /// \cond PRIVATE

--- a/src/gui/qgskeyvaluewidget.h
+++ b/src/gui/qgskeyvaluewidget.h
@@ -17,7 +17,7 @@
 #define QGSKEYVALUEWIDGET_H
 
 #include "qgstablewidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QAbstractTableModel>
 #include <QMap>
 #include "qgis_gui.h"

--- a/src/gui/qgslimitedrandomcolorrampdialog.h
+++ b/src/gui/qgslimitedrandomcolorrampdialog.h
@@ -17,7 +17,7 @@
 #define QGsLIMITEDRANDOMCOLORRAMPDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspanelwidget.h"
 #include "qgscolorramp.h"
 #include "ui_qgslimitedrandomcolorrampwidgetbase.h"

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -25,7 +25,6 @@
 #include "qgsrectangle.h"
 #include "qgsfeatureid.h"
 #include "qgsgeometry.h"
-#include "qgis.h"
 
 #include <QDomDocument>
 #include <QGraphicsView>

--- a/src/gui/qgsmapcanvasitem.h
+++ b/src/gui/qgsmapcanvasitem.h
@@ -17,7 +17,7 @@
 #define QGSMAPCANVASITEM_H
 
 #include <QGraphicsItem>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrectangle.h"
 #include "qgis_gui.h"
 

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -17,7 +17,7 @@
 #define QGSMAPLAYERACTIONREGISTRY_H
 
 #include <QObject>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QList>
 #include <QMap>
 #include <QAction>

--- a/src/gui/qgsmaplayercombobox.h
+++ b/src/gui/qgsmaplayercombobox.h
@@ -21,7 +21,7 @@
 #include "qgsmaplayerproxymodel.h"
 #include "qgis_gui.h"
 
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsMapLayer;
 class QgsVectorLayer;

--- a/src/gui/qgsmenuheader.cpp
+++ b/src/gui/qgsmenuheader.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgsmenuheader.h"
+#include "qgis.h"
 #include <QPainter>
 #include <QApplication>
 

--- a/src/gui/qgsmenuheader.h
+++ b/src/gui/qgsmenuheader.h
@@ -20,7 +20,7 @@
 #include <QWidget>
 #include <QWidgetAction>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 /**
  * \ingroup gui

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -23,7 +23,7 @@
 
 #include <QString>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QStatusBar;
 class QCloseEvent;

--- a/src/gui/qgsnewgeopackagelayerdialog.h
+++ b/src/gui/qgsnewgeopackagelayerdialog.h
@@ -20,7 +20,7 @@
 #include "ui_qgsnewgeopackagelayerdialogbase.h"
 #include "qgsguiutils.h"
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 /**

--- a/src/gui/qgsopacitywidget.cpp
+++ b/src/gui/qgsopacitywidget.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsopacitywidget.h"
 #include "qgsdoublespinbox.h"
+#include "qgis.h"
 #include <QHBoxLayout>
 #include <QSlider>
 

--- a/src/gui/qgsopacitywidget.h
+++ b/src/gui/qgsopacitywidget.h
@@ -17,7 +17,7 @@
 #define QGSOPACITYWIDGET_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsDoubleSpinBox;

--- a/src/gui/qgsoptionswidgetfactory.h
+++ b/src/gui/qgsoptionswidgetfactory.h
@@ -18,7 +18,7 @@
 
 #include <QListWidgetItem>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsoptionsdialoghighlightwidget.h"
 
 /**

--- a/src/gui/qgsorderbydialog.h
+++ b/src/gui/qgsorderbydialog.h
@@ -18,7 +18,7 @@
 #define QGSORDERBYDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "ui_qgsorderbydialogbase.h"
 #include "qgsfeaturerequest.h"

--- a/src/gui/qgsowssourceselect.h
+++ b/src/gui/qgsowssourceselect.h
@@ -21,7 +21,6 @@
 #define QGSOWSSOURCESELECT_H
 #include "ui_qgsowssourceselectbase.h"
 #include "qgis_sip.h"
-#include "qgis.h"
 #include "qgsdatasourceuri.h"
 #include "qgsguiutils.h"
 #include "qgsproviderregistry.h"

--- a/src/gui/qgspixmaplabel.h
+++ b/src/gui/qgspixmaplabel.h
@@ -17,7 +17,7 @@
 #define QGSPIXMAPLABEL_H
 
 #include <QLabel>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 /**

--- a/src/gui/qgspresetcolorrampdialog.h
+++ b/src/gui/qgspresetcolorrampdialog.h
@@ -17,7 +17,7 @@
 #define QGSPRESETCOLORRAMPDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspanelwidget.h"
 #include "qgscolorramp.h"
 #include "ui_qgspresetcolorrampwidgetbase.h"

--- a/src/gui/qgsprevieweffect.h
+++ b/src/gui/qgsprevieweffect.h
@@ -19,7 +19,7 @@
 #define QGSPREVIEWEFFECT_H
 
 #include <QGraphicsEffect>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 /**

--- a/src/gui/qgsprojectionselectiondialog.h
+++ b/src/gui/qgsprojectionselectiondialog.h
@@ -18,7 +18,7 @@
 #ifndef QGSGENERICPROJECTIONSELECTOR_H
 #define QGSGENERICPROJECTIONSELECTOR_H
 #include "ui_qgsgenericprojectionselectorbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsguiutils.h"
 
 #include <QSet>

--- a/src/gui/qgsprojectionselectiontreewidget.h
+++ b/src/gui/qgsprojectionselectiontreewidget.h
@@ -16,7 +16,7 @@
 #include <QSet>
 #include <QStringList>
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgscoordinatereferencesystem.h"
 

--- a/src/gui/qgsprojectionselectionwidget.h
+++ b/src/gui/qgsprojectionselectionwidget.h
@@ -18,7 +18,7 @@
 #define QGSPROJECTIONSELECTIONWIDGET_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QLineEdit>
 #include <QToolButton>
 #include <QComboBox>

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -15,7 +15,7 @@
 #ifndef QGSQUERYBUILDER_H
 #define QGSQUERYBUILDER_H
 #include <map>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <vector>
 #include <QStandardItemModel>
 #include <QSortFilterProxyModel>

--- a/src/gui/qgsrasterpyramidsoptionswidget.h
+++ b/src/gui/qgsrasterpyramidsoptionswidget.h
@@ -19,7 +19,7 @@
 #define QGSRASTERPYRAMIDSOPTIONSWIDGET_H
 
 #include "ui_qgsrasterpyramidsoptionswidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QCheckBox;

--- a/src/gui/qgsratiolockbutton.cpp
+++ b/src/gui/qgsratiolockbutton.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsratiolockbutton.h"
+#include "qgis.h"
 
 #include <QApplication>
 #include <QMouseEvent>

--- a/src/gui/qgsratiolockbutton.h
+++ b/src/gui/qgsratiolockbutton.h
@@ -20,7 +20,7 @@
 
 #include <QToolButton>
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include <QPointer>
 class QDoubleSpinBox;

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -16,7 +16,7 @@
 #define QGSRUBBERBAND_H
 
 #include "qgsmapcanvasitem.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsgeometry.h"
 
 #include <QBrush>

--- a/src/gui/qgsscalecombobox.h
+++ b/src/gui/qgsscalecombobox.h
@@ -19,7 +19,7 @@
 #define QGSSCALECOMBOBOX_H
 
 #include <QComboBox>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 /**

--- a/src/gui/qgsscalerangewidget.h
+++ b/src/gui/qgsscalerangewidget.h
@@ -17,7 +17,7 @@
 #define QGSSCALERANGEWIDGET_H
 
 #include <QGridLayout>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QLabel>
 #include "qgis_gui.h"
 

--- a/src/gui/qgsscalevisibilitydialog.h
+++ b/src/gui/qgsscalevisibilitydialog.h
@@ -17,7 +17,7 @@
 #define QGSSCALEVISIBILITYDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QGroupBox>
 #include "qgis_gui.h"
 

--- a/src/gui/qgsscalewidget.h
+++ b/src/gui/qgsscalewidget.h
@@ -22,7 +22,7 @@
 
 #include "qgsscalecombobox.h"
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsMapCanvas;
 

--- a/src/gui/qgsscrollarea.h
+++ b/src/gui/qgsscrollarea.h
@@ -17,7 +17,7 @@
 #define QGSSCROLLAREA_H
 
 #include <QScrollArea>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include <QTimer>
 class ScrollAreaFilter;

--- a/src/gui/qgsslider.cpp
+++ b/src/gui/qgsslider.cpp
@@ -21,6 +21,7 @@
 #include <QPaintEvent>
 #include <QPainter>
 #include <QRect>
+#include <cmath>
 
 QgsSlider::QgsSlider( QWidget *parent ) : QSlider( parent )
 {

--- a/src/gui/qgsslider.h
+++ b/src/gui/qgsslider.h
@@ -16,7 +16,7 @@
  ***************************************************************************/
 
 #include <QSlider>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QVariant>
 #include "qgis_gui.h"
 

--- a/src/gui/qgssourceselectprovider.h
+++ b/src/gui/qgssourceselectprovider.h
@@ -18,7 +18,7 @@
 
 
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsguiutils.h"
 #include "qgsproviderregistry.h"
 #include "qgsabstractdatasourcewidget.h"

--- a/src/gui/qgssourceselectproviderregistry.h
+++ b/src/gui/qgssourceselectproviderregistry.h
@@ -17,7 +17,7 @@
 #define QGSSOURCESELECTPROVIDERREGISTRY_H
 
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 class QgsSourceSelectProvider;
 

--- a/src/gui/qgssqlcomposerdialog.h
+++ b/src/gui/qgssqlcomposerdialog.h
@@ -20,7 +20,7 @@ email                : even.rouault at spatialys.com
 #define QGSSQLCOMPOSERDIALOG_H
 
 #include "ui_qgssqlcomposerdialogbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsguiutils.h"
 
 #include <QPair>

--- a/src/gui/qgssubstitutionlistwidget.h
+++ b/src/gui/qgssubstitutionlistwidget.h
@@ -19,7 +19,7 @@
 #define QGSSUBSTITUTIONLISTWIDGET_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgspanelwidget.h"
 #include "ui_qgssubstitutionlistwidgetbase.h"
 #include "qgsstringutils.h"

--- a/src/gui/qgssymbolbutton.h
+++ b/src/gui/qgssymbolbutton.h
@@ -16,7 +16,7 @@
 #define QGSSYMBOLBUTTON_H
 
 #include "qgis_gui.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgssymbol.h"
 #include <QToolButton>
 #include <QPointer>

--- a/src/gui/qgstaskmanagerwidget.h
+++ b/src/gui/qgstaskmanagerwidget.h
@@ -18,7 +18,7 @@
 #define QGSTASKMANAGERWIDGET_H
 
 #include "qgsfloatingwidget.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgstaskmanager.h"
 #include <QStyledItemDelegate>
 #include <QToolButton>

--- a/src/gui/qgstextformatwidget.h
+++ b/src/gui/qgstextformatwidget.h
@@ -18,7 +18,7 @@
 #define QGSTEXTFORMATWIDGET_H
 
 #include "ui_qgstextformatwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgstextrenderer.h"
 #include "qgsstringutils.h"
 #include "qgsguiutils.h"

--- a/src/gui/qgstreewidgetitem.h
+++ b/src/gui/qgstreewidgetitem.h
@@ -20,7 +20,7 @@
 #define QGSTREEWIDGETITEM_H
 
 #include <QTreeWidgetItem>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QObject>
 #include "qgis_gui.h"
 

--- a/src/gui/qgsunitselectionwidget.h
+++ b/src/gui/qgsunitselectionwidget.h
@@ -19,7 +19,7 @@
 #define QGSUNITSELECTIONWIDGET_H
 
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QDialog>
 #include "qgspanelwidget.h"
 #include "qgssymbol.h"

--- a/src/gui/qgsuserinputwidget.h
+++ b/src/gui/qgsuserinputwidget.h
@@ -17,7 +17,7 @@
 #ifndef QGSUSERINPUTWIDGET_H
 #define QGSUSERINPUTWIDGET_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 #include "qgsfloatingwidget.h"
 

--- a/src/gui/qgsvariableeditorwidget.h
+++ b/src/gui/qgsvariableeditorwidget.h
@@ -16,7 +16,7 @@
 #ifndef QGSVARIABLEEDITORWIDGET_H
 #define QGSVARIABLEEDITORWIDGET_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QWidget>
 #include <QTreeWidget>
 #include <QItemDelegate>

--- a/src/gui/qgswindowmanagerinterface.h
+++ b/src/gui/qgswindowmanagerinterface.h
@@ -16,7 +16,7 @@
 #ifndef QGSWINDOWMANAGERINTERFACE_H
 #define QGSWINDOWMANAGERINTERFACE_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsVectorLayer;

--- a/src/gui/symbology/characterwidget.h
+++ b/src/gui/symbology/characterwidget.h
@@ -52,7 +52,7 @@
 #include <QSize>
 #include <QString>
 #include <QWidget>
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QMouseEvent;

--- a/src/gui/symbology/qgs25drendererwidget.h
+++ b/src/gui/symbology/qgs25drendererwidget.h
@@ -17,7 +17,7 @@
 #define QGS25DRENDERERWIDGET_H
 
 #include "ui_qgs25drendererwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrendererwidget.h"
 #include "qgis_gui.h"
 

--- a/src/gui/symbology/qgsarrowsymbollayerwidget.h
+++ b/src/gui/symbology/qgsarrowsymbollayerwidget.h
@@ -16,7 +16,7 @@
 #define QGSARROWSYMBOLLAYERWIDGET_H
 
 #include "ui_qgsarrowsymbollayerwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgssymbollayerwidget.h"
 #include "qgis_gui.h"
 

--- a/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgscategorizedsymbolrendererwidget.h
@@ -16,7 +16,7 @@
 #define QGSCATEGORIZEDSYMBOLRENDERERWIDGET_H
 
 #include "qgscategorizedsymbolrenderer.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrendererwidget.h"
 #include "qgsproxystyle.h"
 #include <QStandardItem>

--- a/src/gui/symbology/qgscptcitycolorrampdialog.h
+++ b/src/gui/symbology/qgscptcitycolorrampdialog.h
@@ -18,7 +18,7 @@
 
 
 #include "ui_qgscptcitycolorrampdialogbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include <QDialog>
 
 #include "qgscptcityarchive.h"

--- a/src/gui/symbology/qgsdatadefinedsizelegendwidget.h
+++ b/src/gui/symbology/qgsdatadefinedsizelegendwidget.h
@@ -16,7 +16,7 @@
 #ifndef QGSDATADEFINEDSIZELEGENDWIDGET_H
 #define QGSDATADEFINEDSIZELEGENDWIDGET_H
 
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 #include <memory>

--- a/src/gui/symbology/qgsellipsesymbollayerwidget.h
+++ b/src/gui/symbology/qgsellipsesymbollayerwidget.h
@@ -16,7 +16,7 @@
 #define QGSELLIPSESYMBOLLAYERWIDGET_H
 
 #include "ui_widget_ellipse.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgssymbollayerwidget.h"
 #include "qgis_gui.h"
 

--- a/src/gui/symbology/qgsgraduatedhistogramwidget.h
+++ b/src/gui/symbology/qgsgraduatedhistogramwidget.h
@@ -18,7 +18,7 @@
 #define QGSGRADUATEDHISTOGRAMWIDGET_H
 
 #include "qgshistogramwidget.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QwtPlotPicker;

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.h
@@ -17,7 +17,7 @@
 #define QGSGRADUATEDSYMBOLRENDERERWIDGET_H
 
 #include "qgsgraduatedsymbolrenderer.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrendererwidget.h"
 #include "qgsproxystyle.h"
 #include <QStandardItem>

--- a/src/gui/symbology/qgsheatmaprendererwidget.h
+++ b/src/gui/symbology/qgsheatmaprendererwidget.h
@@ -16,7 +16,7 @@
 #define QGSHEATMAPRENDERERWIDGET_H
 
 #include "ui_qgsheatmaprendererwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrendererwidget.h"
 #include "qgis_gui.h"
 

--- a/src/gui/symbology/qgsinvertedpolygonrendererwidget.h
+++ b/src/gui/symbology/qgsinvertedpolygonrendererwidget.h
@@ -16,7 +16,7 @@
 #define QGSINVERTEDPOLYGONRENDERERWIDGET_H
 
 #include "ui_qgsinvertedpolygonrendererwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsinvertedpolygonrenderer.h"
 #include "qgsrendererwidget.h"
 #include "qgis_gui.h"

--- a/src/gui/symbology/qgsnullsymbolrendererwidget.h
+++ b/src/gui/symbology/qgsnullsymbolrendererwidget.h
@@ -16,7 +16,7 @@
 #define QGSNULLSYMBOLRENDERERWIDGET_H
 
 #include "qgsrendererwidget.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsNullSymbolRenderer;

--- a/src/gui/symbology/qgspointclusterrendererwidget.h
+++ b/src/gui/symbology/qgspointclusterrendererwidget.h
@@ -19,7 +19,7 @@
 #define QGSPOINTCLUSTERRENDERERWIDGET_H
 
 #include "ui_qgspointclusterrendererwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrendererwidget.h"
 #include "qgsexpressioncontextgenerator.h"
 #include "qgis_gui.h"

--- a/src/gui/symbology/qgspointdisplacementrendererwidget.h
+++ b/src/gui/symbology/qgspointdisplacementrendererwidget.h
@@ -19,7 +19,7 @@
 #define QGSPOINTDISPLACEMENTRENDERERWIDGET_H
 
 #include "ui_qgspointdisplacementrendererwidgetbase.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsrendererwidget.h"
 #include "qgsexpressioncontextgenerator.h"
 #include "qgis_gui.h"

--- a/src/gui/symbology/qgsrendererpropertiesdialog.h
+++ b/src/gui/symbology/qgsrendererpropertiesdialog.h
@@ -18,7 +18,7 @@
 #define QGSRENDERERPROPERTIESDIALOG_H
 
 #include <QDialog>
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "ui_qgsrendererpropsdialogbase.h"
 

--- a/src/gui/symbology/qgsrulebasedrendererwidget.h
+++ b/src/gui/symbology/qgsrulebasedrendererwidget.h
@@ -17,7 +17,7 @@
 #define QGSRULEBASEDRENDERERWIDGET_H
 
 #include "qgsrendererwidget.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgsrulebasedrenderer.h"
 class QMenu;

--- a/src/gui/symbology/qgssinglesymbolrendererwidget.h
+++ b/src/gui/symbology/qgssinglesymbolrendererwidget.h
@@ -16,7 +16,7 @@
 #define QGSSINGLESYMBOLRENDERERWIDGET_H
 
 #include "qgsrendererwidget.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgis_gui.h"
 
 class QgsSingleSymbolRenderer;

--- a/src/gui/symbology/qgsstyleexportimportdialog.h
+++ b/src/gui/symbology/qgsstyleexportimportdialog.h
@@ -30,6 +30,8 @@
 #include "qgis_sip.h"
 #include "qgshelp.h"
 
+#include <memory>
+
 class QgsStyle;
 class QgsStyleGroupSelectionDialog;
 class QgsTemporaryCursorOverride;

--- a/src/gui/symbology/qgssvgselectorwidget.h
+++ b/src/gui/symbology/qgssvgselectorwidget.h
@@ -18,7 +18,7 @@
 #define QGSSVGSELECTORWIDGET_H
 
 #include "ui_widget_svgselector.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 
 #include "qgsguiutils.h"
 #include <QAbstractListModel>

--- a/src/gui/symbology/qgssymbollayerwidget.h
+++ b/src/gui/symbology/qgssymbollayerwidget.h
@@ -18,7 +18,7 @@
 #define QGSSYMBOLLAYERWIDGET_H
 
 #include "qgspropertyoverridebutton.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgssymbolwidgetcontext.h"
 #include "qgssymbollayer.h"
 #include <QWidget>

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -18,7 +18,6 @@
 
 #include <QDialog>
 #include "qgis_sip.h"
-#include "qgis.h"
 
 #include "ui_qgssymbolselectordialogbase.h"
 

--- a/src/gui/symbology/qgsvectorfieldsymbollayerwidget.h
+++ b/src/gui/symbology/qgsvectorfieldsymbollayerwidget.h
@@ -16,7 +16,7 @@
 #define QGSVECTORFIELDSYMBOLLAYERWIDGET_H
 
 #include "qgssymbollayerwidget.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "ui_widget_vectorfield.h"
 #include "qgis_gui.h"
 

--- a/src/providers/db2/qgsdb2tablemodel.h
+++ b/src/providers/db2/qgsdb2tablemodel.h
@@ -19,8 +19,10 @@
 #define QGSDB2TABLEMODEL_H
 
 #include <QStandardItemModel>
+#include <QString>
+#include <QObject>
 #include "qgsdataitem.h"
-#include "qgis.h"
+#include "qgswkbtypes.h"
 
 //! Layer Property structure
 struct QgsDb2LayerProperty

--- a/src/server/qgsbufferserverresponse.h
+++ b/src/server/qgsbufferserverresponse.h
@@ -20,12 +20,13 @@
 #define QGSBUFFERSERVERRESPONSE_H
 
 #include "qgis_server.h"
-#include "qgis.h"
+#include "qgis_sip.h"
 #include "qgsserverresponse.h"
 
 #include <QBuffer>
 #include <QByteArray>
 #include <QMap>
+#include <QString>
 
 /**
  * \ingroup server

--- a/src/server/qgsserverinterface.h
+++ b/src/server/qgsserverinterface.h
@@ -40,7 +40,6 @@ class QgsServerCacheFilter;
 #endif
 #include "qgsserviceregistry.h"
 #include "qgis_server.h"
-#include "qgis_sip.h"
 
 SIP_IF_MODULE( HAVE_SERVER_PYTHON_PLUGINS )
 

--- a/src/server/services/qgsmodule.h
+++ b/src/server/services/qgsmodule.h
@@ -17,7 +17,6 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgis.h"
 #include "qgsservicemodule.h"
 #include "qgsserviceregistry.h"
 #include "qgsservice.h"

--- a/tests/src/core/testqgscolorschemeregistry.cpp
+++ b/tests/src/core/testqgscolorschemeregistry.cpp
@@ -17,6 +17,7 @@
 
 #include "qgscolorschemeregistry.h"
 #include "qgscolorscheme.h"
+#include "qgis.h"
 #include <QObject>
 #include <memory>
 #include "qgstest.h"

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -18,6 +18,7 @@
 #include "qgsnetworkcontentfetcher.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsapplication.h"
+#include "qgis.h"
 #include <QObject>
 #include "qgstest.h"
 #include "qgssettings.h"


### PR DESCRIPTION
## Description

This PR continues the work started in PR #8951.

This commit replaces occurences of `#include "qgis.h"` by `#include "qgis_sip.h"`, where possible = when files only depends on SIP_XXX features.
