### PR TITLE
Avoid project being marked dirty as soon as its opened

### DIFF
--- a/src/gui/symbology/qgssymbolselectordialog.cpp
+++ b/src/gui/symbology/qgssymbolselectordialog.cpp
@@ -309,8 +309,10 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
     // have been generated using the temporary "downloading" svg. In this case
     // we require the preview to be regenerated to use the correct fetched
     // svg
+    mBlockModified = true;
     symbolChanged();
     updatePreview();
+    mBlockModified = false;
   } );
   connect( QgsApplication::imageCache(), &QgsImageCache::remoteImageFetched, this, [ = ]
   {
@@ -319,16 +321,20 @@ QgsSymbolSelectorWidget::QgsSymbolSelectorWidget( QgsSymbol *symbol, QgsStyle *s
     // have been generated using the temporary "downloading" image. In this case
     // we require the preview to be regenerated to use the correct fetched
     // image
+    mBlockModified = true;
     symbolChanged();
     updatePreview();
+    mBlockModified = false;
   } );
 
   connect( QgsProject::instance(), &QgsProject::projectColorsChanged, this, [ = ]
   {
     // if project color scheme changes, we need to redraw symbols - they may use project colors and accordingly
     // need updating to reflect the new colors
+    mBlockModified = true;
     symbolChanged();
     updatePreview();
+    mBlockModified = false;
   } );
 }
 
@@ -436,7 +442,8 @@ void QgsSymbolSelectorWidget::updatePreview()
   QImage preview = mSymbol->bigSymbolPreviewImage( &mPreviewExpressionContext );
   lblPreview->setPixmap( QPixmap::fromImage( preview ) );
   // Hope this is a appropriate place
-  emit symbolModified();
+  if ( !mBlockModified )
+    emit symbolModified();
 }
 
 void QgsSymbolSelectorWidget::updateLayerPreview()

--- a/src/gui/symbology/qgssymbolselectordialog.h
+++ b/src/gui/symbology/qgssymbolselectordialog.h
@@ -254,6 +254,7 @@ class GUI_EXPORT QgsSymbolSelectorWidget: public QgsPanelWidget, private Ui::Qgs
     QgsSymbolWidgetContext mContext;
     QgsFeature mPreviewFeature;
     QgsExpressionContext mPreviewExpressionContext;
+    bool mBlockModified = false;
 
 };
 


### PR DESCRIPTION
This is a simple workaround, not a real fix. The real fix is to move the symbolModified signal out of the updatePreview call, because we should be able to refresh a preview image without marking it as a changed symbol. But that's higher risk, so deferred to 3.8
