### PR TITLE
[processing] use background color from the project settings in the rasterize algorithm (fix #19866)

### DIFF
--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -260,10 +260,14 @@ class TileSet():
         self.settings.setFlag(QgsMapSettings.RenderMapTile, True)
         self.settings.setFlag(QgsMapSettings.UseAdvancedEffects, True)
 
+        r = QgsProject.instance().readNumEntry('Gui', '/CanvasColorRedPart', 255)[0]
+        g = QgsProject.instance().readNumEntry('Gui', '/CanvasColorGreenPart', 255)[0]
+        b = QgsProject.instance().readNumEntry('Gui', '/CanvasColorBluePart', 255)[0]
         if make_trans:
-            self.settings.setBackgroundColor(QColor(255, 255, 255, 0))
+            self.bgColor = QColor(r, g, b, 0)
         else:
-            self.settings.setBackgroundColor(QColor(255, 255, 255))
+            self.bgColor = QColor(r, g, b)
+        self.settings.setBackgroundColor(self.bgColor)
 
         if QgsProject.instance().mapThemeCollection().hasMapTheme(map_theme):
             self.settings.setLayers(
@@ -300,11 +304,9 @@ class TileSet():
         """
 
         if make_trans:
-            background_color = QColor(255, 255, 255, 0)
-            self.image.fill(background_color.rgba())
+            self.image.fill(self.bgColor.rgba())
         else:
-            background_color = QColor(255, 255, 255)
-            self.image.fill(background_color.rgb())
+            self.image.fill(self.bgColor.rgb())
 
         painter = QPainter(self.image)
 

--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -194,9 +194,11 @@ class RasterizeAlgorithm(QgisAlgorithm):
             self.OUTPUT,
             context)
 
+        project = context.project()
+
         tile_set = TileSet(map_theme, layer, extent, tile_size, mupp,
                            output_layer, make_trans,
-                           qgis.utils.iface.mapCanvas().mapSettings())
+                           qgis.utils.iface.mapCanvas().mapSettings(), project)
         tile_set.render(feedback, make_trans)
 
         return {self.OUTPUT: output_layer}
@@ -209,7 +211,7 @@ class TileSet():
     """
 
     def __init__(self, map_theme, layer, extent, tile_size, mupp, output,
-                 make_trans, map_settings):
+                 make_trans, map_settings, project):
         """
         :param map_theme:
         :param extent:
@@ -260,9 +262,9 @@ class TileSet():
         self.settings.setFlag(QgsMapSettings.RenderMapTile, True)
         self.settings.setFlag(QgsMapSettings.UseAdvancedEffects, True)
 
-        r = QgsProject.instance().readNumEntry('Gui', '/CanvasColorRedPart', 255)[0]
-        g = QgsProject.instance().readNumEntry('Gui', '/CanvasColorGreenPart', 255)[0]
-        b = QgsProject.instance().readNumEntry('Gui', '/CanvasColorBluePart', 255)[0]
+        r = project.readNumEntry('Gui', '/CanvasColorRedPart', 255)[0]
+        g = project.readNumEntry('Gui', '/CanvasColorGreenPart', 255)[0]
+        b = project.readNumEntry('Gui', '/CanvasColorBluePart', 255)[0]
         if make_trans:
             self.bgColor = QColor(r, g, b, 0)
         else:

--- a/python/plugins/processing/algs/qgis/Rasterize.py
+++ b/python/plugins/processing/algs/qgis/Rasterize.py
@@ -153,7 +153,10 @@ class RasterizeAlgorithm(QgisAlgorithm):
     def tags(self):
         return self.tr('layer,raster,convert,file,map themes,tiles,render').split(',')
 
-    # def processAlgorithm(self, progress):
+    def prepareAlgorithm(self, parameters, context, feedback):
+        self.mapSettings = qgis.utils.iface.mapCanvas().mapSettings()
+        return True
+
     def processAlgorithm(self, parameters, context, feedback):
         """Here is where the processing itself takes place."""
 
@@ -198,7 +201,7 @@ class RasterizeAlgorithm(QgisAlgorithm):
 
         tile_set = TileSet(map_theme, layer, extent, tile_size, mupp,
                            output_layer, make_trans,
-                           qgis.utils.iface.mapCanvas().mapSettings(), project)
+                           self.mapSettings, project)
         tile_set.render(feedback, make_trans)
 
         return {self.OUTPUT: output_layer}


### PR DESCRIPTION
## Description
Native rasterize algorithm ignores project background color and always outputs raster with white background. Proposed fix takes into account project background color making users who non-standard backgrounds a bit more happy.

Fixes https://issues.qgis.org/issues/19866.

@m-kuhn I will be grateful for your review and opinion.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
