### PR TITLE
fixes #18497 : Correct line size method when snapping multipolygon

### DIFF
--- a/src/analysis/vector/qgsgeometrysnapper.cpp
+++ b/src/analysis/vector/qgsgeometrysnapper.cpp
@@ -23,6 +23,7 @@
 #include "qgsgeometryutils.h"
 #include "qgsmapsettings.h"
 #include "qgssurface.h"
+#include "qgsmultisurface.h"
 #include "qgscurve.h"
 
 ///@cond PRIVATE
@@ -718,7 +719,7 @@ int QgsGeometrySnapper::polyLineSize( const QgsAbstractGeometry *geom, int iPart
 {
   int nVerts = geom->vertexCount( iPart, iRing );
 
-  if ( qgsgeometry_cast< const QgsSurface * >( geom ) )
+  if ( qgsgeometry_cast< const QgsSurface * >( geom ) || qgsgeometry_cast< const QgsMultiSurface * >( geom ) )
   {
     QgsPoint front = geom->vertexAt( QgsVertexId( iPart, iRing, 0 ) );
     QgsPoint back = geom->vertexAt( QgsVertexId( iPart, iRing, nVerts - 1 ) );

--- a/tests/src/analysis/testqgsgeometrysnapper.cpp
+++ b/tests/src/analysis/testqgsgeometrysnapper.cpp
@@ -50,6 +50,7 @@ class TestQgsGeometrySnapper : public QObject
     void internalSnapper();
     void insertExtra();
     void duplicateNodes();
+    void snapMultiPolygonToPolygon();
 };
 
 void  TestQgsGeometrySnapper::initTestCase()
@@ -609,6 +610,24 @@ void TestQgsGeometrySnapper::duplicateNodes()
 
   result = snapper.snapFeature( f2 );
   QCOMPARE( result.asWkt( 1 ), QStringLiteral( "LineString (10 10, 20 0)" ) );
+
+}
+
+void TestQgsGeometrySnapper::snapMultiPolygonToPolygon()
+{
+  QgsVectorLayer *rl = new QgsVectorLayer( QStringLiteral( "Polygon" ), QStringLiteral( "x" ), QStringLiteral( "memory" ) );
+  QgsFeature ff( 0 );
+  QgsGeometry refGeom = QgsGeometry::fromWkt( QStringLiteral( "Polygon((0 0, 10 0, 10 10, 0 10, 0 0))" ) );
+  ff.setGeometry( refGeom );
+  QgsFeatureList flist;
+  flist << ff;
+  rl->dataProvider()->addFeatures( flist );
+
+  // test MultiPolygon that could be removed in the process https://issues.qgis.org/issues/18497
+  QgsGeometry polygonGeom = QgsGeometry::fromWkt( QStringLiteral( "MultiPolygon(((0.1 -0.1, 5 0.1, 9.9 0.1, 0.1 -0.1)))" ) );
+  QgsGeometrySnapper snapper( rl );
+  QgsGeometry result = snapper.snapGeometry( polygonGeom, 1 );
+  QCOMPARE( result.asWkt(), QStringLiteral( "MultiPolygon (((0 0, 5 0, 10 0, 0 0)))" ) );
 
 }
 


### PR DESCRIPTION
## Description

polyLineSize method was dealing well with Polygon but not MultiPolygon. This PR corrects this method.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
