### PR TITLE
[processing] show warning when file-based layer could not be loaded 

### DIFF
--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -45,6 +45,7 @@ from qgis.core import (
     QgsSettings,
     QgsProject,
     QgsMapLayer,
+    QgsVectorLayer,
     QgsProcessing,
     QgsProcessingUtils,
     QgsProcessingParameterDefinition,
@@ -79,7 +80,8 @@ from qgis.core import (
     QgsProcessingModelChildParameterSource,
     QgsProcessingModelAlgorithm,
     QgsRasterDataProvider,
-    NULL)
+    NULL,
+    Qgis)
 
 from qgis.PyQt.QtWidgets import (
     QCheckBox,
@@ -1088,6 +1090,7 @@ class FeatureSourceWidgetWrapper(WidgetWrapper):
     NOT_SELECTED = '[Not selected]'
 
     def createWidget(self):
+        self.fileBasedLayers = {}
         if self.dialogType == DIALOG_STANDARD:
             widget = QWidget()
             layout = QHBoxLayout()
@@ -1430,6 +1433,7 @@ class VectorLayerWidgetWrapper(WidgetWrapper):
     NOT_SELECTED = '[Not selected]'
 
     def createWidget(self):
+        self.fileBasedLayers = {}
         if self.dialogType == DIALOG_STANDARD:
             widget = QWidget()
             layout = QHBoxLayout()
@@ -1575,6 +1579,7 @@ class TableFieldWidgetWrapper(WidgetWrapper):
         super().__init__(param, dialog, row, col, **kwargs)
         self.context = dataobjects.createContext()
 
+
     def createWidget(self):
         self._layer = None
 
@@ -1615,14 +1620,26 @@ class TableFieldWidgetWrapper(WidgetWrapper):
                 break
 
     def parentValueChanged(self, wrapper):
-        self.setLayer(wrapper.parameterValue())
+        value = wrapper.parameterValue()
+        if value in wrapper.fileBasedLayers:
+            self.setLayer(wrapper.fileBasedLayers[value])
+        else:
+            self.setLayer(value)
+            wrapper.fileBasedLayers[value] = self._layer
 
     def setLayer(self, layer):
         if isinstance(layer, QgsProcessingFeatureSourceDefinition):
             layer, ok = layer.source.valueAsString(self.context.expressionContext())
         if isinstance(layer, str):
             layer = QgsProcessingUtils.mapLayerFromString(layer, self.context)
-        self._layer = layer
+            if not isinstance(layer, QgsVectorLayer) or not layer.isValid():
+                self.dialog.messageBar().clearWidgets()
+                self.dialog.messageBar().pushMessage("", self.tr("Could not load selected layer/table. Dependent field could not be populated"),
+                                          level=Qgis.Warning, duration=5)
+                return
+
+        self._layer = layer        
+
         self.refreshItems()
 
     def refreshItems(self):

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -1579,7 +1579,6 @@ class TableFieldWidgetWrapper(WidgetWrapper):
         super().__init__(param, dialog, row, col, **kwargs)
         self.context = dataobjects.createContext()
 
-
     def createWidget(self):
         self._layer = None
 
@@ -1635,10 +1634,10 @@ class TableFieldWidgetWrapper(WidgetWrapper):
             if not isinstance(layer, QgsVectorLayer) or not layer.isValid():
                 self.dialog.messageBar().clearWidgets()
                 self.dialog.messageBar().pushMessage("", self.tr("Could not load selected layer/table. Dependent field could not be populated"),
-                                          level=Qgis.Warning, duration=5)
+                                                     level=Qgis.Warning, duration=5)
                 return
 
-        self._layer = layer        
+        self._layer = layer
 
         self.refreshItems()
 


### PR DESCRIPTION

## Description
Show warning when file-based layer could not be loaded and dependent params updated

For algorithms with multiple parameters depending on a vector layer parameter, the code that loads the layer in the background is called repeatedly, impacting performance. A small layer cache is implemented with these changes, so the dialog only tries to load the layer once.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
