### PR TITLE
Add more useful debugging context to QgsNetworkAccessManager

### DIFF
--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -223,6 +223,22 @@ created in any thread.
 .. versionadded:: 3.6
 %End
 
+    void downloadProgress( int requestId, qint64 bytesReceived, qint64 bytesTotal );
+%Docstring
+Emitted when a network reply receives a progress report.
+
+The ``requestId`` argument reflects the unique ID identifying the original request which the progress report relates to.
+
+The ``bytesReceived`` parameter indicates the number of bytes received, while ``bytesTotal`` indicates the total number
+of bytes expected to be downloaded. If the number of bytes to be downloaded is not known, ``bytesTotal`` will be -1.
+
+This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+only to connect to the main thread's signal in order to receive notifications about requests
+created in any thread.
+
+.. versionadded:: 3.6
+%End
+
  void requestCreated( QNetworkReply * ) /Deprecated/;
 %Docstring
 

--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -10,6 +10,7 @@
 
 
 
+
 class QgsNetworkRequestParameters
 {
 %Docstring
@@ -22,6 +23,12 @@ Encapsulates parameters and properties of a network request.
 #include "qgsnetworkaccessmanager.h"
 %End
   public:
+
+    enum RequestAttributes
+    {
+      AttributeInitiatorClass,
+      AttributeInitiatorRequestId,
+    };
 
     QgsNetworkRequestParameters();
 %Docstring
@@ -64,6 +71,27 @@ Returns a unique ID identifying the request.
 %Docstring
 Returns the request's content. This is only used for POST or PUT operation
 requests.
+%End
+
+    QString initiatorClassName() const;
+%Docstring
+Returns the class name of the object which initiated this request.
+
+This is only available for QNetworkRequests which have had the
+QgsNetworkRequestParameters.AttributeInitiatorClass attribute set.
+
+.. seealso:: :py:func:`initiatorRequestId`
+%End
+
+    QVariant initiatorRequestId() const;
+%Docstring
+Returns the internal ID used by the object which initiated this request to identify
+individual requests.
+
+This is only available for QNetworkRequests which have had the
+QgsNetworkRequestParameters.AttributeInitiatorRequestId attribute set.
+
+.. seealso:: :py:func:`initiatorClassName`
 %End
 
 };

--- a/python/pyplugin_installer/installer.py
+++ b/python/pyplugin_installer/installer.py
@@ -32,7 +32,7 @@ from qgis.PyQt.QtWidgets import QApplication, QDialog, QDialogButtonBox, QFrame,
 from qgis.PyQt.QtNetwork import QNetworkRequest
 
 import qgis
-from qgis.core import Qgis, QgsApplication, QgsNetworkAccessManager, QgsSettings
+from qgis.core import Qgis, QgsApplication, QgsNetworkAccessManager, QgsSettings, QgsNetworkRequestParameters
 from qgis.gui import QgsMessageBar, QgsPasswordLineEdit
 from qgis.utils import (iface, startPlugin, unloadPlugin, loadPlugin,
                         reloadPlugin, updateAvailablePlugins)
@@ -527,6 +527,8 @@ class QgsPluginInstaller(QObject):
         url = "http://plugins.qgis.org/plugins/RPC2/"
         params = {"id": "djangorpc", "method": "plugin.vote", "params": [str(plugin_id), str(vote)]}
         req = QNetworkRequest(QUrl(url))
+        req.setAttribute(QNetworkRequest.Attribute(QgsNetworkRequestParameters.AttributeInitiatorClass), "QgsPluginInstaller")
+        req.setAttribute(QNetworkRequest.Attribute(QgsNetworkRequestParameters.AttributeInitiatorRequestId), "sendVote")
         req.setRawHeader(b"Content-Type", b"application/json")
         QgsNetworkAccessManager.instance().post(req, bytes(json.dumps(params), "utf-8"))
         return True

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -28,7 +28,7 @@ from qgis.PyQt.QtCore import (pyqtSignal, QObject, QCoreApplication, QFile,
                               QLocale, QByteArray)
 from qgis.PyQt.QtXml import QDomDocument
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply
-from qgis.core import Qgis, QgsSettings
+from qgis.core import Qgis, QgsSettings, QgsNetworkRequestParameters
 import sys
 import os
 import codecs
@@ -322,6 +322,7 @@ class Repositories(QObject):
         # url.addQueryItem('qgis', '.'.join([str(int(s)) for s in [v[0], v[1:3]]]) ) # don't include the bugfix version!
 
         self.mRepositories[key]["QRequest"] = QNetworkRequest(url)
+        self.mRepositories[key]["QRequest"].setAttribute(QNetworkRequest.Attribute(QgsNetworkRequestParameters.AttributeInitiatorClass), "Relay")
         authcfg = self.mRepositories[key]["authcfg"]
         if authcfg and isinstance(authcfg, str):
             if not QgsApplication.authManager().updateNetworkRequest(

--- a/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
+++ b/python/pyplugin_installer/qgsplugininstallerinstallingdialog.py
@@ -30,7 +30,7 @@ from qgis.PyQt.QtWidgets import QDialog
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply
 
 import qgis
-from qgis.core import QgsNetworkAccessManager, QgsApplication
+from qgis.core import QgsNetworkAccessManager, QgsApplication, QgsNetworkRequestParameters
 
 from .ui_qgsplugininstallerinstallingbase import Ui_QgsPluginInstallerInstallingDialogBase
 from .installer_data import removeDir, repositories
@@ -62,6 +62,7 @@ class QgsPluginInstallerInstallingDialog(QDialog, Ui_QgsPluginInstallerInstallin
 
     def requestDownloading(self):
         self.request = QNetworkRequest(self.url)
+        self.request.setAttribute(QNetworkRequest.Attribute(QgsNetworkRequestParameters.AttributeInitiatorClass), "QgsPluginInstallerInstallingDialog")
         authcfg = repositories.all()[self.plugin["zip_repository"]]["authcfg"]
         if authcfg and isinstance(authcfg, str):
             if not QgsApplication.authManager().updateNetworkRequest(

--- a/src/auth/oauth2/qgsauthoauth2edit.cpp
+++ b/src/auth/oauth2/qgsauthoauth2edit.cpp
@@ -1119,6 +1119,7 @@ void QgsAuthOAuth2Edit::registerSoftStatement( const QString &registrationUrl )
   bool res = false;
   QByteArray json = QJsonWrapper::toJson( QVariant( mSoftwareStatement ), &res, &errStr );
   QNetworkRequest registerRequest( regUrl );
+  QgsSetRequestInitiatorClass( registerRequest, QStringLiteral( "QgsAuthOAuth2Edit" ) );
   registerRequest.setHeader( QNetworkRequest::ContentTypeHeader, QLatin1Literal( "application/json" ) );
   QNetworkReply *registerReply;
   // For testability: use GET if protocol is file://
@@ -1142,6 +1143,7 @@ void QgsAuthOAuth2Edit::getSoftwareStatementConfig()
     QString config = leSoftwareStatementConfigUrl->text();
     QUrl configUrl( config );
     QNetworkRequest configRequest( configUrl );
+    QgsSetRequestInitiatorClass( configRequest, QStringLiteral( "QgsAuthOAuth2Edit" ) );
     QNetworkReply *configReply = QgsNetworkAccessManager::instance()->get( configRequest );
     mDownloading = true;
     connect( configReply, &QNetworkReply::finished, this, &QgsAuthOAuth2Edit::configReplyFinished, Qt::QueuedConnection );

--- a/src/auth/oauth2/qgso2.cpp
+++ b/src/auth/oauth2/qgso2.cpp
@@ -20,6 +20,7 @@
 #include "qgsapplication.h"
 #include "qgsauthoauth2config.h"
 #include "qgslogger.h"
+#include "qgsnetworkaccessmanager.h"
 
 #include <QDir>
 #include <QSettings>
@@ -230,6 +231,7 @@ void QgsO2::link()
 
     QUrl url( tokenUrl_ );
     QNetworkRequest tokenRequest( url );
+    QgsSetRequestInitiatorClass( tokenRequest, QStringLiteral( "QgsO2" ) );
     tokenRequest.setHeader( QNetworkRequest::ContentTypeHeader, QLatin1Literal( "application/x-www-form-urlencoded" ) );
     QNetworkReply *tokenReply = manager_->post( tokenRequest, payload );
 
@@ -291,6 +293,7 @@ void QgsO2::onVerificationReceived( QMap<QString, QString> response )
     if ( !apiKey_.isEmpty() )
       query = QStringLiteral( "?=%1" ).arg( QString( O2_OAUTH2_API_KEY ), apiKey_ );
     QNetworkRequest tokenRequest( QUrl( tokenUrl_.toString() + query ) );
+    QgsSetRequestInitiatorClass( tokenRequest, QStringLiteral( "QgsO2" ) );
     tokenRequest.setHeader( QNetworkRequest::ContentTypeHeader, O2_MIME_TYPE_XFORM );
     QMap<QString, QString> parameters;
     parameters.insert( O2_OAUTH2_GRANT_TYPE_CODE, code() );

--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -185,7 +185,7 @@ void QgsGeoNodeRequest::replyFinished()
         else
         {
           QNetworkRequest request( toUrl );
-
+          QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsGeoNodeRequest" ) );
           request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, mForceRefresh ? QNetworkRequest::AlwaysNetwork : QNetworkRequest::PreferCache );
           request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
@@ -519,6 +519,7 @@ bool QgsGeoNodeRequest::requestBlocking( const QString &endPoint )
 QNetworkReply *QgsGeoNodeRequest::requestUrl( const QString &url )
 {
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsGeoNodeRequest" ) );
   // Add authentication check here
 
   request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, mForceRefresh ? QNetworkRequest::AlwaysNetwork : QNetworkRequest::PreferCache );

--- a/src/core/qgsabstractcontentcache.h
+++ b/src/core/qgsabstractcontentcache.h
@@ -23,6 +23,7 @@
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
 #include "qgsapplication.h"
+#include "qgsnetworkaccessmanager.h"
 
 #include <QObject>
 #include <QMutex>
@@ -322,6 +323,7 @@ class CORE_EXPORT QgsAbstractContentCache : public QgsAbstractContentCacheBase
       mPendingRemoteUrls.insert( path );
       //fire up task to fetch content in background
       QNetworkRequest request( url );
+      QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsAbstractContentCache<%1>" ).arg( mTypeString ) );
       request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
       request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 

--- a/src/core/qgsfiledownloader.cpp
+++ b/src/core/qgsfiledownloader.cpp
@@ -51,6 +51,7 @@ void QgsFileDownloader::startDownload()
   QgsNetworkAccessManager *nam = QgsNetworkAccessManager::instance();
 
   QNetworkRequest request( mUrl );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsFileDownloader" ) );
   if ( !mAuthCfg.isEmpty() )
   {
     QgsApplication::authManager()->updateNetworkRequest( request, mAuthCfg );

--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -61,6 +61,8 @@ int QgsGml::getFeatures( const QString &uri, QgsWkbTypes::Type *wkbType, QgsRect
   mExtent.setMinimal();
 
   QNetworkRequest request( uri );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsGml" ) );
+
   if ( !authcfg.isEmpty() )
   {
     if ( !QgsApplication::authManager()->updateNetworkRequest( request, authcfg ) )

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -264,14 +264,14 @@ void QgsNetworkAccessManager::onReplyFinished( QNetworkReply *reply )
   emit finished( QgsNetworkReplyContent( reply ) );
 }
 
-void QgsNetworkAccessManager::onReplyDownloadProgress( qint64 bytesRecevied, qint64 bytesTotal )
+void QgsNetworkAccessManager::onReplyDownloadProgress( qint64 bytesReceived, qint64 bytesTotal )
 {
   if ( QNetworkReply *reply = qobject_cast< QNetworkReply *>( sender() ) )
   {
     bool ok = false;
     int requestId = reply->property( "requestId" ).toInt( &ok );
     if ( ok )
-      emit downloadProgress( requestId, bytesRecevied, bytesTotal );
+      emit downloadProgress( requestId, bytesReceived, bytesTotal );
   }
 }
 

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -450,5 +450,7 @@ QgsNetworkRequestParameters::QgsNetworkRequestParameters( QNetworkAccessManager:
   , mOriginatingThreadId( QStringLiteral( "0x%2" ).arg( reinterpret_cast<quintptr>( QThread::currentThread() ), 2 * QT_POINTER_SIZE, 16, QLatin1Char( '0' ) ) )
   , mRequestId( requestId )
   , mContent( content )
+  , mInitiatorClass( request.attribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorClass ) ).toString() )
+  , mInitiatorRequestId( request.attribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorRequestId ) ) )
 {
 }

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -222,6 +222,22 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     void requestTimedOut( QgsNetworkRequestParameters request );
 
     /**
+     * Emitted when a network reply receives a progress report.
+     *
+     * The \a requestId argument reflects the unique ID identifying the original request which the progress report relates to.
+     *
+     * The \a bytesReceived parameter indicates the number of bytes received, while \a bytesTotal indicates the total number
+     * of bytes expected to be downloaded. If the number of bytes to be downloaded is not known, \a bytesTotal will be -1.
+     *
+     * This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+     * only to connect to the main thread's signal in order to receive notifications about requests
+     * created in any thread.
+     *
+     * \since QGIS 3.6
+     */
+    void downloadProgress( int requestId, qint64 bytesReceived, qint64 bytesTotal );
+
+    /**
      * \deprecated Use the thread-safe requestAboutToBeCreated( QgsNetworkRequestParameters ) signal instead.
      */
     Q_DECL_DEPRECATED void requestCreated( QNetworkReply * ) SIP_DEPRECATED;
@@ -232,6 +248,8 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     void abortRequest();
 
     void onReplyFinished( QNetworkReply *reply );
+
+    void onReplyDownloadProgress( qint64 bytesRecevied, qint64 bytesTotal );
 
   protected:
     QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = nullptr ) override;

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -287,7 +287,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 
     void onReplyFinished( QNetworkReply *reply );
 
-    void onReplyDownloadProgress( qint64 bytesRecevied, qint64 bytesTotal );
+    void onReplyDownloadProgress( qint64 bytesReceived, qint64 bytesTotal );
 
   protected:
     QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = nullptr ) override;

--- a/src/providers/arcgisrest/qgsarcgisrestutils.cpp
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.cpp
@@ -476,6 +476,7 @@ QByteArray QgsArcGisRestUtils::queryService( const QUrl &u, const QString &authc
   QUrl url = parseUrl( u );
 
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsArcGisRestUtils" ) );
   for ( auto it = requestHeaders.constBegin(); it != requestHeaders.constEnd(); ++it )
   {
     request.setRawHeader( it.key().toUtf8(), it.value().toUtf8() );
@@ -1136,6 +1137,7 @@ void QgsArcGisAsyncQuery::start( const QUrl &url, QByteArray *result, bool allow
 {
   mResult = result;
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsArcGisAsyncQuery" ) );
   if ( allowCache )
   {
     request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
@@ -1161,6 +1163,7 @@ void QgsArcGisAsyncQuery::handleReply()
   if ( !redirect.isNull() )
   {
     QNetworkRequest request = mReply->request();
+    QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsArcGisAsyncQuery" ) );
     QgsDebugMsg( "redirecting to " + redirect.toUrl().toString() );
     request.setUrl( redirect.toUrl() );
     mReply = QgsNetworkAccessManager::instance()->get( request );
@@ -1188,6 +1191,8 @@ void QgsArcGisAsyncParallelQuery::start( const QVector<QUrl> &urls, QVector<QByt
   for ( int i = 0, n = urls.size(); i < n; ++i )
   {
     QNetworkRequest request( urls[i] );
+    QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsArcGisAsyncParallelQuery" ) );
+    QgsSetRequestInitiatorId( request, QString::number( i ) );
     request.setAttribute( QNetworkRequest::HttpPipeliningAllowedAttribute, true );
     if ( allowCache )
     {
@@ -1217,6 +1222,7 @@ void QgsArcGisAsyncParallelQuery::handleReply()
   {
     // Handle HTTP redirects
     QNetworkRequest request = reply->request();
+    QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsArcGisAsyncParallelQuery" ) );
     QgsDebugMsg( "redirecting to " + redirect.toUrl().toString() );
     request.setUrl( redirect.toUrl() );
     reply = QgsNetworkAccessManager::instance()->get( request );

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -130,6 +130,7 @@ bool QgsWcsCapabilities::sendRequest( QString const &url )
   QgsDebugMsg( "url = " + url );
   mError.clear();
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWcsCapabilities" ) );
   if ( !setAuthorization( request ) )
   {
     mError = tr( "Download of capabilities failed: network request update failed for authentication config" );
@@ -347,6 +348,7 @@ void QgsWcsCapabilities::capabilitiesReplyFinished()
       emit statusChanged( tr( "Capabilities request redirected." ) );
 
       QNetworkRequest request( redirect.toUrl() );
+      QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWcsCapabilities" ) );
       if ( !setAuthorization( request ) )
       {
         mCapabilitiesResponse.clear();
@@ -387,6 +389,7 @@ void QgsWcsCapabilities::capabilitiesReplyFinished()
   {
     // Resend request if AlwaysCache
     QNetworkRequest request = mCapabilitiesReply->request();
+    QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWcsCapabilities" ) );
     if ( request.attribute( QNetworkRequest::CacheLoadControlAttribute ).toInt() == QNetworkRequest::AlwaysCache )
     {
       QgsDebugMsg( QStringLiteral( "Resend request with PreferCache" ) );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1626,6 +1626,7 @@ QgsWcsDownloadHandler::QgsWcsDownloadHandler( const QUrl &url, QgsWcsAuthorizati
   }
 
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWcsDownloadHandler" ) );
   if ( !mAuth.setAuthorization( request ) )
   {
     QgsMessageLog::logMessage( tr( "Network request update failed for authentication config" ),
@@ -1676,6 +1677,7 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
 
       QgsDebugMsg( QStringLiteral( "redirected getmap: %1" ).arg( redirect.toString() ) );
       QNetworkRequest request( redirect.toUrl() );
+      QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWcsDownloadHandler" ) );
       if ( !mAuth.setAuthorization( request ) )
       {
         QgsMessageLog::logMessage( tr( "Network request update failed for authentication config" ),
@@ -1851,6 +1853,7 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
     {
       // Resend request if AlwaysCache
       QNetworkRequest request = mCacheReply->request();
+      QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWcsDownloadHandler" ) );
       if ( request.attribute( QNetworkRequest::CacheLoadControlAttribute ).toInt() == QNetworkRequest::AlwaysCache )
       {
         QgsDebugMsg( QStringLiteral( "Resend request with PreferCache" ) );

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -114,6 +114,7 @@ bool QgsWfsRequest::sendGET( const QUrl &url, bool synchronous, bool forceRefres
   QgsDebugMsgLevel( QStringLiteral( "Calling: %1" ).arg( modifiedUrl.toDisplayString( ) ), 4 );
 
   QNetworkRequest request( modifiedUrl );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWfsRequest" ) );
   if ( !mUri.auth().setAuthorization( request ) )
   {
     mErrorCode = QgsWfsRequest::NetworkError;
@@ -252,6 +253,7 @@ bool QgsWfsRequest::sendPOST( const QUrl &url, const QString &contentTypeHeader,
   }
 
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWfsRequest" ) );
   if ( !mUri.auth().setAuthorization( request ) )
   {
     mErrorCode = QgsWfsRequest::NetworkError;
@@ -336,6 +338,7 @@ void QgsWfsRequest::replyFinished()
         else
         {
           QNetworkRequest request( toUrl );
+          QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWfsRequest" ) );
           if ( !mUri.auth().setAuthorization( request ) )
           {
             mResponse.clear();

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1948,6 +1948,7 @@ bool QgsWmsCapabilitiesDownload::downloadCapabilities()
   mError.clear();
 
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsCapabilitiesDownload" ) );
   if ( !mAuth.setAuthorization( request ) )
   {
     mError = tr( "Download of capabilities failed: network request update failed for authentication config" );
@@ -2016,6 +2017,7 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
         else
         {
           QNetworkRequest request( toUrl );
+          QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsCapabilitiesDownload" ) );
           if ( !mAuth.setAuthorization( request ) )
           {
             mHttpCapabilitiesResponse.clear();

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2714,6 +2714,8 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPointXY &point, QgsRa
 
     QgsDebugMsg( QStringLiteral( "getfeatureinfo: %1" ).arg( requestUrl.toString() ) );
     QNetworkRequest request( requestUrl );
+    QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsProvider" ) );
+    QgsSetRequestInitiatorId( request, QStringLiteral( "identify %1,%2" ).arg( point.x() ).arg( point.y() ) );
     mSettings.authorization().setAuthorization( request );
     mIdentifyReply = QgsNetworkAccessManager::instance()->get( request );
     connect( mIdentifyReply, &QNetworkReply::finished, this, &QgsWmsProvider::identifyReplyFinished );
@@ -3582,6 +3584,7 @@ QgsWmsImageDownloadHandler::QgsWmsImageDownloadHandler( const QString &providerU
   }
 
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsImageDownloadHandler" ) );
   auth.setAuthorization( request );
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
   mCacheReply = QgsNetworkAccessManager::instance()->get( request );
@@ -3753,6 +3756,7 @@ QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString 
   Q_FOREACH ( const QgsWmsProvider::TileRequest &r, requests )
   {
     QNetworkRequest request( r.url );
+    QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsTiledImageDownloadHandler" ) );
     auth.setAuthorization( request );
     request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
     request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
@@ -3849,6 +3853,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
     if ( !redirect.isNull() )
     {
       QNetworkRequest request( redirect.toUrl() );
+      QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsTiledImageDownloadHandler" ) );
       mAuth.setAuthorization( request );
       request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
       request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
@@ -4031,6 +4036,7 @@ void QgsWmsTiledImageDownloadHandler::repeatTileRequest( QNetworkRequest const &
   }
 
   QNetworkRequest request( oldRequest );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsTiledImageDownloadHandler" ) );
 
   QString url = request.url().toString();
   int tileReqNo = request.attribute( static_cast<QNetworkRequest::Attribute>( TileReqNo ) ).toInt();
@@ -4141,6 +4147,7 @@ QgsWmsLegendDownloadHandler::startUrl( const QUrl &url )
   QgsDebugMsg( QStringLiteral( "legend url: %1" ).arg( url.toString() ) );
 
   QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWmsLegendDownloadHandler" ) );
   mSettings.authorization().setAuthorization( request );
   request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -1177,7 +1177,9 @@ void QgsWMSSourceSelect::btnSearch_clicked()
   QUrl url( mySearchUrl.arg( leSearchTerm->text() ) );
   QgsDebugMsg( url.toString() );
 
-  QNetworkReply *r = QgsNetworkAccessManager::instance()->get( QNetworkRequest( url ) );
+  QNetworkRequest request( url );
+  QgsSetRequestInitiatorClass( request, QStringLiteral( "QgsWMSSourceSelect" ) );
+  QNetworkReply *r = QgsNetworkAccessManager::instance()->get( request );
   connect( r, &QNetworkReply::finished, this, &QgsWMSSourceSelect::searchFinished );
 }
 

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -201,6 +201,8 @@ void TestQgsNetworkAccessManager::fetchEncodedContent()
     QVERIFY( requestId > 0 );
     QCOMPARE( params.operation(), QNetworkAccessManager::GetOperation );
     QCOMPARE( params.request().url(), u );
+    QCOMPARE( params.initiatorClassName(), QStringLiteral( "myTestClass" ) );
+    QCOMPARE( params.initiatorRequestId().toInt(), 55 );
   } );
   connect( QgsNetworkAccessManager::instance(), qgis::overload< QgsNetworkReplyContent >::of( &QgsNetworkAccessManager::finished ), &context, [&]( const QgsNetworkReplyContent & reply )
   {
@@ -210,7 +212,10 @@ void TestQgsNetworkAccessManager::fetchEncodedContent()
     QCOMPARE( reply.request().url(), u );
     loaded = true;
   } );
-  QgsNetworkAccessManager::instance()->get( QNetworkRequest( u ) );
+  QNetworkRequest r( u );
+  r.setAttribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorClass ), QStringLiteral( "myTestClass" ) );
+  r.setAttribute( static_cast< QNetworkRequest::Attribute >( QgsNetworkRequestParameters::AttributeInitiatorRequestId ), 55 );
+  QgsNetworkAccessManager::instance()->get( r );
 
   while ( !loaded )
   {
@@ -222,7 +227,7 @@ void TestQgsNetworkAccessManager::fetchEncodedContent()
 
   gotRequestAboutToBeCreatedSignal = false;
   loaded = false;
-  BackgroundRequest *thread = new BackgroundRequest( QNetworkRequest( u ) );
+  BackgroundRequest *thread = new BackgroundRequest( r );
 
   thread->start();
 


### PR DESCRIPTION
More follow ups from recent work done to make tracking network requests more transparent and aid in WFS/WMS/etc debugging, this one:

- Bounces reply downloadProgress signals up to the main thread QgsNetworkAccessManager instance, so it is necessary only to connect to the main thread's signal in order to receive notifications about requests created in any thread. The new signal also includes the original requestId to allow linking download progress to original request

- Adds custom QNetworkRequest::Attributes for initiator network request class name and internal id (usually the line number and function name where the request was created). And allow these to be retrieved from QgsNetworkRequestParameters. This allows logging code to identify the area of code where a request originated from, making debugging MUCH easier!