### PR TITLE
[processing] Add API to get an import statement and classname for a parameter type

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparametertype.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparametertype.sip.in
@@ -51,6 +51,27 @@ A human readable and translatable short name for this parameter type.
 This will be used in comboboxes and list widgets.
 %End
 
+
+    virtual QString pythonImportString() const;
+%Docstring
+Returns a valid Python import string for importing the corresponding parameter type,
+e.g. "from qgis.core import :py:class:`QgsProcessingParameterBoolean`".
+
+.. seealso:: :py:func:`className`
+
+.. versionadded:: 3.6
+%End
+
+
+    virtual QString className() const;
+%Docstring
+Returns the corresponding class name for the parameter type.
+
+.. seealso:: :py:func:`pythonImportString`
+
+.. versionadded:: 3.6
+%End
+
     virtual QString id() const = 0;
 %Docstring
 A static id for this type which will be used for storing this parameter type.

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -167,6 +167,12 @@ class FieldsMapper(QgisFeatureBasedAlgorithm):
         def id(self):
             return 'fields_mapping'
 
+        def pythonImportString(self):
+            return 'from processing.algs.qgis.FieldsMapper import FieldsMapper'
+
+        def className(self):
+            return 'FieldsMapper.ParameterFieldsMapping'
+
         def description(self):
             return QCoreApplication.translate('Processing', 'A mapping of field names to field type definitions and expressions. Used for the refactor fields algorithm.')
 

--- a/python/plugins/processing/tests/QgisAlgorithmsTest.py
+++ b/python/plugins/processing/tests/QgisAlgorithmsTest.py
@@ -100,6 +100,14 @@ class TestQgisAlgorithms(unittest.TestCase, AlgorithmsTestBase.AlgorithmsTest):
         results, ok = alg.run({}, context, feedback)
         self.assertFalse(ok)
 
+    def testParameterPythonImport(self):
+        for t in QgsApplication.processingRegistry().parameterTypes():
+            import_string = t.pythonImportString()
+            # check that pythonImportString correctly imports
+            exec(import_string)
+            # and now we should be able to instantiate an object!
+            exec('test = {}(\'id\',\'name\')\nself.assertIsNotNone(test)'.format(t.className()))
+
 
 if __name__ == '__main__':
     nose2.main()

--- a/src/core/processing/qgsprocessingparametertype.h
+++ b/src/core/processing/qgsprocessingparametertype.h
@@ -68,6 +68,30 @@ class CORE_EXPORT QgsProcessingParameterType
      */
     virtual QString name() const = 0;
 
+    // TODO QGIS 4.0 -- make pure virtual
+
+    /**
+     * Returns a valid Python import string for importing the corresponding parameter type,
+     * e.g. "from qgis.core import QgsProcessingParameterBoolean".
+     *
+     * \see className()
+     * \since QGIS 3.6
+     */
+    virtual QString pythonImportString() const { return QString(); }
+
+    // TODO QGIS 4.0 -- make pure virtual
+
+    /**
+     * Returns the corresponding class name for the parameter type.
+     *
+     * \see pythonImportString()
+     * \since QGIS 3.6
+     */
+    virtual QString className() const
+    {
+      return name(); // this is wrong, but it's better than nothing for subclasses which don't implement this method
+    }
+
     /**
      * A static id for this type which will be used for storing this parameter type.
      */

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -49,6 +49,16 @@ class CORE_EXPORT QgsProcessingParameterTypeRasterLayer : public QgsProcessingPa
       return QCoreApplication::translate( "Processing", "Raster Layer" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterRasterLayer" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterRasterLayer" );
+    }
+
     QString id() const override
     {
       return QStringLiteral( "raster" );
@@ -88,6 +98,16 @@ class CORE_EXPORT QgsProcessingParameterTypeMeshLayer : public QgsProcessingPara
       return QCoreApplication::translate( "Processing", "Mesh Layer" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterMeshLayer" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterMeshLayer" );
+    }
+
     QString id() const override
     {
       return QStringLiteral( "mesh" );
@@ -124,6 +144,16 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorLayer : public QgsProcessingPa
     QString name() const override
     {
       return QCoreApplication::translate( "Processing", "Vector Layer" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterVectorLayer" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterVectorLayer" );
     }
 
     QString id() const override
@@ -170,6 +200,16 @@ class CORE_EXPORT QgsProcessingParameterTypeMapLayer : public QgsProcessingParam
       return QStringLiteral( "maplayer" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterMapLayer" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterMapLayer" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QObject::tr( "str: layer ID" )
@@ -211,6 +251,16 @@ class CORE_EXPORT QgsProcessingParameterTypeBoolean : public QgsProcessingParame
       return QStringLiteral( "boolean" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterBoolean" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterBoolean" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QStringLiteral( "bool" )
@@ -249,6 +299,16 @@ class CORE_EXPORT QgsProcessingParameterTypeExpression : public QgsProcessingPar
       return QStringLiteral( "expression" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterExpression" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterExpression" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QStringLiteral( "str" )
@@ -283,6 +343,16 @@ class CORE_EXPORT QgsProcessingParameterTypeCrs : public QgsProcessingParameterT
     QString id() const override
     {
       return QStringLiteral( "crs" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterCrs" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterCrs" );
     }
 
     QStringList acceptedPythonTypes() const override
@@ -331,6 +401,16 @@ class CORE_EXPORT QgsProcessingParameterTypeRange : public QgsProcessingParamete
       return QStringLiteral( "range" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterRange" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterRange" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QObject::tr( "list[float]: list of 2 float values" )
@@ -367,6 +447,16 @@ class CORE_EXPORT QgsProcessingParameterTypePoint : public QgsProcessingParamete
     QString id() const override
     {
       return QStringLiteral( "point" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterPoint" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterPoint" );
     }
 
     QStringList acceptedPythonTypes() const override
@@ -407,6 +497,16 @@ class CORE_EXPORT QgsProcessingParameterTypeEnum : public QgsProcessingParameter
       return QStringLiteral( "enum" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterEnum" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterEnum" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QStringLiteral( "int" )
@@ -442,6 +542,16 @@ class CORE_EXPORT QgsProcessingParameterTypeExtent : public QgsProcessingParamet
     QString id() const override
     {
       return QStringLiteral( "extent" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterExtent" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterExtent" );
     }
 
     QStringList acceptedPythonTypes() const override
@@ -487,6 +597,16 @@ class CORE_EXPORT QgsProcessingParameterTypeMatrix : public QgsProcessingParamet
       return QStringLiteral( "matrix" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterMatrix" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterMatrix" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QObject::tr( "str: as comma delimited list of values" )
@@ -522,6 +642,16 @@ class CORE_EXPORT QgsProcessingParameterTypeFile : public QgsProcessingParameter
     QString id() const override
     {
       return QStringLiteral( "file" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterFile" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterFile" );
     }
 
     QStringList acceptedPythonTypes() const override
@@ -560,6 +690,16 @@ class CORE_EXPORT QgsProcessingParameterTypeField : public QgsProcessingParamete
       return QStringLiteral( "field" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterField" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterField" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QStringLiteral( "str" )
@@ -595,6 +735,16 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorDestination : public QgsProces
     QString id() const override
     {
       return QStringLiteral( "vectorDestination" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterVectorDestination" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterVectorDestination" );
     }
 
     ParameterFlags flags() const override
@@ -642,6 +792,16 @@ class CORE_EXPORT QgsProcessingParameterTypeFileDestination : public QgsProcessi
       return QStringLiteral( "fileDestination" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterFileDestination" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterFileDestination" );
+    }
+
     ParameterFlags flags() const override
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
@@ -685,6 +845,16 @@ class CORE_EXPORT QgsProcessingParameterTypeFolderDestination : public QgsProces
     QString id() const override
     {
       return QStringLiteral( "folderDestination" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterFolderDestination" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterFolderDestination" );
     }
 
     ParameterFlags flags() const override
@@ -731,6 +901,16 @@ class CORE_EXPORT QgsProcessingParameterTypeRasterDestination : public QgsProces
       return QStringLiteral( "rasterDestination" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterRasterDestination" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterRasterDestination" );
+    }
+
     ParameterFlags flags() const override
     {
       ParameterFlags flags = QgsProcessingParameterType::flags();
@@ -775,6 +955,16 @@ class CORE_EXPORT QgsProcessingParameterTypeString : public QgsProcessingParamet
       return QStringLiteral( "string" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterString" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterString" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QStringLiteral( "str" )
@@ -811,6 +1001,16 @@ class CORE_EXPORT QgsProcessingParameterTypeAuthConfig : public QgsProcessingPar
       return QStringLiteral( "authcfg" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterAuthConfig" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterAuthConfig" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QStringLiteral( "str" );
@@ -844,6 +1044,16 @@ class CORE_EXPORT QgsProcessingParameterTypeMultipleLayers : public QgsProcessin
     QString id() const override
     {
       return QStringLiteral( "multilayer" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterMultipleLayers" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterMultipleLayers" );
     }
 
     QStringList acceptedPythonTypes() const override
@@ -883,6 +1093,16 @@ class CORE_EXPORT QgsProcessingParameterTypeFeatureSource : public QgsProcessing
     QString id() const override
     {
       return QStringLiteral( "source" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterFeatureSource" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterFeatureSource" );
     }
 
     QStringList acceptedPythonTypes() const override
@@ -925,6 +1145,16 @@ class CORE_EXPORT QgsProcessingParameterTypeNumber : public QgsProcessingParamet
       return QStringLiteral( "number" );
     }
 
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterNumber" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterNumber" );
+    }
+
     QStringList acceptedPythonTypes() const override
     {
       return QStringList() << QStringLiteral( "int" )
@@ -960,6 +1190,16 @@ class CORE_EXPORT QgsProcessingParameterTypeDistance : public QgsProcessingParam
     QString id() const override
     {
       return QStringLiteral( "distance" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterDistance" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterDistance" );
     }
 
     QStringList acceptedPythonTypes() const override
@@ -998,6 +1238,16 @@ class CORE_EXPORT QgsProcessingParameterTypeBand : public QgsProcessingParameter
     QString id() const override
     {
       return QStringLiteral( "band" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterBand" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterBand" );
     }
 
     QStringList acceptedPythonTypes() const override
@@ -1042,6 +1292,16 @@ class CORE_EXPORT QgsProcessingParameterTypeFeatureSink : public QgsProcessingPa
     QString id() const override
     {
       return QStringLiteral( "sink" );
+    }
+
+    QString pythonImportString() const override
+    {
+      return QStringLiteral( "from qgis.core import QgsProcessingParameterFeatureSink" );
+    }
+
+    QString className() const override
+    {
+      return QStringLiteral( "QgsProcessingParameterFeatureSink" );
     }
 
     QStringList acceptedPythonTypes() const override


### PR DESCRIPTION
This is baby steps towards resurrecting the 2.18 ability to directly convert a Processing model to a Python script.