### PR TITLE
[processing] Add a better API for specifying that outputs are temporary

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessing.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessing.sip.in
@@ -39,6 +39,7 @@ and parameters.
       TypeMesh
     };
 
+    static const QString TEMPORARY_OUTPUT;
 };
 
 /************************************************************************

--- a/python/plugins/processing/gui/DestinationSelectionPanel.py
+++ b/python/plugins/processing/gui/DestinationSelectionPanel.py
@@ -34,7 +34,8 @@ from qgis.PyQt.QtCore import QCoreApplication, QDir, pyqtSignal, QFileInfo
 from qgis.PyQt.QtWidgets import QDialog, QMenu, QAction, QFileDialog, QInputDialog
 from qgis.PyQt.QtGui import QCursor
 from qgis.gui import QgsEncodingSelectionDialog
-from qgis.core import (QgsDataSourceUri,
+from qgis.core import (QgsProcessing,
+                       QgsDataSourceUri,
                        QgsCredentials,
                        QgsExpression,
                        QgsSettings,
@@ -302,7 +303,7 @@ class DestinationSelectionPanel(BASE, WIDGET):
             else:
                 self.saveToTemporary()
         else:
-            if value == 'memory:':
+            if value in ('memory:', QgsProcessing.TEMPORARY_OUTPUT):
                 self.saveToTemporary()
             elif isinstance(value, QgsProcessingOutputLayerDefinition):
                 if value.sink.staticValue() in ('memory:', ''):
@@ -322,16 +323,17 @@ class DestinationSelectionPanel(BASE, WIDGET):
     def getValue(self):
         key = None
         if self.use_temporary and isinstance(self.parameter, QgsProcessingParameterFeatureSink):
-            key = 'memory:'
+            key = QgsProcessing.TEMPORARY_OUTPUT
         elif self.use_temporary and not self.default_selection:
-            key = self.parameter.generateTemporaryDestination()
+            key = QgsProcessing.TEMPORARY_OUTPUT
         else:
             key = self.leText.text()
 
         if not key and self.parameter.flags() & QgsProcessingParameterDefinition.FlagOptional:
             return None
 
-        if key and not key.startswith('memory:') \
+        if key and not key == QgsProcessing.TEMPORARY_OUTPUT \
+                and not key.startswith('memory:') \
                 and not key.startswith('ogr:') \
                 and not key.startswith('postgres:') \
                 and not key.startswith('postgis:'):

--- a/python/plugins/processing/tests/GuiTest.py
+++ b/python/plugins/processing/tests/GuiTest.py
@@ -355,11 +355,17 @@ class WrappersTest(unittest.TestCase):
         alg = QgsApplication.processingRegistry().createAlgorithmById('native:centroids')
         panel = DestinationSelectionPanel(param, alg)
 
+        panel.setValue(QgsProcessing.TEMPORARY_OUTPUT)
+        v = panel.getValue()
+        self.assertIsInstance(v, QgsProcessingOutputLayerDefinition)
+        self.assertEqual(v.createOptions, {'fileEncoding': 'System'})
+        self.assertEqual(v.sink.staticValue(), QgsProcessing.TEMPORARY_OUTPUT)
+
         panel.setValue('memory:')
         v = panel.getValue()
         self.assertIsInstance(v, QgsProcessingOutputLayerDefinition)
         self.assertEqual(v.createOptions, {'fileEncoding': 'System'})
-        self.assertEqual(v.sink.staticValue(), 'memory:')
+        self.assertEqual(v.sink.staticValue(), QgsProcessing.TEMPORARY_OUTPUT)
 
         panel.setValue('''ogr:dbname='/me/a.gpkg' table="d" (geom) sql=''')
         v = panel.getValue()
@@ -390,6 +396,11 @@ class WrappersTest(unittest.TestCase):
         param = QgsProcessingParameterVectorDestination('test')
         alg = QgsApplication.processingRegistry().createAlgorithmById('native:centroids')
         panel = DestinationSelectionPanel(param, alg)
+
+        panel.setValue(QgsProcessing.TEMPORARY_OUTPUT)
+        v = panel.getValue()
+        self.assertIsInstance(v, QgsProcessingOutputLayerDefinition)
+        self.assertEqual(v.sink.staticValue(), QgsProcessing.TEMPORARY_OUTPUT)
 
         panel.setValue('''ogr:dbname='/me/a.gpkg' table="d" (geom) sql=''')
         v = panel.getValue()
@@ -426,6 +437,11 @@ class WrappersTest(unittest.TestCase):
         self.assertIsInstance(v, QgsProcessingOutputLayerDefinition)
         self.assertEqual(v.createOptions, {'fileEncoding': 'System'})
         self.assertEqual(v.sink.staticValue(), '/home/me/test.tif')
+
+        panel.setValue(QgsProcessing.TEMPORARY_OUTPUT)
+        v = panel.getValue()
+        self.assertIsInstance(v, QgsProcessingOutputLayerDefinition)
+        self.assertEqual(v.sink.staticValue(), QgsProcessing.TEMPORARY_OUTPUT)
 
         ProcessingConfig.setSettingValue(ProcessingConfig.OUTPUT_FOLDER, testDataPath)
         panel.setValue('test.tif')

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -111,6 +111,7 @@ SET(QGIS_CORE_SRCS
   locator/qgslocatormodel.cpp
   locator/qgslocatormodelbridge.cpp
 
+  processing/qgsprocessing.cpp
   processing/qgsprocessingalgorithm.cpp
   processing/qgsprocessingalgrunnertask.cpp
   processing/qgsprocessingcontext.cpp

--- a/src/core/processing/qgsprocessing.cpp
+++ b/src/core/processing/qgsprocessing.cpp
@@ -1,0 +1,20 @@
+/***************************************************************************
+                         qgsprocessing.h
+                         ---------------
+    begin                : July 2017
+    copyright            : (C) 2017 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessing.h"
+
+const QString QgsProcessing::TEMPORARY_OUTPUT = QStringLiteral( "TEMPORARY_OUTPUT" );

--- a/src/core/processing/qgsprocessing.h
+++ b/src/core/processing/qgsprocessing.h
@@ -19,6 +19,7 @@
 #define QGSPROCESSING_H
 
 #include "qgis_core.h"
+#include <QString>
 
 //
 // Output definitions
@@ -53,6 +54,12 @@ class CORE_EXPORT QgsProcessing
       TypeMesh = 6 //!< Mesh layers \since QGIS 3.6
     };
 
+    /**
+     * Constant used to indicate that a Processing algorithm output should be a temporary layer/file.
+     *
+     * \since QGIS 3.6
+     */
+    static const QString TEMPORARY_OUTPUT;
 };
 
 #endif // QGSPROCESSING_H

--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -399,6 +399,11 @@ QgsFeatureSink *QgsProcessingParameters::parameterAsSink( const QgsProcessingPar
   {
     dest = val.toString();
   }
+  if ( dest == QgsProcessing::TEMPORARY_OUTPUT )
+  {
+    if ( const QgsProcessingDestinationParameter *destParam = dynamic_cast< const QgsProcessingDestinationParameter * >( definition ) )
+      dest = destParam->generateTemporaryDestination();
+  }
 
   if ( dest.isEmpty() )
     return nullptr;
@@ -624,6 +629,11 @@ QString QgsProcessingParameters::parameterAsOutputLayer( const QgsProcessingPara
   {
     dest = val.toString();
   }
+  if ( dest == QgsProcessing::TEMPORARY_OUTPUT )
+  {
+    if ( const QgsProcessingDestinationParameter *destParam = dynamic_cast< const QgsProcessingDestinationParameter * >( definition ) )
+      dest = destParam->generateTemporaryDestination();
+  }
 
   if ( destinationProject )
   {
@@ -682,7 +692,11 @@ QString QgsProcessingParameters::parameterAsFileOutput( const QgsProcessingParam
   {
     dest = val.toString();
   }
-
+  if ( dest == QgsProcessing::TEMPORARY_OUTPUT )
+  {
+    if ( const QgsProcessingDestinationParameter *destParam = dynamic_cast< const QgsProcessingDestinationParameter * >( definition ) )
+      val = destParam->generateTemporaryDestination();
+  }
   return dest;
 }
 


### PR DESCRIPTION
Instead of requiring clients to generate temporary file names themselves,
(or use the cryptic "memory:" string!), this PR adds a static constant

    QgsProcessing.TEMPORARY_OUTPUT

If a layer/sink output parameter is set to QgsProcessing.TEMPORARY_OUTPUT,
then the temporary output filename will be generated automatically at
algorithm run time. This means callers don't need to mess around with
finding appropriate temporary folders and paths.

Another benefit is that TEMPORARY_OUTPUT is stored in the processing
history, so if you re-run a previous algorithm which was set to
output to a temporary file, it no longer tries to use that same
previous temporary path and instead generates a new one.


(Another baby step to resurrecting the export model to script functionality)