### PR TITLE
[gui] Fix style manager's add button when the 'all' tab is selected

### DIFF
--- a/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
+++ b/python/gui/auto_generated/symbology/qgsstylemanagerdialog.sip.in
@@ -279,7 +279,7 @@ Populates the list view with color ramps of the current type with the given name
     int currentItemType();
     QString currentItemName();
 
-    bool addSymbol();
+    bool addSymbol( int symbolType = -1 );
 %Docstring
 add a new symbol to style
 %End

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -295,22 +295,30 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
     QStringList rampTypes;
     rampTypes << tr( "Gradient" ) << tr( "Color presets" ) << tr( "Random" ) << tr( "Catalog: cpt-city" );
     rampTypes << tr( "Catalog: ColorBrewer" );
-    mMenuBtnAddItemColorRamp = new QMenu( this );
-    for ( const QString &rampType : qgis::as_const( rampTypes ) )
-      mMenuBtnAddItemColorRamp->addAction( new QAction( rampType, this ) );
-    connect( mMenuBtnAddItemColorRamp, &QMenu::triggered,
-             this, static_cast<bool ( QgsStyleManagerDialog::* )( QAction * )>( &QgsStyleManagerDialog::addColorRamp ) );
 
-    mMenuBtnAddItemSymbol = new QMenu( this );
+    mMenuBtnAddItemAll = new QMenu( this );
+    mMenuBtnAddItemColorRamp = new QMenu( this );
+
     QAction *item = new QAction( tr( "Marker" ), this );
     connect( item, &QAction::triggered, this, [ = ]( bool ) { addSymbol( QgsSymbol::Marker ); } );
-    mMenuBtnAddItemSymbol->addAction( item );
+    mMenuBtnAddItemAll->addAction( item );
     item = new QAction( tr( "Line" ), this );
     connect( item, &QAction::triggered, this, [ = ]( bool ) { addSymbol( QgsSymbol::Line ); } );
-    mMenuBtnAddItemSymbol->addAction( item );
+    mMenuBtnAddItemAll->addAction( item );
     item = new QAction( tr( "Fill" ), this );
     connect( item, &QAction::triggered, this, [ = ]( bool ) { addSymbol( QgsSymbol::Fill ); } );
-    mMenuBtnAddItemSymbol->addAction( item );
+    mMenuBtnAddItemAll->addAction( item );
+    mMenuBtnAddItemAll->addSeparator();
+    for ( const QString &rampType : qgis::as_const( rampTypes ) )
+    {
+      item = new QAction( rampType, this );
+      connect( item, &QAction::triggered, this, [ = ]( bool ) { addColorRamp( item ); } );
+      mMenuBtnAddItemAll->addAction( item );
+      mMenuBtnAddItemColorRamp->addAction( new QAction( rampType, this ) );
+    }
+
+    connect( mMenuBtnAddItemColorRamp, &QMenu::triggered,
+             this, static_cast<bool ( QgsStyleManagerDialog::* )( QAction * )>( &QgsStyleManagerDialog::addColorRamp ) );
   }
 
   // Context menu for symbols/colorramps. The menu entries for every group are created when displaying the menu.
@@ -434,7 +442,7 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
   }
   else if ( !mReadOnly && tabItemType->currentIndex() == 0 ) // all symbols tab
   {
-    btnAddItem->setMenu( mMenuBtnAddItemSymbol );
+    btnAddItem->setMenu( mMenuBtnAddItemAll );
   }
   else
   {

--- a/src/gui/symbology/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology/qgsstylemanagerdialog.cpp
@@ -16,7 +16,6 @@
 #include "qgsstylemanagerdialog.h"
 #include "qgsstylesavedialog.h"
 
-#include "qgsstyle.h"
 #include "qgssymbol.h"
 #include "qgssymbollayerutils.h"
 #include "qgscolorramp.h"
@@ -301,6 +300,17 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle *style, QWidget *parent, 
       mMenuBtnAddItemColorRamp->addAction( new QAction( rampType, this ) );
     connect( mMenuBtnAddItemColorRamp, &QMenu::triggered,
              this, static_cast<bool ( QgsStyleManagerDialog::* )( QAction * )>( &QgsStyleManagerDialog::addColorRamp ) );
+
+    mMenuBtnAddItemSymbol = new QMenu( this );
+    QAction *item = new QAction( tr( "Marker" ), this );
+    connect( item, &QAction::triggered, this, [ = ]( bool ) { addSymbol( QgsSymbol::Marker ); } );
+    mMenuBtnAddItemSymbol->addAction( item );
+    item = new QAction( tr( "Line" ), this );
+    connect( item, &QAction::triggered, this, [ = ]( bool ) { addSymbol( QgsSymbol::Line ); } );
+    mMenuBtnAddItemSymbol->addAction( item );
+    item = new QAction( tr( "Fill" ), this );
+    connect( item, &QAction::triggered, this, [ = ]( bool ) { addSymbol( QgsSymbol::Fill ); } );
+    mMenuBtnAddItemSymbol->addAction( item );
   }
 
   // Context menu for symbols/colorramps. The menu entries for every group are created when displaying the menu.
@@ -417,7 +427,20 @@ void QgsStyleManagerDialog::tabItemType_currentChanged( int )
   // when in Color Ramp tab, add menu to add item button and hide "Export symbols as PNG/SVG"
   const bool isSymbol = currentItemType() != 3;
   searchBox->setPlaceholderText( isSymbol ? tr( "Filter symbols…" ) : tr( "Filter color ramps…" ) );
-  btnAddItem->setMenu( isSymbol || mReadOnly ? nullptr : mMenuBtnAddItemColorRamp );
+
+  if ( !mReadOnly && !isSymbol ) // color ramp tab
+  {
+    btnAddItem->setMenu( mMenuBtnAddItemColorRamp );
+  }
+  else if ( !mReadOnly && tabItemType->currentIndex() == 0 ) // all symbols tab
+  {
+    btnAddItem->setMenu( mMenuBtnAddItemSymbol );
+  }
+  else
+  {
+    btnAddItem->setMenu( nullptr );
+  }
+
   actnExportAsPNG->setVisible( isSymbol );
   actnExportAsSVG->setVisible( isSymbol );
 
@@ -701,12 +724,12 @@ void QgsStyleManagerDialog::addItem()
   }
 }
 
-bool QgsStyleManagerDialog::addSymbol()
+bool QgsStyleManagerDialog::addSymbol( int symbolType )
 {
   // create new symbol with current type
   QgsSymbol *symbol = nullptr;
   QString name = tr( "new symbol" );
-  switch ( currentItemType() )
+  switch ( symbolType == -1 ? currentItemType() : symbolType )
   {
     case QgsSymbol::Marker:
       symbol = new QgsMarkerSymbol();

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -382,7 +382,7 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     QMenu *mMenuBtnAddItemColorRamp = nullptr;
 
     //! Menu for the "Add item" toolbutton when in all symbols mode
-    QMenu *mMenuBtnAddItemSymbol = nullptr;
+    QMenu *mMenuBtnAddItemAll = nullptr;
 
     QAction *mActionCopyToDefault = nullptr;
 

--- a/src/gui/symbology/qgsstylemanagerdialog.h
+++ b/src/gui/symbology/qgsstylemanagerdialog.h
@@ -297,7 +297,7 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
     QString currentItemName();
 
     //! add a new symbol to style
-    bool addSymbol();
+    bool addSymbol( int symbolType = -1 );
     //! add a new color ramp to style
     bool addColorRamp();
 
@@ -380,6 +380,9 @@ class GUI_EXPORT QgsStyleManagerDialog : public QDialog, private Ui::QgsStyleMan
 
     //! Menu for the "Add item" toolbutton when in colorramp mode
     QMenu *mMenuBtnAddItemColorRamp = nullptr;
+
+    //! Menu for the "Add item" toolbutton when in all symbols mode
+    QMenu *mMenuBtnAddItemSymbol = nullptr;
 
     QAction *mActionCopyToDefault = nullptr;
 


### PR DESCRIPTION
## Description
@nyalldawson , this PR fixes the [ + ] add button in the style manager when the 'all' tab is selected by adding a menu to select the symbol type to be added. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
