### PR TITLE
Correct crash when read from ogr file in thread (QgsProcessing for instance)

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -19,7 +19,7 @@ email                : lrssvtml (at) gmail (dot) com
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
 
-from qgis.PyQt.QtCore import Qt, QCoreApplication, QThread, QMetaObject, Q_RETURN_ARG, Q_ARG, QObject, pyqtSlot
+from qgis.PyQt.QtCore import Qt, QCoreApplication
 from qgis.PyQt.QtGui import QColor, QFont, QKeySequence, QFontDatabase
 from qgis.PyQt.QtWidgets import QGridLayout, QSpacerItem, QSizePolicy, QShortcut, QMenu, QApplication
 from qgis.PyQt.Qsci import QsciScintilla, QsciLexerPython
@@ -28,7 +28,7 @@ from qgis.gui import QgsMessageBar
 import sys
 
 
-class writeOut(QObject):
+class writeOut(object):
 
     ERROR_COLOR = "#e31a1c"
 
@@ -36,20 +36,12 @@ class writeOut(QObject):
         """
         This class allows writing to stdout and stderr
         """
-        super().__init__()
         self.sO = shellOut
         self.out = None
         self.style = style
         self.fire_keyboard_interrupt = False
 
-    @pyqtSlot(str)
     def write(self, m):
-
-        # This manage the case when console is called from another thread
-        if QThread.currentThread() != QCoreApplication.instance().thread():
-            QMetaObject.invokeMethod(self, "write", Qt.QueuedConnection, Q_ARG(str, m))
-            return
-
         if self.style == "_traceback":
             # Show errors in red
             stderrColor = QColor(self.sO.settings.value("pythonConsole/stderrFontColor", QColor(self.ERROR_COLOR)))

--- a/src/providers/ogr/qgsogrconnpool.h
+++ b/src/providers/ogr/qgsogrconnpool.h
@@ -156,7 +156,7 @@ class QgsOgrConnPool : public QgsConnectionPool<QgsOgrConn *, QgsOgrConnPoolGrou
 
       if ( it.value()->unref() )
       {
-        delete it.value();
+        it.value()->deleteLater();
         mGroups.erase( it );
       }
       mMutex.unlock();

--- a/tests/src/providers/CMakeLists.txt
+++ b/tests/src/providers/CMakeLists.txt
@@ -71,6 +71,7 @@ TARGET_LINK_LIBRARIES(qgis_arcgisrestutilstest arcgisfeatureserverprovider_a)
 
 ADD_QGIS_TEST(gdalprovidertest testqgsgdalprovider.cpp)
 
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 ADD_QGIS_TEST(ogrprovidertest testqgsogrprovider.cpp)
 
 ADD_QGIS_TEST(wmscapabilitiestest


### PR DESCRIPTION
## Description

Fixes [#20581](https://issues.qgis.org/issues/20581)

It corrects only the first part of the issue (the ogr file read, not the python print).

The problems is quite identical but the solution should be different. When a qgis processing algorithm open, read and close a qgsvectorlayer, it finished to kill a QTimer from its running thread but the QTimer belongs to main thread. When the timeout reach the 60 seconds it crashes. I just deleteLater the object who own the timer, so the destruction is made in the main thread.

The test is quite ugly (and has to wait for 60s timeout) but I don't know how to do better.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
