### PR TITLE
Field calculator: provide a list of default field types

### DIFF
--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -348,7 +348,17 @@ void QgsFieldCalculator::populateOutputFieldTypes()
   }
 
   mOutputFieldTypeComboBox->blockSignals( true );
-  const QList< QgsVectorDataProvider::NativeType > &typelist = provider->nativeTypes();
+
+  // Not all providers have a native types list (WFS), provide default
+  // Integer|Real|Character|Date|Boolean
+  const QList< QgsVectorDataProvider::NativeType > &typelist { provider->nativeTypes().isEmpty() ? ( QList< QgsVectorDataProvider::NativeType >()
+      << QgsVectorDataProvider::NativeType( tr( "Whole number (integer)" ), QStringLiteral( "integer" ), QVariant::Int, 0, 10 )
+      << QgsVectorDataProvider::NativeType( tr( "Decimal number (double)" ), QStringLiteral( "double precision" ), QVariant::Double, -1, -1, -1, -1 )
+      << QgsVectorDataProvider::NativeType( tr( "Text (string)" ), QStringLiteral( "string" ), QVariant::String )
+      << QgsVectorDataProvider::NativeType( tr( "Date" ), QStringLiteral( "date" ), QVariant::Date, -1, -1, -1, -1 )
+      << QgsVectorDataProvider::NativeType( tr( "Boolean (bool)" ), QStringLiteral( "bool" ),  QVariant::Bool ) )
+      :  provider->nativeTypes() };
+
   for ( int i = 0; i < typelist.size(); i++ )
   {
     mOutputFieldTypeComboBox->addItem( typelist[i].mTypeDesc );

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -349,16 +349,24 @@ void QgsFieldCalculator::populateOutputFieldTypes()
 
   mOutputFieldTypeComboBox->blockSignals( true );
 
-  // Not all providers have a native types list (WFS), provide default
-  // Integer|Real|Character|Date|Boolean
-  const QList< QgsVectorDataProvider::NativeType > &typelist { provider->nativeTypes().isEmpty() ? ( QList< QgsVectorDataProvider::NativeType >()
+  // Standard subset of fields in case of virtual
+  const QList< QgsVectorDataProvider::NativeType > &typelist { mCreateVirtualFieldCheckbox->isChecked() ? ( QList< QgsVectorDataProvider::NativeType >()
       << QgsVectorDataProvider::NativeType( tr( "Whole number (integer)" ), QStringLiteral( "integer" ), QVariant::Int, 0, 10 )
       << QgsVectorDataProvider::NativeType( tr( "Decimal number (double)" ), QStringLiteral( "double precision" ), QVariant::Double, -1, -1, -1, -1 )
       << QgsVectorDataProvider::NativeType( tr( "Text (string)" ), QStringLiteral( "string" ), QVariant::String )
+      // date time
       << QgsVectorDataProvider::NativeType( tr( "Date" ), QStringLiteral( "date" ), QVariant::Date, -1, -1, -1, -1 )
-      << QgsVectorDataProvider::NativeType( tr( "Boolean (bool)" ), QStringLiteral( "bool" ),  QVariant::Bool ) )
-      :  provider->nativeTypes() };
+      << QgsVectorDataProvider::NativeType( tr( "Time" ), QStringLiteral( "time" ), QVariant::Time, -1, -1, -1, -1 )
+      << QgsVectorDataProvider::NativeType( tr( "Date & Time" ), QStringLiteral( "datetime" ), QVariant::DateTime, -1, -1, -1, -1 )
+      // string types
+      << QgsVectorDataProvider::NativeType( tr( "Text, unlimited length (text)" ), QStringLiteral( "text" ), QVariant::String, -1, -1, -1, -1 )
+      // boolean
+      << QgsVectorDataProvider::NativeType( tr( "Boolean" ), QStringLiteral( "bool" ), QVariant::Bool )
+      // blob
+      << QgsVectorDataProvider::NativeType( tr( "Binary object (BLOB)" ), QStringLiteral( "binary" ), QVariant::ByteArray ) ) :
+      provider->nativeTypes() };
 
+  mOutputFieldTypeComboBox->clear();
   for ( int i = 0; i < typelist.size(); i++ )
   {
     mOutputFieldTypeComboBox->addItem( typelist[i].mTypeDesc );
@@ -427,6 +435,7 @@ void QgsFieldCalculator::mCreateVirtualFieldCheckbox_stateChanged( int state )
   {
     mEditModeAutoTurnOnLabel->setVisible( true );
   }
+  populateOutputFieldTypes();
   mInfoIcon->setVisible( mOnlyVirtualFieldsInfoLabel->isVisible() || mEditModeAutoTurnOnLabel->isVisible() );
 }
 


### PR DESCRIPTION
in case the provider does not (WFS is one of them).

Rationale: consider that there is not such
a thing like a list of supported types for WFS
and parsing the particular describeFeatureType
for the layer would restrict the types to only
those actually existing in the layer, but
we are dealing with virtual fields here (because
WFS has no column add capabilities) so
let's give the users a minimal set of useful
types to play with.

Fixes #21086
