### PR TITLE
[vertex tool] Fix issue with hidden layers being editable (fixes #18434)

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -676,10 +676,11 @@ QgsPointLocator::Match QgsVertexTool::snapToEditableLayer( QgsMapMouseEvent *e )
   QgsPointXY mapPoint = toMapCoordinates( e->pos() );
   double tol = QgsTolerance::vertexSearchRadius( canvas()->mapSettings() );
 
-  QgsSnappingConfig config( QgsProject::instance() );
+  QgsSnappingConfig config;
   config.setEnabled( true );
   config.setMode( QgsSnappingConfig::AdvancedConfiguration );
   config.setIntersectionSnapping( false );  // only snap to layers
+  Q_ASSERT( config.individualLayerSettings().isEmpty() );
 
   // if there is a current layer, it should have priority over other layers
   // because sometimes there may be match from multiple layers at one location


### PR DESCRIPTION
The problem was that QgsSnappingConfig when initialized from a project
loads global settings from QgsSettings and sets individual layer configs
based on that.

The issue was showing up only in "current layer" mode of vertex tool
because for "all layers" mode all individual layer configs were overwritten.
