### PR TITLE
New Shapefile Layer dialog: avoid to show warning message on user cancel

### DIFF
--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -267,12 +267,12 @@ QString QgsNewVectorLayerDialog::runAndCreateLayer( QWidget *parent, QString *pE
     geomDialog.setFilename( initialPath );
   if ( geomDialog.exec() == QDialog::Rejected )
   {
-    return QString();
+    return QString( "" );
   }
 
   if ( QFile::exists( geomDialog.filename() ) && QMessageBox::warning( parent, tr( "New ShapeFile Layer" ), tr( "The layer already exists. Are you sure you want to overwrite the existing file?" ),
        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel ) != QMessageBox::Yes )
-    return QString();
+    return QString( "" );
 
   QgsWkbTypes::Type geometrytype = geomDialog.selectedType();
   QString fileformat = geomDialog.selectedFileFormat();


### PR DESCRIPTION
This fixes a regression introduced at e0fa9eb9cf20d3153489bc995e13b10e30240bd5 and restores the logic introduced at 71c15f0639b2e9356b23fc9e7d113c01f10787da by @jef-n 

## Description
In 3.4 and master (but not in 2.18 and previous versions), a misleading warning message is displayed in the message bar when the user cancels a New Shapefile Layer creation.

This fixes a regression introduced at e0fa9eb9cf20d3153489bc995e13b10e30240bd5 and restores the logic introduced in 71c15f0639b2e9356b23fc9e7d113c01f10787da

As stated in https://github.com/qgis/QGIS/blob/bba67ae65d548b3af20b8f7b8f77fee1b5ebd227/src/gui/qgsnewvectorlayerdialog.h#L42 QgsNewVectorLayerDialog::runAndCreateLayer should return an empty (not null) string when the user aborts the New Shapefile Layer creation.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
