### PR TITLE
Make SSL error handling thread safe, avoid races and crashes when SSL error occurs in non-main thread

### DIFF
--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -96,6 +96,9 @@ QgsNetworkRequestParameters.AttributeInitiatorRequestId attribute set.
 
 };
 
+
+
+
 class QgsNetworkAccessManager : QNetworkAccessManager
 {
 %Docstring
@@ -140,6 +143,7 @@ need to be handled on the main thread. See in-depth discussion below.
 %End
 
     QgsNetworkAccessManager( QObject *parent = 0 );
+
 
     void insertProxyFactory( QNetworkProxyFactory *factory /Transfer/ );
 %Docstring
@@ -267,6 +271,22 @@ created in any thread.
 .. versionadded:: 3.6
 %End
 
+
+    void requestEncounteredSslErrors( int requestId, const QList<QSslError> &errors );
+%Docstring
+Emitted when a network request encounters SSL ``errors``.
+
+The ``requestId`` argument reflects the unique ID identifying the original request which the progress report relates to.
+
+This signal is propagated to the main thread QgsNetworkAccessManager instance, so it is necessary
+only to connect to the main thread's signal in order to receive notifications about SSL errors
+from any thread.
+
+.. versionadded:: 3.6
+%End
+
+
+
  void requestCreated( QNetworkReply * ) /Deprecated/;
 %Docstring
 
@@ -274,6 +294,7 @@ created in any thread.
 %End
 
     void requestTimedOut( QNetworkReply * );
+
 
   protected:
     virtual QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = 0 );

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(QGIS_APP_SRCS
   qgsappscreenshots.cpp
   qgsjoindialog.cpp
   qgsannotationwidget.cpp
+  qgsappsslerrorhandler.cpp
   qgsattributeactiondialog.cpp
   qgsattributeactionpropertiesdialog.cpp
   qgsattributetypedialog.cpp
@@ -251,6 +252,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsalignrasterdialog.h
   qgsappbrowserproviders.h
   qgsappscreenshots.h
+  qgsappsslerrorhandler.h
   qgsjoindialog.h
   qgsaddtaborgroup.h
   qgsannotationwidget.h

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -252,7 +252,6 @@ SET (QGIS_APP_MOC_HDRS
   qgsalignrasterdialog.h
   qgsappbrowserproviders.h
   qgsappscreenshots.h
-  qgsappsslerrorhandler.h
   qgsjoindialog.h
   qgsaddtaborgroup.h
   qgsannotationwidget.h

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -107,6 +107,7 @@ class QgsUserProfileManager;
 class QgsUserProfileManagerWidgetFactory;
 class Qgs3DMapCanvasDockWidget;
 class QgsHandleBadLayersHandler;
+class QgsNetworkAccessManager;
 
 class QDomDocument;
 class QNetworkReply;
@@ -880,9 +881,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! request credentials for network manager
     void namAuthenticationRequired( QNetworkReply *reply, QAuthenticator *auth );
     void namProxyAuthenticationRequired( const QNetworkProxy &proxy, QAuthenticator *auth );
-#ifndef QT_NO_SSL
-    void namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors );
-#endif
     void namRequestTimedOut( const QgsNetworkRequestParameters &request );
 
     //! Schedule and erase of the authentication database upon confirmation

--- a/src/app/qgsappsslerrorhandler.cpp
+++ b/src/app/qgsappsslerrorhandler.cpp
@@ -72,11 +72,8 @@ void QgsAppSslErrorHandler::handleSslErrors( QNetworkReply *reply, const QList<Q
   dlg->resize( 580, 512 );
   if ( dlg->exec() )
   {
-    if ( reply )
-    {
-      QgsDebugMsg( QStringLiteral( "All SSL errors ignored for %1" ).arg( hostport ) );
-      reply->ignoreSslErrors();
-    }
+    QgsDebugMsg( QStringLiteral( "All SSL errors ignored for %1" ).arg( hostport ) );
+    reply->ignoreSslErrors();
   }
   dlg->deleteLater();
 }

--- a/src/app/qgsappsslerrorhandler.cpp
+++ b/src/app/qgsappsslerrorhandler.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************
+    qgsappsslerrorhandler.cpp
+    ---------------------------
+    begin                : December 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsappsslerrorhandler.h"
+#include "qgslogger.h"
+#include "qgsauthcertutils.h"
+#include "qgsapplication.h"
+#include "qgsauthmanager.h"
+#include "qgsauthsslerrorsdialog.h"
+#include "qgisapp.h"
+
+void QgsAppSslErrorHandler::handleSslErrors( QNetworkReply *reply, const QList<QSslError> &errors )
+{
+  Q_ASSERT( QThread::currentThread() == QApplication::instance()->thread() );
+
+  QgsDebugMsg( QStringLiteral( "SSL errors occurred accessing URL:\n%1" ).arg( reply->request().url().toString() ) );
+
+  QString hostport( QStringLiteral( "%1:%2" )
+                    .arg( reply->url().host() )
+                    .arg( reply->url().port() != -1 ? reply->url().port() : 443 )
+                    .trimmed() );
+  QString digest( QgsAuthCertUtils::shaHexForCert( reply->sslConfiguration().peerCertificate() ) );
+  QString dgsthostport( QStringLiteral( "%1:%2" ).arg( digest, hostport ) );
+
+  const QHash<QString, QSet<QSslError::SslError> > &errscache( QgsApplication::authManager()->ignoredSslErrorCache() );
+
+  if ( errscache.contains( dgsthostport ) )
+  {
+    QgsDebugMsg( QStringLiteral( "Ignored SSL errors cached item found, ignoring errors if they match for %1" ).arg( hostport ) );
+    const QSet<QSslError::SslError> &errenums( errscache.value( dgsthostport ) );
+    bool ignore = !errenums.isEmpty();
+    int errmatched = 0;
+    if ( ignore )
+    {
+      for ( const QSslError &error : errors )
+      {
+        if ( error.error() == QSslError::NoError )
+          continue;
+
+        bool errmatch = errenums.contains( error.error() );
+        ignore = ignore && errmatch;
+        errmatched += errmatch ? 1 : 0;
+      }
+    }
+
+    if ( ignore && errenums.size() == errmatched )
+    {
+      QgsDebugMsg( QStringLiteral( "Errors matched cached item's, ignoring all for %1" ).arg( hostport ) );
+      reply->ignoreSslErrors();
+      return;
+    }
+
+    QgsDebugMsg( QStringLiteral( "Errors %1 for cached item for %2" )
+                 .arg( errenums.isEmpty() ? QStringLiteral( "not found" ) : QStringLiteral( "did not match" ),
+                       hostport ) );
+  }
+
+  QgsAuthSslErrorsDialog *dlg = new QgsAuthSslErrorsDialog( reply, errors, QgisApp::instance(), digest, hostport );
+  dlg->setWindowModality( Qt::ApplicationModal );
+  dlg->resize( 580, 512 );
+  if ( dlg->exec() )
+  {
+    if ( reply )
+    {
+      QgsDebugMsg( QStringLiteral( "All SSL errors ignored for %1" ).arg( hostport ) );
+      reply->ignoreSslErrors();
+    }
+  }
+  dlg->deleteLater();
+}

--- a/src/app/qgsappsslerrorhandler.h
+++ b/src/app/qgsappsslerrorhandler.h
@@ -19,9 +19,8 @@
 
 class QgsAppSslErrorHandler : public QgsSslErrorHandler
 {
-    Q_OBJECT
 
-  public slots:
+  public:
 
     void handleSslErrors( QNetworkReply *reply, const QList<QSslError> &errors ) override;
 

--- a/src/app/qgsappsslerrorhandler.h
+++ b/src/app/qgsappsslerrorhandler.h
@@ -1,0 +1,31 @@
+/***************************************************************************
+    qgsappsslerrorhandler.h
+    -------------------------
+    begin                : December 2018
+    copyright            : (C) 2018 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSAPPSSLERRORHANDLER_H
+#define QGSAPPSSLERRORHANDLER_H
+
+#include "qgsnetworkaccessmanager.h"
+
+class CORE_EXPORT QgsAppSslErrorHandler : public QgsSslErrorHandler
+{
+    Q_OBJECT
+
+  public slots:
+
+    void handleSslErrors( QNetworkReply *reply, const QList<QSslError> &errors ) override;
+
+};
+
+
+#endif // QGSAPPSSLERRORHANDLER_H

--- a/src/app/qgsappsslerrorhandler.h
+++ b/src/app/qgsappsslerrorhandler.h
@@ -17,7 +17,7 @@
 
 #include "qgsnetworkaccessmanager.h"
 
-class CORE_EXPORT QgsAppSslErrorHandler : public QgsSslErrorHandler
+class QgsAppSslErrorHandler : public QgsSslErrorHandler
 {
     Q_OBJECT
 

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -245,7 +245,8 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   timer->setObjectName( QStringLiteral( "timeoutTimer" ) );
   connect( timer, &QTimer::timeout, this, &QgsNetworkAccessManager::abortRequest );
   timer->setSingleShot( true );
-  timer->start( s.value( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), QStringLiteral( "60000" ) ).toInt() );
+  const int timeout = s.value( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), QStringLiteral( "60000" ) ).toInt();
+  timer->start( timeout );
 
   connect( reply, &QNetworkReply::downloadProgress, timer, [timer] { timer->start(); } );
   connect( reply, &QNetworkReply::uploadProgress, timer, [timer] { timer->start(); } );

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -242,7 +242,7 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   timer->setObjectName( QStringLiteral( "timeoutTimer" ) );
   connect( timer, &QTimer::timeout, this, &QgsNetworkAccessManager::abortRequest );
   timer->setSingleShot( true );
-  const int timeout = s.value( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), QStringLiteral( "60000" ) ).toInt();
+  const int timeout = s.value( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), 60000 ).toInt();
   timer->start( timeout );
 
   connect( reply, &QNetworkReply::downloadProgress, timer, [timer] { timer->start(); } );
@@ -336,7 +336,7 @@ void QgsNetworkAccessManager::afterSslErrorHandled( QNetworkReply *reply )
       Q_ASSERT( !timer->isActive() );
       QgsDebugMsg( QStringLiteral( "Restarting network reply timeout" ) );
       timer->setSingleShot( true );
-      timer->start( QgsSettings().value( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), QStringLiteral( "60000" ) ).toInt() );
+      timer->start( QgsSettings().value( QStringLiteral( "/qgis/networkAndProxy/networkTimeout" ), 60000 ).toInt() );
     }
   }
   else if ( this == sMainNAM )

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -151,6 +151,9 @@ class QgsNetworkAccessManager;
  * present prompts to users notifying them of the errors and asking them
  * to choose the appropriate response.).
  *
+ * If a reply is coming from background thread, that thread is blocked while handleSslErrors()
+ * is running.
+ *
  * If the errors should be ignored and the request allowed to proceed, the subclasses'
  * handleSslErrors() method MUST call QNetworkReply::ignoreSslErrors() on the specified
  * QNetworkReply object.
@@ -427,9 +430,12 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     bool mUseSystemProxy = false;
     bool mInitialized = false;
     static QgsNetworkAccessManager *sMainNAM;
+    // ssl error handler, will be set for main thread ONLY
     std::unique_ptr< QgsSslErrorHandler > mSslErrorHandler;
-    QMutex mMutex;
-    QWaitCondition mSslWaitCondition;
+    // only in use by work threads, unused in main thread
+    QMutex mSslErrorHandlerMutex;
+    // only in use by work threads, unused in main thread
+    QWaitCondition mSslErrorWaitCondition;
 };
 
 #endif // QGSNETWORKACCESSMANAGER_H

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -162,22 +162,14 @@ class QgsNetworkAccessManager;
  * SSL error handler is set by calling QgsNetworkAccessManager::setSslErrorHandler().
  * By default an instance of the logging-only QgsSslErrorHandler base class is used.
  *
- * \since 3.6
+ * \since QGIS 3.6
  */
-class CORE_EXPORT QgsSslErrorHandler : public QObject
+class CORE_EXPORT QgsSslErrorHandler
 {
-    Q_OBJECT
 
-///@cond PRIVATE
-  public slots:
+  public:
 
-    /**
-     * Called whenever SSL \a errors are encountered during a network \a reply.
-     */
-    void onSslErrors( QNetworkReply *reply, const QList<QSslError> &errors );
-///@endcond
-
-  protected:
+    virtual ~QgsSslErrorHandler() = default;
 
     /**
      * Called whenever SSL \a errors are encountered during a network \a reply.
@@ -190,17 +182,6 @@ class CORE_EXPORT QgsSslErrorHandler : public QObject
      * to SSL errors, which is to abort the network request on any errors.
      */
     virtual void handleSslErrors( QNetworkReply *reply, const QList<QSslError> &errors );
-
-  signals:
-
-    /**
-     * Emitted when the SSL errors for a \a reply have been handled (i.e. the
-     * subclass' handleSslErrors() implementation has completed).
-     *
-     * It is not necessary for subclasses to emit this signal manually, it will
-     * automatically be emitted at the correct time.
-     */
-    void sslErrorsHandled( QNetworkReply *reply );
 
 };
 #endif
@@ -414,16 +395,17 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     void onReplyDownloadProgress( qint64 bytesReceived, qint64 bytesTotal );
 #ifndef QT_NO_SSL
     void onReplySslErrors( const QList<QSslError> &errors );
+
+    void handleSslErrors( QNetworkReply *reply, const QList<QSslError> &errors );
 #endif
-
-    void afterSslErrorHandled( QNetworkReply *reply );
-
   protected:
     QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = nullptr ) override;
 
   private:
+#ifndef QT_NO_SSL
     void unlockAfterSslErrorHandled();
-
+    void afterSslErrorHandled( QNetworkReply *reply );
+#endif
     QList<QNetworkProxyFactory *> mProxyFactories;
     QNetworkProxy mFallbackProxy;
     QStringList mExcludedURLs;

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -374,7 +374,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     // these signals are for internal use only - it's not safe to connect by external code
     void sslErrorsOccurred( QNetworkReply *, const QList<QSslError> &errors );
     void sslErrorsHandled( QNetworkReply *reply );
-///@endconf
+///@endcond
 #endif
 
 #endif

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -145,9 +145,9 @@ class QgsNetworkAccessManager;
  * base QgsSslErrorHandler class responds to SSL errors only by logging the errors,
  * and uses the default Qt response, which is to abort the request.
  *
- * Subclasses can override this behaviour by implementing their own handleSslErrors()
+ * Subclasses can override this behavior by implementing their own handleSslErrors()
  * method. QgsSslErrorHandlers are ONLY ever called from the main thread, so it
- * is safe to utilise gui widgets and dialogs during handleSslErrors (e.g. to
+ * is safe to utilize gui widgets and dialogs during handleSslErrors (e.g. to
  * present prompts to users notifying them of the errors and asking them
  * to choose the appropriate response.).
  *

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -353,14 +353,28 @@ void TestQgsNetworkAccessManager::fetchBadSsl()
   } );
   QgsNetworkAccessManager::instance()->get( QNetworkRequest( u ) );
 
-  while ( !loaded && !gotSslError )
+  while ( !loaded && !gotSslError && !gotRequestAboutToBeCreatedSignal )
   {
     qApp->processEvents();
   }
 
   QVERIFY( gotRequestAboutToBeCreatedSignal );
 
-  // we don't test for background thread ssl error yet -- that signal isn't thread safe
+  gotRequestAboutToBeCreatedSignal = false;
+  loaded = false;
+  gotSslError = false;
+  BackgroundRequest *thread = new BackgroundRequest( QNetworkRequest( u ) );
+
+  thread->start();
+
+  while ( !loaded && !gotSslError && !gotRequestAboutToBeCreatedSignal )
+  {
+    qApp->processEvents();
+  }
+  QVERIFY( gotRequestAboutToBeCreatedSignal );
+  thread->exit();
+  thread->wait();
+  thread->deleteLater();
 }
 
 void TestQgsNetworkAccessManager::fetchTimeout()

--- a/tests/src/core/testqgsnetworkaccessmanager.cpp
+++ b/tests/src/core/testqgsnetworkaccessmanager.cpp
@@ -61,9 +61,7 @@ class BackgroundRequest : public QThread
 
 class TestSslErrorHandler : public QgsSslErrorHandler
 {
-    Q_OBJECT
-
-  protected:
+  public:
 
     void handleSslErrors( QNetworkReply *reply, const QList<QSslError> &errors ) override
     {


### PR DESCRIPTION
This commit reworks how SSL errors are handled in QGIS. Previously,
ssl errors emitted by non-main thread QgsNetworkAccessManager instances
were handled by the main thread in QgisApp on next event loop. But
app (in the main thread) tried to pause the timeout timer for the
QNetworkReply containing the error, which doesn't work, because you
can't stop a timer in the main thread for a timer object created
in another thread. This meant that the reply could get deleted in
the background thread while the main thread was still using it
and waiting for users to respond to the SSL error. Now the timer
handling is done in the background thread's network access manager
instance, so in the thread matching the reply's timeout timer. We
then have to do some fancy thread locking using QWaitCondition,
because we need to "pause" that thread until the SSL error
is handled in the main thread -- if we don't pause the background
thread, Qt immediately resumes the QNetworkReply without ever
giving us the change to ignore ssl errors in the reply. Phew!

Additionally, the previous approach had a shortcoming in that
there was no way to notify background threads that ssl errors
had actually be handled. To do this we need a new signal which
can be fired after app has shown the ssl dialog and given users
a chance to respond. BUT... we can't safely do this -- if we
add a method to notify background threads when ssl errors have
been handled, then it CANNOT safely reside in app -- doing so
would break for QGIS server and QField etc, where theres no
app instance around to provide this notification. As a result
I've abstracted out the ssl error handling. By default there's
a simple error handler which just logs errors and returns
without ignoring them (i.e. default Qt behavior, an ssl error
cancels the request). App has a specific subclass of the ssl
error handler which presents the nice dialog and asks users to
choose what to do. Potentially server could decide to make
its own subclass too, which could e.g. ignore SSL warnings
if an environment variable is present (but at the moment
the behavior is effectively unchanged for server).

The end result is that SSL error handling should now be
totally thread safe, and we shouldn't hit any more deadlocks
and crashes when ssl errors occur in background threads.

I've also taken the opportunity to add a new signal which
is always emitted by the main thread QgsNetworkAccessManager
instance, which is emitted whenever ANY request on any
thread encounters an SSL error, and contains the requestId
so that the ssl error can be linked back to the originating
request. This is for debugging, and for use by the
network monitoring plugin to show ssl errors encountered
by requests.
