### PR TITLE
[processing][needs-docs] allow to exclude features without category from GRASS export

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -943,8 +943,8 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
                     outFormat,
                     'layer={}'.format(layer) if layer else '',
                     ' dsco="{}"'.format(dsco) if dsco else '',
-                    ' lco="{}"'.format(lco) if lco else ''
-                    , ' -c' if exportnocat else ''
+                    ' lco="{}"'.format(lco) if lco else '',
+                    ' -c' if exportnocat else ''
                 )
             )
 

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -324,7 +324,7 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
             param = QgsProcessingParameterBoolean(
                 self.GRASS_VECTOR_EXPORT_NOCAT,
                 self.tr('Also export features without category (not labeled). Otherwise only features with category are exported'),
-                True
+                False
             )
             param.setFlags(param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
             self.params.append(param)

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -90,6 +90,7 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
     GRASS_RASTER_FORMAT_META = 'GRASS_RASTER_FORMAT_META'
     GRASS_VECTOR_DSCO = 'GRASS_VECTOR_DSCO'
     GRASS_VECTOR_LCO = 'GRASS_VECTOR_LCO'
+    GRASS_VECTOR_EXPORT_NOCAT = 'GRASS_VECTOR_EXPORT_NOCAT'
 
     OUTPUT_TYPES = ['auto', 'point', 'line', 'area']
     QGIS_OUTPUT_TYPES = {QgsProcessing.TypeVectorAnyGeometry: 'auto',
@@ -319,6 +320,14 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
             param.setFlags(param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
             self.params.append(param)
 
+            # Add a -c flag for export
+            param = QgsProcessingParameterBoolean(
+                self.GRASS_VECTOR_EXPORT_NOCAT,
+                self.tr('Also export features without category (not labeled). Otherwise only features with category are exported')
+            )
+            param.setFlags(param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
+            self.params.append(param)
+
     def getDefaultCellSize(self):
         """
         Determine a default cell size from all the raster layers.
@@ -533,7 +542,8 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
                              self.GRASS_RASTER_FORMAT_OPT,
                              self.GRASS_RASTER_FORMAT_META,
                              self.GRASS_VECTOR_DSCO,
-                             self.GRASS_VECTOR_LCO]:
+                             self.GRASS_VECTOR_LCO,
+                             self.GRASS_VECTOR_EXPORT_NOCAT]:
                 continue
 
             # Raster and vector layers
@@ -904,10 +914,11 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
         outFormat = QgsVectorFileWriter.driverForExtension(os.path.splitext(fileName)[1]).replace(' ', '_')
         dsco = self.parameterAsString(parameters, self.GRASS_VECTOR_DSCO, context)
         lco = self.parameterAsString(parameters, self.GRASS_VECTOR_LCO, context)
-        self.exportVectorLayer(grassName, fileName, layer, nocats, dataType, outFormat, dsco, lco)
+        exportnocat = self.parameterAsBool(parameters, self.GRASS_VECTOR_EXPORT_NOCAT, context)
+        self.exportVectorLayer(grassName, fileName, layer, nocats, dataType, outFormat, dsco, lco, exportnocat)
 
     def exportVectorLayer(self, grassName, fileName, layer=None, nocats=False, dataType='auto',
-                          outFormat=None, dsco=None, lco=None):
+                          outFormat=None, dsco=None, lco=None, exportnocat=False):
         """
         Creates a dedicated command to export a vector from
         temporary GRASS DB into a file via OGR.
@@ -919,19 +930,21 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
         :param outFormat: file format for export.
         :param dsco: datasource creation options for format.
         :param lco: layer creation options for format.
+        :param exportnocat: do not export features without categories.
         """
         if outFormat is None:
             outFormat = QgsVectorFileWriter.driverForExtension(os.path.splitext(fileName)[1]).replace(' ', '_')
 
         for cmd in [self.commands, self.outputCommands]:
             cmd.append(
-                'v.out.ogr{0} type="{1}" input="{2}" output="{3}" format="{4}" {5}{6}{7} --overwrite'.format(
-                    '' if nocats else ' -c',
+                'v.out.ogr{0} type="{1}" input="{2}" output="{3}" format="{4}" {5}{6}{7}{8} --overwrite'.format(
+                    '' if nocats else '',
                     dataType, grassName, fileName,
                     outFormat,
                     'layer={}'.format(layer) if layer else '',
                     ' dsco="{}"'.format(dsco) if dsco else '',
                     ' lco="{}"'.format(lco) if lco else ''
+                    , ' -c' if exportnocat else ''
                 )
             )
 

--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -323,7 +323,8 @@ class Grass7Algorithm(QgsProcessingAlgorithm):
             # Add a -c flag for export
             param = QgsProcessingParameterBoolean(
                 self.GRASS_VECTOR_EXPORT_NOCAT,
-                self.tr('Also export features without category (not labeled). Otherwise only features with category are exported')
+                self.tr('Also export features without category (not labeled). Otherwise only features with category are exported'),
+                True
             )
             param.setFlags(param.flags() | QgsProcessingParameterDefinition.FlagAdvanced)
             self.params.append(param)

--- a/python/plugins/processing/tests/testdata/grass7_algorithms_vector_tests.yaml
+++ b/python/plugins/processing/tests/testdata/grass7_algorithms_vector_tests.yaml
@@ -406,6 +406,7 @@ tests:
       GRASS_SNAP_TOLERANCE_PARAMETER: -1.0
       GRASS_VECTOR_DSCO: ''
       GRASS_VECTOR_LCO: ''
+      GRASS_VECTOR_EXPORT_NOCAT: true
       input:
         name: pointsz.gml|layername=pointsz
         type: vector


### PR DESCRIPTION
## Description
Ressurects #8419. IMHO this is quite important fix and would be nice to have in both 3.6 and 3.4 LTR.

As per  #8419 while exporting GRASS vectors to a simple features format using `v.out.ogr` now the `-c` flag is always used, and this is not expected as it can lead to wrong/unexpected results. On other hand, to keep API stable and produce same results as older 3.x version this PR keeps `-c` flag enabled by default, allowing user to change it.

If we argee that better to disable `-c` flag by default, I will update all tests accordingly.

@gioman hope you are fine with it.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
