### PR TITLE
[processing] avoid exception when listing DB schemas

### DIFF
--- a/python/plugins/processing/tools/postgis.py
+++ b/python/plugins/processing/tools/postgis.py
@@ -223,25 +223,25 @@ class GeoDB(object):
                 if sslCertFile:
                     sslCertFile = sslCertFile.replace("'", "")
                     try:
-                      os.remove(sslCertFile)
+                        os.remove(sslCertFile)
                     except OSError:
-                      pass
+                        pass
 
                 sslKeyFile = expandedUri.param("sslkey")
                 if sslKeyFile:
                     sslKeyFile = sslKeyFile.replace("'", "")
                     try:
-                      os.remove(sslKeyFile)
+                        os.remove(sslKeyFile)
                     except OSError:
-                      pass
+                        pass
 
                 sslCAFile = expandedUri.param("sslrootcert")
                 if sslCAFile:
                     sslCAFile = sslCAFile.replace("'", "")
                     try:
-                      os.remove(sslCAFile)
+                        os.remove(sslCAFile)
                     except OSError:
-                      pass
+                        pass
 
         self.has_postgis = self.check_postgis()
 

--- a/python/plugins/processing/tools/postgis.py
+++ b/python/plugins/processing/tools/postgis.py
@@ -222,17 +222,26 @@ class GeoDB(object):
                 sslCertFile = expandedUri.param("sslcert")
                 if sslCertFile:
                     sslCertFile = sslCertFile.replace("'", "")
-                    os.remove(sslCertFile)
+                    try:
+                      os.remove(sslCertFile)
+                    except OSError:
+                      pass
 
                 sslKeyFile = expandedUri.param("sslkey")
                 if sslKeyFile:
                     sslKeyFile = sslKeyFile.replace("'", "")
-                    os.remove(sslKeyFile)
+                    try:
+                      os.remove(sslKeyFile)
+                    except OSError:
+                      pass
 
                 sslCAFile = expandedUri.param("sslrootcert")
                 if sslCAFile:
                     sslCAFile = sslCAFile.replace("'", "")
-                    os.remove(sslCAFile)
+                    try:
+                      os.remove(sslCAFile)
+                    except OSError:
+                      pass
 
         self.has_postgis = self.check_postgis()
 


### PR DESCRIPTION
## Description

An exception is raised in Windows when the cert file cannot be deleted (it's in use) when creating GeoDB object

This causes the "output to postgis" option to not work, and also all algorithms that need a schema selected  

fixes #21099

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
