### PR TITLE
fix CRS handling in the DescribeCoverage response (refs #21045) [wcs]

### DIFF
--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -804,7 +804,7 @@ bool QgsWcsCapabilities::parseDescribeCoverageDom10( QByteArray const &xml, QgsW
   }
 
   // exclude invalid CRSs from the lists
-  for ( const QString &crsid : crsList )
+  for ( const QString &crsid : qgis::as_const( crsList ) )
   {
     if ( QgsCoordinateReferenceSystem::fromOgcWmsCrs( crsid ).isValid() )
     {

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -794,9 +794,16 @@ bool QgsWcsCapabilities::parseDescribeCoverageDom10( QByteArray const &xml, QgsW
   QDomElement supportedCRSsElement = firstChild( coverageOfferingElement, QStringLiteral( "supportedCRSs" ) );
 
   // requestResponseCRSs and requestCRSs + responseCRSs are alternatives
+  // we try to parse one or the other
   coverage->supportedCrs = domElementsTexts( coverageOfferingElement, QStringLiteral( "supportedCRSs.requestResponseCRSs" ) );
+  if ( coverage->supportedCrs.isEmpty() )
+  {
+    coverage->supportedCrs = domElementsTexts( coverageOfferingElement, QStringLiteral( "supportedCRSs.requestCRSs" ) );
+    coverage->supportedCrs << domElementsTexts( coverageOfferingElement, QStringLiteral( "supportedCRSs.responseCRSs" ) );
+  }
+
   // TODO: requestCRSs, responseCRSs - must be then implemented also in provider
-  //QgsDebugMsg( "supportedCrs = " + coverage->supportedCrs.join( "," ) );
+  QgsDebugMsg( "supportedCrs = " + coverage->supportedCrs.join( "," ) );
 
   coverage->nativeCrs = domElementText( coverageOfferingElement, QStringLiteral( "supportedCRSs.nativeCRSs" ) );
 

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -226,7 +226,6 @@ QStringList QgsWCSSourceSelect::selectedLayersFormats()
 
 QStringList QgsWCSSourceSelect::selectedLayersCrses()
 {
-
   QString identifier = selectedIdentifier();
   if ( identifier.isEmpty() ) { return QStringList(); }
 


### PR DESCRIPTION
## Description
According to the OGC WCS 1.0.0 specification in the `DescribeCoverage` response the `supportedCRSs` element has either a `requestResponseCRSs` sub-element, or both a `requestCRSs` sub-element and a `responseCRSs` sub-element. QGIS WCS provider handles only case when `requestResponseCRSs` sub-element is present. As result a wrong `GetCoverage` request constructed later as described in https://issues.qgis.org/issues/21045. 

Another related issue is that some WCS servers, for example http://thredds.ucar.edu/thredds/wcs/grib/NCEP/WW3/Regional_US_West_Coast/Best, contain invalid(?) CRS definition `EPSG:0 [Latitude_Longitude]` in the response elements, e.g

```
<gml:RectifiedGrid srsName="EPSG:0 [Latitude_Longitude]" dimension="2">
```

which is used later to construct WCS request.

This PR tries to fix both issues:

1. parsing of the `DescribeCoverage` now handles either a `requestResponseCRSs` sub-element, or both a `requestCRSs` sub-element and a `responseCRSs` sub-element.
2. CRS definitions from the `DescribeCoverage` response now checked for validity and invalid definitions are excluded from the coverage summary.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
