### PR TITLE
Use switch instead of multiple if blocks for layer type logic

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13834,7 +13834,7 @@ void QgisApp::showLayerProperties( QgsMapLayer *mapLayer )
       QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mapLayer );
 
       QgsVectorLayerProperties *vectorLayerPropertiesDialog = new QgsVectorLayerProperties( vlayer, this );
-      Q_FOREACH ( QgsMapLayerConfigWidgetFactory *factory, mMapLayerPanelFactories )
+      for ( QgsMapLayerConfigWidgetFactory *factory : qgis::as_const( mMapLayerPanelFactories ) )
       {
         vectorLayerPropertiesDialog->addPropertiesPageFactory( factory );
       }

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -465,13 +465,19 @@ QTreeWidgetItem *QgsIdentifyResultsDialog::layerItem( QObject *object )
 
 void QgsIdentifyResultsDialog::addFeature( const QgsMapToolIdentify::IdentifyResult &result )
 {
-  if ( result.mLayer->type() == QgsMapLayer::VectorLayer )
+  switch ( result.mLayer->type() )
   {
-    addFeature( qobject_cast<QgsVectorLayer *>( result.mLayer ), result.mFeature, result.mDerivedAttributes );
-  }
-  else if ( result.mLayer->type() == QgsMapLayer::RasterLayer )
-  {
-    addFeature( qobject_cast<QgsRasterLayer *>( result.mLayer ), result.mLabel, result.mAttributes, result.mDerivedAttributes, result.mFields, result.mFeature, result.mParams );
+    case QgsMapLayer::VectorLayer:
+      addFeature( qobject_cast<QgsVectorLayer *>( result.mLayer ), result.mFeature, result.mDerivedAttributes );
+      break;
+
+    case QgsMapLayer::RasterLayer:
+      addFeature( qobject_cast<QgsRasterLayer *>( result.mLayer ), result.mLabel, result.mAttributes, result.mDerivedAttributes, result.mFields, result.mFeature, result.mParams );
+      break;
+
+    case QgsMapLayer::MeshLayer:
+    case QgsMapLayer::PluginLayer:
+      break;
   }
 }
 

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -162,56 +162,66 @@ void QgsLayerStylingWidget::setLayer( QgsMapLayer *layer )
   mOptionsListWidget->blockSignals( true );
   mOptionsListWidget->clear();
   mUserPages.clear();
-  if ( layer->type() == QgsMapLayer::VectorLayer )
-  {
-    QListWidgetItem *symbolItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ), QString() );
-    symbolItem->setData( Qt::UserRole, Symbology );
-    symbolItem->setToolTip( tr( "Symbology" ) );
-    mOptionsListWidget->addItem( symbolItem );
-    QListWidgetItem *labelItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "labelingSingle.svg" ) ), QString() );
-    labelItem->setData( Qt::UserRole, VectorLabeling );
-    labelItem->setToolTip( tr( "Labels" ) );
-    mOptionsListWidget->addItem( labelItem );
 
-#ifdef HAVE_3D
-    QListWidgetItem *symbol3DItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "3d.svg" ) ), QString() );
-    symbol3DItem->setData( Qt::UserRole, Symbology3D );
-    symbol3DItem->setToolTip( tr( "3D View" ) );
-    mOptionsListWidget->addItem( symbol3DItem );
-#endif
-  }
-  else if ( layer->type() == QgsMapLayer::RasterLayer )
+  switch ( layer->type() )
   {
-    QListWidgetItem *symbolItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ), QString() );
-    symbolItem->setData( Qt::UserRole, Symbology );
-    symbolItem->setToolTip( tr( "Symbology" ) );
-    mOptionsListWidget->addItem( symbolItem );
-    QListWidgetItem *transparencyItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/transparency.svg" ) ), QString() );
-    transparencyItem->setToolTip( tr( "Transparency" ) );
-    transparencyItem->setData( Qt::UserRole, RasterTransparency );
-    mOptionsListWidget->addItem( transparencyItem );
-
-    if ( static_cast<QgsRasterLayer *>( layer )->dataProvider()->capabilities() & QgsRasterDataProvider::Size )
+    case QgsMapLayer::VectorLayer:
     {
-      QListWidgetItem *histogramItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/histogram.svg" ) ), QString() );
-      histogramItem->setData( Qt::UserRole, RasterHistogram );
-      mOptionsListWidget->addItem( histogramItem );
-      histogramItem->setToolTip( tr( "Histogram" ) );
-    }
-  }
-  else if ( layer->type() == QgsMapLayer::MeshLayer )
-  {
-    QListWidgetItem *symbolItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ), QString() );
-    symbolItem->setData( Qt::UserRole, Symbology );
-    symbolItem->setToolTip( tr( "Symbology" ) );
-    mOptionsListWidget->addItem( symbolItem );
+      QListWidgetItem *symbolItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ), QString() );
+      symbolItem->setData( Qt::UserRole, Symbology );
+      symbolItem->setToolTip( tr( "Symbology" ) );
+      mOptionsListWidget->addItem( symbolItem );
+      QListWidgetItem *labelItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "labelingSingle.svg" ) ), QString() );
+      labelItem->setData( Qt::UserRole, VectorLabeling );
+      labelItem->setToolTip( tr( "Labels" ) );
+      mOptionsListWidget->addItem( labelItem );
 
 #ifdef HAVE_3D
-    QListWidgetItem *symbol3DItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "3d.svg" ) ), QString() );
-    symbol3DItem->setData( Qt::UserRole, Symbology3D );
-    symbol3DItem->setToolTip( tr( "3D View" ) );
-    mOptionsListWidget->addItem( symbol3DItem );
+      QListWidgetItem *symbol3DItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "3d.svg" ) ), QString() );
+      symbol3DItem->setData( Qt::UserRole, Symbology3D );
+      symbol3DItem->setToolTip( tr( "3D View" ) );
+      mOptionsListWidget->addItem( symbol3DItem );
 #endif
+      break;
+    }
+    case QgsMapLayer::RasterLayer:
+    {
+      QListWidgetItem *symbolItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ), QString() );
+      symbolItem->setData( Qt::UserRole, Symbology );
+      symbolItem->setToolTip( tr( "Symbology" ) );
+      mOptionsListWidget->addItem( symbolItem );
+      QListWidgetItem *transparencyItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/transparency.svg" ) ), QString() );
+      transparencyItem->setToolTip( tr( "Transparency" ) );
+      transparencyItem->setData( Qt::UserRole, RasterTransparency );
+      mOptionsListWidget->addItem( transparencyItem );
+
+      if ( static_cast<QgsRasterLayer *>( layer )->dataProvider()->capabilities() & QgsRasterDataProvider::Size )
+      {
+        QListWidgetItem *histogramItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/histogram.svg" ) ), QString() );
+        histogramItem->setData( Qt::UserRole, RasterHistogram );
+        mOptionsListWidget->addItem( histogramItem );
+        histogramItem->setToolTip( tr( "Histogram" ) );
+      }
+      break;
+    }
+    case QgsMapLayer::MeshLayer:
+    {
+      QListWidgetItem *symbolItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/symbology.svg" ) ), QString() );
+      symbolItem->setData( Qt::UserRole, Symbology );
+      symbolItem->setToolTip( tr( "Symbology" ) );
+      mOptionsListWidget->addItem( symbolItem );
+
+#ifdef HAVE_3D
+      QListWidgetItem *symbol3DItem = new QListWidgetItem( QgsApplication::getThemeIcon( QStringLiteral( "3d.svg" ) ), QString() );
+      symbol3DItem->setData( Qt::UserRole, Symbology3D );
+      symbol3DItem->setToolTip( tr( "3D View" ) );
+      mOptionsListWidget->addItem( symbol3DItem );
+#endif
+      break;
+    }
+
+    case QgsMapLayer::PluginLayer:
+      break;
   }
 
   Q_FOREACH ( QgsMapLayerConfigWidgetFactory *factory, mPageFactories )
@@ -389,169 +399,182 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
   {
     mWidgetStack->setMainPanel( mUndoWidget );
   }
-  else if ( mCurrentLayer->type() == QgsMapLayer::VectorLayer )
-  {
-    QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCurrentLayer );
-
-    switch ( row )
-    {
-      case 0: // Style
-      {
-        QgsRendererPropertiesDialog *styleWidget = new QgsRendererPropertiesDialog( vlayer, QgsStyle::defaultStyle(), true, mStackedWidget );
-        QgsSymbolWidgetContext context;
-        context.setMapCanvas( mMapCanvas );
-        context.setMessageBar( mMessageBar );
-        styleWidget->setContext( context );
-        styleWidget->setDockMode( true );
-        connect( styleWidget, &QgsRendererPropertiesDialog::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-        QgsPanelWidgetWrapper *wrapper = new QgsPanelWidgetWrapper( styleWidget, mStackedWidget );
-        wrapper->setDockMode( true );
-        connect( styleWidget, &QgsRendererPropertiesDialog::showPanel, wrapper, &QgsPanelWidget::openPanel );
-        mWidgetStack->setMainPanel( wrapper );
-        break;
-      }
-      case 1: // Labels
-      {
-        if ( !mLabelingWidget )
-        {
-          mLabelingWidget = new QgsLabelingWidget( nullptr, mMapCanvas, mWidgetStack );
-          mLabelingWidget->setDockMode( true );
-          connect( mLabelingWidget, &QgsLabelingWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-        }
-        mLabelingWidget->setLayer( vlayer );
-        mWidgetStack->setMainPanel( mLabelingWidget );
-        break;
-      }
-#ifdef HAVE_3D
-      case 2:  // 3D View
-      {
-        if ( !mVector3DWidget )
-        {
-          mVector3DWidget = new QgsVectorLayer3DRendererWidget( nullptr, mMapCanvas, mWidgetStack );
-          mVector3DWidget->setDockMode( true );
-          connect( mVector3DWidget, &QgsVectorLayer3DRendererWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-        }
-        mVector3DWidget->setLayer( vlayer );
-        mWidgetStack->setMainPanel( mVector3DWidget );
-        break;
-      }
-#endif
-      default:
-        break;
-    }
-  }
-  else if ( mCurrentLayer->type() == QgsMapLayer::RasterLayer )
-  {
-    QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( mCurrentLayer );
-    bool hasMinMaxCollapsedState = false;
-    bool minMaxCollapsed = false;
-
-    switch ( row )
-    {
-      case 0: // Style
-      {
-        // Backup collapsed state of min/max group so as to restore it
-        // on the new widget.
-        if ( mRasterStyleWidget )
-        {
-          QgsRasterRendererWidget *currentRenderWidget = mRasterStyleWidget->currentRenderWidget();
-          if ( currentRenderWidget )
-          {
-            QgsRasterMinMaxWidget *mmWidget = currentRenderWidget->minMaxWidget();
-            if ( mmWidget )
-            {
-              hasMinMaxCollapsedState = true;
-              minMaxCollapsed = mmWidget->isCollapsed();
-            }
-          }
-        }
-        mRasterStyleWidget = new QgsRendererRasterPropertiesWidget( rlayer, mMapCanvas, mWidgetStack );
-        if ( hasMinMaxCollapsedState )
-        {
-          QgsRasterRendererWidget *currentRenderWidget = mRasterStyleWidget->currentRenderWidget();
-          if ( currentRenderWidget )
-          {
-            QgsRasterMinMaxWidget *mmWidget = currentRenderWidget->minMaxWidget();
-            if ( mmWidget )
-            {
-              mmWidget->setCollapsed( minMaxCollapsed );
-            }
-          }
-        }
-        mRasterStyleWidget->setDockMode( true );
-        connect( mRasterStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-        mWidgetStack->setMainPanel( mRasterStyleWidget );
-        break;
-      }
-
-      case 1: // Transparency
-      {
-        QgsRasterTransparencyWidget *transwidget = new QgsRasterTransparencyWidget( rlayer, mMapCanvas, mWidgetStack );
-        transwidget->setDockMode( true );
-        connect( transwidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-        mWidgetStack->setMainPanel( transwidget );
-        break;
-      }
-      case 2: // Histogram
-      {
-        if ( rlayer->dataProvider()->capabilities() & QgsRasterDataProvider::Size )
-        {
-          if ( !mRasterStyleWidget )
-          {
-            mRasterStyleWidget = new QgsRendererRasterPropertiesWidget( rlayer, mMapCanvas, mWidgetStack );
-            mRasterStyleWidget->syncToLayer( rlayer );
-          }
-          connect( mRasterStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-
-          QgsRasterHistogramWidget *widget = new QgsRasterHistogramWidget( rlayer, mWidgetStack );
-          connect( widget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-          QString name = mRasterStyleWidget->currentRenderWidget()->renderer()->type();
-          widget->setRendererWidget( name, mRasterStyleWidget->currentRenderWidget() );
-          widget->setDockMode( true );
-
-          mWidgetStack->setMainPanel( widget );
-        }
-        break;
-      }
-      default:
-        break;
-    }
-  }
-  else if ( mCurrentLayer->type() == QgsMapLayer::MeshLayer )
-  {
-    QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( mCurrentLayer );
-    switch ( row )
-    {
-      case 0: // Style
-      {
-        mMeshStyleWidget = new QgsRendererMeshPropertiesWidget( meshLayer, mMapCanvas, mWidgetStack );
-
-        mMeshStyleWidget->setDockMode( true );
-        connect( mMeshStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-        mWidgetStack->setMainPanel( mMeshStyleWidget );
-        break;
-      }
-#ifdef HAVE_3D
-      case 1:  // 3D View
-      {
-        if ( !mMesh3DWidget )
-        {
-          mMesh3DWidget = new QgsMeshLayer3DRendererWidget( nullptr, mMapCanvas, mWidgetStack );
-          mMesh3DWidget->setDockMode( true );
-          connect( mMesh3DWidget, &QgsMeshLayer3DRendererWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
-        }
-        mMesh3DWidget->setLayer( meshLayer );
-        mWidgetStack->setMainPanel( mMesh3DWidget );
-        break;
-      }
-#endif
-      default:
-        break;
-    }
-  }
   else
   {
-    mStackedWidget->setCurrentIndex( mNotSupportedPage );
+    switch ( mCurrentLayer->type() )
+    {
+      case QgsMapLayer::VectorLayer:
+      {
+        QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCurrentLayer );
+
+        switch ( row )
+        {
+          case 0: // Style
+          {
+            QgsRendererPropertiesDialog *styleWidget = new QgsRendererPropertiesDialog( vlayer, QgsStyle::defaultStyle(), true, mStackedWidget );
+            QgsSymbolWidgetContext context;
+            context.setMapCanvas( mMapCanvas );
+            context.setMessageBar( mMessageBar );
+            styleWidget->setContext( context );
+            styleWidget->setDockMode( true );
+            connect( styleWidget, &QgsRendererPropertiesDialog::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            QgsPanelWidgetWrapper *wrapper = new QgsPanelWidgetWrapper( styleWidget, mStackedWidget );
+            wrapper->setDockMode( true );
+            connect( styleWidget, &QgsRendererPropertiesDialog::showPanel, wrapper, &QgsPanelWidget::openPanel );
+            mWidgetStack->setMainPanel( wrapper );
+            break;
+          }
+          case 1: // Labels
+          {
+            if ( !mLabelingWidget )
+            {
+              mLabelingWidget = new QgsLabelingWidget( nullptr, mMapCanvas, mWidgetStack );
+              mLabelingWidget->setDockMode( true );
+              connect( mLabelingWidget, &QgsLabelingWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            }
+            mLabelingWidget->setLayer( vlayer );
+            mWidgetStack->setMainPanel( mLabelingWidget );
+            break;
+          }
+#ifdef HAVE_3D
+          case 2:  // 3D View
+          {
+            if ( !mVector3DWidget )
+            {
+              mVector3DWidget = new QgsVectorLayer3DRendererWidget( nullptr, mMapCanvas, mWidgetStack );
+              mVector3DWidget->setDockMode( true );
+              connect( mVector3DWidget, &QgsVectorLayer3DRendererWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            }
+            mVector3DWidget->setLayer( vlayer );
+            mWidgetStack->setMainPanel( mVector3DWidget );
+            break;
+          }
+#endif
+          default:
+            break;
+        }
+        break;
+      }
+
+      case QgsMapLayer::RasterLayer:
+      {
+        QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( mCurrentLayer );
+        bool hasMinMaxCollapsedState = false;
+        bool minMaxCollapsed = false;
+
+        switch ( row )
+        {
+          case 0: // Style
+          {
+            // Backup collapsed state of min/max group so as to restore it
+            // on the new widget.
+            if ( mRasterStyleWidget )
+            {
+              QgsRasterRendererWidget *currentRenderWidget = mRasterStyleWidget->currentRenderWidget();
+              if ( currentRenderWidget )
+              {
+                QgsRasterMinMaxWidget *mmWidget = currentRenderWidget->minMaxWidget();
+                if ( mmWidget )
+                {
+                  hasMinMaxCollapsedState = true;
+                  minMaxCollapsed = mmWidget->isCollapsed();
+                }
+              }
+            }
+            mRasterStyleWidget = new QgsRendererRasterPropertiesWidget( rlayer, mMapCanvas, mWidgetStack );
+            if ( hasMinMaxCollapsedState )
+            {
+              QgsRasterRendererWidget *currentRenderWidget = mRasterStyleWidget->currentRenderWidget();
+              if ( currentRenderWidget )
+              {
+                QgsRasterMinMaxWidget *mmWidget = currentRenderWidget->minMaxWidget();
+                if ( mmWidget )
+                {
+                  mmWidget->setCollapsed( minMaxCollapsed );
+                }
+              }
+            }
+            mRasterStyleWidget->setDockMode( true );
+            connect( mRasterStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            mWidgetStack->setMainPanel( mRasterStyleWidget );
+            break;
+          }
+
+          case 1: // Transparency
+          {
+            QgsRasterTransparencyWidget *transwidget = new QgsRasterTransparencyWidget( rlayer, mMapCanvas, mWidgetStack );
+            transwidget->setDockMode( true );
+            connect( transwidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            mWidgetStack->setMainPanel( transwidget );
+            break;
+          }
+          case 2: // Histogram
+          {
+            if ( rlayer->dataProvider()->capabilities() & QgsRasterDataProvider::Size )
+            {
+              if ( !mRasterStyleWidget )
+              {
+                mRasterStyleWidget = new QgsRendererRasterPropertiesWidget( rlayer, mMapCanvas, mWidgetStack );
+                mRasterStyleWidget->syncToLayer( rlayer );
+              }
+              connect( mRasterStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+
+              QgsRasterHistogramWidget *widget = new QgsRasterHistogramWidget( rlayer, mWidgetStack );
+              connect( widget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+              QString name = mRasterStyleWidget->currentRenderWidget()->renderer()->type();
+              widget->setRendererWidget( name, mRasterStyleWidget->currentRenderWidget() );
+              widget->setDockMode( true );
+
+              mWidgetStack->setMainPanel( widget );
+            }
+            break;
+          }
+          default:
+            break;
+        }
+        break;
+      }
+
+      case QgsMapLayer::MeshLayer:
+      {
+        QgsMeshLayer *meshLayer = qobject_cast<QgsMeshLayer *>( mCurrentLayer );
+        switch ( row )
+        {
+          case 0: // Style
+          {
+            mMeshStyleWidget = new QgsRendererMeshPropertiesWidget( meshLayer, mMapCanvas, mWidgetStack );
+
+            mMeshStyleWidget->setDockMode( true );
+            connect( mMeshStyleWidget, &QgsPanelWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            mWidgetStack->setMainPanel( mMeshStyleWidget );
+            break;
+          }
+#ifdef HAVE_3D
+          case 1:  // 3D View
+          {
+            if ( !mMesh3DWidget )
+            {
+              mMesh3DWidget = new QgsMeshLayer3DRendererWidget( nullptr, mMapCanvas, mWidgetStack );
+              mMesh3DWidget->setDockMode( true );
+              connect( mMesh3DWidget, &QgsMeshLayer3DRendererWidget::widgetChanged, this, &QgsLayerStylingWidget::autoApply );
+            }
+            mMesh3DWidget->setLayer( meshLayer );
+            mWidgetStack->setMainPanel( mMesh3DWidget );
+            break;
+          }
+#endif
+          default:
+            break;
+        }
+        break;
+      }
+
+      case QgsMapLayer::PluginLayer:
+      {
+        mStackedWidget->setCurrentIndex( mNotSupportedPage );
+        break;
+      }
+    }
   }
 
   mBlockAutoApply = false;
@@ -659,5 +682,15 @@ QgsMapLayerConfigWidget *QgsLayerStyleManagerWidgetFactory::createWidget( QgsMap
 
 bool QgsLayerStyleManagerWidgetFactory::supportsLayer( QgsMapLayer *layer ) const
 {
-  return ( layer->type() == QgsMapLayer::VectorLayer || layer->type() == QgsMapLayer::RasterLayer || layer->type() == QgsMapLayer::MeshLayer );
+  switch ( layer->type() )
+  {
+    case QgsMapLayer::VectorLayer:
+    case QgsMapLayer::RasterLayer:
+    case QgsMapLayer::MeshLayer:
+      return true;
+
+    case QgsMapLayer::PluginLayer:
+      return false;
+  }
+  return false; // no warnings
 }

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -195,13 +195,17 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
         return QVariant();
 
       // icons possibly overriding default icon
-      if ( layer->type() == QgsMapLayer::RasterLayer )
+      switch ( layer->type() )
       {
-        return QgsLayerItem::iconRaster();
-      }
-      else if ( layer->type() == QgsMapLayer::MeshLayer )
-      {
-        return QgsLayerItem::iconMesh();
+        case QgsMapLayer::RasterLayer:
+          return QgsLayerItem::iconRaster();
+
+        case QgsMapLayer::MeshLayer:
+          return QgsLayerItem::iconMesh();
+
+        case QgsMapLayer::VectorLayer:
+        case QgsMapLayer::PluginLayer:
+          break;
       }
 
       QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -171,25 +171,33 @@ static void _addLayerTreeNodeToUriList( QgsLayerTreeNode *node, QgsMimeDataUtils
     uri.name = layer->name();
     uri.uri = layer->dataProvider()->dataSourceUri();
     uri.providerKey = layer->dataProvider()->name();
-    if ( layer->type() == QgsMapLayer::VectorLayer )
+
+    switch ( layer->type() )
     {
-      uri.layerType = QStringLiteral( "vector" );
-      if ( uri.providerKey == QStringLiteral( "memory" ) )
+      case QgsMapLayer::VectorLayer:
       {
-        QUrl url = QUrl::fromEncoded( uri.uri.toUtf8() );
-        url.addQueryItem( QStringLiteral( "pid" ), QString::number( QCoreApplication::applicationPid() ) );
-        url.addQueryItem( QStringLiteral( "layerid" ), layer->id() );
-        uri.uri = QString( url.toEncoded() );
+        uri.layerType = QStringLiteral( "vector" );
+        if ( uri.providerKey == QStringLiteral( "memory" ) )
+        {
+          QUrl url = QUrl::fromEncoded( uri.uri.toUtf8() );
+          url.addQueryItem( QStringLiteral( "pid" ), QString::number( QCoreApplication::applicationPid() ) );
+          url.addQueryItem( QStringLiteral( "layerid" ), layer->id() );
+          uri.uri = QString( url.toEncoded() );
+        }
+        break;
       }
-    }
-    else if ( layer->type() == QgsMapLayer::RasterLayer )
-    {
-      uri.layerType = QStringLiteral( "raster" );
-    }
-    else
-    {
-      // plugin layers do not have a standard way of storing their URI...
-      return;
+      case QgsMapLayer::RasterLayer:
+      {
+        uri.layerType = QStringLiteral( "raster" );
+        break;
+      }
+
+      case QgsMapLayer::MeshLayer:
+      case QgsMapLayer::PluginLayer:
+      {
+        // plugin layers do not have a standard way of storing their URI...
+        return;
+      }
     }
     uris << uri;
   }

--- a/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
+++ b/src/gui/layertree/qgslayertreeembeddedwidgetsimpl.cpp
@@ -48,16 +48,27 @@ QgsLayerTreeOpacityWidget::QgsLayerTreeOpacityWidget( QgsMapLayer *layer )
   connect( mSlider, &QAbstractSlider::valueChanged, this, &QgsLayerTreeOpacityWidget::sliderValueChanged );
 
   // init from layer
-  if ( mLayer->type() == QgsMapLayer::VectorLayer )
+  switch ( mLayer->type() )
   {
-    QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( mLayer );
-    mSlider->setValue( vl->opacity() * 1000.0 );
-    connect( vl, &QgsVectorLayer::opacityChanged, this, &QgsLayerTreeOpacityWidget::layerTrChanged );
-  }
-  else if ( mLayer->type() == QgsMapLayer::RasterLayer )
-  {
-    mSlider->setValue( 1000 - qobject_cast<QgsRasterLayer *>( mLayer )->renderer()->opacity() * 1000 );
-    // TODO: there is no signal for raster layers
+    case QgsMapLayer::VectorLayer:
+    {
+      QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( mLayer );
+      mSlider->setValue( vl->opacity() * 1000.0 );
+      connect( vl, &QgsVectorLayer::opacityChanged, this, &QgsLayerTreeOpacityWidget::layerTrChanged );
+      break;
+    }
+
+    case QgsMapLayer::RasterLayer:
+    {
+      mSlider->setValue( 1000 - qobject_cast<QgsRasterLayer *>( mLayer )->renderer()->opacity() * 1000 );
+      // TODO: there is no signal for raster layers
+      break;
+    }
+
+    case QgsMapLayer::PluginLayer:
+    case QgsMapLayer::MeshLayer:
+      break;
+
   }
 }
 
@@ -80,13 +91,22 @@ void QgsLayerTreeOpacityWidget::updateOpacityFromSlider()
 {
   int value = mSlider->value();
 
-  if ( mLayer->type() == QgsMapLayer::VectorLayer )
+  switch ( mLayer->type() )
   {
-    qobject_cast<QgsVectorLayer *>( mLayer )->setOpacity( value / 1000.0 );
-  }
-  else if ( mLayer->type() == QgsMapLayer::RasterLayer )
-  {
-    qobject_cast<QgsRasterLayer *>( mLayer )->renderer()->setOpacity( 1 - value / 1000.0 );
+    case QgsMapLayer::VectorLayer:
+    {
+      qobject_cast<QgsVectorLayer *>( mLayer )->setOpacity( value / 1000.0 );
+      break;
+    }
+    case QgsMapLayer::RasterLayer:
+    {
+      qobject_cast<QgsRasterLayer *>( mLayer )->renderer()->setOpacity( 1 - value / 1000.0 );
+      break;
+    }
+
+    case QgsMapLayer::PluginLayer:
+    case QgsMapLayer::MeshLayer:
+      break;
   }
 
   mLayer->triggerRepaint();
@@ -119,7 +139,17 @@ QgsLayerTreeOpacityWidget *QgsLayerTreeOpacityWidget::Provider::createWidget( Qg
 
 bool QgsLayerTreeOpacityWidget::Provider::supportsLayer( QgsMapLayer *layer )
 {
-  return layer->type() == QgsMapLayer::VectorLayer || layer->type() == QgsMapLayer::RasterLayer;
+  switch ( layer->type() )
+  {
+    case QgsMapLayer::VectorLayer:
+    case QgsMapLayer::RasterLayer:
+      return true;
+
+    case QgsMapLayer::MeshLayer:
+    case QgsMapLayer::PluginLayer:
+      return false;
+  }
+  return false;
 }
 
 ///@endcond

--- a/src/gui/qgsbrowserdockwidget_p.cpp
+++ b/src/gui/qgsbrowserdockwidget_p.cpp
@@ -189,26 +189,35 @@ void QgsBrowserLayerProperties::setItem( QgsDataItem *item )
   // we need to create a temporary layer to get metadata
   // we could use a provider but the metadata is not as complete and "pretty"  and this is easier
   QgsDebugMsg( QStringLiteral( "creating temporary layer using path %1" ).arg( layerItem->path() ) );
-  if ( type == QgsMapLayer::RasterLayer )
+  switch ( type )
   {
-    QgsDebugMsg( QStringLiteral( "creating raster layer" ) );
-    // should copy code from addLayer() to split uri ?
-    mLayer = qgis::make_unique< QgsRasterLayer >( layerItem->uri(), layerItem->name(), layerItem->providerKey() );
-  }
-  else if ( type == QgsMapLayer::MeshLayer )
-  {
-    QgsDebugMsg( QStringLiteral( "creating mesh layer" ) );
-    mLayer = qgis::make_unique < QgsMeshLayer >( layerItem->uri(), layerItem->name(), layerItem->providerKey() );
-  }
-  else if ( type == QgsMapLayer::VectorLayer )
-  {
-    QgsDebugMsg( QStringLiteral( "creating vector layer" ) );
-    mLayer = qgis::make_unique < QgsVectorLayer>( layerItem->uri(), layerItem->name(), layerItem->providerKey() );
-  }
-  else if ( type == QgsMapLayer::PluginLayer )
-  {
-    // TODO: support display of properties for plugin layers
-    return;
+    case QgsMapLayer::RasterLayer:
+    {
+      QgsDebugMsg( QStringLiteral( "creating raster layer" ) );
+      // should copy code from addLayer() to split uri ?
+      mLayer = qgis::make_unique< QgsRasterLayer >( layerItem->uri(), layerItem->name(), layerItem->providerKey() );
+      break;
+    }
+
+    case QgsMapLayer::MeshLayer:
+    {
+      QgsDebugMsg( QStringLiteral( "creating mesh layer" ) );
+      mLayer = qgis::make_unique < QgsMeshLayer >( layerItem->uri(), layerItem->name(), layerItem->providerKey() );
+      break;
+    }
+
+    case QgsMapLayer::VectorLayer:
+    {
+      QgsDebugMsg( QStringLiteral( "creating vector layer" ) );
+      mLayer = qgis::make_unique < QgsVectorLayer>( layerItem->uri(), layerItem->name(), layerItem->providerKey() );
+      break;
+    }
+
+    case QgsMapLayer::PluginLayer:
+    {
+      // TODO: support display of properties for plugin layers
+      return;
+    }
   }
 
   mAttributeTable->setModel( nullptr );

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -108,16 +108,25 @@ QList<QgsMapToolIdentify::IdentifyResult> QgsIdentifyMenu::exec( const QList<Qgs
     ++count;
     it.next();
     QgsMapLayer *layer = it.key();
-    if ( layer->type() == QgsMapLayer::RasterLayer )
+    switch ( layer->type() )
     {
-      addRasterLayer( layer );
-    }
-    else if ( layer->type() == QgsMapLayer::VectorLayer )
-    {
-      QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
-      if ( !vl )
-        continue;
-      addVectorLayer( vl, it.value(), singleLayer );
+      case QgsMapLayer::RasterLayer:
+      {
+        addRasterLayer( layer );
+        break;
+      }
+      case QgsMapLayer::VectorLayer:
+      {
+        QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
+        if ( !vl )
+          continue;
+        addVectorLayer( vl, it.value(), singleLayer );
+        break;
+      }
+
+      case QgsMapLayer::PluginLayer:
+      case QgsMapLayer::MeshLayer:
+        break;
     }
   }
 

--- a/src/server/services/wms/qgslayerrestorer.cpp
+++ b/src/server/services/wms/qgslayerrestorer.cpp
@@ -41,25 +41,34 @@ QgsLayerRestorer::QgsLayerRestorer( const QList<QgsMapLayer *> &layers )
     layer->exportSldStyle( sldDoc, errMsg );
     ( void )settings.mSldStyle.setContent( sldDoc.toString(), true ); // for namespace processing
 
-    if ( layer->type() == QgsMapLayer::LayerType::VectorLayer )
+    switch ( layer->type() )
     {
-      QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( layer );
-
-      if ( vLayer )
+      case QgsMapLayer::VectorLayer:
       {
-        settings.mOpacity = vLayer->opacity();
-        settings.mSelectedFeatureIds = vLayer->selectedFeatureIds();
-        settings.mFilter = vLayer->subsetString();
-      }
-    }
-    else if ( layer->type() == QgsMapLayer::LayerType::RasterLayer )
-    {
-      QgsRasterLayer *rLayer = qobject_cast<QgsRasterLayer *>( layer );
+        QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( layer );
 
-      if ( rLayer )
-      {
-        settings.mOpacity = rLayer->renderer()->opacity();
+        if ( vLayer )
+        {
+          settings.mOpacity = vLayer->opacity();
+          settings.mSelectedFeatureIds = vLayer->selectedFeatureIds();
+          settings.mFilter = vLayer->subsetString();
+        }
+        break;
       }
+      case QgsMapLayer::LayerType::RasterLayer:
+      {
+        QgsRasterLayer *rLayer = qobject_cast<QgsRasterLayer *>( layer );
+
+        if ( rLayer )
+        {
+          settings.mOpacity = rLayer->renderer()->opacity();
+        }
+        break;
+      }
+
+      case QgsMapLayer::MeshLayer:
+      case QgsMapLayer::PluginLayer:
+        break;
     }
 
     mLayerSettings[layer] = settings;
@@ -84,25 +93,34 @@ QgsLayerRestorer::~QgsLayerRestorer()
     }
     layer->removeCustomProperty( "readSLD" );
 
-    if ( layer->type() == QgsMapLayer::LayerType::VectorLayer )
+    switch ( layer->type() )
     {
-      QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( layer );
-
-      if ( vLayer )
+      case QgsMapLayer::LayerType::VectorLayer:
       {
-        vLayer->setOpacity( settings.mOpacity );
-        vLayer->selectByIds( settings.mSelectedFeatureIds );
-        vLayer->setSubsetString( settings.mFilter );
-      }
-    }
-    else if ( layer->type() == QgsMapLayer::LayerType::RasterLayer )
-    {
-      QgsRasterLayer *rLayer = qobject_cast<QgsRasterLayer *>( layer );
+        QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( layer );
 
-      if ( rLayer )
-      {
-        rLayer->renderer()->setOpacity( settings.mOpacity );
+        if ( vLayer )
+        {
+          vLayer->setOpacity( settings.mOpacity );
+          vLayer->selectByIds( settings.mSelectedFeatureIds );
+          vLayer->setSubsetString( settings.mFilter );
+        }
+        break;
       }
+      case QgsMapLayer::LayerType::RasterLayer:
+      {
+        QgsRasterLayer *rLayer = qobject_cast<QgsRasterLayer *>( layer );
+
+        if ( rLayer )
+        {
+          rLayer->renderer()->setOpacity( settings.mOpacity );
+        }
+        break;
+      }
+
+      case QgsMapLayer::MeshLayer:
+      case QgsMapLayer::PluginLayer:
+        break;
     }
   }
 }

--- a/src/server/services/wms/qgswmsdescribelayer.cpp
+++ b/src/server/services/wms/qgswmsdescribelayer.cpp
@@ -155,33 +155,42 @@ namespace QgsWms
       oResNode.setAttribute( QStringLiteral( "xlink:type" ), QStringLiteral( "simple" ) );
       // store the TypeName element
       QDomElement nameNode = myDocument.createElement( QStringLiteral( "TypeName" ) );
-      if ( layer->type() == QgsMapLayer::VectorLayer )
+      switch ( layer->type() )
       {
-        typeNode.appendChild( myDocument.createTextNode( QStringLiteral( "wfs" ) ) );
-
-        if ( wfsLayerIds.indexOf( layer->id() ) != -1 )
+        case QgsMapLayer::VectorLayer:
         {
-          oResNode.setAttribute( QStringLiteral( "xlink:href" ), wfsHrefString );
+          typeNode.appendChild( myDocument.createTextNode( QStringLiteral( "wfs" ) ) );
+
+          if ( wfsLayerIds.indexOf( layer->id() ) != -1 )
+          {
+            oResNode.setAttribute( QStringLiteral( "xlink:href" ), wfsHrefString );
+          }
+
+          // store the se:FeatureTypeName element
+          QDomElement typeNameNode = myDocument.createElement( QStringLiteral( "se:FeatureTypeName" ) );
+          typeNameNode.appendChild( myDocument.createTextNode( name ) );
+          nameNode.appendChild( typeNameNode );
+          break;
+        }
+        case QgsMapLayer::RasterLayer:
+        {
+          typeNode.appendChild( myDocument.createTextNode( QStringLiteral( "wcs" ) ) );
+
+          if ( wcsLayerIds.indexOf( layer->id() ) != -1 )
+          {
+            oResNode.setAttribute( QStringLiteral( "xlink:href" ), wcsHrefString );
+          }
+
+          // store the se:CoverageTypeName element
+          QDomElement typeNameNode = myDocument.createElement( QStringLiteral( "se:CoverageTypeName" ) );
+          typeNameNode.appendChild( myDocument.createTextNode( name ) );
+          nameNode.appendChild( typeNameNode );
+          break;
         }
 
-        // store the se:FeatureTypeName element
-        QDomElement typeNameNode = myDocument.createElement( QStringLiteral( "se:FeatureTypeName" ) );
-        typeNameNode.appendChild( myDocument.createTextNode( name ) );
-        nameNode.appendChild( typeNameNode );
-      }
-      else if ( layer->type() == QgsMapLayer::RasterLayer )
-      {
-        typeNode.appendChild( myDocument.createTextNode( QStringLiteral( "wcs" ) ) );
-
-        if ( wcsLayerIds.indexOf( layer->id() ) != -1 )
-        {
-          oResNode.setAttribute( QStringLiteral( "xlink:href" ), wcsHrefString );
-        }
-
-        // store the se:CoverageTypeName element
-        QDomElement typeNameNode = myDocument.createElement( QStringLiteral( "se:CoverageTypeName" ) );
-        typeNameNode.appendChild( myDocument.createTextNode( name ) );
-        nameNode.appendChild( typeNameNode );
+        case QgsMapLayer::MeshLayer:
+        case QgsMapLayer::PluginLayer:
+          break;
       }
       layerNode.appendChild( typeNode );
       layerNode.appendChild( oResNode );

--- a/src/server/services/wms/qgswmsgetcapabilities.cpp
+++ b/src/server/services/wms/qgswmsgetcapabilities.cpp
@@ -1708,111 +1708,121 @@ namespace QgsWms
       treeNameElem.appendChild( treeNameText );
       layerElem.appendChild( treeNameElem );
 
-      if ( currentLayer->type() == QgsMapLayer::VectorLayer )
+      switch ( currentLayer->type() )
       {
-        QgsVectorLayer *vLayer = static_cast<QgsVectorLayer *>( currentLayer );
-        const QSet<QString> &excludedAttributes = vLayer->excludeAttributesWms();
-
-        int displayFieldIdx = -1;
-        QString displayField = QStringLiteral( "maptip" );
-        QgsExpression exp( vLayer->displayExpression() );
-        if ( exp.isField() )
+        case QgsMapLayer::VectorLayer:
         {
-          displayField = static_cast<const QgsExpressionNodeColumnRef *>( exp.rootNode() )->name();
-          displayFieldIdx = vLayer->fields().lookupField( displayField );
-        }
+          QgsVectorLayer *vLayer = static_cast<QgsVectorLayer *>( currentLayer );
+          const QSet<QString> &excludedAttributes = vLayer->excludeAttributesWms();
 
-        //attributes
-        QDomElement attributesElem = doc.createElement( QStringLiteral( "Attributes" ) );
-        const QgsFields layerFields = vLayer->fields();
-        for ( int idx = 0; idx < layerFields.count(); ++idx )
-        {
-          QgsField field = layerFields.at( idx );
-          if ( excludedAttributes.contains( field.name() ) )
+          int displayFieldIdx = -1;
+          QString displayField = QStringLiteral( "maptip" );
+          QgsExpression exp( vLayer->displayExpression() );
+          if ( exp.isField() )
           {
-            continue;
-          }
-          // field alias in case of displayField
-          if ( idx == displayFieldIdx )
-          {
-            displayField = vLayer->attributeDisplayName( idx );
-          }
-          QDomElement attributeElem = doc.createElement( QStringLiteral( "Attribute" ) );
-          attributeElem.setAttribute( QStringLiteral( "name" ), field.name() );
-          attributeElem.setAttribute( QStringLiteral( "type" ), QVariant::typeToName( field.type() ) );
-          attributeElem.setAttribute( QStringLiteral( "typeName" ), field.typeName() );
-          QString alias = field.alias();
-          if ( !alias.isEmpty() )
-          {
-            attributeElem.setAttribute( QStringLiteral( "alias" ), alias );
+            displayField = static_cast<const QgsExpressionNodeColumnRef *>( exp.rootNode() )->name();
+            displayFieldIdx = vLayer->fields().lookupField( displayField );
           }
 
-          //edit type to text
-          attributeElem.setAttribute( QStringLiteral( "editType" ), vLayer->editorWidgetSetup( idx ).type() );
-          attributeElem.setAttribute( QStringLiteral( "comment" ), field.comment() );
-          attributeElem.setAttribute( QStringLiteral( "length" ), field.length() );
-          attributeElem.setAttribute( QStringLiteral( "precision" ), field.precision() );
-          attributesElem.appendChild( attributeElem );
-        }
-
-        //displayfield
-        layerElem.setAttribute( QStringLiteral( "displayField" ), displayField );
-
-        //primary key
-        QgsAttributeList pkAttributes = vLayer->primaryKeyAttributes();
-        if ( pkAttributes.size() > 0 )
-        {
-          QDomElement pkElem = doc.createElement( QStringLiteral( "PrimaryKey" ) );
-          QgsAttributeList::const_iterator pkIt = pkAttributes.constBegin();
-          for ( ; pkIt != pkAttributes.constEnd(); ++pkIt )
+          //attributes
+          QDomElement attributesElem = doc.createElement( QStringLiteral( "Attributes" ) );
+          const QgsFields layerFields = vLayer->fields();
+          for ( int idx = 0; idx < layerFields.count(); ++idx )
           {
-            QDomElement pkAttributeElem = doc.createElement( QStringLiteral( "PrimaryKeyAttribute" ) );
-            QDomText pkAttName = doc.createTextNode( layerFields.at( *pkIt ).name() );
-            pkAttributeElem.appendChild( pkAttName );
-            pkElem.appendChild( pkAttributeElem );
+            QgsField field = layerFields.at( idx );
+            if ( excludedAttributes.contains( field.name() ) )
+            {
+              continue;
+            }
+            // field alias in case of displayField
+            if ( idx == displayFieldIdx )
+            {
+              displayField = vLayer->attributeDisplayName( idx );
+            }
+            QDomElement attributeElem = doc.createElement( QStringLiteral( "Attribute" ) );
+            attributeElem.setAttribute( QStringLiteral( "name" ), field.name() );
+            attributeElem.setAttribute( QStringLiteral( "type" ), QVariant::typeToName( field.type() ) );
+            attributeElem.setAttribute( QStringLiteral( "typeName" ), field.typeName() );
+            QString alias = field.alias();
+            if ( !alias.isEmpty() )
+            {
+              attributeElem.setAttribute( QStringLiteral( "alias" ), alias );
+            }
+
+            //edit type to text
+            attributeElem.setAttribute( QStringLiteral( "editType" ), vLayer->editorWidgetSetup( idx ).type() );
+            attributeElem.setAttribute( QStringLiteral( "comment" ), field.comment() );
+            attributeElem.setAttribute( QStringLiteral( "length" ), field.length() );
+            attributeElem.setAttribute( QStringLiteral( "precision" ), field.precision() );
+            attributesElem.appendChild( attributeElem );
           }
-          layerElem.appendChild( pkElem );
-        }
 
-        //geometry type
-        layerElem.setAttribute( QStringLiteral( "geometryType" ), QgsWkbTypes::displayString( vLayer->wkbType() ) );
+          //displayfield
+          layerElem.setAttribute( QStringLiteral( "displayField" ), displayField );
 
-        layerElem.appendChild( attributesElem );
-      }
-      else if ( currentLayer->type() == QgsMapLayer::RasterLayer )
-      {
-        const QgsDataProvider *provider = currentLayer->dataProvider();
-        if ( provider && provider->name() == "wms" )
-        {
-          //advertise as web map background layer
-          QVariant wmsBackgroundLayer = currentLayer->customProperty( QStringLiteral( "WMSBackgroundLayer" ), false );
-          QDomElement wmsBackgroundLayerElem = doc.createElement( "WMSBackgroundLayer" );
-          QDomText wmsBackgroundLayerText = doc.createTextNode( wmsBackgroundLayer.toBool() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
-          wmsBackgroundLayerElem.appendChild( wmsBackgroundLayerText );
-          layerElem.appendChild( wmsBackgroundLayerElem );
-
-          //publish datasource
-          QVariant wmsPublishDataSourceUrl = currentLayer->customProperty( QStringLiteral( "WMSPublishDataSourceUrl" ), false );
-          if ( wmsPublishDataSourceUrl.toBool() )
+          //primary key
+          QgsAttributeList pkAttributes = vLayer->primaryKeyAttributes();
+          if ( pkAttributes.size() > 0 )
           {
-            QList< QVariant > resolutionList = provider->property( "resolutions" ).toList();
-            bool tiled = resolutionList.size() > 0;
-
-            QDomElement dataSourceElem = doc.createElement( tiled ? QStringLiteral( "WMTSDataSource" ) : QStringLiteral( "WMSDataSource" ) );
-            QDomText dataSourceUri = doc.createTextNode( provider->dataSourceUri() );
-            dataSourceElem.appendChild( dataSourceUri );
-            layerElem.appendChild( dataSourceElem );
+            QDomElement pkElem = doc.createElement( QStringLiteral( "PrimaryKey" ) );
+            QgsAttributeList::const_iterator pkIt = pkAttributes.constBegin();
+            for ( ; pkIt != pkAttributes.constEnd(); ++pkIt )
+            {
+              QDomElement pkAttributeElem = doc.createElement( QStringLiteral( "PrimaryKeyAttribute" ) );
+              QDomText pkAttName = doc.createTextNode( layerFields.at( *pkIt ).name() );
+              pkAttributeElem.appendChild( pkAttName );
+              pkElem.appendChild( pkAttributeElem );
+            }
+            layerElem.appendChild( pkElem );
           }
+
+          //geometry type
+          layerElem.setAttribute( QStringLiteral( "geometryType" ), QgsWkbTypes::displayString( vLayer->wkbType() ) );
+
+          layerElem.appendChild( attributesElem );
+          break;
         }
 
-        QVariant wmsPrintLayer = currentLayer->customProperty( QStringLiteral( "WMSPrintLayer" ) );
-        if ( wmsPrintLayer.isValid() )
+        case QgsMapLayer::RasterLayer:
         {
-          QDomElement wmsPrintLayerElem = doc.createElement( "WMSPrintLayer" );
-          QDomText wmsPrintLayerText = doc.createTextNode( wmsPrintLayer.toString() );
-          wmsPrintLayerElem.appendChild( wmsPrintLayerText );
-          layerElem.appendChild( wmsPrintLayerElem );
+          const QgsDataProvider *provider = currentLayer->dataProvider();
+          if ( provider && provider->name() == "wms" )
+          {
+            //advertise as web map background layer
+            QVariant wmsBackgroundLayer = currentLayer->customProperty( QStringLiteral( "WMSBackgroundLayer" ), false );
+            QDomElement wmsBackgroundLayerElem = doc.createElement( "WMSBackgroundLayer" );
+            QDomText wmsBackgroundLayerText = doc.createTextNode( wmsBackgroundLayer.toBool() ? QStringLiteral( "1" ) : QStringLiteral( "0" ) );
+            wmsBackgroundLayerElem.appendChild( wmsBackgroundLayerText );
+            layerElem.appendChild( wmsBackgroundLayerElem );
+
+            //publish datasource
+            QVariant wmsPublishDataSourceUrl = currentLayer->customProperty( QStringLiteral( "WMSPublishDataSourceUrl" ), false );
+            if ( wmsPublishDataSourceUrl.toBool() )
+            {
+              QList< QVariant > resolutionList = provider->property( "resolutions" ).toList();
+              bool tiled = resolutionList.size() > 0;
+
+              QDomElement dataSourceElem = doc.createElement( tiled ? QStringLiteral( "WMTSDataSource" ) : QStringLiteral( "WMSDataSource" ) );
+              QDomText dataSourceUri = doc.createTextNode( provider->dataSourceUri() );
+              dataSourceElem.appendChild( dataSourceUri );
+              layerElem.appendChild( dataSourceElem );
+            }
+          }
+
+          QVariant wmsPrintLayer = currentLayer->customProperty( QStringLiteral( "WMSPrintLayer" ) );
+          if ( wmsPrintLayer.isValid() )
+          {
+            QDomElement wmsPrintLayerElem = doc.createElement( "WMSPrintLayer" );
+            QDomText wmsPrintLayerText = doc.createTextNode( wmsPrintLayer.toString() );
+            wmsPrintLayerElem.appendChild( wmsPrintLayerText );
+            layerElem.appendChild( wmsPrintLayerElem );
+          }
+          break;
         }
+
+        case QgsMapLayer::MeshLayer:
+        case QgsMapLayer::PluginLayer:
+          break;
       }
     }
 

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -3080,16 +3080,26 @@ namespace QgsWms
   {
     if ( opacity >= 0 && opacity <= 255 )
     {
-      if ( layer->type() == QgsMapLayer::LayerType::VectorLayer )
+      switch ( layer->type() )
       {
-        QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
-        vl->setOpacity( opacity / 255. );
-      }
-      else if ( layer->type() == QgsMapLayer::LayerType::RasterLayer )
-      {
-        QgsRasterLayer *rl = qobject_cast<QgsRasterLayer *>( layer );
-        QgsRasterRenderer *rasterRenderer = rl->renderer();
-        rasterRenderer->setOpacity( opacity / 255. );
+        case QgsMapLayer::LayerType::VectorLayer:
+        {
+          QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
+          vl->setOpacity( opacity / 255. );
+          break;
+        }
+
+        case QgsMapLayer::LayerType::RasterLayer:
+        {
+          QgsRasterLayer *rl = qobject_cast<QgsRasterLayer *>( layer );
+          QgsRasterRenderer *rasterRenderer = rl->renderer();
+          rasterRenderer->setOpacity( opacity / 255. );
+          break;
+        }
+
+        case QgsMapLayer::MeshLayer:
+        case QgsMapLayer::PluginLayer:
+          break;
       }
     }
   }


### PR DESCRIPTION
Because it gives better warnings, and makes it much easier to identify areas of code which are missing support for new layer types (specifically mesh layers)