### PR TITLE
[needs-docs][layouts] Add checkbox to disable raster tiling for PDF/SVG exports

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutrendercontext.sip.in
@@ -30,6 +30,7 @@ Stores information relating to the current rendering settings for a layout.
       FlagForceVectorOutput,
       FlagHideCoverageLayer,
       FlagDrawSelection,
+      FlagDisableTiledRasterLayerRenders,
     };
     typedef QFlags<QgsLayoutRenderContext::Flag> Flags;
 

--- a/src/core/layout/qgslayoutexporter.cpp
+++ b/src/core/layout/qgslayoutexporter.cpp
@@ -492,6 +492,8 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( const QString &f
   ( void )contextRestorer;
   mLayout->renderContext().setDpi( settings.dpi );
 
+  mLayout->renderContext().setFlags( settings.flags );
+
   // If we are not printing as raster, temporarily disable advanced effects
   // as QPrinter does not support composition modes and can result
   // in items missing from the output
@@ -562,6 +564,8 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToPdf( QgsAbstractLayou
     LayoutContextSettingsRestorer contextRestorer( iterator->layout() );
     ( void )contextRestorer;
     iterator->layout()->renderContext().setDpi( settings.dpi );
+
+    iterator->layout()->renderContext().setFlags( settings.flags );
 
     // If we are not printing as raster, temporarily disable advanced effects
     // as QPrinter does not support composition modes and can result
@@ -673,6 +677,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::print( QPrinter &printer, con
   ( void )contextRestorer;
   mLayout->renderContext().setDpi( settings.dpi );
 
+  mLayout->renderContext().setFlags( settings.flags );
   // If we are not printing as raster, temporarily disable advanced effects
   // as QPrinter does not support composition modes and can result
   // in items missing from the output
@@ -732,6 +737,8 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::print( QgsAbstractLayoutItera
     ( void )contextRestorer;
     iterator->layout()->renderContext().setDpi( settings.dpi );
 
+    iterator->layout()->renderContext().setFlags( settings.flags );
+
     // If we are not printing as raster, temporarily disable advanced effects
     // as QPrinter does not support composition modes and can result
     // in items missing from the output
@@ -786,6 +793,7 @@ QgsLayoutExporter::ExportResult QgsLayoutExporter::exportToSvg( const QString &f
   ( void )contextRestorer;
   mLayout->renderContext().setDpi( settings.dpi );
 
+  mLayout->renderContext().setFlags( settings.flags );
   mLayout->renderContext().setFlag( QgsLayoutRenderContext::FlagForceVectorOutput, settings.forceVectorOutput );
   mLayout->renderContext().setTextRenderFormat( s.textRenderFormat );
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1182,6 +1182,7 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
   jobMapSettings.setFlag( QgsMapSettings::DrawEditingInfo, false );
   jobMapSettings.setSelectionColor( mLayout->renderContext().selectionColor() );
   jobMapSettings.setFlag( QgsMapSettings::DrawSelection, mLayout->renderContext().flags() & QgsLayoutRenderContext::FlagDrawSelection );
+  jobMapSettings.setFlag( QgsMapSettings::RenderPartialOutput, mLayout->renderContext().flags() & QgsLayoutRenderContext::FlagDisableTiledRasterLayerRenders );
   jobMapSettings.setFlag( QgsMapSettings::UseAdvancedEffects, mLayout->renderContext().flags() & QgsLayoutRenderContext::FlagUseAdvancedEffects );
   jobMapSettings.setTransformContext( mLayout->project()->transformContext() );
   jobMapSettings.setPathResolver( mLayout->project()->pathResolver() );

--- a/src/core/layout/qgslayoutrendercontext.h
+++ b/src/core/layout/qgslayoutrendercontext.h
@@ -46,6 +46,7 @@ class CORE_EXPORT QgsLayoutRenderContext : public QObject
       FlagForceVectorOutput = 1 << 5, //!< Force output in vector format where possible, even if items require rasterization to keep their correct appearance.
       FlagHideCoverageLayer = 1 << 6, //!< Hide coverage layer in outputs
       FlagDrawSelection = 1 << 7, //!< Draw selection
+      FlagDisableTiledRasterLayerRenders = 1 << 8, //!< If set, then raster layers will not be drawn as separate tiles. This may improve the appearance in exported files, at the cost of much higher memory usage during exports.
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/ui/layout/qgspdfexportoptions.ui
+++ b/src/ui/layout/qgspdfexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>197</height>
+    <height>276</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,6 +20,26 @@
       <string>Export Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
+      <item row="3" column="1">
+       <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="mForceVectorCheckBox">
+        <property name="toolTip">
+         <string>If checked, the layout will always be kept as vector objects when exported to a compatible format, even if the appearance of the resultant file does not match the layouts settings. If unchecked, some elements in the layout may be rasterized in order to keep their appearance intact.</string>
+        </property>
+        <property name="text">
+         <string>Always export as vectors</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Text export</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0" colspan="2">
        <widget class="QCheckBox" name="mIncludeMetadataCheckbox">
         <property name="text">
@@ -30,23 +50,25 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="mTextRenderFormatComboBox"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Text export</string>
-        </property>
-       </widget>
-      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox_2">
+     <property name="title">
+      <string>Advanced Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
       <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="mForceVectorCheckBox">
+       <widget class="QCheckBox" name="mDisableRasterTilingCheckBox">
         <property name="toolTip">
-         <string>If checked, the layout will always be kept as vector objects when exported to a compatible format, even if the appearance of the resultant file does not match the layouts settings. If unchecked, some elements in the layout may be rasterized in order to keep their appearance intact.</string>
+         <string>Disables tiled rendering of raster layers. This setting may improve the export quality in some circumstances, at the cost of much greater memory usage during exports.</string>
         </property>
         <property name="text">
-         <string>Always export as vectors</string>
+         <string>Disable tiled raster layer exports</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/src/ui/layout/qgssvgexportoptions.ui
+++ b/src/ui/layout/qgssvgexportoptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>489</width>
-    <height>385</height>
+    <height>464</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -180,6 +180,28 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox_2">
+     <property name="title">
+      <string>Advanced Options</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0">
+      <item row="0" column="0" colspan="2">
+       <widget class="QCheckBox" name="mDisableRasterTilingCheckBox">
+        <property name="toolTip">
+         <string>Disables tiled rendering of raster layers. This setting may improve the export quality in some circumstances, at the cost of much greater memory usage during exports.</string>
+        </property>
+        <property name="text">
+         <string>Disable tiled raster layer exports</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
This setting, which is disabled by default and placed into an
"advanced" group on PDF/SFG export, disables the built-in
raster layer tiled rendering. While the tiling is good for
memory usage, it can cause visible "seams" in the rasters
for generated PDF/SVG files.

The setting has a tooltip warning users that disabling the
tiling results in high memory usage during exports.

Fixes #19500