### PR TITLE
fix #17652 Impossible to rename a layer style from the Styling Panel

### DIFF
--- a/src/gui/qgsmaplayerstylemanagerwidget.h
+++ b/src/gui/qgsmaplayerstylemanagerwidget.h
@@ -55,6 +55,7 @@ class GUI_EXPORT QgsMapLayerStyleManagerWidget : public QgsMapLayerConfigWidget
     void styleRenamed( const QString &oldname, const QString &newname );
     void addStyle();
     void removeStyle();
+    void renameStyle( QStandardItem *item );
     void saveAsDefault();
     void loadDefault();
     void saveStyle();


### PR DESCRIPTION
a bit of dilema whether to write custom QgsAbstractItemModel class (there is no itemChanged variant with oldName) or to just disable renaming or to create button or use itemData. Ended up with itemData solution...

fixes https://issues.qgis.org/issues/17652