### PR TITLE
[processing] don't show cancel button in the task manager for algorithms that can not be cancelled (refs #20441)

### DIFF
--- a/src/core/processing/qgsprocessingalgrunnertask.cpp
+++ b/src/core/processing/qgsprocessingalgrunnertask.cpp
@@ -23,7 +23,7 @@
 #include "qgsvectorlayer.h"
 
 QgsProcessingAlgRunnerTask::QgsProcessingAlgRunnerTask( const QgsProcessingAlgorithm *algorithm, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
-  : QgsTask( tr( "Executing “%1”" ).arg( algorithm->displayName() ), algorithm->flags() & QgsProcessingAlgorithm::FlagNoThreading ? QgsTask::CanCancel : QgsTask::Flag() )
+  : QgsTask( tr( "Executing “%1”" ).arg( algorithm->displayName() ), algorithm->flags() & QgsProcessingAlgorithm::FlagCanCancel ? QgsTask::CanCancel : QgsTask::Flag() )
   , mParameters( parameters )
   , mContext( context )
   , mFeedback( feedback )

--- a/src/core/processing/qgsprocessingalgrunnertask.cpp
+++ b/src/core/processing/qgsprocessingalgrunnertask.cpp
@@ -23,7 +23,7 @@
 #include "qgsvectorlayer.h"
 
 QgsProcessingAlgRunnerTask::QgsProcessingAlgRunnerTask( const QgsProcessingAlgorithm *algorithm, const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
-  : QgsTask( tr( "Executing “%1”" ).arg( algorithm->displayName() ), QgsTask::CanCancel )
+  : QgsTask( tr( "Executing “%1”" ).arg( algorithm->displayName() ), algorithm->flags() & QgsProcessingAlgorithm::FlagNoThreading ? QgsTask::CanCancel : QgsTask::Flag() )
   , mParameters( parameters )
   , mContext( context )
   , mFeedback( feedback )


### PR DESCRIPTION
## Description
While for these algorithms we have "Cancel" button disabled (see https://issues.qgis.org/issues/18600), in the task manager UI cancel button still present. This causes some confusion, when user clicks on this button and nothing happens.

Partially fixes https://issues.qgis.org/issues/20441.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
