### PR TITLE
Follow up 1f8708f, fix src / scheme detection

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4669,9 +4669,9 @@ bool QgisApp::addVectorLayers( const QStringList &layerQStringList, const QStrin
 
     QgsDebugMsgLevel( "completeBaseName: " + baseName, 2 );
 
-    const bool isVsiCurl { src.startsWith( QLatin1String( "/vsicurl", Qt::CaseInsensitive ) ) };
+    const bool isVsiCurl = ( src.startsWith( QLatin1String( "/vsicurl" ), Qt::CaseInsensitive ) );
     const auto scheme { QUrl( src ).scheme() };
-    const bool isRemoteUrl { scheme.startsWith( QStringLiteral( "http" ) ) || scheme == QStringLiteral( "ftp" ) };
+    const bool isRemoteUrl = ( scheme.startsWith( QStringLiteral( "http" ) ) || scheme == QStringLiteral( "ftp" ) );
 
     // create the layer
     QgsVectorLayer::LayerOptions options;


### PR DESCRIPTION
## Description
@elpaso , here's a follow up fix to your OGR remove / file PR. Without this, all local data sources are flagged as remote because of the broken isVsiCurl conditional check.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
