### PR TITLE
Show an explicit warning when exporting a layout which contains a broken image [layouts] 

### DIFF
--- a/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
@@ -79,6 +79,8 @@ this value. The path can either be a local path or a remote (http) path.
 :return: path for the source image
 
 .. seealso:: :py:func:`setPicturePath`
+
+.. seealso:: :py:func:`evaluatedPath`
 %End
 
     double pictureRotation() const;
@@ -251,6 +253,24 @@ Returns the current picture mode (image format).
 
     virtual void finalizeRestoreFromXml();
 
+
+    bool isMissingImage() const;
+%Docstring
+Returns true if the source image is missing and the picture
+cannot be rendered.
+
+.. versionadded:: 3.6
+%End
+
+    QString evaluatedPath() const;
+%Docstring
+Returns the current evaluated picture path, which includes
+the result of data defined path overrides.
+
+.. seealso:: :py:func:`picturePath`
+
+.. versionadded:: 3.6
+%End
 
   public slots:
 

--- a/src/app/layout/qgslayoutvaliditychecks.h
+++ b/src/app/layout/qgslayoutvaliditychecks.h
@@ -44,3 +44,18 @@ class APP_EXPORT QgsLayoutOverviewValidityCheck : public QgsAbstractValidityChec
   private:
     QList<QgsValidityCheckResult> mResults;
 };
+
+class APP_EXPORT QgsLayoutPictureSourceValidityCheck : public QgsAbstractValidityCheck
+{
+  public:
+
+    QgsLayoutPictureSourceValidityCheck *create() const override;
+    QString id() const override;
+    int checkType() const override;
+    bool prepareCheck( const QgsValidityCheckContext *context, QgsFeedback *feedback ) override;
+    QList< QgsValidityCheckResult > runCheck( const QgsValidityCheckContext *context, QgsFeedback *feedback ) override;
+
+  private:
+    QList<QgsValidityCheckResult> mResults;
+};
+

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1244,6 +1244,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
 
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutScaleBarValidityCheck() );
   QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutOverviewValidityCheck() );
+  QgsApplication::validityCheckRegistry()->addCheck( new QgsLayoutPictureSourceValidityCheck() );
 
   mSplash->showMessage( tr( "Initializing file filters" ), Qt::AlignHCenter | Qt::AlignBottom );
   qApp->processEvents();

--- a/src/core/layout/qgslayoutitempicture.cpp
+++ b/src/core/layout/qgslayoutitempicture.cpp
@@ -485,6 +485,8 @@ void QgsLayoutItemPicture::updateMapRotation()
 
 void QgsLayoutItemPicture::loadPicture( const QString &path )
 {
+  mIsMissingImage = false;
+  mEvaluatedPath = path;
   if ( path.startsWith( QLatin1String( "http" ) ) )
   {
     //remote location
@@ -503,6 +505,7 @@ void QgsLayoutItemPicture::loadPicture( const QString &path )
   {
     //trying to load an invalid file or bad expression, show cross picture
     mMode = FormatSVG;
+    mIsMissingImage = true;
     QString badFile( QStringLiteral( ":/images/composer/missing_image.svg" ) );
     mSVG.load( badFile );
     if ( mSVG.isValid() )
@@ -567,6 +570,16 @@ QSizeF QgsLayoutItemPicture::pictureSize()
   {
     return QSizeF( 0, 0 );
   }
+}
+
+bool QgsLayoutItemPicture::isMissingImage() const
+{
+  return mIsMissingImage;
+}
+
+QString QgsLayoutItemPicture::evaluatedPath() const
+{
+  return mEvaluatedPath;
 }
 
 void QgsLayoutItemPicture::shapeChanged()

--- a/src/core/layout/qgslayoutitempicture.h
+++ b/src/core/layout/qgslayoutitempicture.h
@@ -94,6 +94,7 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
      * this value. The path can either be a local path or a remote (http) path.
      * \returns path for the source image
      * \see setPicturePath()
+     * \see evaluatedPath()
      */
     QString picturePath() const;
 
@@ -230,6 +231,23 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
 
     void finalizeRestoreFromXml() override;
 
+    /**
+     * Returns true if the source image is missing and the picture
+     * cannot be rendered.
+     *
+     * \since QGIS 3.6
+     */
+    bool isMissingImage() const;
+
+    /**
+     * Returns the current evaluated picture path, which includes
+     * the result of data defined path overrides.
+     *
+     * \see picturePath()
+     * \since QGIS 3.6
+     */
+    QString evaluatedPath() const;
+
   public slots:
 
     /**
@@ -318,6 +336,8 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
     bool mHasExpressionError = false;
     bool mLoaded = false;
     bool mLoadingSvg = false;
+    bool mIsMissingImage = false;
+    QString mEvaluatedPath;
 
     //! Loads an image file into the picture item and redraws the item
     void loadPicture( const QString &path );

--- a/tests/src/core/testqgslayoutpicture.cpp
+++ b/tests/src/core/testqgslayoutpicture.cpp
@@ -60,6 +60,7 @@ class TestQgsLayoutPicture : public QObject
 
     void pictureExpression();
     void pictureInvalidExpression();
+    void valid();
 
 
   private:
@@ -420,6 +421,33 @@ void TestQgsLayoutPicture::pictureInvalidExpression()
 
   mLayout->removeItem( mPicture );
   mPicture->dataDefinedProperties().setProperty( QgsLayoutObject::PictureSource, QgsProperty() );
+}
+
+void TestQgsLayoutPicture::valid()
+{
+  QgsProject p;
+  QgsLayout l( &p );
+
+  QgsLayoutItemPicture *picture = new QgsLayoutItemPicture( &l );
+  l.addItem( picture );
+
+  picture->setPicturePath( mPngImage );
+  QVERIFY( !picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), mPngImage );
+
+  picture->setPicturePath( QStringLiteral( "bad" ) );
+  QVERIFY( picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), QStringLiteral( "bad" ) );
+
+  picture->dataDefinedProperties().setProperty( QgsLayoutObject::PictureSource, QgsProperty::fromExpression( QStringLiteral( "'%1'" ).arg( mSvgImage ) ) );
+  picture->refreshPicture();
+  QVERIFY( !picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), mSvgImage );
+
+  picture->dataDefinedProperties().setProperty( QgsLayoutObject::PictureSource, QgsProperty::fromExpression( QStringLiteral( "'bad'" ) ) );
+  picture->refreshPicture();
+  QVERIFY( picture->isMissingImage() );
+  QCOMPARE( picture->evaluatedPath(), QStringLiteral( "bad" ) );
 }
 
 QGSTEST_MAIN( TestQgsLayoutPicture )


### PR DESCRIPTION
Reduces the chance of users unknowingly exporting layouts with broken images