### PR TITLE
qgsRound: places should be of integer type instead of double

### DIFF
--- a/python/core/auto_generated/qgis.sip.in
+++ b/python/core/auto_generated/qgis.sip.in
@@ -123,7 +123,7 @@ bool qgsDoubleNearSig( double a, double b, int significantDigits = 10 );
 Compare two doubles using specified number of significant digits
 %End
 
-double qgsRound( double number, double places );
+double qgsRound( double number, int places );
 %Docstring
 Returns a double ``number``, rounded (as close as possible) to the specified number of ``places``.
 

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -301,7 +301,7 @@ inline bool qgsDoubleNearSig( double a, double b, int significantDigits = 10 )
  *
  * \since QGIS 3.0
  */
-inline double qgsRound( double number, double places )
+inline double qgsRound( double number, int places )
 {
   double m = ( number < 0.0 ) ? -1.0 : 1.0;
   double scaleFactor = std::pow( 10.0, places );


### PR DESCRIPTION
## Description
I didn't see that in my previous commit #9025, but there's no reason for places to be a double.

cc @nyalldawson 

Do I have to backport these two commits?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [X] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
