### PR TITLE
Allow expression widget to be empty so expression could be removed

### DIFF
--- a/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
@@ -57,6 +57,24 @@ Returns the title used for the expression dialog
 setFilters allows fitering according to the type of field
 %End
 
+    void setAllowEmptyFieldName( bool allowEmpty );
+%Docstring
+Sets whether an optional empty field ("not set") option is shown in the combo box.
+
+.. seealso:: :py:func:`allowEmptyFieldName`
+
+.. versionadded:: 3.0
+%End
+
+    bool allowEmptyFieldName() const;
+%Docstring
+Returns true if the combo box allows the empty field ("not set") choice.
+
+.. seealso:: :py:func:`setAllowEmptyFieldName`
+
+.. versionadded:: 3.0
+%End
+
     void setLeftHandButtonStyle( bool isLeft );
 
     QgsFieldProxyModel::Filters filters() const;

--- a/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
@@ -63,7 +63,7 @@ Sets whether an optional empty field ("not set") option is shown in the combo bo
 
 .. seealso:: :py:func:`allowEmptyFieldName`
 
-.. versionadded:: 3.0
+.. versionadded:: 3.6
 %End
 
     bool allowEmptyFieldName() const;
@@ -72,7 +72,7 @@ Returns true if the combo box allows the empty field ("not set") choice.
 
 .. seealso:: :py:func:`setAllowEmptyFieldName`
 
-.. versionadded:: 3.0
+.. versionadded:: 3.6
 %End
 
     void setLeftHandButtonStyle( bool isLeft );

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -90,6 +90,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   QgsSettings settings;
   restoreGeometry( settings.value( QStringLiteral( "Windows/QgsAttributeTypeDialog/geometry" ) ).toByteArray() );
 
+  constraintExpressionWidget->setAllowEmptyFieldName( true );
   constraintExpressionWidget->setLayer( vl );
 }
 

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -84,6 +84,7 @@ void QgsFieldExpressionWidget::setFilters( QgsFieldProxyModel::Filters filters )
 
 void QgsFieldExpressionWidget::setAllowEmptyFieldName( bool allowEmpty )
 {
+  mCombo->lineEdit()->setClearButtonEnabled( allowEmpty );
   mFieldProxyModel->sourceFieldModel()->setAllowEmptyFieldName( allowEmpty );
 }
 

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -82,6 +82,16 @@ void QgsFieldExpressionWidget::setFilters( QgsFieldProxyModel::Filters filters )
   mFieldProxyModel->setFilters( filters );
 }
 
+void QgsFieldExpressionWidget::setAllowEmptyFieldName( bool allowEmpty )
+{
+  mFieldProxyModel->sourceFieldModel()->setAllowEmptyFieldName( allowEmpty );
+}
+
+bool QgsFieldExpressionWidget::allowEmptyFieldName() const
+{
+  return mFieldProxyModel->sourceFieldModel()->allowEmptyFieldName();
+}
+
 void QgsFieldExpressionWidget::setLeftHandButtonStyle( bool isLeft )
 {
   QHBoxLayout *layout = dynamic_cast<QHBoxLayout *>( this->layout() );

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -79,14 +79,14 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     /**
      * Sets whether an optional empty field ("not set") option is shown in the combo box.
      * \see allowEmptyFieldName()
-     * \since QGIS 3.0
+     * \since QGIS 3.6
      */
     void setAllowEmptyFieldName( bool allowEmpty );
 
     /**
      * Returns true if the combo box allows the empty field ("not set") choice.
      * \see setAllowEmptyFieldName()
-     * \since QGIS 3.0
+     * \since QGIS 3.6
      */
     bool allowEmptyFieldName() const;
 

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -48,6 +48,7 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     Q_OBJECT
     Q_PROPERTY( QString expressionDialogTitle READ expressionDialogTitle WRITE setExpressionDialogTitle )
     Q_PROPERTY( QgsFieldProxyModel::Filters filters READ filters WRITE setFilters )
+    Q_PROPERTY( bool allowEmptyFieldName READ allowEmptyFieldName WRITE setAllowEmptyFieldName )
     Q_PROPERTY( bool allowEvalErrors READ allowEvalErrors WRITE setAllowEvalErrors NOTIFY allowEvalErrorsChanged )
 
   public:
@@ -74,6 +75,20 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
 
     //! setFilters allows fitering according to the type of field
     void setFilters( QgsFieldProxyModel::Filters filters );
+
+    /**
+     * Sets whether an optional empty field ("not set") option is shown in the combo box.
+     * \see allowEmptyFieldName()
+     * \since QGIS 3.0
+     */
+    void setAllowEmptyFieldName( bool allowEmpty );
+
+    /**
+     * Returns true if the combo box allows the empty field ("not set") choice.
+     * \see setAllowEmptyFieldName()
+     * \since QGIS 3.0
+     */
+    bool allowEmptyFieldName() const;
 
     void setLeftHandButtonStyle( bool isLeft );
 

--- a/tests/src/gui/testqgsfieldexpressionwidget.cpp
+++ b/tests/src/gui/testqgsfieldexpressionwidget.cpp
@@ -265,7 +265,7 @@ void TestQgsFieldExpressionWidget::testFilters()
 
   widget->setFilters( QgsFieldProxyModel::Time );
   QCOMPARE( widget->mCombo->count(), 1 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "timefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 1 ), QString( "timefld" ) );
 
   QgsProject::instance()->removeMapLayer( layer );
 }
@@ -293,5 +293,3 @@ void TestQgsFieldExpressionWidget::setNull()
 
 QGSTEST_MAIN( TestQgsFieldExpressionWidget )
 #include "testqgsfieldexpressionwidget.moc"
-
-

--- a/tests/src/gui/testqgsfieldexpressionwidget.cpp
+++ b/tests/src/gui/testqgsfieldexpressionwidget.cpp
@@ -265,7 +265,7 @@ void TestQgsFieldExpressionWidget::testFilters()
 
   widget->setFilters( QgsFieldProxyModel::Time );
   QCOMPARE( widget->mCombo->count(), 1 );
-  QCOMPARE( widget->mCombo->itemText( 1 ), QString( "timefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "timefld" ) );
 
   QgsProject::instance()->removeMapLayer( layer );
 }


### PR DESCRIPTION
## Description

Fixes [#20516](https://issues.qgis.org/issues/20516)

Allow expression widget to be empty so expression could be removed (in attributes form, or in the different processing like order by expression)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
