### PR TITLE
Fix "Allow null" in range widget (fixes #20831)

### DIFF
--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -145,7 +145,12 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
     if ( allowNull )
     {
       int stepval = step.isValid() ? step.toInt() : 1;
-      minval -= stepval;
+      int newMinval = minval - stepval;
+      // make sure there is room for a new value (i.e. signed integer does not overflow)
+      if ( newMinval < minval )
+      {
+        minval = newMinval;
+      }
       mIntSpinBox->setValue( minval );
       QgsSpinBox *intSpinBox( qobject_cast<QgsSpinBox *>( mIntSpinBox ) );
       if ( intSpinBox )


### PR DESCRIPTION
By default a range widget is built with a minimum value set to the
minimal integer that is possible to represent. When "allow null" is
enabled, a new value (minvalue - 1) is inserted. With the default
value, we then had an integer overflow.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
