### PR TITLE
do not show geometryless layers in extent selector [processing] 

### DIFF
--- a/python/plugins/processing/gui/ExtentSelectionPanel.py
+++ b/python/plugins/processing/gui/ExtentSelectionPanel.py
@@ -35,13 +35,16 @@ from qgis.PyQt.QtCore import QCoreApplication, pyqtSignal
 
 from qgis.gui import QgsMessageBar
 from qgis.utils import iface
-from qgis.core import (QgsProcessingUtils,
+from qgis.core import (QgsProcessing,
+                       QgsProcessingUtils,
                        QgsProcessingParameterDefinition,
                        QgsProcessingParameters,
                        QgsProject,
                        QgsCoordinateReferenceSystem,
                        QgsRectangle,
-                       QgsReferencedRectangle)
+                       QgsReferencedRectangle,
+                       QgsWkbTypes,
+                       QgsVectorLayer)
 from processing.gui.RectangleMapTool import RectangleMapTool
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.tools.dataobjects import createContext
@@ -115,6 +118,11 @@ class ExtentSelectionPanel(BASE, WIDGET):
         popupmenu.addSeparator()
         popupmenu.addAction(useLayerExtentAction)
 
+        layers = QgsProcessingUtils.compatibleRasterLayers(QgsProject.instance())
+        layers.extend(QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [QgsProcessing.TypeVectorAnyGeometry]))
+        layers.extend(QgsProcessingUtils.compatibleMeshLayers(QgsProject.instance()))
+        useLayerExtentAction.setEnabled(bool(layers))
+
         selectOnCanvasAction.triggered.connect(self.selectOnCanvas)
         useLayerExtentAction.triggered.connect(self.useLayerExtent)
         useCanvasExtentAction.triggered.connect(self.useCanvasExtent)
@@ -135,7 +143,9 @@ class ExtentSelectionPanel(BASE, WIDGET):
     def useLayerExtent(self):
         extentsDict = {}
         extents = []
-        layers = QgsProcessingUtils.compatibleLayers(QgsProject.instance())
+        layers = QgsProcessingUtils.compatibleRasterLayers(QgsProject.instance())
+        layers.extend(QgsProcessingUtils.compatibleVectorLayers(QgsProject.instance(), [QgsProcessing.TypeVectorAnyGeometry]))
+        layers.extend(QgsProcessingUtils.compatibleMeshLayers(QgsProject.instance()))
         for layer in layers:
             authid = layer.crs().authid()
             if ProcessingConfig.getSetting(ProcessingConfig.SHOW_CRS_DEF) \


### PR DESCRIPTION

## Description

Only valid vector, raster and mesh layers are shon in the item selector

fixes #21129

I could not find a way of getting a list of all map layers that have a spatial component, other than combining raster, mesh and vector (only with geometry) ones. Maybe a method should be added to QgsProcessingUtils to do this easily, or maybe an option to get CompatibleLayers

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
