### PR TITLE
Add the possibility to return a shp if ogr is not compiled with gpkg

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -138,7 +138,13 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
         return QgsApplication.iconPath("/providerGrass.svg")
 
     def defaultVectorFileExtension(self, hasGeometry=True):
-        return 'gpkg'
+        # By default,'gpkg', but if OGR has not been compiled with sqlite3, then
+        # we take "SHP"
+        if 'GPKG' in [o.driverName for o in
+                      QgsVectorFileWriter.ogrDriverList()]:
+            return 'gpkg'
+        else:
+            return 'shp' if hasGeometry else 'dbf'
 
     def supportsNonFileBasedOutput(self):
         """


### PR DESCRIPTION
… compiled with gpkg

## Description
Geopackage is the default format in QGIS, however it is not compiled by default in OGR.

In minimalist installation configurations (mmm...) gpkg is not present.

This PR keeps the default gpkg format included by #8431, but if it is not present we go back to the old system with shp or dbf.

cc @neteler @rhurlin 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
