### PR TITLE
fix the GRASS v_net modules for QGIS 3_4

### DIFF
--- a/python/plugins/processing/algs/grass7/ext/v_net.py
+++ b/python/plugins/processing/algs/grass7/ext/v_net.py
@@ -58,7 +58,7 @@ def incorporatePoints(alg, parameters, context, feedback, pointLayerName='points
         threshold = alg.parameterAsDouble(parameters, 'threshold', context)
 
         # Create the v.net connect command for point layer integration
-        command = u"v.net input={} points={} output={} operation=connect threshold={}".format(
+        command = u"v.net -s input={} points={} output={} operation=connect threshold={}".format(
             lineLayer, pointLayer, intLayer, threshold)
         alg.commands.append(command)
 

--- a/python/plugins/processing/algs/grass7/ext/v_net_distance.py
+++ b/python/plugins/processing/algs/grass7/ext/v_net_distance.py
@@ -48,12 +48,12 @@ def processCommand(alg, parameters, context, feedback):
     threshold = alg.parameterAsDouble(parameters, 'threshold', context)
 
     # Create the v.net connect command for from_layer integration
-    command = u"v.net input={} points={} output={} operation=connect threshold={} arc_layer=1 node_layer=2".format(
+    command = u"v.net -s input={} points={} output={} operation=connect threshold={} arc_layer=1 node_layer=2".format(
         lineLayer, fromLayer, intLayer, threshold)
     alg.commands.append(command)
 
     # Do it again with to_layer
-    command = u"v.net input={} points={} output={} operation=connect threshold={} arc_layer=1 node_layer=3".format(
+    command = u"v.net -s input={} points={} output={} operation=connect threshold={} arc_layer=1 node_layer=3".format(
         intLayer, toLayer, netLayer, threshold)
     alg.commands.append(command)
 


### PR DESCRIPTION
## Description
For some reason in QGIS 3 a fundamental "-s" flag was not added in the v.net GRASS modules.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
