### PR TITLE
fix identify for mesh layers

### DIFF
--- a/python/gui/auto_generated/qgsmaptoolidentify.sip.in
+++ b/python/gui/auto_generated/qgsmaptoolidentify.sip.in
@@ -39,6 +39,7 @@ after selecting a point, performs the identification:
     {
       VectorLayer,
       RasterLayer,
+      MeshLayer,
       AllLayers
     };
     typedef QFlags<QgsMapToolIdentify::Type> LayerType;
@@ -103,9 +104,9 @@ this has been made private and two publics methods are offered
 :param x: x coordinates of mouseEvent
 :param y: y coordinates of mouseEvent
 :param mode: Identification mode. Can use Qgis default settings or a defined mode.
-:param layerType: Only performs identification in a certain type of layers (raster, vector). Default value is AllLayers.
+:param layerType: Only performs identification in a certain type of layers (raster, vector, mesh). Default value is AllLayers.
 
-:return: a list of IdentifyResult*
+:return: a list of IdentifyResult
 %End
 
     QList<QgsMapToolIdentify::IdentifyResult> identify( const QgsGeometry &geometry, IdentifyMode mode, LayerType layerType );
@@ -144,9 +145,9 @@ this has been made private and two publics methods are offered
 :param y: y coordinates of mouseEvent
 :param mode: Identification mode. Can use Qgis default settings or a defined mode.
 :param layerList: Performs the identification within the given list of layers.
-:param layerType: Only performs identification in a certain type of layers (raster, vector).
+:param layerType: Only performs identification in a certain type of layers (raster, vector, mesh).
 
-:return: a list of IdentifyResult*
+:return: a list of IdentifyResult
 %End
 
 
@@ -157,6 +158,15 @@ Call the right method depending on layer type
 
     bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, QgsPointXY point, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
     bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point );
+
+    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsPointXY &point );
+%Docstring
+Identifies data from active scalar and vector dataset from the mesh layer
+
+Works only if layer was already rendered (triangular mesh is created)
+
+.. versionadded:: 3.6
+%End
 
     QMap< QString, QString > derivedAttributesForPoint( const QgsPoint &point );
 %Docstring

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -45,6 +45,7 @@ class QgsVectorLayer;
 class QgsRasterLayer;
 class QgsHighlight;
 class QgsMapCanvas;
+class QgsMeshLayer;
 class QgsDockWidget;
 class QgsMapLayerAction;
 class QgsEditorWidgetSetup;
@@ -123,18 +124,21 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
   public:
 
-    //! Constructor - takes it own copy of the QgsAttributeAction so
-    // that it is independent of whoever created it.
+    /**
+     * Constructor -
+     * takes its own copy of the QgsAttributeAction so
+     * that it is independent of whoever created it.
+     */
     QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidget *parent = nullptr, Qt::WindowFlags f = nullptr );
 
     ~QgsIdentifyResultsDialog() override;
 
-    //! Add add feature from vector layer
+    //! Adds feature from vector layer
     void addFeature( QgsVectorLayer *layer,
                      const QgsFeature &f,
                      const QMap< QString, QString > &derivedAttributes );
 
-    //! Add add feature from other layer
+    //! Adds feature from raster layer
     void addFeature( QgsRasterLayer *layer,
                      const QString &label,
                      const QMap< QString, QString > &attributes,
@@ -143,7 +147,16 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
                      const QgsFeature &feature = QgsFeature(),
                      const QMap<QString, QVariant> &params = ( QMap<QString, QVariant>() ) );
 
-    //! Add feature from identify results
+    /**
+     * Adds results from mesh layer
+     * \since QGIS 3.6
+     */
+    void addFeature( QgsMeshLayer *layer,
+                     const QString &label,
+                     const QMap< QString, QString > &attributes,
+                     const QMap< QString, QString > &derivedAttributes );
+
+    //! Adds feature from identify results
     void addFeature( const QgsMapToolIdentify::IdentifyResult &result );
 
     //! Map tool was deactivated
@@ -261,6 +274,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     QgsMapLayer *layer( QTreeWidgetItem *item );
     QgsVectorLayer *vectorLayer( QTreeWidgetItem *item );
     QgsRasterLayer *rasterLayer( QTreeWidgetItem *item );
+    QgsMeshLayer *meshLayer( QTreeWidgetItem *item );
     QTreeWidgetItem *featureItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QTreeWidgetItem *item );
     QTreeWidgetItem *layerItem( QObject *layer );

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -30,6 +30,7 @@ class QgsRasterLayer;
 class QgsVectorLayer;
 class QgsMapLayer;
 class QgsMapCanvas;
+class QgsMeshLayer;
 class QgsHighlight;
 class QgsIdentifyMenu;
 class QgsDistanceArea;
@@ -63,7 +64,8 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     {
       VectorLayer = 1,
       RasterLayer = 2,
-      AllLayers = VectorLayer | RasterLayer
+      MeshLayer = 4, //!< \since QGIS 3.6
+      AllLayers = VectorLayer | RasterLayer | MeshLayer
     };
     Q_DECLARE_FLAGS( LayerType, Type )
     Q_FLAG( LayerType )
@@ -114,13 +116,14 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
 
     /**
      * Performs the identification.
-    To avoid being forced to specify IdentifyMode with a list of layers
-    this has been made private and two publics methods are offered
-    \param x x coordinates of mouseEvent
-    \param y y coordinates of mouseEvent
-    \param mode Identification mode. Can use Qgis default settings or a defined mode.
-    \param layerType Only performs identification in a certain type of layers (raster, vector). Default value is AllLayers.
-    \returns a list of IdentifyResult*/
+     * To avoid being forced to specify IdentifyMode with a list of layers
+     * this has been made private and two publics methods are offered
+     * \param x x coordinates of mouseEvent
+     * \param y y coordinates of mouseEvent
+     * \param mode Identification mode. Can use Qgis default settings or a defined mode.
+     * \param layerType Only performs identification in a certain type of layers (raster, vector, mesh). Default value is AllLayers.
+     * \returns a list of IdentifyResult
+     */
     QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers );
 
     //! Performs identification based on a geometry (in map coordinates)
@@ -147,14 +150,15 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
 
     /**
      * Performs the identification.
-    To avoid being forced to specify IdentifyMode with a list of layers
-    this has been made private and two publics methods are offered
-    \param x x coordinates of mouseEvent
-    \param y y coordinates of mouseEvent
-    \param mode Identification mode. Can use Qgis default settings or a defined mode.
-    \param layerList Performs the identification within the given list of layers.
-    \param layerType Only performs identification in a certain type of layers (raster, vector).
-    \returns a list of IdentifyResult*/
+     * To avoid being forced to specify IdentifyMode with a list of layers
+     * this has been made private and two publics methods are offered
+     * \param x x coordinates of mouseEvent
+     * \param y y coordinates of mouseEvent
+     * \param mode Identification mode. Can use Qgis default settings or a defined mode.
+     * \param layerList Performs the identification within the given list of layers.
+     * \param layerType Only performs identification in a certain type of layers (raster, vector, mesh).
+     * \returns a list of IdentifyResult
+     */
     QList<QgsMapToolIdentify::IdentifyResult> identify( int x, int y, IdentifyMode mode,  const QList<QgsMapLayer *> &layerList, LayerType layerType = AllLayers );
 
     QgsIdentifyMenu *mIdentifyMenu = nullptr;
@@ -164,6 +168,14 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
 
     bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, QgsPointXY point, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
     bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsPointXY &point );
+
+    /**
+     * Identifies data from active scalar and vector dataset from the mesh layer
+     *
+     * Works only if layer was already rendered (triangular mesh is created)
+     * \since QGIS 3.6
+     */
+    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsPointXY &point );
 
     //! Returns derived attributes map for a clicked point in map coordinates. May be 2D or 3D point.
     QMap< QString, QString > derivedAttributesForPoint( const QgsPoint &point );
@@ -194,6 +206,7 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     bool identifyLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMapLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel, QgsMapToolIdentify::LayerType layerType = AllLayers );
     bool identifyRasterLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsRasterLayer *layer, const QgsGeometry &geometry, const QgsRectangle &viewExtent, double mapUnitsPerPixel );
     bool identifyVectorLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsVectorLayer *layer, const QgsGeometry &geometry );
+    bool identifyMeshLayer( QList<QgsMapToolIdentify::IdentifyResult> *results, QgsMeshLayer *layer, const QgsGeometry &geometry );
 
     /**
      * Desired units for distance display.


### PR DESCRIPTION
Adds identify results from mesh layer to the identify dialog. For active scalar and vector dataset, the values for current time are shown

<img width="564" alt="screenshot 2019-01-31 at 15 10 57" src="https://user-images.githubusercontent.com/804608/52060151-ea0d9d80-256b-11e9-9a87-aaf9e355f650.png">
