### PR TITLE
Add actionVertexToolActiveLayer to Qgis APi

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -452,6 +452,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *actionDeleteRing() { return mActionDeleteRing; }
     QAction *actionDeletePart() { return mActionDeletePart; }
     QAction *actionVertexTool() { return mActionVertexTool; }
+    QAction *actionVertexToolActiveLayer() { return mActionVertexToolActiveLayer; }
     QAction *actionSnappingOptions() { return mActionSnappingOptions; }
     QAction *actionOffsetCurve() { return mActionOffsetCurve; }
     QAction *actionPan() { return mActionPan; }

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -611,6 +611,7 @@ QAction *QgisAppInterface::actionSimplifyFeature() { return qgis->actionSimplify
 QAction *QgisAppInterface::actionDeleteRing() { return qgis->actionDeleteRing(); }
 QAction *QgisAppInterface::actionDeletePart() { return qgis->actionDeletePart(); }
 QAction *QgisAppInterface::actionVertexTool() { return qgis->actionVertexTool(); }
+QAction *QgisAppInterface::actionVertexToolActiveLayer() { return qgis->actionVertexToolActiveLayer(); }
 
 QAction *QgisAppInterface::actionPan() { return qgis->actionPan(); }
 QAction *QgisAppInterface::actionPanToSelected() { return qgis->actionPanToSelected(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -197,6 +197,7 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     QAction *actionDeleteRing() override;
     QAction *actionDeletePart() override;
     QAction *actionVertexTool() override;
+    QAction *actionVertexToolActiveLayer() override;
     QAction *actionPan() override;
     QAction *actionPanToSelected() override;
     QAction *actionZoomIn() override;

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -397,6 +397,8 @@ class GUI_EXPORT QgisInterface : public QObject
     virtual QAction *actionDeletePart() = 0;
     //! Returns the native Vertex Tool action.
     virtual QAction *actionVertexTool() = 0;
+    //! Returns the native Vertex Tool for Active Layer action.
+    virtual QAction *actionVertexToolActiveLayer() = 0;
 
     // View menu actions
     //! Returns the native pan action. Call trigger() on it to set the default pan map tool.

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -363,6 +363,7 @@
     <addaction name="mActionMergeFeatures"/>
     <addaction name="mActionMergeFeatureAttributes"/>
     <addaction name="mActionVertexTool"/>
+    <addaction name="mActionVertexToolActiveLayer"/>
     <addaction name="mActionRotatePointSymbols"/>
     <addaction name="mActionOffsetPointSymbol"/>
     <addaction name="mActionReverseLine"/>
@@ -450,6 +451,7 @@
    <addaction name="mActionSaveLayerEdits"/>
    <addaction name="mActionAddFeature"/>
    <addaction name="mActionVertexTool"/>
+   <addaction name="mActionVertexToolActiveLayer"/>
    <addaction name="mActionMultiEditAttributes"/>
    <addaction name="mActionDeleteSelected"/>
    <addaction name="mActionCutFeatures"/>


### PR DESCRIPTION
## Description
Hi, this is my first pull request, I tried to figure out how to add the actionVertexToolActiveLayer  in the api.  I need this feature and it's already implemented in QGIS... but missing in the interface ...  Maybe you can review it for me.  Thanks a lot.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
