### PR TITLE
Improvements to the right-click behavior to pick locked feature [vertex tool]

### DIFF
--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -294,10 +294,7 @@ bool QgsVertexEditorModel::calcR( int row, double &r, double &minRadius ) const
 }
 
 
-QgsVertexEditor::QgsVertexEditor(
-  QgsVectorLayer *layer,
-  QgsSelectedFeature *selectedFeature,
-  QgsMapCanvas *canvas )
+QgsVertexEditor::QgsVertexEditor( QgsMapCanvas *canvas )
   : mCanvas( canvas )
 {
   setWindowTitle( tr( "Vertex Editor" ) );
@@ -328,11 +325,9 @@ QgsVertexEditor::QgsVertexEditor(
   layout->addWidget( mHintLabel );
 
   setWidget( content );
-
-  updateEditor( layer, selectedFeature );
 }
 
-void QgsVertexEditor::updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *selectedFeature )
+void QgsVertexEditor::updateEditor( QgsSelectedFeature *selectedFeature )
 {
   if ( mSelectedFeature )
   {
@@ -340,13 +335,12 @@ void QgsVertexEditor::updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *s
     mVertexModel = nullptr;
   }
 
-  mLayer = layer;
   mSelectedFeature = selectedFeature;
 
-  if ( mLayer && mSelectedFeature )
+  if ( mSelectedFeature )
   {
     // TODO We really should just update the model itself.
-    mVertexModel = new QgsVertexEditorModel( mLayer, mSelectedFeature, mCanvas, this );
+    mVertexModel = new QgsVertexEditorModel( mSelectedFeature->layer(), mSelectedFeature, mCanvas, this );
     mTableView->setModel( mVertexModel );
 
     mHintLabel->setVisible( false );
@@ -398,7 +392,7 @@ void QgsVertexEditor::updateVertexSelection( const QItemSelection &selected, con
 
   mSelectedFeature->deselectAllVertices();
 
-  QgsCoordinateTransform t( mLayer->crs(), mCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
+  QgsCoordinateTransform t( mSelectedFeature->layer()->crs(), mCanvas->mapSettings().destinationCrs(), QgsProject::instance() );
   std::unique_ptr<QgsRectangle> bbox;
   QModelIndexList indexList = selected.indexes();
   for ( int i = 0; i < indexList.length(); ++i )

--- a/src/app/vertextool/qgsvertexeditor.h
+++ b/src/app/vertextool/qgsvertexeditor.h
@@ -72,13 +72,10 @@ class QgsVertexEditor : public QgsDockWidget
 {
     Q_OBJECT
   public:
-    QgsVertexEditor( QgsVectorLayer *layer,
-                     QgsSelectedFeature *selectedFeature,
-                     QgsMapCanvas *canvas );
+    QgsVertexEditor( QgsMapCanvas *canvas );
 
   public:
-    void updateEditor( QgsVectorLayer *layer, QgsSelectedFeature *selectedFeature );
-    QgsVectorLayer *mLayer = nullptr;
+    void updateEditor( QgsSelectedFeature *selectedFeature );
     QgsSelectedFeature *mSelectedFeature = nullptr;
     QgsMapCanvas *mCanvas = nullptr;
     QTableView *mTableView = nullptr;

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -1188,7 +1188,7 @@ void QgsVertexTool::updateVertexEditor( QgsVectorLayer *layer, QgsFeatureId fid 
   }
 
   // make sure the vertex editor is alive and visible
-  showVertexEditor();
+  showVertexEditor();  //#spellok
 
   mVertexEditor->updateEditor( mSelectedFeature.get() );
 }

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -96,6 +96,9 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     //! Toggle the vertex editor
     void showVertexEditor();  //#spellok
 
+    //! Update vertex editor to show feature from the given match
+    void updateVertexEditor( QgsVectorLayer *layer, QgsFeatureId fid );
+
   private slots:
     //! update geometry of our feature
     void onCachedGeometryChanged( QgsFeatureId fid, const QgsGeometry &geom );
@@ -406,8 +409,6 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
 
     // support for vertex editor
 
-    //! most recent match when moving mouse
-    QgsPointLocator::Match mLastMouseMoveMatch;
     //! Selected feature for the vertex editor
     std::unique_ptr<QgsSelectedFeature> mSelectedFeature;
     //! Dock widget which allows editing vertices

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -146,6 +146,8 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     */
     QgsPointLocator::Match snapToEditableLayer( QgsMapMouseEvent *e );
 
+    QgsPointLocator::Match snapToPolygonInterior( QgsMapMouseEvent *e );
+
     //! check whether we are still close to the mEndpointMarker
     bool isNearEndpointMarker( const QgsPointXY &mapPoint );
 


### PR DESCRIPTION
Vertex tool usability fixes:
 - unlock feature on right-click in an empty area
 - allow selection of locked feature by right-click on polygon interior (in addition to polygon rings)
 - highlight polygons when mouse moves in their interior - this should also decrease the blinking effect as the highlight is more consistent

Next: cycling of "locked" feature selection when repeatedly pressing right mouse button in one location.

@nirvn @bstroebl Keen to hear your feedback!