### PR TITLE
[processing] Resurrect ability to convert models to scripts 

### DIFF
--- a/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelalgorithm.sip.in
@@ -346,9 +346,13 @@ Sets the source file ``path`` for the model, if available.
 .. seealso:: :py:func:`sourceFilePath`
 %End
 
-    QString asPythonCode() const;
+    QStringList asPythonCode( QgsProcessing::PythonOutputType outputType, int indentSize ) const;
 %Docstring
-Attempts to convert the model to executable Python code.
+Attempts to convert the model to executable Python code, and returns the generated lines of code.
+
+The ``outputType`` argument dictates the desired script type.
+
+The ``indentSize`` arguments specifies the size of indented lines.
 %End
 
     QList< QgsProcessingModelChildParameterSource > availableSourcesForChild( const QString &childId, const QStringList &parameterTypes = QStringList(),

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelchildalgorithm.sip.in
@@ -298,9 +298,15 @@ Loads this child from a QVariant.
 .. seealso:: :py:func:`toVariant`
 %End
 
-    QString asPythonCode() const;
+    QStringList asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsStringMap &extraParameters, int currentIndent, int indentSize ) const;
 %Docstring
-Attempts to convert the child to executable Python code.
+Attempts to convert the child to executable Python code, and returns a list of the generated lines of code.
+
+The ``outputType`` argument specifies the type of script to generate.
+
+Additional parameters to be passed to the child algorithm are specified in the ``extraParameters`` argument.
+
+The ``currentIndent`` and ``indentSize`` are used to set the base line indent and size of further indented lines respectively.
 %End
 
 };

--- a/python/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
+++ b/python/core/auto_generated/processing/models/qgsprocessingmodelchildparametersource.sip.in
@@ -240,7 +240,7 @@ Loads this source from a QVariantMap.
 .. seealso:: :py:func:`toVariant`
 %End
 
-    QString asPythonCode() const;
+    QString asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsProcessingParameterDefinition *definition ) const;
 %Docstring
 Attempts to convert the source to executable Python code.
 %End

--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -297,7 +297,6 @@ layers and other factors within the context.
 %Docstring
 Returns a string version of the parameter input ``value``, which is suitable for use as an input
 parameter value when running an algorithm directly from a Python command.
-The returned value must be correctly escaped - e.g. string values must be wrapped in ' 's.
 %End
 
     virtual QString asScriptCode() const;

--- a/python/core/auto_generated/processing/qgsprocessingutils.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingutils.sip.in
@@ -133,9 +133,20 @@ Normalizes a layer ``source`` string for safe comparison across different
 operating system environments.
 %End
 
+    static QString variantToPythonLiteral( const QVariant &value );
+%Docstring
+Converts a variant to a Python literal.
+
+.. seealso:: :py:func:`stringToPythonLiteral`
+
+.. versionadded:: 3.6
+%End
+
     static QString stringToPythonLiteral( const QString &string );
 %Docstring
 Converts a string to a Python string literal. E.g. by replacing ' with \'.
+
+.. seealso:: :py:func:`variantToPythonLiteral`
 %End
 
 

--- a/python/plugins/processing/gui/ContextAction.py
+++ b/python/plugins/processing/gui/ContextAction.py
@@ -27,9 +27,14 @@ __revision__ = '$Format:%H$'
 
 
 from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtGui import QIcon
 
 
 class ContextAction:
+
+    def __init__(self):
+        self.name = None
+        self.is_separator = False
 
     def setData(self, itemData, toolbox):
         self.itemData = itemData
@@ -39,3 +44,12 @@ class ContextAction:
         if context == '':
             context = self.__class__.__name__
         return QCoreApplication.translate(context, string)
+
+    def icon(self):
+        return QIcon()
+
+    def isEnabled(self):
+        return True
+
+    def execute(self):
+        pass

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -192,9 +192,12 @@ class ProcessingToolbox(QgsDockWidget, WIDGET):
                 popupmenu.addSeparator()
             for action in actions:
                 action.setData(alg, self)
-                if action.isEnabled():
+                if action.is_separator:
+                    popupmenu.addSeparator()
+                elif action.isEnabled():
                     contextMenuAction = QAction(action.name,
                                                 popupmenu)
+                    contextMenuAction.setIcon(action.icon())
                     contextMenuAction.triggered.connect(action.execute)
                     popupmenu.addAction(contextMenuAction)
 

--- a/python/plugins/processing/modeler/DeleteModelAction.py
+++ b/python/plugins/processing/modeler/DeleteModelAction.py
@@ -38,6 +38,7 @@ from processing.modeler.ProjectProvider import PROJECT_PROVIDER_ID
 class DeleteModelAction(ContextAction):
 
     def __init__(self):
+        super().__init__()
         self.name = QCoreApplication.translate('DeleteModelAction', 'Delete Model…')
 
     def isEnabled(self):

--- a/python/plugins/processing/modeler/EditModelAction.py
+++ b/python/plugins/processing/modeler/EditModelAction.py
@@ -36,6 +36,7 @@ from qgis.utils import iface
 class EditModelAction(ContextAction):
 
     def __init__(self):
+        super().__init__()
         self.name = QCoreApplication.translate('EditModelAction', 'Edit Model…')
 
     def isEnabled(self):

--- a/python/plugins/processing/modeler/ExportModelAsPythonScriptAction.py
+++ b/python/plugins/processing/modeler/ExportModelAsPythonScriptAction.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    EditModelAction.py
+    ---------------------
+    Date                 : February 2019
+    Copyright            : (C) 2019 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Nyall Dawson'
+__date__ = 'February 2019'
+__copyright__ = '(C) 2019, Nyall Dawson'
+
+# This will get replaced with a git SHA1 when you do a git archive
+
+__revision__ = '$Format:%H$'
+
+from qgis.PyQt.QtCore import QCoreApplication
+from qgis.core import QgsProcessingModelAlgorithm, QgsProcessing, QgsApplication
+from processing.gui.ContextAction import ContextAction
+from processing.script.ScriptEditorDialog import ScriptEditorDialog
+
+
+class ExportModelAsPythonScriptAction(ContextAction):
+
+    def __init__(self):
+        super().__init__()
+        self.name = QCoreApplication.translate('ExportModelAsPythonScriptAction', 'Export Model as Python Algorithm…')
+
+    def isEnabled(self):
+        return isinstance(self.itemData, QgsProcessingModelAlgorithm)
+
+    def icon(self):
+        return QgsApplication.getThemeIcon('/mActionSaveAsPython.svg')
+
+    def execute(self):
+        alg = self.itemData
+        dlg = ScriptEditorDialog(None)
+
+        dlg.editor.setText('\n'.join(alg.asPythonCode(QgsProcessing.PythonQgsProcessingAlgorithmSubclass, 4)))
+        dlg.show()

--- a/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
@@ -39,6 +39,7 @@ from qgis.core import (Qgis,
 
 from processing.core.ProcessingConfig import ProcessingConfig, Setting
 
+from processing.gui.ContextAction import ContextAction
 from processing.gui.ProviderActions import (ProviderActions,
                                             ProviderContextMenuActions)
 

--- a/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithmProvider.py
@@ -47,6 +47,7 @@ from processing.modeler.AddModelFromFileAction import AddModelFromFileAction
 from processing.modeler.CreateNewModelAction import CreateNewModelAction
 from processing.modeler.DeleteModelAction import DeleteModelAction
 from processing.modeler.EditModelAction import EditModelAction
+from processing.modeler.ExportModelAsPythonScriptAction import ExportModelAsPythonScriptAction
 from processing.modeler.OpenModelFromFileAction import OpenModelFromFileAction
 from processing.modeler.exceptions import WrongModelException
 from processing.modeler.ModelerUtils import ModelerUtils
@@ -59,7 +60,9 @@ class ModelerAlgorithmProvider(QgsProcessingProvider):
     def __init__(self):
         super().__init__()
         self.actions = [CreateNewModelAction(), OpenModelFromFileAction(), AddModelFromFileAction()]
-        self.contextMenuActions = [EditModelAction(), DeleteModelAction()]
+        sep_action = ContextAction()
+        sep_action.is_separator = True
+        self.contextMenuActions = [EditModelAction(), DeleteModelAction(), sep_action, ExportModelAsPythonScriptAction()]
         self.algs = []
         self.isLoading = False
 

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -61,7 +61,9 @@ from qgis.PyQt.QtWidgets import (QGraphicsView,
                                  QVBoxLayout,
                                  QGridLayout,
                                  QFrame,
-                                 QLineEdit)
+                                 QLineEdit,
+                                 QToolButton,
+                                 QAction)
 from qgis.PyQt.QtGui import (QIcon,
                              QImage,
                              QPainter,
@@ -70,7 +72,7 @@ from qgis.PyQt.QtSvg import QSvgGenerator
 from qgis.PyQt.QtPrintSupport import QPrinter
 from qgis.core import (Qgis,
                        QgsApplication,
-                       QgsProcessingAlgorithm,
+                       QgsProcessing,
                        QgsProject,
                        QgsSettings,
                        QgsMessageLog,
@@ -92,6 +94,7 @@ from processing.modeler.ModelerParametersDialog import ModelerParametersDialog
 from processing.modeler.ModelerUtils import ModelerUtils
 from processing.modeler.ModelerScene import ModelerScene
 from processing.modeler.ProjectProvider import PROJECT_PROVIDER_ID
+from processing.script.ScriptEditorDialog import ScriptEditorDialog
 from qgis.utils import iface
 
 
@@ -253,6 +256,13 @@ class ModelerDialog(BASE, WIDGET):
             self.mToolbar.setIconSize(iface.iconSize())
             self.setStyleSheet(iface.mainWindow().styleSheet())
 
+        self.toolbutton_export_to_script = QToolButton()
+        self.toolbutton_export_to_script.setPopupMode(QToolButton.InstantPopup)
+        self.export_to_script_algorithm_action = QAction(self.tr('Export as Script Algorithm…'))
+        self.toolbutton_export_to_script.addActions([self.export_to_script_algorithm_action])
+        self.mToolbar.insertWidget(self.mActionExportImage, self.toolbutton_export_to_script)
+        self.export_to_script_algorithm_action.triggered.connect(self.export_as_script_algorithm)
+
         self.mActionOpen.setIcon(
             QgsApplication.getThemeIcon('/mActionFileOpen.svg'))
         self.mActionSave.setIcon(
@@ -275,8 +285,8 @@ class ModelerDialog(BASE, WIDGET):
             QgsApplication.getThemeIcon('/mActionSaveAsPDF.svg'))
         self.mActionExportSvg.setIcon(
             QgsApplication.getThemeIcon('/mActionSaveAsSVG.svg'))
-        #self.mActionExportPython.setIcon(
-        #    QgsApplication.getThemeIcon('/mActionSaveAsPython.svg'))
+        self.toolbutton_export_to_script.setIcon(
+            QgsApplication.getThemeIcon('/mActionSaveAsPython.svg'))
         self.mActionEditHelp.setIcon(
             QgsApplication.getThemeIcon('/mActionEditHelpContent.svg'))
         self.mActionRun.setIcon(
@@ -814,3 +824,9 @@ class ModelerDialog(BASE, WIDGET):
             newX = MARGIN + BOX_WIDTH / 2
             newY = MARGIN * 2 + BOX_HEIGHT + BOX_HEIGHT / 2
         return QPointF(newX, newY)
+
+    def export_as_script_algorithm(self):
+        dlg = ScriptEditorDialog(None)
+
+        dlg.editor.setText('\n'.join(self.model.asPythonCode(QgsProcessing.PythonQgsProcessingAlgorithmSubclass, 4)))
+        dlg.show()

--- a/python/plugins/processing/preconfigured/DeletePreconfiguredAlgorithmAction.py
+++ b/python/plugins/processing/preconfigured/DeletePreconfiguredAlgorithmAction.py
@@ -36,6 +36,7 @@ from processing.preconfigured.PreconfiguredAlgorithm import PreconfiguredAlgorit
 class DeletePreconfiguredAlgorithmAction(ContextAction):
 
     def __init__(self):
+        super().__init__()
         self.name = QCoreApplication.translate('DeletePreconfiguredAlgorithmAction', 'Delete Preconfigured Algorithm…')
 
     def isEnabled(self):

--- a/python/plugins/processing/preconfigured/NewPreconfiguredAlgorithmAction.py
+++ b/python/plugins/processing/preconfigured/NewPreconfiguredAlgorithmAction.py
@@ -36,6 +36,7 @@ from processing.preconfigured.PreconfiguredAlgorithm import PreconfiguredAlgorit
 class NewPreconfiguredAlgorithmAction(ContextAction):
 
     def __init__(self):
+        super().__init__()
         self.name = QCoreApplication.translate('NewPreconfiguredAlgorithmAction', 'Create Preconfigured Algorithm…')
 
     def isEnabled(self):

--- a/python/plugins/processing/script/DeleteScriptAction.py
+++ b/python/plugins/processing/script/DeleteScriptAction.py
@@ -40,6 +40,7 @@ from processing.script import ScriptUtils
 class DeleteScriptAction(ContextAction):
 
     def __init__(self):
+        super().__init__()
         self.name = QCoreApplication.translate("DeleteScriptAction", "Delete Script…")
 
     def isEnabled(self):

--- a/python/plugins/processing/script/EditScriptAction.py
+++ b/python/plugins/processing/script/EditScriptAction.py
@@ -41,6 +41,7 @@ from processing.script import ScriptUtils
 class EditScriptAction(ContextAction):
 
     def __init__(self):
+        super().__init__()
         self.name = QCoreApplication.translate("EditScriptAction", "Edit Script…")
 
     def isEnabled(self):

--- a/python/plugins/processing/ui/DlgModeler.ui
+++ b/python/plugins/processing/ui/DlgModeler.ui
@@ -166,10 +166,10 @@
   </action>
   <action name="mActionExportPython">
    <property name="text">
-    <string>Export as Python script…</string>
+    <string>Export as Python Script…</string>
    </property>
    <property name="toolTip">
-    <string>Export as Python script</string>
+    <string>Export as Python Script</string>
    </property>
   </action>
   <action name="mActionEditHelp">

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.cpp
@@ -413,7 +413,7 @@ QStringList QgsProcessingModelAlgorithm::asPythonCode( const QgsProcessing::Pyth
       if ( !shortHelpString().isEmpty() )
       {
         lines << indent + QStringLiteral( "def shortHelpString(self):" );
-        lines << indent + indent + QStringLiteral( "return '%1'" ).arg( shortHelpString() );
+        lines << indent + indent + QStringLiteral( "return \"\"\"%1\"\"\"" ).arg( shortHelpString() );
         lines << QString();
       }
       if ( !helpUrl().isEmpty() )

--- a/src/core/processing/models/qgsprocessingmodelalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelalgorithm.h
@@ -304,9 +304,13 @@ class CORE_EXPORT QgsProcessingModelAlgorithm : public QgsProcessingAlgorithm
     void setSourceFilePath( const QString &path );
 
     /**
-     * Attempts to convert the model to executable Python code.
+     * Attempts to convert the model to executable Python code, and returns the generated lines of code.
+     *
+     * The \a outputType argument dictates the desired script type.
+     *
+     * The \a indentSize arguments specifies the size of indented lines.
      */
-    QString asPythonCode() const;
+    QStringList asPythonCode( QgsProcessing::PythonOutputType outputType, int indentSize ) const;
 
     /**
      * Returns a list of possible sources which can be used for the parameters for a child

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.cpp
@@ -162,39 +162,53 @@ bool QgsProcessingModelChildAlgorithm::loadVariant( const QVariant &child )
   return true;
 }
 
-QString QgsProcessingModelChildAlgorithm::asPythonCode() const
+QStringList QgsProcessingModelChildAlgorithm::asPythonCode( const QgsProcessing::PythonOutputType outputType, const QgsStringMap &extraParameters, int currentIndent, int indentSize ) const
 {
   QStringList lines;
+  const QString baseIndent = QString( ' ' ).repeated( currentIndent );
+  const QString lineIndent = QString( ' ' ).repeated( indentSize );
 
   if ( !algorithm() )
-    return QString();
+    return QStringList();
 
   QStringList paramParts;
-  QMap< QString, QgsProcessingModelChildParameterSources >::const_iterator paramIt = mParams.constBegin();
-  for ( ; paramIt != mParams.constEnd(); ++paramIt )
+  for ( auto paramIt = mParams.constBegin(); paramIt != mParams.constEnd(); ++paramIt )
   {
     QStringList sourceParts;
-    Q_FOREACH ( const QgsProcessingModelChildParameterSource &source, paramIt.value() )
+    const QgsProcessingParameterDefinition *def = algorithm() ? algorithm()->parameterDefinition( paramIt.key() ) : nullptr;
+    const auto parts = paramIt.value();
+    for ( const QgsProcessingModelChildParameterSource &source : parts )
     {
-      QString part = source.asPythonCode();
+      QString part = source.asPythonCode( outputType, def );
       if ( !part.isEmpty() )
-        sourceParts << QStringLiteral( "'%1':%2" ).arg( paramIt.key(), part );
+        sourceParts << part;
     }
     if ( sourceParts.count() == 1 )
-      paramParts << sourceParts.at( 0 );
+      paramParts << QStringLiteral( "'%1':%2" ).arg( paramIt.key(), sourceParts.at( 0 ) );
     else
-      paramParts << QStringLiteral( "[%1]" ).arg( paramParts.join( ',' ) );
+      paramParts << QStringLiteral( "'%1':[%2]" ).arg( paramIt.key(), sourceParts.join( ',' ) );
   }
 
-  lines << QStringLiteral( "outputs['%1']=processing.run('%2', {%3}, context=context, feedback=feedback)" ).arg( mId, mAlgorithmId, paramParts.join( ',' ) );
-
-  QMap< QString, QgsProcessingModelOutput >::const_iterator outputIt = mModelOutputs.constBegin();
-  for ( ; outputIt != mModelOutputs.constEnd(); ++outputIt )
+  lines << baseIndent + QStringLiteral( "alg_params = {" );
+  lines.reserve( lines.size() + paramParts.size() );
+  for ( const QString &p : qgis::as_const( paramParts ) )
   {
-    lines << QStringLiteral( "results['%1']=outputs['%2']['%3']" ).arg( outputIt.key(), mId, outputIt.value().childOutputName() );
+    lines << baseIndent + lineIndent + p + ',';
+  }
+  for ( auto it = extraParameters.constBegin(); it != extraParameters.constEnd(); ++it )
+  {
+    lines << baseIndent + lineIndent + QgsProcessingUtils::stringToPythonLiteral( it.key() ) + ':' + it.value() + ',';
+  }
+  lines << baseIndent + QStringLiteral( "}" );
+
+  lines << baseIndent + QStringLiteral( "outputs['%1']=processing.run('%2', alg_params, context=context, feedback=feedback, is_child_algorithm=True)" ).arg( mId, mAlgorithmId );
+
+  for ( auto outputIt = mModelOutputs.constBegin(); outputIt != mModelOutputs.constEnd(); ++outputIt )
+  {
+    lines << baseIndent + QStringLiteral( "results['%1:%2']=outputs['%1']['%3']" ).arg( mId, outputIt.key(), outputIt.value().childOutputName() );
   }
 
-  return lines.join( '\n' );
+  return lines;
 }
 
 QVariantMap QgsProcessingModelChildAlgorithm::configuration() const

--- a/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
+++ b/src/core/processing/models/qgsprocessingmodelchildalgorithm.h
@@ -278,9 +278,15 @@ class CORE_EXPORT QgsProcessingModelChildAlgorithm : public QgsProcessingModelCo
     bool loadVariant( const QVariant &child );
 
     /**
-     * Attempts to convert the child to executable Python code.
+     * Attempts to convert the child to executable Python code, and returns a list of the generated lines of code.
+     *
+     * The \a outputType argument specifies the type of script to generate.
+     *
+     * Additional parameters to be passed to the child algorithm are specified in the \a extraParameters argument.
+     *
+     * The \a currentIndent and \a indentSize are used to set the base line indent and size of further indented lines respectively.
      */
-    QString asPythonCode() const;
+    QStringList asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsStringMap &extraParameters, int currentIndent, int indentSize ) const;
 
   private:
 

--- a/src/core/processing/models/qgsprocessingmodelchildparametersource.cpp
+++ b/src/core/processing/models/qgsprocessingmodelchildparametersource.cpp
@@ -16,6 +16,8 @@
  ***************************************************************************/
 
 #include "qgsprocessingmodelchildparametersource.h"
+#include "qgsprocessingparameters.h"
+#include "qgsprocessingcontext.h"
 
 ///@cond NOT_STABLE
 
@@ -145,7 +147,7 @@ bool QgsProcessingModelChildParameterSource::loadVariant( const QVariantMap &map
   return true;
 }
 
-QString QgsProcessingModelChildParameterSource::asPythonCode() const
+QString QgsProcessingModelChildParameterSource::asPythonCode( const QgsProcessing::PythonOutputType, const QgsProcessingParameterDefinition *definition ) const
 {
   switch ( mSource )
   {
@@ -156,7 +158,15 @@ QString QgsProcessingModelChildParameterSource::asPythonCode() const
       return QStringLiteral( "outputs['%1']['%2']" ).arg( mChildId, mOutputName );
 
     case StaticValue:
-      return mStaticValue.toString();
+      if ( definition )
+      {
+        QgsProcessingContext c;
+        return definition->valueAsPythonString( mStaticValue, c );
+      }
+      else
+      {
+        return QgsProcessingUtils::variantToPythonLiteral( mStaticValue );
+      }
 
     case Expression:
       return QStringLiteral( "QgsExpression('%1').evaluate()" ).arg( mExpression );

--- a/src/core/processing/models/qgsprocessingmodelchildparametersource.h
+++ b/src/core/processing/models/qgsprocessingmodelchildparametersource.h
@@ -20,6 +20,8 @@
 
 #include "qgis_core.h"
 #include "qgis.h"
+#include "qgsprocessing.h"
+class QgsProcessingParameterDefinition;
 
 ///@cond NOT_STABLE
 
@@ -214,7 +216,7 @@ class CORE_EXPORT QgsProcessingModelChildParameterSource
     /**
      * Attempts to convert the source to executable Python code.
      */
-    QString asPythonCode() const;
+    QString asPythonCode( QgsProcessing::PythonOutputType outputType, const QgsProcessingParameterDefinition *definition ) const;
 
   private:
 

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -364,7 +364,6 @@ class CORE_EXPORT QgsProcessingParameterDefinition
     /**
      * Returns a string version of the parameter input \a value, which is suitable for use as an input
      * parameter value when running an algorithm directly from a Python command.
-     * The returned value must be correctly escaped - e.g. string values must be wrapped in ' 's.
      */
     virtual QString valueAsPythonString( const QVariant &value, QgsProcessingContext &context ) const;
 

--- a/src/core/processing/qgsprocessingutils.h
+++ b/src/core/processing/qgsprocessingutils.h
@@ -150,7 +150,17 @@ class CORE_EXPORT QgsProcessingUtils
     static QString normalizeLayerSource( const QString &source );
 
     /**
+     * Converts a variant to a Python literal.
+     *
+     * \see stringToPythonLiteral()
+     * \since QGSIS 3.6
+     */
+    static QString variantToPythonLiteral( const QVariant &value );
+
+    /**
      * Converts a string to a Python string literal. E.g. by replacing ' with \'.
+     *
+     * \see variantToPythonLiteral()
      */
     static QString stringToPythonLiteral( const QString &string );
 

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -6152,6 +6152,11 @@ void TestQgsProcessing::modelerAlgorithm()
   QVERIFY( child.setAlgorithmId( QStringLiteral( "native:centroids" ) ) );
   QVERIFY( child.algorithm() );
   QCOMPARE( child.algorithm()->id(), QStringLiteral( "native:centroids" ) );
+  QCOMPARE( child.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, QgsStringMap(), 4, 2 ).join( '\n' ), QStringLiteral( "    alg_params = {\n    }\n    outputs['']=processing.run('native:centroids', alg_params, context=context, feedback=feedback, is_child_algorithm=True)" ) );
+  QgsStringMap extraParams;
+  extraParams[QStringLiteral( "SOMETHING" )] = QStringLiteral( "SOMETHING_ELSE" );
+  extraParams[QStringLiteral( "SOMETHING2" )] = QStringLiteral( "SOMETHING_ELSE2" );
+  QCOMPARE( child.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, extraParams, 4, 2 ).join( '\n' ), QStringLiteral( "    alg_params = {\n      'SOMETHING':SOMETHING_ELSE,\n      'SOMETHING2':SOMETHING_ELSE2,\n    }\n    outputs['']=processing.run('native:centroids', alg_params, context=context, feedback=feedback, is_child_algorithm=True)" ) );
   // bit of a hack -- but try to simulate an algorithm not originally available!
   child.mAlgorithm.reset();
   QVERIFY( !child.algorithm() );
@@ -6194,6 +6199,8 @@ void TestQgsProcessing::modelerAlgorithm()
   QCOMPARE( child.parameterSources().value( QStringLiteral( "b" ) ).at( 0 ).staticValue().toInt(), 7 );
   QCOMPARE( child.parameterSources().value( QStringLiteral( "b" ) ).at( 1 ).staticValue().toInt(), 9 );
 
+  QCOMPARE( child.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, extraParams, 4, 2 ).join( '\n' ), QStringLiteral( "    alg_params = {\n      'a':5,\n      'b':[7,9],\n      'SOMETHING':SOMETHING_ELSE,\n      'SOMETHING2':SOMETHING_ELSE2,\n    }\n    outputs['my_id']=processing.run('native:centroids', alg_params, context=context, feedback=feedback, is_child_algorithm=True)" ) );
+
   QgsProcessingModelOutput testModelOut;
   testModelOut.setChildId( QStringLiteral( "my_id" ) );
   QCOMPARE( testModelOut.childId(), QStringLiteral( "my_id" ) );
@@ -6228,6 +6235,8 @@ void TestQgsProcessing::modelerAlgorithm()
   QCOMPARE( child.modelOutput( "a" ).description(), QStringLiteral( "my output" ) );
   child.modelOutput( "a" ).setDescription( QStringLiteral( "my output 2" ) );
   QCOMPARE( child.modelOutput( "a" ).description(), QStringLiteral( "my output 2" ) );
+  QCOMPARE( child.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, extraParams, 4, 2 ).join( '\n' ), QStringLiteral( "    alg_params = {\n      'a':5,\n      'b':[7,9],\n      'SOMETHING':SOMETHING_ELSE,\n      'SOMETHING2':SOMETHING_ELSE2,\n    }\n    outputs['my_id']=processing.run('native:centroids', alg_params, context=context, feedback=feedback, is_child_algorithm=True)\n    results['my_id:a']=outputs['my_id']['']" ) );
+
   // no existent
   child.modelOutput( "b" ).setDescription( QStringLiteral( "my output 3" ) );
   QCOMPARE( child.modelOutput( "b" ).description(), QStringLiteral( "my output 3" ) );

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -6046,44 +6046,56 @@ void TestQgsProcessing::modelerAlgorithm()
   QCOMPARE( svSource.staticValue().toInt(), 5 );
   svSource.setStaticValue( 7 );
   QCOMPARE( svSource.staticValue().toInt(), 7 );
+  QCOMPARE( svSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "7" ) );
   svSource = QgsProcessingModelChildParameterSource::fromModelParameter( "a" );
   // check that calling setStaticValue flips source to StaticValue
   QCOMPARE( svSource.source(), QgsProcessingModelChildParameterSource::ModelParameter );
+  QCOMPARE( svSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "parameters['a']" ) );
   svSource.setStaticValue( 7 );
   QCOMPARE( svSource.staticValue().toInt(), 7 );
   QCOMPARE( svSource.source(), QgsProcessingModelChildParameterSource::StaticValue );
+  QCOMPARE( svSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "7" ) );
 
   // model parameter source
   QgsProcessingModelChildParameterSource mpSource = QgsProcessingModelChildParameterSource::fromModelParameter( "a" );
   QCOMPARE( mpSource.source(), QgsProcessingModelChildParameterSource::ModelParameter );
   QCOMPARE( mpSource.parameterName(), QStringLiteral( "a" ) );
+  QCOMPARE( mpSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "parameters['a']" ) );
   mpSource.setParameterName( "b" );
   QCOMPARE( mpSource.parameterName(), QStringLiteral( "b" ) );
+  QCOMPARE( mpSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "parameters['b']" ) );
   mpSource = QgsProcessingModelChildParameterSource::fromStaticValue( 5 );
   // check that calling setParameterName flips source to ModelParameter
   QCOMPARE( mpSource.source(), QgsProcessingModelChildParameterSource::StaticValue );
+  QCOMPARE( mpSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "5" ) );
   mpSource.setParameterName( "c" );
   QCOMPARE( mpSource.parameterName(), QStringLiteral( "c" ) );
   QCOMPARE( mpSource.source(), QgsProcessingModelChildParameterSource::ModelParameter );
+  QCOMPARE( mpSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "parameters['c']" ) );
 
   // child alg output source
   QgsProcessingModelChildParameterSource oSource = QgsProcessingModelChildParameterSource::fromChildOutput( "a", "b" );
   QCOMPARE( oSource.source(), QgsProcessingModelChildParameterSource::ChildOutput );
   QCOMPARE( oSource.outputChildId(), QStringLiteral( "a" ) );
   QCOMPARE( oSource.outputName(), QStringLiteral( "b" ) );
+  QCOMPARE( oSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "outputs['a']['b']" ) );
   oSource.setOutputChildId( "c" );
   QCOMPARE( oSource.outputChildId(), QStringLiteral( "c" ) );
+  QCOMPARE( oSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "outputs['c']['b']" ) );
   oSource.setOutputName( "d" );
   QCOMPARE( oSource.outputName(), QStringLiteral( "d" ) );
+  QCOMPARE( oSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "outputs['c']['d']" ) );
   oSource = QgsProcessingModelChildParameterSource::fromStaticValue( 5 );
   // check that calling setOutputChildId flips source to ChildOutput
   QCOMPARE( oSource.source(), QgsProcessingModelChildParameterSource::StaticValue );
+  QCOMPARE( oSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "5" ) );
   oSource.setOutputChildId( "c" );
   QCOMPARE( oSource.outputChildId(), QStringLiteral( "c" ) );
   QCOMPARE( oSource.source(), QgsProcessingModelChildParameterSource::ChildOutput );
   oSource = QgsProcessingModelChildParameterSource::fromStaticValue( 5 );
   // check that calling setOutputName flips source to ChildOutput
   QCOMPARE( oSource.source(), QgsProcessingModelChildParameterSource::StaticValue );
+  QCOMPARE( oSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "5" ) );
   oSource.setOutputName( "d" );
   QCOMPARE( oSource.outputName(), QStringLiteral( "d" ) );
   QCOMPARE( oSource.source(), QgsProcessingModelChildParameterSource::ChildOutput );
@@ -6092,14 +6104,18 @@ void TestQgsProcessing::modelerAlgorithm()
   QgsProcessingModelChildParameterSource expSource = QgsProcessingModelChildParameterSource::fromExpression( "1+2" );
   QCOMPARE( expSource.source(), QgsProcessingModelChildParameterSource::Expression );
   QCOMPARE( expSource.expression(), QStringLiteral( "1+2" ) );
+  QCOMPARE( expSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "QgsExpression('1+2').evaluate()" ) );
   expSource.setExpression( "1+3" );
   QCOMPARE( expSource.expression(), QStringLiteral( "1+3" ) );
+  QCOMPARE( expSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "QgsExpression('1+3').evaluate()" ) );
   expSource = QgsProcessingModelChildParameterSource::fromStaticValue( 5 );
   // check that calling setExpression flips source to Expression
   QCOMPARE( expSource.source(), QgsProcessingModelChildParameterSource::StaticValue );
+  QCOMPARE( expSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "5" ) );
   expSource.setExpression( "1+4" );
   QCOMPARE( expSource.expression(), QStringLiteral( "1+4" ) );
   QCOMPARE( expSource.source(), QgsProcessingModelChildParameterSource::Expression );
+  QCOMPARE( expSource.asPythonCode( QgsProcessing::PythonQgsProcessingAlgorithmSubclass, nullptr ), QStringLiteral( "QgsExpression('1+4').evaluate()" ) );
 
   // source equality operator
   QVERIFY( QgsProcessingModelChildParameterSource::fromStaticValue( 5 ) ==

--- a/tests/src/analysis/testqgsprocessing.cpp
+++ b/tests/src/analysis/testqgsprocessing.cpp
@@ -576,6 +576,7 @@ class TestQgsProcessing: public QObject
     void combineFields();
     void fieldNamesToIndices();
     void indicesToFields();
+    void variantToPythonLiteral();
     void stringToPythonLiteral();
     void defaultExtensionsForProvider();
     void supportedExtensions();
@@ -7504,6 +7505,29 @@ void TestQgsProcessing::indicesToFields()
   QList<int> indices3;
   QgsFields fields3 = QgsProcessingUtils::indicesToFields( indices3, fields );
   QCOMPARE( fields3, QgsFields() );
+}
+
+void TestQgsProcessing::variantToPythonLiteral()
+{
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariant() ), QStringLiteral( "None" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariant::fromValue( QgsProperty::fromExpression( QStringLiteral( "1+2" ) ) ) ), QStringLiteral( "QgsProperty.fromExpression('1+2')" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariant::fromValue( QgsCoordinateReferenceSystem() ) ), QStringLiteral( "QgsCoordinateReferenceSystem()" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariant::fromValue( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:3111" ) ) ) ), QStringLiteral( "QgsCoordinateReferenceSystem('EPSG:3111')" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariant::fromValue( QgsRectangle( 1, 2, 3, 4 ) ) ), QStringLiteral( "'1, 3, 2, 4'" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariant::fromValue( QgsReferencedRectangle( QgsRectangle( 1, 2, 3, 4 ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:28356" ) ) ) ) ), QStringLiteral( "'1, 3, 2, 4 [EPSG:28356]'" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariant::fromValue( QgsPointXY( 1, 2 ) ) ), QStringLiteral( "'1,2'" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariant::fromValue( QgsReferencedPointXY( QgsPointXY( 1, 2 ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:28356" ) ) ) ) ), QStringLiteral( "'1,2 [EPSG:28356]'" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( true ), QStringLiteral( "True" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( false ), QStringLiteral( "False" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( 5 ), QStringLiteral( "5" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( 5.5 ), QStringLiteral( "5.5" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( 5LL ), QStringLiteral( "5" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QVariantList() << true << QVariant() << QStringLiteral( "a" ) ), QStringLiteral( "[True,None,'a']" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QStringLiteral( "a" ) ), QStringLiteral( "'a'" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QString() ), QStringLiteral( "''" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QStringLiteral( "a 'string'" ) ), QStringLiteral( "'a \\'string\\''" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QStringLiteral( "a \"string\"" ) ), QStringLiteral( "'a \\\"string\\\"'" ) );
+  QCOMPARE( QgsProcessingUtils::variantToPythonLiteral( QStringLiteral( "a \n str\tin\\g" ) ), QStringLiteral( "'a \\n str\\tin\\\\g'" ) );
 }
 
 void TestQgsProcessing::stringToPythonLiteral()


### PR DESCRIPTION
(Tagging as a bugfix because it's resurrecting a missing 2.x feature)

Brings back QGIS 2.18's ability to directly convert a Processing model to an equivalent Processing Python script algorithm, correctly updated and working in the 3.x API.

Available from the model dialog, and from the right-click context menu on an existing model.

Sponsored by Solspec

![peek 2019-02-01 12-26](https://user-images.githubusercontent.com/1829991/52098917-b0e13600-261c-11e9-9bd9-2bb49ddde060.gif)
