### PR TITLE
Fix hang when WMS credentials requested

### DIFF
--- a/python/core/auto_generated/qgscredentials.sip.in
+++ b/python/core/auto_generated/qgscredentials.sip.in
@@ -32,7 +32,34 @@ signal destroyed() to be notified of the deletion
     virtual ~QgsCredentials();
 
     bool get( const QString &realm, QString &username /In,Out/, QString &password /In,Out/, const QString &message = QString() );
+%Docstring
+Requests credentials for the specified ``realm``.
+
+If existing credentials exist for the given ``realm``, these will be returned. Otherwise the credential
+handler will prompt for the correct username and password.
+
+The retrieved or user-entered details will be stored in ``username`` and ``password``.
+
+Optionally, a specific ``message`` can be used to advise users of the context for the credentials request.
+
+.. note::
+
+   This method will not automatically store the newly obtained credentials. Callers must
+   manually call put() after verifying that the obtained credentials are correct.
+
+.. seealso:: :py:func:`put`
+%End
+
     void put( const QString &realm, const QString &username, const QString &password );
+%Docstring
+Stores the correct ``username`` and ``password`` for the specified ``realm``.
+
+These values will be used for all future calls to get() for the same ``realm``, without requesting
+users to re-enter them. It is the caller's responsibility to ensure that only valid ``username`` and ``password``
+combinations are used with this method.
+
+.. seealso:: :py:func:`get`
+%End
 
     bool getMasterPassword( QString &password /In,Out/, bool stored = false );
 

--- a/python/core/auto_generated/qgscredentials.sip.in
+++ b/python/core/auto_generated/qgscredentials.sip.in
@@ -41,27 +41,27 @@ signal destroyed() to be notified of the deletion
 retrieves instance
 %End
 
-    void lock();
+ void lock() /Deprecated/;
 %Docstring
 Lock the instance against access from multiple threads. This does not really lock access to get/put methds,
 it will just prevent other threads to lock the instance and continue the execution. When the class is used
 from non-GUI threads, they should call lock() before the get/put calls to avoid race conditions.
 
-.. versionadded:: 2.4
+.. deprecated:: since QGIS 3.4 - mutex locking is automatically handled
 %End
 
-    void unlock();
+ void unlock() /Deprecated/;
 %Docstring
 Unlock the instance after being locked.
 
-.. versionadded:: 2.4
+.. deprecated:: since QGIS 3.4 - mutex locking is automatically handled
 %End
 
-    QMutex *mutex();
+ QMutex *mutex() /Deprecated/;
 %Docstring
 Returns pointer to mutex
 
-.. versionadded:: 2.4
+.. deprecated:: since QGIS 3.4 - mutex locking is automatically handled
 %End
 
   protected:

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1589,10 +1589,6 @@ QgisApp::~QgisApp()
   qDeleteAll( mCustomDropHandlers );
   qDeleteAll( mCustomLayoutDropHandlers );
 
-  // replace gui based network access managers with failing only ones
-  QgsNetworkAccessManager::instance()->setSslErrorHandler( qgis::make_unique< QgsSslErrorHandler >() );
-  QgsNetworkAccessManager::instance()->setAuthHandler( qgis::make_unique< QgsNetworkAuthenticationHandler >() );
-
   const QList<QgsMapCanvas *> canvases = mapCanvases();
   for ( QgsMapCanvas *canvas : canvases )
   {
@@ -13978,7 +13974,6 @@ void QgisApp::namProxyAuthenticationRequired( const QNetworkProxy &proxy, QAuthe
     bool ok;
 
     {
-      QMutexLocker lock( QgsCredentials::instance()->mutex() );
       ok = QgsCredentials::instance()->get(
              QStringLiteral( "proxy %1:%2 [%3]" ).arg( proxy.hostName() ).arg( proxy.port() ).arg( auth->realm() ),
              username, password,
@@ -13992,7 +13987,6 @@ void QgisApp::namProxyAuthenticationRequired( const QNetworkProxy &proxy, QAuthe
 
     // credentials didn't change - stored ones probably wrong? clear password and retry
     {
-      QMutexLocker lock( QgsCredentials::instance()->mutex() );
       QgsCredentials::instance()->put(
         QStringLiteral( "proxy %1:%2 [%3]" ).arg( proxy.hostName() ).arg( proxy.port() ).arg( auth->realm() ),
         username, QString() );
@@ -14000,7 +13994,6 @@ void QgisApp::namProxyAuthenticationRequired( const QNetworkProxy &proxy, QAuthe
   }
 
   {
-    QMutexLocker lock( QgsCredentials::instance()->mutex() );
     QgsCredentials::instance()->put(
       QStringLiteral( "proxy %1:%2 [%3]" ).arg( proxy.hostName() ).arg( proxy.port() ).arg( auth->realm() ),
       username, password

--- a/src/app/qgsappauthrequesthandler.cpp
+++ b/src/app/qgsappauthrequesthandler.cpp
@@ -44,15 +44,10 @@ void QgsAppAuthRequestHandler::handleAuthRequest( QNetworkReply *reply, QAuthent
 
   for ( ;; )
   {
-    bool ok;
-
-    {
-      QMutexLocker lock( QgsCredentials::instance()->mutex() );
-      ok = QgsCredentials::instance()->get(
-             QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
-             username, password,
-             QObject::tr( "Authentication required" ) );
-    }
+    bool ok = QgsCredentials::instance()->get(
+                QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
+                username, password,
+                QObject::tr( "Authentication required" ) );
     if ( !ok )
       return;
 
@@ -60,22 +55,16 @@ void QgsAppAuthRequestHandler::handleAuthRequest( QNetworkReply *reply, QAuthent
       break;
 
     // credentials didn't change - stored ones probably wrong? clear password and retry
-    {
-      QMutexLocker lock( QgsCredentials::instance()->mutex() );
-      QgsCredentials::instance()->put(
-        QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
-        username, QString() );
-    }
+    QgsCredentials::instance()->put(
+      QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
+      username, QString() );
   }
 
   // save credentials
-  {
-    QMutexLocker lock( QgsCredentials::instance()->mutex() );
-    QgsCredentials::instance()->put(
-      QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
-      username, password
-    );
-  }
+  QgsCredentials::instance()->put(
+    QStringLiteral( "%1 at %2" ).arg( auth->realm(), reply->url().host() ),
+    username, password
+  );
 
   auth->setUser( username );
   auth->setPassword( password );

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -3193,10 +3193,8 @@ bool QgsAuthManager::masterPasswordInput()
   if ( ! ok )
   {
     QgsCredentials *creds = QgsCredentials::instance();
-    creds->lock();
     pass.clear();
     ok = creds->getMasterPassword( pass, masterPasswordHashInDatabase() );
-    creds->unlock();
   }
 
   if ( ok && !pass.isEmpty() && mMasterPass != pass )

--- a/src/core/qgscredentials.cpp
+++ b/src/core/qgscredentials.cpp
@@ -47,7 +47,9 @@ bool QgsCredentials::get( const QString &realm, QString &username, QString &pass
     locker.unlock();
     username = credentials.first;
     password = credentials.second;
+#if 0 // don't leak credentials on log
     QgsDebugMsg( QStringLiteral( "retrieved realm:%1 username:%2 password:%3" ).arg( realm, username, password ) );
+#endif
 
     if ( !password.isNull() )
       return true;
@@ -56,19 +58,23 @@ bool QgsCredentials::get( const QString &realm, QString &username, QString &pass
 
   if ( request( realm, username, password, message ) )
   {
+#if 0 // don't leak credentials on log
     QgsDebugMsg( QStringLiteral( "requested realm:%1 username:%2 password:%3" ).arg( realm, username, password ) );
+#endif
     return true;
   }
   else
   {
-    QgsDebugMsg( QStringLiteral( "unset realm:%1" ).arg( realm ) );
+    QgsDebugMsgLevel( QStringLiteral( "unset realm:%1" ).arg( realm ), 4 );
     return false;
   }
 }
 
 void QgsCredentials::put( const QString &realm, const QString &username, const QString &password )
 {
+#if 0 // don't leak credentials on log
   QgsDebugMsg( QStringLiteral( "inserting realm:%1 username:%2 password:%3" ).arg( realm, username, password ) );
+#endif
   QMutexLocker locker( &mMutex );
   mCredentialCache.insert( realm, QPair<QString, QString>( username, password ) );
 }

--- a/src/core/qgscredentials.cpp
+++ b/src/core/qgscredentials.cpp
@@ -40,9 +40,11 @@ QgsCredentials *QgsCredentials::instance()
 
 bool QgsCredentials::get( const QString &realm, QString &username, QString &password, const QString &message )
 {
+  QMutexLocker locker( &mMutex );
   if ( mCredentialCache.contains( realm ) )
   {
     QPair<QString, QString> credentials = mCredentialCache.take( realm );
+    locker.unlock();
     username = credentials.first;
     password = credentials.second;
     QgsDebugMsg( QStringLiteral( "retrieved realm:%1 username:%2 password:%3" ).arg( realm, username, password ) );
@@ -50,6 +52,7 @@ bool QgsCredentials::get( const QString &realm, QString &username, QString &pass
     if ( !password.isNull() )
       return true;
   }
+  locker.unlock();
 
   if ( request( realm, username, password, message ) )
   {
@@ -66,6 +69,7 @@ bool QgsCredentials::get( const QString &realm, QString &username, QString &pass
 void QgsCredentials::put( const QString &realm, const QString &username, const QString &password )
 {
   QgsDebugMsg( QStringLiteral( "inserting realm:%1 username:%2 password:%3" ).arg( realm, username, password ) );
+  QMutexLocker locker( &mMutex );
   mCredentialCache.insert( realm, QPair<QString, QString>( username, password ) );
 }
 

--- a/src/core/qgscredentials.h
+++ b/src/core/qgscredentials.h
@@ -47,7 +47,32 @@ class CORE_EXPORT QgsCredentials
      */
     virtual ~QgsCredentials() = default;
 
+    /**
+     * Requests credentials for the specified \a realm.
+     *
+     * If existing credentials exist for the given \a realm, these will be returned. Otherwise the credential
+     * handler will prompt for the correct username and password.
+     *
+     * The retrieved or user-entered details will be stored in \a username and \a password.
+     *
+     * Optionally, a specific \a message can be used to advise users of the context for the credentials request.
+     *
+     * \note This method will not automatically store the newly obtained credentials. Callers must
+     * manually call put() after verifying that the obtained credentials are correct.
+     *
+     * \see put()
+     */
     bool get( const QString &realm, QString &username SIP_INOUT, QString &password SIP_INOUT, const QString &message = QString() );
+
+    /**
+     * Stores the correct \a username and \a password for the specified \a realm.
+     *
+     * These values will be used for all future calls to get() for the same \a realm, without requesting
+     * users to re-enter them. It is the caller's responsibility to ensure that only valid \a username and \a password
+     * combinations are used with this method.
+     *
+     * \see get()
+     */
     void put( const QString &realm, const QString &username, const QString &password );
 
     bool getMasterPassword( QString &password SIP_INOUT, bool stored = false );

--- a/src/core/qgscredentials.h
+++ b/src/core/qgscredentials.h
@@ -59,21 +59,25 @@ class CORE_EXPORT QgsCredentials
      * Lock the instance against access from multiple threads. This does not really lock access to get/put methds,
      * it will just prevent other threads to lock the instance and continue the execution. When the class is used
      * from non-GUI threads, they should call lock() before the get/put calls to avoid race conditions.
-     * \since QGIS 2.4
+     *
+     * \deprecated since QGIS 3.4 - mutex locking is automatically handled
      */
-    void lock();
+    Q_DECL_DEPRECATED void lock() SIP_DEPRECATED;
 
     /**
      * Unlock the instance after being locked.
-     * \since QGIS 2.4
+     * \deprecated since QGIS 3.4 - mutex locking is automatically handled
      */
-    void unlock();
+    Q_DECL_DEPRECATED void unlock() SIP_DEPRECATED;
 
     /**
      * Returns pointer to mutex
-     * \since QGIS 2.4
+     * \deprecated since QGIS 3.4 - mutex locking is automatically handled
      */
-    QMutex *mutex() { return &mMutex; }
+    Q_DECL_DEPRECATED QMutex *mutex() SIP_DEPRECATED
+    {
+      return &mMutex;
+    }
 
   protected:
 

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -235,7 +235,6 @@ QSqlDatabase QgsDb2Provider::getDatabase( const QString &connInfo, QString &errM
   db.setPort( port.toInt() );
   bool connected = false;
   int i = 0;
-  QgsCredentials::instance()->lock();
   while ( !connected && i < 3 )
   {
     i++;
@@ -249,7 +248,6 @@ QSqlDatabase QgsDb2Provider::getDatabase( const QString &connInfo, QString &errM
       {
         errMsg = QStringLiteral( "Cancel clicked" );
         QgsDebugMsg( errMsg );
-        QgsCredentials::instance()->unlock();
         break;
       }
     }
@@ -291,7 +289,6 @@ QSqlDatabase QgsDb2Provider::getDatabase( const QString &connInfo, QString &errM
   {
     QgsCredentials::instance()->put( databaseName, userName, password );
   }
-  QgsCredentials::instance()->unlock();
 
   return db;
 }

--- a/src/providers/oracle/qgsoracleconn.cpp
+++ b/src/providers/oracle/qgsoracleconn.cpp
@@ -96,8 +96,6 @@ QgsOracleConn::QgsOracleConn( QgsDataSourceUri uri )
   QgsDebugMsg( QStringLiteral( "Connecting with options: " ) + options );
   if ( !mDatabase.open() )
   {
-    QgsCredentials::instance()->lock();
-
     while ( !mDatabase.open() )
     {
       bool ok = QgsCredentials::instance()->get( realm, username, password, mDatabase.lastError().text() );
@@ -127,8 +125,6 @@ QgsOracleConn::QgsOracleConn( QgsDataSourceUri uri )
 
     if ( mDatabase.isOpen() )
       QgsCredentials::instance()->put( realm, username, password );
-
-    QgsCredentials::instance()->unlock();
   }
 
   if ( !mDatabase.isOpen() )

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -272,8 +272,6 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
     QString username = uri.username();
     QString password = uri.password();
 
-    QgsCredentials::instance()->lock();
-
     int i = 0;
     while ( PQstatus() != CONNECTION_OK && i < 5 )
     {
@@ -298,8 +296,6 @@ QgsPostgresConn::QgsPostgresConn( const QString &conninfo, bool readOnly, bool s
 
     if ( PQstatus() == CONNECTION_OK )
       QgsCredentials::instance()->put( conninfo, username, password );
-
-    QgsCredentials::instance()->unlock();
   }
 
   if ( PQstatus() != CONNECTION_OK )

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -90,6 +90,7 @@ SET(TESTS
  testcontrastenhancements.cpp
  testqgscoordinatereferencesystem.cpp
  testqgscoordinatetransform.cpp
+ testqgscredentials.cpp
  testqgscurve.cpp
  testqgsdatadefinedsizelegend.cpp
  testqgsdataitem.cpp

--- a/tests/src/core/testqgscredentials.cpp
+++ b/tests/src/core/testqgscredentials.cpp
@@ -1,0 +1,143 @@
+/***************************************************************************
+     testqgscredentials.cpp
+     --------------------
+    Date                 : February 2019
+    Copyright            : (C) 2019 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstest.h"
+#include <QObject>
+#include <QString>
+#include <QtConcurrent>
+#include "qgscredentials.h"
+
+class TestCredentials : public QgsCredentials
+{
+
+  public:
+    TestCredentials( bool isInstance )
+      : mExpectedRealm( QStringLiteral( "test_realm" ) )
+    {
+      if ( isInstance )
+        setInstance( this );
+    }
+
+  protected:
+    bool request( const QString &realm, QString &username, QString &password, const QString & ) override
+    {
+      Q_ASSERT( realm == mExpectedRealm );
+
+      username = mUsername;
+      password = mPassword;
+      return true;
+    }
+
+    bool requestMasterPassword( QString &, bool ) override
+    {
+      return true;
+    }
+
+  public:
+    QString mUsername;
+    QString mPassword;
+    QString mExpectedRealm;
+};
+
+
+class TestQgsCredentials : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init() {} // will be called before each testfunction is executed.
+    void cleanup() {} // will be called after every testfunction.
+    void basic();
+    void threadSafety();
+
+};
+
+
+void TestQgsCredentials::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+}
+
+void TestQgsCredentials::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsCredentials::basic()
+{
+  TestCredentials *t = new TestCredentials( true );
+  QCOMPARE( QgsCredentials::instance(), t );
+
+  QString username;
+  QString password;
+  QVERIFY( QgsCredentials::instance()->get( QStringLiteral( "test_realm" ), username, password ) );
+  QVERIFY( username.isEmpty() );
+  QVERIFY( password.isEmpty() );
+
+  t->mUsername = QStringLiteral( "user" );
+  t->mPassword = QStringLiteral( "pass" );
+  QVERIFY( QgsCredentials::instance()->get( QStringLiteral( "test_realm" ), username, password ) );
+  QCOMPARE( username, QStringLiteral( "user" ) );
+  QCOMPARE( password, QStringLiteral( "pass" ) );
+
+  // put credential
+  QgsCredentials::instance()->put( QStringLiteral( "test_realm" ), QStringLiteral( "user" ), QStringLiteral( "pass" ) );
+  // TestCredentials should not be used, put credentials should be used instead
+  t->mUsername = QStringLiteral( "user2" );
+  t->mPassword = QStringLiteral( "pass2" );
+  QVERIFY( QgsCredentials::instance()->get( QStringLiteral( "test_realm" ), username, password ) );
+  QCOMPARE( username, QStringLiteral( "user" ) );
+  QCOMPARE( password, QStringLiteral( "pass" ) );
+
+  t->mExpectedRealm = QStringLiteral( "test_realm2" );
+  // should use TestCredentials again, as now cached credentials for test_realm2
+  QVERIFY( QgsCredentials::instance()->get( QStringLiteral( "test_realm2" ), username, password ) );
+  QCOMPARE( username, QStringLiteral( "user2" ) );
+  QCOMPARE( password, QStringLiteral( "pass2" ) );
+}
+
+struct GetPutCredentials
+{
+  void operator()( int i )
+  {
+    QgsCredentials::instance()->put( QStringLiteral( "test_realm%1" ).arg( i ), QStringLiteral( "username" ), QStringLiteral( "password" ) );
+    QString user;
+    QString password;
+    QVERIFY( QgsCredentials::instance()->get( QStringLiteral( "test_realm%1" ).arg( i ), user, password ) );
+    QCOMPARE( user, QStringLiteral( "username" ) );
+    QCOMPARE( password, QStringLiteral( "password" ) );
+  }
+};
+
+void TestQgsCredentials::threadSafety()
+{
+  // ensure credentials storage/retrieval is thread safe
+  TestCredentials *t = new TestCredentials( true );
+
+  t->mUsername = QStringLiteral( "user" );
+  t->mPassword = QStringLiteral( "pass" );
+
+  // smash credentials rendering over multiple threads
+  QVector< int > list;
+  list.resize( 1000 );
+  for ( int i = 0; i < list.size(); ++i )
+    list[i] = i;
+  QtConcurrent::blockingMap( list, GetPutCredentials() );
+}
+
+QGSTEST_MAIN( TestQgsCredentials )
+#include "testqgscredentials.moc"


### PR DESCRIPTION
Remove responsibility for credentials mutex locking from external
callers and handle appropriate locks internally. This allows the
mutex lock to be much "tighter" and avoids deadlocks when
credentials are requested while an existing credentials dialog
is being shown.

(No mutex is required protecting the credentials dialog itself
as this is ALWAYS shown in the main thread)

Fixes #20826
