### PR TITLE
Allow vector rendering cancelation to also cancel feature iteration for that request

### DIFF
--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -76,6 +76,7 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
   public:
     QgsVectorLayerRenderer( QgsVectorLayer *layer, QgsRenderContext &context );
     ~QgsVectorLayerRenderer() override;
+    QgsFeedback *feedback() const override;
 
     bool render() override;
 
@@ -107,7 +108,7 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 
     QgsRenderContext &mContext;
 
-    QgsVectorLayerRendererInterruptionChecker mInterruptionChecker;
+    std::unique_ptr< QgsVectorLayerRendererInterruptionChecker > mInterruptionChecker;
 
     //! The rendered layer
     QgsVectorLayer *mLayer = nullptr;


### PR DESCRIPTION
Connect the cancel rendering signal to the iteration cancelation. This allows providers (e.g. WFS, AFS) to abort slow network requests when they have been triggered by a render request and that request
is no longer required.

Allows much faster quit, render cancelation when using WFS/AFS layers.
