### PR TITLE
[RPM] GRASS 7.6 support for F30+

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -254,6 +254,8 @@ rm -f %{buildroot}%{_datadir}/%{name}/doc/INSTALL*
 
 %find_lang %{name} --with-qt
 
+# TODO: Remove after F28 EoL
+# Ref: https://fedoraproject.org/wiki/Changes/RemoveObsoleteScriptlets
 %post
 /sbin/ldconfig
 touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
@@ -279,6 +281,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %post -n python3-qgis -p /sbin/ldconfig
 
 %postun -n python3-qgis -p /sbin/ldconfig
+# END TODO #
 
 %files -f %{name}.lang
 %doc BUGS NEWS Exception_to_GPL_for_Qt.txt ChangeLog.gz

--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -12,7 +12,11 @@
 # py files located under /usr/share/qgis/python/plugins
 %global __python %{__python3}
 
+%if 0%{?fedora} >= 30
+%define grass grass76
+%else
 %define grass grass74
+%endif
 
 %if %{_timestamp} > 0
 # Epoch is set only when building packages from master


### PR DESCRIPTION
## Description
Rawhide/F30 now has GRASS 7.6 in the official repos. Adapt the spec file to use it.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
