### PR TITLE
[RPM] Backport some fixes for master, add F30+ compatibility

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -12,15 +12,21 @@
 # py files located under /usr/share/qgis/python/plugins
 %global __python %{__python3}
 
+%if 0%{?fedora} >= 30
+%define grass grass76
+%else
+%define grass grass74
+%endif
+
 %if %{_timestamp} > 0
 # Epoch is set only when building packages from master
 Epoch: %{_timestamp}
+%define combinedversion %{epoch}:%{version}
 %define builddate %(date -d @%{_timestamp} '+%a %b %d %Y')
 %else
+%define combinedversion %{version}
 %define builddate %(date '+%a %b %d %Y')
 %endif
-
-%define grass grass74
 
 Name:           qgis
 Version:        %{_version}
@@ -64,10 +70,13 @@ BuildRequires:  spatialindex-devel
 BuildRequires:  grass-devel
 
 # Other stuff
+BuildRequires:  exiv2-devel
 BuildRequires:  gsl-devel
 BuildRequires:  libzip-devel
 BuildRequires:  postgresql-devel
 BuildRequires:  sqlite-devel
+BuildRequires:  hdf5-devel
+BuildRequires:  netcdf-devel
 BuildRequires:  fcgi-devel
 
 # OpenCL
@@ -130,14 +139,14 @@ and USGS ASCII DEM.
 
 %package devel
 Summary:        Development Libraries for the QGIS
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{combinedversion}-%{release}
 
 %description devel
 Development packages for QGIS including the C header files.
 
 %package grass
 Summary:        GRASS Support Libraries for QGIS
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{combinedversion}-%{release}
 
 # The plug-in requires more than just the grass-libs.
 # This questions the sense of the libs package.
@@ -152,12 +161,12 @@ GRASS plugin for QGIS required to interface with the GRASS system.
 %package -n python3-qgis
 %{?python_provide:%python_provide python3-qgis}
 # Remove before F30
-Provides:       %{name}-python = %{version}-%{release}
-Provides:       %{name}-python%{?_isa} = %{version}-%{release}
+Provides:       %{name}-python = %{combinedversion}-%{release}
+Provides:       %{name}-python%{?_isa} = %{combinedversion}-%{release}
 Obsoletes:      %{name}-python < %{version}-%{release}
 Obsoletes:      python2-%{name} < %{version}-%{release}
 Summary:        Python integration and plug-ins for QGIS
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{combinedversion}-%{release}
 Requires:       gdal-python3
 Requires:       python3-future
 Requires:       python3-jinja2
@@ -175,7 +184,7 @@ Python integration and plug-ins for QGIS.
 
 %package server
 Summary:        FCGI-based OGC web map server
-Requires:       %{name}%{?_isa} = %{epoch}:%{version}-%{release}
+Requires:       %{name}%{?_isa} = %{combinedversion}-%{release}
 Requires:       mod_fcgid
 Provides:       mapserver = %{version}-%{release}
 Obsoletes:      mapserver < 2.8.1-1
@@ -244,6 +253,8 @@ rm -f %{buildroot}%{_datadir}/%{name}/doc/INSTALL*
 
 %find_lang %{name} --with-qt
 
+# TODO: Remove after F28 EoL
+# Ref: https://fedoraproject.org/wiki/Changes/RemoveObsoleteScriptlets
 %post
 /sbin/ldconfig
 touch --no-create %{_datadir}/icons/hicolor &>/dev/null || :
@@ -269,6 +280,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %post -n python3-qgis -p /sbin/ldconfig
 
 %postun -n python3-qgis -p /sbin/ldconfig
+# END TODO #
 
 %files -f %{name}.lang
 %doc BUGS NEWS Exception_to_GPL_for_Qt.txt ChangeLog.gz


### PR DESCRIPTION
## Description
Backport GRASS 7.6 RPM compatibility to allow build QGIS on the upcoming F30. Backports also some fixes from master (which were actually bugs, not new features: new features like nginx compatibility in packaging are left in master for 3.6).

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
