### PR TITLE
New Shapefile Layer: reorganise additional dimensions checkboxes

### DIFF
--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -170,10 +170,10 @@ QgsWkbTypes::Type QgsNewVectorLayerDialog::selectedType() const
   wkbType = static_cast<QgsWkbTypes::Type>
             ( mGeometryTypeBox->currentData( Qt::UserRole ).toInt() );
 
-  if ( mGeometryWithZCheckBox->isChecked() )
+  if ( mGeometryWithZRadioButton->isChecked() )
     wkbType = QgsWkbTypes::addZ( wkbType );
 
-  if ( mGeometryWithMCheckBox->isChecked() )
+  if ( mGeometryWithMRadioButton->isChecked() )
     wkbType = QgsWkbTypes::addM( wkbType );
 
   return wkbType;

--- a/src/ui/qgsnewvectorlayerdialogbase.ui
+++ b/src/ui/qgsnewvectorlayerdialogbase.ui
@@ -17,7 +17,7 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout">
-   <item row="14" column="0" colspan="2">
+   <item row="14" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -27,7 +27,7 @@
      </property>
     </widget>
    </item>
-   <item row="10" column="0" colspan="2">
+   <item row="10" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>New Field</string>
@@ -127,13 +127,13 @@
      </layout>
     </widget>
    </item>
-   <item row="12" column="0" colspan="2">
+   <item row="12" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Fields List</string>
      </property>
      <layout class="QGridLayout">
-      <item row="2" column="0" colspan="2">
+      <item row="2" column="0" colspan="3">
        <widget class="QTreeWidget" name="mAttributeView">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -211,7 +211,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item row="4" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout_3">
      <item row="3" column="0">
       <widget class="QLabel" name="mGeometryTypeLabel">
@@ -271,14 +271,43 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QCheckBox" name="mGeometryWithZCheckBox">
+     <item row="4" column="0">
+      <widget class="QLabel" name="mAdditionalDimensionsLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
-        <string>Include Z dimension</string>
+        <string>Additional dimensions</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1" colspan="2">
+     <item row="4" column="1">
+      <widget class="QRadioButton" name="mGeometryWithNoneRadioButton">
+       <property name="text">
+        <string>None</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="autoExclusive">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QRadioButton" name="mGeometryWithZRadioButton">
+       <property name="text">
+        <string>Z (+ M values)</string>
+       </property>
+       <property name="autoExclusive">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1" colspan="3">
       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
        <property name="minimumSize">
         <size>
@@ -291,28 +320,31 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="2">
-      <widget class="QCheckBox" name="mGeometryWithMCheckBox">
+     <item row="4" column="3">
+      <widget class="QRadioButton" name="mGeometryWithMRadioButton">
        <property name="text">
-        <string>Include M values</string>
+        <string>M values</string>
+       </property>
+       <property name="autoExclusive">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="1" column="1" colspan="2">
+     <item row="1" column="1" colspan="3">
       <widget class="QComboBox" name="mFileEncoding">
        <property name="enabled">
         <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="2" column="1" colspan="2">
+     <item row="2" column="1" colspan="3">
       <widget class="QComboBox" name="mFileFormatComboBox">
        <property name="enabled">
         <bool>true</bool>
        </property>
       </widget>
      </item>
-     <item row="3" column="1" colspan="2">
+     <item row="3" column="1" colspan="3">
       <widget class="QComboBox" name="mGeometryTypeBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -322,7 +354,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" colspan="2">
+     <item row="0" column="1" colspan="3">
       <widget class="QgsFileWidget" name="mFileName" native="true"/>
      </item>
     </layout>
@@ -348,8 +380,9 @@
   <tabstop>mFileEncoding</tabstop>
   <tabstop>mFileFormatComboBox</tabstop>
   <tabstop>mGeometryTypeBox</tabstop>
-  <tabstop>mGeometryWithZCheckBox</tabstop>
-  <tabstop>mGeometryWithMCheckBox</tabstop>
+  <tabstop>mGeometryWithNoneRadioButton</tabstop>
+  <tabstop>mGeometryWithZRadioButton</tabstop>
+  <tabstop>mGeometryWithMRadioButton</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>mNameEdit</tabstop>
   <tabstop>mTypeBox</tabstop>


### PR DESCRIPTION
## Description
In the New Shapefile Layer dialog there are two checkboxes ("Include Z dimension", "Include M values") that allow to create shapefiles with added Z and M "additional dimensions"

![image](https://user-images.githubusercontent.com/16253859/52096572-a5afeb00-25c7-11e9-9fc2-da38e1c103b5.png)

Since the two checkboxes are not non mutually exclusive, the user could check none, only one, or both of them, thus wrongly thinking that 4 kinds of new shapefile layer could be created, e.g. for Point geometry type:
- Point (X,Y)
- PointZ (X,Y,Z)
- PointM (X,Y,M)
- PointZM (X,Y,Z,M)

while actually only 3 types of Point shapefiles do exists:
- Point (X,Y)
- PointM (X,Y,M)
- PointZ = PointZM (X,Y,Z,M)

In fact, whether checking only the "Include Z dimension" checkbox or checking both the "Include Z dimension" and the "Include M values" checkboxes, will lead to create the very same ZM new shapefile layer.

In order to solve this ambiguity, I propose to change the New Shapefile Layer dialog adding the label "Additional dimensions" in the checkboxes row and changing the two non mutually exclusive in three mutually exclusive checkboxes "None", "Z + M values", "M values", with "None" pre checked by default (since it seems to me it's not possible to have two mutually exclusive checkboxes that could be both unchecked after one of them is chechekd).

![image](https://user-images.githubusercontent.com/16253859/52111112-0577b780-2603-11e9-87bb-a1515ecc4ae2.png)

Note: this proposed change however will make the New Shapefile Layer dialog inconsistent with the other New SpatiaLite/GeoPackage/Memory layer dialogs about the Z and M checkboxes. Could this be a problem?

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
