### PR TITLE
Avoid undefined behaviour with signed integer overflow

### DIFF
--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -144,12 +144,12 @@ void QgsRangeWidgetWrapper::initWidget( QWidget *editor )
     int minval = min.toInt();
     if ( allowNull )
     {
-      int stepval = step.isValid() ? step.toInt() : 1;
-      int newMinval = minval - stepval;
+      uint stepval = step.isValid() ? step.toUInt() : 1;
       // make sure there is room for a new value (i.e. signed integer does not overflow)
-      if ( newMinval < minval )
+      int minvalOverflow = uint( minval ) - stepval;
+      if ( minvalOverflow < minval )
       {
-        minval = newMinval;
+        minval = minvalOverflow;
       }
       mIntSpinBox->setValue( minval );
       QgsSpinBox *intSpinBox( qobject_cast<QgsSpinBox *>( mIntSpinBox ) );


### PR DESCRIPTION
## Description

Followup to https://github.com/qgis/QGIS/pull/9033
Signed integer overflow is an undefined behavior. By converting first to unsigned, this should avoid any problem.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
