### PR TITLE
Deprecate QgsGeometry::set for usage in Python

### DIFF
--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -133,6 +133,12 @@ Sets the underlying geometry store. Ownership of geometry is transferred.
 
    In QGIS 2.x this method was named setGeometry().
 
+.. note::
+
+   This method is deprecated for usage in Python and will be removed from Python bindings with QGIS 4.
+   Using this method will confuse Python's memory management and type information system.
+   Better create a new QgsGeometry object instead.
+
 .. seealso:: :py:func:`get`
 
 .. seealso:: :py:func:`constGet`

--- a/python/core/auto_generated/geometry/qgsgeometry.sip.in
+++ b/python/core/auto_generated/geometry/qgsgeometry.sip.in
@@ -125,7 +125,7 @@ and a deep copy. Where possible, use constGet() instead.
 .. versionadded:: 3.0
 %End
 
-    void set( QgsAbstractGeometry *geometry /Transfer/ );
+    void set( QgsAbstractGeometry *geometry /Transfer/ ) /Deprecated/;
 %Docstring
 Sets the underlying geometry store. Ownership of geometry is transferred.
 

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -196,6 +196,9 @@ class CORE_EXPORT QgsGeometry
      * Sets the underlying geometry store. Ownership of geometry is transferred.
      *
      * \note In QGIS 2.x this method was named setGeometry().
+     * \note This method is deprecated for usage in Python and will be removed from Python bindings with QGIS 4.
+     *       Using this method will confuse Python's memory management and type information system.
+     *       Better create a new QgsGeometry object instead.
      *
      * \see get()
      * \see constGet()

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -204,7 +204,7 @@ class CORE_EXPORT QgsGeometry
      * \see constGet()
      * \since QGIS 3.0
      */
-    void set( QgsAbstractGeometry *geometry SIP_TRANSFER );
+    void set( QgsAbstractGeometry *geometry SIP_TRANSFER ) SIP_DEPRECATED;
 
     /**
      * Returns true if the geometry is null (ie, contains no underlying geometry


### PR DESCRIPTION
When a new QgsAbstractGeometry is `set` on a geometry object, the previous child is deleted.
If the previous object was constructed by Python, it's wrapper will still be alive for
as long as the QgsGeometry is alive. If a new QgsAbstractGeometry is constructed at the same
memory address as the old one, the wrapper will be reused with wrong type (and other)
information, leading to all kind of weird issues.

See also https://www.riverbankcomputing.com/pipermail/pyqt/2019-January/041251.html

Please note, that this not solve https://issues.qgis.org/issues/20661 but avoids similar issues. 20661 should hopefully be solved with the next sip release