### PR TITLE
Allow maximum number of entries to show in relation reference widget to be configured

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -77,3 +77,9 @@ helpSearchPath=https://docs.qgis.org/$qgis_short_version/$qgis_locale/docs/user_
 [providers]
 # Default timeout for PostgreSQL servers (seconds)
 PostgreSQL\default_timeout=30
+
+[gui]
+# Maximum number of entries to show in Relation Reference widgets. Too large a number here can
+# cause performance issues, as the records must all be loaded from the related table on display.
+maxEntriesRelationWidget=100
+

--- a/src/core/qgsfeaturefiltermodel.cpp
+++ b/src/core/qgsfeaturefiltermodel.cpp
@@ -19,6 +19,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsconditionalstyle.h"
 #include "qgsapplication.h"
+#include "qgssettings.h"
 
 QgsFeatureFilterModel::QgsFeatureFilterModel( QObject *parent )
   : QAbstractItemModel( parent )
@@ -353,7 +354,7 @@ void QgsFeatureFilterModel::scheduledReload()
   request.setSubsetOfAttributes( attributes, mSourceLayer->fields() );
   request.setFlags( QgsFeatureRequest::NoGeometry );
 
-  request.setLimit( 100 );
+  request.setLimit( QgsSettings().value( QStringLiteral( "maxEntriesRelationWidget" ), 100, QgsSettings::Gui ).toInt() );
 
   mGatherer = new QgsFieldExpressionValuesGatherer( mSourceLayer, mDisplayExpression, mIdentifierField, request );
   mGatherer->setData( mShouldReloadCurrentFeature );


### PR DESCRIPTION
...via an advanced setting configuration option

In some circumstances 100 is not enough
