### PR TITLE
Quick and dirty patch to DB-Manager after PR 8831

### DIFF
--- a/python/plugins/db_manager/db_plugins/gpkg/plugin.py
+++ b/python/plugins/db_manager/db_plugins/gpkg/plugin.py
@@ -301,6 +301,10 @@ class GPKGTableField(TableField):
         self.num, self.name, self.dataType, self.notNull, self.default, self.primaryKey = row
         self.hasDefault = self.default
 
+    def getComment(self):
+        """Returns the comment for a field"""
+        return ''
+
 
 class GPKGTableIndex(TableIndex):
 

--- a/python/plugins/db_manager/db_plugins/oracle/plugin.py
+++ b/python/plugins/db_manager/db_plugins/oracle/plugin.py
@@ -557,6 +557,10 @@ class ORTableField(TableField):
             self.table().refreshIndexes()
         return ret
 
+    def getComment(self):
+        """Returns the comment for a field"""
+        return ''
+
 
 class ORTableConstraint(TableConstraint):
 

--- a/python/plugins/db_manager/db_plugins/oracle/plugin.py
+++ b/python/plugins/db_manager/db_plugins/oracle/plugin.py
@@ -91,7 +91,8 @@ class OracleDBPlugin(DBPlugin):
         uri = QgsDataSourceUri()
 
         settingsList = ["host", "port", "database", "username", "password"]
-        host, port, database, username, password = [settings.value(x, "", type=str) for x in settingsList]
+        host, port, database, username, password = [
+            settings.value(x, "", type=str) for x in settingsList]
 
         # get all of the connexion options
 
@@ -202,7 +203,8 @@ class ORDatabase(Database):
         uri = self.uri()
         con = self.database().connector
 
-        uri.setDataSource(u"", u"({}\n)".format(sql), geomCol, filter, uniqueCol.strip(u'"'))
+        uri.setDataSource(u"", u"({}\n)".format(
+            sql), geomCol, filter, uniqueCol.strip(u'"'))
         if avoidSelectById:
             uri.disableSelectAtId(True)
         provider = self.dbplugin().providerName()
@@ -403,18 +405,18 @@ class ORTable(Table):
             for idx in indexes:
                 if idx.isUnique and len(idx.columns) == 1:
                     fld = idx.fields()[idx.columns[0]]
-                    if (fld.dataType == u"NUMBER"
-                            and not fld.modifier
-                            and fld.notNull
-                            and fld not in ret):
+                    if (fld.dataType == u"NUMBER" and
+                            not fld.modifier and
+                            fld.notNull and
+                            fld not in ret):
                         ret.append(fld)
 
         # and finally append the other suitable fields
         for fld in self.fields():
-            if (fld.dataType == u"NUMBER"
-                    and not fld.modifier
-                    and fld.notNull
-                    and fld not in ret):
+            if (fld.dataType == u"NUMBER" and
+                    not fld.modifier and
+                    fld.notNull and
+                    fld not in ret):
                 ret.append(fld)
 
         if onlyOne:
@@ -514,14 +516,14 @@ class ORTableField(TableField):
 
         # find out whether fields are part of primary key
         for con in self.table().constraints():
-            if (con.type == ORTableConstraint.TypePrimaryKey
-                    and self.name == con.column):
+            if (con.type == ORTableConstraint.TypePrimaryKey and
+                    self.name == con.column):
                 self.primaryKey = True
                 break
 
     def type2String(self):
-        if (u"TIMESTAMP" in self.dataType
-            or self.dataType in [u"DATE", u"SDO_GEOMETRY",
+        if (u"TIMESTAMP" in self.dataType or
+            self.dataType in [u"DATE", u"SDO_GEOMETRY",
                                  u"BINARY_FLOAT", u"BINARY_DOUBLE"]):
             return u"{}".format(self.dataType)
         if self.charMaxLen in [None, -1]:

--- a/python/plugins/db_manager/db_plugins/oracle/plugin.py
+++ b/python/plugins/db_manager/db_plugins/oracle/plugin.py
@@ -403,18 +403,18 @@ class ORTable(Table):
             for idx in indexes:
                 if idx.isUnique and len(idx.columns) == 1:
                     fld = idx.fields()[idx.columns[0]]
-                    if (fld.dataType == u"NUMBER" and
-                            not fld.modifier and
-                            fld.notNull and
-                            fld not in ret):
+                    if (fld.dataType == u"NUMBER"
+                            and not fld.modifier
+                            and fld.notNull
+                            and fld not in ret):
                         ret.append(fld)
 
         # and finally append the other suitable fields
         for fld in self.fields():
-            if (fld.dataType == u"NUMBER" and
-                    not fld.modifier and
-                    fld.notNull and
-                    fld not in ret):
+            if (fld.dataType == u"NUMBER"
+                    and not fld.modifier
+                    and fld.notNull
+                    and fld not in ret):
                 ret.append(fld)
 
         if onlyOne:
@@ -514,15 +514,15 @@ class ORTableField(TableField):
 
         # find out whether fields are part of primary key
         for con in self.table().constraints():
-            if (con.type == ORTableConstraint.TypePrimaryKey and
-                    self.name == con.column):
+            if (con.type == ORTableConstraint.TypePrimaryKey
+                    and self.name == con.column):
                 self.primaryKey = True
                 break
 
     def type2String(self):
-        if (u"TIMESTAMP" in self.dataType or
-            self.dataType in [u"DATE", u"SDO_GEOMETRY",
-                              u"BINARY_FLOAT", u"BINARY_DOUBLE"]):
+        if (u"TIMESTAMP" in self.dataType
+            or self.dataType in [u"DATE", u"SDO_GEOMETRY",
+                                 u"BINARY_FLOAT", u"BINARY_DOUBLE"]):
             return u"{}".format(self.dataType)
         if self.charMaxLen in [None, -1]:
             return u"{}".format(self.dataType)

--- a/python/plugins/db_manager/db_plugins/spatialite/plugin.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/plugin.py
@@ -294,6 +294,10 @@ class SLTableField(TableField):
         self.num, self.name, self.dataType, self.notNull, self.default, self.primaryKey = row
         self.hasDefault = self.default
 
+    def getComment(self):
+        """Returns the comment for a field"""
+        return ''
+
 
 class SLTableIndex(TableIndex):
 

--- a/python/plugins/db_manager/db_plugins/vlayers/plugin.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/plugin.py
@@ -192,3 +192,7 @@ class LTableField(TableField):
         TableField.__init__(self, table)
         self.num, self.name, self.dataType, self.notNull, self.default, self.primaryKey = row
         self.hasDefault = self.default
+
+    def getComment(self):
+        """Returns the comment for a field"""
+        return ''

--- a/python/plugins/db_manager/dlg_field_properties.py
+++ b/python/plugins/db_manager/dlg_field_properties.py
@@ -56,18 +56,23 @@ class DlgFieldProperties(QDialog, Ui_Dialog):
         self.chkNull.setChecked(not fld.notNull)
         if fld.hasDefault:
             self.editDefault.setText(fld.default)
-        # Check with SQL query if a comment exists for the field
-        sql_cpt = "Select count(*) from pg_description pd, pg_class pc, pg_attribute pa where relname = '%s' and attname = '%s' and pa.attrelid = pc.oid and pd.objoid = pc.oid and pd.objsubid = pa.attnum" % (self.table.name, self.editName.text())
-        # Get the comment for the field with SQL Query
-        sql = "Select pd.description from pg_description pd, pg_class pc, pg_attribute pa where relname = '%s' and attname = '%s' and pa.attrelid = pc.oid and pd.objoid = pc.oid and pd.objsubid = pa.attnum" % (self.table.name, self.editName.text())
-        c = self.db.connector._execute(None, sql_cpt) # Execute check query
-        res = self.db.connector._fetchone(c)[0] # Fetch data
-        # Check if result is 1 then it's ok, else we don't want to get a value
-        if res == 1:
-            c = self.db.connector._execute(None, sql) # Execute query returning the comment value
-            res = self.db.connector._fetchone(c)[0] # Fetch the comment value
-            self.db.connector._close_cursor(c) # Close cursor
-            self.editCom.setText(res) # Set comment value
+        # This is an ugly patch, but the comments PR https://github.com/qgis/QGIS/pull/8831 added
+        # support for postgres only and broke all the others :(
+        try:
+            # Check with SQL query if a comment exists for the field
+            sql_cpt = "Select count(*) from pg_description pd, pg_class pc, pg_attribute pa where relname = '%s' and attname = '%s' and pa.attrelid = pc.oid and pd.objoid = pc.oid and pd.objsubid = pa.attnum" % (self.table.name, self.editName.text())
+            # Get the comment for the field with SQL Query
+            sql = "Select pd.description from pg_description pd, pg_class pc, pg_attribute pa where relname = '%s' and attname = '%s' and pa.attrelid = pc.oid and pd.objoid = pc.oid and pd.objsubid = pa.attnum" % (self.table.name, self.editName.text())
+            c = self.db.connector._execute(None, sql_cpt) # Execute check query
+            res = self.db.connector._fetchone(c)[0] # Fetch data
+            # Check if result is 1 then it's ok, else we don't want to get a value
+            if res == 1:
+                c = self.db.connector._execute(None, sql) # Execute query returning the comment value
+                res = self.db.connector._fetchone(c)[0] # Fetch the comment value
+                self.db.connector._close_cursor(c) # Close cursor
+                self.editCom.setText(res) # Set comment value
+        except:
+            self.editCom.setEnabled(False)
 
     def getField(self, newCopy=False):
         fld = TableField(self.table) if not self.fld or newCopy else self.fld


### PR DESCRIPTION
The "comments" PR #8831 added support for postgres only
(and broke all the others backends).

I'd be in favor of a revert of the whole original PR but
this patch restores functionality and could be an acceptable
temporary fix until the comments PR is reworked in a more
maintainable and elegant way.

Fixes [#21151](https://issues.qgis.org/issues/21151)