### PR TITLE
Vertex tool: right-click to loop through editable features

### DIFF
--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -200,6 +200,21 @@ Optional filter may discard unwanted matches.
 Override of edgesInRect that construct rectangle from a center point and tolerance
 %End
 
+    MatchList verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = 0 );
+%Docstring
+Find vertices within a specified recangle
+Optional filter may discard unwanted matches.
+
+.. versionadded:: 3.6
+%End
+
+    MatchList verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = 0 );
+%Docstring
+Override of verticesInRect that construct rectangle from a center point and tolerance
+
+.. versionadded:: 3.6
+%End
+
 
     MatchList pointInPolygon( const QgsPointXY &point );
 %Docstring

--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -306,7 +306,7 @@ QgsVertexEditor::QgsVertexEditor( QgsMapCanvas *canvas )
   layout->setContentsMargins( 0, 0, 0, 0 );
 
   mHintLabel = new QLabel( this );
-  mHintLabel->setText( QStringLiteral( "%1\n\n%2" ).arg( tr( "Right click on the edge of an editable feature to show its table of vertices." ),
+  mHintLabel->setText( QStringLiteral( "%1\n\n%2" ).arg( tr( "Right click on an editable feature to show its table of vertices." ),
                        tr( "When a feature is bound to this panel, dragging a rectangle to select vertices on the canvas will only select those of the bound feature." ) ) );
   mHintLabel->setWordWrap( true );
   mHintLabel->setAlignment( Qt::AlignHCenter | Qt::AlignVCenter );

--- a/src/app/vertextool/qgsvertextool.h
+++ b/src/app/vertextool/qgsvertextool.h
@@ -146,7 +146,31 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     */
     QgsPointLocator::Match snapToEditableLayer( QgsMapMouseEvent *e );
 
+    /**
+     * Tries to find a match in polygon interiors. This is useful for mouse move
+     * events to keep features highlighted to see their area.
+     */
     QgsPointLocator::Match snapToPolygonInterior( QgsMapMouseEvent *e );
+
+    /**
+     * Returns a list of all matches at the given map point. That is a concatenation
+     * of all vertex, edge and area matches (vertex/edge matches using standard search tolerance).
+     * Layer is only searched if it is editable.
+     */
+    QList<QgsPointLocator::Match> findEditableLayerMatches( const QgsPointXY &mapPoint, QgsVectorLayer *layer );
+
+    /**
+     * Returns a set of all matches at the given map point from all editable layers (respecting the mode).
+     * The set does not contain only the closest match from each layer, but all matches in the standard
+     * vertex search tolerance. It also includes area matches.
+     */
+    QSet<QPair<QgsVectorLayer *, QgsFeatureId> > findAllEditableFeatures( const QgsPointXY &mapPoint );
+
+    /**
+     * Implements behavior for mouse right-click to select a feature for editing (and in case of multiple
+     * features in one place, repeated right-clicks will cycle through the features).
+     */
+    void tryToSelectFeature( QgsMapMouseEvent *e );
 
     //! check whether we are still close to the mEndpointMarker
     bool isNearEndpointMarker( const QgsPointXY &mapPoint );
@@ -415,6 +439,21 @@ class APP_EXPORT QgsVertexTool : public QgsMapToolAdvancedDigitizing
     std::unique_ptr<QgsSelectedFeature> mSelectedFeature;
     //! Dock widget which allows editing vertices
     std::unique_ptr<QgsVertexEditor> mVertexEditor;
+
+    /**
+     * Data structure that stores alternative features to the currently selected (locked) feature.
+     * This is used when user clicks with right mouse button multiple times in one location
+     * to easily switch to the desired feature.
+     */
+    struct SelectedFeatureAlternatives
+    {
+      QPoint screenPoint;
+      QList< QPair<QgsVectorLayer *, QgsFeatureId> > alternatives;
+      int index = -1;
+    };
+
+    //! Keeps information about other possible features to select with right click. Null if no info is currently held.
+    std::unique_ptr<SelectedFeatureAlternatives> mSelectedFeatureAlternatives;
 
     // support for validation of geometries
 

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -570,10 +570,12 @@ class QgsPointLocator_VisitorEdgesInRect : public IVisitor
  * \ingroup core
  * Helper class used when traversing the index looking for vertices - builds a list of matches.
  * \note not available in Python bindings
+ * \since QGIS 3.6
 */
 class QgsPointLocator_VisitorVerticesInRect : public IVisitor
 {
   public:
+    //! Constructs the visitor
     QgsPointLocator_VisitorVerticesInRect( QgsPointLocator *pl, QgsPointLocator::MatchList &lst, const QgsRectangle &srcRect, QgsPointLocator::MatchFilter *filter = nullptr )
       : mLocator( pl )
       , mList( lst )

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -564,6 +564,52 @@ class QgsPointLocator_VisitorEdgesInRect : public IVisitor
     QgsPointLocator::MatchFilter *mFilter = nullptr;
 };
 
+////////////////////////////////////////////////////////////////////////////
+
+/**
+ * \ingroup core
+ * Helper class used when traversing the index looking for vertices - builds a list of matches.
+ * \note not available in Python bindings
+*/
+class QgsPointLocator_VisitorVerticesInRect : public IVisitor
+{
+  public:
+    QgsPointLocator_VisitorVerticesInRect( QgsPointLocator *pl, QgsPointLocator::MatchList &lst, const QgsRectangle &srcRect, QgsPointLocator::MatchFilter *filter = nullptr )
+      : mLocator( pl )
+      , mList( lst )
+      , mSrcRect( srcRect )
+      , mFilter( filter )
+    {}
+
+    void visitNode( const INode &n ) override { Q_UNUSED( n ); }
+    void visitData( std::vector<const IData *> &v ) override { Q_UNUSED( v ); }
+
+    void visitData( const IData &d ) override
+    {
+      QgsFeatureId id = d.getIdentifier();
+      const QgsGeometry *geom = mLocator->mGeoms.value( id );
+
+      for ( QgsAbstractGeometry::vertex_iterator it = geom->vertices_begin(); it != geom->vertices_end(); ++it )
+      {
+        if ( mSrcRect.contains( *it ) )
+        {
+          QgsPointLocator::Match m( QgsPointLocator::Vertex, mLocator->mLayer, id, 0, *it, geom->vertexNrFromVertexId( it.vertexId() ) );
+
+          // in range queries the filter may reject some matches
+          if ( mFilter && !mFilter->acceptMatch( m ) )
+            continue;
+
+          mList << m;
+        }
+      }
+    }
+
+  private:
+    QgsPointLocator *mLocator = nullptr;
+    QgsPointLocator::MatchList &mList;
+    QgsRectangle mSrcRect;
+    QgsPointLocator::MatchFilter *mFilter = nullptr;
+};
 
 
 ////////////////////////////////////////////////////////////////////////////
@@ -1018,6 +1064,28 @@ QgsPointLocator::MatchList QgsPointLocator::edgesInRect( const QgsPointXY &point
 {
   QgsRectangle rect( point.x() - tolerance, point.y() - tolerance, point.x() + tolerance, point.y() + tolerance );
   return edgesInRect( rect, filter );
+}
+
+QgsPointLocator::MatchList QgsPointLocator::verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter )
+{
+  if ( !mRTree )
+  {
+    init();
+    if ( !mRTree ) // still invalid?
+      return MatchList();
+  }
+
+  MatchList lst;
+  QgsPointLocator_VisitorVerticesInRect visitor( this, lst, rect, filter );
+  mRTree->intersectsWithQuery( rect2region( rect ), visitor );
+
+  return lst;
+}
+
+QgsPointLocator::MatchList QgsPointLocator::verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter )
+{
+  QgsRectangle rect( point.x() - tolerance, point.y() - tolerance, point.x() + tolerance, point.y() + tolerance );
+  return verticesInRect( rect, filter );
 }
 
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -256,6 +256,19 @@ class CORE_EXPORT QgsPointLocator : public QObject
     //! Override of edgesInRect that construct rectangle from a center point and tolerance
     MatchList edgesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
 
+    /**
+     * Find vertices within a specified recangle
+     * Optional filter may discard unwanted matches.
+     * \since QGIS 3.6
+     */
+    MatchList verticesInRect( const QgsRectangle &rect, QgsPointLocator::MatchFilter *filter = nullptr );
+
+    /**
+     * Override of verticesInRect that construct rectangle from a center point and tolerance
+     * \since QGIS 3.6
+     */
+    MatchList verticesInRect( const QgsPointXY &point, double tolerance, QgsPointLocator::MatchFilter *filter = nullptr );
+
     // point-in-polygon query
 
     // TODO: function to return just the first match?
@@ -300,6 +313,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
     friend class QgsPointLocator_VisitorNearestEdge;
     friend class QgsPointLocator_VisitorArea;
     friend class QgsPointLocator_VisitorEdgesInRect;
+    friend class QgsPointLocator_VisitorVerticesInRect;
 };
 
 

--- a/tests/src/core/testqgspointlocator.cpp
+++ b/tests/src/core/testqgspointlocator.cpp
@@ -210,6 +210,24 @@ class TestQgsPointLocator : public QObject
       QCOMPARE( lst3.count(), 2 );
     }
 
+    void testVerticesInTolerance()
+    {
+      QgsPointLocator loc( mVL );
+      QgsPointLocator::MatchList lst = loc.verticesInRect( QgsPointXY( 0, 2 ), 0.5 );
+      QCOMPARE( lst.count(), 0 );
+
+      QgsPointLocator::MatchList lst2 = loc.verticesInRect( QgsPointXY( 0, 1.5 ), 0.5 );
+      QCOMPARE( lst2.count(), 2 );  // one matching point, but it is the first point in ring, so it is duplicated
+      QCOMPARE( lst2[0].vertexIndex(), 0 );
+      QCOMPARE( lst2[1].vertexIndex(), 3 );
+
+      QgsPointLocator::MatchList lst3 = loc.verticesInRect( QgsPointXY( 0, 1.5 ), 1 );
+      QCOMPARE( lst3.count(), 3 );
+      QCOMPARE( lst3[0].vertexIndex(), 0 );
+      QCOMPARE( lst3[1].vertexIndex(), 2 );
+      QCOMPARE( lst3[2].vertexIndex(), 3 );
+    }
+
 
     void testLayerUpdates()
     {


### PR DESCRIPTION
Continuation of usability fixes in the vertex tool...

Until now mouse right-click could only select and deselect the highlighted feature to "lock" vertex tool (and numerical editor) to it, so that it is easier to focus only on editing of the particular feature. It was however still difficult to pick the right feature in case there were multiple features in one location or very close to each other. This is now solved by the fact that repeated right button clicks will loop through the editable features. So if there are two features in one location (A, B) then repeated right-clicks will select: A - B - nothing - A - B - nothing ...

![peek 2019-02-04 22-16](https://user-images.githubusercontent.com/193367/52237831-d5fad080-28ca-11e9-9180-1f080f8c76ad.gif)

@nirvn @bstroebl As usual your feedback is highly appreciated :)