### PR TITLE
[MetaSearch] OWS GetCapabilities checking regression (fixes #19787) [needs-docs]

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -141,11 +141,6 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.mActionAddGisFile.triggered.connect(self.add_gis_file)
         self.btnShowXml.clicked.connect(self.show_xml)
 
-        # settings
-        self.radioTitleAsk.clicked.connect(self.set_ows_save_title_ask)
-        self.radioTitleNoAsk.clicked.connect(self.set_ows_save_title_no_ask)
-        self.radioTempName.clicked.connect(self.set_ows_save_temp_name)
-
         self.manageGui()
 
     def manageGui(self):
@@ -165,16 +160,6 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.set_bbox_global()
 
         self.reset_buttons()
-
-        # get preferred connection save strategy from settings and set it
-        save_strategy = self.settings.value('/MetaSearch/ows_save_strategy',
-                                            'title_ask')
-        if save_strategy == 'temp_name':
-            self.radioTempName.setChecked(True)
-        elif save_strategy == 'title_no_ask':
-            self.radioTitleNoAsk.setChecked(True)
-        else:
-            self.radioTitleAsk.setChecked(True)
 
         # install proxy handler if specified in QGIS settings
         self.install_proxy()
@@ -748,15 +733,10 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
 
         # check for duplicates
         if sname in keys:  # duplicate found
-            if self.radioTitleAsk.isChecked():  # ask to overwrite
-                msg = self.tr('Connection {0} exists. Overwrite?').format(sname)
-                res = QMessageBox.warning(self, self.tr('Saving server'), msg,
-                                          QMessageBox.Yes | QMessageBox.No)
-                if res != QMessageBox.Yes:  # assign new name with serial
-                    sname = serialize_string(sname)
-            elif self.radioTitleNoAsk.isChecked():  # don't ask to overwrite
-                pass
-            elif self.radioTempName.isChecked():  # use temp name
+            msg = self.tr('Connection {0} exists. Overwrite?').format(sname)
+            res = QMessageBox.warning(self, self.tr('Saving server'), msg,
+                                      QMessageBox.Yes | QMessageBox.No)
+            if res != QMessageBox.Yes:  # assign new name with serial
                 sname = serialize_string(sname)
 
         # no dups detected or overwrite is allowed

--- a/python/plugins/MetaSearch/ui/maindialog.ui
+++ b/python/plugins/MetaSearch/ui/maindialog.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tabSearch">
       <attribute name="title">
@@ -486,46 +486,6 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QGroupBox" name="saveStrategyGroup">
-         <property name="title">
-          <string>Connection Naming</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <widget class="QLabel" name="lblSaveStrategy">
-            <property name="text">
-             <string>When saving the connection of an OWS service</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="radioTitleAsk">
-            <property name="text">
-             <string>Use the OWS Service Title and ask before overwriting</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="radioTitleNoAsk">
-            <property name="text">
-             <string>Use the OWS Service Title and always overwrite if already available</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="radioTempName">
-            <property name="text">
-             <string>Use a temporary name, which you can change later</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
         <widget class="QGroupBox" name="groupBox_4">
          <property name="title">
           <string>Server Timeout</string>
@@ -606,6 +566,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgis.gui</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>
@@ -641,11 +608,4 @@
    </hints>
   </connection>
  </connections>
- <customwidgets>
-  <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgis.gui</header>
-  </customwidget>
- </customwidgets>
 </ui>


### PR DESCRIPTION
## Description

- Fixes regression as per https://issues.qgis.org/issues/19787
- note removes some UI text from MetaSearch Settings tab 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
