### PR TITLE
[processing] Port matrix widget wrapper to newer c++ API

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -199,6 +199,7 @@ SET(QGIS_GUI_SRCS
   processing/qgsprocessingalgorithmdialogbase.cpp
   processing/qgsprocessingconfigurationwidgets.cpp
   processing/qgsprocessingguiregistry.cpp
+  processing/qgsprocessingmatrixparameterdialog.cpp
   processing/qgsprocessingmodelerparameterwidget.cpp
   processing/qgsprocessingrecentalgorithmlog.cpp
   processing/qgsprocessingtoolboxmodel.cpp
@@ -741,6 +742,7 @@ SET(QGIS_GUI_MOC_HDRS
   processing/qgsprocessingalgorithmconfigurationwidget.h
   processing/qgsprocessingalgorithmdialogbase.h
   processing/qgsprocessingconfigurationwidgets.h
+  processing/qgsprocessingmatrixparameterdialog.h
   processing/qgsprocessingmodelerparameterwidget.h
   processing/qgsprocessingrecentalgorithmlog.h
   processing/qgsprocessingtoolboxmodel.h

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -34,6 +34,7 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingDistanceWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingRangeWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingAuthConfigWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingMatrixWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/gui/processing/qgsprocessingmatrixparameterdialog.cpp
+++ b/src/gui/processing/qgsprocessingmatrixparameterdialog.cpp
@@ -1,0 +1,192 @@
+/***************************************************************************
+                             qgsprocessingmatrixparameterdialog.cpp
+                             ------------------------------------
+    Date                 : February 2019
+    Copyright            : (C) 2019 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsprocessingmatrixparameterdialog.h"
+#include "qgsgui.h"
+#include <QStandardItemModel>
+#include <QStandardItem>
+#include <QPushButton>
+#include <QLineEdit>
+#include <QToolButton>
+
+///@cond NOT_STABLE
+
+QgsProcessingMatrixParameterDialog::QgsProcessingMatrixParameterDialog( QWidget *parent, Qt::WindowFlags flags, const QgsProcessingParameterMatrix *param, const QVariantList &initialTable )
+  : QDialog( parent, flags )
+  , mParam( param )
+{
+  setupUi( this );
+
+  QgsGui::enableAutoGeometryRestore( this );
+
+  mTblView->setSelectionBehavior( QAbstractItemView::SelectRows );
+  mTblView->setSelectionMode( QAbstractItemView::ExtendedSelection );
+
+  mButtonAdd = new QPushButton( tr( "Add Row" ) );
+  mButtonBox->addButton( mButtonAdd, QDialogButtonBox::ActionRole );
+
+  mButtonRemove = new QPushButton( tr( "Remove Row(s)" ) );
+  mButtonBox->addButton( mButtonRemove, QDialogButtonBox::ActionRole );
+
+  mButtonRemoveAll = new QPushButton( tr( "Remove All" ) );
+  mButtonBox->addButton( mButtonRemoveAll, QDialogButtonBox::ActionRole );
+
+  connect( mButtonAdd, &QPushButton::clicked, this, &QgsProcessingMatrixParameterDialog::addRow );
+  connect( mButtonRemove, &QPushButton::clicked, this, &QgsProcessingMatrixParameterDialog::deleteRow );
+  connect( mButtonRemoveAll, &QPushButton::clicked, this, &QgsProcessingMatrixParameterDialog::deleteAllRows );
+
+  if ( param && param->hasFixedNumberRows() )
+  {
+    mButtonAdd->setEnabled( false );
+    mButtonRemove->setEnabled( false );
+    mButtonRemoveAll->setEnabled( false );
+  }
+
+  populateTable( initialTable );
+}
+
+QVariantList QgsProcessingMatrixParameterDialog::table() const
+{
+  const int cols = mModel->columnCount();
+  const int rows = mModel->rowCount();
+  // Table MUST BE 1-dimensional to match core QgsProcessingParameterMatrix expectations
+  QVariantList res;
+  res.reserve( cols * rows );
+  for ( int row = 0; row < rows; ++row )
+  {
+    for ( int col = 0; col < cols; ++col )
+    {
+      res << mModel->item( row, col )->text();
+    }
+  }
+  return res;
+}
+
+void QgsProcessingMatrixParameterDialog::addRow()
+{
+  QList< QStandardItem * > items;
+  for ( int i = 0; i < mTblView->model()->columnCount(); ++i )
+  {
+    items << new QStandardItem( '0' );
+  }
+  mModel->appendRow( items );
+}
+
+void QgsProcessingMatrixParameterDialog::deleteRow()
+{
+  QModelIndexList selected = mTblView->selectionModel()->selectedRows();
+  QSet< int > rows;
+  rows.reserve( selected.count() );
+  for ( const QModelIndex &i : selected )
+    rows << i.row();
+
+  QList< int > rowsToDelete = rows.toList();
+  std::sort( rowsToDelete.begin(), rowsToDelete.end(), std::greater<int>() );
+  mTblView->setUpdatesEnabled( false );
+  for ( int i : qgis::as_const( rowsToDelete ) )
+    mModel->removeRows( i, 1 );
+
+  mTblView->setUpdatesEnabled( true );
+}
+
+void QgsProcessingMatrixParameterDialog::deleteAllRows()
+{
+  mModel->clear();
+  if ( mParam )
+    mModel->setHorizontalHeaderLabels( mParam->headers() );
+}
+
+void QgsProcessingMatrixParameterDialog::populateTable( const QVariantList &contents )
+{
+  if ( !mParam )
+    return;
+
+  const int cols = mParam->headers().count();
+  const int rows = contents.length() / cols;
+  mModel = new QStandardItemModel( rows, cols, this );
+  mModel->setHorizontalHeaderLabels( mParam->headers() );
+
+  for ( int row = 0; row < rows; ++row )
+  {
+    for ( int col = 0; col < cols; ++col )
+    {
+      QStandardItem *item = new QStandardItem( contents.at( row * cols + col ).toString() );
+      mModel->setItem( row, col, item );
+    }
+  }
+  mTblView->setModel( mModel );
+}
+
+//
+// QgsProcessingMatrixParameterPanel
+//
+
+QgsProcessingMatrixParameterPanel::QgsProcessingMatrixParameterPanel( QWidget *parent, const QgsProcessingParameterMatrix *param )
+  : QWidget( parent )
+  , mParam( param )
+{
+  QHBoxLayout *hl = new QHBoxLayout();
+  hl->setMargin( 0 );
+  hl->setContentsMargins( 0, 0, 0, 0 );
+
+  mLineEdit = new QLineEdit();
+  mLineEdit->setEnabled( false );
+  hl->addWidget( mLineEdit, 1 );
+
+  mToolButton = new QToolButton();
+  mToolButton->setText( tr( "…" ) );
+  hl->addWidget( mToolButton );
+
+  setLayout( hl );
+
+  if ( mParam )
+  {
+    for ( int row = 0; row < mParam->numberRows(); ++row )
+    {
+      for ( int col = 0; col < mParam->headers().count(); ++col )
+      {
+        mTable.append( '0' );
+      }
+    }
+    mLineEdit->setText( tr( "Fixed table (%1x%2)" ).arg( mParam->numberRows() ).arg( mParam->headers().count() ) );
+  }
+
+  connect( mToolButton, &QToolButton::clicked, this, &QgsProcessingMatrixParameterPanel::showDialog );
+}
+
+void QgsProcessingMatrixParameterPanel::setValue( const QVariantList &value )
+{
+  mTable = value;
+  updateSummaryText();
+  emit changed();
+}
+
+void QgsProcessingMatrixParameterPanel::showDialog()
+{
+  QgsProcessingMatrixParameterDialog dlg( this, nullptr, mParam, mTable );
+  if ( dlg.exec() )
+  {
+    setValue( dlg.table() );
+  }
+}
+
+void QgsProcessingMatrixParameterPanel::updateSummaryText()
+{
+  if ( mParam )
+    mLineEdit->setText( tr( "Fixed table (%1x%2)" ).arg( mTable.count() / mParam->headers().count() ).arg( mParam->headers().count() ) );
+}
+
+
+///@endcond

--- a/src/gui/processing/qgsprocessingmatrixparameterdialog.h
+++ b/src/gui/processing/qgsprocessingmatrixparameterdialog.h
@@ -1,0 +1,115 @@
+/***************************************************************************
+                             qgsprocessingmatrixparameterdialog.h
+                             ----------------------------------
+    Date                 : February 2019
+    Copyright            : (C) 2019 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPROCESSINGMATRIXPARAMETERDIALOG_H
+#define QGSPROCESSINGMATRIXPARAMETERDIALOG_H
+
+#include "qgis.h"
+#include "qgis_gui.h"
+#include "ui_qgsprocessingmatrixparameterdialogbase.h"
+#include "qgsprocessingparameters.h"
+
+#define SIP_NO_FILE
+
+class QStandardItemModel;
+class QToolButton;
+
+///@cond NOT_STABLE
+
+/**
+ * \ingroup gui
+ * \brief Dialog for configuration of a matrix (fixed table) parameter.
+ * \note Not stable API
+ * \since QGIS 3.6
+ */
+class GUI_EXPORT QgsProcessingMatrixParameterDialog : public QDialog, private Ui::QgsProcessingMatrixParameterDialogBase
+{
+    Q_OBJECT
+
+  public:
+
+    /**
+     * Constructor for QgsProcessingMatrixParameterDialog.
+     */
+    QgsProcessingMatrixParameterDialog( QWidget *parent SIP_TRANSFERTHIS = nullptr, Qt::WindowFlags flags = nullptr, const QgsProcessingParameterMatrix *param = nullptr,
+                                        const QVariantList &initialTable = QVariantList() );
+
+    /**
+     * Returns the table's contents as a 1 dimensional array.
+     */
+    QVariantList table() const;
+
+  private slots:
+
+    void addRow();
+    void deleteRow();
+    void deleteAllRows();
+
+  private:
+
+    QPushButton *mButtonAdd = nullptr;
+    QPushButton *mButtonRemove = nullptr;
+    QPushButton *mButtonRemoveAll = nullptr;
+    const QgsProcessingParameterMatrix *mParam = nullptr;
+    QStandardItemModel *mModel = nullptr;
+
+    void populateTable( const QVariantList &contents );
+
+    friend class TestProcessingGui;
+};
+
+
+/**
+ * \ingroup gui
+ * \brief Widget for configuration of a matrix (fixed table) parameter.
+ * \note Not stable API
+ * \since QGIS 3.6
+ */
+class GUI_EXPORT QgsProcessingMatrixParameterPanel : public QWidget
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingMatrixParameterPanel( QWidget *parent = nullptr, const QgsProcessingParameterMatrix *param = nullptr );
+
+    QVariantList value() const { return mTable; }
+
+    void setValue( const QVariantList &value );
+
+  signals:
+
+    void changed();
+
+  private slots:
+
+    void showDialog();
+
+  private:
+
+    void updateSummaryText();
+
+    const QgsProcessingParameterMatrix *mParam = nullptr;
+    QLineEdit *mLineEdit = nullptr;
+    QToolButton *mToolButton = nullptr;
+
+    QVariantList mTable;
+
+    friend class TestProcessingGui;
+};
+
+///@endcond
+
+#endif // QGSPROCESSINGMATRIXPARAMETERDIALOG_H

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -19,6 +19,7 @@
 #include "qgsprocessingparameters.h"
 #include "qgsprocessingoutputs.h"
 #include "qgsprojectionselectionwidget.h"
+#include "qgsprocessingmatrixparameterdialog.h"
 #include "qgsspinbox.h"
 #include "qgsdoublespinbox.h"
 #include "qgsprocessingcontext.h"
@@ -1021,6 +1022,86 @@ QString QgsProcessingRangeWidgetWrapper::parameterType() const
 QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingRangeWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
 {
   return new QgsProcessingRangeWidgetWrapper( parameter, type );
+}
+
+
+
+//
+// QgsProcessingMatrixWidgetWrapper
+//
+
+QgsProcessingMatrixWidgetWrapper::QgsProcessingMatrixWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type, QWidget *parent )
+  : QgsAbstractProcessingParameterWidgetWrapper( parameter, type, parent )
+{
+
+}
+
+QWidget *QgsProcessingMatrixWidgetWrapper::createWidget()
+{
+  mMatrixWidget = new QgsProcessingMatrixParameterPanel( nullptr, dynamic_cast< const QgsProcessingParameterMatrix *>( parameterDefinition() ) );
+  mMatrixWidget->setToolTip( parameterDefinition()->toolTip() );
+
+  connect( mMatrixWidget, &QgsProcessingMatrixParameterPanel::changed, this, [ = ]
+  {
+    emit widgetValueHasChanged( this );
+  } );
+
+  switch ( type() )
+  {
+    case QgsProcessingGui::Standard:
+    case QgsProcessingGui::Batch:
+    case QgsProcessingGui::Modeler:
+    {
+      return mMatrixWidget;
+    };
+  }
+  return nullptr;
+}
+
+void QgsProcessingMatrixWidgetWrapper::setWidgetValue( const QVariant &value, QgsProcessingContext &context )
+{
+  const QVariantList v = QgsProcessingParameters::parameterAsMatrix( parameterDefinition(), value, context );
+  if ( mMatrixWidget )
+    mMatrixWidget->setValue( v );
+}
+
+QVariant QgsProcessingMatrixWidgetWrapper::widgetValue() const
+{
+  if ( mMatrixWidget )
+    return mMatrixWidget->value().isEmpty() ? QVariant() : mMatrixWidget->value();
+  else
+    return QVariant();
+}
+
+QStringList QgsProcessingMatrixWidgetWrapper::compatibleParameterTypes() const
+{
+  return QStringList()
+         << QgsProcessingParameterMatrix::typeName();
+}
+
+QStringList QgsProcessingMatrixWidgetWrapper::compatibleOutputTypes() const
+{
+  return QStringList();
+}
+
+QList<int> QgsProcessingMatrixWidgetWrapper::compatibleDataTypes() const
+{
+  return QList< int >();
+}
+
+QString QgsProcessingMatrixWidgetWrapper::modelerExpressionFormatString() const
+{
+  return tr( "comma delimited string of values, or an array of values" );
+}
+
+QString QgsProcessingMatrixWidgetWrapper::parameterType() const
+{
+  return QgsProcessingParameterMatrix::typeName();
+}
+
+QgsAbstractProcessingParameterWidgetWrapper *QgsProcessingMatrixWidgetWrapper::createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type )
+{
+  return new QgsProcessingMatrixWidgetWrapper( parameter, type );
 }
 
 

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -30,6 +30,7 @@ class QgsProjectionSelectionWidget;
 class QgsSpinBox;
 class QgsDoubleSpinBox;
 class QgsAuthConfigSelect;
+class QgsProcessingMatrixParameterPanel;
 
 ///@cond PRIVATE
 
@@ -285,6 +286,40 @@ class GUI_EXPORT QgsProcessingRangeWidgetWrapper : public QgsAbstractProcessingP
   private:
 
     int mBlockChangedSignal = 0;
+
+    friend class TestProcessingGui;
+};
+
+
+class GUI_EXPORT QgsProcessingMatrixWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingMatrixWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                      QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+    // QgsProcessingParameterWidgetWrapper interface
+    QWidget *createWidget() override SIP_FACTORY;
+
+  protected:
+
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
+    QVariant widgetValue() const override;
+
+    QStringList compatibleParameterTypes() const override;
+    QStringList compatibleOutputTypes() const override;
+    QList< int > compatibleDataTypes() const override;
+    QString modelerExpressionFormatString() const override;
+
+  private:
+
+    QgsProcessingMatrixParameterPanel *mMatrixWidget = nullptr;
 
     friend class TestProcessingGui;
 };

--- a/src/ui/processing/qgsprocessingmatrixparameterdialogbase.ui
+++ b/src/ui/processing/qgsprocessingmatrixparameterdialogbase.ui
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsProcessingMatrixParameterDialogBase</class>
+ <widget class="QDialog" name="QgsProcessingMatrixParameterDialogBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>380</width>
+    <height>320</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Fixed table</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="spacing">
+    <number>6</number>
+   </property>
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <item>
+    <widget class="QTableView" name="mTblView">
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsProcessingMatrixParameterDialogBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsProcessingMatrixParameterDialogBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Allows matrix parameters to be correctly set for model child algorithms. Also fully covered by unit tests.

Fixes #20914
