### PR TITLE
MetaSearch: add version to settings tab

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -42,7 +42,7 @@ from qgis.core import (QgsApplication, QgsCoordinateReferenceSystem,
                        QgsCoordinateTransform, QgsGeometry, QgsPointXY,
                        QgsProviderRegistry, QgsSettings, QgsProject)
 from qgis.gui import QgsRubberBand
-from qgis.utils import OverrideCursor
+from qgis.utils import OverrideCursor, pluginMetadata
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=ResourceWarning)
@@ -140,6 +140,10 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
         self.mActionAddAfs.triggered.connect(self.add_to_ows)
         self.mActionAddGisFile.triggered.connect(self.add_gis_file)
         self.btnShowXml.clicked.connect(self.show_xml)
+
+        # Settings tab
+        self.lblVersion.setText('MetaSearch version: {}'.format(
+            pluginMetadata('MetaSearch', 'version')))
 
         self.manageGui()
 

--- a/python/plugins/MetaSearch/ui/maindialog.ui
+++ b/python/plugins/MetaSearch/ui/maindialog.ui
@@ -550,6 +550,13 @@
          </property>
         </spacer>
        </item>
+       <item>
+        <widget class="QLabel" name="lblVersion">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>


### PR DESCRIPTION
## Description
This PR adds a label to MetaSearch's Settings tab to display the version of the plugin, which can be helpful when diagnosing issues.  Note that I previously had this in the window title which had been removed for useability.  Hopefully this addition is less intrusive.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
