### PR TITLE
Don't add extra linebreak in print composer tables

### DIFF
--- a/src/core/layout/qgslayouttable.cpp
+++ b/src/core/layout/qgslayouttable.cpp
@@ -1157,6 +1157,12 @@ QString QgsLayoutTable::wrappedText( const QString &value, double columnWidth, c
         int lastPos = remainingText.lastIndexOf( ' ' );
         while ( lastPos > -1 )
         {
+          //check if remaining text is short enough to go in one line
+          if ( !textRequiresWrapping( remainingText, columnWidth, font ) )
+          {
+            break;
+          }
+
           if ( !textRequiresWrapping( remainingText.left( lastPos ), columnWidth, font ) )
           {
             outLines << remainingText.left( lastPos );

--- a/tests/src/core/testqgslayouttable.cpp
+++ b/tests/src/core/testqgslayouttable.cpp
@@ -71,6 +71,7 @@ class TestQgsLayoutTable : public QObject
     void cellStyles(); //test cell styles
     void cellStylesRender(); //test rendering cell styles
     void dataDefinedSource();
+    void wrappedText();
 
   private:
     QgsVectorLayer *mVectorLayer = nullptr;
@@ -1410,6 +1411,20 @@ void TestQgsLayoutTable::dataDefinedSource()
   table->refreshAttributes();
   QCOMPARE( table->contents().length(), 1 );
   QCOMPARE( table->contents().at( 0 ), QVector< QVariant >() << 1 << 2 << 3 );
+}
+
+void TestQgsLayoutTable::wrappedText()
+{
+    QgsProject p;
+    QgsLayout l( &p );
+    QgsLayoutItemAttributeTable* t = new QgsLayoutItemAttributeTable( &l );
+    t->setWrapBehavior( QgsLayoutTable::WrapText );
+
+    QFont f;
+    QString sourceText( "Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua" );
+    QString wrapText = t->wrappedText( sourceText, 100 /*columnWidth*/, f );
+    //there should be no line break before the last word (bug #20546)
+    QVERIFY( !wrapText.endsWith( "\naliqua" ) );
 }
 
 QGSTEST_MAIN( TestQgsLayoutTable )

--- a/tests/src/core/testqgslayouttable.cpp
+++ b/tests/src/core/testqgslayouttable.cpp
@@ -1415,16 +1415,16 @@ void TestQgsLayoutTable::dataDefinedSource()
 
 void TestQgsLayoutTable::wrappedText()
 {
-    QgsProject p;
-    QgsLayout l( &p );
-    QgsLayoutItemAttributeTable* t = new QgsLayoutItemAttributeTable( &l );
-    t->setWrapBehavior( QgsLayoutTable::WrapText );
+  QgsProject p;
+  QgsLayout l( &p );
+  QgsLayoutItemAttributeTable *t = new QgsLayoutItemAttributeTable( &l );
+  t->setWrapBehavior( QgsLayoutTable::WrapText );
 
-    QFont f;
-    QString sourceText( "Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua" );
-    QString wrapText = t->wrappedText( sourceText, 100 /*columnWidth*/, f );
-    //there should be no line break before the last word (bug #20546)
-    QVERIFY( !wrapText.endsWith( "\naliqua" ) );
+  QFont f;
+  QString sourceText( "Lorem ipsum dolor sit amet, consectetur adipisici elit, sed eiusmod tempor incidunt ut labore et dolore magna aliqua" );
+  QString wrapText = t->wrappedText( sourceText, 100 /*columnWidth*/, f );
+  //there should be no line break before the last word (bug #20546)
+  QVERIFY( !wrapText.endsWith( "\naliqua" ) );
 }
 
 QGSTEST_MAIN( TestQgsLayoutTable )


### PR DESCRIPTION
The line break algorithm of QgsLayoutTable::wrappedText does not check if the remaining text is short enough to go in one line. Therefore it can often be ovserved that a single word is on the last line, even if there is enough space on the second to last line (https://issues.qgis.org/issues/20546)

This PR provides a fix.
