### PR TITLE
 [browser] Avoid always opening every file using gdal to test for update capabilities

### DIFF
--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -206,10 +206,12 @@ Items that return valid URI will be returned in mime data when dragging a select
     typedef QFlags<QgsDataItem::Capability> Capabilities;
 
 
-    virtual bool setCrs( const QgsCoordinateReferenceSystem &crs );
+ virtual bool setCrs( const QgsCoordinateReferenceSystem &crs ) /Deprecated/;
 %Docstring
 Writes the selected crs into data source. The original data source will be modified when calling this
 method.
+
+.. deprecated:: since QGIS 3.6. This method is no longer used by QGIS and will be removed in QGIS 4.0.
 %End
 
     virtual bool rename( const QString &name );

--- a/src/core/geocms/geonode/qgsgeonodeconnection.cpp
+++ b/src/core/geocms/geonode/qgsgeonodeconnection.cpp
@@ -48,7 +48,7 @@ QgsGeoNodeConnection::QgsGeoNodeConnection( const QString &name )
     mUri.setParam( QStringLiteral( "authcfg" ), authcfg );
   }
 
-  QgsDebugMsg( QStringLiteral( "encodedUri: '%1'." ).arg( QString( mUri.encodedUri() ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "encodedUri: '%1'." ).arg( QString( mUri.encodedUri() ) ), 4 );
 }
 
 QgsDataSourceUri QgsGeoNodeConnection::uri() const

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -207,7 +207,7 @@ class CORE_EXPORT QgsDataItem : public QObject
     enum Capability
     {
       NoCapabilities    = 0,
-      SetCrs            = 1 << 0, //!< Can set CRS on layer or group of layers
+      SetCrs            = 1 << 0, //!< Can set CRS on layer or group of layers. \deprecated in QGIS 3.6 -- no longer used by QGIS and will be removed in QGIS 4.0
       Fertile           = 1 << 1, //!< Can create children. Even items without this capability may have children, but cannot create them, it means that children are created by item ancestors.
       Fast              = 1 << 2, //!< CreateChildren() is fast enough to be run in main thread when refreshing items, most root items (wms,wfs,wcs,postgres...) are considered fast because they are reading data only from QgsSettings
       Collapse          = 1 << 3, //!< The collapse/expand status for this items children should be ignored in order to avoid undesired network connections (wms etc.)
@@ -219,8 +219,14 @@ class CORE_EXPORT QgsDataItem : public QObject
     /**
      * Writes the selected crs into data source. The original data source will be modified when calling this
      * method.
+     *
+     * \deprecated since QGIS 3.6. This method is no longer used by QGIS and will be removed in QGIS 4.0.
      */
-    virtual bool setCrs( const QgsCoordinateReferenceSystem &crs ) { Q_UNUSED( crs ); return false; }
+    Q_DECL_DEPRECATED virtual bool setCrs( const QgsCoordinateReferenceSystem &crs ) SIP_DEPRECATED
+    {
+      Q_UNUSED( crs );
+      return false;
+    }
 
     /**
      * Sets a new \a name for the item, and returns true if the item was successfully renamed.

--- a/src/core/qgslogger.cpp
+++ b/src/core/qgslogger.cpp
@@ -85,7 +85,7 @@ void QgsLogger::debug( const QString &msg, int debuglevel, const char *file, con
     if ( line != -1 )
     {
 #ifndef _MSC_VER
-      m.prepend( QStringLiteral( ": %1:" ).arg( line ) );
+      m.prepend( QStringLiteral( ":%1 :" ).arg( line ) );
 #else
       m.prepend( QString( "(%1) :" ).arg( line ) );
 #endif

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -38,7 +38,7 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
   : mConnName( connName )
   , mService( service )
 {
-  QgsDebugMsg( "theConnName = " + connName );
+  QgsDebugMsgLevel( "theConnName = " + connName, 4 );
 
   QgsSettings settings;
 
@@ -82,7 +82,7 @@ QgsOwsConnection::QgsOwsConnection( const QString &service, const QString &connN
     addWfsConnectionSettings( mUri, key );
   }
 
-  QgsDebugMsg( QStringLiteral( "encoded uri: '%1'." ).arg( QString( mUri.encodedUri() ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "encoded uri: '%1'." ).arg( QString( mUri.encodedUri() ) ), 4 );
 }
 
 QString QgsOwsConnection::connectionName() const

--- a/src/gui/qgsbrowserdockwidget.cpp
+++ b/src/gui/qgsbrowserdockwidget.cpp
@@ -305,11 +305,11 @@ void QgsBrowserDockWidget::refreshModel( const QModelIndex &index )
     QgsDataItem *item = mModel->dataItem( index );
     if ( item )
     {
-      QgsDebugMsg( "path = " + item->path() );
+      QgsDebugMsgLevel( "path = " + item->path(), 4 );
     }
     else
     {
-      QgsDebugMsg( QStringLiteral( "invalid item" ) );
+      QgsDebugMsgLevel( QStringLiteral( "invalid item" ), 4 );
     }
 
     if ( item && ( item->capabilities2() & QgsDataItem::Fertile ) )

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -48,14 +48,6 @@ QgsGdalLayerItem::QgsGdalLayerItem( QgsDataItem *parent,
   }
   else
     setState( Populated );
-
-  GDALAllRegister();
-  gdal::dataset_unique_ptr hDS( GDALOpen( mPath.toUtf8().constData(), GA_Update ) );
-
-  if ( hDS )
-  {
-    mCapabilities |= SetCrs;
-  }
 }
 
 

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -53,30 +53,11 @@ QgsOgrLayerItem::QgsOgrLayerItem( QgsDataItem *parent,
   mIsSubLayer = isSubLayer;
   mToolTip = uri;
   setState( Populated ); // children are not expected
-
-  if ( mPath.endsWith( QLatin1String( ".shp" ), Qt::CaseInsensitive ) )
-  {
-    if ( OGRGetDriverCount() == 0 )
-    {
-      OGRRegisterAll();
-    }
-    gdal::dataset_unique_ptr hDataSource( GDALOpenEx( mPath.toUtf8().constData(), GDAL_OF_VECTOR | GDAL_OF_UPDATE, nullptr, nullptr, nullptr ) );
-    if ( hDataSource )
-    {
-      mCapabilities |= SetCrs;
-    }
-
-    // It it is impossible to assign a crs to an existing layer
-    // No OGR_L_SetSpatialRef : http://trac.osgeo.org/gdal/ticket/4032
-  }
 }
 
 
 bool QgsOgrLayerItem::setCrs( const QgsCoordinateReferenceSystem &crs )
 {
-  if ( !( mCapabilities & SetCrs ) )
-    return false;
-
   QString layerName = mPath.left( mPath.indexOf( QLatin1String( ".shp" ), Qt::CaseInsensitive ) );
   QString wkt = crs.toWkt();
 

--- a/src/providers/wfs/qgswfsconnection.cpp
+++ b/src/providers/wfs/qgswfsconnection.cpp
@@ -53,7 +53,7 @@ QgsWfsConnection::QgsWfsConnection( const QString &connName )
                    settings.value( key + "/" + QgsWFSConstants::SETTINGS_PAGING_ENABLED, true ).toBool() ? QStringLiteral( "true" ) : QStringLiteral( "false" ) );
   }
 
-  QgsDebugMsg( QStringLiteral( "WFS full uri: '%1'." ).arg( QString( mUri.uri() ) ) );
+  QgsDebugMsgLevel( QStringLiteral( "WFS full uri: '%1'." ).arg( QString( mUri.uri() ) ), 4 );
 }
 
 QStringList QgsWfsConnection::connectionList()

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1912,105 +1912,38 @@
                  <property name="title">
                   <string>Data source handling</string>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_24">
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_14">
-                    <item>
-                     <widget class="QLabel" name="label_30">
-                      <property name="text">
-                       <string>Scan for valid items in the browser dock</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_12">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="cmbScanItemsInBrowser"/>
-                    </item>
-                   </layout>
+                 <layout class="QGridLayout" name="gridLayout_23" columnstretch="0,2,1,0">
+                  <item row="0" column="2">
+                   <widget class="QComboBox" name="cmbScanItemsInBrowser"/>
                   </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_13">
-                    <item>
-                     <widget class="QLabel" name="label_29">
-                      <property name="text">
-                       <string>Scan for contents of compressed files (.zip) in browser dock</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_11">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="cmbScanZipInBrowser">
-                      <property name="currentIndex">
-                       <number>-1</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_29">
+                    <property name="text">
+                     <string>Scan for contents of compressed files (.zip) in browser dock</string>
+                    </property>
+                   </widget>
                   </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_12">
-                    <item>
-                     <widget class="QLabel" name="textLabel1_13">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Prompt for raster sublayers when opening</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_10">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QComboBox" name="cmbPromptRasterSublayers">
-                      <item>
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </item>
-                     </widget>
-                    </item>
-                   </layout>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="textLabel1_13">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Prompt for raster sublayers when opening</string>
+                    </property>
+                   </widget>
                   </item>
-                  <item>
+                  <item row="6" column="0" colspan="4">
+                   <widget class="QCheckBox" name="cbxCompileExpressions">
+                    <property name="text">
+                     <string>Execute expressions on server-side if possible</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0" colspan="4">
                    <widget class="QCheckBox" name="cbxIgnoreShapeEncoding">
                     <property name="toolTip">
                      <string>Disable OGR on-the-fly conversion from declared encoding to UTF-8</string>
@@ -2020,28 +1953,28 @@
                     </property>
                    </widget>
                   </item>
-                  <item>
+                  <item row="4" column="0" colspan="4">
                    <widget class="QCheckBox" name="cbxAddPostgisDC">
                     <property name="text">
                      <string>Add PostGIS layers with double-click and select in extended mode</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
+                  <item row="5" column="0" colspan="4">
                    <widget class="QCheckBox" name="cbxAddOracleDC">
                     <property name="text">
                      <string>Add Oracle layers with double-click and select in extended mode</string>
                     </property>
                    </widget>
                   </item>
-                  <item>
-                   <widget class="QCheckBox" name="cbxCompileExpressions">
-                    <property name="text">
-                     <string>Execute expressions on server-side if possible</string>
+                  <item row="1" column="2">
+                   <widget class="QComboBox" name="cmbScanZipInBrowser">
+                    <property name="currentIndex">
+                     <number>-1</number>
                     </property>
                    </widget>
                   </item>
-                  <item>
+                  <item row="7" column="0" colspan="4">
                    <widget class="QCheckBox" name="cbxEvaluateDefaultValues">
                     <property name="toolTip">
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When digitizing a new feature, default values are retrieved from the database. With this option turned on, the default values will be evaluated at the time of digitizing. With this option turned off, the default values will be evaluated at the time of saving.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -2050,6 +1983,35 @@
                      <string>Evaluate default values</string>
                     </property>
                    </widget>
+                  </item>
+                  <item row="2" column="2">
+                   <widget class="QComboBox" name="cmbPromptRasterSublayers">
+                    <item>
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_30">
+                    <property name="text">
+                     <string>Scan for valid items in the browser dock</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <spacer name="horizontalSpacer_3">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
                   </item>
                  </layout>
                 </widget>
@@ -4203,7 +4165,14 @@ The bigger the number, the faster zooming with the mouse wheel will be.</string>
                    </widget>
                   </item>
                   <item row="5" column="2">
-                   <widget class="QgsColorButton" name="mSnappingMarkerColorButton"/>
+                   <widget class="QgsColorButton" name="mSnappingMarkerColorButton">
+                    <property name="minimumSize">
+                     <size>
+                      <width>120</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </widget>
                   </item>
                   <item row="6" column="0" colspan="4">
                    <widget class="QCheckBox" name="mSnappingTooltipsCheckbox">


### PR DESCRIPTION
This is no longer required - it was previously done in order to
detect if the item should expose the SetCrs capability, but
that's deprecated and unused.

Fixes #16807, fixes #20411, and avoids QGIS opening every file encountered in
the browser even when the Data Source setting is set to the
default (fast) "Check Extension" setting only.