### PR TITLE
Resurrect dedicated action to create virtual layers in main window

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -744,6 +744,7 @@
         <file>themes/default/mIconFieldBool.svg</file>
         <file>themes/default/mIconDataDefineColor.svg</file>
         <file>themes/default/mIconDataDefineColorOn.svg</file>
+        <file>themes/default/mActionNewVirtualLayer.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/mActionNewVirtualLayer.svg
+++ b/images/themes/default/mActionNewVirtualLayer.svg
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg39"
+   sodipodi:docname="mActionNewVirtualLayer.svg"
+   inkscape:version="0.92.4 (unknown)">
+  <metadata
+     id="metadata45">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs43" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3840"
+     inkscape:window-height="2031"
+     id="namedview41"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="5.5084741"
+     inkscape:cy="15.932203"
+     inkscape:window-x="0"
+     inkscape:window-y="55"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg39">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4606" />
+  </sodipodi:namedview>
+  <linearGradient
+     id="a"
+     gradientUnits="userSpaceOnUse"
+     x1="33.051174"
+     x2="4.6237812"
+     y1="35.070534"
+     y2="4.7282839"
+     gradientTransform="matrix(0.78185227,0,0,0.7818667,-0.53814044,-0.51053502)">
+    <stop
+       offset="0"
+       stop-color="#6e97c4"
+       id="stop2" />
+    <stop
+       offset="1"
+       stop-color="#ecedef"
+       id="stop4" />
+  </linearGradient>
+  <path
+     inkscape:connector-curvature="0"
+     style="overflow:visible;fill:url(#a);stroke:#2e4e72;stroke-width:0.49999997"
+     id="path7"
+     overflow="visible"
+     d="M 2.7635417,1.2486651 H 21.179451 c 0.857905,0 1.542514,0.6887606 1.542514,1.5518652 V 21.172272 c 0,0.863104 -0.684609,1.577728 -1.542514,1.577728 H 2.7635417 c -0.8579045,0 -1.5425144,-0.714624 -1.5425144,-1.577728 V 2.8005303 c 0,-0.8631046 0.6846099,-1.5518652 1.5425144,-1.5518652 z" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path9"
+     style="overflow:visible;fill:none;stroke:#415a75;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round"
+     d="M 2.1983425,2.2259985 8.4531608,17.863327 15.489831,2.2259985 h 6.254818" />
+  <ellipse
+     id="ellipse11"
+     style="overflow:visible;fill:#eeeeec;fill-rule:evenodd;stroke:#415a75;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+     ry="1.954667"
+     rx="1.9546306"
+     cy="17.863331"
+     cx="8.4531603" />
+  <path
+     style="fill:#eeeeec;fill-rule:evenodd;stroke-width:0.99999994"
+     inkscape:connector-curvature="0"
+     id="path13"
+     d="M 4.2027216,1.2809209 3.8279679,3.4018646 2.7119121,4.2113267 1.3193231,4.4284967 1.3620678,2.4307094 1.8374251,1.583324 2.7190964,1.360099 Z" />
+  <path
+     style="overflow:visible;fill:#415a75;fill-rule:evenodd;stroke-width:0.99999994"
+     inkscape:connector-curvature="0"
+     id="path15"
+     overflow="visible"
+     d="m 2.6595133,1.100538 c -0.037307,0 -0.071813,0.00812 -0.108421,0.01069 0.4784828,0.1473855 0.8200286,0.5820943 0.8200286,1.1147709 0,0.6569806 -0.51581,1.1728 -1.1727784,1.1728 -0.4927263,0 -0.9052881,-0.29091 -1.0811551,-0.713148 v 2.049346 c 0.3325298,0.1448605 0.6976374,0.2275353 1.0811551,0.2275353 1.502057,0 2.7364829,-1.2344486 2.7364829,-2.7365333 0,-0.4014789 -0.094052,-0.7806817 -0.2519641,-1.1254605 z" />
+  <path
+     style="fill:#eeeeec;fill-rule:evenodd;stroke-width:0.99999994"
+     inkscape:connector-curvature="0"
+     id="path17"
+     d="m 13.692203,1.2803045 0.173445,1.867702 2.054968,1.0510556 1.520779,-0.3924665 0.54384,-2.5750941 z" />
+  <path
+     style="overflow:visible;fill:#415a75;fill-rule:evenodd;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+     inkscape:connector-curvature="0"
+     id="path19"
+     overflow="visible"
+     d="m 12.942698,1.248665 c -0.118404,0.3049135 -0.189349,0.6325171 -0.189349,0.9773335 0,1.5020847 1.234427,2.7365333 2.736482,2.7365333 1.502056,0 2.736483,-1.2344486 2.736483,-2.7365333 0,-0.3448164 -0.07248,-0.67242 -0.190889,-0.9773335 h -1.89202 c 0.314719,0.2083397 0.519204,0.5642488 0.519204,0.9773335 0,0.6569806 -0.515811,1.1728 -1.172778,1.1728 -0.656975,0 -1.172778,-0.5158194 -1.172778,-1.1728 0,-0.4130993 0.204462,-0.7689969 0.519197,-0.9773335 z" />
+  <path
+     style="fill:#eeeeec;fill-rule:evenodd;stroke-width:0.99999994"
+     inkscape:connector-curvature="0"
+     id="path21"
+     d="M 20.26938,1.2949286 20.655168,3.4230568 22.68986,4.2642325 22.652409,2.1853302 22.182618,1.6202262 21.432284,1.329257 Z" />
+  <path
+     style="overflow:visible;fill:#415a75;fill-rule:evenodd;stroke-width:0.99999994"
+     inkscape:connector-curvature="0"
+     id="path23"
+     overflow="visible"
+     d="m 19.9809,1.248665 c -0.118351,0.3048523 -0.190881,0.6326004 -0.190881,0.9773335 0,1.5020848 1.234426,2.7365333 2.736482,2.7365333 0.06675,0 0.129856,-0.015061 0.195464,-0.019852 V 3.3789461 c -0.06362,0.010317 -0.128513,0.019852 -0.195464,0.019852 -0.656968,0 -1.172778,-0.5158194 -1.172778,-1.1728 0,-0.3496134 0.149137,-0.6572339 0.384818,-0.8704376 C 21.56521,1.2884392 21.377748,1.248665 21.179639,1.248665 Z" />
+  <path
+     style="overflow:visible;fill:none;stroke:#2e4e72;stroke-width:0.49999997"
+     inkscape:connector-curvature="0"
+     id="path25"
+     overflow="visible"
+     d="M 2.7635417,1.248665 H 21.179451 c 0.857905,0 1.542514,0.6887605 1.542514,1.5518652 V 21.172271 c 0,0.863103 -0.684609,1.577728 -1.542514,1.577728 H 2.7635417 c -0.8579045,0 -1.5425144,-0.714625 -1.5425144,-1.577728 V 2.8005302 c 0,-0.8631047 0.6846099,-1.5518652 1.5425144,-1.5518652 z" />
+  <g
+     id="g74"
+     transform="matrix(0.692,0,0,0.692,1.86,1.82)">
+    <rect
+       style="fill:#c4a000"
+       id="rect68"
+       ry="2.6099999"
+       rx="2.6099999"
+       height="13"
+       width="13"
+       y="19"
+       x="19" />
+    <path
+       style="opacity:0.3;fill:#fcffff;fill-rule:evenodd"
+       inkscape:connector-curvature="0"
+       id="path70"
+       d="m 20.3,25.5 h 10.4 v -2.6 c 0,-2.6 -0.65,-2.6 -5.2,-2.6 -4.55,0 -5.2,0 -5.2,2.6 z" />
+    <path
+       style="fill:#ffffff;stroke:#ffffff;stroke-width:0.49700001"
+       inkscape:connector-curvature="0"
+       id="path72"
+       d="m -6.46,-5.81 v 0.76 c 0,1.04 -0.16,1.76 -0.64,2.68 -0.72,1.56 -0.8,1.76 -0.8,2.36 0,1.16 0.88,2.12 1.92,2.12 1.08,0 1.92,-0.96 1.92,-2.16 0,-0.4 -0.12,-0.92 -0.4,-1.44 -0.92,-1.96 -1,-2.28 -1,-3.56 v -0.76 l 0.64,0.4 c 0.84,0.48 1.48,1.04 2.04,1.84 1.32,1.8 1.76,2.16 2.84,2.16 1,0 1.8,-0.76 1.8,-1.76 0,-1.24 -1.04,-2.16 -2.6,-2.28 -1.96,-0.12 -2.32,-0.2 -3.56,-0.88 l -0.64,-0.36 0.64,-0.36 c 0.92,-0.52 1.6,-0.76 2.64,-0.8 1.6,-0.16 1.72,-0.16 2.2,-0.36 0.8,-0.4 1.32,-1.12 1.32,-1.96 0,-1.04 -0.84,-1.84 -1.88,-1.84 -0.88,0 -1.6,0.44 -2.24,1.4 -1.12,1.68 -1.36,1.92 -2.56,2.64 l -0.64,0.4 v -0.76 c 0,-1 0.16,-1.76 0.64,-2.68 0.76,-1.6 0.8,-1.76 0.8,-2.32 0,-1.2 -0.88,-2.16 -1.96,-2.16 -1.04,0 -1.92,0.96 -1.92,2.12 0,0.44 0.12,0.96 0.4,1.48 0.96,2 1.04,2.28 1.04,3.56 v 0.76 l -0.64,-0.4 c -0.92,-0.52 -1.44,-1.04 -2.04,-1.88 -0.8,-1.2 -0.8,-1.2 -1.12,-1.52 -0.44,-0.4 -1.08,-0.64 -1.6,-0.64 -1.08,0 -1.92,0.84 -1.92,1.84 0,1.24 1,2.12 2.56,2.24 2.04,0.12 2.36,0.2 3.6,0.88 l 0.64,0.36 -0.64,0.4 c -0.84,0.48 -1.64,0.72 -2.64,0.8 -1.56,0.08 -1.68,0.12 -2.2,0.32 -0.8,0.36 -1.32,1.12 -1.32,1.96 0,1 0.84,1.84 1.88,1.84 0.88,0 1.64,-0.48 2.24,-1.4 1.08,-1.6 1.4,-1.96 2.56,-2.64 z"
+       transform="matrix(0.603,0,0,0.604,29.1,29.5)" />
+  </g>
+</svg>

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2203,6 +2203,7 @@ void QgisApp::createActions()
   connect( mActionNewSpatiaLiteLayer, &QAction::triggered, this, &QgisApp::newSpatialiteLayer );
   connect( mActionNewGeoPackageLayer, &QAction::triggered, this, &QgisApp::newGeoPackageLayer );
   connect( mActionNewMemoryLayer, &QAction::triggered, this, &QgisApp::newMemoryLayer );
+  connect( mActionNewVirtualLayer, &QAction::triggered, this, &QgisApp::addVirtualLayer );
   connect( mActionShowRasterCalculator, &QAction::triggered, this, &QgisApp::showRasterCalculator );
   connect( mActionShowMeshCalculator, &QAction::triggered, this, &QgisApp::showMeshCalculator );
   connect( mActionShowAlignRasterTool, &QAction::triggered, this, &QgisApp::showAlignRasterTool );
@@ -5315,7 +5316,7 @@ void QgisApp::addDatabaseLayers( QStringList const &layerPathList, QString const
 
 void QgisApp::addVirtualLayer()
 {
-  // show the Delimited text dialog
+  // show the virtual layer dialog
   QDialog *dts = dynamic_cast<QDialog *>( QgsProviderRegistry::instance()->createSelectionWidget( QStringLiteral( "virtual" ), this ) );
   if ( !dts )
   {
@@ -5323,7 +5324,7 @@ void QgisApp::addVirtualLayer()
     return;
   }
   connect( dts, SIGNAL( addVectorLayer( QString, QString, QString ) ),
-           this, SLOT( addSelectedVectorLayer( QString, QString, QString ) ) );
+           this, SLOT( onVirtualLayerAdded( QString, QString ) ) );
   connect( dts, SIGNAL( replaceVectorLayer( QString, QString, QString, QString ) ),
            this, SLOT( replaceSelectedVectorLayer( QString, QString, QString, QString ) ) );
   dts->exec();
@@ -12134,6 +12135,11 @@ int QgisApp::addDatabaseToolBarIcon( QAction *qAction )
 {
   mDatabaseToolBar->addAction( qAction );
   return 0;
+}
+
+void QgisApp::onVirtualLayerAdded( const QString &uri, const QString &layerName )
+{
+  addVectorLayer( uri, layerName, QStringLiteral( "virtual" ) );
 }
 
 QAction *QgisApp::addDatabaseToolBarWidget( QWidget *widget )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1244,6 +1244,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Add an icon to the Database toolbar
     int addDatabaseToolBarIcon( QAction *qAction );
 
+    void onVirtualLayerAdded( const QString &uri, const QString &layerName );
+
     /**
      * Add a widget to the database toolbar.
      * To remove this widget again, call removeDatabaseToolBarIcon()

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -164,6 +164,8 @@
      <addaction name="mActionNewVectorLayer"/>
      <addaction name="mActionNewSpatiaLiteLayer"/>
      <addaction name="mActionNewMemoryLayer"/>
+     <addaction name="separator"/>
+     <addaction name="mActionNewVirtualLayer"/>
     </widget>
     <widget class="QMenu" name="mAddLayerMenu">
      <property name="title">
@@ -683,6 +685,8 @@
    <addaction name="mActionNewVectorLayer"/>
    <addaction name="mActionNewSpatiaLiteLayer"/>
    <addaction name="mActionNewMemoryLayer"/>
+   <addaction name="separator"/>
+   <addaction name="mActionNewVirtualLayer"/>
   </widget>
   <widget class="QToolBar" name="mShapeDigitizeToolBar">
    <property name="windowTitle">
@@ -3169,6 +3173,18 @@ Acts on currently active editable layer</string>
    </property>
    <property name="text">
     <string>Add Mesh Layer...</string>
+   </property>
+  </action>
+  <action name="mActionNewVirtualLayer">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionNewVirtualLayer.svg</normaloff>:/images/themes/default/mActionNewVirtualLayer.svg</iconset>
+   </property>
+   <property name="text">
+    <string>New Virtual Layer…</string>
+   </property>
+   <property name="toolTip">
+    <string>New Virtual Layer</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This was removed when the data source manager was created, but
new virtual layers are a "creation" action, so it belongs alongside
the other "Create" actions like new shapefile, new gpkg, etc

It "feels" more natural then using the open data source dialog
to create a new virtual layer
