### PR TITLE
Do not remove parameters from virtual methods which should be used in…

### DIFF
--- a/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
@@ -38,7 +38,7 @@ Constructor for QgsAttributeFormEditorWidget.
 
     ~QgsAttributeFormEditorWidget();
 
-    virtual void createSearchWidgetWrappers();
+    virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() );
 
 
     void initialize( const QVariant &initialValue, bool mixedValues = false );

--- a/python/gui/auto_generated/qgsattributeformrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformrelationeditorwidget.sip.in
@@ -29,7 +29,7 @@ Widget to show for child relations on an attribute form.
 Constructor
 %End
 
-    virtual void createSearchWidgetWrappers();
+    virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() );
 
     virtual QString currentFilterExpression() const;
 

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
 
     ~QgsAttributeFormEditorWidget() override;
 
-    void createSearchWidgetWrappers( const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() ) override;
+    void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() ) override;
 
     /**
      * Resets the widget to an initial value.

--- a/src/gui/qgsattributeformrelationeditorwidget.h
+++ b/src/gui/qgsattributeformrelationeditorwidget.h
@@ -41,7 +41,7 @@ class GUI_EXPORT QgsAttributeFormRelationEditorWidget : public QgsAttributeFormW
      */
     explicit QgsAttributeFormRelationEditorWidget( QgsRelationWidgetWrapper *wrapper, QgsAttributeForm *form );
 
-    void createSearchWidgetWrappers( const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() ) override;
+    void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() ) override;
     QString currentFilterExpression() const override;
 
   private:


### PR DESCRIPTION
… python

These methods did not actually override their parent methods but just coexisted and were never called.

Fixes compilation with SIP version: 4.19.14
