### PR TITLE
Sip keep reference to registry

### DIFF
--- a/python/analysis/auto_generated/qgsanalysis.sip.in
+++ b/python/analysis/auto_generated/qgsanalysis.sip.in
@@ -32,7 +32,7 @@ related to analysis classes.
 Returns a pointer to the singleton instance.
 %End
 
-    static QgsGeometryCheckRegistry *geometryCheckRegistry();
+    static QgsGeometryCheckRegistry *geometryCheckRegistry() /KeepReference/;
 %Docstring
 Returns the global geometry checker registry, used for managing all geometry check factories.
 %End

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -613,21 +613,21 @@ wide background task handling.
 .. versionadded:: 3.0
 %End
 
-    static QgsColorSchemeRegistry *colorSchemeRegistry();
+    static QgsColorSchemeRegistry *colorSchemeRegistry() /KeepReference/;
 %Docstring
 Returns the application's color scheme registry, used for managing color schemes.
 
 .. versionadded:: 3.0
 %End
 
-    static QgsPaintEffectRegistry *paintEffectRegistry();
+    static QgsPaintEffectRegistry *paintEffectRegistry() /KeepReference/;
 %Docstring
 Returns the application's paint effect registry, used for managing paint effects.
 
 .. versionadded:: 3.0
 %End
 
-    static QgsRendererRegistry *rendererRegistry();
+    static QgsRendererRegistry *rendererRegistry() /KeepReference/;
 %Docstring
 Returns the application's renderer registry, used for managing vector layer renderers.
 
@@ -635,7 +635,7 @@ Returns the application's renderer registry, used for managing vector layer rend
 %End
 
 
-    static QgsDataItemProviderRegistry *dataItemProviderRegistry();
+    static QgsDataItemProviderRegistry *dataItemProviderRegistry() /KeepReference/;
 %Docstring
 Returns the application's data item provider registry, which keeps a list of data item
 providers that may add items to the browser tree.
@@ -662,14 +662,14 @@ Returns the application's image cache, used for caching resampled versions of ra
 .. versionadded:: 3.6
 %End
 
-    static QgsNetworkContentFetcherRegistry *networkContentFetcherRegistry();
+    static QgsNetworkContentFetcherRegistry *networkContentFetcherRegistry() /KeepReference/;
 %Docstring
 Returns the application's network content registry used for fetching temporary files during QGIS session
 
 .. versionadded:: 3.2
 %End
 
-    static QgsValidityCheckRegistry *validityCheckRegistry();
+    static QgsValidityCheckRegistry *validityCheckRegistry() /KeepReference/;
 %Docstring
 Returns the application's validity check registry, used for managing validity checks.
 
@@ -740,7 +740,7 @@ Returns the application's page size registry, used for managing layout page size
 %End
 
 
-    static QgsActionScopeRegistry *actionScopeRegistry();
+    static QgsActionScopeRegistry *actionScopeRegistry() /KeepReference/;
 %Docstring
 Returns the action scope registry.
 
@@ -754,19 +754,19 @@ Returns the application runtime profiler.
 .. versionadded:: 3.0
 %End
 
-    static QgsFieldFormatterRegistry *fieldFormatterRegistry();
+    static QgsFieldFormatterRegistry *fieldFormatterRegistry() /KeepReference/;
 %Docstring
 Gets the registry of available field formatters.
 %End
 
-    static Qgs3DRendererRegistry *renderer3DRegistry();
+    static Qgs3DRendererRegistry *renderer3DRegistry() /KeepReference/;
 %Docstring
 Returns registry of available 3D renderers.
 
 .. versionadded:: 3.0
 %End
 
-    static QgsProjectStorageRegistry *projectStorageRegistry();
+    static QgsProjectStorageRegistry *projectStorageRegistry() /KeepReference/;
 %Docstring
 Returns registry of available project storage implementations.
 

--- a/python/gui/auto_generated/qgsgui.sip.in
+++ b/python/gui/auto_generated/qgsgui.sip.in
@@ -32,12 +32,12 @@ Returns a pointer to the singleton instance.
 %End
 
 
-    static QgsEditorWidgetRegistry *editorWidgetRegistry();
+    static QgsEditorWidgetRegistry *editorWidgetRegistry() /KeepReference/;
 %Docstring
 Returns the global editor widget registry, used for managing all known edit widget factories.
 %End
 
-    static QgsSourceSelectProviderRegistry *sourceSelectProviderRegistry();
+    static QgsSourceSelectProviderRegistry *sourceSelectProviderRegistry() /KeepReference/;
 %Docstring
 Returns the global source select provider registry, used for managing all known source select widget factories.
 %End
@@ -47,22 +47,22 @@ Returns the global source select provider registry, used for managing all known 
 Returns the global shortcuts manager, used for managing a QAction and QShortcut sequences.
 %End
 
-    static QgsLayerTreeEmbeddedWidgetRegistry *layerTreeEmbeddedWidgetRegistry();
+    static QgsLayerTreeEmbeddedWidgetRegistry *layerTreeEmbeddedWidgetRegistry() /KeepReference/;
 %Docstring
 Returns the global layer tree embedded widget registry, used for registering widgets that may be embedded into layer tree view.
 %End
 
-    static QgsMapLayerActionRegistry *mapLayerActionRegistry();
+    static QgsMapLayerActionRegistry *mapLayerActionRegistry() /KeepReference/;
 %Docstring
 Returns the global map layer action registry, used for registering map layer actions.
 %End
 
-    static QgsLayoutItemGuiRegistry *layoutItemGuiRegistry();
+    static QgsLayoutItemGuiRegistry *layoutItemGuiRegistry() /KeepReference/;
 %Docstring
 Returns the global layout item GUI registry, used for registering the GUI behavior of layout items.
 %End
 
-    static QgsProcessingGuiRegistry *processingGuiRegistry();
+    static QgsProcessingGuiRegistry *processingGuiRegistry() /KeepReference/;
 %Docstring
 Returns the global processing gui registry, used for registering the GUI behavior of processing algorithms.
 
@@ -76,7 +76,7 @@ Returns the global processing recent algorithm log, used for tracking recently u
 .. versionadded:: 3.4
 %End
 
-    static QgsDataItemGuiProviderRegistry *dataItemGuiProviderRegistry();
+    static QgsDataItemGuiProviderRegistry *dataItemGuiProviderRegistry() /KeepReference/;
 %Docstring
 Returns the global data item GUI provider registry, used for tracking providers which affect the browser
 GUI.

--- a/src/analysis/qgsanalysis.h
+++ b/src/analysis/qgsanalysis.h
@@ -49,7 +49,7 @@ class ANALYSIS_EXPORT QgsAnalysis
     /**
      * Returns the global geometry checker registry, used for managing all geometry check factories.
      */
-    static QgsGeometryCheckRegistry *geometryCheckRegistry();
+    static QgsGeometryCheckRegistry *geometryCheckRegistry() SIP_KEEPREFERENCE;
 
   private:
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -549,19 +549,19 @@ class CORE_EXPORT QgsApplication : public QApplication
      * Returns the application's color scheme registry, used for managing color schemes.
      * \since QGIS 3.0
      */
-    static QgsColorSchemeRegistry *colorSchemeRegistry();
+    static QgsColorSchemeRegistry *colorSchemeRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the application's paint effect registry, used for managing paint effects.
      * \since QGIS 3.0
      */
-    static QgsPaintEffectRegistry *paintEffectRegistry();
+    static QgsPaintEffectRegistry *paintEffectRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the application's renderer registry, used for managing vector layer renderers.
      * \since QGIS 3.0
      */
-    static QgsRendererRegistry *rendererRegistry();
+    static QgsRendererRegistry *rendererRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the application's raster renderer registry, used for managing raster layer renderers.
@@ -575,7 +575,7 @@ class CORE_EXPORT QgsApplication : public QApplication
      * providers that may add items to the browser tree.
      * \since QGIS 3.0
      */
-    static QgsDataItemProviderRegistry *dataItemProviderRegistry();
+    static QgsDataItemProviderRegistry *dataItemProviderRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the application's SVG cache, used for caching SVG images and handling parameter replacement
@@ -598,13 +598,13 @@ class CORE_EXPORT QgsApplication : public QApplication
      * Returns the application's network content registry used for fetching temporary files during QGIS session
      * \since QGIS 3.2
      */
-    static QgsNetworkContentFetcherRegistry *networkContentFetcherRegistry();
+    static QgsNetworkContentFetcherRegistry *networkContentFetcherRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the application's validity check registry, used for managing validity checks.
      * \since QGIS 3.6
      */
-    static QgsValidityCheckRegistry *validityCheckRegistry();
+    static QgsValidityCheckRegistry *validityCheckRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the application's symbol layer registry, used for managing symbol layers.
@@ -669,7 +669,7 @@ class CORE_EXPORT QgsApplication : public QApplication
      *
      * \since QGIS 3.0
      */
-    static QgsActionScopeRegistry *actionScopeRegistry();
+    static QgsActionScopeRegistry *actionScopeRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the application runtime profiler.
@@ -680,19 +680,19 @@ class CORE_EXPORT QgsApplication : public QApplication
     /**
      * Gets the registry of available field formatters.
      */
-    static QgsFieldFormatterRegistry *fieldFormatterRegistry();
+    static QgsFieldFormatterRegistry *fieldFormatterRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns registry of available 3D renderers.
      * \since QGIS 3.0
      */
-    static Qgs3DRendererRegistry *renderer3DRegistry();
+    static Qgs3DRendererRegistry *renderer3DRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns registry of available project storage implementations.
      * \since QGIS 3.2
      */
-    static QgsProjectStorageRegistry *projectStorageRegistry();
+    static QgsProjectStorageRegistry *projectStorageRegistry() SIP_KEEPREFERENCE;
 
     /**
      * This string is used to represent the value `NULL` throughout QGIS.

--- a/src/gui/qgsgui.h
+++ b/src/gui/qgsgui.h
@@ -67,12 +67,12 @@ class GUI_EXPORT QgsGui
     /**
      * Returns the global editor widget registry, used for managing all known edit widget factories.
      */
-    static QgsEditorWidgetRegistry *editorWidgetRegistry();
+    static QgsEditorWidgetRegistry *editorWidgetRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the global source select provider registry, used for managing all known source select widget factories.
      */
-    static QgsSourceSelectProviderRegistry *sourceSelectProviderRegistry();
+    static QgsSourceSelectProviderRegistry *sourceSelectProviderRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the global shortcuts manager, used for managing a QAction and QShortcut sequences.
@@ -82,23 +82,23 @@ class GUI_EXPORT QgsGui
     /**
      * Returns the global layer tree embedded widget registry, used for registering widgets that may be embedded into layer tree view.
      */
-    static QgsLayerTreeEmbeddedWidgetRegistry *layerTreeEmbeddedWidgetRegistry();
+    static QgsLayerTreeEmbeddedWidgetRegistry *layerTreeEmbeddedWidgetRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the global map layer action registry, used for registering map layer actions.
      */
-    static QgsMapLayerActionRegistry *mapLayerActionRegistry();
+    static QgsMapLayerActionRegistry *mapLayerActionRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the global layout item GUI registry, used for registering the GUI behavior of layout items.
      */
-    static QgsLayoutItemGuiRegistry *layoutItemGuiRegistry();
+    static QgsLayoutItemGuiRegistry *layoutItemGuiRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the global processing gui registry, used for registering the GUI behavior of processing algorithms.
      * \since QGIS 3.2
      */
-    static QgsProcessingGuiRegistry *processingGuiRegistry();
+    static QgsProcessingGuiRegistry *processingGuiRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Returns the global processing recent algorithm log, used for tracking recently used processing algorithms.
@@ -111,7 +111,7 @@ class GUI_EXPORT QgsGui
      * GUI.
      * \since QGIS 3.6
      */
-    static QgsDataItemGuiProviderRegistry *dataItemGuiProviderRegistry();
+    static QgsDataItemGuiProviderRegistry *dataItemGuiProviderRegistry() SIP_KEEPREFERENCE;
 
     /**
      * Register the widget to allow its position to be automatically saved and restored when open and closed.


### PR DESCRIPTION
When adding item to registries they are transferred to C++ via `/Transfer/`.

This adds an additional reference to the wrapper of the registered instance from the registry wrapper. If the registry wrapper scoped out, this reference was deleted and the child sip wrapper therefore garbage collected. By adding /KeepReference/ annotation to the registry accessors, the wrapper of the registries will never be deleted. This is no big deal, since they are de facto singletons.

The only slight shortcoming here is, that the python wrappers of registered items will never be garbage collected. But that should really only lead to minimal overhead.