### PR TITLE
Append ? to WMTS GetCapabilities

### DIFF
--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -272,8 +272,12 @@ namespace QgsWmts
     QDomElement httpElement = doc.createElement( QStringLiteral( "ows:HTTP" )/*ows:HTTP*/ );
     dcpElement.appendChild( httpElement );
 
-    //Prepare url
-    QString hrefString = serviceUrl( request, project );
+    // Get service URL
+    const QUrl href = serviceUrl( request, project );
+
+    //href needs to be a prefix
+    QString hrefString = href.toString();
+    hrefString.append( href.hasQuery() ? '&' : '?' );
 
     //ows:Get
     QDomElement getElement = doc.createElement( QStringLiteral( "ows:Get" )/*ows:Get*/ );

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
@@ -27,14 +27,14 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetTile">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/"/>
+     <ows:Get xlink:href="https://www.qgis.org/?"/>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>
   <ows:Operation name="GetFeatureInfo">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/"/>
+     <ows:Get xlink:href="https://www.qgis.org/?"/>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config.txt
@@ -20,7 +20,7 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetCapabilities">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/"/>
+     <ows:Get xlink:href="https://www.qgis.org/?"/>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config_3857.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config_3857.txt
@@ -27,14 +27,14 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetTile">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/"/>
+     <ows:Get xlink:href="https://www.qgis.org/?"/>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>
   <ows:Operation name="GetFeatureInfo">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/"/>
+     <ows:Get xlink:href="https://www.qgis.org/?"/>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>

--- a/tests/testdata/qgis_server/wmts_getcapabilities_config_3857.txt
+++ b/tests/testdata/qgis_server/wmts_getcapabilities_config_3857.txt
@@ -20,7 +20,7 @@ Content-Type: text/xml; charset=utf-8
   <ows:Operation name="GetCapabilities">
    <ows:DCP>
     <ows:HTTP>
-     <ows:Get xlink:href="https://www.qgis.org/"/>
+     <ows:Get xlink:href="https://www.qgis.org/?"/>
     </ows:HTTP>
    </ows:DCP>
   </ows:Operation>


### PR DESCRIPTION
This makes WMTS behave equal to the WMS implementation which already appends a `?` in case there is no query string supplied.

Some parsers rely on a terminating `?` to work properly.

Also examples on WMTS Spec 1.0.0 (http://portal.opengeospatial.org/files/?artifact_id=35326) and the KVP example in Annex H use this style.

```
<ows:Operation name="GetTile">
<ows:DCP>
<ows:HTTP>
<ows:Get xlink:href=
"http://www.maps.bob/cgi-bin/MiraMon5_0.cgi?">
<ows:Constraint name="GetEncoding">
<ows:AllowedValues>
<ows:Value>KVP</ows:Value>
</ows:AllowedValues>
</ows:Constraint>
</ows:Get>
</ows:HTTP>
</ows:DCP>
</ows:Operation>
```

on behalf of Thomas Bettler, BAFU