### PR TITLE
Vertex tool: misc small UX improvements

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3028,7 +3028,7 @@ void QgisApp::createToolBars()
   vertexToolButton->addAction( mActionVertexTool );
   vertexToolButton->addAction( mActionVertexToolActiveLayer );
   QAction *defActionVertexTool = mActionVertexTool;
-  switch ( settings.enumValue( QStringLiteral( "UI/defaultVertexTool" ), QgsVertexTool::AllLayers ) )
+  switch ( settings.enumValue( QStringLiteral( "UI/defaultVertexTool" ), QgsVertexTool::ActiveLayer ) )
   {
     case QgsVertexTool::AllLayers:
       defActionVertexTool = mActionVertexTool;


### PR DESCRIPTION
The vertex tool saga continues...

1. "current layer" mode is the new default - more conservative and safer

2. when a feature is locked:
   - vertex tool will not highlight other features
   - vertex tool will not allow selection of vertices from other features

cc @nirvn @bstroebl

![peek 2019-02-06 18-29](https://user-images.githubusercontent.com/193367/52360878-4a558100-2a3d-11e9-8061-f0e226356ed4.gif)
