### PR TITLE
Fix condition to enable Postgresql insert optimization

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2040,19 +2040,22 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist, Flags flags )
       if ( mPrimaryKeyAttrs.size() == 1 &&
            defaultValueClause( mPrimaryKeyAttrs[0] ).startsWith( "nextval(" ) )
       {
-        bool foundNonNullPK = false;
+        bool foundNonEmptyPK = false;
         int idx = mPrimaryKeyAttrs[0];
+        QString defaultValue = defaultValueClause( idx );
         for ( int i = 0; i < flist.size(); i++ )
         {
           QgsAttributes attrs2 = flist[i].attributes();
           QVariant v2 = attrs2.value( idx, QVariant( QVariant::Int ) );
-          if ( !v2.isNull() )
+          // a PK field with a sequence val is auto populate by QGIS with this default
+          // we are only interested in non default values
+          if ( !v2.isNull() && v2.toString() != defaultValue )
           {
-            foundNonNullPK = true;
+            foundNonEmptyPK = true;
             break;
           }
         }
-        skipSinglePKField = !foundNonNullPK;
+        skipSinglePKField = !foundNonEmptyPK;
       }
 
       if ( !skipSinglePKField )


### PR DESCRIPTION
## Description

While debugging #20170 I have found that QgsPostgresProvider::addFeatures does not 
use the insert optimization when it is supposed to (by skipping the PK column if its default is a sequence and all new features are using this default value)

The check must ensure that each value is also not the SQL default of nextval('seq'::regclass) (which is auto populated by QGIS) otherwise the condition will never be met by, for example, a table having a serial column as primary key:
```sql
create table foo( id serial primary key,  geometry geometry(Point, 4326) );
```

Adding features in QGIS and saving:
```
qgis@gis LOG:  statement: BEGIN
qgis@gis LOG:  statement: SELECT nextval('foo_id_seq'::regclass)
qgis@gis LOG:  execute addfeatures: INSERT INTO "public"."foo"("geometry","id") VALUES (st_geomfromwkb($1::bytea,4326),$2) RETURNING "id"
qgis@gis DETAIL:  parameters: $1 = '\xxxxxxxxxx', $2 = '13'
qgis@gis LOG:  statement: SELECT nextval('foo_id_seq'::regclass)
qgis@gis LOG:  execute addfeatures: INSERT INTO "public"."foo"("geometry","id") VALUES (st_geomfromwkb($1::bytea,4326),$2) RETURNING "id"
qgis@gis DETAIL:  parameters: $1 = '\xxxxxxxxxx', $2 = '14'
qgis@gis LOG:  statement: DEALLOCATE addfeatures
qgis@gis LOG:  statement: COMMIT
```

With my proposed patch:

```
qgis@mq LOG:  statement: BEGIN
qgis@mq LOG:  execute addfeatures: INSERT INTO "public"."foo"("geometry") VALUES (st_geomfromwkb($1::bytea,4326)) RETURNING "id"
qgis@mq DETAIL:  parameters: $1 = '\xxxxxxxxxx'
qgis@mq LOG:  execute addfeatures: INSERT INTO "public"."foo"("geometry") VALUES (st_geomfromwkb($1::bytea,4326)) RETURNING "id"
qgis@mq DETAIL:  parameters: $1 = '\xxxxxxxxxx'
qgis@mq LOG:  statement: DEALLOCATE addfeatures
qgis@mq LOG:  statement: COMMIT
```

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
