### PR TITLE
remove 'multithreading is not supported in server text'

### DIFF
--- a/tests/src/python/qgis_wrapped_server.py
+++ b/tests/src/python/qgis_wrapped_server.py
@@ -39,9 +39,6 @@ A XYZ map service is also available for multithreading testing:
 
   ?MAP=/path/to/projects.qgs&SERVICE=XYZ&X=1&Y=0&Z=1&LAYERS=world
 
-Note that multi threading in QGIS server is not officially supported and
-it is not supposed to work in any case
-
 Set MULTITHREADING environment variable to 1 to activate.
 
 


### PR DESCRIPTION
This isn't true anymore as many use it in production.