### PR TITLE
Append ? to WMTS GetCapabilities

### DIFF
--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -278,8 +278,12 @@ namespace QgsWmts
     QDomElement httpElement = doc.createElement( QStringLiteral( "ows:HTTP" )/*ows:HTTP*/ );
     dcpElement.appendChild( httpElement );
 
-    //Prepare url
-    QString hrefString = serviceUrl( request, project );
+    // Get service URL
+    const QUrl href = serviceUrl( request, project );
+
+    //href needs to be a prefix
+    QString hrefString = href.toString();
+    hrefString.append( href.hasQuery() ? '&' : '?' );
 
     //ows:Get
     QDomElement getElement = doc.createElement( QStringLiteral( "ows:Get" )/*ows:Get*/ );


### PR DESCRIPTION
This makes WMTS behave equal to the WMS implementation which already appends a ? in case there is no query string supplied.

Some parsers rely on a terminating ? to work properly.

Backport of #9115 