### PR TITLE
Revert "remove 'multithreading is not supported in server text'"

### DIFF
--- a/tests/src/python/qgis_wrapped_server.py
+++ b/tests/src/python/qgis_wrapped_server.py
@@ -39,6 +39,9 @@ A XYZ map service is also available for multithreading testing:
 
   ?MAP=/path/to/projects.qgs&SERVICE=XYZ&X=1&Y=0&Z=1&LAYERS=world
 
+Note that multi threading in QGIS server is not officially supported and
+it is not supposed to work in any case
+
 Set MULTITHREADING environment variable to 1 to activate.
 
 

--- a/tests/src/python/qgis_wrapped_server.py
+++ b/tests/src/python/qgis_wrapped_server.py
@@ -39,7 +39,7 @@ A XYZ map service is also available for multithreading testing:
 
   ?MAP=/path/to/projects.qgs&SERVICE=XYZ&X=1&Y=0&Z=1&LAYERS=world
 
-Note that multi threading in QGIS server is not officially supported and
+Note that multithreading in QGIS server is not officially supported and
 it is not supposed to work in any case
 
 Set MULTITHREADING environment variable to 1 to activate.


### PR DESCRIPTION
Reverts qgis/QGIS#9124

that sentence refers to the testing script only and it is still true: you cannot run a multithreaded python-based server because most of the server request/response code is not thread safe.

The recommended way to run server code through python is multiprocessing.