### PR TITLE
Vertex tool: two more UX fixes

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -2030,17 +2030,9 @@ void QgsVertexTool::applyEditsToLayers( QgsVertexTool::VertexEdits &edits )
     for ( ; it2 != layerEdits.end(); ++it2 )
     {
       layer->changeGeometry( it2.key(), it2.value() );
-      for ( int i = 0; i < mSelectedVertices.length(); ++i )
-      {
-        if ( mSelectedVertices.at( i ).layer == layer && mSelectedVertices.at( i ).fid == it2.key() )
-        {
-          mSelectedFeature->selectVertex( mSelectedVertices.at( i ).vertexId );
-        }
-      }
     }
     layer->endEditCommand();
     layer->triggerRepaint();
-
 
     if ( mVertexEditor )
       mVertexEditor->updateEditor( mSelectedFeature.get() );
@@ -2209,6 +2201,11 @@ void QgsVertexTool::deleteVertex()
 
 void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, HighlightMode mode )
 {
+  // we need to make a local copy of vertices - often this method gets called
+  // just to refresh positions and so mSelectedVertices is passed. But then in reset mode
+  // we clear that array, which could clear also listVertices.
+  QList<Vertex> listVerticesLocal( listVertices );
+
   if ( mode == ModeReset )
   {
     qDeleteAll( mSelectedVerticesMarkers );
@@ -2241,7 +2238,7 @@ void QgsVertexTool::setHighlightedVertices( const QList<Vertex> &listVertices, H
     return true;
   };
 
-  for ( const Vertex &vertex : listVertices )
+  for ( const Vertex &vertex : listVerticesLocal )
   {
     if ( mode == ModeAdd && mSelectedVertices.contains( vertex ) )
     {

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -479,6 +479,14 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
     // so we need to cancel edge moving before we start dragging new vertex
     stopDragging();
     startDraggingAddVertex( m );
+
+    if ( e->modifiers() & Qt::ShiftModifier )
+    {
+      // if this was shift + double click, immediately place the vertex
+      moveVertex( m.point(), &m );
+      // force update of rubber bands
+      mouseMoveNotDragging( e );
+    }
   }
   else if ( mSelectionRect )
   {

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -475,14 +475,14 @@ void QgsVertexTool::cadCanvasReleaseEvent( QgsMapMouseEvent *e )
 
     mNewVertexFromDoubleClick.reset();
 
-    // dragging of edges and double clicking on edges to add vertex are slightly overlapping
+    // dragging of edges and double-clicking on edges to add vertex are slightly overlapping
     // so we need to cancel edge moving before we start dragging new vertex
     stopDragging();
     startDraggingAddVertex( m );
 
     if ( e->modifiers() & Qt::ShiftModifier )
     {
-      // if this was shift + double click, immediately place the vertex
+      // if this was shift + double-click, immediately place the vertex
       moveVertex( m.point(), &m );
       // force update of rubber bands
       mouseMoveNotDragging( e );

--- a/tests/src/app/testqgsvertextool.cpp
+++ b/tests/src/app/testqgsvertextool.cpp
@@ -547,6 +547,9 @@ void TestQgsVertexTool::testMoveMultipleVertices()
   mouseClick( 1, 1, Qt::LeftButton );
   mouseClick( 0, 0, Qt::LeftButton );
 
+  // extra click away from everything to clear the selection
+  mouseClick( 8, 8, Qt::LeftButton );
+
   QCOMPARE( mLayerLine->undoStack()->index(), 2 );
   QCOMPARE( mLayerLine->getFeature( mFidLineF1 ).geometry(), QgsGeometry::fromWkt( "LINESTRING(2 1, 0 0, 0 2)" ) );
 


### PR DESCRIPTION
Vertex tool is back again:
1. use shift + double click to add a vertex without moving it. (double click without shift adds a vertex but requires user to place it - the variant with shift will immediately place it at the place of the double click)
2. keep selected vertices after moving them (this was always the intention, but didn't work due to a bug)

cc @nirvn @bstroebl 