### PR TITLE
Add ESCAPE when compiling LIKE for oracle

### DIFF
--- a/src/providers/oracle/qgsoracleexpressioncompiler.cpp
+++ b/src/providers/oracle/qgsoracleexpressioncompiler.cpp
@@ -58,11 +58,11 @@ QgsSqlExpressionCompiler::Result QgsOracleExpressionCompiler::compileNode( const
             return Complete;
 
           case QgsExpressionNodeBinaryOperator::boILike:
-            result = QStringLiteral( "lower(%1) LIKE lower(%2)" ).arg( op1, op2 );
+            result = QStringLiteral( "lower(%1) LIKE lower(%2) ESCAPE '\\'" ).arg( op1, op2 );
             return Complete;
 
           case QgsExpressionNodeBinaryOperator::boNotILike:
-            result = QStringLiteral( "NOT lower(%1) LIKE lower(%2)" ).arg( op1, op2 );
+            result = QStringLiteral( "NOT lower(%1) LIKE lower(%2) ESCAPE '\\'" ).arg( op1, op2 );
             return Complete;
 
           case QgsExpressionNodeBinaryOperator::boIntDiv:

--- a/tests/src/python/featuresourcetestbase.py
+++ b/tests/src/python/featuresourcetestbase.py
@@ -155,6 +155,8 @@ class FeatureSourceTestCase(object):
         self.assert_query(source, '(name = \'Apple\') is not null', [1, 2, 3, 4])
         self.assert_query(source, 'name LIKE \'Apple\'', [2])
         self.assert_query(source, 'name LIKE \'aPple\'', [])
+        self.assert_query(source, 'name LIKE \'Ap_le\'', [2])
+        self.assert_query(source, 'name LIKE \'Ap\\_le\'', [])
         self.assert_query(source, 'name ILIKE \'aPple\'', [2])
         self.assert_query(source, 'name ILIKE \'%pp%\'', [2])
         self.assert_query(source, 'cnt > 0', [1, 2, 3, 4])

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -203,6 +203,8 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
                     'name = \'apple\'',
                     'name LIKE \'Apple\'',
                     'name LIKE \'aPple\'',
+                    'name LIKE \'Ap_le\'',
+                    'name LIKE \'Ap\\_le\'',
                     '"name"="name2"'])
 
     def testRepack(self):


### PR DESCRIPTION
## Description

The oracle SQL documentation specifies that *there is no default escape character* and *the escape character, if specified, must be a character string of length 1*.
In expression the underscore (_) and the percent sign (%) can be escaped with the backslash (\). So in the Oracle Expression Compiler if the ESCAPE clause is not specified, the pattern is not valid.
To fix it, the Oracle Expression Compiler has to add the ESCAPE clause.

https://docs.oracle.com/cd/B12037_01/server.101/b10759/conditions016.htm

Forward porting #8875
Forward porting #8835 

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit