### PR TITLE
[processing] Simplify algorithm should not run validity checks on geometries

### DIFF
--- a/src/analysis/processing/qgsalgorithmsimplify.cpp
+++ b/src/analysis/processing/qgsalgorithmsimplify.cpp
@@ -132,6 +132,11 @@ QgsFeatureList QgsSimplifyAlgorithm::processFeature( const QgsFeature &feature, 
   return QgsFeatureList() << f;
 }
 
+QgsProcessingFeatureSource::Flag QgsSimplifyAlgorithm::sourceFlags() const
+{
+  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
+}
+
 ///@endcond
 
 

--- a/src/analysis/processing/qgsalgorithmsimplify.h
+++ b/src/analysis/processing/qgsalgorithmsimplify.h
@@ -52,7 +52,7 @@ class QgsSimplifyAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &, QgsProcessingFeedback *feedback ) override;
-
+    QgsProcessingFeatureSource::Flag sourceFlags() const override;
   private:
 
     double mTolerance = 1.0;

--- a/src/analysis/processing/qgsalgorithmsmooth.cpp
+++ b/src/analysis/processing/qgsalgorithmsmooth.cpp
@@ -156,6 +156,11 @@ QgsFeatureList QgsSmoothAlgorithm::processFeature( const QgsFeature &feature, Qg
   return QgsFeatureList() << f;
 }
 
+QgsProcessingFeatureSource::Flag QgsSmoothAlgorithm::sourceFlags() const
+{
+  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
+}
+
 ///@endcond
 
 

--- a/src/analysis/processing/qgsalgorithmsmooth.h
+++ b/src/analysis/processing/qgsalgorithmsmooth.h
@@ -49,6 +49,7 @@ class QgsSmoothAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QgsProcessing::SourceType outputLayerType() const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsProcessingFeatureSource::Flag sourceFlags() const override;
 
   private:
     int mIterations = 1;

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.cpp
@@ -154,6 +154,11 @@ QgsFeatureList QgsSnapToGridAlgorithm::processFeature( const QgsFeature &feature
   return QgsFeatureList() << f;
 }
 
+QgsProcessingFeatureSource::Flag QgsSnapToGridAlgorithm::sourceFlags() const
+{
+  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
+}
+
 ///@endcond
 
 

--- a/src/analysis/processing/qgsalgorithmsnaptogrid.h
+++ b/src/analysis/processing/qgsalgorithmsnaptogrid.h
@@ -47,6 +47,7 @@ class QgsSnapToGridAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsProcessingFeatureSource::Flag sourceFlags() const override;
 
   private:
     double mIntervalX = 0.0;

--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.cpp
@@ -144,6 +144,11 @@ QgsFeatureList QgsSplitLinesByLengthAlgorithm::processFeature( const QgsFeature 
   }
 }
 
+QgsProcessingFeatureSource::Flag QgsSplitLinesByLengthAlgorithm::sourceFlags() const
+{
+  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
+}
+
 
 ///@endcond
 

--- a/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
+++ b/src/analysis/processing/qgsalgorithmsplitlinesbylength.h
@@ -51,6 +51,7 @@ class QgsSplitLinesByLengthAlgorithm : public QgsProcessingFeatureBasedAlgorithm
     QString outputName() const override;
     QgsWkbTypes::Type outputWkbType( QgsWkbTypes::Type inputWkbType ) const override;
     QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsProcessingFeatureSource::Flag sourceFlags() const override;
 
   private:
 


### PR DESCRIPTION
Simplify (by its intrinsic nature) can output invalid geometries, and its processing is not affected by the presence of input geometry validity.

Also tag a few other algorithms which aren't sensitive to input ngeometry validity.
