### PR TITLE
Dropping a file onto a file widget in directory mode should set the widget...

### DIFF
--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -533,8 +533,19 @@ A Collection: logical collection of layers or subcollections, e.g. GRASS locatio
 
     void addChild( QgsDataItem *item /Transfer/ );
 
-    static QIcon iconDir(); // shared icon: open/closed directory
-    static QIcon iconDataCollection(); // default icon for data collection
+    static QIcon iconDir();
+%Docstring
+Returns the standard browser directory icon.
+
+.. seealso:: :py:func:`iconDataCollection`
+%End
+
+    static QIcon iconDataCollection();
+%Docstring
+Returns the standard browser data collection icon.
+
+.. seealso:: :py:func:`iconDir`
+%End
 
   protected:
 
@@ -593,6 +604,10 @@ Constructor.
 
 
     QString dirPath() const;
+%Docstring
+Returns the full path to the directory the item represents.
+%End
+
     virtual bool equal( const QgsDataItem *other );
 
     virtual QIcon icon();

--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -574,16 +574,6 @@ A directory: contains subdirectories and layers
 #include "qgsdataitem.h"
 %End
   public:
-    enum Column
-    {
-      Name,
-      Size,
-      Date,
-      Permissions,
-      Owner,
-      Group,
-      Type
-    };
 
     QgsDirectoryItem( QgsDataItem *parent, const QString &name, const QString &path );
 

--- a/python/core/auto_generated/qgsdataitem.sip.in
+++ b/python/core/auto_generated/qgsdataitem.sip.in
@@ -599,6 +599,9 @@ Constructor.
 
     virtual QWidget *paramWidget() /Factory/;
 
+    virtual bool hasDragEnabled() const;
+    virtual QgsMimeDataUtils::Uri mimeUri() const;
+
 
     static bool hiddenPath( const QString &path );
 %Docstring

--- a/python/core/auto_generated/qgsmimedatautils.sip.in
+++ b/python/core/auto_generated/qgsmimedatautils.sip.in
@@ -67,6 +67,7 @@ Gets mesh layer from uri if possible, otherwise returns None and error is set
       QString layerType;
 
       QString providerKey;
+
       QString name;
       QString uri;
       QStringList supportedCrs;

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -1021,6 +1021,15 @@ QWidget *QgsDirectoryItem::paramWidget()
   return new QgsDirectoryParamWidget( mPath );
 }
 
+QgsMimeDataUtils::Uri QgsDirectoryItem::mimeUri() const
+{
+  QgsMimeDataUtils::Uri u;
+  u.layerType = QStringLiteral( "directory" );
+  u.name = mName;
+  u.uri = mDirPath;
+  return u;
+}
+
 QgsDirectoryParamWidget::QgsDirectoryParamWidget( const QString &path, QWidget *parent )
   : QTreeWidget( parent )
 {

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -556,8 +556,17 @@ class CORE_EXPORT QgsDataCollectionItem : public QgsDataItem
 
     void addChild( QgsDataItem *item SIP_TRANSFER ) { mChildren.append( item ); }
 
-    static QIcon iconDir(); // shared icon: open/closed directory
-    static QIcon iconDataCollection(); // default icon for data collection
+    /**
+     * Returns the standard browser directory icon.
+     * \see iconDataCollection()
+     */
+    static QIcon iconDir();
+
+    /**
+     * Returns the standard browser data collection icon.
+     * \see iconDir()
+     */
+    static QIcon iconDataCollection();
 
   protected:
 
@@ -607,7 +616,11 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
 
     QVector<QgsDataItem *> createChildren() override;
 
+    /**
+     * Returns the full path to the directory the item represents.
+     */
     QString dirPath() const { return mDirPath; }
+
     bool equal( const QgsDataItem *other ) override;
     QIcon icon() override;
     QWidget *paramWidget() override SIP_FACTORY;

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -611,6 +611,8 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
     bool equal( const QgsDataItem *other ) override;
     QIcon icon() override;
     QWidget *paramWidget() override SIP_FACTORY;
+    bool hasDragEnabled() const override { return true; }
+    QgsMimeDataUtils::Uri mimeUri() const override;
 
     //! Check if the given path is hidden from the browser model
     static bool hiddenPath( const QString &path );

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -591,16 +591,6 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
 {
     Q_OBJECT
   public:
-    enum Column
-    {
-      Name,
-      Size,
-      Date,
-      Permissions,
-      Owner,
-      Group,
-      Type
-    };
 
     QgsDirectoryItem( QgsDataItem *parent, const QString &name, const QString &path );
 

--- a/src/core/qgsmimedatautils.h
+++ b/src/core/qgsmimedatautils.h
@@ -72,16 +72,30 @@ class CORE_EXPORT QgsMimeDataUtils
        */
       QgsMeshLayer *meshLayer( bool &owner, QString &error ) const;
 
-      //! Type of URI. Recognized types: "vector" / "raster" / "mesh" / "plugin" / "custom" / "project"
+      /**
+       * Type of URI.
+       *
+       * Recognized types include
+       * - "vector": vector layers
+       * - "raster": raster layers
+       * - "mesh": mesh layers
+       * - "plugin": plugin layers
+       * - "custom": custom types
+       * - "project": QGS/QGZ project file
+       * - "directory": directory path
+       *
+       * Mime data from plugins may use additional custom layer types.
+       */
       QString layerType;
 
       /**
        * For "vector" / "raster" type: provider id.
        * For "plugin" type: plugin layer type name.
        * For "custom" type: key of its QgsCustomDropHandler
-       * For "project" type: unused
+       * For "project" and "directory" types: unused
        */
       QString providerKey;
+
       //! Human readable name to be used e.g. in layer tree
       QString name;
       //! Identifier of the data source recognized by its providerKey

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -435,10 +435,31 @@ QString QgsFileDropEdit::acceptableFilePath( QDropEvent *event ) const
     Q_FOREACH ( const QUrl &url, event->mimeData()->urls() )
     {
       QFileInfo file( url.toLocalFile() );
-      if ( ( mStorageMode != QgsFileWidget::GetDirectory && file.isFile() &&
-             ( mAcceptableExtensions.isEmpty() || mAcceptableExtensions.contains( file.suffix(), Qt::CaseInsensitive ) ) )
-           || ( mStorageMode == QgsFileWidget::GetDirectory && file.isDir() ) )
-        paths.append( file.filePath() );
+      switch ( mStorageMode )
+      {
+        case QgsFileWidget::GetFile:
+        case QgsFileWidget::GetMultipleFiles:
+        case QgsFileWidget::SaveFile:
+        {
+          if ( file.isFile() && ( mAcceptableExtensions.isEmpty() || mAcceptableExtensions.contains( file.suffix(), Qt::CaseInsensitive ) ) )
+            paths.append( file.filePath() );
+
+          break;
+        }
+
+        case QgsFileWidget::GetDirectory:
+        {
+          if ( file.isDir() )
+            paths.append( file.filePath() );
+          else if ( file.isFile() )
+          {
+            // folder mode, but a file dropped. So get folder name from file
+            paths.append( file.absolutePath() );
+          }
+
+          break;
+        }
+      }
     }
   }
   if ( paths.size() > 1 )

--- a/src/gui/qgsfilewidget.cpp
+++ b/src/gui/qgsfilewidget.cpp
@@ -54,6 +54,7 @@ QgsFileWidget::QgsFileWidget( QWidget *parent )
 
   // otherwise, use the traditional QLineEdit subclass
   mLineEdit = new QgsFileDropEdit( this );
+  mLineEdit->setDragEnabled( true );
   connect( mLineEdit, &QLineEdit::textChanged, this, &QgsFileWidget::textEdited );
   mLayout->addWidget( mLineEdit );
 
@@ -438,16 +439,23 @@ QString QgsFileDropEdit::acceptableFilePath( QDropEvent *event ) const
     rawPaths.reserve( urls.count() );
     for ( const QUrl &url : urls )
     {
-      rawPaths.append( url.toLocalFile() );
+      const QString local =  url.toLocalFile();
+      if ( !rawPaths.contains( local ) )
+        rawPaths.append( local );
     }
   }
 
   QgsMimeDataUtils::UriList lst = QgsMimeDataUtils::decodeUriList( event->mimeData() );
   for ( const QgsMimeDataUtils::Uri &u : lst )
   {
-    rawPaths.append( u.uri );
+    if ( !rawPaths.contains( u.uri ) )
+      rawPaths.append( u.uri );
   }
 
+  if ( !event->mimeData()->text().isEmpty() && !rawPaths.contains( event->mimeData()->text() ) )
+    rawPaths.append( event->mimeData()->text() );
+
+  paths.reserve( rawPaths.count() );
   for ( const QString &path : qgis::as_const( rawPaths ) )
   {
     QFileInfo file( path );

--- a/tests/src/core/testqgsdataitem.cpp
+++ b/tests/src/core/testqgsdataitem.cpp
@@ -47,6 +47,7 @@ class TestQgsDataItem : public QObject
     void cleanup() {} // will be called after every testfunction.
 
     void testValid();
+    void testDirItem();
     void testDirItemChildren();
     void testLayerItemType();
     void testProjectItemCreation();
@@ -108,6 +109,19 @@ void TestQgsDataItem::testValid()
     QgsDebugMsg( QStringLiteral( "dirItem has %1 children" ).arg( mDirItem->rowCount() ) );
   }
   QVERIFY( isValidDirItem( mDirItem ) );
+}
+
+void TestQgsDataItem::testDirItem()
+{
+  std::unique_ptr< QgsDirectoryItem > dirItem = qgis::make_unique< QgsDirectoryItem >( nullptr, QStringLiteral( "Test" ), TEST_DATA_DIR );
+  QCOMPARE( dirItem->dirPath(), TEST_DATA_DIR );
+  QCOMPARE( dirItem->name(), QStringLiteral( "Test" ) );
+
+  QVERIFY( dirItem->hasDragEnabled() );
+  QgsMimeDataUtils::Uri mime = dirItem->mimeUri();
+  QVERIFY( mime.isValid() );
+  QCOMPARE( mime.uri, TEST_DATA_DIR );
+  QCOMPARE( mime.layerType, QStringLiteral( "directory" ) );
 }
 
 void TestQgsDataItem::testDirItemChildren()

--- a/tests/src/core/testqgsdataitem.cpp
+++ b/tests/src/core/testqgsdataitem.cpp
@@ -114,13 +114,13 @@ void TestQgsDataItem::testValid()
 void TestQgsDataItem::testDirItem()
 {
   std::unique_ptr< QgsDirectoryItem > dirItem = qgis::make_unique< QgsDirectoryItem >( nullptr, QStringLiteral( "Test" ), TEST_DATA_DIR );
-  QCOMPARE( dirItem->dirPath(), TEST_DATA_DIR );
+  QCOMPARE( dirItem->dirPath(), QStringLiteral( TEST_DATA_DIR ) );
   QCOMPARE( dirItem->name(), QStringLiteral( "Test" ) );
 
   QVERIFY( dirItem->hasDragEnabled() );
   QgsMimeDataUtils::Uri mime = dirItem->mimeUri();
   QVERIFY( mime.isValid() );
-  QCOMPARE( mime.uri, TEST_DATA_DIR );
+  QCOMPARE( mime.uri, QStringLiteral( TEST_DATA_DIR ) );
   QCOMPARE( mime.layerType, QStringLiteral( "directory" ) );
 }
 

--- a/tests/src/gui/testqgsfilewidget.cpp
+++ b/tests/src/gui/testqgsfilewidget.cpp
@@ -129,9 +129,11 @@ void TestQgsFileWidget::testDroppedFiles()
   // try with folders
   w->setStorageMode( QgsFileWidget::GetDirectory );
   w->setFilePath( QString() );
-  // should be rejected
+  // dropping a file should accept only the folder containing that file
+  mime->setUrls( QList<QUrl>() << QUrl::fromLocalFile( TEST_DATA_DIR + QStringLiteral( "/mesh/quad_and_triangle.2dm" ) ) );
+  event.reset( new QDropEvent( QPointF( 1, 1 ), Qt::CopyAction, mime.get(), Qt::LeftButton,  Qt::NoModifier ) );
   qobject_cast< QgsFileDropEdit * >( w->lineEdit() )->dropEvent( event.get() );
-  QVERIFY( w->lineEdit()->text().isEmpty() );
+  QCOMPARE( w->lineEdit()->text(), QString( TEST_DATA_DIR ) +  QStringLiteral( "/mesh" ) );
 
   // but dropping a folder should work
   mime->setUrls( QList<QUrl>() << QUrl::fromLocalFile( TEST_DATA_DIR ) );

--- a/tests/src/gui/testqgsfilewidget.cpp
+++ b/tests/src/gui/testqgsfilewidget.cpp
@@ -126,6 +126,13 @@ void TestQgsFileWidget::testDroppedFiles()
   qobject_cast< QgsFileDropEdit * >( w->lineEdit() )->dropEvent( event.get() );
   QCOMPARE( w->lineEdit()->text(), QString( TEST_DATA_DIR ) + QStringLiteral( "/mesh/quad_and_triangle.txt" ) );
 
+  // plain text should also be permitted
+  mime = qgis::make_unique< QMimeData >();
+  mime->setText( TEST_DATA_DIR + QStringLiteral( "/mesh/quad_and_triangle.2dm" ) );
+  event.reset( new QDropEvent( QPointF( 1, 1 ), Qt::CopyAction, mime.get(), Qt::LeftButton,  Qt::NoModifier ) );
+  qobject_cast< QgsFileDropEdit * >( w->lineEdit() )->dropEvent( event.get() );
+  QCOMPARE( w->lineEdit()->text(), TEST_DATA_DIR + QStringLiteral( "/mesh/quad_and_triangle.2dm" ) );
+
   mime.reset( new QMimeData() );
   mime->setUrls( QList<QUrl>() << QUrl::fromLocalFile( TEST_DATA_DIR + QStringLiteral( "/bug5598.shp" ) ) );
   event.reset( new QDropEvent( QPointF( 1, 1 ), Qt::CopyAction, mime.get(), Qt::LeftButton,  Qt::NoModifier ) );
@@ -183,11 +190,12 @@ void TestQgsFileWidget::testMultipleFiles()
 
   std::unique_ptr< QMimeData > mime( new QMimeData() );
   mime->setUrls( QList<QUrl>() << QUrl::fromLocalFile( TEST_DATA_DIR + QStringLiteral( "/bug5598.shp" ) )
-                 << QUrl::fromLocalFile( TEST_DATA_DIR + QStringLiteral( "/bug5598.shp" ) ) );
+                 << QUrl::fromLocalFile( TEST_DATA_DIR + QStringLiteral( "/elev.gpx" ) ) );
   std::unique_ptr< QDropEvent > event( new QDropEvent( QPointF( 1, 1 ), Qt::CopyAction, mime.get(), Qt::LeftButton, Qt::NoModifier ) );
 
   qobject_cast< QgsFileDropEdit * >( w->lineEdit() )->dropEvent( event.get() );
-  QCOMPARE( w->lineEdit()->text(), QStringLiteral( "\"%1\" \"%1\"" ).arg( TEST_DATA_DIR + QStringLiteral( "/bug5598.shp" ) ) );
+  QCOMPARE( w->lineEdit()->text(), QStringLiteral( "\"%1\" \"%2\"" ).arg( TEST_DATA_DIR + QStringLiteral( "/bug5598.shp" ) )
+            .arg( TEST_DATA_DIR + QStringLiteral( "/elev.gpx" ) ) );
 }
 
 

--- a/tests/src/gui/testqgsfilewidget.cpp
+++ b/tests/src/gui/testqgsfilewidget.cpp
@@ -17,6 +17,7 @@
 #include "qgstest.h"
 
 #include "qgsfilewidget.h"
+#include "qgsmimedatautils.h"
 #include <memory>
 
 class TestQgsFileWidget: public QObject
@@ -103,6 +104,20 @@ void TestQgsFileWidget::testDroppedFiles()
   qobject_cast< QgsFileDropEdit * >( w->lineEdit() )->dropEvent( event.get() );
   QCOMPARE( w->lineEdit()->text(), TEST_DATA_DIR + QStringLiteral( "/bug5598.shp" ) );
 
+  // also should support files dragged from browser
+  mime->setUrls( QList<QUrl>() );
+  QgsMimeDataUtils::Uri uri;
+  uri.uri = TEST_DATA_DIR + QStringLiteral( "/mesh/quad_and_triangle.2dm" );
+  QgsMimeDataUtils::UriList uriList;
+  uriList << uri;
+  mime.reset( QgsMimeDataUtils::encodeUriList( uriList ) );
+  event.reset( new QDropEvent( QPointF( 1, 1 ), Qt::CopyAction, mime.get(), Qt::LeftButton,  Qt::NoModifier ) );
+  qobject_cast< QgsFileDropEdit * >( w->lineEdit() )->dropEvent( event.get() );
+  QCOMPARE( w->lineEdit()->text(), TEST_DATA_DIR + QStringLiteral( "/mesh/quad_and_triangle.2dm" ) );
+
+  mime.reset( new QMimeData() );
+  mime->setUrls( QList<QUrl>() << QUrl::fromLocalFile( TEST_DATA_DIR + QStringLiteral( "/bug5598.shp" ) ) );
+  event.reset( new QDropEvent( QPointF( 1, 1 ), Qt::CopyAction, mime.get(), Qt::LeftButton,  Qt::NoModifier ) );
   // with file filter
   w->setFilter( QStringLiteral( "Data (*.shp)" ) );
   w->setFilePath( QString() );


### PR DESCRIPTION
…to the folder containing that file, not reject the event entirely
