### PR TITLE
Fix #21160 having geojson in protocol and file twice (add geojsonseq)

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1006,7 +1006,7 @@ class QgsVectorFileWriterMetadataContainer
 
       layerOptions.insert( QStringLiteral( "COORDINATE_PRECISION" ), new QgsVectorFileWriter::IntOption(
                              QObject::tr( "Maximum number of figures after decimal separator to write in coordinates. "
-                                          "Default to 15. Truncation will occur to remove trailing zeros." ),
+                                          "Defaults to 15. Truncation will occur to remove trailing zeros." ),
                              15 // Default value
                            ) );
 
@@ -1016,6 +1016,35 @@ class QgsVectorFileWriterMetadataContainer
                                QObject::tr( "GeoJSON" ),
                                QStringLiteral( "*.geojson" ),
                                QStringLiteral( "geojson" ),
+                               datasetOptions,
+                               layerOptions,
+                               QStringLiteral( "UTF-8" )
+                             )
+                           );
+
+      // GeoJSONSeq
+      datasetOptions.clear();
+      layerOptions.clear();
+
+      layerOptions.insert( QStringLiteral( "COORDINATE_PRECISION" ), new QgsVectorFileWriter::IntOption(
+                             QObject::tr( "Maximum number of figures after decimal separator to write in coordinates. "
+                                          "Defaults to 15. Truncation will occur to remove trailing zeros." ),
+                             15 // Default value
+                           ) );
+
+      layerOptions.insert( QStringLiteral( "RS" ), new QgsVectorFileWriter::BoolOption(
+                             QObject::tr( "Whether to start records with the RS=0x1E character (RFC 8142 standard). "
+                                          "Defaults to NO: Newline Delimited JSON (geojsonl). \n"
+                                          "If set to YES:  RFC 8142 standard: GeoJSON Text Sequences  (geojsons)." ),
+                             false  // Default value = NO
+                           ) );
+
+      driverMetadata.insert( QStringLiteral( "GeoJSONSeq" ),
+                             QgsVectorFileWriter::MetaData(
+                               QStringLiteral( "GeoJSON - Newline Delimited" ),
+                               QObject::tr( "GeoJSON - Newline Delimited" ),
+                               QStringLiteral( "*.geojsonl *.geojsons *.json" ),
+                               QStringLiteral( "json" ),  // add json for now
                                datasetOptions,
                                layerOptions,
                                QStringLiteral( "UTF-8" )

--- a/src/gui/ogr/qgsogrhelperfunctions.cpp
+++ b/src/gui/ogr/qgsogrhelperfunctions.cpp
@@ -256,7 +256,8 @@ QString createProtocolURI( const QString &type, const QString &url,  const QStri
     uri = url;
     uri.prepend( QStringLiteral( "/vsiswift/" ) );
   }
-  else if ( type == QLatin1String( "GeoJSON" ) )
+  // catching both GeoJSON and GeoJSONSeq
+  else if ( type.startsWith( QLatin1String( "GeoJSON" ) ) )
   {
     uri = url;
   }

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -2770,9 +2770,15 @@ QString createFilters( const QString &type )
         sFileFilters += createFileFilter_( QObject::tr( "FMEObjects Gateway" ), QStringLiteral( "*.fdd" ) );
         sExtensions << QStringLiteral( "fdd" );
       }
+      else if ( driverName.startsWith( QLatin1String( "GeoJSONSeq" ) ) )
+      {
+        sProtocolDrivers += QLatin1String( "GeoJSON - Newline Delimited;" );
+        sFileFilters += createFileFilter_( QObject::tr( "GeoJSON Newline Delimited JSON" ), QStringLiteral( "*.geojsonl *.geojsons *.nlgeojson *.json" ) );
+        sExtensions << QStringLiteral( "geojsonl" ) << QStringLiteral( "geojsons" ) << QStringLiteral( "nlgeojson" ) << QStringLiteral( "json" );
+      }
       else if ( driverName.startsWith( QLatin1String( "GeoJSON" ) ) )
       {
-        sProtocolDrivers += QLatin1String( "GeoJSON,GeoJSON;" );
+        sProtocolDrivers += QLatin1String( "GeoJSON;" );
         sFileFilters += createFileFilter_( QObject::tr( "GeoJSON" ), QStringLiteral( "*.geojson" ) );
         sExtensions << QStringLiteral( "geojson" );
       }


### PR DESCRIPTION
## Description

OGR provides a driver list with geojson and geojsonseq
Going over the list we only tested if the name 'startsWith',
resulting in having geojson double.

Split up to work with both geojson (*.geojson) and
geojsonseq (*.geojsonl and *.geojsons)

See: https://www.gdal.org/drv_geojsonseq.html in short: instead of a FeatureCollection with Features, 
you stream one type (probably only Features) sequentially separated with newlines. Example: https://duif.net/mw.geojsonl

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ X] Commit messages are descriptive and explain the rationale for changes
- [ X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ X] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
