### PR TITLE
[geonode] more robust version string parsing (fix #21093, #21140)

### DIFF
--- a/src/core/geocms/geonode/qgsgeonoderequest.cpp
+++ b/src/core/geocms/geonode/qgsgeonoderequest.cpp
@@ -26,6 +26,7 @@
 #include <QJsonObject>
 #include <QUrl>
 #include <QDomDocument>
+#include <QRegularExpression>
 
 QgsGeoNodeRequest::QgsGeoNodeRequest( const QString &baseUrl, bool forceRefresh, QObject *parent )
   : QObject( parent )
@@ -272,9 +273,18 @@ QList<QgsGeoNodeRequest::ServiceLayerDetail> QgsGeoNodeRequest::parseLayers( con
   qint16 minorVersion;
   if ( jsonVariantMap.contains( QStringLiteral( "geonode_version" ) ) )
   {
-    const QStringList geonodeVersionSplit = jsonVariantMap.value( QStringLiteral( "geonode_version" ) ).toString().split( '.' );
-    majorVersion = geonodeVersionSplit.at( 0 ).toInt();
-    minorVersion = geonodeVersionSplit.at( 1 ).toInt();
+    QRegularExpression re( "((\\d+)(\\.\\d+))" );
+    QRegularExpressionMatch match = re.match( jsonVariantMap.value( QStringLiteral( "geonode_version" ) ).toString() );
+    if ( match.hasMatch() )
+    {
+      const QStringList geonodeVersionSplit = match.captured( 0 ).split( '.' );
+      majorVersion = geonodeVersionSplit.at( 0 ).toInt();
+      minorVersion = geonodeVersionSplit.at( 1 ).toInt();
+    }
+    else
+    {
+      return layers;
+    }
   }
   else
   {


### PR DESCRIPTION
## Description
Improves version parsing for GeoNode provider. Backport of #9117 to the LTR branch.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
