### PR TITLE
Improve map settings flags for canvas [quick]

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -102,9 +102,16 @@ void QgsQuickMapCanvasMap::refreshMap()
   if ( project )
   {
     expressionContext << QgsExpressionContextUtils::projectScope( project );
+
+    mapSettings.setLabelingEngineSettings( project->labelingEngineSettings() );
   }
 
   mapSettings.setExpressionContext( expressionContext );
+
+  // enables on-the-fly simplification of geometries to spend less time rendering
+  mapSettings.setFlag( QgsMapSettings::UseRenderingOptimization );
+  // with incremental rendering - enables updates of partially rendered layers (good for WMTS, XYZ layers)
+  mapSettings.setFlag( QgsMapSettings::RenderPartialOutput, mIncrementalRendering );
 
   // create the renderer job
   Q_ASSERT( !mJob );


### PR DESCRIPTION
A bunch of small fixes/improvements for qgis_quick map canvas:
- labeling engine settings from project were not being applied
- enable simplification of geometries (faster map rendering)
- enable partial map updates when incremental rendering is enabled
  (to be able to see how wmts/xyz tiles are being loaded)
