### PR TITLE
[processing] Port expression widget wrapper to new API 

### DIFF
--- a/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingwidgetwrapper.sip.in
@@ -293,6 +293,17 @@ Returns the current value of the parameter.
 .. seealso:: :py:func:`setWidgetValue`
 %End
 
+    virtual const QgsVectorLayer *linkedVectorLayer() const;
+%Docstring
+Returns the optional vector layer associated with this widget wrapper, or None if no vector
+layer is applicable.
+
+This is used to correctly generate expression contexts within the GUI, e.g. to allow expression
+buttons and property override buttons to correctly show the appropriate vector layer fields.
+
+.. versionadded:: 3.6
+%End
+
   protected:
 
 

--- a/src/gui/processing/qgsprocessingguiregistry.cpp
+++ b/src/gui/processing/qgsprocessingguiregistry.cpp
@@ -36,6 +36,7 @@ QgsProcessingGuiRegistry::QgsProcessingGuiRegistry()
   addParameterWidgetFactory( new QgsProcessingAuthConfigWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingMatrixWidgetWrapper() );
   addParameterWidgetFactory( new QgsProcessingFileWidgetWrapper() );
+  addParameterWidgetFactory( new QgsProcessingExpressionWidgetWrapper() );
 }
 
 QgsProcessingGuiRegistry::~QgsProcessingGuiRegistry()

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -187,6 +187,13 @@ QLabel *QgsAbstractProcessingParameterWidgetWrapper::createLabel()
   return nullptr;
 }
 
+const QgsVectorLayer *QgsAbstractProcessingParameterWidgetWrapper::linkedVectorLayer() const
+{
+  if ( mPropertyButton )
+    return mPropertyButton->vectorLayer();
+  return nullptr;
+}
+
 void QgsAbstractProcessingParameterWidgetWrapper::postInitialize( const QList<QgsAbstractProcessingParameterWidgetWrapper *> &wrappers )
 {
   switch ( mType )
@@ -230,8 +237,8 @@ QgsExpressionContext QgsAbstractProcessingParameterWidgetWrapper::createExpressi
 
   QgsExpressionContext c = context->expressionContext();
 
-  if ( mPropertyButton->vectorLayer() )
-    c << QgsExpressionContextUtils::layerScope( mPropertyButton->vectorLayer() );
+  if ( linkedVectorLayer() )
+    c << QgsExpressionContextUtils::layerScope( linkedVectorLayer() );
 
   if ( mWidgetContext.model() )
   {

--- a/src/gui/processing/qgsprocessingwidgetwrapper.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.cpp
@@ -200,7 +200,7 @@ void QgsAbstractProcessingParameterWidgetWrapper::postInitialize( const QList<Qg
         {
           if ( wrapper->parameterDefinition()->name() == parameterDefinition()->dynamicLayerParameterName() )
           {
-            setDynamicParentLayerParameter( wrapper->parameterValue() );
+            setDynamicParentLayerParameter( wrapper );
             connect( wrapper, &QgsAbstractProcessingParameterWidgetWrapper::widgetValueHasChanged, this, &QgsAbstractProcessingParameterWidgetWrapper::parentLayerChanged );
             break;
           }
@@ -259,11 +259,11 @@ void QgsAbstractProcessingParameterWidgetWrapper::parentLayerChanged( QgsAbstrac
 {
   if ( wrapper )
   {
-    setDynamicParentLayerParameter( wrapper->parameterValue() );
+    setDynamicParentLayerParameter( wrapper );
   }
 }
 
-void QgsAbstractProcessingParameterWidgetWrapper::setDynamicParentLayerParameter( const QVariant &value )
+void QgsAbstractProcessingParameterWidgetWrapper::setDynamicParentLayerParameter( const QgsAbstractProcessingParameterWidgetWrapper *parentWrapper )
 {
   if ( mPropertyButton )
   {
@@ -279,7 +279,7 @@ void QgsAbstractProcessingParameterWidgetWrapper::setDynamicParentLayerParameter
       context = tmpContext.get();
     }
 
-    QgsVectorLayer *layer = QgsProcessingParameters::parameterAsVectorLayer( parameterDefinition(), value, *context );
+    QgsVectorLayer *layer = QgsProcessingParameters::parameterAsVectorLayer( parentWrapper->parameterDefinition(), parentWrapper->parameterValue(), *context );
     if ( !layer )
     {
       mPropertyButton->setVectorLayer( nullptr );

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -334,7 +334,7 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject, p
     QgsProcessingGui::WidgetType mType = QgsProcessingGui::Standard;
     const QgsProcessingParameterDefinition *mParameterDefinition = nullptr;
 
-    void setDynamicParentLayerParameter( const QVariant &value );
+    void setDynamicParentLayerParameter( const QgsAbstractProcessingParameterWidgetWrapper *parentWrapper );
 
     QPointer< QWidget > mWidget;
     QPointer< QgsPropertyOverrideButton > mPropertyButton;

--- a/src/gui/processing/qgsprocessingwidgetwrapper.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapper.h
@@ -320,6 +320,17 @@ class GUI_EXPORT QgsAbstractProcessingParameterWidgetWrapper : public QObject, p
      */
     virtual QVariant widgetValue() const = 0;
 
+    /**
+     * Returns the optional vector layer associated with this widget wrapper, or nullptr if no vector
+     * layer is applicable.
+     *
+     * This is used to correctly generate expression contexts within the GUI, e.g. to allow expression
+     * buttons and property override buttons to correctly show the appropriate vector layer fields.
+     *
+     * \since QGIS 3.6
+     */
+    virtual const QgsVectorLayer *linkedVectorLayer() const;
+
   protected:
 
     QgsProcessingContextGenerator *mProcessingContextGenerator = nullptr;

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.h
@@ -32,6 +32,8 @@ class QgsDoubleSpinBox;
 class QgsAuthConfigSelect;
 class QgsProcessingMatrixParameterPanel;
 class QgsFileWidget;
+class QgsFieldExpressionWidget;
+class QgsExpressionLineEdit;
 
 ///@cond PRIVATE
 
@@ -356,6 +358,45 @@ class GUI_EXPORT QgsProcessingFileWidgetWrapper : public QgsAbstractProcessingPa
   private:
 
     QgsFileWidget *mFileWidget = nullptr;
+
+    friend class TestProcessingGui;
+};
+
+class GUI_EXPORT QgsProcessingExpressionWidgetWrapper : public QgsAbstractProcessingParameterWidgetWrapper, public QgsProcessingParameterWidgetFactoryInterface
+{
+    Q_OBJECT
+
+  public:
+
+    QgsProcessingExpressionWidgetWrapper( const QgsProcessingParameterDefinition *parameter = nullptr,
+                                          QgsProcessingGui::WidgetType type = QgsProcessingGui::Standard, QWidget *parent = nullptr );
+
+    // QgsProcessingParameterWidgetFactoryInterface
+    QString parameterType() const override;
+    QgsAbstractProcessingParameterWidgetWrapper *createWidgetWrapper( const QgsProcessingParameterDefinition *parameter, QgsProcessingGui::WidgetType type ) override;
+
+    // QgsProcessingParameterWidgetWrapper interface
+    QWidget *createWidget() override SIP_FACTORY;
+    void postInitialize( const QList< QgsAbstractProcessingParameterWidgetWrapper * > &wrappers ) override;
+  public slots:
+    void setParentLayerWrapperValue( const QgsAbstractProcessingParameterWidgetWrapper *parentWrapper );
+  protected:
+
+    void setWidgetValue( const QVariant &value, QgsProcessingContext &context ) override;
+    QVariant widgetValue() const override;
+
+    QStringList compatibleParameterTypes() const override;
+
+    QStringList compatibleOutputTypes() const override;
+
+    QList< int > compatibleDataTypes() const override;
+    QString modelerExpressionFormatString() const override;
+    const QgsVectorLayer *linkedVectorLayer() const override;
+  private:
+
+    QgsFieldExpressionWidget *mFieldExpWidget = nullptr;
+    QgsExpressionLineEdit *mExpLineEdit = nullptr;
+    std::unique_ptr< QgsVectorLayer > mParentLayer;
 
     friend class TestProcessingGui;
 };

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -177,6 +177,8 @@ void QgsFieldExpressionWidget::setField( const QString &fieldName )
   if ( fieldName.isEmpty() )
   {
     setRow( -1 );
+    emit fieldChanged( QString() );
+    emit fieldChanged( QString(), true );
     return;
   }
 

--- a/tests/src/gui/testqgsfieldexpressionwidget.cpp
+++ b/tests/src/gui/testqgsfieldexpressionwidget.cpp
@@ -141,21 +141,60 @@ void TestQgsFieldExpressionWidget::asExpression()
   std::unique_ptr< QgsFieldExpressionWidget > widget( new QgsFieldExpressionWidget() );
   widget->setLayer( layer );
 
+  QSignalSpy spy( widget.get(), static_cast < void ( QgsFieldExpressionWidget::* )( const QString & ) >( &QgsFieldExpressionWidget::fieldChanged ) );
+  QSignalSpy spy2( widget.get(), static_cast < void ( QgsFieldExpressionWidget::* )( const QString &, bool ) >( &QgsFieldExpressionWidget::fieldChanged ) );
+
   // check with field set
   widget->setField( QStringLiteral( "fld" ) );
-  QCOMPARE( widget->asExpression(), QString( "\"fld\"" ) );
+  QCOMPARE( widget->asExpression(), QStringLiteral( "\"fld\"" ) );
+  QCOMPARE( spy.count(), 1 );
+  QCOMPARE( spy.constLast().at( 0 ).toString(), QStringLiteral( "fld" ) );
+  QCOMPARE( spy2.count(), 1 );
+  QCOMPARE( spy2.constLast().at( 0 ).toString(), QStringLiteral( "fld" ) );
+  QVERIFY( spy2.constLast().at( 1 ).toBool() );
 
   // check with expressions set
   widget->setField( QStringLiteral( "fld + 1" ) );
-  QCOMPARE( widget->asExpression(), QString( "fld + 1" ) );
+  QCOMPARE( widget->asExpression(), QStringLiteral( "fld + 1" ) );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( spy.constLast().at( 0 ).toString(), QStringLiteral( "fld + 1" ) );
+  QCOMPARE( spy2.count(), 2 );
+  QCOMPARE( spy2.constLast().at( 0 ).toString(), QStringLiteral( "fld + 1" ) );
+  QVERIFY( spy2.constLast().at( 1 ).toBool() );
+
   widget->setField( QStringLiteral( "1" ) );
-  QCOMPARE( widget->asExpression(), QString( "1" ) );
+  QCOMPARE( widget->asExpression(), QStringLiteral( "1" ) );
+  QCOMPARE( spy.count(), 3 );
+  QCOMPARE( spy.constLast().at( 0 ).toString(), QStringLiteral( "1" ) );
+  QCOMPARE( spy2.count(), 3 );
+  QCOMPARE( spy2.constLast().at( 0 ).toString(), QStringLiteral( "1" ) );
+  QVERIFY( spy2.constLast().at( 1 ).toBool() );
+
   widget->setField( QStringLiteral( "\"fld2\"" ) );
-  QCOMPARE( widget->asExpression(), QString( "\"fld2\"" ) );
+  QCOMPARE( widget->asExpression(), QStringLiteral( "\"fld2\"" ) );
+  QCOMPARE( spy.count(), 4 );
+  QCOMPARE( spy.constLast().at( 0 ).toString(), QStringLiteral( "fld2" ) );
+  QCOMPARE( spy2.count(), 4 );
+  QCOMPARE( spy2.constLast().at( 0 ).toString(), QStringLiteral( "fld2" ) );
+  QVERIFY( spy2.constLast().at( 1 ).toBool() );
 
   // check switching back to a field
   widget->setField( QStringLiteral( "fld3" ) );
-  QCOMPARE( widget->asExpression(), QString( "\"fld3\"" ) );
+  QCOMPARE( widget->asExpression(), QStringLiteral( "\"fld3\"" ) );
+  QCOMPARE( spy.count(), 5 );
+  QCOMPARE( spy.constLast().at( 0 ).toString(), QStringLiteral( "fld3" ) );
+  QCOMPARE( spy2.count(), 5 );
+  QCOMPARE( spy2.constLast().at( 0 ).toString(), QStringLiteral( "fld3" ) );
+  QVERIFY( spy2.constLast().at( 1 ).toBool() );
+
+  // and back to null
+  widget->setField( QString() );
+  QVERIFY( widget->asExpression().isEmpty() );
+  QCOMPARE( spy.count(), 6 );
+  QVERIFY( spy.constLast().at( 0 ).toString().isEmpty() );
+  QCOMPARE( spy2.count(), 6 );
+  QVERIFY( spy2.constLast().at( 0 ).toString().isEmpty() );
+  QVERIFY( spy2.constLast().at( 1 ).toBool() );
 
   QgsProject::instance()->removeMapLayer( layer );
 }
@@ -175,43 +214,43 @@ void TestQgsFieldExpressionWidget::testIsValid()
   bool isExpression = false;
   bool isValid = false;
   widget->setField( QStringLiteral( "fld" ) );
-  QCOMPARE( widget->currentField( &isExpression, &isValid ), QString( "fld" ) );
+  QCOMPARE( widget->currentField( &isExpression, &isValid ), QStringLiteral( "fld" ) );
   QVERIFY( !isExpression );
   QVERIFY( isValid );
   QVERIFY( widget->isValidExpression() );
   QCOMPARE( spy.count(), 1 );
-  QCOMPARE( spy.last().at( 0 ).toString(), QString( "fld" ) );
+  QCOMPARE( spy.last().at( 0 ).toString(), QStringLiteral( "fld" ) );
   QVERIFY( spy.last().at( 1 ).toBool() );
 
 
   //check with complex field name set
   widget->setField( QStringLiteral( "name with space" ) );
-  QCOMPARE( widget->currentField( &isExpression, &isValid ), QString( "name with space" ) );
+  QCOMPARE( widget->currentField( &isExpression, &isValid ), QStringLiteral( "name with space" ) );
   QVERIFY( !isExpression );
   QVERIFY( isValid );
   QVERIFY( !widget->isValidExpression() );
   QCOMPARE( spy.count(), 2 );
-  QCOMPARE( spy.last().at( 0 ).toString(), QString( "name with space" ) );
+  QCOMPARE( spy.last().at( 0 ).toString(), QStringLiteral( "name with space" ) );
   QVERIFY( spy.last().at( 1 ).toBool() );
 
   //check with valid expression set
   widget->setField( QStringLiteral( "2 * 4" ) );
-  QCOMPARE( widget->currentField( &isExpression, &isValid ), QString( "2 * 4" ) );
+  QCOMPARE( widget->currentField( &isExpression, &isValid ), QStringLiteral( "2 * 4" ) );
   QVERIFY( isExpression );
   QVERIFY( isValid );
   QVERIFY( widget->isValidExpression() );
   QCOMPARE( spy.count(), 3 );
-  QCOMPARE( spy.last().at( 0 ).toString(), QString( "2 * 4" ) );
+  QCOMPARE( spy.last().at( 0 ).toString(), QStringLiteral( "2 * 4" ) );
   QVERIFY( spy.last().at( 1 ).toBool() );
 
   //check with invalid expression set
   widget->setField( QStringLiteral( "2 *" ) );
-  QCOMPARE( widget->currentField( &isExpression, &isValid ), QString( "2 *" ) );
+  QCOMPARE( widget->currentField( &isExpression, &isValid ), QStringLiteral( "2 *" ) );
   QVERIFY( isExpression );
   QVERIFY( !isValid );
   QVERIFY( !widget->isValidExpression() );
   QCOMPARE( spy.count(), 4 );
-  QCOMPARE( spy.last().at( 0 ).toString(), QString( "2 *" ) );
+  QCOMPARE( spy.last().at( 0 ).toString(), QStringLiteral( "2 *" ) );
   QVERIFY( !spy.last().at( 1 ).toBool() );
 
   QgsProject::instance()->removeMapLayer( layer );
@@ -226,46 +265,46 @@ void TestQgsFieldExpressionWidget::testFilters()
   widget->setLayer( layer );
 
   QCOMPARE( widget->mCombo->count(), 8 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "intfld" ) );
-  QCOMPARE( widget->mCombo->itemText( 1 ), QString( "stringfld" ) );
-  QCOMPARE( widget->mCombo->itemText( 2 ), QString( "string2fld" ) );
-  QCOMPARE( widget->mCombo->itemText( 3 ), QString( "longfld" ) );
-  QCOMPARE( widget->mCombo->itemText( 4 ), QString( "doublefld" ) );
-  QCOMPARE( widget->mCombo->itemText( 5 ), QString( "datefld" ) );
-  QCOMPARE( widget->mCombo->itemText( 6 ), QString( "timefld" ) );
-  QCOMPARE( widget->mCombo->itemText( 7 ), QString( "datetimefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "intfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 1 ), QStringLiteral( "stringfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 2 ), QStringLiteral( "string2fld" ) );
+  QCOMPARE( widget->mCombo->itemText( 3 ), QStringLiteral( "longfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 4 ), QStringLiteral( "doublefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 5 ), QStringLiteral( "datefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 6 ), QStringLiteral( "timefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 7 ), QStringLiteral( "datetimefld" ) );
 
   widget->setFilters( QgsFieldProxyModel::String );
   QCOMPARE( widget->mCombo->count(), 2 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "stringfld" ) );
-  QCOMPARE( widget->mCombo->itemText( 1 ), QString( "string2fld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "stringfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 1 ), QStringLiteral( "string2fld" ) );
 
   widget->setFilters( QgsFieldProxyModel::Int );
   QCOMPARE( widget->mCombo->count(), 1 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "intfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "intfld" ) );
 
   widget->setFilters( QgsFieldProxyModel::LongLong );
   QCOMPARE( widget->mCombo->count(), 1 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "longfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "longfld" ) );
 
   widget->setFilters( QgsFieldProxyModel::Double );
   QCOMPARE( widget->mCombo->count(), 1 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "doublefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "doublefld" ) );
 
   widget->setFilters( QgsFieldProxyModel::Numeric );
   QCOMPARE( widget->mCombo->count(), 3 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "intfld" ) );
-  QCOMPARE( widget->mCombo->itemText( 1 ), QString( "longfld" ) );
-  QCOMPARE( widget->mCombo->itemText( 2 ), QString( "doublefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "intfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 1 ), QStringLiteral( "longfld" ) );
+  QCOMPARE( widget->mCombo->itemText( 2 ), QStringLiteral( "doublefld" ) );
 
   widget->setFilters( QgsFieldProxyModel::Date );
   QCOMPARE( widget->mCombo->count(), 2 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "datefld" ) );
-  QCOMPARE( widget->mCombo->itemText( 1 ), QString( "datetimefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "datefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 1 ), QStringLiteral( "datetimefld" ) );
 
   widget->setFilters( QgsFieldProxyModel::Time );
   QCOMPARE( widget->mCombo->count(), 1 );
-  QCOMPARE( widget->mCombo->itemText( 0 ), QString( "timefld" ) );
+  QCOMPARE( widget->mCombo->itemText( 0 ), QStringLiteral( "timefld" ) );
 
   QgsProject::instance()->removeMapLayer( layer );
 }


### PR DESCRIPTION
Fixes confusing expression parameter definitions in modeler child algorithms (there's no direction as to what the widget should be) and ensures that the correct expression context is revealed to the widget when in all modes.

Also includes some other fixes revealed during this work.