### PR TITLE
[ui] Harmonize CAD panel by using toolbar (fixes hidpi et cie)

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -492,7 +492,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     std::unique_ptr<QgsMessageBarItem> mErrorMessage;
 
     // UI
-    QAction *mEnableAction = nullptr;
     QMap< QAction *, double > mCommonAngleActions; // map the common angle actions with their angle values
 
     // Snap indicator

--- a/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
+++ b/src/ui/qgsadvanceddigitizingdockwidgetbase.ui
@@ -6,21 +6,24 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>228</width>
+    <width>208</width>
     <height>220</height>
    </rect>
   </property>
   <property name="maximumSize">
    <size>
     <width>524287</width>
-    <height>220</height>
+    <height>500</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>Advanced Digitizing</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
-   <layout class="QGridLayout" name="gridLayout">
+   <layout class="QVBoxLayout" name="parentLayout">
+    <property name="spacing">
+     <number>0</number>
+    </property>
     <property name="leftMargin">
      <number>0</number>
     </property>
@@ -33,7 +36,27 @@
     <property name="bottomMargin">
      <number>0</number>
     </property>
-    <item row="0" column="0">
+    <item>
+     <widget class="QToolBar" name="mToolbar">
+      <property name="iconSize">
+       <size>
+        <width>16</width>
+        <height>16</height>
+       </size>
+      </property>
+      <property name="floatable">
+       <bool>false</bool>
+      </property>
+      <addaction name="mEnableAction"/>
+      <addaction name="separator"/>
+      <addaction name="mConstructionModeAction"/>
+      <addaction name="mParallelAction"/>
+      <addaction name="mPerpendicularAction"/>
+      <addaction name="separator"/>
+      <addaction name="mSettingsAction"/>
+     </widget>
+    </item>
+    <item>
      <layout class="QVBoxLayout" name="mLayout">
       <item>
        <widget class="QLabel" name="mErrorLabel">
@@ -69,152 +92,6 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item>
-          <layout class="QHBoxLayout" name="mButtonsLayout">
-           <item>
-            <widget class="QToolButton" name="mEnabledButton">
-             <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-             </property>
-             <property name="text">
-              <string>…</string>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>24</width>
-               <height>24</height>
-              </size>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QWidget" name="mCadButtons" native="true">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <layout class="QGridLayout" name="gridLayout_2">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <property name="spacing">
-               <number>3</number>
-              </property>
-              <item row="0" column="2">
-               <widget class="QToolButton" name="mParallelButton">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="text">
-                 <string>…</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../images/images.qrc">
-                  <normaloff>:/images/themes/default/cadtools/parallel.svg</normaloff>:/images/themes/default/cadtools/parallel.svg</iconset>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QToolButton" name="mPerpendicularButton">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="text">
-                 <string>…</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../images/images.qrc">
-                  <normaloff>:/images/themes/default/cadtools/perpendicular.svg</normaloff>:/images/themes/default/cadtools/perpendicular.svg</iconset>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QToolButton" name="mConstructionModeButton">
-                <property name="toolTip">
-                 <string/>
-                </property>
-                <property name="text">
-                 <string>…</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../images/images.qrc">
-                  <normaloff>:/images/themes/default/cadtools/construction.svg</normaloff>:/images/themes/default/cadtools/construction.svg</iconset>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>24</width>
-                  <height>24</height>
-                 </size>
-                </property>
-                <property name="checkable">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="0" column="4">
-               <widget class="QToolButton" name="mSettingsButton">
-                <property name="text">
-                 <string>…</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../images/images.qrc">
-                  <normaloff>:/images/themes/default/propertyicons/settings.svg</normaloff>:/images/themes/default/propertyicons/settings.svg</iconset>
-                </property>
-                <property name="popupMode">
-                 <enum>QToolButton::InstantPopup</enum>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </item>
          <item>
           <widget class="QWidget" name="mInputWidgets" native="true">
            <layout class="QGridLayout" name="mInputLayout">
@@ -262,6 +139,9 @@
               <property name="checkable">
                <bool>true</bool>
               </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item row="2" column="3">
@@ -277,6 +157,9 @@
                 <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
               </property>
               <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
                <bool>true</bool>
               </property>
              </widget>
@@ -296,6 +179,9 @@
               <property name="checkable">
                <bool>true</bool>
               </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item row="1" column="3">
@@ -311,6 +197,9 @@
                 <normaloff>:/images/themes/default/cadtools/lock.svg</normaloff>:/images/themes/default/cadtools/lock.svg</iconset>
               </property>
               <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
                <bool>true</bool>
               </property>
              </widget>
@@ -345,6 +234,9 @@
                <bool>true</bool>
               </property>
               <property name="checked">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
                <bool>true</bool>
               </property>
              </widget>
@@ -385,6 +277,9 @@
               <property name="checkable">
                <bool>true</bool>
               </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item row="0" column="2">
@@ -409,6 +304,9 @@
               <property name="checkable">
                <bool>true</bool>
               </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item row="0" column="4">
@@ -424,6 +322,9 @@
                 <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
               </property>
               <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
                <bool>true</bool>
               </property>
              </widget>
@@ -443,6 +344,9 @@
               <property name="checkable">
                <bool>true</bool>
               </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item row="2" column="4">
@@ -458,6 +362,9 @@
                 <normaloff>:/images/themes/default/locked_repeating.svg</normaloff>:/images/themes/default/locked_repeating.svg</iconset>
               </property>
               <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="autoRaise">
                <bool>true</bool>
               </property>
              </widget>
@@ -477,7 +384,23 @@
               <property name="checkable">
                <bool>true</bool>
               </property>
+              <property name="autoRaise">
+               <bool>true</bool>
+              </property>
              </widget>
+            </item>
+            <item row="4" column="0">
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </widget>
@@ -487,20 +410,61 @@
       </item>
      </layout>
     </item>
-    <item row="1" column="0">
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
    </layout>
+   <action name="mEnableAction">
+    <property name="toolTip">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable advanced digitizing tools&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+    <property name="icon">
+     <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/cadtools/cad.svg</normaloff>:/images/themes/default/cadtools/cad.svg</iconset>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </action>
+   <action name="mConstructionModeAction">
+    <property name="toolTip">
+     <string/>
+    </property>
+    <property name="icon">
+     <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/cadtools/construction.svg</normaloff>:/images/themes/default/cadtools/construction.svg</iconset>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </action>
+   <action name="mParallelAction">
+    <property name="toolTip">
+     <string/>
+    </property>
+    <property name="icon">
+     <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/cadtools/parallel.svg</normaloff>:/images/themes/default/cadtools/parallel.svg</iconset>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </action>
+   <action name="mPerpendicularAction">
+    <property name="toolTip">
+     <string/>
+    </property>
+    <property name="icon">
+     <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/cadtools/perpendicular.svg</normaloff>:/images/themes/default/cadtools/perpendicular.svg</iconset>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </action>
+   <action name="mSettingsAction">
+    <property name="icon">
+     <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/propertyicons/settings.svg</normaloff>:/images/themes/default/propertyicons/settings.svg</iconset>
+    </property>
+   </action>
   </widget>
  </widget>
  <customwidgets>
@@ -512,11 +476,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mEnabledButton</tabstop>
-  <tabstop>mConstructionModeButton</tabstop>
-  <tabstop>mPerpendicularButton</tabstop>
-  <tabstop>mParallelButton</tabstop>
-  <tabstop>mSettingsButton</tabstop>
   <tabstop>mDistanceLineEdit</tabstop>
   <tabstop>mLockDistanceButton</tabstop>
   <tabstop>mRepeatingLockDistanceButton</tabstop>


### PR DESCRIPTION
## Description
While refining the UI theme support in QGIS, the CAD panel jumped out at me, calling for harmonization :) This PR does that, and in doing so improves HiDPI compatibility.

Basically, instead of using buttons as toolbar buttons, we use a true toolbar.

Before vs PR:
![image](https://user-images.githubusercontent.com/1728657/52553148-3a5ee800-2e15-11e9-9e7a-8eb629b4364d.png)

@nyalldawson , there we are :)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
