### PR TITLE
Use cache for sld layers if they use NamedLayer / NamedStyle

### DIFF
--- a/src/server/qgssldconfigparser.cpp
+++ b/src/server/qgssldconfigparser.cpp
@@ -263,7 +263,7 @@ QList<QgsMapLayer*> QgsSLDConfigParser::mapLayerFromStyle( const QString& lName,
     QDomElement namedStyleElement = findNamedStyleElement( namedLayerElemList[i], styleName );
     if ( !namedStyleElement.isNull() )
     {
-      fallbackLayerList = mFallbackParser->mapLayerFromStyle( lName, styleName, false );
+      fallbackLayerList = mFallbackParser->mapLayerFromStyle( lName, styleName, useCache );
       if ( !fallbackLayerList.isEmpty() )
       {
         resultList << fallbackLayerList;


### PR DESCRIPTION
In 2.18 Server, layers from SLD are currently not using the layer cache, even if they use predefined styles (NamedLayer/NamedStyle)
