### PR TITLE
Snapping options in meters rounded to integers (fixes #20829)

### DIFF
--- a/src/app/qgssnappingwidget.cpp
+++ b/src/app/qgssnappingwidget.cpp
@@ -350,14 +350,14 @@ void QgsSnappingWidget::projectSnapSettingsChanged()
     mTypeButton->setDefaultAction( mSegmentAction );
   }
 
-  if ( mToleranceSpinBox->value() != config.tolerance() )
-  {
-    mToleranceSpinBox->setValue( config.tolerance() );
-  }
-
   if ( static_cast<QgsTolerance::UnitType>( mUnitsComboBox->currentData().toInt() ) != config.units() )
   {
     mUnitsComboBox->setCurrentIndex( mUnitsComboBox->findData( config.units() ) );
+  }
+
+  if ( mToleranceSpinBox->value() != config.tolerance() )
+  {
+    mToleranceSpinBox->setValue( config.tolerance() );
   }
 
   if ( config.intersectionSnapping() != mIntersectionSnappingAction->isChecked() )


### PR DESCRIPTION
## Description
The widget add the tolerance before determining the unit and therefore whether it will be of integer or double type. As the default entry is on px, so integer, the tolerance is rounded. Changing the order solves the problem.

cc @mhugo 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
