### PR TITLE
Add API to QgsSpatialIndex to perform exact nearest neighbour queries

### DIFF
--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -39,12 +39,19 @@ QgsSpatialIndex objects are implicitly shared and can be inexpensively copied.
   public:
 
 
-    QgsSpatialIndex();
+    enum Flag
+    {
+      FlagStoreFeatureGeometries,
+    };
+    typedef QFlags<QgsSpatialIndex::Flag> Flags;
+
+
+    QgsSpatialIndex( QgsSpatialIndex::Flags flags = 0 );
 %Docstring
 Constructor for QgsSpatialIndex. Creates an empty R-tree index.
 %End
 
-    explicit QgsSpatialIndex( const QgsFeatureIterator &fi, QgsFeedback *feedback = 0 );
+    explicit QgsSpatialIndex( const QgsFeatureIterator &fi, QgsFeedback *feedback = 0, QgsSpatialIndex::Flags flags = 0 );
 %Docstring
 Constructor - creates R-tree and bulk loads it with features from the iterator.
 This is much faster approach than creating an empty index and then inserting features one by one.
@@ -56,7 +63,7 @@ that of the spatial index construction.
 .. versionadded:: 2.8
 %End
 
-    explicit QgsSpatialIndex( const QgsFeatureSource &source, QgsFeedback *feedback = 0 );
+    explicit QgsSpatialIndex( const QgsFeatureSource &source, QgsFeedback *feedback = 0, QgsSpatialIndex::Flags flags = 0 );
 %Docstring
 Constructor - creates R-tree and bulk loads it with features from the source.
 This is much faster approach than creating an empty index and then inserting features one by one.
@@ -152,12 +159,38 @@ by the ``neighbours`` argument.
 %End
 
 
+    SIP_PYOBJECT geometry( QgsFeatureId id ) const /TypeHint="QgsGeometry"/;
+%Docstring
+Returns the stored geometry for the indexed feature with matching ``id``. A KeyError will be raised if no
+geometry with the specified feature id exists in the index.
+
+Geometry is only stored if the QgsSpatialIndex was created with the FlagStoreFeatureGeometries flag.
+
+.. versionadded:: 3.6
+%End
+%MethodCode
+    std::unique_ptr< QgsGeometry > g = qgis::make_unique< QgsGeometry >( sipCpp->geometry( a0 ) );
+    if ( g->isNull() )
+    {
+      PyErr_SetString( PyExc_KeyError, QStringLiteral( "No geometry with feature id %1 exists in the index." ).arg( a0 ).toUtf8().constData() );
+      sipIsErr = 1;
+    }
+    else
+    {
+      sipRes = sipConvertFromType( g.release(), sipType_QgsGeometry, Py_None );
+    }
+%End
+
+
     int  refs() const;
 %Docstring
 Gets reference count - just for debugging!
 %End
 
 };
+
+QFlags<QgsSpatialIndex::Flag> operator|(QgsSpatialIndex::Flag f1, QFlags<QgsSpatialIndex::Flag> f2);
+
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -152,9 +152,10 @@ Returns a list of features with a bounding box which intersects the specified ``
 Returns nearest neighbors to a ``point``. The number of neighbours returned is specified
 by the ``neighbours`` argument.
 
-.. note::
+.. warning::
 
-   The nearest neighbour test is performed based on the feature bounding boxes only, so for non-point
+   If this QgsSpatialIndex object was not constructed with the FlagStoreFeatureGeometries flag,
+   then the nearest neighbour test is performed based on the feature bounding boxes ONLY, so for non-point
    geometry features this method is not guaranteed to return the actual closest neighbours.
 %End
 

--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -147,16 +147,24 @@ Returns a list of features with a bounding box which intersects the specified ``
    when required.
 %End
 
-    QList<QgsFeatureId> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;
+    QList<QgsFeatureId> nearestNeighbor( const QgsPointXY &point, int neighbors = 1, double maxDistance = 0 ) const;
 %Docstring
-Returns nearest neighbors to a ``point``. The number of neighbours returned is specified
-by the ``neighbours`` argument.
+Returns nearest neighbors to a ``point``. The number of neighbors returned is specified
+by the ``neighbors`` argument.
+
+If the ``maxDistance`` argument is greater than 0, then only features within the specified
+distance of ``point`` will be considered.
+
+Note that in some cases the number of returned features may differ from the requested
+number of ``neighbors``. E.g. if not enough features exist within the ``maxDistance`` of the
+search point. If multiple features are equidistant from the search ``point`` then the
+number of returned feature IDs may exceed ``neighbors``.
 
 .. warning::
 
    If this QgsSpatialIndex object was not constructed with the FlagStoreFeatureGeometries flag,
-   then the nearest neighbour test is performed based on the feature bounding boxes ONLY, so for non-point
-   geometry features this method is not guaranteed to return the actual closest neighbours.
+   then the nearest neighbor test is performed based on the feature bounding boxes ONLY, so for non-point
+   geometry features this method is not guaranteed to return the actual closest neighbors.
 %End
 
 

--- a/src/core/qgsspatialindex.cpp
+++ b/src/core/qgsspatialindex.cpp
@@ -87,6 +87,7 @@ class QgsSpatialIndexCopyVisitor : public SpatialIndex::IVisitor
     SpatialIndex::ISpatialIndex *mNewIndex = nullptr;
 };
 
+///@cond PRIVATE
 class QgsNearestNeighbourComparator : public INearestNeighborComparator
 {
   public:
@@ -188,7 +189,7 @@ class QgsFeatureIteratorDataStream : public IDataStream
 
 /**
  * \ingroup core
- *  \class QgsSpatialIndexData
+ * \class QgsSpatialIndexData
  * \brief Data of spatial index that may be implicitly shared
  * \note not available in Python bindings
 */
@@ -279,6 +280,8 @@ class QgsSpatialIndexData : public QSharedData
     mutable QMutex mMutex;
 
 };
+
+///@endcond
 
 // -------------------------------------------------------------------------
 

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -74,7 +74,7 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
     //! Flags controlling index behavior
     enum Flag
     {
-      FlagStoreFeatureGeometries = 1 << 0, //!< Indicates that the spatial index should also store feature geometries. This requires more memory, but can speed up operations by avoiding additional requests to data providers to fetch matching feature geometries. Additionally, it is required for non-bounding box nearest neighbour searches.
+      FlagStoreFeatureGeometries = 1 << 0, //!< Indicates that the spatial index should also store feature geometries. This requires more memory, but can speed up operations by avoiding additional requests to data providers to fetch matching feature geometries. Additionally, it is required for non-bounding box nearest neighbor searches.
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 
@@ -175,14 +175,22 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
     QList<QgsFeatureId> intersects( const QgsRectangle &rectangle ) const;
 
     /**
-     * Returns nearest neighbors to a \a point. The number of neighbours returned is specified
-     * by the \a neighbours argument.
+     * Returns nearest neighbors to a \a point. The number of neighbors returned is specified
+     * by the \a neighbors argument.
+     *
+     * If the \a maxDistance argument is greater than 0, then only features within the specified
+     * distance of \a point will be considered.
+     *
+     * Note that in some cases the number of returned features may differ from the requested
+     * number of \a neighbors. E.g. if not enough features exist within the \a maxDistance of the
+     * search point. If multiple features are equidistant from the search \a point then the
+     * number of returned feature IDs may exceed \a neighbors.
      *
      * \warning If this QgsSpatialIndex object was not constructed with the FlagStoreFeatureGeometries flag,
-     * then the nearest neighbour test is performed based on the feature bounding boxes ONLY, so for non-point
-     * geometry features this method is not guaranteed to return the actual closest neighbours.
+     * then the nearest neighbor test is performed based on the feature bounding boxes ONLY, so for non-point
+     * geometry features this method is not guaranteed to return the actual closest neighbors.
      */
-    QList<QgsFeatureId> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;
+    QList<QgsFeatureId> nearestNeighbor( const QgsPointXY &point, int neighbors = 1, double maxDistance = 0 ) const;
 
 #ifndef SIP_RUN
 

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -178,7 +178,8 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
      * Returns nearest neighbors to a \a point. The number of neighbours returned is specified
      * by the \a neighbours argument.
      *
-     * \note The nearest neighbour test is performed based on the feature bounding boxes only, so for non-point
+     * \warning If this QgsSpatialIndex object was not constructed with the FlagStoreFeatureGeometries flag,
+     * then the nearest neighbour test is performed based on the feature bounding boxes ONLY, so for non-point
      * geometry features this method is not guaranteed to return the actual closest neighbours.
      */
     QList<QgsFeatureId> nearestNeighbor( const QgsPointXY &point, int neighbors ) const;

--- a/tests/src/core/testqgsspatialindex.cpp
+++ b/tests/src/core/testqgsspatialindex.cpp
@@ -315,15 +315,33 @@ class TestQgsSpatialIndex : public QObject
       f1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "LineString(1 1, 3 1, 3 3)" ) ) );
       QgsFeature f2( 2 );
       f2.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "LineString(0 1, 0 3)" ) ) );
+      QgsFeature f3( 3 );
+      f3.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "LineString(0 4, 1 5, 3 3)" ) ) );
       i.addFeature( f1 );
       i2.addFeature( f1 );
       i.addFeature( f2 );
       i2.addFeature( f2 );
+      i.addFeature( f3 );
+      i2.addFeature( f3 );
 
       // i does not store feature geometries, so nearest neighbour search uses bounding box only
-      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 3 ), 1 ), QList< QgsFeatureId >() << 1 );
+      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 2.9 ), 1 ), QList< QgsFeatureId >() << 1 );
+      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 2.9 ), 2 ), QList< QgsFeatureId >() << 1 << 3 );
       // i2 does store feature geometries, so nearest neighbour is exact
-      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 3 ), 1 ), QList< QgsFeatureId >() << 2 );
+      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 2.9 ), 1 ), QList< QgsFeatureId >() << 2 );
+      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 2.9 ), 2 ), QList< QgsFeatureId >() << 2 << 3 );
+
+      // with maximum distance
+      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 2.9 ), 1, 0.5 ), QList< QgsFeatureId >() << 1 );
+      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 2.9 ), 1, 0.5 ), QList< QgsFeatureId >() );
+      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 2.9 ), 2, 0.5 ), QList< QgsFeatureId >() << 1 << 3 );
+      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 2.9 ), 2, 0.5 ), QList< QgsFeatureId >() );
+      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 2.9 ), 1, 1.1 ), QList< QgsFeatureId >() << 1 );
+      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 2.9 ), 1, 1.1 ), QList< QgsFeatureId >() << 2 );
+      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 2.9 ), 2, 1.1 ), QList< QgsFeatureId >() << 1 << 3 );
+      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 2.9 ), 2, 1.1 ), QList< QgsFeatureId >() << 2 );
+      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 2.9 ), 2, 2 ), QList< QgsFeatureId >() << 1 << 3 );
+      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 2.9 ), 2, 2 ), QList< QgsFeatureId >() << 2 << 3 );
 
     }
 

--- a/tests/src/core/testqgsspatialindex.cpp
+++ b/tests/src/core/testqgsspatialindex.cpp
@@ -306,6 +306,27 @@ class TestQgsSpatialIndex : public QObject
       QVERIFY( i6.geometry( 50 ).isNull() );
     }
 
+    void testNearestNeighbour()
+    {
+      QgsSpatialIndex i;
+      QgsSpatialIndex i2( QgsSpatialIndex::FlagStoreFeatureGeometries );
+
+      QgsFeature f1( 1 );
+      f1.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "LineString(1 1, 3 1, 3 3)" ) ) );
+      QgsFeature f2( 2 );
+      f2.setGeometry( QgsGeometry::fromWkt( QStringLiteral( "LineString(0 1, 0 3)" ) ) );
+      i.addFeature( f1 );
+      i2.addFeature( f1 );
+      i.addFeature( f2 );
+      i2.addFeature( f2 );
+
+      // i does not store feature geometries, so nearest neighbour search uses bounding box only
+      QCOMPARE( i.nearestNeighbor( QgsPointXY( 1, 3 ), 1 ), QList< QgsFeatureId >() << 1 );
+      // i2 does store feature geometries, so nearest neighbour is exact
+      QCOMPARE( i2.nearestNeighbor( QgsPointXY( 1, 3 ), 1 ), QList< QgsFeatureId >() << 2 );
+
+    }
+
 };
 
 QGSTEST_MAIN( TestQgsSpatialIndex )

--- a/tests/src/python/test_qgsspatialindex.py
+++ b/tests/src/python/test_qgsspatialindex.py
@@ -18,7 +18,7 @@ from qgis.core import (QgsSpatialIndex,
                        QgsFeature,
                        QgsGeometry,
                        QgsRectangle,
-                       QgsPoint)
+                       QgsPointXY)
 
 from qgis.testing import start_app, unittest
 
@@ -60,3 +60,37 @@ class TestQgsSpatialIndex(unittest.TestCase):
         myMessage = ('Expected: %s\nGot: %s\n' %
                      ([0, 1, 5], fids))
         assert fids == [0, 1, 5], myMessage
+
+    def testGetGeometry(self):
+        idx = QgsSpatialIndex()
+        idx2 = QgsSpatialIndex(QgsSpatialIndex.FlagStoreFeatureGeometries)
+        fid = 0
+        for y in range(5):
+            for x in range(10, 15):
+                ft = QgsFeature()
+                ft.setId(fid)
+                ft.setGeometry(QgsGeometry.fromPointXY(QgsPointXY(x, y)))
+                idx.insertFeature(ft)
+                idx2.insertFeature(ft)
+                fid += 1
+
+        # not storing geometries, a keyerror should be raised
+        with self.assertRaises(KeyError):
+            idx.geometry(-100)
+        with self.assertRaises(KeyError):
+            idx.geometry(1)
+        with self.assertRaises(KeyError):
+            idx.geometry(2)
+        with self.assertRaises(KeyError):
+            idx.geometry(1000)
+
+        self.assertEqual(idx2.geometry(1).asWkt(1), 'Point (11 0)')
+        self.assertEqual(idx2.geometry(2).asWkt(1), 'Point (12 0)')
+        with self.assertRaises(KeyError):
+            idx2.geometry(-100)
+        with self.assertRaises(KeyError):
+            idx2.geometry(1000)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adapts the QgsSpatialIndex API, by:

1. Adding API for QgsSpatialIndex to optionally store feature geometries. This potentially avoids a second expensive feature request after building a spatial index and later needing to re-request features
which match spatial index search. It's non-default, as it requires the index to store all feature
geometries, so it's more memory expensive.

2.  When a QgsSpatialIndex is storing feature geometry, then nearestNeighbor search performs an EXACT nearest neighbour search, instead of just a nearest-neighbour-by-bounding-box search

Without this change, there's NO API in QGIS to perform accurate, non-point nearest neighbour searches. Which is kind of strange for a GIS program ;)