### PR TITLE
Enable HTML5 local storage for qgsexternalresourcewidget and maptips

### DIFF
--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -231,6 +231,7 @@ void QgsExternalResourceWidget::loadDocument( const QString &path )
     if ( mDocumentViewerContent == Web )
     {
       mWebView->setUrl( QUrl::fromEncoded( resolvedPath.toUtf8() ) );
+      mWebView->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
     }
 #endif
 

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -84,6 +84,7 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   mWebView->page()->settings()->setAttribute( QWebSettings::DeveloperExtrasEnabled, true );
   mWebView->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
+  mWebView->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
 
   // Disable scrollbars, avoid random resizing issues
   mWebView->page()->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );


### PR DESCRIPTION
This enables embedding web pages that make use of HTML5 local storage in the map tips + external resource widget. I didn't managed to do this from Python and if you know how to do it it would be very nice to know.
Was there any reason why this wasn't enabled by default?

E.g. embedding grafana panels now work:
![merge](https://user-images.githubusercontent.com/3179646/52766431-ccdad380-302f-11e9-8d41-d61da9a61072.jpg)

Versus before:
![bad](https://user-images.githubusercontent.com/3179646/52766612-5c808200-3030-11e9-891d-6d60bf8b4cff.jpg)
