### PR TITLE
Give more information when errors opening zip happens

### DIFF
--- a/src/core/qgsziputils.cpp
+++ b/src/core/qgsziputils.cpp
@@ -129,7 +129,7 @@ bool QgsZipUtils::unzip( const QString &zipFilename, const QString &dir, QString
   }
   else
   {
-    QString err = QObject::tr( "Error opening zip archive: '%1' (ERROR: %2)" ).arg( z ? zip_strerror( z ) : zipFilename, rc );
+    QString err = QObject::tr( "Error opening zip archive: '%1' (Error code: %2)" ).arg( z ? zip_strerror( z ) : zipFilename, rc );
     QgsMessageLog::logMessage( err, QStringLiteral( "QgsZipUtils" ) );
     return false;
   }

--- a/src/core/qgsziputils.cpp
+++ b/src/core/qgsziputils.cpp
@@ -129,7 +129,7 @@ bool QgsZipUtils::unzip( const QString &zipFilename, const QString &dir, QString
   }
   else
   {
-    QString err = QObject::tr( "Error opening zip archive: '%1'" ).arg( z ? zip_strerror( z ) : zipFilename );
+    QString err = QObject::tr( "Error opening zip archive: '%1' (ERROR: %2)" ).arg( z ? zip_strerror( z ) : zipFilename, rc );
     QgsMessageLog::logMessage( err, QStringLiteral( "QgsZipUtils" ) );
     return false;
   }


### PR DESCRIPTION
## Description
When opening a QGZ file and something goes wrong this should give us the libzip error to see what went wrong. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
