### PR TITLE
Enable html5 local storage for qgsexternalresourcewidget and maptips

### DIFF
--- a/src/gui/qgsexternalresourcewidget.cpp
+++ b/src/gui/qgsexternalresourcewidget.cpp
@@ -231,6 +231,7 @@ void QgsExternalResourceWidget::loadDocument( const QString &path )
     if ( mDocumentViewerContent == Web )
     {
       mWebView->setUrl( QUrl::fromEncoded( resolvedPath.toUtf8() ) );
+      mWebView->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
     }
 #endif
 

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -82,6 +82,7 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
 
   mWebView->page()->settings()->setAttribute( QWebSettings::DeveloperExtrasEnabled, true );
   mWebView->page()->settings()->setAttribute( QWebSettings::JavascriptEnabled, true );
+  mWebView->page()->settings()->setAttribute( QWebSettings::LocalStorageEnabled, true );
 
   // Disable scrollbars, avoid random resizing issues
   mWebView->page()->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );


### PR DESCRIPTION
Backport of #9176

I am not entirely sure that this counts as a bugfix, but I tend to think it does as I would have expected web pages to be embedded in maptips and external resource widget.