### PR TITLE
Backport 1a87fce for SIP 4.19.14 compatibility

### DIFF
--- a/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformeditorwidget.sip.in
@@ -38,7 +38,7 @@ Constructor for QgsAttributeFormEditorWidget.
 
     ~QgsAttributeFormEditorWidget();
 
-    virtual void createSearchWidgetWrappers();
+    virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() );
 
 
     void initialize( const QVariant &initialValue, bool mixedValues = false );

--- a/python/gui/auto_generated/qgsattributeformrelationeditorwidget.sip.in
+++ b/python/gui/auto_generated/qgsattributeformrelationeditorwidget.sip.in
@@ -29,7 +29,7 @@ Widget to show for child relations on an attribute form.
 Constructor
 %End
 
-    virtual void createSearchWidgetWrappers();
+    virtual void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() );
 
     virtual QString currentFilterExpression() const;
 

--- a/src/gui/qgsattributeformeditorwidget.h
+++ b/src/gui/qgsattributeformeditorwidget.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsAttributeFormEditorWidget : public QgsAttributeFormWidget
 
     ~QgsAttributeFormEditorWidget() override;
 
-    void createSearchWidgetWrappers( const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() ) override;
+    void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() ) override;
 
     /**
      * Resets the widget to an initial value.

--- a/src/gui/qgsattributeformrelationeditorwidget.h
+++ b/src/gui/qgsattributeformrelationeditorwidget.h
@@ -41,7 +41,7 @@ class GUI_EXPORT QgsAttributeFormRelationEditorWidget : public QgsAttributeFormW
      */
     explicit QgsAttributeFormRelationEditorWidget( QgsRelationWidgetWrapper *wrapper, QgsAttributeForm *form );
 
-    void createSearchWidgetWrappers( const QgsAttributeEditorContext &context SIP_PYARGREMOVE = QgsAttributeEditorContext() ) override;
+    void createSearchWidgetWrappers( const QgsAttributeEditorContext &context = QgsAttributeEditorContext() ) override;
     QString currentFilterExpression() const override;
 
   private:


### PR DESCRIPTION
## Description
Straight cherry-pick of 1a87fce33c0ba9d230940a7787cd5cc0

Tested with 3.4.4.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
