### PR TITLE
keep comments when saving query, fix single line comment

### DIFF
--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -351,7 +351,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
 
     def executeSql(self):
 
-        sql = self._getSqlQuery()
+        sql = self._getExecutableSqlQuery()
         if sql == "":
             return
 
@@ -393,7 +393,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         else:
             geomFieldName = None
 
-        query = self._getSqlQuery()
+        query = self._getSqlExecutableQuery()
         if query == "":
             return None
 
@@ -438,7 +438,7 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
             QgsProject.instance().addMapLayers([layer], True)
 
     def fillColumnCombos(self):
-        query = self._getSqlQuery()
+        query = self._getExecutableSqlQuery()
         if query == "":
             return
 
@@ -588,15 +588,26 @@ class DlgSqlWindow(QWidget, Ui_Dialog):
         name, ok = QInputDialog.getText(None, self.tr("View Name"), self.tr("View name"))
         if ok:
             try:
-                self.db.connector.createSpatialView(name, self._getSqlQuery())
+                self.db.connector.createSpatialView(name, self._getExecutableSqlQuery())
             except BaseError as e:
                 DlgDbError.showError(e, self)
 
     def _getSqlQuery(self):
         sql = self.editSql.selectedText()
         if len(sql) == 0:
-            sql = self.editSql.text().replace('\n', ' ').strip()
+            sql = self.editSql.text()
         return sql
+
+    def _getExecutableSqlQuery(self):
+        sql = self._getSqlQuery()
+
+        # Clean it up!
+        lines = []
+        for line in sql.split('\n'):
+            if not line.strip().startswith('--'):
+                lines.append(line)
+        sql = ' '.join(lines)
+        return sql.strip()
 
     def uniqueChanged(self):
         # when an item is (un)checked, simply trigger an update of the combobox text


### PR DESCRIPTION
## Description

* Fix usage of single line comment
* Keep comments and original carriage return when save query as file or preset
* Multiline comment are working already

```sql
--single line comment
SELECT a, /*b,*/ c FROM foo --LIMIT 5;
```
```sql
SELECT
/*
a,b
*/
c FROM foo;
```
are working fine for both executing the query and writing the query into prest/text file (with comments and carriage return)

This need backporting.

@elpaso superseded https://github.com/qgis/QGIS/pull/9180
