### PR TITLE
fix pasting features into vector layer from clipboard (fix #21154)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8801,7 +8801,7 @@ void QgisApp::pasteFromClipboard( QgsMapLayer *destinationLayer )
     }
 
     QgsAttributeMap attrMap;
-    for ( int i = 0; i < feature.fields().count(); i++ )
+    for ( int i = 0; i < feature.attributes().count(); i++ )
     {
       attrMap[i] = feature.attribute( i );
     }


### PR DESCRIPTION
## Description
This is backport of #9065, which fixes features pasting from one vector layer to another when pasted features have only subset of attributes of the destination layer.