### PR TITLE
Remove non-prepared expression warnings

### DIFF
--- a/src/core/expression/qgsexpression.cpp
+++ b/src/core/expression/qgsexpression.cpp
@@ -414,7 +414,6 @@ QVariant QgsExpression::evaluate( const QgsExpressionContext *context )
 
   if ( ! d->mIsPrepared )
   {
-    qWarning( "QgsExpression::evaluate() called on an expression not yet prepared !" );
     prepare( context );
   }
   return d->mRootNode->eval( this, context );


### PR DESCRIPTION
## Description
@nyalldawson , this PR fixes a flood of console messages following the addition of a warning when evaluating a non-prepared expression. 

Looking good? 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
