### PR TITLE
Fix saga algorithm when QgsProcessingParameterMultipleLayers. Fixes #21264

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithm.py
@@ -214,9 +214,9 @@ class SagaAlgorithm(SagaAlgorithmBase):
                     files = []
                     for i, layer in enumerate(layers):
                         if layer.source().lower().endswith('sdat'):
-                            files.append(parameters[param.name()].source()[:-4] + 'sgrd')
+                            files.append(layer.source()[:-4] + 'sgrd')
                         if layer.source().lower().endswith('sgrd'):
-                            files.append(parameters[param.name()].source())
+                            files.append(layer.source())
                         else:
                             exportCommand = self.exportRasterLayer(param.name(), layer)
                             files.append(self.exportedLayers[param.name()])


### PR DESCRIPTION
## Description
Crashes QGIS or corrupts data
QgsProcessingParameterMultipleLayers param, XGRIDS was attempted to be added as a file instead of the layer source
