### PR TITLE
Use the most recent GRASS version

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7Utils.py
+++ b/python/plugins/processing/algs/grass7/Grass7Utils.py
@@ -223,7 +223,7 @@ class Grass7Utils:
                         break
                     # If nothing found, try standalone GRASS installation
                     if folder is None:
-                        for version in ['0', '1', '2', '4']:
+                        for version in ['6', '4', '2', '1', '0']:
                             testfolder = '/Applications/GRASS-7.{}.app/Contents/MacOS'.format(version)
                             if os.path.isdir(testfolder):
                                 folder = testfolder


### PR DESCRIPTION
This is backporting: https://github.com/qgis/QGIS/pull/9200
It is a continuation of:

    * [8db3dea](https://github.com/qgis/QGIS/commit/8db3dead87e385f2798356d1c3048d2b7df73efd)
    * [9efe4c5](https://github.com/qgis/QGIS/commit/9efe4c5f1c99526a8bde125112d9b086fe3d81e7)

This commit only affects users that have multiple GRASS installations on
their Macs. Using the most recent GRASS version is what we do on Linux too.
