### PR TITLE
Make it easier to subclass "Grass7AlgorithmProvider"

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
+++ b/python/plugins/processing/algs/grass7/Grass7AlgorithmProvider.py
@@ -44,6 +44,10 @@ pluginPath = os.path.normpath(os.path.join(
 
 class Grass7AlgorithmProvider(QgsProcessingProvider):
 
+    # Subclasses of `Grass7AlgorithmProvider` should override `descriptionFolder`
+    # and set its value to their own description folder.
+    descriptionFolder = Grass7Utils.grassDescriptionPath()
+
     def __init__(self):
         super().__init__()
         self.algs = []
@@ -99,7 +103,7 @@ class Grass7AlgorithmProvider(QgsProcessingProvider):
 
     def createAlgsList(self):
         algs = []
-        folder = Grass7Utils.grassDescriptionPath()
+        folder = self.descriptionFolder
         for descriptionFile in os.listdir(folder):
             if descriptionFile.endswith('txt'):
                 try:


### PR DESCRIPTION
After @Nyalldawson suggestion [1], we've implemented a Processing plugin
that exposes a GRASS Addon [2]. In order to do this we had to subclass
`Grass7AlgorithmProvider` and override `createAlgsList()`.

`createAlgsList()` had to be overriden in order to change the
"description folder" location.

Nyall wrote:

> And if you do it right (and only import existing
> processing grass code, minimising the copy/paste of this code), then
> your provider will automatically inherit any future fixes and
> features added to the main grass provider.

With this commit we convert the `descriptionFolder` to a class attribute
and in this way, subclasses of `Grass7AlgorithmProvider` will no longer
have to override `createAlgsList()` and will be able to continue inheriting
future enhancements.

References:

1. https://lists.osgeo.org/pipermail/qgis-developer/2019-February/056155.html
2. https://gitlab.com/pmav99/estimap_recreation_qgis/blob/948820b1c0068a7112cb67bc8537d8074e9defb1/estimap_recreation_provider.py#L40-59
