### PR TITLE
Fix advanced digitizing display for rotated map canvas

### DIFF
--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -38,7 +38,16 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   if ( !mAdvancedDigitizingDockWidget->cadEnabled() )
     return;
 
-  QgsRectangle mapRect = mMapCanvas->extent();
+  // Use visible polygon rather than extent to properly handle rotated maps
+  QPolygonF mapPoly = mMapCanvas->mapSettings().visiblePolygon();
+  double canvasWidth = QLineF( mapPoly[0], mapPoly[1] ).length();
+  double canvasHeight = QLineF( mapPoly[0], mapPoly[3] ).length();
+  QgsRectangle mapRect = QgsRectangle( mapPoly[0],
+                                       QgsPointXY(
+                                         mapPoly[0].x() + canvasWidth,
+                                         mapPoly[0].y() - canvasHeight
+                                       )
+                                     );
   if ( rect() != mapRect )
     setRect( mapRect );
 
@@ -54,11 +63,15 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   const QList<QgsPointXY> snappedSegment = mAdvancedDigitizingDockWidget->snappedSegment();
   const bool hasSnappedSegment = snappedSegment.count() == 2;
 
-  const bool curPointExist = mapRect.contains( curPoint );
+  const bool curPointExist = mapPoly.containsPoint( curPoint.toQPointF(), Qt::OddEvenFill );
 
   const double mupp = mMapCanvas->getCoordinateTransform()->mapUnitsPerPixel();
   if ( mupp == 0 )
     return;
+
+  const double canvasRotation = mMapCanvas->rotation();
+  const double canvasRotationRad = canvasRotation * M_PI / 180;
+  const double canvasMaxDimension = std::max( canvasWidth / mupp, canvasHeight / mupp );
 
   QPointF curPointPix, prevPointPix, penulPointPix, snapSegmentPix1, snapSegmentPix2;
 
@@ -116,11 +129,11 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     double a0, a;
     if ( mAdvancedDigitizingDockWidget->constraintAngle()->relative() && nPoints > 2 )
     {
-      a0 = std::atan2( -( prevPoint.y() - penulPoint.y() ), prevPoint.x() - penulPoint.x() );
+      a0 = std::atan2( -( prevPoint.y() - penulPoint.y() ), prevPoint.x() - penulPoint.x() ) + canvasRotationRad;
     }
     else
     {
-      a0 = 0;
+      a0 = canvasRotationRad;
     }
     if ( mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() )
     {
@@ -128,7 +141,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     }
     else
     {
-      a = std::atan2( -( curPoint.y() - prevPoint.y() ), curPoint.x() - prevPoint.x() );
+      a = std::atan2( -( curPoint.y() - prevPoint.y() ), curPoint.x() - prevPoint.x() ) + canvasRotationRad;
     }
     painter->setPen( mConstruction2Pen );
     painter->drawArc( QRectF( prevPointPix.x() - 20,
@@ -143,9 +156,8 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     if ( mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() )
     {
       painter->setPen( mLockedPen );
-      double d = std::max( boundingRect().width(), boundingRect().height() );
-      painter->drawLine( prevPointPix - d * QPointF( std::cos( a ), std::sin( a ) ),
-                         prevPointPix + d * QPointF( std::cos( a ), std::sin( a ) ) );
+      painter->drawLine( prevPointPix - canvasMaxDimension * QPointF( std::cos( a ), std::sin( a ) ),
+                         prevPointPix + canvasMaxDimension * QPointF( std::cos( a ), std::sin( a ) ) );
     }
   }
 
@@ -167,7 +179,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     {
       if ( nPoints > 1 )
       {
-        x = mAdvancedDigitizingDockWidget->constraintX()->value() / mupp + prevPointPix.x();
+        x = mAdvancedDigitizingDockWidget->constraintX()->value() + prevPoint.x();
       }
       else
       {
@@ -176,12 +188,12 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     }
     else
     {
-      x = toCanvasCoordinates( QgsPointXY( mAdvancedDigitizingDockWidget->constraintX()->value(), 0 ) ).x();
+      x = mAdvancedDigitizingDockWidget->constraintX()->value();
     }
     if ( draw )
     {
-      painter->drawLine( QPointF( x, 0 ),
-                         QPointF( x, boundingRect().height() ) );
+      painter->drawLine( toCanvasCoordinates( QgsPointXY( x, mapPoly[0].y() ) ) - canvasMaxDimension * QPointF( std::sin( -canvasRotationRad ), std::cos( -canvasRotationRad ) ),
+                         toCanvasCoordinates( QgsPointXY( x, mapPoly[0].y() ) ) + canvasMaxDimension * QPointF( std::sin( -canvasRotationRad ), std::cos( -canvasRotationRad ) ) );
     }
   }
 
@@ -195,8 +207,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     {
       if ( nPoints > 1 )
       {
-        // y is reversed!
-        y = -mAdvancedDigitizingDockWidget->constraintY()->value() / mupp + prevPointPix.y();
+        y = mAdvancedDigitizingDockWidget->constraintY()->value() + prevPoint.y();
       }
       else
       {
@@ -205,12 +216,13 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     }
     else
     {
-      y = toCanvasCoordinates( QgsPointXY( 0, mAdvancedDigitizingDockWidget->constraintY()->value() ) ).y();
+      y = mAdvancedDigitizingDockWidget->constraintY()->value();
     }
     if ( draw )
     {
-      painter->drawLine( QPointF( 0, y ),
-                         QPointF( boundingRect().width(), y ) );
+      painter->drawLine( toCanvasCoordinates( QgsPointXY( mapPoly[0].x(), y ) ) - canvasMaxDimension * QPointF( std::cos( -canvasRotationRad ), -std::sin( -canvasRotationRad ) ),
+                         toCanvasCoordinates( QgsPointXY( mapPoly[0].x(), y ) ) + canvasMaxDimension * QPointF( std::cos( -canvasRotationRad ), -std::sin( -canvasRotationRad ) ) );
+
     }
   }
 

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -128,11 +128,11 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     double a0, a;
     if ( mAdvancedDigitizingDockWidget->constraintAngle()->relative() && nPoints > 2 )
     {
-      a0 = std::atan2( -( prevPoint.y() - penulPoint.y() ), prevPoint.x() - penulPoint.x() ) + canvasRotationRad;
+      a0 = std::atan2( -( prevPoint.y() - penulPoint.y() ), prevPoint.x() - penulPoint.x() );
     }
     else
     {
-      a0 = canvasRotationRad;
+      a0 = 0;
     }
     if ( mAdvancedDigitizingDockWidget->constraintAngle()->isLocked() )
     {
@@ -140,8 +140,12 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
     }
     else
     {
-      a = std::atan2( -( curPoint.y() - prevPoint.y() ), curPoint.x() - prevPoint.x() ) + canvasRotationRad;
+      a = std::atan2( -( curPoint.y() - prevPoint.y() ), curPoint.x() - prevPoint.x() );
     }
+
+    a0 += canvasRotationRad;
+    a += canvasRotationRad;
+
     painter->setPen( mConstruction2Pen );
     painter->drawArc( QRectF( prevPointPix.x() - 20,
                               prevPointPix.y() - 20,

--- a/src/gui/qgsadvanceddigitizingcanvasitem.cpp
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.cpp
@@ -69,8 +69,7 @@ void QgsAdvancedDigitizingCanvasItem::paint( QPainter *painter )
   if ( mupp == 0 )
     return;
 
-  const double canvasRotation = mMapCanvas->rotation();
-  const double canvasRotationRad = canvasRotation * M_PI / 180;
+  const double canvasRotationRad = mMapCanvas->rotation() * M_PI / 180;
   const double canvasMaxDimension = std::max( canvasWidth / mupp, canvasHeight / mupp );
 
   QPointF curPointPix, prevPointPix, penulPointPix, snapSegmentPix1, snapSegmentPix2;


### PR DESCRIPTION
## Description
The current implementation of the advanced digitizing tools does not display the constraint lines for angles and x/y components in the correct location when the canvas is rotated.

![advanced_digitizing_rotated_incorrect](https://user-images.githubusercontent.com/2399255/53050533-cf0eb900-3499-11e9-93ff-07faf5bf133a.png)


This pull request fixes this behaviour.

![advanced_digitizing_rotated_correct](https://user-images.githubusercontent.com/2399255/53050393-82c37900-3499-11e9-8f04-46e1c3b6d717.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
