### PR TITLE
Few more UX improvements [vertex tool]

### DIFF
--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -959,7 +959,6 @@ void QgsVertexTool::tryToSelectFeature( QgsMapMouseEvent *e )
     // we have a feature to select
     QPair<QgsVectorLayer *, QgsFeatureId> alternative = mSelectedFeatureAlternatives->alternatives.at( mSelectedFeatureAlternatives->index );
     updateVertexEditor( alternative.first, alternative.second );
-    updateFeatureBand( QgsPointLocator::Match( QgsPointLocator::Area, alternative.first, alternative.second, 0, QgsPointXY() ) );
   }
   else
   {
@@ -970,8 +969,11 @@ void QgsVertexTool::tryToSelectFeature( QgsMapMouseEvent *e )
     {
       mVertexEditor->updateEditor( nullptr );
     }
-    updateFeatureBand( QgsPointLocator::Match() );
   }
+
+  // we have either locked ourselves to a feature or unlocked again
+  // in any case, we don't want feature highlight anymore (vertex editor has its own highlight)
+  updateFeatureBand( QgsPointLocator::Match() );
 }
 
 

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -931,7 +931,7 @@ void QgsVertexTool::tryToSelectFeature( QgsMapMouseEvent *e )
 
       mSelectedFeatureAlternatives.reset( new SelectedFeatureAlternatives );
       mSelectedFeatureAlternatives->screenPoint = e->pos();
-      mSelectedFeatureAlternatives->index = 0;
+      mSelectedFeatureAlternatives->index = -1;
       if ( m.isValid() )
       {
         // ideally the feature that would get normally highlighted should be also the first choice
@@ -942,17 +942,23 @@ void QgsVertexTool::tryToSelectFeature( QgsMapMouseEvent *e )
         alternatives.remove( firstChoice );
       }
       mSelectedFeatureAlternatives->alternatives.append( alternatives.toList() );
+
+      if ( mSelectedFeature )
+      {
+        // in case there is already a feature locked, continue in the loop from it
+        QPair<QgsVectorLayer *, QgsFeatureId> currentSelection( mSelectedFeature->layer(), mSelectedFeature->featureId() );
+        int currentIndex = mSelectedFeatureAlternatives->alternatives.indexOf( currentSelection );
+        if ( currentIndex != -1 )
+          mSelectedFeatureAlternatives->index = currentIndex;
+      }
     }
   }
+
+  // move to the next alternative
+  if ( mSelectedFeatureAlternatives->index < mSelectedFeatureAlternatives->alternatives.count() - 1 )
+    ++mSelectedFeatureAlternatives->index;
   else
-  {
-    // we have had right-click before on this mouse location - so let's just cycle in our alternatives
-    // move to the next alternative
-    if ( mSelectedFeatureAlternatives->index < mSelectedFeatureAlternatives->alternatives.count() - 1 )
-      ++mSelectedFeatureAlternatives->index;
-    else
-      mSelectedFeatureAlternatives->index = -1;
-  }
+    mSelectedFeatureAlternatives->index = -1;
 
   if ( mSelectedFeatureAlternatives && mSelectedFeatureAlternatives->index != -1 )
   {

--- a/src/app/vertextool/qgsvertextool.cpp
+++ b/src/app/vertextool/qgsvertextool.cpp
@@ -968,11 +968,14 @@ void QgsVertexTool::tryToSelectFeature( QgsMapMouseEvent *e )
     }
   }
 
-  // move to the next alternative
-  if ( mSelectedFeatureAlternatives->index < mSelectedFeatureAlternatives->alternatives.count() - 1 )
-    ++mSelectedFeatureAlternatives->index;
-  else
-    mSelectedFeatureAlternatives->index = -1;
+  if ( mSelectedFeatureAlternatives )
+  {
+    // move to the next alternative
+    if ( mSelectedFeatureAlternatives->index < mSelectedFeatureAlternatives->alternatives.count() - 1 )
+      ++mSelectedFeatureAlternatives->index;
+    else
+      mSelectedFeatureAlternatives->index = -1;
+  }
 
   if ( mSelectedFeatureAlternatives && mSelectedFeatureAlternatives->index != -1 )
   {


### PR DESCRIPTION
### Do not keep highlight when locking/unlocking feature
    
It was a bit strange effect when locking feature... when moving mouse over a feature it would have highlight, then on right click it would also get vertex editor square markers in addition to the highlight, but then immediately after mouse move the original highlight would be gone. Now it's simplified so that feature highlight on right click gets removed.

### Continue loop of locked features after mouse move
    
A small UX improvement: after right click in a location with feature A and B, we would do a loop A - B - nothing - A - B - nothing ... But if after first click to get A locked user would move the mouse a bit, the loop would get broken and would end up with A - nothing - B - nothing - A - B - nothing. The fix is to identify where we are in the cycle and set the index correctly after mouse move.

### Fix an issue with vertex selection when a feature is locked

See https://issues.qgis.org/issues/21283 for the description