### PR TITLE
Geometry validator summary cleanup

### DIFF
--- a/python/core/auto_generated/qgsgeometryvalidator.sip.in
+++ b/python/core/auto_generated/qgsgeometryvalidator.sip.in
@@ -28,11 +28,29 @@ Constructor for QgsGeometryValidator.
 
     static void validateGeometry( const QgsGeometry &geometry, QVector<QgsGeometry::Error> &errors /Out/, QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal );
 %Docstring
-Validate geometry and produce a list of geometry errors
+Validate geometry and produce a list of geometry errors.
+This method blocks the thread until the validation is finished.
 %End
 
   signals:
-    void errorFound( const QgsGeometry::Error & );
+
+    void errorFound( const QgsGeometry::Error &error );
+%Docstring
+Sent when an error has been found during the validation process.
+
+The ``error`` contains details about the error.
+%End
+
+    void validationFinished( const QString &summary );
+%Docstring
+Sent when the validation is finished.
+
+The result is in a human readable ``summary``, mentioning
+if the validation has been aborted, successfully been validated
+or how many errors have been found.
+
+.. versionadded:: 3.6
+%End
 
   public slots:
     void addError( const QgsGeometry::Error & );

--- a/python/plugins/processing/tests/CheckValidityAlgorithm.py
+++ b/python/plugins/processing/tests/CheckValidityAlgorithm.py
@@ -116,7 +116,7 @@ class TestQgsProcessingCheckValidity(unittest.TestCase):
         self.assertEqual(invalid_layer.featureCount(), 1)
         f = next(invalid_layer.getFeatures())
         self.assertEqual(f.attributes(), [
-                         1, 'segments 0 and 2 of line 0 intersect at 1, 1\nGeometry has 1 errors.'])
+                         1, 'segments 0 and 2 of line 0 intersect at 1, 1'])
 
         # GEOS method
         parameters['METHOD'] = 2

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -349,18 +349,16 @@ void QgsGeometryValidator::run()
 
       if ( mStop )
       {
-        emit errorFound( QgsGeometry::Error( QObject::tr( "Geometry validation was aborted." ) ) );
+        emit validationFinished( QObject::tr( "Geometry validation was aborted." ) );
       }
       else if ( mErrorCount > 0 )
       {
-        emit errorFound( QgsGeometry::Error( QObject::tr( "Geometry has %1 errors." ).arg( mErrorCount ) ) );
+        emit validationFinished( QObject::tr( "Geometry has %1 errors." ).arg( mErrorCount ) );
       }
-#if 0
       else
       {
-        emit errorFound( QgsGeometry::Error( QObject::tr( "Geometry is valid." ) ) );
+        emit validationFinished( QObject::tr( "Geometry is valid." ) );
       }
-#endif
       break;
     }
   }

--- a/src/core/qgsgeometryvalidator.h
+++ b/src/core/qgsgeometryvalidator.h
@@ -40,11 +40,31 @@ class CORE_EXPORT QgsGeometryValidator : public QThread
     void run() override;
     void stop();
 
-    //! Validate geometry and produce a list of geometry errors
+    /**
+     * Validate geometry and produce a list of geometry errors.
+     * This method blocks the thread until the validation is finished.
+     */
     static void validateGeometry( const QgsGeometry &geometry, QVector<QgsGeometry::Error> &errors SIP_OUT, QgsGeometry::ValidationMethod method = QgsGeometry::ValidatorQgisInternal );
 
   signals:
-    void errorFound( const QgsGeometry::Error & );
+
+    /**
+     * Sent when an error has been found during the validation process.
+     *
+     * The \a error contains details about the error.
+     */
+    void errorFound( const QgsGeometry::Error &error );
+
+    /**
+     * Sent when the validation is finished.
+     *
+     * The result is in a human readable \a summary, mentioning
+     * if the validation has been aborted, successfully been validated
+     * or how many errors have been found.
+     *
+     * \since QGIS 3.6
+     */
+    void validationFinished( const QString &summary );
 
   public slots:
     void addError( const QgsGeometry::Error & );


### PR DESCRIPTION
The QgsGeometryValidator class is currently sending out the following signals as errors:

 * Geometry validation has been aborted
 * The final error count

This makes it (almost) impossible to ignore these summaries from ordinary errors. Probably for this reason the status "has successfully been validated" is `#ifdef 0`'ed

This adds a new signal `validationFinished( summary )` to send these status messages through a different channel.

Previously this reported 2 errors:

1. Self intersection at position ...
2. 1 Error found

Being interpreted as 2 Errors in total

![image](https://user-images.githubusercontent.com/588407/53112176-fd929f80-353e-11e9-853a-7e39fe3e1b6f.png)


And adds some doxygen