### PR TITLE
[quick] Small canvas UX fixes

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -67,6 +67,7 @@ void QgsQuickMapCanvasMap::zoom( QPointF center, qreal scale )
   // same as zoomWithCenter (no coordinate transformations are needed)
   extent.scale( scale, &newCenter );
   mMapSettings->setExtent( extent );
+  mNeedsRefresh = true;
 }
 
 void QgsQuickMapCanvasMap::pan( QPointF oldPos, QPointF newPos )
@@ -86,6 +87,7 @@ void QgsQuickMapCanvasMap::pan( QPointF oldPos, QPointF newPos )
   extent.setYMinimum( extent.yMinimum() + dy );
 
   mMapSettings->setExtent( extent );
+  mNeedsRefresh = true;
 }
 
 void QgsQuickMapCanvasMap::refreshMap()
@@ -257,8 +259,13 @@ void QgsQuickMapCanvasMap::setFreeze( bool freeze )
 
   mFreeze = freeze;
 
-  if ( !mFreeze )
+  if ( !mFreeze && mNeedsRefresh )
+  {
     refresh();
+  }
+
+  // we are freezing or unfreezing - either way we can reset "needs refresh"
+  mNeedsRefresh = false;
 
   emit freezeChanged();
 }

--- a/src/quickgui/qgsquickmapcanvasmap.h
+++ b/src/quickgui/qgsquickmapcanvasmap.h
@@ -196,6 +196,7 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
     QTimer mRefreshTimer;
     bool mDirty = false;
     bool mFreeze = false;
+    bool mNeedsRefresh = false;  //!< Whether refresh is needed after unfreezing
     QList<QMetaObject::Connection> mLayerConnections;
     QTimer mMapUpdateTimer;
     bool mIncrementalRendering = false;


### PR DESCRIPTION
Two UX improvements for qgis_quick map canvas

### Do not refresh map on click
    
Whenever user would click on the map (e.g. to identify a feature), the freeze and subsequent unfreeze would force map refresh even though it is not needed. A new internal flag is introduced to avoid the unnecessary map refresh in cases when map has not been moved nor zoomed.

### Do not start moving canvas if the drag distance is too small
    
Often when users want to click (tap) the map, they still move the cursor position a bit. This would trigger unwanted map pan and map refresh afterwards. A configurable minimum drag distance is introduced in order to prevent that.