### PR TITLE
[processing] Merge lines on dissolve

### DIFF
--- a/python/plugins/processing/tests/testdata/custom/consecutivelines.gml
+++ b/python/plugins/processing/tests/testdata/custom/consecutivelines.gml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ consecutivelines.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-0.9142351900972591</gml:X><gml:Y>-0.1405835543766578</gml:Y></gml:coord>
+      <gml:coord><gml:X>0.5411140583554377</gml:X><gml:Y>0.6870026525198939</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                          
+  <gml:featureMember>
+    <ogr:consecutivelines fid="consecutivelines.0">
+      <ogr:geometryProperty><gml:MultiLineString srsName="EPSG:4326"><gml:lineStringMember><gml:LineString><gml:coordinates>-0.914235190097259,0.687002652519894 -0.799292661361627,0.184792219274978 -0.36604774535809,0.19893899204244</gml:coordinates></gml:LineString></gml:lineStringMember></gml:MultiLineString></ogr:geometryProperty>
+      <ogr:id xsi:nil="true"/>
+    </ogr:consecutivelines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:consecutivelines fid="consecutivelines.1">
+      <ogr:geometryProperty><gml:MultiLineString srsName="EPSG:4326"><gml:lineStringMember><gml:LineString><gml:coordinates>-0.199823165340407,0.679929266136163 -0.076038903625111,0.315649867374005 0.541114058355438,-0.09814323607427</gml:coordinates></gml:LineString></gml:lineStringMember></gml:MultiLineString></ogr:geometryProperty>
+      <ogr:id xsi:nil="true"/>
+    </ogr:consecutivelines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:consecutivelines fid="consecutivelines.2">
+      <ogr:geometryProperty><gml:MultiLineString srsName="EPSG:4326"><gml:lineStringMember><gml:LineString><gml:coordinates>0.541114058355438,-0.09814323607427 0.173297966401415,-0.140583554376658</gml:coordinates></gml:LineString></gml:lineStringMember></gml:MultiLineString></ogr:geometryProperty>
+      <ogr:id xsi:nil="true"/>
+    </ogr:consecutivelines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:consecutivelines fid="consecutivelines.3">
+      <ogr:geometryProperty><gml:MultiLineString srsName="EPSG:4326"><gml:lineStringMember><gml:LineString><gml:coordinates>0.173297966401415,-0.140583554376658 -0.205128205128205,-0.057471264367816</gml:coordinates></gml:LineString></gml:lineStringMember></gml:MultiLineString></ogr:geometryProperty>
+      <ogr:id xsi:nil="true"/>
+    </ogr:consecutivelines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:consecutivelines fid="consecutivelines.4">
+      <ogr:geometryProperty><gml:MultiLineString srsName="EPSG:4326"><gml:lineStringMember><gml:LineString><gml:coordinates>-0.364279398762157,0.013262599469496 -0.205128205128205,-0.057471264367816</gml:coordinates></gml:LineString></gml:lineStringMember></gml:MultiLineString></ogr:geometryProperty>
+      <ogr:id xsi:nil="true"/>
+    </ogr:consecutivelines>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/custom/consecutivelines.xsd
+++ b/python/plugins/processing/tests/testdata/custom/consecutivelines.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="consecutivelines" type="ogr:consecutivelines_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="consecutivelines_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:MultiLineStringPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:long">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/dissolved_consecutive_lines.gml
+++ b/python/plugins/processing/tests/testdata/expected/dissolved_consecutive_lines.gml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ dissolved_consecutive_lines.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-0.914235190097259</gml:X><gml:Y>-0.140583554376658</gml:Y></gml:coord>
+      <gml:coord><gml:X>0.541114058355438</gml:X><gml:Y>0.687002652519894</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                              
+  <gml:featureMember>
+    <ogr:dissolved_consecutive_lines fid="consecutivelines.0">
+      <ogr:geometryProperty><gml:MultiLineString srsName="EPSG:4326"><gml:lineStringMember><gml:LineString><gml:coordinates>-0.914235190097259,0.687002652519894 -0.799292661361627,0.184792219274978 -0.36604774535809,0.19893899204244</gml:coordinates></gml:LineString></gml:lineStringMember><gml:lineStringMember><gml:LineString><gml:coordinates>-0.199823165340407,0.679929266136163 -0.076038903625111,0.315649867374005 0.541114058355438,-0.09814323607427 0.173297966401415,-0.140583554376658 -0.205128205128205,-0.057471264367816 -0.364279398762157,0.013262599469496</gml:coordinates></gml:LineString></gml:lineStringMember></gml:MultiLineString></ogr:geometryProperty>
+      <ogr:id xsi:nil="true"/>
+    </ogr:dissolved_consecutive_lines>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -6997,4 +6997,16 @@ tests:
         name: expected/surface_vol_gaps.gml
         type: vector
 
+  - algorithm: native:dissolve
+    name: Test dissolve with consecutive lines
+    params:
+      INPUT:
+        name: custom/consecutivelines.gml|layername=consecutivelines
+        type: vector
+    results:
+      OUTPUT:
+        name: expected/dissolved_consecutive_lines.gml
+        type: vector
+
+
 # See ../README.md for a description of the file format

--- a/src/analysis/processing/qgsalgorithmdissolve.cpp
+++ b/src/analysis/processing/qgsalgorithmdissolve.cpp
@@ -227,6 +227,8 @@ QVariantMap QgsDissolveAlgorithm::processAlgorithm( const QVariantMap &parameter
       for ( const auto &p : parts )
       {
         result = QgsGeometry::unaryUnion( QVector< QgsGeometry >() << result << p );
+        if ( QgsWkbTypes::flatType( result.wkbType() ) == QgsWkbTypes::LineString )
+          result = result.mergeLines();
         if ( feedback->isCanceled() )
           return result;
       }

--- a/src/analysis/processing/qgsalgorithmdissolve.cpp
+++ b/src/analysis/processing/qgsalgorithmdissolve.cpp
@@ -215,6 +215,8 @@ QVariantMap QgsDissolveAlgorithm::processAlgorithm( const QVariantMap &parameter
   return processCollection( parameters, context, feedback, [ & ]( const QVector< QgsGeometry > &parts )->QgsGeometry
   {
     QgsGeometry result( QgsGeometry::unaryUnion( parts ) );
+    if ( QgsWkbTypes::geometryType( result.wkbType() ) == QgsWkbTypes::LineGeometry )
+      result = result.mergeLines();
     // Geos may fail in some cases, let's try a slower but safer approach
     // See: https://issues.qgis.org/issues/20591 - Dissolve tool failing to produce outputs
     if ( ! result.lastError().isEmpty() && parts.count() >  2 )
@@ -227,7 +229,7 @@ QVariantMap QgsDissolveAlgorithm::processAlgorithm( const QVariantMap &parameter
       for ( const auto &p : parts )
       {
         result = QgsGeometry::unaryUnion( QVector< QgsGeometry >() << result << p );
-        if ( QgsWkbTypes::flatType( result.wkbType() ) == QgsWkbTypes::LineString )
+        if ( QgsWkbTypes::geometryType( result.wkbType() ) == QgsWkbTypes::LineGeometry )
           result = result.mergeLines();
         if ( feedback->isCanceled() )
           return result;


### PR DESCRIPTION
This is a difference between how polygons and lines are handled on dissolve.
Neighbouring polygons are merged automatically, while lines are collected as
MultiLineString.

With this patch it will be possible to call multipart to singlepart on dissolved
line layers to extract spatially separated parts of a linestring.

@gioman I wouldn't be surprised if you had some feedback on this topic.

It's completely untested so far, mostly for getting feedback if this needs to be an option.