### PR TITLE
[processing] Script decorators: correctly check that parent exist

### DIFF
--- a/python/processing/algfactory.py
+++ b/python/processing/algfactory.py
@@ -176,7 +176,7 @@ class AlgWrapper(QgsProcessingAlgorithm):
             if parentname == name:
                 raise ProcessingAlgFactoryException("{} can't depend on itself. "
                                                     "We know QGIS is smart but it's not that smart".format(name))
-            if parentname not in self._inputs or parentname not in self._outputs:
+            if parentname not in self._inputs and parentname not in self._outputs:
                 raise ProcessingAlgFactoryException("Can't find parent named {}".format(parentname))
 
         kwargs['description'] = kwargs.pop("label", "")


### PR DESCRIPTION


## Description

The check for parent parameter is wrong. This PR fixes it.

Not sure about the utility of this, though. The name "parent" is not an argument name for those parameters that require a parent (such as QgsProcessingParameterField, which has a "parentLayerParameterName" argument)

This fix avoids the script causing a "Can't find parent named XXX" error if a "parent" argument is used, but then the algorithm will fail when defining the parameter.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
