### PR TITLE
Rename the style tab in the layer styling panel

### DIFF
--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -670,7 +670,7 @@ bool QgsMapLayerStyleCommand::mergeWith( const QUndoCommand *other )
 QgsLayerStyleManagerWidgetFactory::QgsLayerStyleManagerWidgetFactory()
 {
   setIcon( QgsApplication::getThemeIcon( QStringLiteral( "propertyicons/stylepreset.svg" ) ) );
-  setTitle( QObject::tr( "Style Manager" ) );
+  setTitle( QObject::tr( "Style" ) );
 }
 
 QgsMapLayerConfigWidget *QgsLayerStyleManagerWidgetFactory::createWidget( QgsMapLayer *layer, QgsMapCanvas *canvas, bool dockMode, QWidget *parent ) const


### PR DESCRIPTION
Let's call it "Style" instead of "Style manager" because:
- there's already a "style manager" (for symbols and colors) and all the attempts to rename that one have failed
- the corresponding tool in the layer properties dialog is simply labeled "Style" and not "Style manager"
- the other tabs in the layer styling panel are not named "Symbology manager" nor "Label manager"...
- this is confusing when documentation has to refer to this tab