### PR TITLE
Fixed notation of doxygen comments that were after a member

### DIFF
--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -77,7 +77,7 @@ is the MDAL connection string. QGIS must be built with MDAL support to allow thi
 
     struct LayerOptions
     {
-      int unused;  //! @todo remove me once there are actual members here (breaks SIP <4.19)
+      int unused;  //!< @todo remove me once there are actual members here (breaks SIP <4.19)
     };
 
     explicit QgsMeshLayer( const QString &path = QString(), const QString &baseName = QString(), const QString &providerLib = "mesh_memory",

--- a/python/core/auto_generated/qgsdataprovider.sip.in
+++ b/python/core/auto_generated/qgsdataprovider.sip.in
@@ -58,7 +58,7 @@ Abstract base class for spatial data provider implementations.
 
     struct ProviderOptions
     {
-      int unused; //! @todo remove me once there are actual members here (breaks SIP <4.19)
+      int unused; //!< @todo remove me once there are actual members here (breaks SIP <4.19)
     };
 
     QgsDataProvider( const QString &uri = QString(), const QgsDataProvider::ProviderOptions &options = QgsDataProvider::ProviderOptions() );

--- a/src/analysis/vector/geometry_checker/qgsgeometrymissingvertexcheck.h
+++ b/src/analysis/vector/geometry_checker/qgsgeometrymissingvertexcheck.h
@@ -44,7 +44,7 @@ class ANALYSIS_EXPORT QgsGeometryMissingVertexCheck : public QgsGeometryCheck
     enum ResolutionMethod
     {
       NoChange, //!< Do nothing
-      AddMissingVertex //! Add the missing vertex
+      AddMissingVertex //!< Add the missing vertex
     };
     Q_ENUM( ResolutionMethod )
 

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -195,7 +195,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
       DecimalDegrees, //!< Decimal degrees
       DegreesMinutes, //!< Degrees, decimal minutes
       DegreesMinutesSeconds, //!< Degrees, minutes, seconds
-      MapUnits, //! Show coordinates in map units
+      MapUnits, //!< Show coordinates in map units
     };
 
     QgsRelationManagerDialog *mRelationManagerDlg = nullptr;

--- a/src/core/layout/qgslayoutgridsettings.h
+++ b/src/core/layout/qgslayoutgridsettings.h
@@ -40,9 +40,9 @@ class CORE_EXPORT QgsLayoutGridSettings : public QgsLayoutSerializableObject
     //! Style for drawing the page/snapping grid
     enum Style
     {
-      StyleLines, //! Solid lines
-      StyleDots, //! Dots
-      StyleCrosses //! Crosses
+      StyleLines, //!< Solid lines
+      StyleDots, //!< Dots
+      StyleCrosses //!< Crosses
     };
 
     /**

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -96,7 +96,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      */
     struct LayerOptions
     {
-      int unused;  //! @todo remove me once there are actual members here (breaks SIP <4.19)
+      int unused;  //!< @todo remove me once there are actual members here (breaks SIP <4.19)
     };
 
     /**

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -62,7 +62,7 @@ namespace pal
     POPMUSIC_TABU_CHAIN = 1, //!< Is the best but slowest
     POPMUSIC_TABU = 2, //!< Is a little bit better than CHAIN but slower
     POPMUSIC_CHAIN = 3, //!< Is slower and best than TABU, worse and faster than TABU_CHAIN
-    FALP = 4 //! only initial solution
+    FALP = 4 //!< only initial solution
   };
 
   //! Enumeration line arrangement flags. Flags can be combined.

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -62,7 +62,7 @@ namespace pal
     POPMUSIC_TABU_CHAIN = 1, //!< Is the best but slowest
     POPMUSIC_TABU = 2, //!< Is a little bit better than CHAIN but slower
     POPMUSIC_CHAIN = 3, //!< Is slower and best than TABU, worse and faster than TABU_CHAIN
-    FALP = 4 //!< only initial solution
+    FALP = 4 //!< Only initial solution
   };
 
   //! Enumeration line arrangement flags. Flags can be combined.

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -79,9 +79,9 @@ class CORE_EXPORT QgsAggregateCalculator
       InterQuartileRange, //!< Inter quartile range (IQR) (numeric fields only)
       StringMinimumLength, //!< Minimum length of string (string fields only)
       StringMaximumLength, //!< Maximum length of string (string fields only)
-      StringConcatenate, //! Concatenate values with a joining string (string fields only). Specify the delimiter using setDelimiter().
-      GeometryCollect, //! Create a multipart geometry from aggregated geometries
-      ArrayAggregate //! Create an array of values
+      StringConcatenate, //!< Concatenate values with a joining string (string fields only). Specify the delimiter using setDelimiter().
+      GeometryCollect, //!< Create a multipart geometry from aggregated geometries
+      ArrayAggregate //!< Create an array of values
     };
 
     //! A bundle of parameters controlling aggregate calculation

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -94,7 +94,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      */
     struct ProviderOptions
     {
-      int unused; //! @todo remove me once there are actual members here (breaks SIP <4.19)
+      int unused; //!< @todo remove me once there are actual members here (breaks SIP <4.19)
     };
 
     /**

--- a/src/core/qgsdatetimestatisticalsummary.h
+++ b/src/core/qgsdatetimestatisticalsummary.h
@@ -55,7 +55,7 @@ class CORE_EXPORT QgsDateTimeStatisticalSummary
       Min = 8, //!< Minimum (earliest) datetime value
       Max = 16, //!< Maximum (latest) datetime value
       Range = 32, //!< Interval between earliest and latest datetime value
-      All = Count | CountDistinct | CountMissing | Min | Max | Range, //! All statistics
+      All = Count | CountDistinct | CountMissing | Min | Max | Range, //!< All statistics
     };
     Q_DECLARE_FLAGS( Statistics, Statistic )
 

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -89,15 +89,15 @@ class CORE_EXPORT QgsDiagramLayerSettings
       BackgroundColor, //!< Diagram background color
       StrokeColor, //!< Stroke color
       StrokeWidth, //!< Stroke width
-      PositionX, //! x-coordinate data defined diagram position
-      PositionY, //! y-coordinate data defined diagram position
-      Distance, //! Distance to diagram from feature
-      Priority, //! Diagram priority (between 0 and 10)
-      ZIndex, //! Z-index for diagram ordering
-      IsObstacle, //! Whether diagram features act as obstacles for other diagrams/labels
-      Show, //! Whether to show the diagram
-      AlwaysShow, //! Whether the diagram should always be shown, even if it overlaps other diagrams/labels
-      StartAngle, //! Angle offset for pie diagram
+      PositionX, //!< x-coordinate data defined diagram position
+      PositionY, //!< y-coordinate data defined diagram position
+      Distance, //!< Distance to diagram from feature
+      Priority, //!< Diagram priority (between 0 and 10)
+      ZIndex, //!< Z-index for diagram ordering
+      IsObstacle, //!< Whether diagram features act as obstacles for other diagrams/labels
+      Show, //!< Whether to show the diagram
+      AlwaysShow, //!< Whether the diagram should always be shown, even if it overlaps other diagrams/labels
+      StartAngle, //!< Angle offset for pie diagram
     };
 
     /**

--- a/src/core/qgsdiagramrenderer.h
+++ b/src/core/qgsdiagramrenderer.h
@@ -89,8 +89,8 @@ class CORE_EXPORT QgsDiagramLayerSettings
       BackgroundColor, //!< Diagram background color
       StrokeColor, //!< Stroke color
       StrokeWidth, //!< Stroke width
-      PositionX, //!< x-coordinate data defined diagram position
-      PositionY, //!< y-coordinate data defined diagram position
+      PositionX, //!< X-coordinate data defined diagram position
+      PositionY, //!< Y-coordinate data defined diagram position
       Distance, //!< Distance to diagram from feature
       Priority, //!< Diagram priority (between 0 and 10)
       ZIndex, //!< Z-index for diagram ordering

--- a/src/core/qgsfeature_p.h
+++ b/src/core/qgsfeature_p.h
@@ -64,7 +64,7 @@ class QgsFeaturePrivate : public QSharedData
     //! Feature ID
     QgsFeatureId fid;
 
-    ///! Attributes accessed by field index
+    //! Attributes accessed by field index
     QgsAttributes attributes;
 
     //! Geometry, may be empty if feature has no geometry

--- a/src/core/qgsgml.h
+++ b/src/core/qgsgml.h
@@ -283,7 +283,7 @@ class CORE_EXPORT QgsGmlStreamingParser
     //! Parsing depth
     int mParseDepth;
     int mFeatureTupleDepth;
-    QString mCurrentTypename; //! Used to track the current (unprefixed) typename for wfs:Member in join layer
+    QString mCurrentTypename; //!< Used to track the current (unprefixed) typename for wfs:Member in join layer
     //! Keep track about the most important nested elements
     QStack<ParseMode> mParseModeStack;
     //! This contains the character data if an important element has been encountered

--- a/src/core/qgsopenclutils.h
+++ b/src/core/qgsopenclutils.h
@@ -80,8 +80,8 @@ class CORE_EXPORT QgsOpenClUtils
      */
     enum ExceptionBehavior
     {
-      Catch,  //! Write errors in the message log and silently fail
-      Throw   //! Write errors in the message log and re-throw exceptions
+      Catch,  //!< Write errors in the message log and silently fail
+      Throw   //!< Write errors in the message log and re-throw exceptions
     };
 
     /**

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -137,13 +137,13 @@ class CORE_EXPORT QgsPalLayerSettings
     enum Placement
     {
       AroundPoint, //!< Arranges candidates in a circle around a point (or centroid of a polygon). Applies to point or polygon layers only.
-      OverPoint, //! Arranges candidates over a point (or centroid of a polygon), or at a preset offset from the point. Applies to point or polygon layers only.
+      OverPoint, //!< Arranges candidates over a point (or centroid of a polygon), or at a preset offset from the point. Applies to point or polygon layers only.
       Line, //!< Arranges candidates parallel to a generalised line representing the feature or parallel to a polygon's perimeter. Applies to line or polygon layers only.
-      Curved, //! Arranges candidates following the curvature of a line feature. Applies to line layers only.
+      Curved, //!< Arranges candidates following the curvature of a line feature. Applies to line layers only.
       Horizontal, //!< Arranges horizontal candidates scattered throughout a polygon feature. Applies to polygon layers only.
       Free, //!< Arranges candidates scattered throughout a polygon feature. Candidates are rotated to respect the polygon's orientation. Applies to polygon layers only.
       OrderedPositionsAroundPoint, //!< Candidates are placed in predefined positions around a point. Preference is given to positions with greatest cartographic appeal, e.g., top right, bottom right, etc. Applies to point layers only.
-      PerimeterCurved, //! Arranges candidates following the curvature of a polygon's boundary. Applies to polygon layers only.
+      PerimeterCurved, //!< Arranges candidates following the curvature of a polygon's boundary. Applies to polygon layers only.
     };
 
     //TODO QGIS 4.0 - move to QgsLabelingEngine
@@ -151,16 +151,16 @@ class CORE_EXPORT QgsPalLayerSettings
     enum PredefinedPointPosition
     {
       TopLeft, //!< Label on top-left of point
-      TopSlightlyLeft, //! Label on top of point, slightly left of center
+      TopSlightlyLeft, //!< Label on top of point, slightly left of center
       TopMiddle, //!< Label directly above point
-      TopSlightlyRight, //! Label on top of point, slightly right of center
+      TopSlightlyRight, //!< Label on top of point, slightly right of center
       TopRight, //!< Label on top-right of point
       MiddleLeft, //!< Label on left of point
       MiddleRight, //!< Label on right of point
       BottomLeft, //!< Label on bottom-left of point
-      BottomSlightlyLeft, //! Label below point, slightly left of center
+      BottomSlightlyLeft, //!< Label below point, slightly left of center
       BottomMiddle, //!< Label directly below point
-      BottomSlightlyRight, //! Label below point, slightly right of center
+      BottomSlightlyRight, //!< Label below point, slightly right of center
       BottomRight, //!< Label on bottom right of point
     };
 
@@ -268,7 +268,7 @@ class CORE_EXPORT QgsPalLayerSettings
       FontCase = 27, //!< Label text case
       FontLetterSpacing = 28, //!< Letter spacing
       FontWordSpacing = 29, //!< Word spacing
-      FontBlendMode = 30, //! Text blend mode
+      FontBlendMode = 30, //!< Text blend mode
 
       // text formatting
       MultiLineWrapChar = 31,

--- a/src/core/qgsproperty.h
+++ b/src/core/qgsproperty.h
@@ -233,7 +233,7 @@ class CORE_EXPORT QgsProperty
     //! Property types
     enum Type
     {
-      InvalidProperty, //! Invalid (not set) property
+      InvalidProperty, //!< Invalid (not set) property
       StaticProperty, //!< Static property (QgsStaticProperty)
       FieldBasedProperty, //!< Field based property (QgsFieldBasedProperty)
       ExpressionBasedProperty, //!< Expression based property (QgsExpressionBasedProperty)

--- a/src/core/qgsstringstatisticalsummary.h
+++ b/src/core/qgsstringstatisticalsummary.h
@@ -55,7 +55,7 @@ class CORE_EXPORT QgsStringStatisticalSummary
       MinimumLength = 32, //!< Minimum length of string
       MaximumLength = 64, //!< Maximum length of string
       MeanLength = 128, //!< Mean length of strings
-      All = Count | CountDistinct | CountMissing | Min | Max | MinimumLength | MaximumLength | MeanLength, //! All statistics
+      All = Count | CountDistinct | CountMissing | Min | Max | MinimumLength | MaximumLength | MeanLength, //!< All statistics
     };
     Q_DECLARE_FLAGS( Statistics, Statistic )
 

--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -88,8 +88,8 @@ class CORE_EXPORT QgsUnitTypes
       AreaAcres, //!< Acres
       AreaSquareNauticalMiles, //!< Square nautical miles
       AreaSquareDegrees, //!< Square degrees, for planar geographic CRS area measurements
-      AreaSquareCentimeters, //! Square centimeters
-      AreaSquareMillimeters, //! Square millimeters
+      AreaSquareCentimeters, //!< Square centimeters
+      AreaSquareMillimeters, //!< Square millimeters
       AreaUnknownUnit, //!< Unknown areal unit
     };
     Q_ENUM( AreaUnit )
@@ -114,8 +114,8 @@ class CORE_EXPORT QgsUnitTypes
       RenderMapUnits, //!< Map units
       RenderPixels, //!< Pixels
       RenderPercentage, //!< Percentage of another measurement (e.g., canvas size, feature size)
-      RenderPoints, //! points (e.g., for font sizes)
-      RenderInches, //! Inches
+      RenderPoints, //!< points (e.g., for font sizes)
+      RenderInches, //!< Inches
       RenderUnknownUnit, //!< Mixed or unknown units
       RenderMetersInMapUnits, //!< Meters value as Map units
     };

--- a/src/core/qgsunittypes.h
+++ b/src/core/qgsunittypes.h
@@ -114,7 +114,7 @@ class CORE_EXPORT QgsUnitTypes
       RenderMapUnits, //!< Map units
       RenderPixels, //!< Pixels
       RenderPercentage, //!< Percentage of another measurement (e.g., canvas size, feature size)
-      RenderPoints, //!< points (e.g., for font sizes)
+      RenderPoints, //!< Points (e.g., for font sizes)
       RenderInches, //!< Inches
       RenderUnknownUnit, //!< Mixed or unknown units
       RenderMetersInMapUnits, //!< Meters value as Map units

--- a/src/gui/qgsfilewidget.h
+++ b/src/gui/qgsfilewidget.h
@@ -62,10 +62,10 @@ class GUI_EXPORT QgsFileWidget : public QWidget
      */
     enum StorageMode
     {
-      GetFile, //! Select a single file
-      GetDirectory, //! Select a directory
-      GetMultipleFiles, //! Select multiple files
-      SaveFile, //! Select a single new or pre-existing file
+      GetFile, //!< Select a single file
+      GetDirectory, //!< Select a directory
+      GetMultipleFiles, //!< Select multiple files
+      SaveFile, //!< Select a single new or pre-existing file
     };
 
     /**

--- a/src/providers/ogr/qgsgeopackagerasterwriter.h
+++ b/src/providers/ogr/qgsgeopackagerasterwriter.h
@@ -31,7 +31,7 @@ class QgsGeoPackageRasterWriter
     enum WriterError
     {
       NoError = 0, //!< No errors were encountered
-      WriteError, //! Generic GDAL Translate error
+      WriteError, //!< Generic GDAL Translate error
       ErrUserCanceled, //!< User canceled the export
     };
 

--- a/src/providers/oracle/qgsoraclefeatureiterator.h
+++ b/src/providers/oracle/qgsoraclefeatureiterator.h
@@ -39,11 +39,11 @@ class QgsOracleFeatureSource : public QgsAbstractFeatureSource
     QgsDataSourceUri mUri;
     QgsFields mFields;
 
-    QString mGeometryColumn;          //!< name of the geometry column
-    int mSrid;                        //!< srid of column
-    bool mHasSpatialIndex;            //!< has spatial index of geometry column
-    QgsWkbTypes::Type mDetectedGeomType;  //!< geometry type detected in the database
-    QgsWkbTypes::Type mRequestedGeomType; //!< geometry type requested in the uri
+    QString mGeometryColumn;          //!< Name of the geometry column
+    int mSrid;                        //!< Srid of column
+    bool mHasSpatialIndex;            //!< Has spatial index of geometry column
+    QgsWkbTypes::Type mDetectedGeomType;  //!< Geometry type detected in the database
+    QgsWkbTypes::Type mRequestedGeomType; //!< Geometry type requested in the uri
     QString mSqlWhereClause;
     QgsOraclePrimaryKeyType mPrimaryKeyType;
     QList<int> mPrimaryKeyAttrs;

--- a/src/providers/oracle/qgsoraclefeatureiterator.h
+++ b/src/providers/oracle/qgsoraclefeatureiterator.h
@@ -39,11 +39,11 @@ class QgsOracleFeatureSource : public QgsAbstractFeatureSource
     QgsDataSourceUri mUri;
     QgsFields mFields;
 
-    QString mGeometryColumn;          //! name of the geometry column
-    int mSrid;                        //! srid of column
-    bool mHasSpatialIndex;            //! has spatial index of geometry column
-    QgsWkbTypes::Type mDetectedGeomType;  //! geometry type detected in the database
-    QgsWkbTypes::Type mRequestedGeomType; //! geometry type requested in the uri
+    QString mGeometryColumn;          //!< name of the geometry column
+    int mSrid;                        //!< srid of column
+    bool mHasSpatialIndex;            //!< has spatial index of geometry column
+    QgsWkbTypes::Type mDetectedGeomType;  //!< geometry type detected in the database
+    QgsWkbTypes::Type mRequestedGeomType; //!< geometry type requested in the uri
     QString mSqlWhereClause;
     QgsOraclePrimaryKeyType mPrimaryKeyType;
     QList<int> mPrimaryKeyAttrs;

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -190,8 +190,8 @@ class QgsOracleProvider : public QgsVectorDataProvider
     //! Convert a QgsField to work with Oracle
     static bool convertField( QgsField &field );
 
-    QgsFields mAttributeFields;  //! List of fields
-    QVariantList mDefaultValues; //! List of default values
+    QgsFields mAttributeFields;  //!< List of fields
+    QVariantList mDefaultValues; //!< List of default values
     QString mDataComment;
 
     //! Data source URI struct for this layer
@@ -238,14 +238,14 @@ class QgsOracleProvider : public QgsVectorDataProvider
     QList<int> mPrimaryKeyAttrs;
     QString mPrimaryKeyDefault;
 
-    QString mGeometryColumn;           //! name of the geometry column
-    mutable QgsRectangle mLayerExtent; //! Rectangle that contains the extent (bounding box) of the layer
-    mutable long mFeaturesCounted;     //! Number of features in the layer
-    int mSrid;                         //! srid of column
-    QgsVectorDataProvider::Capabilities mEnabledCapabilities;          //! capabilities of layer
+    QString mGeometryColumn;           //!< name of the geometry column
+    mutable QgsRectangle mLayerExtent; //!< Rectangle that contains the extent (bounding box) of the layer
+    mutable long mFeaturesCounted;     //!< Number of features in the layer
+    int mSrid;                         //!< srid of column
+    QgsVectorDataProvider::Capabilities mEnabledCapabilities;          //!< capabilities of layer
 
-    QgsWkbTypes::Type mDetectedGeomType;   //! geometry type detected in the database
-    QgsWkbTypes::Type mRequestedGeomType;  //! geometry type requested in the uri
+    QgsWkbTypes::Type mDetectedGeomType;   //!< geometry type detected in the database
+    QgsWkbTypes::Type mRequestedGeomType;  //!< geometry type requested in the uri
 
     bool getGeometryDetails();
 
@@ -299,12 +299,12 @@ class QgsOracleProvider : public QgsVectorDataProvider
     static QString quotedIdentifier( QString ident ) { return QgsOracleConn::quotedIdentifier( ident ); }
     static QString quotedValue( const QVariant &value, QVariant::Type type = QVariant::Invalid ) { return QgsOracleConn::quotedValue( value, type ); }
 
-    QMap<QVariant, QgsFeatureId> mKeyToFid;  //! map key values to feature id
-    QMap<QgsFeatureId, QVariant> mFidToKey;  //! map feature back to fea
+    QMap<QVariant, QgsFeatureId> mKeyToFid;  //!< map key values to feature id
+    QMap<QgsFeatureId, QVariant> mFidToKey;  //!< map feature back to fea
     QgsOracleConn *mConnection = nullptr;
 
-    bool mHasSpatialIndex;                   //! Geometry column is indexed
-    QString mSpatialIndexName;               //! name of spatial index of geometry column
+    bool mHasSpatialIndex;                   //!< Geometry column is indexed
+    QString mSpatialIndexName;               //!< name of spatial index of geometry column
 
     std::shared_ptr<QgsOracleSharedData> mShared;
 

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -238,14 +238,14 @@ class QgsOracleProvider : public QgsVectorDataProvider
     QList<int> mPrimaryKeyAttrs;
     QString mPrimaryKeyDefault;
 
-    QString mGeometryColumn;           //!< name of the geometry column
+    QString mGeometryColumn;           //!< Name of the geometry column
     mutable QgsRectangle mLayerExtent; //!< Rectangle that contains the extent (bounding box) of the layer
     mutable long mFeaturesCounted;     //!< Number of features in the layer
-    int mSrid;                         //!< srid of column
-    QgsVectorDataProvider::Capabilities mEnabledCapabilities;          //!< capabilities of layer
+    int mSrid;                         //!< Srid of column
+    QgsVectorDataProvider::Capabilities mEnabledCapabilities;          //!< Capabilities of layer
 
-    QgsWkbTypes::Type mDetectedGeomType;   //!< geometry type detected in the database
-    QgsWkbTypes::Type mRequestedGeomType;  //!< geometry type requested in the uri
+    QgsWkbTypes::Type mDetectedGeomType;   //!< Geometry type detected in the database
+    QgsWkbTypes::Type mRequestedGeomType;  //!< Geometry type requested in the uri
 
     bool getGeometryDetails();
 
@@ -299,12 +299,12 @@ class QgsOracleProvider : public QgsVectorDataProvider
     static QString quotedIdentifier( QString ident ) { return QgsOracleConn::quotedIdentifier( ident ); }
     static QString quotedValue( const QVariant &value, QVariant::Type type = QVariant::Invalid ) { return QgsOracleConn::quotedValue( value, type ); }
 
-    QMap<QVariant, QgsFeatureId> mKeyToFid;  //!< map key values to feature id
-    QMap<QgsFeatureId, QVariant> mFidToKey;  //!< map feature back to fea
+    QMap<QVariant, QgsFeatureId> mKeyToFid;  //!< Map key values to feature id
+    QMap<QgsFeatureId, QVariant> mFidToKey;  //!< Map feature back to fea
     QgsOracleConn *mConnection = nullptr;
 
     bool mHasSpatialIndex;                   //!< Geometry column is indexed
-    QString mSpatialIndexName;               //!< name of spatial index of geometry column
+    QString mSpatialIndexName;               //!< Name of spatial index of geometry column
 
     std::shared_ptr<QgsOracleSharedData> mShared;
 

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -431,7 +431,7 @@ class QgsPostgresConn : public QObject
 
     int mNextCursorId;
 
-    bool mShared; //! < whether the connection is shared by more providers (must not be if going to be used in worker threads)
+    bool mShared; //!< whether the connection is shared by more providers (must not be if going to be used in worker threads)
 
     bool mTransaction;
 

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -431,7 +431,7 @@ class QgsPostgresConn : public QObject
 
     int mNextCursorId;
 
-    bool mShared; //!< whether the connection is shared by more providers (must not be if going to be used in worker threads)
+    bool mShared; //!< Whether the connection is shared by more providers (must not be if going to be used in worker threads)
 
     bool mTransaction;
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -44,8 +44,8 @@ class QgsPostgresFeatureSource : public QgsAbstractFeatureSource
     QgsPostgresGeometryColumnType mSpatialColType;
     QString mRequestedSrid;
     QString mDetectedSrid;
-    QgsWkbTypes::Type mRequestedGeomType; //!< geometry type requested in the uri
-    QgsWkbTypes::Type mDetectedGeomType;  //!< geometry type detected in the database
+    QgsWkbTypes::Type mRequestedGeomType; //!< Geometry type requested in the uri
+    QgsWkbTypes::Type mDetectedGeomType;  //!< Geometry type detected in the database
     QgsPostgresPrimaryKeyType mPrimaryKeyType;
     QList<int> mPrimaryKeyAttrs;
     QString mQuery;

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -44,8 +44,8 @@ class QgsPostgresFeatureSource : public QgsAbstractFeatureSource
     QgsPostgresGeometryColumnType mSpatialColType;
     QString mRequestedSrid;
     QString mDetectedSrid;
-    QgsWkbTypes::Type mRequestedGeomType; //! geometry type requested in the uri
-    QgsWkbTypes::Type mDetectedGeomType;  //! geometry type detected in the database
+    QgsWkbTypes::Type mRequestedGeomType; //!< geometry type requested in the uri
+    QgsWkbTypes::Type mDetectedGeomType;  //!< geometry type detected in the database
     QgsPostgresPrimaryKeyType mPrimaryKeyType;
     QList<int> mPrimaryKeyAttrs;
     QString mQuery;

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -378,13 +378,13 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QList<int> mPrimaryKeyAttrs;
     QString mPrimaryKeyDefault;
 
-    QString mGeometryColumn;          //! name of the geometry column
-    mutable QgsRectangle mLayerExtent;        //! Rectangle that contains the extent (bounding box) of the layer
+    QString mGeometryColumn;          //!< name of the geometry column
+    mutable QgsRectangle mLayerExtent;        //!< Rectangle that contains the extent (bounding box) of the layer
 
-    QgsWkbTypes::Type mDetectedGeomType = QgsWkbTypes::Unknown ;  //! geometry type detected in the database
-    QgsWkbTypes::Type mRequestedGeomType = QgsWkbTypes::Unknown ; //! geometry type requested in the uri
-    QString mDetectedSrid;            //! Spatial reference detected in the database
-    QString mRequestedSrid;           //! Spatial reference requested in the uri
+    QgsWkbTypes::Type mDetectedGeomType = QgsWkbTypes::Unknown ;  //!< geometry type detected in the database
+    QgsWkbTypes::Type mRequestedGeomType = QgsWkbTypes::Unknown ; //!< geometry type requested in the uri
+    QString mDetectedSrid;            //!< Spatial reference detected in the database
+    QString mRequestedSrid;           //!< Spatial reference requested in the uri
 
     std::shared_ptr<QgsPostgresSharedData> mShared;  //!< Mutable data shared between provider and feature sources
 
@@ -409,7 +409,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     /* Use estimated metadata. Uses fast table counts, geometry type and extent determination */
     bool mUseEstimatedMetadata = false;
 
-    bool mSelectAtIdDisabled = false; //! Disable support for SelectAtId
+    bool mSelectAtIdDisabled = false; //!< Disable support for SelectAtId
 
     struct PGFieldNotFound {}; //! Exception to throw
 
@@ -438,8 +438,8 @@ class QgsPostgresProvider : public QgsVectorDataProvider
 
     QString paramValue( const QString &fieldvalue, const QString &defaultValue ) const;
 
-    QgsPostgresConn *mConnectionRO = nullptr ; //! read-only database connection (initially)
-    QgsPostgresConn *mConnectionRW = nullptr ; //! read-write database connection (on update)
+    QgsPostgresConn *mConnectionRO = nullptr ; //!< read-only database connection (initially)
+    QgsPostgresConn *mConnectionRW = nullptr ; //!< read-write database connection (on update)
 
     QgsPostgresConn *connectionRO() const;
     QgsPostgresConn *connectionRW();
@@ -530,7 +530,7 @@ class QgsPostgresSharedData
   protected:
     QMutex mMutex; //!< Access to all data members is guarded by the mutex
 
-    long mFeaturesCounted = -1 ;    //! Number of features in the layer
+    long mFeaturesCounted = -1 ;    //!< Number of features in the layer
 
     QgsFeatureId mFidCounter = 0;                    // next feature id if map is used
     QMap<QVariantList, QgsFeatureId> mKeyToFid;      // map key values to feature id

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -378,11 +378,11 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QList<int> mPrimaryKeyAttrs;
     QString mPrimaryKeyDefault;
 
-    QString mGeometryColumn;          //!< name of the geometry column
+    QString mGeometryColumn;          //!< Name of the geometry column
     mutable QgsRectangle mLayerExtent;        //!< Rectangle that contains the extent (bounding box) of the layer
 
-    QgsWkbTypes::Type mDetectedGeomType = QgsWkbTypes::Unknown ;  //!< geometry type detected in the database
-    QgsWkbTypes::Type mRequestedGeomType = QgsWkbTypes::Unknown ; //!< geometry type requested in the uri
+    QgsWkbTypes::Type mDetectedGeomType = QgsWkbTypes::Unknown ;  //!< Geometry type detected in the database
+    QgsWkbTypes::Type mRequestedGeomType = QgsWkbTypes::Unknown ; //!< Geometry type requested in the uri
     QString mDetectedSrid;            //!< Spatial reference detected in the database
     QString mRequestedSrid;           //!< Spatial reference requested in the uri
 
@@ -438,8 +438,8 @@ class QgsPostgresProvider : public QgsVectorDataProvider
 
     QString paramValue( const QString &fieldvalue, const QString &defaultValue ) const;
 
-    QgsPostgresConn *mConnectionRO = nullptr ; //!< read-only database connection (initially)
-    QgsPostgresConn *mConnectionRW = nullptr ; //!< read-write database connection (on update)
+    QgsPostgresConn *mConnectionRO = nullptr ; //!< Read-only database connection (initially)
+    QgsPostgresConn *mConnectionRW = nullptr ; //!< Read-write database connection (on update)
 
     QgsPostgresConn *connectionRO() const;
     QgsPostgresConn *connectionRW();


### PR DESCRIPTION
## Description
While reading the documentation, I met some missing info in an enum's table. It was caused by the doxygen comment being inline after the member but written as `//!` instead of `//!<`
A `grep "\S *//\! " *` revealed some more.
Only comments are modified, not code.

