### PR TITLE
Fix space inserted at start of graduated legend entries

### DIFF
--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -176,7 +176,7 @@ const int QgsRendererRangeLabelFormat::MAX_PRECISION = 15;
 const int QgsRendererRangeLabelFormat::MIN_PRECISION = -6;
 
 QgsRendererRangeLabelFormat::QgsRendererRangeLabelFormat()
-  : mFormat( QStringLiteral( " %1 - %2 " ) )
+  : mFormat( QStringLiteral( "%1 - %2" ) )
   , mReTrailingZeroes( "[.,]?0*$" )
   , mReNegativeZero( "^\\-0(?:[.,]0*)?$" )
 {


### PR DESCRIPTION
Fixes #21339

