### PR TITLE
Fix spelling errors for 3.4

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -1892,7 +1892,7 @@ QgsRasterCalculator     {#qgis_api_break_3_0_QgsRasterCalculator}
 
 - Cancelled (Result enum value) has been renamed to Canceled  <!--#spellok-->
 - processCalculation() now uses an optional QgsFeedback instead of QProgressDialog
-for progress reports and cancelation.
+for progress reports and cancellation.
 
 QgsRasterDataProvider        {#qgis_api_break_3_0_QgsRasterDataProvider}
 ---------------------
@@ -2576,7 +2576,7 @@ QgsRendererAbstractMetadata   {#qgis_api_break_3_0_QgsRendererAbstractMetadata}
 QgsGraphDirector   {#qgis_api_break_3_0_QgsGraphDirector}
 ----------------
 
-- makeGraph() now uses QgsFeedback for progress reporting and cancelation
+- makeGraph() now uses QgsFeedback for progress reporting and cancellation
 - buildProgress() signal was removed
 - buildMessage() signal was removed
 
@@ -2584,7 +2584,7 @@ QgsVectorLayerDirector   {#qgis_api_break_3_0_QgsVectorLayerDirector}
 ----------------------
 
 - QgsVectorLayerDirector() constructor now expects a reference to QgsFeatureSource as the first argument
-- makeGraph() now uses QgsFeedback for progress reporting and cancelation
+- makeGraph() now uses QgsFeedback for progress reporting and cancellation
 
 Processing        {#qgis_api_break_3_0_Processing}
 ----------

--- a/doc/porting_processing.dox
+++ b/doc/porting_processing.dox
@@ -74,7 +74,7 @@ Other porting notes
 
 - Your algorithm's processAlgorithm methods should return a dict with output values. In the case of output feature sinks, the sink's ID string should be included in this dictionary.
 
-- Since Processing algorithms can now be run in the background, it's important to implement support for cancelation in your algorithms. Whenever looping (or before/after calling lengthy operations) listen out for user cancelation via the provided feedback object. E.g.
+- Since Processing algorithms can now be run in the background, it's important to implement support for cancellation in your algorithms. Whenever looping (or before/after calling lengthy operations) listen out for user cancellation via the provided feedback object. E.g.
 
    if feedback.isCanceled():
        break
@@ -93,7 +93,7 @@ object to pushInfo or reportError so that the lack of features is brought to use
 
 - Don't write outputs using TableWriter or by directly creating a CSV file. Wherever possible use a feature sink instead so that the output is created as a proper vector layer. This allows other algorithms in a multi-step model to easily use the tabular outputs from the algorithm. 
 
-- To run another Processing algorithm as part of your algorithm, you can use  processing.run(...). Make sure you pass the current context and feedback to processing.run to ensure that all temporary layer outputs are available to the executed algorithm, and that the executed algorithm can send feedback reports to the user (and correctly handle cancelation and progress reports!)
+- To run another Processing algorithm as part of your algorithm, you can use  processing.run(...). Make sure you pass the current context and feedback to processing.run to ensure that all temporary layer outputs are available to the executed algorithm, and that the executed algorithm can send feedback reports to the user (and correctly handle cancellation and progress reports!)
 
 - A new API contract exists for Processing. Now, only the c++ base class (e.g. those prefixed with "Qgs"), the gui wrappers, and the methods from processing.tools are considered stable, public API. All other Processing classes and methods are considered private and may change between QGIS versions. These should not be relied on by custom algorithms.
 

--- a/python/analysis/auto_generated/interpolation/qgsgridfilewriter.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgsgridfilewriter.sip.in
@@ -31,7 +31,7 @@ The ``extent`` and ``nCols``, ``nRows`` arguments dictate the extent and size of
 %Docstring
 Writes the grid file.
 
-An optional ``feedback`` object can be set for progress reports and cancelation support
+An optional ``feedback`` object can be set for progress reports and cancellation support
 
 :return: 0 in case of success
 %End

--- a/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgsinterpolator.sip.in
@@ -83,7 +83,7 @@ Calculates interpolation value for map coordinates x, y
 :param x: x-coordinate (in map units)
 :param y: y-coordinate (in map units)
 :param result: out: interpolation result
-:param feedback: optional feedback object for progress and cancelation support
+:param feedback: optional feedback object for progress and cancellation support
 
 :return: 0 in case of success*
 %End
@@ -96,7 +96,7 @@ Calculates interpolation value for map coordinates x, y
 Caches the vertex and value data from the provider. All the vertex data
 will be held in virtual memory.
 
-An optional ``feedback`` argument may be specified to allow cancelation and
+An optional ``feedback`` argument may be specified to allow cancellation and
 progress reports from the cache operation.
 
 :return: Success in case of success

--- a/python/analysis/auto_generated/interpolation/qgstininterpolator.sip.in
+++ b/python/analysis/auto_generated/interpolation/qgstininterpolator.sip.in
@@ -32,7 +32,7 @@ Interpolation in a triangular irregular network
     QgsTinInterpolator( const QList<QgsInterpolator::LayerData> &inputData, TinInterpolation interpolation = Linear, QgsFeedback *feedback = 0 );
 %Docstring
 Constructor for QgsTinInterpolator.
-The ``feedback`` object specifies an optional QgsFeedback object for progress reports and cancelation support.
+The ``feedback`` object specifies an optional QgsFeedback object for progress reports and cancellation support.
 Ownership of ``feedback`` is not transferred and callers must ensure that it exists for the lifetime of this object.
 %End
     ~QgsTinInterpolator();

--- a/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
+++ b/python/analysis/auto_generated/raster/qgsninecellfilter.sip.in
@@ -33,7 +33,7 @@ Constructor that takes input file, output file and output format (GDAL string)
 %Docstring
 Starts the calculation, reads from mInputFile and stores the result in mOutputFile
 
-:param feedback: feedback object that receives update and that is checked for cancelation.
+:param feedback: feedback object that receives update and that is checked for cancellation.
 
 :return: 0 in case of success
 %End

--- a/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrastercalculator.sip.in
@@ -87,7 +87,7 @@ QgsRasterCalculator constructor.
 %Docstring
 Starts the calculation and writes a new raster.
 
-The optional ``feedback`` argument can be used for progress reporting and cancelation support.
+The optional ``feedback`` argument can be used for progress reporting and cancellation support.
 
 :return: QgsRasterCalculator.Success in case of success. If an error is encountered then
          a description of the error can be obtained by calling lastError().

--- a/python/analysis/auto_generated/raster/qgsrelief.sip.in
+++ b/python/analysis/auto_generated/raster/qgsrelief.sip.in
@@ -36,7 +36,7 @@ Produces colored relief rasters from DEM*
 %Docstring
 Starts the calculation, reads from mInputFile and stores the result in mOutputFile
 
-:param feedback: feedback object that receives update and that is checked for cancelation.
+:param feedback: feedback object that receives update and that is checked for cancellation.
 
 :return: 0 in case of success*
 %End

--- a/python/core/auto_generated/locator/qgslocator.sip.in
+++ b/python/core/auto_generated/locator/qgslocator.sip.in
@@ -114,7 +114,7 @@ all filters.
 
     void cancelWithoutBlocking();
 %Docstring
-Triggers cancelation of any current running query without blocking. The query may
+Triggers cancellation of any current running query without blocking. The query may
 take some time to cancel after calling this.
 
 .. seealso:: :py:func:`cancel`
@@ -143,7 +143,7 @@ is called.
     void finished();
 %Docstring
 Emitted when locator has finished a query, either as a result
-of successful completion or early cancelation.
+of successful completion or early cancellation.
 %End
 
 };

--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -888,7 +888,7 @@ will be added to the algorithm's output. This allows for "explode" type algorith
 input feature results in multiple output features.
 
 The provided ``feedback`` object can be used to push messages to the log and for giving feedback
-to users. Note that handling of progress reports and algorithm cancelation is handled by
+to users. Note that handling of progress reports and algorithm cancellation is handled by
 the base class and subclasses do not need to reimplement this logic.
 
 Algorithms can throw a QgsProcessingException if a fatal error occurred which should

--- a/python/core/auto_generated/qgsauxiliarystorage.sip.in
+++ b/python/core/auto_generated/qgsauxiliarystorage.sip.in
@@ -291,7 +291,7 @@ the target filename if the auxiliary storage is opened in copy mode.
     QString errorString() const;
 %Docstring
 Returns the underlying error string describing potential errors
-hapenning in saveAs(). Empty by default.
+happening in saveAs(). Empty by default.
 
 .. versionadded:: 3.4
 %End

--- a/python/core/auto_generated/qgsfeedback.sip.in
+++ b/python/core/auto_generated/qgsfeedback.sip.in
@@ -12,13 +12,13 @@
 class QgsFeedback : QObject
 {
 %Docstring
-Base class for feedback objects to be used for cancelation of something running in a worker thread.
+Base class for feedback objects to be used for cancellation of something running in a worker thread.
 The class may be used as is or it may be subclassed for extended functionality
 for a particular operation (e.g. report progress or pass some data for preview).
 
-When cancel() is called, the internal code has two options to check for cancelation state:
+When cancel() is called, the internal code has two options to check for cancellation state:
 - if the worker thread uses an event loop (e.g. for network communication), the code can
-make a queued connection to canceled() signal and handle the cancelation in its slot.
+make a queued connection to canceled() signal and handle the cancellation in its slot.
 - if the worker thread does not use an event loop, it can poll isCanceled() method regularly
 to see if the operation should be canceled.
 

--- a/python/core/auto_generated/qgsfiledownloader.sip.in
+++ b/python/core/auto_generated/qgsfiledownloader.sip.in
@@ -77,7 +77,7 @@ Emitted when data are ready to be processed
 
     void cancelDownload();
 %Docstring
-Call to abort the download and delete this object after the cancelation
+Call to abort the download and delete this object after the cancellation
 has been processed.
 
 .. seealso:: :py:func:`downloadCanceled`

--- a/python/core/auto_generated/qgshistogram.sip.in
+++ b/python/core/auto_generated/qgshistogram.sip.in
@@ -47,7 +47,7 @@ result of an expression.
 
 :param layer: vector layer
 :param fieldOrExpression: field name or expression to be evaluated
-:param feedback: optional feedback object to allow cancelation of calculation
+:param feedback: optional feedback object to allow cancellation of calculation
 
 :return: true if values were successfully set
 %End

--- a/python/core/auto_generated/qgsmaprendererjob.sip.in
+++ b/python/core/auto_generated/qgsmaprendererjob.sip.in
@@ -61,7 +61,7 @@ Does nothing if the rendering is not active.
 
     virtual void cancelWithoutBlocking() = 0;
 %Docstring
-Triggers cancelation of the rendering job without blocking. The render job will continue
+Triggers cancellation of the rendering job without blocking. The render job will continue
 to operate until it is able to cancel, at which stage the finished() signal will be emitted.
 Does nothing if the rendering is not active.
 %End

--- a/python/core/auto_generated/qgsspatialindex.sip.in
+++ b/python/core/auto_generated/qgsspatialindex.sip.in
@@ -47,7 +47,7 @@ Constructor for QgsSpatialIndex. Creates an empty R-tree index.
 Constructor - creates R-tree and bulk loads it with features from the iterator.
 This is much faster approach than creating an empty index and then inserting features one by one.
 
-The optional ``feedback`` object can be used to allow cancelation of bulk feature loading. Ownership
+The optional ``feedback`` object can be used to allow cancellation of bulk feature loading. Ownership
 of ``feedback`` is not transferred, and callers must take care that the lifetime of feedback exceeds
 that of the spatial index construction.
 
@@ -59,7 +59,7 @@ that of the spatial index construction.
 Constructor - creates R-tree and bulk loads it with features from the source.
 This is much faster approach than creating an empty index and then inserting features one by one.
 
-The optional ``feedback`` object can be used to allow cancelation of bulk feature loading. Ownership
+The optional ``feedback`` object can be used to allow cancellation of bulk feature loading. Ownership
 of ``feedback`` is not transferred, and callers must take care that the lifetime of feedback exceeds
 that of the spatial index construction.
 

--- a/python/core/auto_generated/qgsspatialindexkdbush.sip.in
+++ b/python/core/auto_generated/qgsspatialindexkdbush.sip.in
@@ -40,7 +40,7 @@ QgsSpatialIndexKDBush objects are implicitly shared and can be inexpensively cop
 %Docstring
 Constructor - creates KDBush index and bulk loads it with features from the iterator.
 
-The optional ``feedback`` object can be used to allow cancelation of bulk feature loading. Ownership
+The optional ``feedback`` object can be used to allow cancellation of bulk feature loading. Ownership
 of ``feedback`` is not transferred, and callers must take care that the lifetime of feedback exceeds
 that of the spatial index construction.
 
@@ -51,7 +51,7 @@ Any non-single point features encountered during iteration will be ignored and n
 %Docstring
 Constructor - creates KDBush index and bulk loads it with features from the source.
 
-The optional ``feedback`` object can be used to allow cancelation of bulk feature loading. Ownership
+The optional ``feedback`` object can be used to allow cancellation of bulk feature loading. Ownership
 of ``feedback`` is not transferred, and callers must take care that the lifetime of feedback exceeds
 that of the spatial index construction.
 

--- a/python/core/auto_generated/qgsvectorlayerexporter.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerexporter.sip.in
@@ -66,7 +66,7 @@ Writes the contents of vector layer to a different datasource.
 :param onlySelected: set to true to export only selected features
 :param errorMessage: if non-null, will be set to any error messages
 :param options: optional provider dataset options
-:param feedback: optional feedback object to show progress and cancelation of export
+:param feedback: optional feedback object to show progress and cancellation of export
 
 :return: NoError for a successful export, or encountered error
 %End

--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -79,7 +79,7 @@ Fetches all values from a specified field name or expression.
 :param fieldOrExpression: field name or an expression string
 :param ok: will be set to false if field or expression is invalid, otherwise true
 :param selectedOnly: set to true to get values from selected features only
-:param feedback: optional feedback object to allow cancelation
+:param feedback: optional feedback object to allow cancellation
 
 :return: list of fetched values
 
@@ -98,7 +98,7 @@ invalid expression results are skipped.
 :param ok: will be set to false if field or expression is invalid, otherwise true
 :param selectedOnly: set to true to get values from selected features only
 :param nullCount: optional pointer to integer to store number of null values encountered in
-:param feedback: optional feedback object to allow cancelation
+:param feedback: optional feedback object to allow cancellation
 
 :return: list of fetched values
 

--- a/python/core/auto_generated/raster/qgsrasterdrawer.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdrawer.sip.in
@@ -29,7 +29,7 @@ Draws raster data.
 :param p: destination QPainter
 :param viewPort: viewport to render
 :param qgsMapToPixel: map to pixel converter
-:param feedback: optional raster feedback object for cancelation/preview. Added in QGIS 3.0.
+:param feedback: optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
 %End
 
   protected:

--- a/python/core/auto_generated/raster/qgsrasterinterface.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterinterface.sip.in
@@ -215,7 +215,7 @@ Caller is responsible to free the memory returned.
 :param extent: extent of block
 :param width: pixel width of block
 :param height: pixel height of block
-:param feedback: optional raster feedback object for cancelation/preview. Added in QGIS 3.0.
+:param feedback: optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
 %End
 
     virtual bool setInput( QgsRasterInterface *input );

--- a/python/core/auto_generated/raster/qgsrasteriterator.sip.in
+++ b/python/core/auto_generated/raster/qgsrasteriterator.sip.in
@@ -32,7 +32,7 @@ Start reading of raster band. Raster data can then be retrieved by calling readN
 :param nCols: number of columns
 :param nRows: number of rows
 :param extent: area to read
-:param feedback: optional raster feedback object for cancelation/preview. Added in QGIS 3.0.
+:param feedback: optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
 %End
 
     bool readNextRasterPart( int bandNumber,

--- a/python/core/auto_generated/raster/qgsrastertransparency.sip.in
+++ b/python/core/auto_generated/raster/qgsrastertransparency.sip.in
@@ -87,7 +87,7 @@ Searches through the transparency list, and if a match is found, the global tran
 by the stored transparency value.
 
 :param value: the needle to search for in the transparency hay stack
-:param globalTransparency: the overal transparency level for the layer
+:param globalTransparency: the overall transparency level for the layer
 %End
 
 
@@ -101,7 +101,7 @@ by the stored transparency value.
 :param redValue: the red portion of the needle to search for in the transparency hay stack
 :param greenValue: the green portion of the needle to search for in the transparency hay stack
 :param blueValue: the green portion of the needle to search for in the transparency hay stack
-:param globalTransparency: the overal transparency level for the layer
+:param globalTransparency: the overall transparency level for the layer
 %End
 
     bool isEmpty() const;

--- a/python/gui/auto_generated/locator/qgslocator.sip
+++ b/python/gui/auto_generated/locator/qgslocator.sip
@@ -104,7 +104,7 @@ class QgsLocator : QObject
 
     void cancelWithoutBlocking();
 %Docstring
- Triggers cancelation of any current running query without blocking. The query may
+ Triggers cancellation of any current running query without blocking. The query may
  take some time to cancel after calling this.
 .. seealso:: cancel()
 %End
@@ -126,7 +126,7 @@ class QgsLocator : QObject
     void finished();
 %Docstring
  Emitted when locator has finished a query, either as a result
- of successful completion or early cancelation.
+ of successful completion or early cancellation.
 %End
 
 };

--- a/python/gui/auto_generated/qgsfiledownloaderdialog.sip.in
+++ b/python/gui/auto_generated/qgsfiledownloaderdialog.sip.in
@@ -17,7 +17,7 @@ handles file downloads and user feedback.
 
 Internally, it uses QgsFileDownloader to handle the download,
 while showing progress via a progress dialog and supporting
-cancelation.
+cancellation.
 
 .. note::
 

--- a/python/plugins/processing/script/ScriptTemplate.py
+++ b/python/plugins/processing/script/ScriptTemplate.py
@@ -179,7 +179,7 @@ class ExampleProcessingAlgorithm(QgsProcessingAlgorithm):
         # processing.run(...). Make sure you pass the current context and feedback
         # to processing.run to ensure that all temporary layer outputs are available
         # to the executed algorithm, and that the executed algorithm can send feedback
-        # reports to the user (and correctly handle cancelation and progress reports!)
+        # reports to the user (and correctly handle cancellation and progress reports!)
         if False:
             buffered_layer = processing.run("native:buffer", {
                 'INPUT': dest_id,

--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -1094,7 +1094,7 @@ campagin:campaign
 campain:campaign
 campaing:campaign
 campains:campaigns
-cancellation:cancelation
+cancelation:cancellation
 cancelled:canceled
 cancelling:canceling
 candadate:candidate

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -152,7 +152,7 @@ static QByteArray _readDtmData( QgsRasterDataProvider *provider, const QgsRectan
   QElapsedTimer t;
   t.start();
 
-  // TODO: use feedback object? (but GDAL currently does not support cancelation anyway)
+  // TODO: use feedback object? (but GDAL currently does not support cancellation anyway)
   QgsRasterInterface *input = provider;
   std::unique_ptr<QgsRasterProjector> projector;
   if ( provider->crs() != destCrs )

--- a/src/analysis/interpolation/qgsgridfilewriter.h
+++ b/src/analysis/interpolation/qgsgridfilewriter.h
@@ -46,7 +46,7 @@ class ANALYSIS_EXPORT QgsGridFileWriter
     /**
      * Writes the grid file.
      *
-     * An optional \a feedback object can be set for progress reports and cancelation support
+     * An optional \a feedback object can be set for progress reports and cancellation support
      *
      * \returns 0 in case of success
     */

--- a/src/analysis/interpolation/qgsinterpolator.h
+++ b/src/analysis/interpolation/qgsinterpolator.h
@@ -111,7 +111,7 @@ class ANALYSIS_EXPORT QgsInterpolator
      * \param x x-coordinate (in map units)
      * \param y y-coordinate (in map units)
      * \param result out: interpolation result
-     * \param feedback optional feedback object for progress and cancelation support
+     * \param feedback optional feedback object for progress and cancellation support
      * \returns 0 in case of success*/
     virtual int interpolatePoint( double x, double y, double &result SIP_OUT, QgsFeedback *feedback = nullptr ) = 0;
 
@@ -124,7 +124,7 @@ class ANALYSIS_EXPORT QgsInterpolator
      * Caches the vertex and value data from the provider. All the vertex data
      * will be held in virtual memory.
      *
-     * An optional \a feedback argument may be specified to allow cancelation and
+     * An optional \a feedback argument may be specified to allow cancellation and
      * progress reports from the cache operation.
      *
      * \returns Success in case of success

--- a/src/analysis/interpolation/qgstininterpolator.h
+++ b/src/analysis/interpolation/qgstininterpolator.h
@@ -47,7 +47,7 @@ class ANALYSIS_EXPORT QgsTinInterpolator: public QgsInterpolator
 
     /**
      * Constructor for QgsTinInterpolator.
-     * The \a feedback object specifies an optional QgsFeedback object for progress reports and cancelation support.
+     * The \a feedback object specifies an optional QgsFeedback object for progress reports and cancellation support.
      * Ownership of \a feedback is not transferred and callers must ensure that it exists for the lifetime of this object.
      */
     QgsTinInterpolator( const QList<QgsInterpolator::LayerData> &inputData, TinInterpolation interpolation = Linear, QgsFeedback *feedback = nullptr );

--- a/src/analysis/processing/qgsreclassifyutils.h
+++ b/src/analysis/processing/qgsreclassifyutils.h
@@ -95,7 +95,7 @@ class ANALYSIS_EXPORT QgsReclassifyUtils
      * a class will be changed to the no data value. Otherwise they are saved unchanged.
      *
      * The \a feedback argument gives an optional processing feedback, for progress reports
-     * and cancelation.
+     * and cancellation.
      */
     static void reclassify( const QVector< RasterClass > &classes,
                             QgsRasterInterface *sourceRaster,

--- a/src/analysis/raster/qgsalignraster.h
+++ b/src/analysis/raster/qgsalignraster.h
@@ -277,7 +277,7 @@ class ANALYSIS_EXPORT QgsAlignRaster
 
     // set by the client
 
-    //! Object that facilitates reporting of progress / cancelation
+    //! Object that facilitates reporting of progress / cancellation
     ProgressHandler *mProgressHandler = nullptr;
 
     //! Last error message from run()

--- a/src/analysis/raster/qgsninecellfilter.h
+++ b/src/analysis/raster/qgsninecellfilter.h
@@ -40,7 +40,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
 
     /**
      * Starts the calculation, reads from mInputFile and stores the result in mOutputFile
-     * \param feedback feedback object that receives update and that is checked for cancelation.
+     * \param feedback feedback object that receives update and that is checked for cancellation.
      * \returns 0 in case of success
      */
     int processRaster( QgsFeedback *feedback = nullptr );
@@ -99,7 +99,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
 
     /**
      * \brief processRasterCPU executes the computation on the CPU
-     * \param feedback instance of QgsFeedback, to allow for progress monitoring and cancelation
+     * \param feedback instance of QgsFeedback, to allow for progress monitoring and cancellation
      * \return an opaque integer for error codes: 0 in case of success
      */
     int processRasterCPU( QgsFeedback *feedback = nullptr );
@@ -109,7 +109,7 @@ class ANALYSIS_EXPORT QgsNineCellFilter
     /**
      * \brief processRasterGPU executes the computation on the GPU
      * \param source path to the OpenCL source file
-     * \param feedback instance of QgsFeedback, to allow for progress monitoring and cancelation
+     * \param feedback instance of QgsFeedback, to allow for progress monitoring and cancellation
      * \return an opaque integer for error codes: 0 in case of success
      */
     int processRasterGPU( const QString &source, QgsFeedback *feedback = nullptr );

--- a/src/analysis/raster/qgsrastercalculator.h
+++ b/src/analysis/raster/qgsrastercalculator.h
@@ -107,7 +107,7 @@ class ANALYSIS_EXPORT QgsRasterCalculator
     /**
      * Starts the calculation and writes a new raster.
      *
-     * The optional \a feedback argument can be used for progress reporting and cancelation support.
+     * The optional \a feedback argument can be used for progress reporting and cancellation support.
      *
      * \returns QgsRasterCalculator::Success in case of success. If an error is encountered then
      * a description of the error can be obtained by calling lastError().

--- a/src/analysis/raster/qgsrelief.h
+++ b/src/analysis/raster/qgsrelief.h
@@ -55,7 +55,7 @@ class ANALYSIS_EXPORT QgsRelief
 
     /**
      * Starts the calculation, reads from mInputFile and stores the result in mOutputFile
-      \param feedback feedback object that receives update and that is checked for cancelation.
+      \param feedback feedback object that receives update and that is checked for cancellation.
       \returns 0 in case of success*/
     int processRaster( QgsFeedback *feedback = nullptr );
 

--- a/src/app/layout/qgslayoutattributetablewidget.cpp
+++ b/src/app/layout/qgslayoutattributetablewidget.cpp
@@ -204,7 +204,7 @@ void QgsLayoutAttributeTableWidget::mAttributesPushButton_clicked()
     return;
   }
 
-  //make deep copy of current columns, so we can restore them in case of cancelation
+  //make deep copy of current columns, so we can restore them in case of cancellation
   QVector<QgsLayoutTableColumn *> currentColumns;
   auto it = mTable->columns().constBegin();
   for ( ; it != mTable->columns().constEnd() ; ++it )

--- a/src/app/locator/qgslocatoroptionswidget.h
+++ b/src/app/locator/qgslocatoroptionswidget.h
@@ -104,7 +104,7 @@ class QgsLocatorFiltersModel : public QAbstractTableModel
 
     QgsLocator *mLocator = nullptr;
 
-    // changes are deferred to support cancelation
+    // changes are deferred to support cancellation
     QHash< QgsLocatorFilter *, QString > mPrefixes;
     QHash< QgsLocatorFilter *, bool > mEnabledChanges;
     QHash< QgsLocatorFilter *, bool > mDefaultChanges;

--- a/src/core/locator/qgslocator.h
+++ b/src/core/locator/qgslocator.h
@@ -128,7 +128,7 @@ class CORE_EXPORT QgsLocator : public QObject
     void cancel();
 
     /**
-     * Triggers cancelation of any current running query without blocking. The query may
+     * Triggers cancellation of any current running query without blocking. The query may
      * take some time to cancel after calling this.
      * \see cancel()
      */
@@ -155,7 +155,7 @@ class CORE_EXPORT QgsLocator : public QObject
 
     /**
      * Emitted when locator has finished a query, either as a result
-     * of successful completion or early cancelation.
+     * of successful completion or early cancellation.
      */
     void finished();
 

--- a/src/core/mesh/qgsmeshlayerrenderer.h
+++ b/src/core/mesh/qgsmeshlayerrenderer.h
@@ -99,7 +99,7 @@ class QgsMeshLayerRenderer : public QgsMapLayerRenderer
     void calculateOutputSize();
 
   protected:
-    //! feedback class for cancelation
+    //! feedback class for cancellation
     std::unique_ptr<QgsMeshLayerRendererFeedback> mFeedback;
 
     // copy from mesh layer

--- a/src/core/pal/pal.h
+++ b/src/core/pal/pal.h
@@ -253,7 +253,7 @@ namespace pal
 
       //! Callback that may be called from PAL to check whether the job has not been canceled in meanwhile
       FnIsCanceled fnIsCanceled;
-      //! Application-specific context for the cancelation check function
+      //! Application-specific context for the cancellation check function
       void *fnIsCanceledContext = nullptr;
 
       /**

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -893,7 +893,7 @@ class CORE_EXPORT QgsProcessingFeatureBasedAlgorithm : public QgsProcessingAlgor
      * input feature results in multiple output features.
      *
      * The provided \a feedback object can be used to push messages to the log and for giving feedback
-     * to users. Note that handling of progress reports and algorithm cancelation is handled by
+     * to users. Note that handling of progress reports and algorithm cancellation is handled by
      * the base class and subclasses do not need to reimplement this logic.
      *
      * Algorithms can throw a QgsProcessingException if a fatal error occurred which should

--- a/src/core/qgsauxiliarystorage.h
+++ b/src/core/qgsauxiliarystorage.h
@@ -321,7 +321,7 @@ class CORE_EXPORT QgsAuxiliaryStorage
 
     /**
      * Returns the underlying error string describing potential errors
-     * hapenning in saveAs(). Empty by default.
+     * happening in saveAs(). Empty by default.
      *
      * \since QGIS 3.4
      */

--- a/src/core/qgsfeedback.h
+++ b/src/core/qgsfeedback.h
@@ -23,13 +23,13 @@
 
 /**
  * \ingroup core
- * Base class for feedback objects to be used for cancelation of something running in a worker thread.
+ * Base class for feedback objects to be used for cancellation of something running in a worker thread.
  * The class may be used as is or it may be subclassed for extended functionality
  * for a particular operation (e.g. report progress or pass some data for preview).
  *
- * When cancel() is called, the internal code has two options to check for cancelation state:
+ * When cancel() is called, the internal code has two options to check for cancellation state:
  * - if the worker thread uses an event loop (e.g. for network communication), the code can
- *   make a queued connection to canceled() signal and handle the cancelation in its slot.
+ *   make a queued connection to canceled() signal and handle the cancellation in its slot.
  * - if the worker thread does not use an event loop, it can poll isCanceled() method regularly
  *   to see if the operation should be canceled.
  *

--- a/src/core/qgsfiledownloader.h
+++ b/src/core/qgsfiledownloader.h
@@ -77,7 +77,7 @@ class CORE_EXPORT QgsFileDownloader : public QObject
   public slots:
 
     /**
-     * Call to abort the download and delete this object after the cancelation
+     * Call to abort the download and delete this object after the cancellation
      * has been processed.
      * \see downloadCanceled()
      */

--- a/src/core/qgshistogram.h
+++ b/src/core/qgshistogram.h
@@ -56,7 +56,7 @@ class CORE_EXPORT QgsHistogram
      * result of an expression.
      * \param layer vector layer
      * \param fieldOrExpression field name or expression to be evaluated
-     * \param feedback optional feedback object to allow cancelation of calculation
+     * \param feedback optional feedback object to allow cancellation of calculation
      * \returns true if values were successfully set
      */
     bool setValues( const QgsVectorLayer *layer, const QString &fieldOrExpression, QgsFeedback *feedback = nullptr );

--- a/src/core/qgslabelingengine.cpp
+++ b/src/core/qgslabelingengine.cpp
@@ -27,7 +27,7 @@
 #include "qgsmaplayer.h"
 
 
-// helper function for checking for job cancelation within PAL
+// helper function for checking for job cancellation within PAL
 static bool _palIsCanceled( void *ctx )
 {
   return ( reinterpret_cast< QgsRenderContext * >( ctx ) )->renderingStopped();

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -132,7 +132,7 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
     virtual void cancel() = 0;
 
     /**
-     * Triggers cancelation of the rendering job without blocking. The render job will continue
+     * Triggers cancellation of the rendering job without blocking. The render job will continue
      * to operate until it is able to cancel, at which stage the finished() signal will be emitted.
      * Does nothing if the rendering is not active.
      */

--- a/src/core/qgsogrutils.h
+++ b/src/core/qgsogrutils.h
@@ -136,7 +136,7 @@ namespace gdal
   /**
    * Performs a fast close of an unwanted GDAL dataset handle by deleting the underlying
    * data store. Use when the resultant dataset is no longer required, e.g. as a result
-   * of user cancelation of an operation.
+   * of user cancellation of an operation.
    *
    * Requires a gdal \a dataset pointer, the corresponding gdal \a driver and underlying
    * dataset file \a path.

--- a/src/core/qgsspatialindex.cpp
+++ b/src/core/qgsspatialindex.cpp
@@ -172,7 +172,7 @@ class QgsSpatialIndexData : public QSharedData
      * Constructor for QgsSpatialIndexData which bulk loads features from the specified feature iterator
      * \a fi.
      *
-     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * The optional \a feedback object can be used to allow cancellation of bulk feature loading. Ownership
      * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
      * that of the spatial index construction.
      */

--- a/src/core/qgsspatialindex.h
+++ b/src/core/qgsspatialindex.h
@@ -80,7 +80,7 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
      * Constructor - creates R-tree and bulk loads it with features from the iterator.
      * This is much faster approach than creating an empty index and then inserting features one by one.
      *
-     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * The optional \a feedback object can be used to allow cancellation of bulk feature loading. Ownership
      * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
      * that of the spatial index construction.
      *
@@ -92,7 +92,7 @@ class CORE_EXPORT QgsSpatialIndex : public QgsFeatureSink
      * Constructor - creates R-tree and bulk loads it with features from the source.
      * This is much faster approach than creating an empty index and then inserting features one by one.
      *
-     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * The optional \a feedback object can be used to allow cancellation of bulk feature loading. Ownership
      * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
      * that of the spatial index construction.
 

--- a/src/core/qgsspatialindexkdbush.h
+++ b/src/core/qgsspatialindexkdbush.h
@@ -57,7 +57,7 @@ class CORE_EXPORT QgsSpatialIndexKDBush
     /**
      * Constructor - creates KDBush index and bulk loads it with features from the iterator.
      *
-     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * The optional \a feedback object can be used to allow cancellation of bulk feature loading. Ownership
      * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
      * that of the spatial index construction.
      *
@@ -68,7 +68,7 @@ class CORE_EXPORT QgsSpatialIndexKDBush
     /**
      * Constructor - creates KDBush index and bulk loads it with features from the source.
      *
-     * The optional \a feedback object can be used to allow cancelation of bulk feature loading. Ownership
+     * The optional \a feedback object can be used to allow cancellation of bulk feature loading. Ownership
      * of \a feedback is not transferred, and callers must take care that the lifetime of feedback exceeds
      * that of the spatial index construction.
      *

--- a/src/core/qgstaskmanager.h
+++ b/src/core/qgstaskmanager.h
@@ -341,7 +341,7 @@ class CORE_EXPORT QgsTask : public QObject
     void completed();
 
     /**
-     * Called when the task has failed, as either a result of an internal failure or via cancelation.
+     * Called when the task has failed, as either a result of an internal failure or via cancellation.
      */
     void terminated();
 

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -175,7 +175,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
       ErrProjection,
       ErrFeatureWriteFailed,
       ErrInvalidLayer,
-      Canceled, //!< Writing was interrupted by manual cancelation
+      Canceled, //!< Writing was interrupted by manual cancellation
     };
 
     enum SymbologyExport
@@ -504,7 +504,7 @@ class CORE_EXPORT QgsVectorFileWriter : public QgsFeatureSink
          */
         QgsVectorFileWriter::FieldValueConverter *fieldValueConverter = nullptr;
 
-        //! Optional feedback object allowing cancelation of layer save
+        //! Optional feedback object allowing cancellation of layer save
         QgsFeedback *feedback = nullptr;
     };
 

--- a/src/core/qgsvectorlayerexporter.h
+++ b/src/core/qgsvectorlayerexporter.h
@@ -75,7 +75,7 @@ class CORE_EXPORT QgsVectorLayerExporter : public QgsFeatureSink
      * \param onlySelected set to true to export only selected features
      * \param errorMessage if non-null, will be set to any error messages
      * \param options optional provider dataset options
-     * \param feedback optional feedback object to show progress and cancelation of export
+     * \param feedback optional feedback object to show progress and cancellation of export
      * \returns NoError for a successful export, or encountered error
      */
     static ExportError exportLayer( QgsVectorLayer *layer,

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -87,7 +87,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      * \param fieldOrExpression field name or an expression string
      * \param ok will be set to false if field or expression is invalid, otherwise true
      * \param selectedOnly set to true to get values from selected features only
-     * \param feedback optional feedback object to allow cancelation
+     * \param feedback optional feedback object to allow cancellation
      * \returns list of fetched values
      * \see getDoubleValues
      * \since QGIS 3.0
@@ -102,7 +102,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      * \param ok will be set to false if field or expression is invalid, otherwise true
      * \param selectedOnly set to true to get values from selected features only
      * \param nullCount optional pointer to integer to store number of null values encountered in
-     * \param feedback optional feedback object to allow cancelation
+     * \param feedback optional feedback object to allow cancellation
      * \returns list of fetched values
      * \see getValues
      * \since QGIS 3.0

--- a/src/core/raster/qgsrasterdrawer.h
+++ b/src/core/raster/qgsrasterdrawer.h
@@ -44,7 +44,7 @@ class CORE_EXPORT QgsRasterDrawer
      * \param p destination QPainter
      * \param viewPort viewport to render
      * \param qgsMapToPixel map to pixel converter
-     * \param feedback optional raster feedback object for cancelation/preview. Added in QGIS 3.0.
+     * \param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
     void draw( QPainter *p, QgsRasterViewPort *viewPort, const QgsMapToPixel *qgsMapToPixel, QgsRasterBlockFeedback *feedback = nullptr );
 

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -234,7 +234,7 @@ class CORE_EXPORT QgsRasterInterface
      * \param extent extent of block
      * \param width pixel width of block
      * \param height pixel height of block
-     * \param feedback optional raster feedback object for cancelation/preview. Added in QGIS 3.0.
+     * \param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
     virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback *feedback = nullptr ) = 0 SIP_FACTORY;
 

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -45,7 +45,7 @@ class CORE_EXPORT QgsRasterIterator
      * \param nCols number of columns
      * \param nRows number of rows
      * \param extent area to read
-     * \param feedback optional raster feedback object for cancelation/preview. Added in QGIS 3.0.
+     * \param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
     void startRasterRead( int bandNumber, int nCols, int nRows, const QgsRectangle &extent, QgsRasterBlockFeedback *feedback = nullptr );
 

--- a/src/core/raster/qgsrasterlayerrenderer.h
+++ b/src/core/raster/qgsrasterlayerrenderer.h
@@ -84,7 +84,7 @@ class CORE_EXPORT QgsRasterLayerRenderer : public QgsMapLayerRenderer
     QgsRasterPipe *mPipe = nullptr;
     QgsRenderContext &mContext;
 
-    //! feedback class for cancelation and preview generation
+    //! feedback class for cancellation and preview generation
     QgsRasterLayerRendererFeedback *mFeedback = nullptr;
 
     friend class QgsRasterLayerRendererFeedback;

--- a/src/core/raster/qgsrastertransparency.h
+++ b/src/core/raster/qgsrastertransparency.h
@@ -102,7 +102,7 @@ class CORE_EXPORT QgsRasterTransparency
      * by the stored transparency value.
      *
      * \param value the needle to search for in the transparency hay stack
-     * \param globalTransparency the overal transparency level for the layer
+     * \param globalTransparency the overall transparency level for the layer
     */
     int alphaValue( double value, int globalTransparency = 255 ) const;
 
@@ -116,7 +116,7 @@ class CORE_EXPORT QgsRasterTransparency
      * \param redValue the red portion of the needle to search for in the transparency hay stack
      * \param greenValue  the green portion of the needle to search for in the transparency hay stack
      * \param blueValue the green portion of the needle to search for in the transparency hay stack
-     * \param globalTransparency the overal transparency level for the layer
+     * \param globalTransparency the overall transparency level for the layer
     */
     int alphaValue( double redValue, double greenValue, double blueValue, int globalTransparency = 255 ) const;
 

--- a/src/gui/qgscurveeditorwidget.h
+++ b/src/gui/qgscurveeditorwidget.h
@@ -64,7 +64,7 @@ class QgsHistogramValuesGatherer: public QThread
         return;
       }
 
-      // allow responsive cancelation
+      // allow responsive cancellation
       mFeedback = new QgsFeedback();
 
       mHistogram.setValues( mLayer, mExpression, mFeedback );

--- a/src/gui/qgsfieldvalueslineedit.cpp
+++ b/src/gui/qgsfieldvalueslineedit.cpp
@@ -145,7 +145,7 @@ void QgsFieldValuesLineEditValuesGatherer::run()
     return;
   }
 
-  // allow responsive cancelation
+  // allow responsive cancellation
   mFeedback = new QgsFeedback();
   // just get 100 values... maybe less/more would be useful?
   mValues = mLayer->uniqueStringsMatching( mAttributeIndex, mSubstring, 100, mFeedback );

--- a/src/gui/qgsfiledownloaderdialog.h
+++ b/src/gui/qgsfiledownloaderdialog.h
@@ -28,7 +28,7 @@ class QgsFileDownloader;
  *
  * Internally, it uses QgsFileDownloader to handle the download,
  * while showing progress via a progress dialog and supporting
- * cancelation.
+ * cancellation.
  *
  * \note Until QGIS 3.0 this functionality was available via QgsFileDownloader.
  *

--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -807,7 +807,7 @@ void QgsPalettedRendererClassGatherer::run()
 {
   mWasCanceled = false;
 
-  // allow responsive cancelation
+  // allow responsive cancellation
   mFeedback = new QgsRasterBlockFeedback();
   connect( mFeedback, &QgsRasterBlockFeedback::progressChanged, this, &QgsPalettedRendererClassGatherer::progressChanged );
 

--- a/src/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/providers/gdal/qgsgdalproviderbase.cpp
@@ -281,10 +281,10 @@ CPLErr QgsGdalProviderBase::gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWF
   INIT_RASTERIO_EXTRA_ARG( extra );
   if ( false && feedback )  // disabled!
   {
-    // Currently the cancelation is disabled... When RasterIO call is canceled,
+    // Currently the cancellation is disabled... When RasterIO call is canceled,
     // GDAL returns CE_Failure with error code = 0 (CPLE_None), however one would
     // expect to get CPLE_UserInterrupt to clearly identify that the failure was
-    // caused by the cancelation and not that something dodgy is going on.
+    // caused by the cancellation and not that something dodgy is going on.
     // Are both error codes acceptable?
     extra.pfnProgress = _gdalProgressFnWithFeedback;
     extra.pProgressData = ( void * ) feedback;


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build of QGIS 3.4.5:

 * cancelation -> cancellation
 * hapenning   -> happening
 * overal      -> overall

Note that the 'cancelation' typo is also present in the `registerCancelationCallback` method name in `src/core/pal/pal.h`, but not touched by the changes in this PR.