### PR TITLE
add tooltips in the vertex editor

### DIFF
--- a/src/app/vertextool/qgsvertexeditor.cpp
+++ b/src/app/vertextool/qgsvertexeditor.cpp
@@ -197,6 +197,28 @@ QVariant QgsVertexEditorModel::headerData( int section, Qt::Orientation orientat
         return QVariant();
     }
   }
+  else if ( role == Qt::ToolTipRole )
+  {
+    if ( orientation == Qt::Vertical )
+    {
+      return QVariant( tr( "Vertex %1" ).arg( section ) );
+    }
+    else
+    {
+      if ( section == 0 )
+        return QVariant( tr( "X Coordinate" ) );
+      else if ( section == 1 )
+        return QVariant( tr( "Y Coordinate" ) );
+      else if ( section == mZCol )
+        return QVariant( tr( "Z Coordinate" ) );
+      else if ( section == mMCol )
+        return QVariant( tr( "M Value" ) );
+      else if ( section == mRCol )
+        return QVariant( tr( "Radius Value" ) );
+      else
+        return QVariant();
+    }
+  }
   else
   {
     return QVariant();


### PR DESCRIPTION
I was using the vertex editor with a point layer, it took me a few seconds to wonder what could be this `r` column on a point layer.

The `r` is column is always shown: https://github.com/qgis/QGIS/blob/master/src/app/vertextool/qgsvertexeditor.h#L56

