### PR TITLE
 Fix use of trailing */ in dox, which messes with sipify Python docs

### DIFF
--- a/python/core/auto_generated/effects/qgscoloreffect.sip.in
+++ b/python/core/auto_generated/effects/qgscoloreffect.sip.in
@@ -143,7 +143,7 @@ Sets whether the effect should colorize a picture.
 %Docstring
 Returns whether the effect will colorize a picture.
 
-:return: true if colorization is enableds
+:return: true if colorization is enabled
 
 .. seealso:: :py:func:`setColorizeOn`
 

--- a/python/core/auto_generated/qgsbrowsermodel.sip.in
+++ b/python/core/auto_generated/qgsbrowsermodel.sip.in
@@ -113,7 +113,7 @@ items, i.e. it does not fetch children.
 :param matchFlag: supported is Qt.MatchExactly and Qt.MatchStartsWith which has reverse meaning, i.e. find
                   item with the longest match from start with path (to get as close/deep as possible to deleted item).
 
-:return: model index, invalid if item not found *
+:return: model index, invalid if item not found
 %End
 
 

--- a/python/core/auto_generated/qgsgml.sip.in
+++ b/python/core/auto_generated/qgsgml.sip.in
@@ -17,7 +17,7 @@ class QgsGml : QObject
 This class reads data from a WFS server or alternatively from a GML file. It
 uses the expat XML parser and an event based model to keep performance high.
 The parsing starts when the first data arrives, it does not wait until the
-request is finished *
+request is finished
 %End
 
 %TypeHeaderCode

--- a/python/core/auto_generated/qgsgmlschema.sip.in
+++ b/python/core/auto_generated/qgsgmlschema.sip.in
@@ -57,7 +57,7 @@ Supports only UTF-8, UTF-16, ISO-8859-1, US-ASCII XML encodings.
 
 :param data: GML data
 
-:return: true in case of success *
+:return: true in case of success
 %End
 
     QStringList typeNames() const;

--- a/python/core/auto_generated/qgspluginlayerregistry.sip.in
+++ b/python/core/auto_generated/qgspluginlayerregistry.sip.in
@@ -72,7 +72,6 @@ Constructor for QgsPluginLayerRegistry.
     QStringList pluginLayerTypes();
 %Docstring
 List all known layer types
-\since QGIS *
 %End
 
     bool addPluginLayerType( QgsPluginLayerType *pluginLayerType /Transfer/ );

--- a/python/core/auto_generated/qgspointlocator.sip.in
+++ b/python/core/auto_generated/qgspointlocator.sip.in
@@ -97,7 +97,7 @@ Configure render context  - if not null, it will use to index only visible featu
 Prepare the index for queries. Does nothing if the index already exists.
 If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
 to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used. Returns
-false if the creation of index has been prematurely stopped due to the limit of features, otherwise true *
+false if the creation of index has been prematurely stopped due to the limit of features, otherwise true
 %End
 
     bool hasIndex() const;

--- a/python/core/auto_generated/qgssqlstatement.sip.in
+++ b/python/core/auto_generated/qgssqlstatement.sip.in
@@ -48,7 +48,7 @@ Returns parser error
 %Docstring
 Performs basic validity checks. Basically checking that columns referencing
 a table, references a specified table. Returns true if the validation is
-successful *
+successful
 %End
 
 
@@ -177,7 +177,7 @@ Returns a quoted version of a string (in single quotes)
     class Node
 {
 %Docstring
-Abstract node class *
+Abstract node class
 %End
 
 %TypeHeaderCode
@@ -299,7 +299,7 @@ Dump list
     class NodeUnaryOperator : QgsSQLStatement::Node
 {
 %Docstring
-Unary logicial/arithmetical operator ( NOT, - ) *
+Unary logicial/arithmetical operator ( NOT, - )
 %End
 
 %TypeHeaderCode
@@ -336,7 +336,7 @@ Operand
     class NodeBinaryOperator : QgsSQLStatement::Node
 {
 %Docstring
-Binary logical/arithmetical operator (AND, OR, =, +, ...) *
+Binary logical/arithmetical operator (AND, OR, =, +, ...)
 %End
 
 %TypeHeaderCode
@@ -389,7 +389,7 @@ Is left associative ?
     class NodeInOperator : QgsSQLStatement::Node
 {
 %Docstring
-'x IN (y, z)' operator *
+'x IN (y, z)' operator
 %End
 
 %TypeHeaderCode
@@ -431,7 +431,7 @@ Values list
     class NodeBetweenOperator : QgsSQLStatement::Node
 {
 %Docstring
-'X BETWEEN y and z' operator *
+'X BETWEEN y and z' operator
 %End
 
 %TypeHeaderCode
@@ -477,7 +477,7 @@ Maximum bound
     class NodeFunction : QgsSQLStatement::Node
 {
 %Docstring
-Function with a name and arguments node *
+Function with a name and arguments node
 %End
 
 %TypeHeaderCode
@@ -515,7 +515,7 @@ Returns arguments
     class NodeLiteral : QgsSQLStatement::Node
 {
 %Docstring
-Literal value (integer, integer64, double, string) *
+Literal value (integer, integer64, double, string)
 %End
 
 %TypeHeaderCode
@@ -546,7 +546,7 @@ The value of the literal.
     class NodeColumnRef : QgsSQLStatement::Node
 {
 %Docstring
-Reference to a column *
+Reference to a column
 %End
 
 %TypeHeaderCode
@@ -605,7 +605,7 @@ Clone with same type return
     class NodeSelectedColumn : QgsSQLStatement::Node
 {
 %Docstring
-Selected column *
+Selected column
 %End
 
 %TypeHeaderCode
@@ -651,7 +651,7 @@ Clone with same type return
     class NodeCast : QgsSQLStatement::Node
 {
 %Docstring
-CAST operator *
+CAST operator
 %End
 
 %TypeHeaderCode
@@ -688,7 +688,7 @@ Type
     class NodeTableDef : QgsSQLStatement::Node
 {
 %Docstring
-Table definition *
+Table definition
 %End
 
 %TypeHeaderCode
@@ -732,7 +732,7 @@ Clone with same type return
     class NodeJoin : QgsSQLStatement::Node
 {
 %Docstring
-Join definition *
+Join definition
 %End
 
 %TypeHeaderCode
@@ -787,7 +787,7 @@ Clone with same type return
     class NodeColumnSorted : QgsSQLStatement::Node
 {
 %Docstring
-Column in a ORDER BY *
+Column in a ORDER BY
 %End
 
 %TypeHeaderCode
@@ -828,7 +828,7 @@ Clone with same type return
     class NodeSelect : QgsSQLStatement::Node
 {
 %Docstring
-SELECT node *
+SELECT node
 %End
 
 %TypeHeaderCode
@@ -899,7 +899,7 @@ Returns the list of order by columns
 {
 %Docstring
 Support for visitor pattern - algorithms dealing with the statement
-may be implemented without modifying the Node classes *
+may be implemented without modifying the Node classes
 %End
 
 %TypeHeaderCode
@@ -964,7 +964,7 @@ Visit NodeCast
     class RecursiveVisitor: QgsSQLStatement::Visitor
 {
 %Docstring
-A visitor that recursively explores all children *
+A visitor that recursively explores all children
 %End
 
 %TypeHeaderCode

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -433,14 +433,14 @@ Joins another vector layer to this layer
 
 .. note::
 
-   since 2.6 returns bool indicating whether the join can be added *
+   since 2.6 returns bool indicating whether the join can be added
 %End
 
     bool removeJoin( const QString &joinLayerId );
 %Docstring
 Removes a vector layer join
 
-:return: true if join was found and successfully removed *
+:return: true if join was found and successfully removed
 %End
 
     QgsVectorLayerJoinBuffer *joinBuffer();

--- a/python/core/auto_generated/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayereditbuffer.sip.in
@@ -72,7 +72,7 @@ Changes values of attributes (but does not commit it).
     virtual bool addAttribute( const QgsField &field );
 %Docstring
 Add an attribute field (but does not commit it)
-returns true if the field was added *
+returns true if the field was added
 %End
 
     virtual bool deleteAttribute( int attr );

--- a/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerjoinbuffer.sip.in
@@ -32,14 +32,14 @@ Joins another vector layer to this layer
 
 :param joinInfo: join object containing join layer id, target and source field
 
-:return: (since 2.6) whether the join was successfully added *
+:return: (since 2.6) whether the join was successfully added
 %End
 
     bool removeJoin( const QString &joinLayerId );
 %Docstring
 Removes a vector layer join
 
-:return: true if join was found and successfully removed *
+:return: true if join was found and successfully removed
 %End
 
     void updateFields( QgsFields &fields );

--- a/python/core/auto_generated/raster/qgsrasterblock.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterblock.sip.in
@@ -103,7 +103,7 @@ Returns true if the block may contain no data. It does not guarantee
 that it really contains any no data. It can be used to speed up processing.
 Not the difference between this method and hasNoDataValue().
 
-:return: true if the block may contain no data *
+:return: true if the block may contain no data
 %End
 
     void setNoDataValue( double noDataValue );
@@ -142,7 +142,7 @@ Gets byte array representing a value.
 :param dataType: data type
 :param value: value
 
-:return: byte array representing the value *
+:return: byte array representing the value
 %End
 
     double value( int row, int column ) const;
@@ -180,7 +180,7 @@ Read a single color
 :param row: row index
 :param column: column index
 
-:return: color *
+:return: color
 %End
 
     QRgb color( qgssize index ) const;
@@ -189,7 +189,7 @@ Read a single value
 
 :param index: data matrix index (long type in Python)
 
-:return: color *
+:return: color
 %End
 
     bool isNoData( int row, int column ) const;
@@ -235,7 +235,7 @@ Set value on position
 :param column: column index
 :param value: the value to be set
 
-:return: true on success *
+:return: true on success
 %End
 
     bool setValue( qgssize index, double value );
@@ -245,7 +245,7 @@ Set value on index (indexed line by line)
 :param index: data matrix index (long type in Python)
 :param value: the value to be set
 
-:return: true on success *
+:return: true on success
 %End
 
     bool setColor( int row, int column, QRgb color );
@@ -256,7 +256,7 @@ Set color on position
 :param column: column index
 :param color: the color to be set, QRgb value
 
-:return: true on success *
+:return: true on success
 %End
 
     bool setColor( qgssize index, QRgb color );
@@ -266,7 +266,7 @@ Set color on index (indexed line by line)
 :param index: data matrix index (long type in Python)
 :param color: the color to be set, QRgb value
 
-:return: true on success *
+:return: true on success
 %End
 
 
@@ -277,7 +277,7 @@ Set no data on pixel
 :param row: row index
 :param column: column index
 
-:return: true on success *
+:return: true on success
 %End
 
     bool setIsNoData( qgssize index );
@@ -286,21 +286,21 @@ Set no data on pixel
 
 :param index: data matrix index (long type in Python)
 
-:return: true on success *
+:return: true on success
 %End
 
     bool setIsNoData();
 %Docstring
 Set the whole block to no data
 
-:return: true on success *
+:return: true on success
 %End
 
     bool setIsNoDataExcept( QRect exceptRect );
 %Docstring
 Set the whole block to no data except specified rectangle
 
-:return: true on success *
+:return: true on success
 %End
 
     void setIsData( int row, int column );
@@ -375,7 +375,7 @@ Convert data to different type.
 
 :param destDataType: dest data type
 
-:return: true on success *
+:return: true on success
 %End
 
     QImage image() const;

--- a/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterdataprovider.sip.in
@@ -37,7 +37,7 @@ Starts the image download
 
 .. note::
 
-   Make sure to connect to "finish" and "error" before starting *
+   Make sure to connect to "finish" and "error" before starting
 %End
 
   signals:
@@ -46,7 +46,7 @@ Starts the image download
 %Docstring
 Emitted when the download completes
 
-:param legend: The downloaded legend image *
+:param legend: The downloaded legend image
 %End
     void progress( qint64 received, qint64 total );
 %Docstring
@@ -189,7 +189,7 @@ Returns a list of user no data value ranges.
     virtual QStringList subLayers() const;
 %Docstring
 Returns the sublayers of this layer - useful for providers that manage
-their own layers, such as WMS *
+their own layers, such as WMS
 %End
 
     virtual bool supportsLegendGraphic() const;

--- a/python/core/auto_generated/raster/qgsrasterinterface.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterinterface.sip.in
@@ -171,7 +171,7 @@ Returns data type for the band specified by number
     virtual Qgis::DataType sourceDataType( int bandNo ) const;
 %Docstring
 Returns source data type for the band specified by number,
-source data type may be shorter than dataType *
+source data type may be shorter than dataType
 %End
 
     virtual QgsRectangle extent() const;
@@ -221,7 +221,7 @@ Caller is responsible to free the memory returned.
     virtual bool setInput( QgsRasterInterface *input );
 %Docstring
 Set input.
-Returns true if set correctly, false if cannot use that input *
+Returns true if set correctly, false if cannot use that input
 %End
 
     virtual QgsRasterInterface *input() const;

--- a/python/core/auto_generated/raster/qgsrasterpipe.sip.in
+++ b/python/core/auto_generated/raster/qgsrasterpipe.sip.in
@@ -45,7 +45,7 @@ Constructor for QgsRasterPipe.
     bool insert( int idx, QgsRasterInterface *interface /Transfer/ );
 %Docstring
 Try to insert interface at specified index and connect
-if connection would fail, the interface is not inserted and false is returned *
+if connection would fail, the interface is not inserted and false is returned
 %End
 %MethodCode
     sipRes = sipCpp->insert( a0, a1 );
@@ -61,7 +61,7 @@ if connection would fail, the interface is not inserted and false is returned *
     bool replace( int idx, QgsRasterInterface *interface /Transfer/ );
 %Docstring
 Try to replace interface at specified index and connect
-if connection would fail, the interface is not inserted and false is returned *
+if connection would fail, the interface is not inserted and false is returned
 %End
 
     bool set( QgsRasterInterface *interface /Transfer/ );
@@ -90,7 +90,7 @@ Remove and delete interface from pipe if possible
     bool setOn( int idx, bool on );
 %Docstring
 Set interface at index on/off
-Returns true on success *
+Returns true on success
 %End
 
     bool canSetOn( int idx, bool on );

--- a/python/core/auto_generated/symbology/qgscptcityarchive.sip.in
+++ b/python/core/auto_generated/symbology/qgscptcityarchive.sip.in
@@ -247,7 +247,7 @@ A selection: contains subdirectories and color ramps
 class QgsCptCityAllRampsItem : QgsCptCityCollectionItem
 {
 %Docstring
-An "All ramps item", which contains all items in a flat hierarchy *
+An "All ramps item", which contains all items in a flat hierarchy
 %End
 
 %TypeHeaderCode

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -110,7 +110,7 @@ Returns vector layers in edit mode
 
 :param modified: whether to return only layers that have been modified
 
-:return: list of layers in legend order, or empty list *
+:return: list of layers in legend order, or empty list
 %End
 
     virtual QgsMapLayer *activeLayer() = 0;
@@ -953,13 +953,13 @@ Open attribute table dialog
     virtual void addWindow( QAction *action ) = 0;
 %Docstring
 Add window to Window menu. The action title is the window title
-and the action should raise, unminimize and activate the window. *
+and the action should raise, unminimize and activate the window.
 %End
 
     virtual void removeWindow( QAction *action ) = 0;
 %Docstring
 Remove window from Window menu. Calling this is necessary only for
-windows which are hidden rather than deleted when closed. *
+windows which are hidden rather than deleted when closed.
 %End
 
     virtual bool registerMainWindowAction( QAction *action, const QString &defaultShortcut ) = 0;

--- a/python/gui/auto_generated/qgscollapsiblegroupbox.sip.in
+++ b/python/gui/auto_generated/qgscollapsiblegroupbox.sip.in
@@ -160,7 +160,7 @@ Set this to true to save/restore checked state
 .. note::
 
    only turn on mSaveCheckedState for groupboxes NOT used
-   in multiple places or used as options for different parent objects *
+   in multiple places or used as options for different parent objects
 %End
     bool saveCollapsedState();
     bool saveCheckedState();

--- a/python/gui/auto_generated/qgsmapcanvasitem.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvasitem.sip.in
@@ -49,7 +49,7 @@ Sets render context parameters
 :param p: painter for rendering
 :param context: out: configured context
 
-:return: true in case of success *
+:return: true in case of success
 %End
 
   public:

--- a/python/gui/auto_generated/qgsnewgeopackagelayerdialog.sip.in
+++ b/python/gui/auto_generated/qgsnewgeopackagelayerdialog.sip.in
@@ -12,7 +12,7 @@
 class QgsNewGeoPackageLayerDialog: QDialog
 {
 %Docstring
-Dialog to set up parameters to create a new GeoPackage layer, and on accept() to create it and add it to the layers *
+Dialog to set up parameters to create a new GeoPackage layer, and on accept() to create it and add it to the layers
 %End
 
 %TypeHeaderCode

--- a/scripts/spell_check/spelling.dat
+++ b/scripts/spell_check/spelling.dat
@@ -2578,6 +2578,7 @@ emties:empties
 emtpy:empty
 emty:empty
 emtying:emptying
+enableds:enabled
 enameld:enameled
 enbale:enable
 enbaled:enabled

--- a/src/core/effects/qgscoloreffect.h
+++ b/src/core/effects/qgscoloreffect.h
@@ -130,7 +130,7 @@ class CORE_EXPORT QgsColorEffect : public QgsPaintEffect
 
     /**
      * Returns whether the effect will colorize a picture.
-     * \returns true if colorization is enableds
+     * \returns true if colorization is enabled
      * \see setColorizeOn
      * \see colorizeColor
      * \see colorizeStrength

--- a/src/core/qgsbrowsermodel.h
+++ b/src/core/qgsbrowsermodel.h
@@ -130,7 +130,8 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
      * \param path item path
      * \param matchFlag supported is Qt::MatchExactly and Qt::MatchStartsWith which has reverse meaning, i.e. find
      *        item with the longest match from start with path (to get as close/deep as possible to deleted item).
-     * \returns model index, invalid if item not found */
+     * \returns model index, invalid if item not found
+    */
     QModelIndex findPath( const QString &path, Qt::MatchFlag matchFlag = Qt::MatchExactly );
 
     //! \note not available in Python bindings

--- a/src/core/qgsgml.h
+++ b/src/core/qgsgml.h
@@ -347,7 +347,8 @@ class CORE_EXPORT QgsGmlStreamingParser
  * This class reads data from a WFS server or alternatively from a GML file. It
  * uses the expat XML parser and an event based model to keep performance high.
  * The parsing starts when the first data arrives, it does not wait until the
- * request is finished */
+ * request is finished
+*/
 class CORE_EXPORT QgsGml : public QObject
 {
     Q_OBJECT

--- a/src/core/qgsgmlschema.h
+++ b/src/core/qgsgmlschema.h
@@ -93,7 +93,8 @@ class CORE_EXPORT QgsGmlSchema : public QObject
       * Currently only recognizes UMN Mapserver GetFeatureInfo GML response.
       * Supports only UTF-8, UTF-16, ISO-8859-1, US-ASCII XML encodings.
       * \param data GML data
-      * \returns true in case of success */
+      * \returns true in case of success
+    */
     bool guessSchema( const QByteArray &data );
 
     //! Gets list of dot separated paths to feature classes parsed from GML or XSD

--- a/src/core/qgspluginlayerregistry.h
+++ b/src/core/qgspluginlayerregistry.h
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsPluginLayerRegistry
 
     /**
      * List all known layer types
-     *  \since QGIS */
+     */
     QStringList pluginLayerTypes();
 
     //! Add plugin layer type (take ownership) and return true on success

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -121,7 +121,8 @@ class CORE_EXPORT QgsPointLocator : public QObject
      * Prepare the index for queries. Does nothing if the index already exists.
      * If the number of features is greater than the value of maxFeaturesToIndex, creation of index is stopped
      * to make sure we do not run out of memory. If maxFeaturesToIndex is -1, no limits are used. Returns
-     * false if the creation of index has been prematurely stopped due to the limit of features, otherwise true */
+     * false if the creation of index has been prematurely stopped due to the limit of features, otherwise true
+    */
     bool init( int maxFeaturesToIndex = -1 );
 
     //! Indicate whether the data have been already indexed

--- a/src/core/qgssqlstatement.h
+++ b/src/core/qgssqlstatement.h
@@ -62,7 +62,8 @@ class CORE_EXPORT QgsSQLStatement
     /**
      * Performs basic validity checks. Basically checking that columns referencing
      * a table, references a specified table. Returns true if the validation is
-     * successful */
+     * successful
+    */
     bool doBasicValidationChecks( QString &errorMsgOut SIP_OUT ) const;
 
     class Node;
@@ -206,7 +207,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Abstract node class */
+     * Abstract node class
+    */
     class CORE_EXPORT Node
     {
 
@@ -314,7 +316,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Unary logicial/arithmetical operator ( NOT, - ) */
+     * Unary logicial/arithmetical operator ( NOT, - )
+    */
     class CORE_EXPORT NodeUnaryOperator : public QgsSQLStatement::Node
     {
       public:
@@ -341,7 +344,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Binary logical/arithmetical operator (AND, OR, =, +, ...) */
+     * Binary logical/arithmetical operator (AND, OR, =, +, ...)
+    */
     class CORE_EXPORT NodeBinaryOperator : public QgsSQLStatement::Node
     {
       public:
@@ -383,7 +387,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * 'x IN (y, z)' operator */
+     * 'x IN (y, z)' operator
+    */
     class CORE_EXPORT NodeInOperator : public QgsSQLStatement::Node
     {
       public:
@@ -414,7 +419,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * 'X BETWEEN y and z' operator */
+     * 'X BETWEEN y and z' operator
+    */
     class CORE_EXPORT NodeBetweenOperator : public QgsSQLStatement::Node
     {
       public:
@@ -450,7 +456,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Function with a name and arguments node */
+     * Function with a name and arguments node
+    */
     class CORE_EXPORT NodeFunction : public QgsSQLStatement::Node
     {
       public:
@@ -478,7 +485,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Literal value (integer, integer64, double, string) */
+     * Literal value (integer, integer64, double, string)
+    */
     class CORE_EXPORT NodeLiteral : public QgsSQLStatement::Node
     {
       public:
@@ -500,7 +508,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Reference to a column */
+     * Reference to a column
+    */
     class CORE_EXPORT NodeColumnRef : public QgsSQLStatement::Node
     {
       public:
@@ -541,7 +550,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Selected column */
+     * Selected column
+    */
     class CORE_EXPORT NodeSelectedColumn : public QgsSQLStatement::Node
     {
       public:
@@ -573,7 +583,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * CAST operator */
+     * CAST operator
+    */
     class CORE_EXPORT NodeCast : public QgsSQLStatement::Node
     {
       public:
@@ -600,7 +611,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Table definition */
+     * Table definition
+    */
     class CORE_EXPORT NodeTableDef : public QgsSQLStatement::Node
     {
       public:
@@ -630,7 +642,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Join definition */
+     * Join definition
+    */
     class CORE_EXPORT NodeJoin : public QgsSQLStatement::Node
     {
       public:
@@ -669,7 +682,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * Column in a ORDER BY */
+     * Column in a ORDER BY
+    */
     class CORE_EXPORT NodeColumnSorted : public QgsSQLStatement::Node
     {
       public:
@@ -698,7 +712,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * SELECT node */
+     * SELECT node
+    */
     class CORE_EXPORT NodeSelect : public QgsSQLStatement::Node
     {
       public:
@@ -748,7 +763,8 @@ class CORE_EXPORT QgsSQLStatement
     /**
      * \ingroup core
      * Support for visitor pattern - algorithms dealing with the statement
-        may be implemented without modifying the Node classes */
+        may be implemented without modifying the Node classes
+    */
     class CORE_EXPORT Visitor
     {
       public:
@@ -783,7 +799,8 @@ class CORE_EXPORT QgsSQLStatement
 
     /**
      * \ingroup core
-     * A visitor that recursively explores all children */
+     * A visitor that recursively explores all children
+    */
     class CORE_EXPORT RecursiveVisitor: public QgsSQLStatement::Visitor
     {
       public:

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -505,12 +505,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     /**
      * Joins another vector layer to this layer
       \param joinInfo join object containing join layer id, target and source field
-      \note since 2.6 returns bool indicating whether the join can be added */
+      \note since 2.6 returns bool indicating whether the join can be added
+    */
     bool addJoin( const QgsVectorLayerJoinInfo &joinInfo );
 
     /**
      * Removes a vector layer join
-      \returns true if join was found and successfully removed */
+     * \returns true if join was found and successfully removed
+    */
     bool removeJoin( const QString &joinLayerId );
 
     /**

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -74,7 +74,8 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
 
     /**
      * Add an attribute field (but does not commit it)
-        returns true if the field was added */
+        returns true if the field was added
+    */
     virtual bool addAttribute( const QgsField &field );
 
     //! Delete an attribute field (but does not commit it)

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -42,12 +42,14 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer : public QObject, public QgsFeatureSi
     /**
      * Joins another vector layer to this layer
       \param joinInfo join object containing join layer id, target and source field
-      \returns (since 2.6) whether the join was successfully added */
+      \returns (since 2.6) whether the join was successfully added
+    */
     bool addJoin( const QgsVectorLayerJoinInfo &joinInfo );
 
     /**
      * Removes a vector layer join
-      \returns true if join was found and successfully removed */
+      \returns true if join was found and successfully removed
+    */
     bool removeJoin( const QString &joinLayerId );
 
     /**

--- a/src/core/raster/qgsrasterblock.h
+++ b/src/core/raster/qgsrasterblock.h
@@ -142,7 +142,8 @@ class CORE_EXPORT QgsRasterBlock
      * Returns true if the block may contain no data. It does not guarantee
      * that it really contains any no data. It can be used to speed up processing.
      * Not the difference between this method and hasNoDataValue().
-     * \returns true if the block may contain no data */
+     * \returns true if the block may contain no data
+    */
     bool hasNoData() const
     {
       return mHasNoDataValue || mNoDataBitmap;
@@ -175,7 +176,8 @@ class CORE_EXPORT QgsRasterBlock
      * Gets byte array representing a value.
      * \param dataType data type
      * \param value value
-     * \returns byte array representing the value */
+     * \returns byte array representing the value
+    */
     static QByteArray valueBytes( Qgis::DataType dataType, double value );
 
     /**
@@ -249,7 +251,8 @@ class CORE_EXPORT QgsRasterBlock
      * \brief Read a single color
      *  \param row row index
      *  \param column column index
-     *  \returns color */
+     *  \returns color
+    */
     QRgb color( int row, int column ) const
     {
       if ( !mImage ) return NO_DATA_COLOR;
@@ -260,7 +263,8 @@ class CORE_EXPORT QgsRasterBlock
     /**
      * \brief Read a single value
      *  \param index data matrix index (long type in Python)
-     *  \returns color */
+     *  \returns color
+    */
     QRgb color( qgssize index ) const
     {
       int row = static_cast< int >( std::floor( static_cast< double >( index ) / mWidth ) );
@@ -334,7 +338,8 @@ class CORE_EXPORT QgsRasterBlock
      *  \param row row index
      *  \param column column index
      *  \param value the value to be set
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool setValue( int row, int column, double value )
     {
       return setValue( static_cast< qgssize >( row ) * mWidth + column, value );
@@ -344,7 +349,8 @@ class CORE_EXPORT QgsRasterBlock
      * \brief Set value on index (indexed line by line)
      *  \param index data matrix index (long type in Python)
      *  \param value the value to be set
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool setValue( qgssize index, double value )
     {
       if ( !mData )
@@ -366,7 +372,8 @@ class CORE_EXPORT QgsRasterBlock
      *  \param row row index
      *  \param column column index
      *  \param color the color to be set, QRgb value
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool setColor( int row, int column, QRgb color )
     {
       return setColor( static_cast< qgssize >( row ) * mWidth + column, color );
@@ -376,7 +383,8 @@ class CORE_EXPORT QgsRasterBlock
      * \brief Set color on index (indexed line by line)
      *  \param index data matrix index (long type in Python)
      *  \param color the color to be set, QRgb value
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool setColor( qgssize index, QRgb color )
     {
       if ( !mImage )
@@ -415,7 +423,8 @@ class CORE_EXPORT QgsRasterBlock
      * \brief Set no data on pixel
      *  \param row row index
      *  \param column column index
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool setIsNoData( int row, int column )
     {
       return setIsNoData( static_cast< qgssize >( row ) * mWidth + column );
@@ -424,7 +433,8 @@ class CORE_EXPORT QgsRasterBlock
     /**
      * \brief Set no data on pixel
      *  \param index data matrix index (long type in Python)
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool setIsNoData( qgssize index )
     {
       if ( mHasNoDataValue )
@@ -454,12 +464,14 @@ class CORE_EXPORT QgsRasterBlock
 
     /**
      * \brief Set the whole block to no data
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool setIsNoData();
 
     /**
      * \brief Set the whole block to no data except specified rectangle
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool setIsNoDataExcept( QRect exceptRect );
 
     /**
@@ -469,7 +481,8 @@ class CORE_EXPORT QgsRasterBlock
      * method. This method has no effect for raster blocks with an explicit no data value set.
      *  \param row row index
      *  \param column column index
-     *  \since QGIS 2.10 */
+     *  \since QGIS 2.10
+    */
     void setIsData( int row, int column )
     {
       setIsData( static_cast< qgssize >( row )*mWidth + column );
@@ -481,7 +494,8 @@ class CORE_EXPORT QgsRasterBlock
      * In this case it is possible to reset a pixel to flag it as having valid data using this
      * method. This method has no effect for raster blocks with an explicit no data value set.
      *  \param index data matrix index (long type in Python)
-     *  \since QGIS 2.10 */
+     *  \since QGIS 2.10
+    */
     void setIsData( qgssize index )
     {
       if ( mHasNoDataValue )
@@ -567,7 +581,8 @@ class CORE_EXPORT QgsRasterBlock
     /**
      * \brief Convert data to different type.
      *  \param destDataType dest data type
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool convert( Qgis::DataType destDataType );
 
     /**
@@ -637,7 +652,8 @@ class CORE_EXPORT QgsRasterBlock
      * Test if value is nodata comparing to noDataValue
      * \param value tested value
      * \param noDataValue no data value
-     * \returns true if value is nodata */
+     * \returns true if value is nodata
+    */
     static bool isNoDataValue( double value, double noDataValue )
     {
       // TODO: optimize no data value test by memcmp()
@@ -650,12 +666,14 @@ class CORE_EXPORT QgsRasterBlock
     /**
      * Test if value is nodata for specific band
      * \param value tested value
-     * \returns true if value is nodata */
+     * \returns true if value is nodata
+    */
     bool isNoDataValue( double value ) const;
 
     /**
      * Allocate no data bitmap
-     *  \returns true on success */
+     *  \returns true on success
+    */
     bool createNoDataBitmap();
 
     /**
@@ -665,7 +683,8 @@ class CORE_EXPORT QgsRasterBlock
      *  \param srcDataType source data type
      *  \param destDataType dest data type
      *  \param size block size (width * height)
-     *  \returns block of data in destDataType */
+     *  \returns block of data in destDataType
+    */
     static void *convert( void *srcData, Qgis::DataType srcDataType, Qgis::DataType destDataType, qgssize size );
 
     // Valid

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -62,14 +62,16 @@ class CORE_EXPORT QgsImageFetcher : public QObject
 
     /**
      * Starts the image download
-     * \note Make sure to connect to "finish" and "error" before starting */
+     * \note Make sure to connect to "finish" and "error" before starting
+    */
     virtual void start() = 0;
 
   signals:
 
     /**
      * Emitted when the download completes
-     *  \param legend The downloaded legend image */
+     *  \param legend The downloaded legend image
+    */
     void finish( const QImage &legend );
     //! Emitted to report progress
     void progress( qint64 received, qint64 total );
@@ -250,7 +252,8 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
 
     /**
      * \brief Returns the sublayers of this layer - useful for providers that manage
-     *  their own layers, such as WMS */
+     *  their own layers, such as WMS
+    */
     QStringList subLayers() const override
     {
       return QStringList();
@@ -556,12 +559,14 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
 
     /**
      * Dots per inch. Extended WMS (e.g. QGIS mapserver) support DPI dependent output and therefore
-    are suited for printing. A value of -1 means it has not been set */
+    are suited for printing. A value of -1 means it has not been set
+    */
     int mDpi = -1;
 
     /**
      * Source no data value is available and is set to be used or internal no data
-     *  is available. Used internally only  */
+     *  is available. Used internally only
+    */
     //bool hasNoDataValue ( int bandNo );
 
     //! \brief Cell value representing original source no data. e.g. -9999, indexed from 0
@@ -573,12 +578,14 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
     /**
      * \brief Use source nodata value. User can disable usage of source nodata
      *  value as nodata. It may happen that a value is wrongly given by GDAL
-     *  as nodata (e.g. 0) and it has to be treated as regular value. */
+     *  as nodata (e.g. 0) and it has to be treated as regular value.
+    */
     QList<bool> mUseSrcNoDataValue;
 
     /**
      * \brief List of lists of user defined additional no data values
-     *  for each band, indexed from 0 */
+     *  for each band, indexed from 0
+    */
     QList< QgsRasterRangeList > mUserNoDataValue;
 
     mutable QgsRectangle mExtent;

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -197,7 +197,8 @@ class CORE_EXPORT QgsRasterInterface
 
     /**
      * Returns source data type for the band specified by number,
-     *  source data type may be shorter than dataType */
+     *  source data type may be shorter than dataType
+    */
     virtual Qgis::DataType sourceDataType( int bandNo ) const { return mInput ? mInput->sourceDataType( bandNo ) : Qgis::UnknownDataType; }
 
     /**
@@ -239,7 +240,8 @@ class CORE_EXPORT QgsRasterInterface
 
     /**
      * Set input.
-      * Returns true if set correctly, false if cannot use that input */
+      * Returns true if set correctly, false if cannot use that input
+    */
     virtual bool setInput( QgsRasterInterface *input ) { mInput = input; return true; }
 
     //! Current input

--- a/src/core/raster/qgsrasterpipe.h
+++ b/src/core/raster/qgsrasterpipe.h
@@ -72,7 +72,8 @@ class CORE_EXPORT QgsRasterPipe
 
     /**
      * Try to insert interface at specified index and connect
-     * if connection would fail, the interface is not inserted and false is returned */
+     * if connection would fail, the interface is not inserted and false is returned
+    */
     bool insert( int idx, QgsRasterInterface *interface SIP_TRANSFER );
 #ifdef SIP_RUN
     % MethodCode
@@ -89,7 +90,8 @@ class CORE_EXPORT QgsRasterPipe
 
     /**
      * Try to replace interface at specified index and connect
-     * if connection would fail, the interface is not inserted and false is returned */
+     * if connection would fail, the interface is not inserted and false is returned
+    */
     bool replace( int idx, QgsRasterInterface *interface SIP_TRANSFER );
 
     /**
@@ -113,7 +115,8 @@ class CORE_EXPORT QgsRasterPipe
 
     /**
      * Set interface at index on/off
-     *  Returns true on success */
+     *  Returns true on success
+    */
     bool setOn( int idx, bool on );
 
     //! Test if interface at index may be switched on/off
@@ -155,7 +158,8 @@ class CORE_EXPORT QgsRasterPipe
 
     /**
      * \brief Try to connect interfaces in pipe and to the provider at beginning.
-        Returns true if connected or false if connection failed */
+        Returns true if connected or false if connection failed
+    */
     bool connect( QVector<QgsRasterInterface *> interfaces );
 
 };

--- a/src/core/symbology/qgscptcityarchive.h
+++ b/src/core/symbology/qgscptcityarchive.h
@@ -308,7 +308,8 @@ class CORE_EXPORT QgsCptCitySelectionItem : public QgsCptCityCollectionItem
 
 /**
  * \ingroup core
- * An "All ramps item", which contains all items in a flat hierarchy */
+ * An "All ramps item", which contains all items in a flat hierarchy
+*/
 class CORE_EXPORT QgsCptCityAllRampsItem : public QgsCptCityCollectionItem
 {
     Q_OBJECT

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -145,7 +145,8 @@ class GUI_EXPORT QgisInterface : public QObject
     /**
      * Returns vector layers in edit mode
      * \param modified whether to return only layers that have been modified
-     * \returns list of layers in legend order, or empty list */
+     * \returns list of layers in legend order, or empty list
+    */
     virtual QList<QgsMapLayer *> editableLayers( bool modified = false ) const = 0;
 
     //! Returns a pointer to the active layer (layer selected in the legend)
@@ -809,12 +810,14 @@ class GUI_EXPORT QgisInterface : public QObject
 
     /**
      * Add window to Window menu. The action title is the window title
-     * and the action should raise, unminimize and activate the window. */
+     * and the action should raise, unminimize and activate the window.
+    */
     virtual void addWindow( QAction *action ) = 0;
 
     /**
      * Remove window from Window menu. Calling this is necessary only for
-     * windows which are hidden rather than deleted when closed. */
+     * windows which are hidden rather than deleted when closed.
+    */
     virtual void removeWindow( QAction *action ) = 0;
 
     //! Register action to the shortcuts manager so its shortcut can be changed in GUI

--- a/src/gui/qgscollapsiblegroupbox.h
+++ b/src/gui/qgscollapsiblegroupbox.h
@@ -203,7 +203,8 @@ class GUI_EXPORT QgsCollapsibleGroupBox : public QgsCollapsibleGroupBoxBasic
     /**
      * Set this to true to save/restore checked state
      * \note only turn on mSaveCheckedState for groupboxes NOT used
-     * in multiple places or used as options for different parent objects */
+     * in multiple places or used as options for different parent objects
+    */
     void setSaveCheckedState( bool save ) { mSaveCheckedState = save; }
     bool saveCollapsedState() { return mSaveCollapsedState; }
     bool saveCheckedState() { return mSaveCheckedState; }

--- a/src/gui/qgsmapcanvasitem.h
+++ b/src/gui/qgsmapcanvasitem.h
@@ -53,7 +53,8 @@ class GUI_EXPORT QgsMapCanvasItem : public QGraphicsItem
      * Sets render context parameters
     \param p painter for rendering
     \param context out: configured context
-    \returns true in case of success */
+    \returns true in case of success
+    */
     bool setRenderContextVariables( QPainter *p, QgsRenderContext &context ) const;
 
   public:

--- a/src/gui/qgsnewgeopackagelayerdialog.h
+++ b/src/gui/qgsnewgeopackagelayerdialog.h
@@ -25,7 +25,8 @@
 
 /**
  * \ingroup gui
- * Dialog to set up parameters to create a new GeoPackage layer, and on accept() to create it and add it to the layers */
+ * Dialog to set up parameters to create a new GeoPackage layer, and on accept() to create it and add it to the layers
+*/
 class GUI_EXPORT QgsNewGeoPackageLayerDialog: public QDialog, private Ui::QgsNewGeoPackageLayerDialogBase
 {
     Q_OBJECT


### PR DESCRIPTION
Makes it looks like there's a * footnote for a docstring line.