### PR TITLE
Standardise dox for signals

### DIFF
--- a/python/core/auto_generated/layout/qgslayout.sip.in
+++ b/python/core/auto_generated/layout/qgslayout.sip.in
@@ -624,7 +624,7 @@ Updates the scene bounds of the layout.
 
     void changed();
 %Docstring
-Is emitted when properties of the layout change. This signal is only
+Emitted when properties of the layout change. This signal is only
 emitted for settings directly managed by the layout, and is not emitted
 when child items change.
 %End
@@ -642,7 +642,7 @@ If None, no item is selected.
 
     void refreshed();
 %Docstring
-Is emitted when the layout has been refreshed and items should also be refreshed
+Emitted when the layout has been refreshed and items should also be refreshed
 and updated.
 %End
 

--- a/python/core/auto_generated/layout/qgslayoutatlas.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutatlas.sip.in
@@ -371,7 +371,7 @@ Emitted when the coverage layer for the atlas changes.
 
     void messagePushed( const QString &message );
 %Docstring
-Is emitted when the atlas has an updated status bar ``message``.
+Emitted when the atlas has an updated status bar ``message``.
 %End
 
     void numberFeaturesChanged( int numFeatures );
@@ -381,7 +381,7 @@ Emitted when the number of features for the atlas changes.
 
     void featureChanged( const QgsFeature &feature );
 %Docstring
-Is emitted when the current atlas ``feature`` changes.
+Emitted when the current atlas ``feature`` changes.
 %End
 
     void renderBegun();

--- a/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitemmap.sip.in
@@ -612,7 +612,7 @@ Calculates the extent to request and the yShift of the top-left point in case of
 
     void extentChanged();
 %Docstring
-Is emitted when the map's extent changes.
+Emitted when the map's extent changes.
 
 .. seealso:: :py:func:`setExtent`
 
@@ -621,7 +621,7 @@ Is emitted when the map's extent changes.
 
     void mapRotationChanged( double newRotation );
 %Docstring
-Is emitted when the map's rotation changes.
+Emitted when the map's rotation changes.
 
 .. seealso:: :py:func:`setMapRotation`
 
@@ -630,7 +630,7 @@ Is emitted when the map's rotation changes.
 
     void preparedForAtlas();
 %Docstring
-Is emitted when the map has been prepared for atlas rendering, just before actual rendering
+Emitted when the map has been prepared for atlas rendering, just before actual rendering
 %End
 
     void layerStyleOverridesChanged();

--- a/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
+++ b/python/core/auto_generated/layout/qgslayoutitempicture.sip.in
@@ -310,7 +310,7 @@ Forces a recalculation of the picture's frame size
   signals:
     void pictureRotationChanged( double newRotation );
 %Docstring
-Is emitted on picture rotation change
+Emitted on picture rotation change
 %End
 
   protected:

--- a/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
+++ b/python/core/auto_generated/qgsnetworkaccessmanager.sip.in
@@ -326,7 +326,7 @@ created in any thread.
 
     void finished( QgsNetworkReplyContent reply );
 %Docstring
-This signal is emitted whenever a pending network reply is finished.
+Emitted whenever a pending network reply is finished.
 
 The ``reply`` parameter will contain a QgsNetworkReplyContent object, containing all the useful
 information relating to the reply, including headers and reply content.

--- a/python/core/auto_generated/qgsofflineediting.sip.in
+++ b/python/core/auto_generated/qgsofflineediting.sip.in
@@ -61,12 +61,12 @@ Synchronize to remote layers
 
     void progressStarted();
 %Docstring
-The signal is emitted when the process has started.
+Emitted when the process has started.
 %End
 
     void layerProgressUpdated( int layer, int numLayers );
 %Docstring
-Is emitted whenever a new layer is being processed.
+Emitted whenever a new layer is being processed.
 It is possible to estimate the progress of the complete operation by
 comparing the index of the current ``layer`` to the total amount
 ``numLayers``.
@@ -74,7 +74,7 @@ comparing the index of the current ``layer`` to the total amount
 
     void progressModeSet( QgsOfflineEditing::ProgressMode mode, int maximum );
 %Docstring
-Is emitted when the mode for the progress of the current operation is
+Emitted when the mode for the progress of the current operation is
 set.
 
 :param mode: progress mode

--- a/python/core/auto_generated/qgsrelationmanager.sip.in
+++ b/python/core/auto_generated/qgsrelationmanager.sip.in
@@ -128,7 +128,7 @@ Discover all the relations available from the current layers.
   signals:
     void relationsLoaded();
 %Docstring
-This signal is emitted when the relations were loaded after reading a project
+Emitted when the relations were loaded after reading a project
 %End
 
     void changed();

--- a/python/core/auto_generated/qgsvectorlayer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayer.sip.in
@@ -2329,7 +2329,7 @@ by the backend data provider).
 
     void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 %Docstring
-This signal is emitted when selection was changed
+Emitted when selection was changed
 
 :param selected: Newly selected feature ids
 :param deselected: Ids of all features which have previously been selected but are not any more
@@ -2338,7 +2338,7 @@ This signal is emitted when selection was changed
 
     void layerModified();
 %Docstring
-This signal is emitted when modifications has been done on layer
+Emitted when modifications has been done on layer
 %End
 
     void allowCommitChanged();
@@ -2350,37 +2350,37 @@ Emitted whenever the allowCommitChanged() property of this layer changes.
 
     void beforeModifiedCheck() const;
 %Docstring
-Is emitted, when layer is checked for modifications. Use for last-minute additions
+Emitted when the layer is checked for modifications. Use for last-minute additions.
 %End
 
     void beforeEditingStarted();
 %Docstring
-Is emitted, before editing on this layer is started
+Emitted before editing on this layer is started.
 %End
 
     void editingStarted();
 %Docstring
-Is emitted, when editing on this layer has started
+Emitted when editing on this layer has started.
 %End
 
     void editingStopped();
 %Docstring
-Is emitted, when edited changes successfully have been written to the data provider
+Emitted when edited changes have been successfully written to the data provider.
 %End
 
     void beforeCommitChanges();
 %Docstring
-Is emitted, before changes are committed to the data provider
+Emitted before changes are committed to the data provider.
 %End
 
     void beforeRollBack();
 %Docstring
-Is emitted, before changes are rolled back
+Emitted before changes are rolled back.
 %End
 
     void afterRollBack();
 %Docstring
-Is emitted, after changes are rolled back
+Emitted after changes are rolled back.
 
 .. versionadded:: 3.4
 %End
@@ -2451,7 +2451,7 @@ If features are deleted outside of an edit command, this signal will be emitted 
 
     void updatedFields();
 %Docstring
-Is emitted, whenever the fields available from this layer have been changed.
+Emitted whenever the fields available from this layer have been changed.
 This can be due to manually adding attributes or due to a join.
 %End
 
@@ -2464,7 +2464,7 @@ Emitted when the layer's subset string has changed.
 
     void attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value );
 %Docstring
-Is emitted whenever an attribute value change is done in the edit buffer.
+Emitted whenever an attribute value change is done in the edit buffer.
 Note that at this point the attribute change is not yet saved to the provider.
 
 :param fid: The id of the changed feature
@@ -2474,7 +2474,7 @@ Note that at this point the attribute change is not yet saved to the provider.
 
     void geometryChanged( QgsFeatureId fid, const QgsGeometry &geometry );
 %Docstring
-Is emitted whenever a geometry change is done in the edit buffer.
+Emitted whenever a geometry change is done in the edit buffer.
 Note that at this point the geometry change is not yet saved to the provider.
 
 :param fid: The id of the changed feature
@@ -2483,27 +2483,27 @@ Note that at this point the geometry change is not yet saved to the provider.
 
     void committedAttributesDeleted( const QString &layerId, const QgsAttributeList &deletedAttributes );
 %Docstring
-This signal is emitted, when attributes are deleted from the provider
+Emitted when attributes are deleted from the provider
 %End
     void committedAttributesAdded( const QString &layerId, const QList<QgsField> &addedAttributes );
 %Docstring
-This signal is emitted, when attributes are added to the provider
+Emitted when attributes are added to the provider
 %End
     void committedFeaturesAdded( const QString &layerId, const QgsFeatureList &addedFeatures );
 %Docstring
-This signal is emitted, when features are added to the provider
+Emitted when features are added to the provider
 %End
     void committedFeaturesRemoved( const QString &layerId, const QgsFeatureIds &deletedFeatureIds );
 %Docstring
-This signal is emitted, when features are deleted from the provider
+Emitted when features are deleted from the provider
 %End
     void committedAttributeValuesChanges( const QString &layerId, const QgsChangedAttributesMap &changedAttributesValues );
 %Docstring
-This signal is emitted, when attribute value changes are saved to the provider
+Emitted when attribute value changes are saved to the provider
 %End
     void committedGeometriesChanges( const QString &layerId, const QgsGeometryMap &changedGeometries );
 %Docstring
-This signal is emitted, when geometry changes are saved to the provider
+Emitted when geometry changes are saved to the provider
 %End
 
     void labelingFontNotFound( QgsVectorLayer *layer, const QString &fontfamily );

--- a/python/core/auto_generated/qgsvectorlayercache.sip.in
+++ b/python/core/auto_generated/qgsvectorlayercache.sip.in
@@ -281,13 +281,13 @@ layer() will still return a valid pointer for cleanup purpose.
 
     void attributeValueChanged( QgsFeatureId fid, int field, const QVariant &value );
 %Docstring
-Is emitted when an attribute is changed. Is re-emitted after the layer itself emits this signal.
+Emitted when an attribute is changed. Is re-emitted after the layer itself emits this signal.
 You should connect to this signal, to be sure, to not get a cached value if querying the cache.
 %End
 
     void featureAdded( QgsFeatureId fid );
 %Docstring
-Is emitted, when a new feature has been added to the layer and this cache.
+Emitted when a new feature has been added to the layer and this cache.
 You should connect to this signal instead of the layers', if you want to be sure
 that this cache has updated information for the new feature
 

--- a/python/core/auto_generated/qgsvectorlayereditbuffer.sip.in
+++ b/python/core/auto_generated/qgsvectorlayereditbuffer.sip.in
@@ -214,7 +214,7 @@ Returns true if the specified feature ID has been deleted but not committed.
   signals:
     void layerModified();
 %Docstring
-This signal is emitted when modifications has been done on layer
+Emitted when modifications has been done on layer
 %End
 
     void featureAdded( QgsFeatureId fid );

--- a/python/core/auto_generated/symbology/qgsstyle.sip.in
+++ b/python/core/auto_generated/symbology/qgsstyle.sip.in
@@ -498,7 +498,7 @@ name or tag changes.
 
     void groupsModified();
 %Docstring
-Is emitted every time a tag or smartgroup has been added, removed, or renamed
+Emitted every time a tag or smartgroup has been added, removed, or renamed
 %End
 
     void entityTagsChanged( QgsStyle::StyleEntity entity, const QString &name, const QStringList &newTags );

--- a/python/gui/auto_generated/attributetable/qgsattributetabledelegate.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetabledelegate.sip.in
@@ -67,7 +67,7 @@ Sets data from model into the editor. Overloads default method
 
     void actionColumnItemPainted( const QModelIndex &index ) const;
 %Docstring
-Is emitted when an action column item is painted.
+Emitted when an action column item is painted.
 The consumer of this signal can initialize the index widget.
 
 .. note::

--- a/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetablefiltermodel.sip.in
@@ -202,7 +202,7 @@ is shown.
 
     void sortColumnChanged( int column, Qt::SortOrder order );
 %Docstring
-Is emitted whenever the sort column is changed
+Emitted whenever the sort column is changed
 
 :param column: The sort column
 :param order: The sort order

--- a/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsattributetableview.sip.in
@@ -128,7 +128,7 @@ Saves geometry to the settings on close
 
     void willShowContextMenu( QMenu *menu, const QModelIndex &atIndex );
 %Docstring
-Is emitted, in order to provide a hook to add additional* menu entries to the context menu.
+Emitted in order to provide a hook to add additional* menu entries to the context menu.
 
 :param menu: If additional QMenuItems are added, they will show up in the context menu.
 :param atIndex: The QModelIndex, to which the context menu belongs. Relative to the source model.

--- a/python/gui/auto_generated/attributetable/qgsdualview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsdualview.sip.in
@@ -227,19 +227,19 @@ Cancel the progress dialog (if any)
 
     void displayExpressionChanged( const QString &expression );
 %Docstring
-Is emitted, whenever the display expression is successfully changed
+Emitted whenever the display expression is successfully changed
 
 :param expression: The expression that was applied
 %End
 
     void filterChanged();
 %Docstring
-Is emitted, whenever the filter changes
+Emitted whenever the filter changes
 %End
 
     void filterExpressionSet( const QString &expression, QgsAttributeForm::FilterType type );
 %Docstring
-Is emitted when a filter expression is set using the view.
+Emitted when a filter expression is set using the view.
 
 :param expression: filter expression
 :param type: filter type

--- a/python/gui/auto_generated/attributetable/qgsfeaturelistview.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsfeaturelistview.sip.in
@@ -115,14 +115,14 @@ setFeatureSelectionManager
 
     void currentEditSelectionChanged( QgsFeature &feat );
 %Docstring
-Is emitted, whenever the current edit selection has been changed.
+Emitted whenever the current edit selection has been changed.
 
 :param feat: the feature, which will be edited.
 %End
 
     void displayExpressionChanged( const QString &expression );
 %Docstring
-Is emitted, whenever the display expression is successfully changed
+Emitted whenever the display expression is successfully changed
 
 :param expression: The expression that was applied
 %End
@@ -130,7 +130,7 @@ Is emitted, whenever the display expression is successfully changed
 
     void willShowContextMenu( QgsActionMenu *menu, const QModelIndex &atIndex );
 %Docstring
-Is emitted, when the context menu is created to add the specific actions to it
+Emitted when the context menu is created to add the specific actions to it
 
 :param menu: is the already created context menu
 :param atIndex: is the position of the current feature in the model

--- a/python/gui/auto_generated/attributetable/qgsifeatureselectionmanager.sip.in
+++ b/python/gui/auto_generated/attributetable/qgsifeatureselectionmanager.sip.in
@@ -61,7 +61,7 @@ Returns reference to identifiers of selected features
 
     void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 %Docstring
-This signal is emitted when selection was changed
+Emitted when selection was changed.
 
 :param selected: Newly selected feature ids
 :param deselected: Ids of all features which have previously been selected but are not any more

--- a/python/gui/auto_generated/layertree/qgslayertreeviewindicator.sip.in
+++ b/python/gui/auto_generated/layertree/qgslayertreeviewindicator.sip.in
@@ -51,7 +51,7 @@ Sets tool tip text
   signals:
     void clicked( const QModelIndex &index );
 %Docstring
-Signal that is emitted when user clicks on the indicator
+Emitted when user clicks on the indicator
 %End
 
 };

--- a/python/gui/auto_generated/layout/qgslayoutruler.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutruler.sip.in
@@ -76,7 +76,7 @@ the view.
   signals:
     void cursorPosChanged( QPointF );
 %Docstring
-Is emitted when mouse cursor coordinates change
+Emitted when mouse cursor coordinates change
 %End
 
   protected:

--- a/python/gui/auto_generated/layout/qgslayoutview.sip.in
+++ b/python/gui/auto_generated/layout/qgslayoutview.sip.in
@@ -517,12 +517,12 @@ Emitted when the current ``tool`` is changed.
 
     void zoomLevelChanged();
 %Docstring
-Is emitted whenever the zoom level of the view is changed.
+Emitted whenever the zoom level of the view is changed.
 %End
 
     void cursorPosChanged( QPointF layoutPoint );
 %Docstring
-Is emitted when the mouse cursor coordinates change within the view.
+Emitted when the mouse cursor coordinates change within the view.
 The ``layoutPoint`` argument indicates the cursor position within
 the layout coordinate system.
 %End

--- a/python/gui/auto_generated/qgisinterface.sip.in
+++ b/python/gui/auto_generated/qgisinterface.sip.in
@@ -1195,7 +1195,7 @@ The pointer to layer can be null if no layer is selected.
 
     void currentThemeChanged( const QString &theme );
 %Docstring
-Signal emitted when the current ``theme`` is changed so plugins
+Emitted when the current ``theme`` is changed so plugins
 can change their tool button icons.
 
 .. versionadded:: 3.0
@@ -1203,7 +1203,7 @@ can change their tool button icons.
 
     void layoutDesignerOpened( QgsLayoutDesignerInterface *designer );
 %Docstring
-This signal is emitted when a new layout ``designer`` has been opened.
+Emitted when a new layout ``designer`` has been opened.
 
 .. seealso:: :py:func:`layoutDesignerWillBeClosed`
 
@@ -1212,7 +1212,7 @@ This signal is emitted when a new layout ``designer`` has been opened.
 
     void layoutDesignerWillBeClosed( QgsLayoutDesignerInterface *designer );
 %Docstring
-This signal is emitted before a layout ``designer`` is going to be closed
+Emitted before a layout ``designer`` is going to be closed
 and deleted.
 
 .. seealso:: :py:func:`layoutDesignerClosed`
@@ -1224,7 +1224,7 @@ and deleted.
 
     void layoutDesignerClosed();
 %Docstring
-This signal is emitted after a layout designer window is closed.
+Emitted after a layout designer window is closed.
 
 .. seealso:: :py:func:`layoutDesignerWillBeClosed`
 
@@ -1235,7 +1235,7 @@ This signal is emitted after a layout designer window is closed.
 
     void initializationCompleted();
 %Docstring
-This signal is emitted when the initialization is complete.
+Emitted when the initialization is complete.
 %End
 
     void projectRead();
@@ -1264,7 +1264,7 @@ Emitted when starting an entirely new project.
 
     void layerSavedAs( QgsMapLayer *l, const QString &path );
 %Docstring
-This signal is emitted when a layer has been saved using save as.
+Emitted when a layer has been saved using save as.
 
 .. versionadded:: 2.7
 %End

--- a/python/gui/auto_generated/qgsattributeform.sip.in
+++ b/python/gui/auto_generated/qgsattributeform.sip.in
@@ -185,12 +185,12 @@ Notifies about changes of attributes
 
     void featureSaved( const QgsFeature &feature );
 %Docstring
-Is emitted, when a feature is changed or added
+Emitted when a feature is changed or added
 %End
 
     void filterExpressionSet( const QString &expression, QgsAttributeForm::FilterType type );
 %Docstring
-Is emitted when a filter expression is set using the form.
+Emitted when a filter expression is set using the form.
 
 :param expression: filter expression
 :param type: filter type

--- a/python/gui/auto_generated/qgscheckablecombobox.sip.in
+++ b/python/gui/auto_generated/qgscheckablecombobox.sip.in
@@ -122,7 +122,7 @@ Filters events to enable context menu
 
     void checkedItemsChanged( const QStringList &items );
 %Docstring
-This signal is emitted whenever the checked items list changed.
+Emitted whenever the checked items list changed.
 %End
 
   public slots:

--- a/python/gui/auto_generated/qgscolorbutton.sip.in
+++ b/python/gui/auto_generated/qgscolorbutton.sip.in
@@ -433,7 +433,7 @@ Unlinks the button from a project color.
 
     void colorChanged( const QColor &color );
 %Docstring
-Is emitted whenever a new color is set for the button. The color is always valid.
+Emitted whenever a new color is set for the button. The color is always valid.
 In case the new color is the same no signal is emitted, to avoid infinite loops.
 
 :param color: New color

--- a/python/gui/auto_generated/qgsfieldcombobox.sip.in
+++ b/python/gui/auto_generated/qgsfieldcombobox.sip.in
@@ -77,7 +77,7 @@ Returns the layer currently associated with the combobox.
   signals:
     void fieldChanged( const QString &fieldName );
 %Docstring
-the signal is emitted when the currently selected field changes
+Emitted when the currently selected field changes.
 %End
 
   public slots:

--- a/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
@@ -167,7 +167,7 @@ provide an expression context of which we are sure it's completely populated.
   signals:
     void fieldChanged( const QString &fieldName );
 %Docstring
-the signal is emitted when the currently selected field changes
+Emitted when the currently selected field changes.
 %End
 
     void fieldChanged( const QString &fieldName, bool isValid );

--- a/python/gui/auto_generated/qgsmaplayercombobox.sip.in
+++ b/python/gui/auto_generated/qgsmaplayercombobox.sip.in
@@ -151,7 +151,7 @@ setLayer set the current layer selected in the combo
   signals:
     void layerChanged( QgsMapLayer *layer );
 %Docstring
-layerChanged this signal is emitted whenever the currently selected layer changes
+Emitted whenever the currently selected layer changes.
 %End
 
   protected slots:

--- a/python/gui/auto_generated/qgstreewidgetitem.sip.in
+++ b/python/gui/auto_generated/qgstreewidgetitem.sip.in
@@ -176,7 +176,7 @@ Sets the value for the item's column and role to the given value.
   signals:
     void itemEdited( QTreeWidgetItem *item, int column );
 %Docstring
-This signal is emitted when the contents of the column in the specified item has been edited by the user.
+Emitted when the contents of the column in the specified item has been edited by the user.
 %End
 };
 

--- a/python/gui/auto_generated/raster/qgsrasterbandcombobox.sip.in
+++ b/python/gui/auto_generated/raster/qgsrasterbandcombobox.sip.in
@@ -79,7 +79,7 @@ Sets the current ``band`` number selected in the combobox.
 
     void bandChanged( int band );
 %Docstring
-This signal is emitted when the currently selected band changes.
+Emitted when the currently selected band changes.
 %End
 
 };

--- a/src/app/layout/qgslayoutpagepropertieswidget.h
+++ b/src/app/layout/qgslayoutpagepropertieswidget.h
@@ -44,7 +44,7 @@ class QgsLayoutPagePropertiesWidget : public QgsLayoutItemBaseWidget, private Ui
 
   signals:
 
-    //! Is emitted when page orientation changes
+    //! Emitted when page orientation changes
     void pageOrientationChanged();
 
   private slots:

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1723,14 +1723,14 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void currentThemeChanged( const QString & );
 
     /**
-     * This signal is emitted when a new layout \a designer has been opened.
+     * Emitted when a new layout \a designer has been opened.
      * \see layoutDesignerWillBeClosed()
      * \since QGIS 3.0
      */
     void layoutDesignerOpened( QgsLayoutDesignerInterface *designer );
 
     /**
-     * This signal is emitted before a layout \a designer is going to be closed
+     * Emitted before a layout \a designer is going to be closed
      * and deleted.
      * \see layoutDesignerClosed()
      * \see layoutDesignerOpened()
@@ -1739,20 +1739,20 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void layoutDesignerWillBeClosed( QgsLayoutDesignerInterface *designer );
 
     /**
-     * This signal is emitted after a layout designer window is closed.
+     * Emitted after a layout designer window is closed.
      * \see layoutDesignerWillBeClosed()
      * \see layoutDesignerOpened()
      * \since QGIS 3.0
      */
     void layoutDesignerClosed();
 
-    //! This signal is emitted when QGIS' initialization is complete
+    //! Emitted when QGIS' initialization is complete
     void initializationCompleted();
 
     void customCrsValidation( QgsCoordinateReferenceSystem &crs );
 
     /**
-     * This signal is emitted when a layer has been saved using save as
+     * Emitted when a layer has been saved using save as
        \since QGIS 2.7
      */
     void layerSavedAs( QgsMapLayer *l, const QString &path );

--- a/src/app/qgslayertreeviewbadlayerindicator.h
+++ b/src/app/qgslayertreeviewbadlayerindicator.h
@@ -32,7 +32,7 @@ class QgsLayerTreeViewBadLayerIndicatorProvider : public QgsLayerTreeViewIndicat
   signals:
 
     /**
-     * This signal is emitted when the user clicks on the bad layer indicator icon
+     * Emitted when the user clicks on the bad layer indicator icon
      * \param maplayer for change data source request
      */
     void requestChangeDataSource( QgsMapLayer *maplayer );

--- a/src/core/layout/qgslayout.h
+++ b/src/core/layout/qgslayout.h
@@ -666,7 +666,7 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
   signals:
 
     /**
-     * Is emitted when properties of the layout change. This signal is only
+     * Emitted when properties of the layout change. This signal is only
      * emitted for settings directly managed by the layout, and is not emitted
      * when child items change.
      */
@@ -684,7 +684,7 @@ class CORE_EXPORT QgsLayout : public QGraphicsScene, public QgsExpressionContext
     void selectedItemChanged( QgsLayoutItem *selected );
 
     /**
-     * Is emitted when the layout has been refreshed and items should also be refreshed
+     * Emitted when the layout has been refreshed and items should also be refreshed
      * and updated.
      */
     void refreshed();

--- a/src/core/layout/qgslayoutatlas.h
+++ b/src/core/layout/qgslayoutatlas.h
@@ -317,7 +317,7 @@ class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutItera
     //! Emitted when the coverage layer for the atlas changes.
     void coverageLayerChanged( QgsVectorLayer *layer );
 
-    //! Is emitted when the atlas has an updated status bar \a message.
+    //! Emitted when the atlas has an updated status bar \a message.
     void messagePushed( const QString &message );
 
     /**
@@ -325,7 +325,7 @@ class CORE_EXPORT QgsLayoutAtlas : public QObject, public QgsAbstractLayoutItera
      */
     void numberFeaturesChanged( int numFeatures );
 
-    //! Is emitted when the current atlas \a feature changes.
+    //! Emitted when the current atlas \a feature changes.
     void featureChanged( const QgsFeature &feature );
 
     //! Emitted when atlas rendering has begun.

--- a/src/core/layout/qgslayoutitemmap.h
+++ b/src/core/layout/qgslayoutitemmap.h
@@ -543,20 +543,20 @@ class CORE_EXPORT QgsLayoutItemMap : public QgsLayoutItem
   signals:
 
     /**
-     * Is emitted when the map's extent changes.
+     * Emitted when the map's extent changes.
      * \see setExtent()
      * \see extent()
      */
     void extentChanged();
 
     /**
-     * Is emitted when the map's rotation changes.
+     * Emitted when the map's rotation changes.
      * \see setMapRotation()
      * \see mapRotation()
      */
     void mapRotationChanged( double newRotation );
 
-    //! Is emitted when the map has been prepared for atlas rendering, just before actual rendering
+    //! Emitted when the map has been prepared for atlas rendering, just before actual rendering
     void preparedForAtlas();
 
     /**

--- a/src/core/layout/qgslayoutitempicture.h
+++ b/src/core/layout/qgslayoutitempicture.h
@@ -279,7 +279,7 @@ class CORE_EXPORT QgsLayoutItemPicture: public QgsLayoutItem
     void refreshDataDefinedProperty( QgsLayoutObject::DataDefinedProperty property = QgsLayoutObject::AllProperties ) override;
 
   signals:
-    //! Is emitted on picture rotation change
+    //! Emitted on picture rotation change
     void pictureRotationChanged( double newRotation );
 
   protected:

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -481,7 +481,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     void requestAboutToBeCreated( QgsNetworkRequestParameters request );
 
     /**
-     * This signal is emitted whenever a pending network reply is finished.
+     * Emitted whenever a pending network reply is finished.
      *
      * The \a reply parameter will contain a QgsNetworkReplyContent object, containing all the useful
      * information relating to the reply, including headers and reply content.

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -76,12 +76,12 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
   signals:
 
     /**
-     * The signal is emitted when the process has started.
+     * Emitted when the process has started.
      */
     void progressStarted();
 
     /**
-     * Is emitted whenever a new layer is being processed.
+     * Emitted whenever a new layer is being processed.
      * It is possible to estimate the progress of the complete operation by
      * comparing the index of the current \a layer to the total amount
      * \a numLayers.
@@ -89,7 +89,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void layerProgressUpdated( int layer, int numLayers );
 
     /**
-     * Is emitted when the mode for the progress of the current operation is
+     * Emitted when the mode for the progress of the current operation is
      * set.
      * \param mode progress mode
      * \param maximum total number of entities to process in the current operation

--- a/src/core/qgsrelationmanager.h
+++ b/src/core/qgsrelationmanager.h
@@ -134,7 +134,7 @@ class CORE_EXPORT QgsRelationManager : public QObject
     static QList<QgsRelation> discoverRelations( const QList<QgsRelation> &existingRelations, const QList<QgsVectorLayer *> &layers );
 
   signals:
-    //! This signal is emitted when the relations were loaded after reading a project
+    //! Emitted when the relations were loaded after reading a project
     void relationsLoaded();
 
     /**

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -2140,7 +2140,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
   signals:
 
     /**
-     * This signal is emitted when selection was changed
+     * Emitted when selection was changed
      *
      * \param selected        Newly selected feature ids
      * \param deselected      Ids of all features which have previously been selected but are not any more
@@ -2148,7 +2148,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     void selectionChanged( const QgsFeatureIds &selected, const QgsFeatureIds &deselected, bool clearAndSelect );
 
-    //! This signal is emitted when modifications has been done on layer
+    //! Emitted when modifications has been done on layer
     void layerModified();
 
     /**
@@ -2158,26 +2158,26 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     void allowCommitChanged();
 
-    //! Is emitted, when layer is checked for modifications. Use for last-minute additions
+    //! Emitted when the layer is checked for modifications. Use for last-minute additions.
     void beforeModifiedCheck() const;
 
-    //! Is emitted, before editing on this layer is started
+    //! Emitted before editing on this layer is started.
     void beforeEditingStarted();
 
-    //! Is emitted, when editing on this layer has started
+    //! Emitted when editing on this layer has started.
     void editingStarted();
 
-    //! Is emitted, when edited changes successfully have been written to the data provider
+    //! Emitted when edited changes have been successfully written to the data provider.
     void editingStopped();
 
-    //! Is emitted, before changes are committed to the data provider
+    //! Emitted before changes are committed to the data provider.
     void beforeCommitChanges();
 
-    //! Is emitted, before changes are rolled back
+    //! Emitted before changes are rolled back.
     void beforeRollBack();
 
     /**
-     * Is emitted, after changes are rolled back
+     * Emitted after changes are rolled back.
      * \since QGIS 3.4
      */
     void afterRollBack();
@@ -2247,7 +2247,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void featuresDeleted( const QgsFeatureIds &fids );
 
     /**
-     * Is emitted, whenever the fields available from this layer have been changed.
+     * Emitted whenever the fields available from this layer have been changed.
      * This can be due to manually adding attributes or due to a join.
      */
     void updatedFields();
@@ -2259,7 +2259,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void subsetStringChanged();
 
     /**
-     * Is emitted whenever an attribute value change is done in the edit buffer.
+     * Emitted whenever an attribute value change is done in the edit buffer.
      * Note that at this point the attribute change is not yet saved to the provider.
      *
      * \param fid The id of the changed feature
@@ -2269,7 +2269,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     void attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value );
 
     /**
-     * Is emitted whenever a geometry change is done in the edit buffer.
+     * Emitted whenever a geometry change is done in the edit buffer.
      * Note that at this point the geometry change is not yet saved to the provider.
      *
      * \param fid The id of the changed feature
@@ -2277,17 +2277,17 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
      */
     void geometryChanged( QgsFeatureId fid, const QgsGeometry &geometry );
 
-    //! This signal is emitted, when attributes are deleted from the provider
+    //! Emitted when attributes are deleted from the provider
     void committedAttributesDeleted( const QString &layerId, const QgsAttributeList &deletedAttributes );
-    //! This signal is emitted, when attributes are added to the provider
+    //! Emitted when attributes are added to the provider
     void committedAttributesAdded( const QString &layerId, const QList<QgsField> &addedAttributes );
-    //! This signal is emitted, when features are added to the provider
+    //! Emitted when features are added to the provider
     void committedFeaturesAdded( const QString &layerId, const QgsFeatureList &addedFeatures );
-    //! This signal is emitted, when features are deleted from the provider
+    //! Emitted when features are deleted from the provider
     void committedFeaturesRemoved( const QString &layerId, const QgsFeatureIds &deletedFeatureIds );
-    //! This signal is emitted, when attribute value changes are saved to the provider
+    //! Emitted when attribute value changes are saved to the provider
     void committedAttributeValuesChanges( const QString &layerId, const QgsChangedAttributesMap &changedAttributesValues );
-    //! This signal is emitted, when geometry changes are saved to the provider
+    //! Emitted when geometry changes are saved to the provider
     void committedGeometriesChanges( const QString &layerId, const QgsGeometryMap &changedGeometries );
 
     //! Emitted when the font family defined for labeling layer is not found on system

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -353,13 +353,13 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
     void cachedLayerDeleted();
 
     /**
-     * \brief Is emitted when an attribute is changed. Is re-emitted after the layer itself emits this signal.
-     *        You should connect to this signal, to be sure, to not get a cached value if querying the cache.
+     * Emitted when an attribute is changed. Is re-emitted after the layer itself emits this signal.
+     * You should connect to this signal, to be sure, to not get a cached value if querying the cache.
      */
     void attributeValueChanged( QgsFeatureId fid, int field, const QVariant &value );
 
     /**
-     * Is emitted, when a new feature has been added to the layer and this cache.
+     * Emitted when a new feature has been added to the layer and this cache.
      * You should connect to this signal instead of the layers', if you want to be sure
      * that this cache has updated information for the new feature
      *

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -190,7 +190,7 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     void undoIndexChanged( int index );
 
   signals:
-    //! This signal is emitted when modifications has been done on layer
+    //! Emitted when modifications has been done on layer
     void layerModified();
 
     void featureAdded( QgsFeatureId fid );

--- a/src/core/symbology/qgsstyle.h
+++ b/src/core/symbology/qgsstyle.h
@@ -473,7 +473,7 @@ class CORE_EXPORT QgsStyle : public QObject
      */
     void symbolChanged( const QString &name );
 
-    //! Is emitted every time a tag or smartgroup has been added, removed, or renamed
+    //! Emitted every time a tag or smartgroup has been added, removed, or renamed
     void groupsModified();
 
     /**

--- a/src/gui/attributetable/qgsattributetabledelegate.h
+++ b/src/gui/attributetable/qgsattributetabledelegate.h
@@ -81,7 +81,7 @@ class GUI_EXPORT QgsAttributeTableDelegate : public QItemDelegate
   signals:
 
     /**
-     * Is emitted when an action column item is painted.
+     * Emitted when an action column item is painted.
      * The consumer of this signal can initialize the index widget.
      *
      * \note This signal is emitted repeatedly whenever the item is being painted.

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -224,7 +224,7 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
   signals:
 
     /**
-     * Is emitted whenever the sort column is changed
+     * Emitted whenever the sort column is changed
      * \param column The sort column
      * \param order The sort order
      */

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -141,7 +141,7 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
 
     /**
      * \brief
-     * Is emitted, in order to provide a hook to add additional* menu entries to the context menu.
+     * Emitted in order to provide a hook to add additional* menu entries to the context menu.
      *
      * \param menu     If additional QMenuItems are added, they will show up in the context menu.
      * \param atIndex  The QModelIndex, to which the context menu belongs. Relative to the source model.

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -250,18 +250,18 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
   signals:
 
     /**
-     * Is emitted, whenever the display expression is successfully changed
+     * Emitted whenever the display expression is successfully changed
      * \param expression The expression that was applied
      */
     void displayExpressionChanged( const QString &expression );
 
     /**
-     * Is emitted, whenever the filter changes
+     * Emitted whenever the filter changes
      */
     void filterChanged();
 
     /**
-     * Is emitted when a filter expression is set using the view.
+     * Emitted when a filter expression is set using the view.
      * \param expression filter expression
      * \param type filter type
      * \since QGIS 2.16

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -131,14 +131,14 @@ class GUI_EXPORT QgsFeatureListView : public QListView
   signals:
 
     /**
-     * Is emitted, whenever the current edit selection has been changed.
+     * Emitted whenever the current edit selection has been changed.
      *
      * \param feat the feature, which will be edited.
      */
     void currentEditSelectionChanged( QgsFeature &feat );
 
     /**
-     * Is emitted, whenever the display expression is successfully changed
+     * Emitted whenever the display expression is successfully changed
      * \param expression The expression that was applied
      */
     void displayExpressionChanged( const QString &expression );
@@ -147,7 +147,7 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     void aboutToChangeEditSelection( bool &ok ) SIP_SKIP;
 
     /**
-     * Is emitted, when the context menu is created to add the specific actions to it
+     * Emitted when the context menu is created to add the specific actions to it
      * \param menu is the already created context menu
      * \param atIndex is the position of the current feature in the model
      */

--- a/src/gui/attributetable/qgsifeatureselectionmanager.h
+++ b/src/gui/attributetable/qgsifeatureselectionmanager.h
@@ -72,7 +72,7 @@ class GUI_EXPORT QgsIFeatureSelectionManager : public QObject
   signals:
 
     /**
-     * This signal is emitted when selection was changed
+     * Emitted when selection was changed.
      *
      * \param selected        Newly selected feature ids
      * \param deselected      Ids of all features which have previously been selected but are not any more

--- a/src/gui/layertree/qgslayertreeviewindicator.h
+++ b/src/gui/layertree/qgslayertreeviewindicator.h
@@ -50,7 +50,7 @@ class GUI_EXPORT QgsLayerTreeViewIndicator : public QObject
     void setToolTip( const QString &tip ) { mToolTip = tip; }
 
   signals:
-    //! Signal that is emitted when user clicks on the indicator
+    //! Emitted when user clicks on the indicator
     void clicked( const QModelIndex &index );
 
   private:

--- a/src/gui/layout/qgslayoutruler.h
+++ b/src/gui/layout/qgslayoutruler.h
@@ -89,7 +89,7 @@ class GUI_EXPORT QgsLayoutRuler: public QWidget
     void setCursorPosition( QPointF position );
 
   signals:
-    //! Is emitted when mouse cursor coordinates change
+    //! Emitted when mouse cursor coordinates change
     void cursorPosChanged( QPointF );
 
   protected:

--- a/src/gui/layout/qgslayoutview.h
+++ b/src/gui/layout/qgslayoutview.h
@@ -494,12 +494,12 @@ class GUI_EXPORT QgsLayoutView: public QGraphicsView
     void toolSet( QgsLayoutViewTool *tool );
 
     /**
-     * Is emitted whenever the zoom level of the view is changed.
+     * Emitted whenever the zoom level of the view is changed.
      */
     void zoomLevelChanged();
 
     /**
-     * Is emitted when the mouse cursor coordinates change within the view.
+     * Emitted when the mouse cursor coordinates change within the view.
      * The \a layoutPoint argument indicates the cursor position within
      * the layout coordinate system.
      */

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -1003,21 +1003,21 @@ class GUI_EXPORT QgisInterface : public QObject
     void currentLayerChanged( QgsMapLayer *layer );
 
     /**
-     * Signal emitted when the current \a theme is changed so plugins
+     * Emitted when the current \a theme is changed so plugins
      * can change their tool button icons.
      * \since QGIS 3.0
     */
     void currentThemeChanged( const QString &theme );
 
     /**
-     * This signal is emitted when a new layout \a designer has been opened.
+     * Emitted when a new layout \a designer has been opened.
      * \see layoutDesignerWillBeClosed()
      * \since QGIS 3.0
      */
     void layoutDesignerOpened( QgsLayoutDesignerInterface *designer );
 
     /**
-     * This signal is emitted before a layout \a designer is going to be closed
+     * Emitted before a layout \a designer is going to be closed
      * and deleted.
      * \see layoutDesignerClosed()
      * \see layoutDesignerOpened()
@@ -1026,7 +1026,7 @@ class GUI_EXPORT QgisInterface : public QObject
     void layoutDesignerWillBeClosed( QgsLayoutDesignerInterface *designer );
 
     /**
-     * This signal is emitted after a layout designer window is closed.
+     * Emitted after a layout designer window is closed.
      * \see layoutDesignerWillBeClosed()
      * \see layoutDesignerOpened()
      * \since QGIS 3.0
@@ -1034,7 +1034,7 @@ class GUI_EXPORT QgisInterface : public QObject
     void layoutDesignerClosed();
 
     /**
-     * This signal is emitted when the initialization is complete.
+     * Emitted when the initialization is complete.
      */
     void initializationCompleted();
 
@@ -1057,7 +1057,7 @@ class GUI_EXPORT QgisInterface : public QObject
     void newProjectCreated();
 
     /**
-     * This signal is emitted when a layer has been saved using save as.
+     * Emitted when a layer has been saved using save as.
      * \since QGIS 2.7
      */
     void layerSavedAs( QgsMapLayer *l, const QString &path );

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -207,12 +207,12 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void beforeSave( bool &ok ) SIP_SKIP;
 
     /**
-     * Is emitted, when a feature is changed or added
+     * Emitted when a feature is changed or added
      */
     void featureSaved( const QgsFeature &feature );
 
     /**
-     * Is emitted when a filter expression is set using the form.
+     * Emitted when a filter expression is set using the form.
      * \param expression filter expression
      * \param type filter type
      * \since QGIS 2.16

--- a/src/gui/qgscheckablecombobox.h
+++ b/src/gui/qgscheckablecombobox.h
@@ -77,7 +77,7 @@ class QgsCheckableItemModel : public QStandardItemModel
   signals:
 
     /**
-     * This signal is emitted whenever the items checkstate has changed.
+     * Emitted whenever the items checkstate has changed.
      */
     void itemCheckStateChanged();
 };
@@ -208,7 +208,7 @@ class GUI_EXPORT QgsCheckableComboBox : public QComboBox
   signals:
 
     /**
-     * This signal is emitted whenever the checked items list changed.
+     * Emitted whenever the checked items list changed.
      */
     void checkedItemsChanged( const QStringList &items );
 

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -380,7 +380,7 @@ class GUI_EXPORT QgsColorButton : public QToolButton
   signals:
 
     /**
-     * Is emitted whenever a new color is set for the button. The color is always valid.
+     * Emitted whenever a new color is set for the button. The color is always valid.
      * In case the new color is the same no signal is emitted, to avoid infinite loops.
      * \param color New color
      */

--- a/src/gui/qgsfieldcombobox.h
+++ b/src/gui/qgsfieldcombobox.h
@@ -78,7 +78,7 @@ class GUI_EXPORT QgsFieldComboBox : public QComboBox
     QgsVectorLayer *layer() const;
 
   signals:
-    //! the signal is emitted when the currently selected field changes
+    //! Emitted when the currently selected field changes.
     void fieldChanged( const QString &fieldName );
 
   public slots:

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -171,7 +171,7 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     void setAllowEvalErrors( bool allowEvalErrors );
 
   signals:
-    //! the signal is emitted when the currently selected field changes
+    //! Emitted when the currently selected field changes.
     void fieldChanged( const QString &fieldName );
 
     //! fieldChanged signal with indication of the validity of the expression

--- a/src/gui/qgsmaplayercombobox.h
+++ b/src/gui/qgsmaplayercombobox.h
@@ -136,7 +136,7 @@ class GUI_EXPORT QgsMapLayerComboBox : public QComboBox
     void setLayer( QgsMapLayer *layer );
 
   signals:
-    //! layerChanged this signal is emitted whenever the currently selected layer changes
+    //! Emitted whenever the currently selected layer changes.
     void layerChanged( QgsMapLayer *layer );
 
   protected slots:

--- a/src/gui/qgstreewidgetitem.h
+++ b/src/gui/qgstreewidgetitem.h
@@ -178,7 +178,7 @@ class GUI_EXPORT QgsTreeWidgetItemObject: public QObject, public QgsTreeWidgetIt
     void setData( int column, int role, const QVariant &value ) override;
 
   signals:
-    //! This signal is emitted when the contents of the column in the specified item has been edited by the user.
+    //! Emitted when the contents of the column in the specified item has been edited by the user.
     void itemEdited( QTreeWidgetItem *item, int column );
 };
 

--- a/src/gui/raster/qgsrasterbandcombobox.h
+++ b/src/gui/raster/qgsrasterbandcombobox.h
@@ -87,7 +87,7 @@ class GUI_EXPORT QgsRasterBandComboBox : public QComboBox
   signals:
 
     /**
-     * This signal is emitted when the currently selected band changes.
+     * Emitted when the currently selected band changes.
      */
     void bandChanged( int band );
 

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -234,20 +234,6 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      */
     void setListening( bool isListening ) override;
 
-  signals:
-
-    /**
-     *   This is emitted when this provider is satisfied that all objects
-     *   have had a chance to adjust themselves after they'd been notified that
-     *   the full extent is available.
-     *
-     *   \note  It currently isn't being emitted because we don't have an easy way
-     *          for the overview canvas to only be repainted.  In the meantime
-     *          we are satisfied for the overview to reflect the new extent
-     *          when the user adjusts the extent of the main map canvas.
-     */
-    void repaintRequested();
-
   private:
     Relkind relkind() const;
 

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -183,20 +183,6 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
      */
     QgsSqliteHandle *mHandle = nullptr;
 
-  signals:
-
-    /**
-     *   This is emitted when this provider is satisfied that all objects
-     *   have had a chance to adjust themselves after they'd been notified that
-     *   the full extent is available.
-     *
-     *   \note  It currently isn't being emitted because we don't have an easy way
-     *          for the overview canvas to only be repainted.  In the meantime
-     *          we are satisfied for the overview to reflect the new extent
-     *          when the user adjusts the extent of the main map canvas.
-     */
-    void repaintRequested();
-
   private:
 
     //! Loads fields from input file to member mAttributeFields

--- a/src/quickgui/qgsquickmapcanvasmap.h
+++ b/src/quickgui/qgsquickmapcanvasmap.h
@@ -122,12 +122,12 @@ class QUICK_EXPORT QgsQuickMapCanvasMap : public QQuickItem
   signals:
 
     /**
-     * Signal is emitted when a rendering is starting
+     * Emitted when a rendering is starting.
      */
     void renderStarting();
 
     /**
-     * Signal is emitted when a canvas is refreshed
+     * Emitted when the canvas is refreshed.
      */
     void mapCanvasRefreshed();
 


### PR DESCRIPTION
Avoids the clunky "is emitted, when ... " wording and ensures consistent wording in the dox.