### PR TITLE
[processing] consider destination params as outputs when defining scripts

### DIFF
--- a/python/processing/algfactory.py
+++ b/python/processing/algfactory.py
@@ -211,7 +211,8 @@ class AlgWrapper(QgsProcessingAlgorithm):
         """
         True if this alg wrapper has outputs defined.
         """
-        return bool(self._outputs)
+        dests = [p for p in self._inputs.values() if p.isDestination()]
+        return bool(self._outputs) or bool(dests)
 
     @property
     def has_inputs(self):

--- a/tests/src/python/test_processing_alg_decorator.py
+++ b/tests/src/python/test_processing_alg_decorator.py
@@ -36,6 +36,18 @@ def define_new_no_inputs(newid=1):
         Test doc string text
         """
 
+def define_new_no_outputs_but_sink_instead(newid=1):
+    @alg(name=ARGNAME.format(newid), label=alg.tr("Test func"), group="unittest",
+         group_label=alg.tr("Test label"))
+    @alg.help(HELPSTRING.format(newid))
+    @alg.input(type=alg.SOURCE, name="INPUT", label="Input layer")
+    @alg.input(type=alg.DISTANCE, name="DISTANCE", label="Distance", default=30)
+    @alg.input(type=alg.SINK, name="SINK", label="Output layer")
+    def testalg(instance, parameters, context, feedback, inputs):
+        """
+        Given a distance will split a line layer into segments of the distance
+        """
+
 
 def define_new_doc_string(newid=1):
     @alg(name=ARGNAME.format(newid), label=alg.tr("Test func"), group="unittest",
@@ -73,6 +85,14 @@ class AlgNoInputs(unittest.TestCase):
 
     def test_can_have_no_inputs(self):
         define_new_no_inputs()
+
+class AlgNoOutputsButSinkInstead(unittest.TestCase):
+
+    def setUp(self):
+        cleanup()
+
+    def test_can_have_no_outputs_if_there_is_destination(self):
+        define_new_no_outputs_but_sink_instead()        
 
 
 class AlgInstanceTests(unittest.TestCase):

--- a/tests/src/python/test_processing_alg_decorator.py
+++ b/tests/src/python/test_processing_alg_decorator.py
@@ -36,6 +36,7 @@ def define_new_no_inputs(newid=1):
         Test doc string text
         """
 
+
 def define_new_no_outputs_but_sink_instead(newid=1):
     @alg(name=ARGNAME.format(newid), label=alg.tr("Test func"), group="unittest",
          group_label=alg.tr("Test label"))
@@ -86,13 +87,14 @@ class AlgNoInputs(unittest.TestCase):
     def test_can_have_no_inputs(self):
         define_new_no_inputs()
 
+
 class AlgNoOutputsButSinkInstead(unittest.TestCase):
 
     def setUp(self):
         cleanup()
 
     def test_can_have_no_outputs_if_there_is_destination(self):
-        define_new_no_outputs_but_sink_instead()        
+        define_new_no_outputs_but_sink_instead()
 
 
 class AlgInstanceTests(unittest.TestCase):


### PR DESCRIPTION

## Description

Now it is not possible to define a script with, for instance,  just a feature sink, since that is not understood as an output by the script parser (although it behaves as such)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
