### PR TITLE
[browser] Always show non-spatial tables when expanding an sqlite database file

### DIFF
--- a/python/core/auto_generated/qgssqliteutils.sip.in
+++ b/python/core/auto_generated/qgssqliteutils.sip.in
@@ -1,0 +1,63 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgssqliteutils.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+
+
+
+class QgsSqliteUtils
+{
+%Docstring
+Contains utilities for working with Sqlite data sources.
+
+.. versionadded:: 3.4
+%End
+
+%TypeHeaderCode
+#include "qgssqliteutils.h"
+%End
+  public:
+
+    static QString quotedString( const QString &value );
+%Docstring
+Returns a quoted string ``value``, surround by ' characters and with special
+characters correctly escaped.
+%End
+
+    static QString quotedIdentifier( const QString &identifier );
+%Docstring
+Returns a properly quoted version of ``identifier``.
+
+.. versionadded:: 3.6
+%End
+
+    static QString quotedValue( const QVariant &value );
+%Docstring
+Returns a properly quoted and escaped version of ``value``
+for use in SQL strings.
+
+.. versionadded:: 3.6
+%End
+
+    static QStringList systemTables();
+%Docstring
+Returns a string list of SQLite (and spatialite) system tables
+
+.. versionadded:: 3.8
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgssqliteutils.h                                            *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -120,6 +120,7 @@
 %Include auto_generated/qgsspatialindexkdbush.sip
 %Include auto_generated/qgsspatialindexkdbushdata.sip
 %Include auto_generated/qgssqlstatement.sip
+%Include auto_generated/qgssqliteutils.sip
 %Include auto_generated/qgsstatisticalsummary.sip
 %Include auto_generated/qgsstringstatisticalsummary.sip
 %Include auto_generated/qgsstringutils.sip

--- a/python/plugins/db_manager/db_plugins/spatialite/connector.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/connector.py
@@ -23,7 +23,7 @@ from builtins import str
 
 from functools import cmp_to_key
 
-from qgis.core import Qgis
+from qgis.core import Qgis, QgsSqliteUtils
 from qgis.PyQt.QtCore import QFile
 from qgis.PyQt.QtWidgets import QApplication
 
@@ -171,19 +171,7 @@ class SpatiaLiteDBConnector(DBConnector):
         tablenames = []
         items = []
 
-        sys_tables = ["SpatialIndex", "geom_cols_ref_sys", "geometry_columns", "geometry_columns_auth",
-                      "views_geometry_columns", "virts_geometry_columns", "spatial_ref_sys", "spatial_ref_sys_all", "spatial_ref_sys_aux",
-                      "sqlite_sequence", "tableprefix_metadata", "tableprefix_rasters",
-                      "layer_params", "layer_statistics", "layer_sub_classes", "layer_table_layout",
-                      "pattern_bitmaps", "symbol_bitmaps", "project_defs", "raster_pyramids",
-                      "sqlite_stat1", "sqlite_stat2", "spatialite_history",
-                      "geometry_columns_field_infos",
-                      "geometry_columns_statistics", "geometry_columns_time",
-                      "sql_statements_log", "vector_layers", "vector_layers_auth", "vector_layers_field_infos", "vector_layers_statistics",
-                      "views_geometry_columns_auth", "views_geometry_columns_field_infos", "views_geometry_columns_statistics",
-                      "virts_geometry_columns_auth", "virts_geometry_columns_field_infos", "virts_geometry_columns_statistics",
-                      "virts_layer_statistics", "views_layer_statistics", "ElementaryGeometries"
-                      ]
+        sys_tables = QgsSqliteUtils.systemTables()
 
         try:
             vectors = self.getVectorTables(schema)

--- a/src/core/qgssqliteutils.cpp
+++ b/src/core/qgssqliteutils.cpp
@@ -151,6 +151,25 @@ QString QgsSqliteUtils::quotedValue( const QVariant &value )
   }
 }
 
+QStringList QgsSqliteUtils::systemTables()
+{
+  return QStringList() << QStringLiteral( "SpatialIndex" ) << QStringLiteral( "geom_cols_ref_sys" ) << QStringLiteral( "geometry_columns" )
+         << QStringLiteral( "geometry_columns_auth" ) << QStringLiteral( "views_geometry_columns" ) << QStringLiteral( "virts_geometry_columns" )
+         << QStringLiteral( "spatial_ref_sys" ) << QStringLiteral( "spatial_ref_sys_all" ) << QStringLiteral( "spatial_ref_sys_aux" )
+         << QStringLiteral( "sqlite_sequence" ) << QStringLiteral( "tableprefix_metadata" ) << QStringLiteral( "tableprefix_rasters" )
+         << QStringLiteral( "layer_params" ) << QStringLiteral( "layer_statistics" ) << QStringLiteral( "layer_sub_classes" )
+         << QStringLiteral( "layer_table_layout" ) << QStringLiteral( "pattern_bitmaps" ) << QStringLiteral( "symbol_bitmaps" )
+         << QStringLiteral( "project_defs" ) << QStringLiteral( "raster_pyramids" ) << QStringLiteral( "sqlite_stat1" ) << QStringLiteral( "sqlite_stat2" )
+         << QStringLiteral( "spatialite_history" ) << QStringLiteral( "geometry_columns_field_infos" ) << QStringLiteral( "geometry_columns_statistics" )
+         << QStringLiteral( "geometry_columns_time" ) << QStringLiteral( "sql_statements_log" ) << QStringLiteral( "vector_layers" )
+         << QStringLiteral( "vector_layers_auth" ) << QStringLiteral( "vector_layers_field_infos" ) << QStringLiteral( "vector_layers_statistics" )
+         << QStringLiteral( "views_geometry_columns_auth" ) << QStringLiteral( "views_geometry_columns_field_infos" )
+         << QStringLiteral( "views_geometry_columns_statistics" ) << QStringLiteral( "virts_geometry_columns_auth" )
+         << QStringLiteral( "virts_geometry_columns_field_infos" ) << QStringLiteral( "virts_geometry_columns_statistics" )
+         << QStringLiteral( "virts_layer_statistics" ) << QStringLiteral( "views_layer_statistics" )
+         << QStringLiteral( "ElementaryGeometries" );
+}
+
 QString QgsSqlite3Mprintf( const char *format, ... )
 {
   va_list ap;

--- a/src/core/qgssqliteutils.h
+++ b/src/core/qgssqliteutils.h
@@ -18,8 +18,6 @@
 #ifndef QGSSQLITEUTILS_H
 #define QGSSQLITEUTILS_H
 
-#define SIP_NO_FILE
-
 #include "qgis_core.h"
 #include "qgis_sip.h"
 
@@ -29,6 +27,8 @@
 struct sqlite3;
 struct sqlite3_stmt;
 class QVariant;
+
+#ifndef SIP_RUN
 
 /**
  * \ingroup core
@@ -151,8 +151,16 @@ class CORE_EXPORT sqlite3_database_unique_ptr : public std::unique_ptr< sqlite3,
 };
 
 /**
+ * Wraps sqlite3_mprintf() by automatically freeing the memory.
+ * \note not available in Python bindings.
+ * \since QGIS 3.2
+ */
+QString CORE_EXPORT QgsSqlite3Mprintf( const char *format, ... );
+
+#endif
+
+/**
  * Contains utilities for working with Sqlite data sources.
- * \note not available in Python bindings
  * \ingroup core
  * \since QGIS 3.4
  */
@@ -188,13 +196,5 @@ class CORE_EXPORT QgsSqliteUtils
      */
     static QStringList systemTables();
 };
-
-/**
- * Wraps sqlite3_mprintf() by automatically freeing the memory.
- * \note not available in Python bindings.
- * \since QGIS 3.2
- */
-QString CORE_EXPORT QgsSqlite3Mprintf( const char *format, ... );
-
 
 #endif // QGSSQLITEUTILS_H

--- a/src/core/qgssqliteutils.h
+++ b/src/core/qgssqliteutils.h
@@ -180,6 +180,13 @@ class CORE_EXPORT QgsSqliteUtils
      * \since QGIS 3.6
      */
     static QString quotedValue( const QVariant &value );
+
+    /**
+     * Returns a string list of SQLite (and spatialite) system tables
+     *
+     * \since QGIS 3.8
+     */
+    static QStringList systemTables();
 };
 
 /**

--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -16,6 +16,7 @@
 #include "qgssettings.h"
 #include "qgslogger.h"
 #include "qgsspatialiteutils.h"
+#include "qgssqliteutils.h"
 
 #include <QFileInfo>
 #include <cstdlib> // atoi
@@ -239,22 +240,8 @@ bool QgsSpatiaLiteConnection::getTableInfoAbstractInterface( sqlite3 *handle, bo
   }
 
   // List of system tables not to be shown if geometryless tables are requested
-  QStringList ignoreTableNames;
-  ignoreTableNames << QStringLiteral( "SpatialIndex" ) << QStringLiteral( "geom_cols_ref_sys" ) << QStringLiteral( "geometry_columns" )
-                   << QStringLiteral( "geometry_columns_auth" ) << QStringLiteral( "views_geometry_columns" ) << QStringLiteral( "virts_geometry_columns" )
-                   << QStringLiteral( "spatial_ref_sys" ) << QStringLiteral( "spatial_ref_sys_all" ) << QStringLiteral( "spatial_ref_sys_aux" )
-                   << QStringLiteral( "sqlite_sequence" ) << QStringLiteral( "tableprefix_metadata" ) << QStringLiteral( "tableprefix_rasters" )
-                   << QStringLiteral( "layer_params" ) << QStringLiteral( "layer_statistics" ) << QStringLiteral( "layer_sub_classes" )
-                   << QStringLiteral( "layer_table_layout" ) << QStringLiteral( "pattern_bitmaps" ) << QStringLiteral( "symbol_bitmaps" )
-                   << QStringLiteral( "project_defs" ) << QStringLiteral( "raster_pyramids" ) << QStringLiteral( "sqlite_stat1" ) << QStringLiteral( "sqlite_stat2" )
-                   << QStringLiteral( "spatialite_history" ) << QStringLiteral( "geometry_columns_field_infos" ) << QStringLiteral( "geometry_columns_statistics" )
-                   << QStringLiteral( "geometry_columns_time" ) << QStringLiteral( "sql_statements_log" ) << QStringLiteral( "vector_layers" )
-                   << QStringLiteral( "vector_layers_auth" ) << QStringLiteral( "vector_layers_field_infos" ) << QStringLiteral( "vector_layers_statistics" )
-                   << QStringLiteral( "views_geometry_columns_auth" ) << QStringLiteral( "views_geometry_columns_field_infos" )
-                   << QStringLiteral( "views_geometry_columns_statistics" ) << QStringLiteral( "virts_geometry_columns_auth" )
-                   << QStringLiteral( "virts_geometry_columns_field_infos" ) << QStringLiteral( "virts_geometry_columns_statistics" )
-                   << QStringLiteral( "virts_layer_statistics" ) << QStringLiteral( "views_layer_statistics" )
-                   << QStringLiteral( "ElementaryGeometries" );
+  QStringList ignoreTableNames = QgsSqliteUtils::systemTables();
+
   // attempting to load the VectorLayersList
   list = gaiaGetVectorLayersList( handle, nullptr, nullptr, GAIA_VECTORS_LIST_FAST );
   if ( list )


### PR DESCRIPTION
## Description
Long story short: GDAL only shows spatial tables when a sqlite database contains a geometry_column table (i.e. when it detects a spatialite context). In the context of a "mixed" sqlite database (i.e. a couple of spatial and non-spatial tables), this is a problem as non-spatial tables are not listed by default as available layers by GDAL.

This PR offers a solution to list such non-spatial layers by forcing GDAL to list all layers (via the LIST_ALL_TABLES=YES option) and filtering out any system tables. This way, we get both spatial and non-spatial layers in the browser.

(* Note: this won't result in non-spatial tables shown in the select sub layer dialog when drag and dropping an sqlite file onto the QGIS main window. There, the best solution would be for GDAL to add a new listing mode to its SQLite driver that'd match that of its GeoPackage driver. The request has been filed here: https://github.com/OSGeo/gdal/issues/1326 )

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
