### PR TITLE
Fix build without HAVE_SERVER_PYTHON_PLUGINS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,10 +128,14 @@ IF(WITH_CORE)
   IF(WITH_SERVER)
     SET (SERVER_SKIP_ECW FALSE CACHE BOOL "Determines whether QGIS server should disable ECW (ECW in server apps requires a special license)")
 
-    SET (WITH_SERVER_PLUGINS TRUE CACHE BOOL "Determines whether QGIS server support for python plugins should be built")
+    SET (WITH_SERVER_PLUGINS ${WITH_BINDINGS} CACHE BOOL "Determines whether QGIS server support for python plugins should be built")
+    IF(WITH_SERVER_PLUGINS AND NOT WITH_BINDINGS)
+      MESSAGE(FATAL_ERROR "Server plugins are not supported without python bindings. Enable WITH_BINDINGS or disable WITH_SERVER_PLUGINS")
+    ENDIF(WITH_SERVER_PLUGINS AND NOT WITH_BINDINGS)
     IF(WITH_SERVER_PLUGINS)
       SET(HAVE_SERVER_PYTHON_PLUGINS TRUE)
     ENDIF(WITH_SERVER_PLUGINS)
+
   ENDIF(WITH_SERVER)
 
   # Custom widgets

--- a/src/server/qgsserverinterfaceimpl.cpp
+++ b/src/server/qgsserverinterfaceimpl.cpp
@@ -29,7 +29,7 @@ QgsServerInterfaceImpl::QgsServerInterfaceImpl( QgsCapabilitiesCache *capCache, 
   mRequestHandler = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
   mAccessControls = new QgsAccessControl();
-  mCacheManager.reset( new QgsServerCacheManager() );
+  mCacheManager = new QgsServerCacheManager();
 #endif
 }
 
@@ -43,7 +43,7 @@ QgsServerInterfaceImpl::~QgsServerInterfaceImpl()
 {
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
   delete mAccessControls;
-  mCacheManager.reset();
+  delete mCacheManager;
 #endif
 }
 
@@ -97,7 +97,7 @@ void QgsServerInterfaceImpl::registerServerCache( QgsServerCacheFilter *serverCa
 
 QgsServerCacheManager *QgsServerInterfaceImpl::cacheManager() const
 {
-  return mCacheManager.get();
+  return mCacheManager;
 }
 
 void QgsServerInterfaceImpl::removeConfigCacheEntry( const QString &path )

--- a/src/server/qgsserverinterfaceimpl.h
+++ b/src/server/qgsserverinterfaceimpl.h
@@ -92,7 +92,7 @@ class SERVER_EXPORT QgsServerInterfaceImpl : public QgsServerInterface
     QString mConfigFilePath;
     QgsServerFiltersMap mFilters;
     QgsAccessControl *mAccessControls = nullptr;
-    std::unique_ptr<QgsServerCacheManager> mCacheManager = nullptr;
+    QgsServerCacheManager *mCacheManager = nullptr;
     QgsCapabilitiesCache *mCapabilitiesCache = nullptr;
     QgsRequestHandler *mRequestHandler = nullptr;
     QgsServiceRegistry *mServiceRegistry = nullptr;

--- a/src/server/services/wcs/qgswcsdescribecoverage.cpp
+++ b/src/server/services/wcs/qgswcsdescribecoverage.cpp
@@ -43,7 +43,6 @@ namespace QgsWcs
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       describeDocument = &doc;
@@ -58,7 +57,9 @@ namespace QgsWcs
       }
       describeDocument = &doc;
     }
-
+#else
+    doc = createDescribeCoverageDocument( serverIface, project, version, request );
+#endif
     response.setHeader( "Content-Type", "text/xml; charset=utf-8" );
     response.write( describeDocument->toByteArray() );
   }

--- a/src/server/services/wcs/qgswcsgetcapabilities.cpp
+++ b/src/server/services/wcs/qgswcsgetcapabilities.cpp
@@ -42,7 +42,6 @@ namespace QgsWcs
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;
@@ -57,7 +56,9 @@ namespace QgsWcs
       }
       capabilitiesDocument = &doc;
     }
-
+#else
+    doc = createGetCapabilitiesDocument( serverIface, project, version, request );
+#endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( capabilitiesDocument->toByteArray() );
   }

--- a/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
+++ b/src/server/services/wfs/qgswfsdescribefeaturetype.cpp
@@ -44,7 +44,6 @@ namespace QgsWfs
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       describeDocument = &doc;
@@ -59,7 +58,9 @@ namespace QgsWfs
       }
       describeDocument = &doc;
     }
-
+#else
+    doc = createDescribeFeatureTypeDocument( serverIface, project, version, request );
+#endif
     response.setHeader( "Content-Type", "text/xml; charset=utf-8" );
     response.write( describeDocument->toByteArray() );
   }
@@ -152,7 +153,7 @@ namespace QgsWfs
       {
         continue;
       }
-
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl && !accessControl->layerReadPermission( layer ) )
       {
         if ( !typeNameList.isEmpty() )
@@ -164,7 +165,7 @@ namespace QgsWfs
           continue;
         }
       }
-
+#endif
       QgsVectorLayer *vLayer = qobject_cast<QgsVectorLayer *>( layer );
       QgsVectorDataProvider *provider = vLayer->dataProvider();
       if ( !provider )

--- a/src/server/services/wfs/qgswfsgetcapabilities.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities.cpp
@@ -48,7 +48,6 @@ namespace QgsWfs
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;
@@ -63,7 +62,9 @@ namespace QgsWfs
       }
       capabilitiesDocument = &doc;
     }
-
+#else
+    doc = createGetCapabilitiesDocument( serverIface, project, version, request );
+#endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( capabilitiesDocument->toByteArray() );
   }
@@ -458,11 +459,12 @@ namespace QgsWfs
       {
         continue;
       }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl && !accessControl->layerReadPermission( layer ) )
       {
         continue;
       }
-
+#endif
       QDomElement layerElem = doc.createElement( QStringLiteral( "FeatureType" ) );
 
       //create Name

--- a/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfsgetcapabilities_1_0_0.cpp
@@ -49,7 +49,6 @@ namespace QgsWfs
       QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
       cacheManager = serverIface->cacheManager();
-#endif
       if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
       {
         capabilitiesDocument = &doc;
@@ -64,7 +63,9 @@ namespace QgsWfs
         }
         capabilitiesDocument = &doc;
       }
-
+#else
+      doc = createGetCapabilitiesDocument( serverIface, project, version, request );
+#endif
       response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
       response.write( capabilitiesDocument->toByteArray() );
     }
@@ -294,11 +295,12 @@ namespace QgsWfs
         {
           continue;
         }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl && !accessControl->layerReadPermission( layer ) )
         {
           continue;
         }
-
+#endif
         QDomElement layerElem = doc.createElement( QStringLiteral( "FeatureType" ) );
 
         //create Name

--- a/src/server/services/wfs/qgswfsgetfeature.cpp
+++ b/src/server/services/wfs/qgswfsgetfeature.cpp
@@ -179,9 +179,11 @@ namespace QgsWfs
 
     QgsAccessControl *accessControl = serverIface->accessControls();
 
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
     //scoped pointer to restore all original layer filters (subsetStrings) when pointer goes out of scope
     //there's LOTS of potential exit paths here, so we avoid having to restore the filters manually
     std::unique_ptr< QgsOWSServerFilterRestorer > filterRestorer( new QgsOWSServerFilterRestorer() );
+#endif
 
     // features counters
     long sentFeatures = 0;
@@ -200,11 +202,12 @@ namespace QgsWfs
       }
 
       QgsMapLayer *layer = mapLayerMap[typeName];
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl && !accessControl->layerReadPermission( layer ) )
       {
         throw QgsSecurityAccessException( QStringLiteral( "Feature access permission denied" ) );
       }
-
+#endif
       QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
       if ( !vlayer )
       {
@@ -217,12 +220,12 @@ namespace QgsWfs
       {
         throw QgsRequestNotWellFormedException( QStringLiteral( "TypeName '%1' layer's provider error" ).arg( typeName ) );
       }
-
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl )
       {
         QgsOWSServerFilterRestorer::applyAccessControlLayerFilters( accessControl, vlayer, filterRestorer->originalFilters() );
       }
-
+#endif
       //is there alias info for this vector layer?
       QMap< int, QString > layerAliasInfo;
       QgsStringMap aliasMap = vlayer->attributeAliases();
@@ -312,7 +315,7 @@ namespace QgsWfs
         featureRequest.setFlags( featureRequest.flags() | ( withGeom ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry ) );
       // subset of attributes
       featureRequest.setSubsetOfAttributes( attrIndexes );
-
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl )
       {
         accessControl->filterFeatures( vlayer, featureRequest );
@@ -326,7 +329,7 @@ namespace QgsWfs
           accessControl->layerAttributes( vlayer, attributes ),
           vlayer->fields() );
       }
-
+#endif
       if ( onlyOneLayer )
       {
         requestPrecision = QgsServerProjectUtils::wfsLayerPrecision( *project, vlayer->id() );

--- a/src/server/services/wfs/qgswfstransaction.cpp
+++ b/src/server/services/wfs/qgswfstransaction.cpp
@@ -299,6 +299,7 @@ namespace QgsWfs
       {
         throw QgsSecurityAccessException( QStringLiteral( "No permissions to do WFS changes on layer '%1'" ).arg( name ) );
       }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl && !accessControl->layerUpdatePermission( vlayer )
            && !accessControl->layerDeletePermission( vlayer ) && !accessControl->layerInsertPermission( vlayer ) )
       {
@@ -309,7 +310,7 @@ namespace QgsWfs
       {
         QgsOWSServerFilterRestorer::applyAccessControlLayerFilters( accessControl, vlayer, filterRestorer->originalFilters() );
       }
-
+#endif
       // store layers
       mapLayerMap[name] = vlayer;
     }
@@ -338,13 +339,14 @@ namespace QgsWfs
         action.errorMsg = QStringLiteral( "No permissions to do WFS updates on layer '%1'" ).arg( typeName );
         continue;
       }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl && !accessControl->layerUpdatePermission( vlayer ) )
       {
         action.error = true;
         action.errorMsg = QStringLiteral( "No permissions to do WFS updates on layer '%1'" ).arg( typeName );
         continue;
       }
-
+#endif
       //get provider
       QgsVectorDataProvider *provider = vlayer->dataProvider();
 
@@ -368,12 +370,12 @@ namespace QgsWfs
                         << QgsExpressionContextUtils::projectScope( project )
                         << QgsExpressionContextUtils::layerScope( vlayer );
       featureRequest.setExpressionContext( expressionContext );
-
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl )
       {
         accessControl->filterFeatures( vlayer, featureRequest );
       }
-
+#endif
       // get iterator
       QgsFeatureIterator fit = vlayer->getFeatures( featureRequest );
       QgsFeature feature;
@@ -390,6 +392,7 @@ namespace QgsWfs
       // Update the features
       while ( fit.nextFeature( feature ) )
       {
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl && !accessControl->allowToEdit( vlayer, feature ) )
         {
           action.error = true;
@@ -397,6 +400,7 @@ namespace QgsWfs
           vlayer->rollBack();
           break;
         }
+#endif
         QMap< QString, QString >::const_iterator it = propertyMap.constBegin();
         for ( ; it != propertyMap.constEnd(); ++it )
         {
@@ -485,6 +489,7 @@ namespace QgsWfs
       {
         continue;
       }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       // verifying changes
       if ( accessControl )
       {
@@ -500,6 +505,7 @@ namespace QgsWfs
           }
         }
       }
+#endif
       if ( action.error )
       {
         continue;
@@ -543,13 +549,14 @@ namespace QgsWfs
         action.errorMsg = QStringLiteral( "No permissions to do WFS deletes on layer '%1'" ).arg( typeName );
         continue;
       }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl && !accessControl->layerDeletePermission( vlayer ) )
       {
         action.error = true;
         action.errorMsg = QStringLiteral( "No permissions to do WFS deletes on layer '%1'" ).arg( typeName );
         continue;
       }
-
+#endif
       //get provider
       QgsVectorDataProvider *provider = vlayer->dataProvider();
 
@@ -581,6 +588,7 @@ namespace QgsWfs
       QgsFeatureIds fids;
       while ( fit.nextFeature( feature ) )
       {
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl && !accessControl->allowToEdit( vlayer, feature ) )
         {
           action.error = true;
@@ -588,6 +596,7 @@ namespace QgsWfs
           vlayer->rollBack();
           break;
         }
+#endif
         fids << feature.id();
       }
       if ( action.error )
@@ -640,13 +649,14 @@ namespace QgsWfs
         action.errorMsg = QStringLiteral( "No permissions to do WFS inserts on layer '%1'" ).arg( typeName );
         continue;
       }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       if ( accessControl && !accessControl->layerDeletePermission( vlayer ) )
       {
         action.error = true;
         action.errorMsg = QStringLiteral( "No permissions to do WFS inserts on layer '%1'" ).arg( typeName );
         continue;
       }
-
+#endif
       //get provider
       QgsVectorDataProvider *provider = vlayer->dataProvider();
 
@@ -674,6 +684,7 @@ namespace QgsWfs
         action.errorMsg = QStringLiteral( "%1 '%2'" ).arg( ex.message() ).arg( typeName );
         continue;
       }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
       // control features
       if ( accessControl )
       {
@@ -690,6 +701,7 @@ namespace QgsWfs
           featureIt++;
         }
       }
+#endif
       if ( action.error )
       {
         continue;

--- a/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
+++ b/src/server/services/wfs/qgswfstransaction_1_0_0.cpp
@@ -281,6 +281,7 @@ namespace QgsWfs
         {
           throw QgsSecurityAccessException( QStringLiteral( "No permissions to do WFS changes on layer '%1'" ).arg( name ) );
         }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl && !accessControl->layerUpdatePermission( vlayer )
              && !accessControl->layerDeletePermission( vlayer ) && !accessControl->layerInsertPermission( vlayer ) )
         {
@@ -291,7 +292,7 @@ namespace QgsWfs
         {
           QgsOWSServerFilterRestorer::applyAccessControlLayerFilters( accessControl, vlayer, filterRestorer->originalFilters() );
         }
-
+#endif
         // store layers
         mapLayerMap[name] = vlayer;
       }
@@ -320,13 +321,14 @@ namespace QgsWfs
           action.errorMsg = QStringLiteral( "No permissions to do WFS updates on layer '%1'" ).arg( typeName );
           continue;
         }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl && !accessControl->layerUpdatePermission( vlayer ) )
         {
           action.error = true;
           action.errorMsg = QStringLiteral( "No permissions to do WFS updates on layer '%1'" ).arg( typeName );
           continue;
         }
-
+#endif
         //get provider
         QgsVectorDataProvider *provider = vlayer->dataProvider();
 
@@ -350,12 +352,12 @@ namespace QgsWfs
                           << QgsExpressionContextUtils::projectScope( project )
                           << QgsExpressionContextUtils::layerScope( vlayer );
         featureRequest.setExpressionContext( expressionContext );
-
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl )
         {
           accessControl->filterFeatures( vlayer, featureRequest );
         }
-
+#endif
         // get iterator
         QgsFeatureIterator fit = vlayer->getFeatures( featureRequest );
         QgsFeature feature;
@@ -371,6 +373,7 @@ namespace QgsWfs
         // Update the features
         while ( fit.nextFeature( feature ) )
         {
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
           if ( accessControl && !accessControl->allowToEdit( vlayer, feature ) )
           {
             action.error = true;
@@ -378,6 +381,7 @@ namespace QgsWfs
             vlayer->rollBack();
             break;
           }
+#endif
           QMap< QString, QString >::const_iterator it = propertyMap.constBegin();
           for ( ; it != propertyMap.constEnd(); ++it )
           {
@@ -465,6 +469,7 @@ namespace QgsWfs
         {
           continue;
         }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         // verifying changes
         if ( accessControl )
         {
@@ -480,6 +485,7 @@ namespace QgsWfs
             }
           }
         }
+#endif
         if ( action.error )
         {
           continue;
@@ -522,13 +528,14 @@ namespace QgsWfs
           action.errorMsg = QStringLiteral( "No permissions to do WFS deletes on layer '%1'" ).arg( typeName );
           continue;
         }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl && !accessControl->layerDeletePermission( vlayer ) )
         {
           action.error = true;
           action.errorMsg = QStringLiteral( "No permissions to do WFS deletes on layer '%1'" ).arg( typeName );
           continue;
         }
-
+#endif
         //get provider
         QgsVectorDataProvider *provider = vlayer->dataProvider();
 
@@ -560,6 +567,7 @@ namespace QgsWfs
         QgsFeatureIds fids;
         while ( fit.nextFeature( feature ) )
         {
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
           if ( accessControl && !accessControl->allowToEdit( vlayer, feature ) )
           {
             action.error = true;
@@ -567,6 +575,7 @@ namespace QgsWfs
             vlayer->rollBack();
             break;
           }
+#endif
           fids << feature.id();
         }
         if ( action.error )
@@ -618,13 +627,14 @@ namespace QgsWfs
           action.errorMsg = QStringLiteral( "No permissions to do WFS inserts on layer '%1'" ).arg( typeName );
           continue;
         }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl && !accessControl->layerDeletePermission( vlayer ) )
         {
           action.error = true;
           action.errorMsg = QStringLiteral( "No permissions to do WFS inserts on layer '%1'" ).arg( typeName );
           continue;
         }
-
+#endif
         //get provider
         QgsVectorDataProvider *provider = vlayer->dataProvider();
 
@@ -652,6 +662,7 @@ namespace QgsWfs
           action.errorMsg = QStringLiteral( "%1 '%2'" ).arg( ex.message() ).arg( typeName );
           continue;
         }
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         // control features
         if ( accessControl )
         {
@@ -668,6 +679,7 @@ namespace QgsWfs
             featureIt++;
           }
         }
+#endif
         if ( action.error )
         {
           continue;

--- a/src/server/services/wms/qgswmsgetcontext.cpp
+++ b/src/server/services/wms/qgswmsgetcontext.cpp
@@ -65,7 +65,6 @@ namespace QgsWms
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       contextDocument = &doc;
@@ -80,7 +79,9 @@ namespace QgsWms
       }
       contextDocument = &doc;
     }
-
+#else
+    doc = getContext( serverIface, project, version, request );
+#endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( contextDocument->toByteArray() );
   }
@@ -261,13 +262,13 @@ namespace QgsWms
           {
             continue;
           }
-
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
           QgsAccessControl *accessControl = serverIface->accessControls();
           if ( accessControl && !accessControl->layerReadPermission( l ) )
           {
             continue;
           }
-
+#endif
           QDomElement layerElem = doc.createElement( QStringLiteral( "Layer" ) );
 
           // queryable layer

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -54,7 +54,7 @@ namespace QgsWms
         break;
       default:
         throw QgsServiceException( "InvalidFormat",
-                                   QString( "Output format '%1' is not supported in the GetLegendGraphic request" ).arg( format ) );
+                                   QStringLiteral( "Output format '%1' is not supported in the GetLegendGraphic request" ).arg( format ) );
         break;
     }
 

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -34,6 +34,11 @@ namespace QgsWms
     // get parameters from query
     QgsWmsParameters parameters( QUrlQuery( request.url() ) );
 
+    // init render context
+    QgsWmsRenderContext context( project, serverIface );
+    context.setFlag( QgsWmsRenderContext::UseScaleDenominator );
+    context.setParameters( parameters );
+
     const QString format = request.parameters().value( QStringLiteral( "FORMAT" ), QStringLiteral( "PNG" ) );
     ImageOutputFormat outputFormat = parseImageFormat( format );
 
@@ -76,11 +81,6 @@ namespace QgsWms
       }
     }
 #endif
-    // init render context
-    QgsWmsRenderContext context( project, serverIface );
-    context.setFlag( QgsWmsRenderContext::UseScaleDenominator );
-    context.setParameters( parameters );
-
     QgsRenderer renderer( context );
 
     std::unique_ptr<QImage> result( renderer.getLegendGraphics() );

--- a/src/server/services/wms/qgswmsgetstyles.cpp
+++ b/src/server/services/wms/qgswmsgetstyles.cpp
@@ -156,12 +156,12 @@ namespace QgsWms
         {
           throw QgsSecurityException( QStringLiteral( "You are not allowed to access to this layer" ) );
         }
-
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
         if ( accessControl && !accessControl->layerReadPermission( layer ) )
         {
           throw QgsSecurityException( QStringLiteral( "You are not allowed to access to this layer" ) );
         }
-
+#endif
         // Create the NamedLayer element
         QDomElement namedLayerNode = myDocument.createElement( QStringLiteral( "NamedLayer" ) );
         root.appendChild( namedLayerNode );

--- a/src/server/services/wmts/qgswmtsgetcapabilities.cpp
+++ b/src/server/services/wmts/qgswmtsgetcapabilities.cpp
@@ -50,7 +50,6 @@ namespace QgsWmts
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager && cacheManager->getCachedDocument( &doc, project, request, accessControl ) )
     {
       capabilitiesDocument = &doc;
@@ -65,7 +64,9 @@ namespace QgsWmts
       }
       capabilitiesDocument = &doc;
     }
-
+#else
+    doc = createGetCapabilitiesDocument( serverIface, project, version, request );
+#endif
     response.setHeader( QStringLiteral( "Content-Type" ), QStringLiteral( "text/xml; charset=utf-8" ) );
     response.write( capabilitiesDocument->toByteArray() );
   }

--- a/src/server/services/wmts/qgswmtsgettile.cpp
+++ b/src/server/services/wmts/qgswmtsgettile.cpp
@@ -39,7 +39,6 @@ namespace QgsWmts
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     accessControl = serverIface->accessControls();
     cacheManager = serverIface->cacheManager();
-#endif
     if ( cacheManager )
     {
       QgsWmtsParameters::Format f = params.format();
@@ -67,18 +66,20 @@ namespace QgsWmts
         return;
       }
     }
-
+#endif
 
     QgsServerParameters wmsParams( query );
     QgsServerRequest wmsRequest( "?" + query.query( QUrl::FullyDecoded ) );
     QgsService *service = serverIface->serviceRegistry()->getService( wmsParams.service(), wmsParams.version() );
     service->executeRequest( wmsRequest, response, project );
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
     if ( cacheManager )
     {
       QByteArray content = response.data();
       if ( !content.isEmpty() )
         cacheManager->setCachedImage( &content, project, request, accessControl );
     }
+#endif
   }
 
 } // namespace QgsWmts


### PR DESCRIPTION
## Description

Fix build without HAVE_SERVER_PYTHON_PLUGINS defined



This PR fix compile errors and link error when HAVE_SERVER_PYTHON_PLUGINS is undefined.

The main problem was  the fact that without HAVE_SERVER_PYTHON_PLUGINS then QgsAccessControl and QgsServerCacheManager are  forward declaration  only that do not resolve to any type.  Usually, this should not lead to problem as long as QgsAccessControl* should no be de-referenced nor any member accessed. Originally, this was an attempt to reduce the number of #ifdef/#endif directive in the code.

Subsequent refactoring has introduced new dependencies in QgsAccessControl and QgsServerCacheManager that access members at location not bracketed with #ifdef/#endif pair and thus leading to compile error.

This fix is not totally satisfactory in the sense that it reintroduce a bunch #define directive that does not contribute to readibility and maintenance.

Also this PR  fix the problem at hand, I have noticed that many patterns involving HAVE_SERVER_PYTHON_PLUGINS are the same in many places and that a cleaner refactoring of the 
code specific to server plugins should be possible.

