### PR TITLE
Fix auth manager crash on exit

### DIFF
--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -900,6 +900,8 @@ class CORE_EXPORT QgsAuthManager : public QObject
     //! password helper folder in the wallets
     static const QLatin1String AUTH_PASSWORD_HELPER_FOLDER_NAME;
 
+    mutable QMap<QThread *, QMetaObject::Connection> mConnectedThreads;
+
     friend class QgsApplication;
 
 };

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1177,6 +1177,8 @@ QgsAuthManager *QgsApplication::authManager()
 
 void QgsApplication::exitQgis()
 {
+  delete QgsApplication::authManager();
+  
   //Ensure that all remaining deleteLater QObjects are actually deleted before we exit.
   //This isn't strictly necessary (since we're exiting anyway) but doing so prevents a lot of
   //LeakSanitiser noise which hides real issues
@@ -1188,8 +1190,6 @@ void QgsApplication::exitQgis()
   delete QgsProject::instance();
 
   delete QgsProviderRegistry::instance();
-
-  delete QgsApplication::authManager();
 
   // invalidate coordinate cache while the PROJ context held by the thread-locale
   // QgsProjContextStore object is still alive. Otherwise if this later object

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1177,8 +1177,6 @@ QgsAuthManager *QgsApplication::authManager()
 
 void QgsApplication::exitQgis()
 {
-  delete QgsApplication::authManager();
-
   //Ensure that all remaining deleteLater QObjects are actually deleted before we exit.
   //This isn't strictly necessary (since we're exiting anyway) but doing so prevents a lot of
   //LeakSanitiser noise which hides real issues
@@ -1190,6 +1188,8 @@ void QgsApplication::exitQgis()
   delete QgsProject::instance();
 
   delete QgsProviderRegistry::instance();
+
+  delete QgsApplication::authManager();
 
   // invalidate coordinate cache while the PROJ context held by the thread-locale
   // QgsProjContextStore object is still alive. Otherwise if this later object

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -1178,7 +1178,7 @@ QgsAuthManager *QgsApplication::authManager()
 void QgsApplication::exitQgis()
 {
   delete QgsApplication::authManager();
-  
+
   //Ensure that all remaining deleteLater QObjects are actually deleted before we exit.
   //This isn't strictly necessary (since we're exiting anyway) but doing so prevents a lot of
   //LeakSanitiser noise which hides real issues


### PR DESCRIPTION
Fixes a crash on exit due to `QThread::finished` signals triggering code in the auth manager when it was already destroyed.

This is actually a double-protection. The issue itself is fixed by changing the destruction order, but the extra check should avoid similar issues caused by other situations.