### PR TITLE
[geometry validation] Allow deactivating is valid checks in an edit session

### DIFF
--- a/src/app/qgsgeometryvalidationmodel.cpp
+++ b/src/app/qgsgeometryvalidationmodel.cpp
@@ -27,6 +27,7 @@ QgsGeometryValidationModel::QgsGeometryValidationModel( QgsGeometryValidationSer
   : QAbstractItemModel( parent )
   , mGeometryValidationService( geometryValidationService )
 {
+  connect( mGeometryValidationService, &QgsGeometryValidationService::singleGeometryCheckCleared, this, &QgsGeometryValidationModel::onSingleGeometryCheckCleared );
   connect( mGeometryValidationService, &QgsGeometryValidationService::geometryCheckCompleted, this, &QgsGeometryValidationModel::onGeometryCheckCompleted );
   connect( mGeometryValidationService, &QgsGeometryValidationService::geometryCheckStarted, this, &QgsGeometryValidationModel::onGeometryCheckStarted );
   connect( mGeometryValidationService, &QgsGeometryValidationService::topologyChecksUpdated, this, &QgsGeometryValidationModel::onTopologyChecksUpdated );
@@ -248,6 +249,24 @@ void QgsGeometryValidationModel::setCurrentLayer( QgsVectorLayer *currentLayer )
     mExpressionContext = QgsExpressionContext();
   }
   endResetModel();
+}
+
+void QgsGeometryValidationModel::onSingleGeometryCheckCleared( QgsVectorLayer *layer )
+{
+  auto &layerErrors = mErrorStorage[layer];
+
+  if ( mCurrentLayer == layer && !layerErrors.empty() )
+  {
+    beginRemoveRows( QModelIndex(), 0, layerErrors.size() - 1 );
+  }
+
+  layerErrors.clear();
+
+  if ( mCurrentLayer == layer && !layerErrors.empty() )
+  {
+    endRemoveRows();
+  }
+
 }
 
 void QgsGeometryValidationModel::onGeometryCheckCompleted( QgsVectorLayer *layer, QgsFeatureId fid, const QList<std::shared_ptr<QgsSingleGeometryCheckError>> &errors )

--- a/src/app/qgsgeometryvalidationmodel.h
+++ b/src/app/qgsgeometryvalidationmodel.h
@@ -53,6 +53,7 @@ class QgsGeometryValidationModel : public QAbstractItemModel
     void setCurrentLayer( QgsVectorLayer *currentLayer );
 
   private slots:
+    void onSingleGeometryCheckCleared( QgsVectorLayer *layer );
     void onGeometryCheckCompleted( QgsVectorLayer *layer, QgsFeatureId fid, const QList<std::shared_ptr<QgsSingleGeometryCheckError> > &errors );
     void onGeometryCheckStarted( QgsVectorLayer *layer, QgsFeatureId fid );
     void onTopologyChecksUpdated( QgsVectorLayer *layer, const QList<std::shared_ptr<QgsGeometryCheckError> > &errors );

--- a/src/app/qgsgeometryvalidationservice.cpp
+++ b/src/app/qgsgeometryvalidationservice.cpp
@@ -250,6 +250,12 @@ void QgsGeometryValidationService::enableLayerChecks( QgsVectorLayer *layer )
     singleGeometryChecks.append( dynamic_cast<QgsSingleGeometryCheck *>( check ) );
   }
 
+  if ( singleGeometryChecks.empty() )
+  {
+    mLayerChecks[layer].singleFeatureCheckErrors.clear();
+    emit singleGeometryCheckCleared( layer );
+  }
+
   checkInformation.singleFeatureChecks = singleGeometryChecks;
 
   // Topology checks

--- a/src/app/qgsgeometryvalidationservice.h
+++ b/src/app/qgsgeometryvalidationservice.h
@@ -71,6 +71,13 @@ class QgsGeometryValidationService : public QObject
     void setMessageBar( QgsMessageBar *messageBar );
 
   signals:
+
+    /**
+     * Emitted when geometry checks for this layer have been disabled and
+     * any existing cached result should be cleared.
+     */
+    void singleGeometryCheckCleared( QgsVectorLayer *layer );
+
     void geometryCheckStarted( QgsVectorLayer *layer, QgsFeatureId fid );
     void geometryCheckCompleted( QgsVectorLayer *layer, QgsFeatureId fid, const QList<std::shared_ptr<QgsSingleGeometryCheckError>> &errors );
     void topologyChecksUpdated( QgsVectorLayer *layer, const QList<std::shared_ptr<QgsGeometryCheckError> > &errors );


### PR DESCRIPTION
If an is valid check is deactivated in an ongoing edit session, all check results
are invalidated and removed. This will help a user to save his edits if he wants
to even if is valid checks have been activated before.