### PR TITLE
Add topological points on layers with configured precision

### DIFF
--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -25,6 +25,7 @@
 #include "qgswkbtypes.h"
 #include "qgsvectorlayerutils.h"
 #include "qgsvectorlayer.h"
+#include "qgsgeometryoptions.h"
 
 #include <limits>
 
@@ -614,14 +615,20 @@ int QgsVectorLayerEditUtils::addTopologicalPoints( const QgsPointXY &p )
   double segmentSearchEpsilon = mLayer->crs().isGeographic() ? 1e-12 : 1e-8;
 
   //work with a tolerance because coordinate projection may introduce some rounding
-  double threshold = 0.0000001;
-  if ( mLayer->crs().mapUnits() == QgsUnitTypes::DistanceMeters )
+  double threshold = mLayer->geometryOptions()->geometryPrecision();
+
+  if ( qgsDoubleNear( threshold, 0.0 ) )
   {
-    threshold = 0.001;
-  }
-  else if ( mLayer->crs().mapUnits() == QgsUnitTypes::DistanceFeet )
-  {
-    threshold = 0.0001;
+    threshold = 0.0000001;
+
+    if ( mLayer->crs().mapUnits() == QgsUnitTypes::DistanceMeters )
+    {
+      threshold = 0.001;
+    }
+    else if ( mLayer->crs().mapUnits() == QgsUnitTypes::DistanceFeet )
+    {
+      threshold = 0.0001;
+    }
   }
 
   QgsRectangle searchRect( p.x() - threshold, p.y() - threshold,


### PR DESCRIPTION
The tolerance was hardcoded to 1mm before, so when working with a reduced tolerance, topological points were very unlikely to be added.