### PR TITLE
Do not store default values in user's QgsSettings

### DIFF
--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -282,12 +282,19 @@ void QgsSettings::setValue( const QString &key, const QVariant &value, const Qgs
 {
   // TODO: add valueChanged signal
   // Do not store if it hasn't changed from default value
-  QVariant v = QgsSettings::value( prefixedKey( key, section ) );
+  // Fist check if the values are different and if at least one of them is valid.
+  // The valid check is required because different invalid QVariant flavours
+  // like QVariant(QVariant::String) and QVariant(QVariant::Int ))
+  // may be considered different and we don't want to store the value in that case.
   QVariant currentValue { QgsSettings::value( prefixedKey( key, section ) ) };
   if ( ( currentValue.isValid() || value.isValid() ) && ( currentValue != value ) )
   {
     mUserSettings->setValue( prefixedKey( key, section ), value );
   }
+  // Deliberately an "else if" because we want to remove a value from the user settings
+  // only if the value is different than the one stored in the global settings (because
+  // it would be the default anyway). The first check is necessary because the global settings
+  // might be a nullptr (for example in case of standalone scripts or apps).
   else if ( mGlobalSettings && mGlobalSettings->value( prefixedKey( key, section ) ) == currentValue )
   {
     mUserSettings->remove( prefixedKey( key, section ) );

--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -281,7 +281,17 @@ void QgsSettings::setArrayIndex( int i )
 void QgsSettings::setValue( const QString &key, const QVariant &value, const QgsSettings::Section section )
 {
   // TODO: add valueChanged signal
-  mUserSettings->setValue( prefixedKey( key, section ), value );
+  // Do not store if it hasn't changed from default value
+  QVariant v = QgsSettings::value( prefixedKey( key, section ) );
+  QVariant currentValue { QgsSettings::value( prefixedKey( key, section ) ) };
+  if ( ( currentValue.isValid() || value.isValid() ) && ( currentValue != value ) )
+  {
+    mUserSettings->setValue( prefixedKey( key, section ), value );
+  }
+  else if ( mGlobalSettings->value( prefixedKey( key, section ) ) == currentValue )
+  {
+    mUserSettings->remove( prefixedKey( key, section ) );
+  }
 }
 
 // To lower case and clean the path

--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -288,7 +288,7 @@ void QgsSettings::setValue( const QString &key, const QVariant &value, const Qgs
   {
     mUserSettings->setValue( prefixedKey( key, section ), value );
   }
-  else if ( mGlobalSettings->value( prefixedKey( key, section ) ) == currentValue )
+  else if ( mGlobalSettings && mGlobalSettings->value( prefixedKey( key, section ) ) == currentValue )
   {
     mUserSettings->remove( prefixedKey( key, section ) );
   }

--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -283,8 +283,8 @@ void QgsSettings::setValue( const QString &key, const QVariant &value, const Qgs
   // TODO: add valueChanged signal
   // Do not store if it hasn't changed from default value
   // Fist check if the values are different and if at least one of them is valid.
-  // The valid check is required because different invalid QVariant flavours
-  // like QVariant(QVariant::String) and QVariant(QVariant::Int ))
+  // The valid check is required because different invalid QVariant types
+  // like QVariant(QVariant::String) and QVariant(QVariant::Int))
   // may be considered different and we don't want to store the value in that case.
   QVariant currentValue { QgsSettings::value( prefixedKey( key, section ) ) };
   if ( ( currentValue.isValid() || value.isValid() ) && ( currentValue != value ) )

--- a/src/core/qgssettings.cpp
+++ b/src/core/qgssettings.cpp
@@ -282,7 +282,7 @@ void QgsSettings::setValue( const QString &key, const QVariant &value, const Qgs
 {
   // TODO: add valueChanged signal
   // Do not store if it hasn't changed from default value
-  // Fist check if the values are different and if at least one of them is valid.
+  // First check if the values are different and if at least one of them is valid.
   // The valid check is required because different invalid QVariant types
   // like QVariant(QVariant::String) and QVariant(QVariant::Int))
   // may be considered different and we don't want to store the value in that case.


### PR DESCRIPTION
The new behavior is to store a value in user's QSettings
(that overrides the global settings) only if the the value
has changed from the default reported by QgsSettings.

If a value was changed and it is changed back to the default
the override must be removed from the user settings.

The rationale is that global settings should be the ultimate
source of default values, unless the user overrides the
default with a different value.

Fixes #21049
