### PR TITLE
[quick] Fix map canvas rendering DPI

### DIFF
--- a/src/quickgui/qgsquickmapcanvasmap.cpp
+++ b/src/quickgui/qgsquickmapcanvasmap.cpp
@@ -193,7 +193,12 @@ void QgsQuickMapCanvasMap::onWindowChanged( QQuickWindow *window )
 void QgsQuickMapCanvasMap::onScreenChanged( QScreen *screen )
 {
   if ( screen )
-    mMapSettings->setOutputDpi( screen->physicalDotsPerInch() );
+  {
+    // QgsMapSettings by default uses DPI from qt_defaultDpiX()
+    // which outputs qRound(QGuiApplication::primaryScreen()->logicalDotsPerInchX())
+    // (see implementation in qtbase/src/gui/text/qfont.cpp)
+    mMapSettings->setOutputDpi( std::round( screen->logicalDotsPerInchX() ) );
+  }
 }
 
 void QgsQuickMapCanvasMap::onExtentChanged()


### PR DESCRIPTION
I have realized that rendered map looks different on my laptop screen when it is in QgsMapCanvas or within QgsQuick.MapCanvas. The reason was that they use different output DPIs... QgsMapCanvas uses logical DPI of the screen while QgsQuick.MapCanvas uses physical DPI which are different on my screen (logical = 192 / physical = 277).

I am not really 100% sure which one is the right one here:
- physical is the true DPI of the screen
- logical is configurable and the one used to convert font point sizes to pixel (and QImage instances get this DPI assigned by default)

Since we have been using logical DPI in QgsMapCanvas for a long time, it makes sense to me to use it as the reference.
