### PR TITLE
Add new plugin metadata and hooks for starting only Processing component of plugins

### DIFF
--- a/python/plugins/processing/metadata.txt
+++ b/python/plugins/processing/metadata.txt
@@ -14,3 +14,5 @@ icon=:/images/themes/default/processingAlgorithm.svg
 homepage=http://qgis.org
 tracker=https://issues.qgis.org/projects/qgis/issues
 repository=https://github.com/qgis/QGIS
+
+hasProcessingProvider=yes

--- a/src/python/qgspythonutils.h
+++ b/src/python/qgspythonutils.h
@@ -162,6 +162,16 @@ class PYTHON_EXPORT QgsPythonUtils
     virtual bool startPlugin( const QString &packageName ) = 0;
 
     /**
+     * Start a Processing plugin
+     *
+     * This command adds a plugin to active plugins and calls initProcessing(),
+     * initializing only Processing related components of that plugin.
+     *
+     * \since QGIS 3.8
+     */
+    virtual bool startProcessingPlugin( const QString &packageName ) = 0;
+
+    /**
      * Helper function to return some information about a plugin.
      *
      * \param function metadata component to return. Must match one of the strings: name, type, version, or description.

--- a/src/python/qgspythonutils.h
+++ b/src/python/qgspythonutils.h
@@ -167,6 +167,7 @@ class PYTHON_EXPORT QgsPythonUtils
      * This command adds a plugin to active plugins and calls initProcessing(),
      * initializing only Processing related components of that plugin.
      *
+     * \see pluginHasProcessingProvider()
      * \since QGIS 3.8
      */
     virtual bool startProcessingPlugin( const QString &packageName ) = 0;
@@ -174,9 +175,19 @@ class PYTHON_EXPORT QgsPythonUtils
     /**
      * Helper function to return some information about a plugin.
      *
-     * \param function metadata component to return. Must match one of the strings: name, type, version, or description.
+     * \param function metadata component to return. Must match one of the strings: name, type, version, description, hasProcessingProvider.
      */
     virtual QString getPluginMetadata( const QString &pluginName, const QString &function ) = 0;
+
+    /**
+     * Returns TRUE if a plugin implements a Processing provider.
+     *
+     * This is determined by checking the plugin metadata for the "hasProcessingProvider=yes" line.
+     *
+     * \see startProcessingPlugin()
+     * \since QGIS 3.8
+     */
+    virtual bool pluginHasProcessingProvider( const QString &pluginName ) = 0;
 
     /**
      * Confirms that the plugin can be uninstalled.

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -623,6 +623,13 @@ bool QgsPythonUtilsImpl::startPlugin( const QString &packageName )
   return ( output == QLatin1String( "True" ) );
 }
 
+bool QgsPythonUtilsImpl::startProcessingPlugin( const QString &packageName )
+{
+  QString output;
+  evalString( "qgis.utils.startProcessingPlugin('" + packageName + "')", output );
+  return ( output == QLatin1String( "True" ) );
+}
+
 bool QgsPythonUtilsImpl::canUninstallPlugin( const QString &packageName )
 {
   QString output;

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -140,9 +140,9 @@ bool QgsPythonUtilsImpl::checkSystemImports()
   }
 
   // tell the utils script where to look for the plugins
-  runString( "qgis.utils.plugin_paths = [" + pluginpaths.join( QStringLiteral( "," ) ) + ']' );
-  runString( "qgis.utils.sys_plugin_path = \"" + pluginsPath() + '\"' );
-  runString( "qgis.utils.home_plugin_path = " + homePluginsPath() );
+  runString( QStringLiteral( "qgis.utils.plugin_paths = [%1]" ).arg( pluginpaths.join( ',' ) ) );
+  runString( QStringLiteral( "qgis.utils.sys_plugin_path = \"%1\"" ).arg( pluginsPath() ) );
+  runString( QStringLiteral( "qgis.utils.home_plugin_path = %1" ).arg( homePluginsPath() ) ); // note - homePluginsPath() returns a python expression, not a string literal
 
 #ifdef Q_OS_WIN
   runString( "if oldhome: os.environ['HOME']=oldhome\n" );
@@ -260,7 +260,7 @@ void QgsPythonUtilsImpl::initServerPython( QgsServerInterface *interface )
 bool QgsPythonUtilsImpl::startServerPlugin( QString packageName )
 {
   QString output;
-  evalString( "qgis.utils.startServerPlugin('" + packageName + "')", output );
+  evalString( QStringLiteral( "qgis.utils.startServerPlugin('%1')" ).arg( packageName ), output );
   return ( output == QLatin1String( "True" ) );
 }
 
@@ -545,14 +545,14 @@ bool QgsPythonUtilsImpl::evalString( const QString &command, QString &result )
 QString QgsPythonUtilsImpl::pythonPath() const
 {
   if ( QgsApplication::isRunningFromBuildDir() )
-    return QgsApplication::buildOutputPath() + "/python";
+    return QgsApplication::buildOutputPath() + QStringLiteral( "/python" );
   else
-    return QgsApplication::pkgDataPath() + "/python";
+    return QgsApplication::pkgDataPath() + QStringLiteral( "/python" );
 }
 
 QString QgsPythonUtilsImpl::pluginsPath() const
 {
-  return pythonPath() + "/plugins";
+  return pythonPath() + QStringLiteral( "/plugins" );
 }
 
 QString QgsPythonUtilsImpl::homePythonPath() const
@@ -564,13 +564,13 @@ QString QgsPythonUtilsImpl::homePythonPath() const
   }
   else
   {
-    return "\"" + settingsDir.replace( '\\', QLatin1String( "\\\\" ) ) + "python\"";
+    return QStringLiteral( "\"" ) + settingsDir.replace( '\\', QLatin1String( "\\\\" ) ) + QStringLiteral( "python\"" );
   }
 }
 
 QString QgsPythonUtilsImpl::homePluginsPath() const
 {
-  return homePythonPath() + " + \"/plugins\"";
+  return homePythonPath() + QStringLiteral( " + \"/plugins\"" );
 }
 
 QStringList QgsPythonUtilsImpl::extraPluginsPaths() const
@@ -603,7 +603,7 @@ QStringList QgsPythonUtilsImpl::pluginList()
 QString QgsPythonUtilsImpl::getPluginMetadata( const QString &pluginName, const QString &function )
 {
   QString res;
-  QString str = "qgis.utils.pluginMetadata('" + pluginName + "', '" + function + "')";
+  QString str = QStringLiteral( "qgis.utils.pluginMetadata('%1', '%2')" ).arg( pluginName, function );
   evalString( str, res );
   //QgsDebugMsg("metadata "+pluginName+" - '"+function+"' = "+res);
   return res;
@@ -617,47 +617,47 @@ bool QgsPythonUtilsImpl::pluginHasProcessingProvider( const QString &pluginName 
 bool QgsPythonUtilsImpl::loadPlugin( const QString &packageName )
 {
   QString output;
-  evalString( "qgis.utils.loadPlugin('" + packageName + "')", output );
+  evalString( QStringLiteral( "qgis.utils.loadPlugin('%1')" ).arg( packageName ), output );
   return ( output == QLatin1String( "True" ) );
 }
 
 bool QgsPythonUtilsImpl::startPlugin( const QString &packageName )
 {
   QString output;
-  evalString( "qgis.utils.startPlugin('" + packageName + "')", output );
+  evalString( QStringLiteral( "qgis.utils.startPlugin('%1')" ).arg( packageName ), output );
   return ( output == QLatin1String( "True" ) );
 }
 
 bool QgsPythonUtilsImpl::startProcessingPlugin( const QString &packageName )
 {
   QString output;
-  evalString( "qgis.utils.startProcessingPlugin('" + packageName + "')", output );
+  evalString( QStringLiteral( "qgis.utils.startProcessingPlugin('%1')" ).arg( packageName ), output );
   return ( output == QLatin1String( "True" ) );
 }
 
 bool QgsPythonUtilsImpl::canUninstallPlugin( const QString &packageName )
 {
   QString output;
-  evalString( "qgis.utils.canUninstallPlugin('" + packageName + "')", output );
+  evalString( QStringLiteral( "qgis.utils.canUninstallPlugin('%1')" ).arg( packageName ), output );
   return ( output == QLatin1String( "True" ) );
 }
 
 bool QgsPythonUtilsImpl::unloadPlugin( const QString &packageName )
 {
   QString output;
-  evalString( "qgis.utils.unloadPlugin('" + packageName + "')", output );
+  evalString( QStringLiteral( "qgis.utils.unloadPlugin('%1')" ).arg( packageName ), output );
   return ( output == QLatin1String( "True" ) );
 }
 
 bool QgsPythonUtilsImpl::isPluginEnabled( const QString &packageName ) const
 {
-  return QgsSettings().value( "/PythonPlugins/" + packageName, QVariant( false ) ).toBool();
+  return QgsSettings().value( QStringLiteral( "/PythonPlugins/" ) + packageName, QVariant( false ) ).toBool();
 }
 
 bool QgsPythonUtilsImpl::isPluginLoaded( const QString &packageName )
 {
   QString output;
-  evalString( "qgis.utils.isPluginLoaded('" + packageName + "')", output );
+  evalString( QStringLiteral( "qgis.utils.isPluginLoaded('%1')" ).arg( packageName ), output );
   return ( output == QLatin1String( "True" ) );
 }
 

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -609,6 +609,11 @@ QString QgsPythonUtilsImpl::getPluginMetadata( const QString &pluginName, const 
   return res;
 }
 
+bool QgsPythonUtilsImpl::pluginHasProcessingProvider( const QString &pluginName )
+{
+  return getPluginMetadata( pluginName, QStringLiteral( "hasProcessingProvider" ) ).compare( QLatin1String( "yes" ), Qt::CaseInsensitive ) == 0;
+}
+
 bool QgsPythonUtilsImpl::loadPlugin( const QString &packageName )
 {
   QString output;

--- a/src/python/qgspythonutilsimpl.h
+++ b/src/python/qgspythonutilsimpl.h
@@ -85,6 +85,7 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
     QStringList listActivePlugins() override;
     bool loadPlugin( const QString &packageName ) override;
     bool startPlugin( const QString &packageName ) override;
+    bool startProcessingPlugin( const QString &packageName ) override;
     QString getPluginMetadata( const QString &pluginName, const QString &function ) override;
     bool canUninstallPlugin( const QString &packageName ) override;
     bool unloadPlugin( const QString &packageName ) override;

--- a/src/python/qgspythonutilsimpl.h
+++ b/src/python/qgspythonutilsimpl.h
@@ -87,6 +87,7 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
     bool startPlugin( const QString &packageName ) override;
     bool startProcessingPlugin( const QString &packageName ) override;
     QString getPluginMetadata( const QString &pluginName, const QString &function ) override;
+    bool pluginHasProcessingProvider( const QString &pluginName ) override;
     bool canUninstallPlugin( const QString &packageName ) override;
     bool unloadPlugin( const QString &packageName ) override;
     bool isPluginEnabled( const QString &packageName ) const override;

--- a/tests/src/app/testqgisapppython.cpp
+++ b/tests/src/app/testqgisapppython.cpp
@@ -43,6 +43,7 @@ class TestQgisAppPython : public QObject
     void hasPython();
     void plugins();
     void pythonPlugin();
+    void pluginMetadata();
     void runString();
     void evalString();
 
@@ -103,6 +104,25 @@ void TestQgisAppPython::pythonPlugin()
   QVERIFY( mQgisApp->mPythonUtils->loadPlugin( QStringLiteral( "ProcessingPluginTest" ) ) );
   QVERIFY( mQgisApp->mPythonUtils->startProcessingPlugin( QStringLiteral( "ProcessingPluginTest" ) ) );
   QVERIFY( !mQgisApp->mPythonUtils->startProcessingPlugin( QStringLiteral( "PluginPathTest" ) ) );
+}
+
+void TestQgisAppPython::pluginMetadata()
+{
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "not a plugin" ), QStringLiteral( "name" ) ), QStringLiteral( "__error__" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "PluginPathTest" ), QStringLiteral( "invalid" ) ), QStringLiteral( "__error__" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "PluginPathTest" ), QStringLiteral( "name" ) ), QStringLiteral( "plugin path test" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "PluginPathTest" ), QStringLiteral( "qgisMinimumVersion" ) ), QStringLiteral( "2.0" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "PluginPathTest" ), QStringLiteral( "description" ) ), QStringLiteral( "desc" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "PluginPathTest" ), QStringLiteral( "version" ) ), QStringLiteral( "0.1" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "PluginPathTest" ), QStringLiteral( "author" ) ), QStringLiteral( "HM/Oslandia" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "PluginPathTest" ), QStringLiteral( "email" ) ), QStringLiteral( "hugo.mercier@oslandia.com" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "PluginPathTest" ), QStringLiteral( "hasProcessingProvider" ) ), QStringLiteral( "__error__" ) );
+  QVERIFY( !mQgisApp->mPythonUtils->pluginHasProcessingProvider( QStringLiteral( "x" ) ) );
+  QVERIFY( !mQgisApp->mPythonUtils->pluginHasProcessingProvider( QStringLiteral( "PluginPathTest" ) ) );
+
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "ProcessingPluginTest" ), QStringLiteral( "name" ) ), QStringLiteral( "processing plugin test" ) );
+  QCOMPARE( mQgisApp->mPythonUtils->getPluginMetadata( QStringLiteral( "ProcessingPluginTest" ), QStringLiteral( "hasProcessingProvider" ) ), QStringLiteral( "yes" ) );
+  QVERIFY( mQgisApp->mPythonUtils->pluginHasProcessingProvider( QStringLiteral( "ProcessingPluginTest" ) ) );
 }
 
 void TestQgisAppPython::runString()

--- a/tests/testdata/test_plugin_path/ProcessingPluginTest/__init__.py
+++ b/tests/testdata/test_plugin_path/ProcessingPluginTest/__init__.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    __init__.py
+    ---------------------
+    Date                 : July 2013
+    Copyright            : (C) 2013 by Hugo Mercier
+    Email                : hugo dot mercier at oslandia dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Hugo Mercier'
+__date__ = 'July 2013'
+__copyright__ = '(C) 2013, Hugo Mercier'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+import os
+
+
+class Test:
+
+    def __init__(self, iface):
+        pass
+
+    def initGui(self):
+        assert False
+
+    def initProcessing(self):
+        pass
+
+    def unload(self):
+        pass
+
+def classFactory(iface):
+    # load Test class from file Test
+    return Test(iface)

--- a/tests/testdata/test_plugin_path/ProcessingPluginTest/metadata.txt
+++ b/tests/testdata/test_plugin_path/ProcessingPluginTest/metadata.txt
@@ -1,0 +1,7 @@
+[general]
+name=plugin path test
+qgisMinimumVersion=2.0
+description=desc
+version=0.1
+author=HM/Oslandia
+email=hugo.mercier@oslandia.com

--- a/tests/testdata/test_plugin_path/ProcessingPluginTest/metadata.txt
+++ b/tests/testdata/test_plugin_path/ProcessingPluginTest/metadata.txt
@@ -1,7 +1,7 @@
 [general]
-name=plugin path test
-qgisMinimumVersion=2.0
+name=processing plugin test
+qgisMinimumVersion=3.8
 description=desc
 version=0.1
-author=HM/Oslandia
-email=hugo.mercier@oslandia.com
+author=matt cauthin
+hasProcessingProvider=yes


### PR DESCRIPTION
Allows for identification of plugins which implement Processing functionality (without having to load them first), and the new initProcessing() hook allows for plugins to load only their Processing functionality (without any GUI or iface dependant components)
