### PR TITLE
[processing] Some modeler UI tweaks

### DIFF
--- a/python/plugins/processing/modeler/ModelerArrowItem.py
+++ b/python/plugins/processing/modeler/ModelerArrowItem.py
@@ -68,6 +68,7 @@ class ModelerArrowItem(QGraphicsPathItem):
         self.endPoints = []
         self.setFlag(QGraphicsItem.ItemIsSelectable, False)
         self.myColor = QApplication.palette().color(QPalette.WindowText)
+        self.myColor.setAlpha(150)
         self.setPen(QPen(self.myColor, 1, Qt.SolidLine,
                          Qt.RoundCap, Qt.RoundJoin))
         self.setZValue(0)
@@ -125,10 +126,19 @@ class ModelerArrowItem(QGraphicsPathItem):
         self.setPath(path)
 
     def paint(self, painter, option, widget=None):
+        color = self.myColor
+
+        if self.startItem.isSelected() or self.endItem.isSelected():
+            color.setAlpha(220)
+        elif self.startItem.hover_over_item or self.endItem.hover_over_item:
+            color.setAlpha(150)
+        else:
+            color.setAlpha(80)
+
         myPen = self.pen()
-        myPen.setColor(self.myColor)
+        myPen.setColor(color)
         painter.setPen(myPen)
-        painter.setBrush(self.myColor)
+        painter.setBrush(color)
         painter.setRenderHint(QPainter.Antialiasing)
 
         for point in self.endPoints:

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -51,6 +51,7 @@ class ModelerGraphicItem(QGraphicsItem):
 
     def __init__(self, element, model, controls, scene=None):
         super(ModelerGraphicItem, self).__init__(None)
+        self.setAcceptHoverEvents(True)
         self.controls = controls
         self.model = model
         self.scene = scene
@@ -175,6 +176,18 @@ class ModelerGraphicItem(QGraphicsItem):
     def mouseDoubleClickEvent(self, event):
         self.editElement()
 
+    def hoverEnterEvent(self, event):
+        self.updateToolTip(event)
+
+    def hoverMoveEvent(self, event):
+        self.updateToolTip(event)
+
+    def updateToolTip(self, event):
+        if self.itemRect().contains(event.pos()):
+            self.setToolTip(self.text)
+        else:
+            self.setToolTip('')
+
     def contextMenuEvent(self, event):
         if isinstance(self.element, QgsProcessingModelOutput):
             return
@@ -291,11 +304,14 @@ class ModelerGraphicItem(QGraphicsItem):
             w = fm.width(text)
         return text
 
-    def paint(self, painter, option, widget=None):
-        rect = QRectF(-(ModelerGraphicItem.BOX_WIDTH + 2) / 2.0,
+    def itemRect(self):
+        return QRectF(-(ModelerGraphicItem.BOX_WIDTH + 2) / 2.0,
                       -(ModelerGraphicItem.BOX_HEIGHT + 2) / 2.0,
                       ModelerGraphicItem.BOX_WIDTH + 2,
                       ModelerGraphicItem.BOX_HEIGHT + 2)
+
+    def paint(self, painter, option, widget=None):
+        rect = self.itemRect()
 
         if isinstance(self.element, QgsProcessingModelParameter):
             color = QColor(238, 242, 131)

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -188,6 +188,7 @@ class ModelerGraphicItem(QGraphicsItem):
         if self.hover_over_item:
             self.hover_over_item = False
             self.update()
+            self.repaintArrows()
 
     def updateToolTip(self, event):
         prev_status = self.hover_over_item
@@ -199,6 +200,7 @@ class ModelerGraphicItem(QGraphicsItem):
             self.hover_over_item = False
         if self.hover_over_item != prev_status:
             self.update()
+            self.repaintArrows()
 
     def contextMenuEvent(self, event):
         if isinstance(self.element, QgsProcessingModelOutput):
@@ -427,6 +429,10 @@ class ModelerGraphicItem(QGraphicsItem):
         else:
             return QPointF(0, 0)
 
+    def repaintArrows(self):
+        for arrow in self.arrows:
+            arrow.update()
+
     def itemChange(self, change, value):
         if change == QGraphicsItem.ItemPositionHasChanged:
             for arrow in self.arrows:
@@ -440,8 +446,10 @@ class ModelerGraphicItem(QGraphicsItem):
                 self.model.parameterComponent(self.element.parameterName()).setPosition(self.pos())
             elif isinstance(self.element, QgsProcessingModelOutput):
                 self.model.childAlgorithm(self.element.childId()).modelOutput(self.element.name()).setPosition(self.pos())
+        elif change == QGraphicsItem.ItemSelectedChange:
+            self.repaintArrows()
 
-        return value
+        return super().itemChange(change, value)
 
     def polygon(self):
         font = QFont('Verdana', 8)

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -56,6 +56,7 @@ class ModelerGraphicItem(QGraphicsItem):
         self.model = model
         self.scene = scene
         self.element = element
+        self.hover_over_item = False
         if isinstance(element, QgsProcessingModelParameter):
             svg = QSvgRenderer(os.path.join(pluginPath, 'images', 'input.svg'))
             self.picture = QPicture()
@@ -182,11 +183,22 @@ class ModelerGraphicItem(QGraphicsItem):
     def hoverMoveEvent(self, event):
         self.updateToolTip(event)
 
+    def hoverLeaveEvent(self, event):
+        self.setToolTip('')
+        if self.hover_over_item:
+            self.hover_over_item = False
+            self.update()
+
     def updateToolTip(self, event):
+        prev_status = self.hover_over_item
         if self.itemRect().contains(event.pos()):
             self.setToolTip(self.text)
+            self.hover_over_item = True
         else:
             self.setToolTip('')
+            self.hover_over_item = False
+        if self.hover_over_item != prev_status:
+            self.update()
 
     def contextMenuEvent(self, event):
         if isinstance(self.element, QgsProcessingModelOutput):
@@ -328,6 +340,8 @@ class ModelerGraphicItem(QGraphicsItem):
         if self.isSelected():
             stroke = selected
             color = color.darker(110)
+        if self.hover_over_item:
+            color = color.darker(105)
         painter.setPen(QPen(stroke, 0))  # 0 width "cosmetic" pen
         painter.setBrush(QBrush(color, Qt.SolidPattern))
         painter.drawRect(rect)


### PR DESCRIPTION
Some tweaks to make working with complex models easier:
- show tooltips for components, helps with long component names
- prehighlight model components on hover
- draw arrows connected to selected/hovered components slightly darker