### PR TITLE
Silence annoying PyQt5.uic.loadUiType deprecation warnings

### DIFF
--- a/python/PyQt/PyQt5/uic/__init__.py
+++ b/python/PyQt/PyQt5/uic/__init__.py
@@ -31,7 +31,6 @@ from PyQt5.uic import *
 
 __PyQtLoadUiType = loadUiType
 
-
 def __loadUiType(*args, **kwargs):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/python/PyQt/PyQt5/uic/__init__.py
+++ b/python/PyQt/PyQt5/uic/__init__.py
@@ -31,9 +31,11 @@ from PyQt5.uic import *
 
 __PyQtLoadUiType = loadUiType
 
+
 def __loadUiType(*args, **kwargs):
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         return __PyQtLoadUiType(*args, **kwargs)
+
 
 loadUiType = __loadUiType

--- a/python/PyQt/PyQt5/uic/__init__.py
+++ b/python/PyQt/PyQt5/uic/__init__.py
@@ -23,7 +23,18 @@ __copyright__ = '(C) 2016, Jürgen E. Fischer'
 # This will get replaced with a git SHA1 when you do a git archive
 __revision__ = '$Format:%H$'
 
+import warnings
 from PyQt5.uic.Compiler import indenter, compiler
 from PyQt5.uic.objcreator import widgetPluginPath
 from PyQt5.uic import properties, uiparser, Compiler
 from PyQt5.uic import *
+
+__PyQtLoadUiType = loadUiType
+
+
+def __loadUiType(*args, **kwargs):
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        return __PyQtLoadUiType(*args, **kwargs)
+
+loadUiType = __loadUiType


### PR DESCRIPTION
These aren't our fault -- they come from the PyQt library itself,
so we may as well hide them and avoid the noise.
