### PR TITLE
Fix default setting for gauss parameter

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.neighbors.txt
+++ b/python/plugins/processing/algs/grass7/description/r.neighbors.txt
@@ -5,7 +5,7 @@ QgsProcessingParameterRasterLayer|input|Input raster layer|None|False
 QgsProcessingParameterRasterLayer|selection|Raster layer to select the cells which should be processed|None|True
 QgsProcessingParameterEnum|method|Neighborhood operation|average;median;mode;minimum;maximum;stddev;sum;variance;diversity;interspersion|False|0|True
 QgsProcessingParameterNumber|size|Neighborhood size|QgsProcessingParameterNumber.Integer|3|True|1|None
-QgsProcessingParameterNumber|gauss|Sigma (in cells) for Gaussian filter|QgsProcessingParameterNumber.Integer|0|True|0|None
+QgsProcessingParameterNumber|gauss|Sigma (in cells) for Gaussian filter|QgsProcessingParameterNumber.Integer|None|True|0|None
 QgsProcessingParameterString|quantile|Quantile to calculate for method=quantile|None|False|True
 QgsProcessingParameterBoolean|-c|Use circular neighborhood|False
 *QgsProcessingParameterBoolean|-a|Do not align output with the input|False


### PR DESCRIPTION
## Description
Fix default setting for gauss parameter which must be "none" rather than 0 (which leads to empty maps as gauss=0 is unhelpful)
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
