### PR TITLE
[geometry validation] Fix double delete and memory leak

### DIFF
--- a/src/app/qgsgeometryvalidationdock.cpp
+++ b/src/app/qgsgeometryvalidationdock.cpp
@@ -335,7 +335,7 @@ void QgsGeometryValidationDock::showHighlight( const QModelIndex &current )
 
     QPropertyAnimation *errorAnimation = new QPropertyAnimation( mErrorRubberband, "fillColor" );
     errorAnimation->setEasingCurve( QEasingCurve::OutQuad );
-    connect( errorAnimation, &QPropertyAnimation::finished, featureAnimation, &QPropertyAnimation::deleteLater );
+    connect( errorAnimation, &QPropertyAnimation::finished, errorAnimation, &QPropertyAnimation::deleteLater );
     connect( errorAnimation, &QPropertyAnimation::valueChanged, this, [this]
     {
       mErrorRubberband->update();


### PR DESCRIPTION
One item is never the deleted, the other one twice in some circumstances resulting in crashes.
