### PR TITLE
Some cleanup in QgsMessageBar

### DIFF
--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -133,15 +133,11 @@ void QgsMessageBar::popItem( QgsMessageBarItem *item )
 
   if ( item == mCurrentItem )
   {
-    if ( mCurrentItem )
-    {
-      QWidget *widget = mCurrentItem;
-      mLayout->removeWidget( widget );
-      mCurrentItem->hide();
-      disconnect( mCurrentItem, &QgsMessageBarItem::styleChanged, this, &QWidget::setStyleSheet );
-      mCurrentItem->deleteLater();
-      mCurrentItem = nullptr;
-    }
+    mLayout->removeWidget( mCurrentItem );
+    mCurrentItem->hide();
+    disconnect( mCurrentItem, &QgsMessageBarItem::styleChanged, this, &QWidget::setStyleSheet );
+    mCurrentItem->deleteLater();
+    mCurrentItem = nullptr;
 
     if ( !mItems.isEmpty() )
     {
@@ -171,7 +167,7 @@ bool QgsMessageBar::popWidget( QgsMessageBarItem *item )
     return true;
   }
 
-  Q_FOREACH ( QgsMessageBarItem *existingItem, mItems )
+  for ( QgsMessageBarItem *existingItem : qgis::as_const( mItems ) )
   {
     if ( existingItem == item )
     {


### PR DESCRIPTION
A bit of code simplification in QgsMessageBar, remove of an extra check (https://github.com/qgis/QGIS/compare/master...m-kuhn:messagebar-cleanup?expand=1#diff-f275bbab81d1fe6efefe1f50b9d67c6dR129 should already guarantee noone tries to blow things up) and a range-based-for-loop because why not.