### PR TITLE
[processing] Add acceptable string values to parameter metadata

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparametertype.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparametertype.sip.in
@@ -97,6 +97,22 @@ E.g. "str", ":py:class:`QgsVectorLayer`", ":py:class:`QgsMapLayer`", etc.
 These values should should match the Python types exactly
 (e.g. "str" not "string", "bool" not "boolean"). Extra explanatory help can
 be used (which must be translated), eg "str: as comma delimited list of numbers".
+
+.. seealso:: :py:func:`acceptedStringValues`
+%End
+
+    virtual QStringList acceptedStringValues() const;
+%Docstring
+Returns a descriptive list of the possible string values acceptable for the parameter.
+
+E.g. for a QgsProcessingParameterVectorLayer this may include "Path to a vector layer",
+for :py:class:`QgsProcessingParameterBoolean` "1 for true, 0 for false" etc.
+
+Extra explanatory help can be used (which must be translated), eg "a comma delimited list of numbers".
+
+.. seealso:: :py:func:`acceptedPythonTypes`
+
+.. versionadded:: 3.8
 %End
 };
 

--- a/src/core/processing/qgsprocessingparametertype.cpp
+++ b/src/core/processing/qgsprocessingparametertype.cpp
@@ -31,3 +31,8 @@ QStringList QgsProcessingParameterType::acceptedPythonTypes() const
 {
   return QStringList();
 }
+
+QStringList QgsProcessingParameterType::acceptedStringValues() const
+{
+  return QStringList();
+}

--- a/src/core/processing/qgsprocessingparametertype.h
+++ b/src/core/processing/qgsprocessingparametertype.h
@@ -116,8 +116,23 @@ class CORE_EXPORT QgsProcessingParameterType
      * These values should should match the Python types exactly
      * (e.g. "str" not "string", "bool" not "boolean"). Extra explanatory help can
      * be used (which must be translated), eg "str: as comma delimited list of numbers".
+     *
+     * \see acceptedStringValues()
      */
     virtual QStringList acceptedPythonTypes() const;
+
+    /**
+     * Returns a descriptive list of the possible string values acceptable for the parameter.
+     *
+     * E.g. for a QgsProcessingParameterVectorLayer this may include "Path to a vector layer",
+     * for QgsProcessingParameterBoolean "1 for true, 0 for false" etc.
+     *
+     * Extra explanatory help can be used (which must be translated), eg "a comma delimited list of numbers".
+     *
+     * \see acceptedPythonTypes()
+     * \since QGIS 3.8
+     */
+    virtual QStringList acceptedStringValues() const;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsProcessingParameterType::ParameterFlags )

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -72,6 +72,11 @@ class CORE_EXPORT QgsProcessingParameterTypeRasterLayer : public QgsProcessingPa
              << QStringLiteral( "QgsProperty" )
              << QStringLiteral( "QgsRasterLayer" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path to a raster layer" );
+    }
 };
 
 /**
@@ -119,6 +124,11 @@ class CORE_EXPORT QgsProcessingParameterTypeMeshLayer : public QgsProcessingPara
              << QObject::tr( "str: layer name" )
              << QObject::tr( "str: layer source" )
              << QStringLiteral( "QgsMeshLayer" );
+    }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path to a mesh layer" );
     }
 };
 
@@ -168,6 +178,11 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorLayer : public QgsProcessingPa
              << QObject::tr( "str: layer source" )
              << QStringLiteral( "QgsProperty" )
              << QStringLiteral( "QgsVectorLayer" );
+    }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path to a vector layer" );
     }
 };
 
@@ -220,6 +235,11 @@ class CORE_EXPORT QgsProcessingParameterTypeMapLayer : public QgsProcessingParam
              << QStringLiteral( "QgsRasterLayer" )
              << QStringLiteral( "QgsVectorLayer" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path to a vector, raster or mesh layer" );
+    }
 };
 
 /**
@@ -268,6 +288,12 @@ class CORE_EXPORT QgsProcessingParameterTypeBoolean : public QgsProcessingParame
              << QStringLiteral( "str" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "1 for true/yes" )
+             << QObject::tr( "0 for false/no" );
+    }
 };
 
 /**
@@ -313,6 +339,11 @@ class CORE_EXPORT QgsProcessingParameterTypeExpression : public QgsProcessingPar
     {
       return QStringList() << QStringLiteral( "str" )
              << QStringLiteral( "QgsProperty" );
+    }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "A valid QGIS expression string, e.g \"road_name\" = 'MAIN RD'" );
     }
 };
 
@@ -370,6 +401,14 @@ class CORE_EXPORT QgsProcessingParameterTypeCrs : public QgsProcessingParameterT
              << QObject::tr( "QgsProcessingFeatureSourceDefinition: CRS of source is used" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "CRS as an auth ID (e.g. 'EPSG:3111')" )
+             << QObject::tr( "CRS as a PROJ4 string (e.g. 'PROJ4:…')" )
+             << QObject::tr( "CRS as a WKT string (e.g. 'WKT:…')" )
+             << QObject::tr( "Path to a layer. The CRS of the layer is used." ) ;
+    }
 };
 
 /**
@@ -417,6 +456,11 @@ class CORE_EXPORT QgsProcessingParameterTypeRange : public QgsProcessingParamete
              << QObject::tr( "list[str]: list of strings representing floats" )
              << QObject::tr( "str: as two comma delimited floats, e.g. '1,10'" )
              << QStringLiteral( "QgsProperty" );
+    }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Two comma separated numeric values, e.g. '1,10'" );
     }
 };
 
@@ -466,6 +510,11 @@ class CORE_EXPORT QgsProcessingParameterTypePoint : public QgsProcessingParamete
              << QStringLiteral( "QgsProperty" )
              << QStringLiteral( "QgsReferencedPointXY" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Point coordinate as an 'x,y' string, e.g. '1.5,10.1'" );
+    }
 };
 
 /**
@@ -512,6 +561,12 @@ class CORE_EXPORT QgsProcessingParameterTypeEnum : public QgsProcessingParameter
       return QStringList() << QStringLiteral( "int" )
              << QObject::tr( "str: as string representation of int, e.g. '1'" )
              << QStringLiteral( "QgsProperty" );
+    }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Number of selected option, e.g. '1'" )
+             << QObject::tr( "Comma separated list of options, e.g. '1,3'" );
     }
 };
 
@@ -566,6 +621,12 @@ class CORE_EXPORT QgsProcessingParameterTypeExtent : public QgsProcessingParamet
              << QStringLiteral( "QgsRectangle" )
              << QStringLiteral( "QgsReferencedRectangle" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "A comma delimited string of x min, x max, y min, y max. E.g. '4,10,101,105'" )
+             << QObject::tr( "Path to a layer. The extent of the layer is used." ) ;
+    }
 };
 
 /**
@@ -613,6 +674,11 @@ class CORE_EXPORT QgsProcessingParameterTypeMatrix : public QgsProcessingParamet
              << QStringLiteral( "list" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "A comma delimited list of values" );
+    }
 };
 
 /**
@@ -659,6 +725,11 @@ class CORE_EXPORT QgsProcessingParameterTypeFile : public QgsProcessingParameter
       return QStringList() << QStringLiteral( "str" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path to a file" );
+    }
 };
 
 /**
@@ -704,6 +775,12 @@ class CORE_EXPORT QgsProcessingParameterTypeField : public QgsProcessingParamete
     {
       return QStringList() << QStringLiteral( "str" )
              << QStringLiteral( "QgsProperty" );
+    }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "The name of an existing field" )
+             << QObject::tr( "; delimited list of existing field names" );
     }
 };
 
@@ -760,6 +837,12 @@ class CORE_EXPORT QgsProcessingParameterTypeVectorDestination : public QgsProces
              << QStringLiteral( "QgsProperty" )
              << QStringLiteral( "QgsProcessingOutputLayerDefinition" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path for new vector layer" );
+    }
+
 };
 
 /**
@@ -814,6 +897,12 @@ class CORE_EXPORT QgsProcessingParameterTypeFileDestination : public QgsProcessi
       return QStringList() << QStringLiteral( "str" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path for new file" );
+    }
+
 };
 
 /**
@@ -869,6 +958,12 @@ class CORE_EXPORT QgsProcessingParameterTypeFolderDestination : public QgsProces
       return QStringList() << QStringLiteral( "str" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path for an existing or new folder" );
+    }
+
 };
 
 /**
@@ -924,6 +1019,12 @@ class CORE_EXPORT QgsProcessingParameterTypeRasterDestination : public QgsProces
              << QStringLiteral( "QgsProperty" )
              << QStringLiteral( "QgsProcessingOutputLayerDefinition" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path for new raster layer" );
+    }
+
 };
 
 /**
@@ -970,6 +1071,12 @@ class CORE_EXPORT QgsProcessingParameterTypeString : public QgsProcessingParamet
       return QStringList() << QStringLiteral( "str" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "String value" );
+    }
+
 };
 
 /**
@@ -1015,6 +1122,12 @@ class CORE_EXPORT QgsProcessingParameterTypeAuthConfig : public QgsProcessingPar
     {
       return QStringList() << QStringLiteral( "str" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "An existing QGIS authentication ID string" );
+    }
+
 };
 
 /**
@@ -1114,6 +1227,12 @@ class CORE_EXPORT QgsProcessingParameterTypeFeatureSource : public QgsProcessing
              << QStringLiteral( "QgsProperty" )
              << QStringLiteral( "QgsVectorLayer" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path to a vector layer" );
+    }
+
 };
 
 /**
@@ -1161,6 +1280,12 @@ class CORE_EXPORT QgsProcessingParameterTypeNumber : public QgsProcessingParamet
              << QStringLiteral( "float" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "A numeric value" );
+    }
+
 };
 
 /**
@@ -1209,6 +1334,12 @@ class CORE_EXPORT QgsProcessingParameterTypeDistance : public QgsProcessingParam
              << QStringLiteral( "QgsProperty" );
     }
 
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "A numeric value" );
+    }
+
+
 };
 
 /**
@@ -1255,6 +1386,12 @@ class CORE_EXPORT QgsProcessingParameterTypeBand : public QgsProcessingParameter
       return QStringList() << QStringLiteral( "int" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Integer value representing an existing raster band number" );
+    }
+
 
 };
 
@@ -1312,6 +1449,12 @@ class CORE_EXPORT QgsProcessingParameterTypeFeatureSink : public QgsProcessingPa
              << QStringLiteral( "QgsProcessingOutputLayerDefinition" )
              << QStringLiteral( "QgsProperty" );
     }
+
+    QStringList acceptedStringValues() const override
+    {
+      return QStringList() << QObject::tr( "Path for new vector layer" );
+    }
+
 
 };
 


### PR DESCRIPTION
Returns a descriptive list of the possible string values acceptable for the parameter metadata.

E.g. for a QgsProcessingParameterVectorLayer this may include "Path to a vector layer", for QgsProcessingParameterBoolean "1 for true, 0 for false" etc.
