### PR TITLE
Fix default setting for ew_step and ns_step parameter

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.resamp.bspline.txt
+++ b/python/plugins/processing/algs/grass7/description/r.resamp.bspline.txt
@@ -4,8 +4,8 @@ Raster (r.*)
 QgsProcessingParameterRasterLayer|input|Input raster layer|None|False
 QgsProcessingParameterRasterLayer|mask|Name of raster map to use for masking. Only cells that are not NULL and not zero are interpolated|None|True
 QgsProcessingParameterEnum|method|Sampling interpolation method|bilinear;bicubic|False|1|False
-QgsProcessingParameterNumber|ew_step|Length (float) of each spline step in the east-west direction|QgsProcessingParameterNumber.Double|1.5|True|0.0|None
-QgsProcessingParameterNumber|ns_step|Length (float) of each spline step in the north-south direction|QgsProcessingParameterNumber.Double|1.5|True|0.0|None
+QgsProcessingParameterNumber|ew_step|Length (float) of each spline step in the east-west direction|QgsProcessingParameterNumber.Double|None|True|0.0|None
+QgsProcessingParameterNumber|ns_step|Length (float) of each spline step in the north-south direction|QgsProcessingParameterNumber.Double|None|True|0.0|None
 QgsProcessingParameterNumber|lambda|Tykhonov regularization parameter (affects smoothing)|QgsProcessingParameterNumber.Double|0.01|True|0.0|None
 QgsProcessingParameterNumber|memory|Maximum memory to be used (in MB). Cache size for raster rows|QgsProcessingParameterNumber.Integer|300|True|10|None
 *QgsProcessingParameterBoolean|-n|Only interpolate null cells in input raster map|False|True


### PR DESCRIPTION
## Description
Fix default setting for ew_step and ns_step parameter which must be "none" rather than 1.5 (which leads to wrong default values in GRASS GIS)

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
