### PR TITLE
[asf] Fix parsing of polygons

### DIFF
--- a/src/providers/arcgisrest/qgsarcgisrestutils.h
+++ b/src/providers/arcgisrest/qgsarcgisrestutils.h
@@ -15,10 +15,23 @@
 #ifndef QGSARCGISRESTUTILS_H
 #define QGSARCGISRESTUTILS_H
 
-#include <QStringList>
-#include <QVariant>
 #include "qgswkbtypes.h"
 #include "qgsrectangle.h"
+#include "qgsmarkersymbollayer.h"
+#include "geometry/qgsabstractgeometry.h"
+#include "geometry/qgscircularstring.h"
+#include "geometry/qgscompoundcurve.h"
+#include "geometry/qgscurvepolygon.h"
+#include "geometry/qgsgeometryengine.h"
+#include "geometry/qgslinestring.h"
+#include "geometry/qgsmultipoint.h"
+#include "geometry/qgsmulticurve.h"
+#include "geometry/qgsmultisurface.h"
+#include "geometry/qgspolygon.h"
+#include "geometry/qgspoint.h"
+
+#include <QStringList>
+#include <QVariant>
 
 class QNetworkReply;
 class QgsNetworkAccessManager;
@@ -52,6 +65,15 @@ class QgsArcGisRestUtils
     static QByteArray queryService( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsStringMap &requestHeaders = QgsStringMap(), QgsFeedback *feedback = nullptr );
     static QVariantMap queryServiceJSON( const QUrl &url, const QString &authcfg, QString &errorTitle, QString &errorText, const QgsStringMap &requestHeaders = QgsStringMap(), QgsFeedback *feedback = nullptr );
 
+    static std::unique_ptr< QgsPoint > parsePoint( const QVariantList &coordList, QgsWkbTypes::Type pointType );
+    static std::unique_ptr< QgsCircularString > parseCircularString( const QVariantMap &curveData, QgsWkbTypes::Type pointType, const QgsPoint &startPoint );
+    static std::unique_ptr< QgsCompoundCurve > parseCompoundCurve( const QVariantList &curvesList, QgsWkbTypes::Type pointType );
+    static std::unique_ptr< QgsPoint > parseEsriGeometryPoint( const QVariantMap &geometryData, QgsWkbTypes::Type pointType );
+    static std::unique_ptr< QgsMultiPoint > parseEsriGeometryMultiPoint( const QVariantMap &geometryData, QgsWkbTypes::Type pointType );
+    static std::unique_ptr< QgsMultiCurve > parseEsriGeometryPolyline( const QVariantMap &geometryData, QgsWkbTypes::Type pointType );
+    static std::unique_ptr< QgsMultiSurface > parseEsriGeometryPolygon( const QVariantMap &geometryData, QgsWkbTypes::Type pointType );
+    static std::unique_ptr< QgsPolygon > parseEsriEnvelope( const QVariantMap &geometryData );
+
     static std::unique_ptr< QgsSymbol > parseEsriSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsLineSymbol > parseEsriLineSymbolJson( const QVariantMap &symbolData );
     static std::unique_ptr< QgsFillSymbol > parseEsriFillSymbolJson( const QVariantMap &symbolData );
@@ -65,6 +87,7 @@ class QgsArcGisRestUtils
     static QColor parseEsriColorJson( const QVariant &colorData );
     static Qt::PenStyle parseEsriLineStyle( const QString &style );
     static Qt::BrushStyle parseEsriFillStyle( const QString &style );
+    static QgsSimpleMarkerSymbolLayerBase::Shape parseEsriMarkerShape( const QString &style );
 
     static QDateTime parseDateTime( const QVariant &value );
 


### PR DESCRIPTION
## Description
The commit has a small message, but it's a pretty big deal.

Until now, the ASF provider was doing a very, very bad job at parsing polygons. The result was polygons failing to render altogether or randomly disappearing while panning / zooming around the canvas:
![peek 2019-03-03 16-55](https://user-images.githubusercontent.com/1728657/53728893-513dab00-3ea6-11e9-960f-e7e40f00309b.gif)

This PR fixes that. Thanks to @nyalldawson for having figured out how ESRI formats its multipolgyons.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
