### PR TITLE
Needs to snap point too when CadDockWidget is enabled. Fixes #18138

### DIFF
--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -555,6 +555,8 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
 
   mSnapMatch = context.snappingUtils->snapToMap( point );
 
+  mSnappedToVertex = mSnapMatch.hasVertex();
+
   // update the point list
   updateCurrentPoint( point );
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -555,8 +555,6 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
 
   mSnapMatch = context.snappingUtils->snapToMap( point );
 
-  mSnappedToVertex = mSnapMatch.hasVertex();
-
   // update the point list
   updateCurrentPoint( point );
 
@@ -1028,7 +1026,6 @@ void QgsAdvancedDigitizingDockWidget::clearPoints()
 {
   mCadPointList.clear();
   mSnappedSegment.clear();
-  mSnappedToVertex = false;
 
   updateCapacity();
 }

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -554,7 +554,17 @@ bool QgsAdvancedDigitizingDockWidget::applyConstraints( QgsMapMouseEvent *e )
   e->setMapPoint( point );
 
   mSnapMatch = context.snappingUtils->snapToMap( point );
-
+  /*
+   * Constraints are applied in 2D, they are always called when using the tool
+   * but they do not take into account if when you snap on a vertex it has
+   * a Z value.
+   * To get the value we use the snapPoint method. However, we only apply it
+   * when the snapped point corresponds to the constrained point.
+   */
+  if ( mSnapMatch.hasVertex() && ( point == mSnapMatch.point() ) )
+  {
+    e->snapPoint();
+  }
   // update the point list
   updateCurrentPoint( point );
 

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -316,7 +316,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
      * Is it snapped to a vertex
      */
-    inline bool snappedToVertex() const { return mSnappedToVertex; }
+    inline bool snappedToVertex() const { return ( mSnapMatch.isValid() && mSnapMatch.hasVertex() ); }
 
     /**
      * Snapped to a segment
@@ -484,7 +484,6 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     // point list and current snap point / segment
     QList<QgsPointXY> mCadPointList;
     QList<QgsPointXY> mSnappedSegment;
-    bool mSnappedToVertex = false;
 
     bool mSessionActive = false;
 

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -34,6 +34,11 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
   {
     mCadDockWidget->applyConstraints( e );  // updates event's map point
 
+    if ( mCadDockWidget->mapPointMatch().hasVertex() )
+    {
+      e->snapPoint();
+    }
+
     if ( mCadDockWidget->constructionMode() )
       return;  // decided to eat the event and not pass it to the map tool (construction mode)
   }
@@ -72,6 +77,11 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
       mCadDockWidget->addPoint( e->mapPoint() );
 
       mCadDockWidget->releaseLocks( false );
+
+      if ( mCadDockWidget->mapPointMatch().hasVertex() )
+      {
+        e->snapPoint();
+      }
 
       if ( mCadDockWidget->constructionMode() )
         return;  // decided to eat the event and not pass it to the map tool (construction mode)

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -34,11 +34,6 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent *e )
   {
     mCadDockWidget->applyConstraints( e );  // updates event's map point
 
-    if ( mCadDockWidget->mapPointMatch().hasVertex() )
-    {
-      e->snapPoint();
-    }
-
     if ( mCadDockWidget->constructionMode() )
       return;  // decided to eat the event and not pass it to the map tool (construction mode)
   }
@@ -77,11 +72,6 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent *e )
       mCadDockWidget->addPoint( e->mapPoint() );
 
       mCadDockWidget->releaseLocks( false );
-
-      if ( mCadDockWidget->mapPointMatch().hasVertex() )
-      {
-        e->snapPoint();
-      }
 
       if ( mCadDockWidget->constructionMode() )
         return;  // decided to eat the event and not pass it to the map tool (construction mode)


### PR DESCRIPTION
## Description
The PR corrects the Z support when the CadDock is activated. It only adds a test, which calls the snapPoint function if a snapped point is a vertex like when the CadDock is not enabled. 

This fixes the bug #18138

I also updated mSnappedToVertex which I thought was never modified in this case.

@wonder-sk @3nids is it ok for you ?

cc @ponceta @pblottiere 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
