### PR TITLE
[processing] By default, hide algorithms with known issues from toolbox

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingalgorithm.sip.in
@@ -45,6 +45,7 @@ Abstract base class for processing algorithms.
       FlagNoThreading,
       FlagDisplayNameIsLiteral,
       FlagSupportsInPlaceEdits,
+      FlagKnownIssues,
       FlagDeprecated,
     };
     typedef QFlags<QgsProcessingAlgorithm::Flag> Flags;

--- a/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingtoolboxmodel.sip.in
@@ -380,6 +380,7 @@ the results.
       FilterToolbox,
       FilterModeler,
       FilterInPlace,
+      FilterShowKnownIssues,
     };
     typedef QFlags<QgsProcessingToolboxProxyModel::Filter> Filters;
 

--- a/python/gui/auto_generated/processing/qgsprocessingtoolboxtreeview.sip.in
+++ b/python/gui/auto_generated/processing/qgsprocessingtoolboxtreeview.sip.in
@@ -71,8 +71,18 @@ if no algorithm is currently selected.
     void setFilters( QgsProcessingToolboxProxyModel::Filters filters );
 %Docstring
 Sets ``filters`` controlling the view's contents.
+
+.. seealso:: :py:func:`filters`
 %End
 
+    QgsProcessingToolboxProxyModel::Filters filters() const;
+%Docstring
+Returns the current filters controlling the view's contents.
+
+.. seealso:: :py:func:`setFilters`
+
+.. versionadded:: 3.8
+%End
 
     void setInPlaceLayer( QgsVectorLayer *layer );
 %Docstring

--- a/python/plugins/processing/algs/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithm.py
@@ -78,6 +78,7 @@ class SagaAlgorithm(SagaAlgorithmBase):
         self._group = ''
         self._groupId = ''
         self.params = []
+        self.known_issues = False
         self.defineCharacteristicsFromFile()
 
     def createInstance(self):
@@ -110,11 +111,15 @@ class SagaAlgorithm(SagaAlgorithmBase):
 
     def flags(self):
         # TODO - maybe it's safe to background thread this?
-        return super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+        f = super().flags() | QgsProcessingAlgorithm.FlagNoThreading
+        if self.known_issues:
+            f = f | QgsProcessingAlgorithm.FlagKnownIssues
+        return f
 
     def defineCharacteristicsFromFile(self):
         with open(self.description_file, encoding="utf-8") as lines:
             line = lines.readline().strip('\n').strip()
+
             self._name = line
             if '|' in self._name:
                 tokens = self._name.split('|')
@@ -134,6 +139,10 @@ class SagaAlgorithm(SagaAlgorithmBase):
             self._name = ''.join(c for c in self._name if c in validChars)
 
             line = lines.readline().strip('\n').strip()
+            if line == '##known_issues':
+                self.known_issues = True
+                line = lines.readline().strip('\n').strip()
+
             self.undecorated_group = line
             self._group = self.tr(decoratedGroupName(self.undecorated_group))
 

--- a/python/plugins/processing/algs/saga/description/Difference.txt
+++ b/python/plugins/processing/algs/saga/description/Difference.txt
@@ -1,4 +1,5 @@
 Difference
+##known_issues
 shapes_polygons
 QgsProcessingParameterFeatureSource|A|Layer A|2|None|False
 QgsProcessingParameterFeatureSource|B|Layer B|2|None|False

--- a/python/plugins/processing/algs/saga/description/SymmetricalDifference.txt
+++ b/python/plugins/processing/algs/saga/description/SymmetricalDifference.txt
@@ -1,4 +1,5 @@
 Symmetrical Difference
+##known_issues
 shapes_polygons
 QgsProcessingParameterFeatureSource|A|Layer A|2|None|False
 QgsProcessingParameterFeatureSource|B|Layer B|2|None|False

--- a/python/plugins/processing/core/ProcessingConfig.py
+++ b/python/plugins/processing/core/ProcessingConfig.py
@@ -59,6 +59,7 @@ class ProcessingConfig:
     SHOW_CRS_DEF = 'SHOW_CRS_DEF'
     WARN_UNMATCHING_CRS = 'WARN_UNMATCHING_CRS'
     SHOW_PROVIDERS_TOOLTIP = 'SHOW_PROVIDERS_TOOLTIP'
+    SHOW_ALGORITHMS_KNOWN_ISSUES = 'SHOW_ALGORITHMS_KNOWN_ISSUES'
 
     settings = {}
     settingIcons = {}
@@ -92,6 +93,10 @@ class ProcessingConfig:
             ProcessingConfig.tr('General'),
             ProcessingConfig.WARN_UNMATCHING_CRS,
             ProcessingConfig.tr("Warn before executing if parameter CRS's do not match"), True))
+        ProcessingConfig.addSetting(Setting(
+            ProcessingConfig.tr('General'),
+            ProcessingConfig.SHOW_ALGORITHMS_KNOWN_ISSUES,
+            ProcessingConfig.tr("Show algorithms with known issues"), False))
         ProcessingConfig.addSetting(Setting(
             ProcessingConfig.tr('General'),
             ProcessingConfig.RASTER_STYLE,

--- a/python/plugins/processing/gui/AlgorithmLocatorFilter.py
+++ b/python/plugins/processing/gui/AlgorithmLocatorFilter.py
@@ -40,6 +40,7 @@ from processing.gui.MessageDialog import MessageDialog
 from processing.gui.AlgorithmDialog import AlgorithmDialog
 from processing.gui.AlgorithmExecutor import execute_in_place
 from qgis.utils import iface
+from processing.core.ProcessingConfig import ProcessingConfig
 
 
 class AlgorithmLocatorFilter(QgsLocatorFilter):
@@ -70,6 +71,9 @@ class AlgorithmLocatorFilter(QgsLocatorFilter):
         # accessing the processing registry is not thread safe
         for a in QgsApplication.processingRegistry().algorithms():
             if a.flags() & QgsProcessingAlgorithm.FlagHideFromToolbox:
+                continue
+            if not ProcessingConfig.getSetting(ProcessingConfig.SHOW_ALGORITHMS_KNOWN_ISSUES) and \
+                    a.flags() & QgsProcessingAlgorithm.FlagKnownIssues:
                 continue
 
             if QgsLocatorFilter.stringMatches(a.displayName(), string) or [t for t in a.tags() if QgsLocatorFilter.stringMatches(t, string)] or \

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -99,6 +99,7 @@ from processing.modeler.ModelerUtils import ModelerUtils
 from processing.modeler.ModelerScene import ModelerScene
 from processing.modeler.ProjectProvider import PROJECT_PROVIDER_ID
 from processing.script.ScriptEditorDialog import ScriptEditorDialog
+from processing.core.ProcessingConfig import ProcessingConfig
 from qgis.utils import iface
 
 
@@ -439,7 +440,10 @@ class ModelerDialog(BASE, WIDGET):
         self.algorithmTree.setDragDropMode(QTreeWidget.DragOnly)
         self.algorithmTree.setDropIndicatorShown(True)
 
-        self.algorithmTree.setFilters(QgsProcessingToolboxProxyModel.FilterModeler)
+        filters = QgsProcessingToolboxProxyModel.Filters(QgsProcessingToolboxProxyModel.FilterModeler)
+        if ProcessingConfig.getSetting(ProcessingConfig.SHOW_ALGORITHMS_KNOWN_ISSUES):
+            filters |= QgsProcessingToolboxProxyModel.FilterShowKnownIssues
+        self.algorithmTree.setFilters(filters)
 
         if hasattr(self.searchBox, 'setPlaceholderText'):
             self.searchBox.setPlaceholderText(QCoreApplication.translate('ModelerDialog', 'Search…'))

--- a/src/core/processing/qgsprocessingalgorithm.h
+++ b/src/core/processing/qgsprocessingalgorithm.h
@@ -75,6 +75,7 @@ class CORE_EXPORT QgsProcessingAlgorithm
       FlagNoThreading = 1 << 6, //!< Algorithm is not thread safe and cannot be run in a background thread, e.g. for algorithms which manipulate the current project, layer selections, or with external dependencies which are not thread-safe.
       FlagDisplayNameIsLiteral = 1 << 7, //!< Algorithm's display name is a static literal string, and should not be translated or automatically formatted. For use with algorithms named after commands, e.g. GRASS 'v.in.ogr'.
       FlagSupportsInPlaceEdits = 1 << 8, //!< Algorithm supports in-place editing
+      FlagKnownIssues = 1 << 9, //!< Algorithm has known issues
       FlagDeprecated = FlagHideFromToolbox | FlagHideFromModeler, //!< Algorithm is deprecated
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/gui/processing/qgsprocessingtoolboxmodel.h
+++ b/src/gui/processing/qgsprocessingtoolboxmodel.h
@@ -425,6 +425,7 @@ class GUI_EXPORT QgsProcessingToolboxProxyModel: public QSortFilterProxyModel
       FilterToolbox = 1 << 1, //!< Filters out any algorithms and content which should not be shown in the toolbox
       FilterModeler = 1 << 2, //!< Filters out any algorithms and content which should not be shown in the modeler
       FilterInPlace = 1 << 3, //!< Only show algorithms which support in-place edits
+      FilterShowKnownIssues = 1 << 4, //!< Show algorithms with known issues (hidden by default)
     };
     Q_DECLARE_FLAGS( Filters, Filter )
     Q_FLAG( Filters )

--- a/src/gui/processing/qgsprocessingtoolboxtreeview.cpp
+++ b/src/gui/processing/qgsprocessingtoolboxtreeview.cpp
@@ -93,6 +93,11 @@ void QgsProcessingToolboxTreeView::setFilters( QgsProcessingToolboxProxyModel::F
   mModel->setFilters( filters );
 }
 
+QgsProcessingToolboxProxyModel::Filters QgsProcessingToolboxTreeView::filters() const
+{
+  return mModel->filters();
+}
+
 void QgsProcessingToolboxTreeView::setInPlaceLayer( QgsVectorLayer *layer )
 {
   mModel->setInPlaceLayer( layer );

--- a/src/gui/processing/qgsprocessingtoolboxtreeview.h
+++ b/src/gui/processing/qgsprocessingtoolboxtreeview.h
@@ -82,9 +82,16 @@ class GUI_EXPORT QgsProcessingToolboxTreeView : public QTreeView
 
     /**
      * Sets \a filters controlling the view's contents.
+     * \see filters()
      */
     void setFilters( QgsProcessingToolboxProxyModel::Filters filters );
 
+    /**
+     * Returns the current filters controlling the view's contents.
+     * \see setFilters()
+     * \since QGIS 3.8
+     */
+    QgsProcessingToolboxProxyModel::Filters filters() const;
 
     /**
      * Sets the vector \a layer for the in-place algorithms


### PR DESCRIPTION
And add a Processing setting to allow these to be shown. When shown, they are highlighted in red with a tooltip explaining that the algorithm has known issues.

To be used whenever an algorithm has serious known issues which make it dangerous to use, and where we CANNOT fix the underlying issues (e.g. due to issues in 3rd party dependencies)

Mark SAGA difference and symmetric difference as having known issues in SAGA LTR version.

![image](https://user-images.githubusercontent.com/1829991/53787058-4d269180-3f69-11e9-9e94-911a60a352be.png)

