### PR TITLE
Fixes intersection on (multi)linestring/polygon/curve Z, M and ZM

### DIFF
--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -23,7 +23,7 @@
 #include "qgslogger.h"
 #include "qgsrenderer.h"
 #include "qgsexpressioncontextutils.h"
-
+#include "qgslinestring.h"
 #include <spatialindex/SpatialIndex.h>
 
 #include <QLinkedListIterator>
@@ -332,196 +332,48 @@ static QgsPointLocator::MatchList _geometrySegmentsInRect( QgsGeometry *geom, co
   // we need iterator for segments...
 
   QgsPointLocator::MatchList lst;
-  QByteArray wkb( geom->asWkb() );
-  if ( wkb.isEmpty() )
+
+  // geom is converted to a MultiCurve
+  QgsGeometry straightGeom = geom->convertToType( QgsWkbTypes::LineGeometry, true );
+  // and convert to straight segemnt / converts curve to linestring
+  straightGeom.convertToStraightSegment();
+
+  // so, you must have multilinestring
+  //
+  // Special case: Intersections cannot be done on an empty linestring like
+  // QgsGeometry(QgsLineString()) or QgsGeometry::fromWkt("LINESTRING EMPTY")
+  if ( straightGeom.isEmpty() || ( ( straightGeom.type() != QgsWkbTypes::LineGeometry ) && ( !straightGeom.isMultipart() ) ) )
     return lst;
 
   _CohenSutherland cs( rect );
 
-  QgsConstWkbPtr wkbPtr( wkb );
-  wkbPtr.readHeader();
-
-  QgsWkbTypes::Type wkbType = geom->wkbType();
-
-  bool hasZValue = false;
-  switch ( wkbType )
+  int pointIndex = 0;
+  for ( auto part = straightGeom.const_parts_begin(); part != straightGeom.const_parts_end(); ++part )
   {
-    case QgsWkbTypes::Point25D:
-    case QgsWkbTypes::Point:
-    case QgsWkbTypes::MultiPoint25D:
-    case QgsWkbTypes::MultiPoint:
-    {
-      // Points have no lines
-      return lst;
-    }
+    // Checking for invalid linestrings
+    // A linestring should/(must?) have at least two points
+    if ( qgsgeometry_cast<QgsLineString *>( *part )->numPoints() < 2 )
+      continue;
 
-    case QgsWkbTypes::LineString25D:
-      hasZValue = true;
-      //intentional fall-through
-      FALLTHROUGH
-    case QgsWkbTypes::LineString:
+    QgsAbstractGeometry::vertex_iterator it = ( *part )->vertices_begin();
+    QgsPointXY prevPoint( *it );
+    it++;
+    while ( it != ( *part )->vertices_end() )
     {
-      int nPoints;
-      wkbPtr >> nPoints;
-
-      double prevx = 0.0, prevy = 0.0;
-      for ( int index = 0; index < nPoints; ++index )
+      QgsPointXY thisPoint( *it );
+      if ( cs.isSegmentInRect( prevPoint.x(), prevPoint.y(), thisPoint.x(), thisPoint.y() ) )
       {
-        double thisx = 0.0, thisy = 0.0;
-        wkbPtr >> thisx >> thisy;
-        if ( hasZValue )
-          wkbPtr += sizeof( double );
-
-        if ( index > 0 )
-        {
-          if ( cs.isSegmentInRect( prevx, prevy, thisx, thisy ) )
-          {
-            QgsPointXY edgePoints[2];
-            edgePoints[0].set( prevx, prevy );
-            edgePoints[1].set( thisx, thisy );
-            lst << QgsPointLocator::Match( QgsPointLocator::Edge, vl, fid, 0, QgsPointXY(), index - 1, edgePoints );
-          }
-        }
-
-        prevx = thisx;
-        prevy = thisy;
+        QgsPointXY edgePoints[2];
+        edgePoints[0] = prevPoint;
+        edgePoints[1] = thisPoint;
+        lst << QgsPointLocator::Match( QgsPointLocator::Edge, vl, fid, 0, QgsPointXY(), pointIndex - 1, edgePoints );
       }
-      break;
+      prevPoint = QgsPointXY( *it );
+      it++;
+      pointIndex += 1;
+
     }
-
-    case QgsWkbTypes::MultiLineString25D:
-      hasZValue = true;
-      //intentional fall-through
-      FALLTHROUGH
-    case QgsWkbTypes::MultiLineString:
-    {
-      int nLines;
-      wkbPtr >> nLines;
-      for ( int linenr = 0, pointIndex = 0; linenr < nLines; ++linenr )
-      {
-        wkbPtr.readHeader();
-        int nPoints;
-        wkbPtr >> nPoints;
-
-        double prevx = 0.0, prevy = 0.0;
-        for ( int pointnr = 0; pointnr < nPoints; ++pointnr )
-        {
-          double thisx = 0.0, thisy = 0.0;
-          wkbPtr >> thisx >> thisy;
-          if ( hasZValue )
-            wkbPtr += sizeof( double );
-
-          if ( pointnr > 0 )
-          {
-            if ( cs.isSegmentInRect( prevx, prevy, thisx, thisy ) )
-            {
-              QgsPointXY edgePoints[2];
-              edgePoints[0].set( prevx, prevy );
-              edgePoints[1].set( thisx, thisy );
-              lst << QgsPointLocator::Match( QgsPointLocator::Edge, vl, fid, 0, QgsPointXY(), pointIndex - 1, edgePoints );
-            }
-          }
-
-          prevx = thisx;
-          prevy = thisy;
-          ++pointIndex;
-        }
-      }
-      break;
-    }
-
-    case QgsWkbTypes::Polygon25D:
-      hasZValue = true;
-      //intentional fall-through
-      FALLTHROUGH
-    case QgsWkbTypes::Polygon:
-    {
-      int nRings;
-      wkbPtr >> nRings;
-
-      for ( int ringnr = 0, pointIndex = 0; ringnr < nRings; ++ringnr )//loop over rings
-      {
-        int nPoints;
-        wkbPtr >> nPoints;
-
-        double prevx = 0.0, prevy = 0.0;
-        for ( int pointnr = 0; pointnr < nPoints; ++pointnr )//loop over points in a ring
-        {
-          double thisx = 0.0, thisy = 0.0;
-          wkbPtr >> thisx >> thisy;
-          if ( hasZValue )
-            wkbPtr += sizeof( double );
-
-          if ( pointnr > 0 )
-          {
-            if ( cs.isSegmentInRect( prevx, prevy, thisx, thisy ) )
-            {
-              QgsPointXY edgePoints[2];
-              edgePoints[0].set( prevx, prevy );
-              edgePoints[1].set( thisx, thisy );
-              lst << QgsPointLocator::Match( QgsPointLocator::Edge, vl, fid, 0, QgsPointXY(), pointIndex - 1, edgePoints );
-            }
-          }
-
-          prevx = thisx;
-          prevy = thisy;
-          ++pointIndex;
-        }
-      }
-      break;
-    }
-
-    case QgsWkbTypes::MultiPolygon25D:
-      hasZValue = true;
-      //intentional fall-through
-      FALLTHROUGH
-    case QgsWkbTypes::MultiPolygon:
-    {
-      int nPolygons;
-      wkbPtr >> nPolygons;
-      for ( int polynr = 0, pointIndex = 0; polynr < nPolygons; ++polynr )
-      {
-        wkbPtr.readHeader();
-        int nRings;
-        wkbPtr >> nRings;
-        for ( int ringnr = 0; ringnr < nRings; ++ringnr )
-        {
-          int nPoints;
-          wkbPtr >> nPoints;
-
-          double prevx = 0.0, prevy = 0.0;
-          for ( int pointnr = 0; pointnr < nPoints; ++pointnr )
-          {
-            double thisx = 0.0, thisy = 0.0;
-            wkbPtr >> thisx >> thisy;
-            if ( hasZValue )
-              wkbPtr += sizeof( double );
-
-            if ( pointnr > 0 )
-            {
-              if ( cs.isSegmentInRect( prevx, prevy, thisx, thisy ) )
-              {
-                QgsPointXY edgePoints[2];
-                edgePoints[0].set( prevx, prevy );
-                edgePoints[1].set( thisx, thisy );
-                lst << QgsPointLocator::Match( QgsPointLocator::Edge, vl, fid, 0, QgsPointXY(), pointIndex - 1, edgePoints );
-              }
-            }
-
-            prevx = thisx;
-            prevy = thisy;
-            ++pointIndex;
-          }
-        }
-      }
-      break;
-    }
-
-    case QgsWkbTypes::Unknown:
-    default:
-      return lst;
-  } // switch (wkbType)
-
+  }
   return lst;
 }
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -811,9 +811,8 @@ QgsPoint QgsMapToolCapture::mapPoint( const QgsMapMouseEvent &e ) const
     if ( e.isSnapped() )
     {
       const QgsPointLocator::Match match = e.mapPointMatch();
-      const QgsWkbTypes::Type snappedType = match.layer()->wkbType();
 
-      if ( QgsWkbTypes::hasZ( snappedType ) )
+      if ( match.layer() && QgsWkbTypes::hasZ( match.layer()->wkbType() ) )
       {
         const QgsFeature ft = match.layer()->getFeature( match.featureId() );
         newPoint.setZ( ft.geometry().vertexAt( match.vertexIndex() ).z() );


### PR DESCRIPTION
… ZM. Fixes #21422

## Description
Snapping on intersections doesn't work on (multi) linestrings or (multi) polygons Z, M or ZM. 

It should be noted that the returned intersection point is the point of the lines projected in 2D. For example, 3D lines that are not on the same plane and cannot intersect will still return a 2D intersection point with the default Z value determined in the preferences.
Ex:
`LineStringZ (2749170 1265190 34, 2749175 1265195 34)`
 intersecting 
`LineStringZ (2749172 1265194 21, 2749175 1265190 21)`
 with Z = 1234 in default will give 
`PointZ (2749172.85714285727590322 1265192.85714285704307258 1234)`

Bug with 3.6 (and before)
![qgis_3 6](https://user-images.githubusercontent.com/7521540/54116118-5cd12a80-43ee-11e9-84b0-64baff13e136.gif)

Fixed by this PR (The little display delay is caused by X11 ssh connection on my dev machine)
![qgis_master](https://user-images.githubusercontent.com/7521540/54116119-5cd12a80-43ee-11e9-8154-5cf96cc27adb.gif)


@wonder-sk I'd like your review, please :)

@DelazJ I think that this kind of clarification should be indicated in the documentation.

cc @ponceta @pblottiere 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [X] Commit messages are descriptive and explain the rationale for changes
- [X] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [X] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [X] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [X] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
