### PR TITLE
[QgsQuick] Feature form improvements #2

### DIFF
--- a/src/quickgui/plugin/editor/qgsquickcheckbox.qml
+++ b/src/quickgui/plugin/editor/qgsquickcheckbox.qml
@@ -25,12 +25,13 @@ import QgsQuick 0.1 as QgsQuick
 Item {
   signal valueChanged( var value, bool isNull )
 
+  id: fieldItem
+  enabled: !readOnly
   height: childrenRect.height
   anchors {
     right: parent.right
     left: parent.left
   }
-  id: fieldItem
 
   CheckBox {
     property var currentValue: value

--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -28,6 +28,7 @@ Item {
     signal valueChanged(var value, bool isNull)
 
     id: fieldItem
+    enabled: !readOnly
     height: childrenRect.height
     anchors {
       left: parent.left

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -22,6 +22,7 @@ import QgsQuick 0.1 as QgsQuick
  * External Resource (Photo capture) for QGIS Attribute Form
  * Requires various global properties set to function, see qgsquickfeatureform Loader section
  * Do not use directly from Application QML
+ * The widget is interactive which allows interactions even in readOnly state (e.g showing preview), but no edit!
  */
 Item {
   signal valueChanged(var value, bool isNull)
@@ -32,6 +33,7 @@ Item {
   property real iconSize:  customStyle.height * 0.75
 
   id: fieldItem
+  enabled: true // its interactive widget
   height: image.hasValidSource? customStyle.height * 3 : customStyle.height
   anchors {
     left: parent.left
@@ -94,7 +96,7 @@ Item {
 
   Button {
     id: deleteButton
-    visible: enableChildren && image.hasValidSource
+    visible: !readOnly && image.hasValidSource
     width: fieldItem.iconSize
     height: width
     padding: 0
@@ -124,7 +126,7 @@ Item {
 
   Button {
     id: imageBrowserButton
-    visible: enableChildren
+    visible: !readOnly
     width: fieldItem.iconSize
     height: width
     padding: 0
@@ -154,7 +156,7 @@ Item {
 
   Button {
     id: button
-    visible: enableChildren
+    visible: !readOnly
     width: fieldItem.iconSize
     height: width
     padding: 0

--- a/src/quickgui/plugin/editor/qgsquickexternalresource.qml
+++ b/src/quickgui/plugin/editor/qgsquickexternalresource.qml
@@ -29,6 +29,7 @@ Item {
   property var image: image
   property var brokenImageSource: QgsQuick.Utils.getThemeIcon("ic_broken_image_black")
   property var notavailableImageSource: QgsQuick.Utils.getThemeIcon("ic_photo_notavailable_white")
+  property real iconSize:  customStyle.height * 0.75
 
   id: fieldItem
   height: image.hasValidSource? customStyle.height * 3 : customStyle.height
@@ -53,7 +54,7 @@ Item {
 
     id: image
     height: fieldItem.height
-    sourceSize.height: height
+    sourceSize.height: image.hasValidSource? customStyle.height * 3 : fieldItem.iconSize
     autoTransform: true
     fillMode: Image.PreserveAspectFit
     visible: hasValidSource
@@ -93,8 +94,8 @@ Item {
 
   Button {
     id: deleteButton
-    visible: fieldItem.enabled && image.hasValidSource
-    width: customStyle.height
+    visible: enableChildren && image.hasValidSource
+    width: fieldItem.iconSize
     height: width
     padding: 0
 
@@ -117,14 +118,14 @@ Item {
     ColorOverlay {
         anchors.fill: deleteIcon
         source: deleteIcon
-        color: customStyle.fontColor
+        color: customStyle.attentionColor
     }
   }
 
   Button {
     id: imageBrowserButton
-    visible: fieldItem.enabled
-    width: customStyle.height
+    visible: enableChildren
+    width: fieldItem.iconSize
     height: width
     padding: 0
 
@@ -153,8 +154,8 @@ Item {
 
   Button {
     id: button
-    visible: fieldItem.enabled
-    width: customStyle.height
+    visible: enableChildren
+    width: fieldItem.iconSize
     height: width
     padding: 0
 

--- a/src/quickgui/plugin/editor/qgsquicktextedit.qml
+++ b/src/quickgui/plugin/editor/qgsquicktextedit.qml
@@ -28,14 +28,13 @@ Item {
   signal valueChanged(var value, bool isNull)
 
   id: fieldItem
-
+  enabled: !readOnly
+  height: childrenRect.height
   anchors {
     left: parent.left
     right: parent.right
     rightMargin: 10 * QgsQuick.Utils.dp
   }
-
-  height: childrenRect.height
 
   TextField {
     id: textField

--- a/src/quickgui/plugin/editor/qgsquicktextedit.qml
+++ b/src/quickgui/plugin/editor/qgsquicktextedit.qml
@@ -92,6 +92,7 @@ Item {
 
     background: Rectangle {
         color: customStyle.backgroundColor
+        radius: customStyle.cornerRadius
     }
 
     onEditingFinished: {

--- a/src/quickgui/plugin/editor/qgsquickvaluemap.qml
+++ b/src/quickgui/plugin/editor/qgsquickvaluemap.qml
@@ -25,15 +25,15 @@ import QgsQuick 0.1 as QgsQuick
  */
 Item {
   signal valueChanged(var value, bool isNull)
-  id: fieldItem
 
+  id: fieldItem
+  enabled: !readOnly
+  height: customStyle.height
   anchors {
     left: parent.left
     right: parent.right
     rightMargin: 10 * QgsQuick.Utils.dp
   }
-
-  height: customStyle.height
 
   ComboBox {
     id: comboBox

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -339,9 +339,6 @@ Item {
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }
 
-          // always enable ExternalResource widget due to preview
-          enabled:EditorWidget === "ExternalResource" || (form.state !== "ReadOnly" && !!AttributeEditable)
-
           property var value: AttributeValue
           property var config: EditorWidgetConfig
           property var widget: EditorWidget
@@ -350,7 +347,7 @@ Item {
           property var homePath: form.project ? form.project.homePath : ""
           property var customStyle: form.style.fields
           property var externalResourceHandler: form.externalResourceHandler
-          property bool enableChildren: form.state !== "ReadOnly" && !!AttributeEditable
+          property bool readOnly: form.state == "ReadOnly" || !AttributeEditable
 
           active: widget !== 'Hidden'
 

--- a/src/quickgui/plugin/qgsquickfeatureform.qml
+++ b/src/quickgui/plugin/qgsquickfeatureform.qml
@@ -170,7 +170,7 @@ Item {
         left: parent.left
         right: parent.right
       }
-      height: tabRow.height
+      height: form.model.hasTabs ? tabRow.height : 0
 
       flickableDirection: Flickable.HorizontalFlick
       contentWidth: tabRow.width
@@ -339,7 +339,8 @@ Item {
           height: childrenRect.height
           anchors { left: parent.left; right: parent.right }
 
-          enabled: form.state !== "ReadOnly" && !!AttributeEditable
+          // always enable ExternalResource widget due to preview
+          enabled:EditorWidget === "ExternalResource" || (form.state !== "ReadOnly" && !!AttributeEditable)
 
           property var value: AttributeValue
           property var config: EditorWidgetConfig
@@ -349,6 +350,7 @@ Item {
           property var homePath: form.project ? form.project.homePath : ""
           property var customStyle: form.style.fields
           property var externalResourceHandler: form.externalResourceHandler
+          property bool enableChildren: form.state !== "ReadOnly" && !!AttributeEditable
 
           active: widget !== 'Hidden'
 

--- a/src/quickgui/plugin/qgsquickfeatureformstyling.qml
+++ b/src/quickgui/plugin/qgsquickfeatureformstyling.qml
@@ -50,6 +50,7 @@ QtObject {
       property color backgroundColor: "lightGray"
       property color backgroundColorInactive: "lightGray"
       property color activeColor: "#1B5E20"
+      property color attentionColor: "red"
       property color normalColor: "#4CAF50"
       property real height: 48 * QgsQuick.Utils.dp
       property real cornerRadius: 0 * QgsQuick.Utils.dp


### PR DESCRIPTION
TextEdit
 - added radius property

QgsQuickFeatureFormStyling and ExternalResource widget 
- added optional color for the trash icon

ExternalResource
- smaller icons
- preview available in read-only mode

FeatureForm
- fix of empty space for tabs which exists even if there are no tabs - Feature form had an empty space on top of it. The place is a placeholder for tabs, but its unused where a form is simple.