### PR TITLE
[plugin manager] Details view layout fixes

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -899,11 +899,14 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
   }
 
 #ifdef WITH_QTWEBKIT
-  html += QLatin1String( "<div id='stars_bg'/><div id='stars'/>" );
-  html += QLatin1String( "<div id='votes'>" );
-  html += votes;
-  html += QLatin1String( "</div>" );
-  html += QLatin1String( "<div><a id='send_vote_trigger'/></div>" );
+  if ( metadata->value( QStringLiteral( "readonly" ) ) == QLatin1String( "false" ) )
+  {
+    html += QLatin1String( "<div id='stars_bg'/><div id='stars'/>" );
+    html += QLatin1String( "<div id='votes'>" );
+    html += votes;
+    html += QLatin1String( "</div>" );
+    html += QLatin1String( "<div><a id='send_vote_trigger'/></div>" );
+  }
 #else
   voteRating->setText( votes );
 #endif
@@ -992,7 +995,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem *item )
     html += QStringLiteral( "<tr><td class='key'>%1 </td><td>%2</td></tr>" ).arg( tr( "Changelog" ), changelog );
   }
 
-  html += QLatin1String( "</td></tr></table>" );
+  html += QLatin1String( "</table>" );
 
   html += QLatin1String( "</body>" );
 


### PR DESCRIPTION
## Description
This was first intended to be a layout fix for the plugin manager's details view whereas some plugins have a long list of comma-separated tags without spaces, forcing an extra wide details view. While fixing this, I thought it'd be useful to add a bit of functionality to the tags list by allowing users - via hyperlink - to click on a tag to set the text filter to that tag.

Before vs. PR:
![image](https://user-images.githubusercontent.com/1728657/53856277-d7233880-4003-11e9-8e3b-23a511eb8c7c.png)



## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
