### PR TITLE
Fix makeFeatureCompatible wrong field count

### DIFF
--- a/python/core/auto_generated/qgsvectorlayerutils.sip.in
+++ b/python/core/auto_generated/qgsvectorlayerutils.sip.in
@@ -231,6 +231,7 @@ If the ``feature`` does not have a valid fields container set, then the feature'
 are simply truncated to match the number of fields present in ``fields`` (or if
 less attributes are present in ``feature`` than in ``fields``, the feature's attributes
 are padded with NULL values to match the required length).
+Finally, the feature's fields are set to ``fields``.
 
 .. versionadded:: 3.4
 %End

--- a/src/core/qgsvectorlayerutils.cpp
+++ b/src/core/qgsvectorlayerutils.cpp
@@ -673,6 +673,7 @@ void QgsVectorLayerUtils::matchAttributesToFields( QgsFeature &feature, const Qg
       feature.setAttributes( attributes );
     }
   }
+  feature.setFields( fields );
 }
 
 QgsFeatureList QgsVectorLayerUtils::makeFeatureCompatible( const QgsFeature &feature, const QgsVectorLayer *layer )

--- a/src/core/qgsvectorlayerutils.h
+++ b/src/core/qgsvectorlayerutils.h
@@ -237,6 +237,7 @@ class CORE_EXPORT QgsVectorLayerUtils
      * are simply truncated to match the number of fields present in \a fields (or if
      * less attributes are present in \a feature than in \a fields, the feature's attributes
      * are padded with NULL values to match the required length).
+     * Finally, the feature's fields are set to \a fields.
      *
      * \since QGIS 3.4
      */

--- a/tests/src/python/test_qgsprocessinginplace.py
+++ b/tests/src/python/test_qgsprocessinginplace.py
@@ -412,6 +412,26 @@ class TestQgsProcessingInPlace(unittest.TestCase):
         self.assertEqual(new_features[0].attributes()[0], 1)
         self.assertEqual(new_features[0].attributes()[1], 'foo')
 
+    def test_make_features_compatible_different_field_length(self):
+        """Test regression #21497"""
+        fields = QgsFields()
+        fields.append(QgsField('int_f1', QVariant.Int))
+        f1 = QgsFeature(fields)
+        f1.setAttributes([12345])
+        f1.setGeometry(QgsGeometry.fromWkt('Point(9 45)'))
+
+        fields = QgsFields()
+        fields.append(QgsField('int_f2', QVariant.Int))
+        fields.append(QgsField('int_f1', QVariant.Int))
+        vl2 = QgsMemoryProviderUtils.createMemoryLayer(
+            'mymultiplayer', fields, QgsWkbTypes.Point, QgsCoordinateReferenceSystem(4326))
+        new_features = QgsVectorLayerUtils.makeFeaturesCompatible([f1], vl2)
+        self.assertEqual(new_features[0].attributes(), [None, 12345])
+
+        f1.setGeometry(QgsGeometry.fromWkt('MultiPoint((9 45))'))
+        new_features = QgsVectorLayerUtils.makeFeaturesCompatible([f1], vl2)
+        self.assertEqual(new_features[0].attributes(), [None, 12345])
+
     def test_make_features_compatible_geometry(self):
         """Test corner cases for geometries"""
 

--- a/tests/src/python/test_qgsvectorlayerutils.py
+++ b/tests/src/python/test_qgsvectorlayerutils.py
@@ -552,10 +552,10 @@ class TestQgsVectorLayerUtils(unittest.TestCase):
         f1.setAttributes([1, 'foo', 'blah'])
         QgsVectorLayerUtils.matchAttributesToFields(f1, fields)
         self.assertEqual(len(f1.attributes()), 4)
-        self.assertEqual(f1.attributes()[0], 'foo')
-        self.assertEqual(f1.attributes()[1], 1)
-        self.assertEqual(f1.attributes()[2], QVariant())
-        self.assertEqual(f1.attributes()[3], 'blah')
+        self.assertEqual(f1.attributes()[0], 1)
+        self.assertEqual(f1.attributes()[1], 'foo')
+        self.assertEqual(f1.attributes()[2], 'blah')
+        self.assertEqual(f1.attributes()[3], QVariant())
 
         # case insensitive
         fields2.append(QgsField('extra3', QVariant.String))


### PR DESCRIPTION
Fixes #21497 - Copying features from source layer to target layer - field values are not copied

With test case