### PR TITLE
[Server] Add unit test for WFS GetFeature with BBOX param without EPSG

### DIFF
--- a/tests/src/python/test_qgsserver_wfs.py
+++ b/tests/src/python/test_qgsserver_wfs.py
@@ -374,6 +374,13 @@ class TestQgsServerWFS(QgsServerTestBase):
     def test_getFeatureBBOX(self):
         """Test with (1.1.0) and without (1.0.0) CRS"""
 
+        # Tests without CRS
+        self.wfs_request_compare(
+            "GetFeature", '1.0.0', "TYPENAME=testlayer&RESULTTYPE=hits&BBOX=8.20347,44.901471,8.2035354,44.901493", 'wfs_getFeature_1_0_0_bbox_1_feature')
+        self.wfs_request_compare(
+            "GetFeature", '1.0.0', "TYPENAME=testlayer&RESULTTYPE=hits&BBOX=8.203127,44.9012765,8.204138,44.901632", 'wfs_getFeature_1_0_0_bbox_3_feature')
+
+        # Tests with CRS
         self.wfs_request_compare(
             "GetFeature", '1.0.0', "SRSNAME=EPSG:4326&TYPENAME=testlayer&RESULTTYPE=hits&BBOX=8.20347,44.901471,8.2035354,44.901493,EPSG:4326", 'wfs_getFeature_1_0_0_epsgbbox_1_feature')
         self.wfs_request_compare(

--- a/tests/testdata/qgis_server/wfs_getFeature_1_0_0_bbox_1_feature_1_0_0.txt
+++ b/tests/testdata/qgis_server/wfs_getFeature_1_0_0_bbox_1_feature_1_0_0.txt
@@ -1,0 +1,6 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ale/dev/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SRSNAME=EPSG:4326&amp;RESULTTYPE=hits&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA"
+ timeStamp="2019-01-23T12:09:05"
+ numberOfFeatures="1">
+</wfs:FeatureCollection>

--- a/tests/testdata/qgis_server/wfs_getFeature_1_0_0_bbox_3_feature_1_0_0.txt
+++ b/tests/testdata/qgis_server/wfs_getFeature_1_0_0_bbox_3_feature_1_0_0.txt
@@ -1,0 +1,6 @@
+Content-Type: text/xml; subtype=gml/2.1.2; charset=utf-8
+
+<wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:qgs="http://www.qgis.org/gml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd http://www.qgis.org/gml ?MAP=/home/ale/dev/QGIS/tests/testdata/qgis_server/test_project_wfs.qgs&amp;SRSNAME=EPSG:4326&amp;RESULTTYPE=hits&amp;SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=testlayer&amp;OUTPUTFORMAT=XMLSCHEMA"
+ timeStamp="2019-01-23T12:09:05"
+ numberOfFeatures="3">
+</wfs:FeatureCollection>


### PR DESCRIPTION
## Description
Even if the description in the QGIS Server WFS unit test explain that WFS GetFeature BBOX param is tested with and without EPSG, there was no unit test for BBOX without EPSG.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
