### PR TITLE
Hide orange measure line and points while measure tool is inactive

### DIFF
--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -68,6 +68,8 @@ QVector<QgsPointXY> QgsMeasureTool::points() const
 void QgsMeasureTool::activate()
 {
   mDialog->show();
+  mRubberBand->show();
+  mRubberBandPoints->show();
   QgsMapTool::activate();
 
   // ensure that we have correct settings
@@ -98,6 +100,8 @@ void QgsMeasureTool::deactivate()
   mSnapIndicator->setMatch( QgsPointLocator::Match() );
 
   mDialog->hide();
+  mRubberBand->hide();
+  mRubberBandPoints->hide();
   QgsMapTool::deactivate();
 }
 


### PR DESCRIPTION
## Description
When selecting another tool while using the measure tool, the measure dialog disappeares but the orange rubberband lines and points stayed visible. They could only be removed by reselecting the measure tool and close the dialog, being confusing to the user.

This new code makes the rubberband hidden while not using the measure tool and shows it when reselecting the tool.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [v] Commit messages are descriptive and explain the rationale for changes
- [-] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [-] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [-] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [v] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [v] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [-] New unit tests have been added for core changes
- [v] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
