### PR TITLE
adding explanation and information icon

### DIFF
--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -76,7 +76,10 @@
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Display expression</string>
+      <string>Display expression Ⓘ</string>
+     </property>
+     <property name="tooltip">
+      <string>This setting is not saved in the style. It is changing the display name on the referenced layer.</string>
      </property>
     </widget>
    </item>

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -78,7 +78,7 @@
      <property name="text">
       <string>Display expression Ⓘ</string>
      </property>
-     <property name="tooltip">
+     <property name="toolTip">
       <string>This setting is not saved in the style. It is changing the display name on the referenced layer.</string>
      </property>
     </widget>


### PR DESCRIPTION
## Description
An information icon and a warning on saving the layer style has been added to make the process of saving the layer file more transparent and clear from the user perspective. It is preferable to let the user know that variation to the "display expression" are made on the referenced layer and not on the layer where the changes are made.
Hopefully the explanation above is clear.
