### PR TITLE
Better GRASS r.series description to help workaround a limitation of Processing

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.series.txt
+++ b/python/plugins/processing/algs/grass7/description/r.series.txt
@@ -1,5 +1,5 @@
 r.series
-Makes each output cell value a function of the values assigned to the corresponding cells in the input raster layers.
+Makes each output cell value a function of the values assigned to the corresponding cells in the input raster layers. Input rasters layers/bands must be separated in different data sources.
 Raster (r.*)
 QgsProcessingParameterMultipleLayers|input|Input raster layer(s)|3|None|False
 QgsProcessingParameterBoolean|-n|Propagate NULLs|False


### PR DESCRIPTION
## Description
In Processing the different bands of a raster layer cannot be used as different inputs (when the module uses the "select input raster layers" widget), so we improve the description stating that the inputs/bands must be in separate datasources.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] Did not drink while coding
