### PR TITLE
(re)add the alpha option for the GDAL color relief tool

### DIFF
--- a/python/plugins/processing/algs/gdal/ColorRelief.py
+++ b/python/plugins/processing/algs/gdal/ColorRelief.py
@@ -45,6 +45,7 @@ class ColorRelief(GdalAlgorithm):
     INPUT = 'INPUT'
     BAND = 'BAND'
     COMPUTE_EDGES = 'COMPUTE_EDGES'
+    ALPHA = 'ALPHA'
     COLOR_TABLE = 'COLOR_TABLE'
     MATCH_MODE = 'MATCH_MODE'
     OPTIONS = 'OPTIONS'
@@ -66,6 +67,9 @@ class ColorRelief(GdalAlgorithm):
                                                      parentLayerParameterName=self.INPUT))
         self.addParameter(QgsProcessingParameterBoolean(self.COMPUTE_EDGES,
                                                         self.tr('Compute edges'),
+                                                        defaultValue=False))
+        self.addParameter(QgsProcessingParameterBoolean(self.ALPHA,
+                                                        self.tr('Add an alpha channel to the output raster'),
                                                         defaultValue=False))
         self.addParameter(QgsProcessingParameterFile(self.COLOR_TABLE,
                                                      self.tr('Color configuration file')))
@@ -122,6 +126,9 @@ class ColorRelief(GdalAlgorithm):
 
         if self.parameterAsBool(parameters, self.COMPUTE_EDGES, context):
             arguments.append('-compute_edges')
+
+        if self.parameterAsBool(parameters, self.ALPHA, context):
+            arguments.append('-alpha')
 
         arguments.append(self.modes[self.parameterAsEnum(parameters, self.MATCH_MODE, context)][1])
 


### PR DESCRIPTION
## Description
This option was not ported when we got rid of the old GDAL tools core plugin.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
- [ ] Did not drink while coding
