### PR TITLE
[browser] Fix addition of PostGIS layers with unknown CRS

### DIFF
--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -516,7 +516,7 @@ QString QgsPGLayerItem::createUri()
 
   uri.setDataSource( mLayerProperty.schemaName, mLayerProperty.tableName, mLayerProperty.geometryColName, mLayerProperty.sql, cols.join( ',' ) );
   uri.setWkbType( mLayerProperty.types.at( 0 ) );
-  if ( uri.wkbType() != QgsWkbTypes::NoGeometry )
+  if ( uri.wkbType() != QgsWkbTypes::NoGeometry && mLayerProperty.srids.at( 0 ) != std::numeric_limits<int>::min() )
     uri.setSrid( QString::number( mLayerProperty.srids.at( 0 ) ) );
   QgsDebugMsg( QStringLiteral( "layer uri: %1" ).arg( uri.uri( false ) ) );
   return uri.uri( false );
@@ -750,7 +750,12 @@ QgsPGLayerItem *QgsPGSchemaItem::createLayer( QgsPostgresLayerProperty layerProp
     tip = tr( "Table" );
   }
   QgsWkbTypes::Type wkbType = layerProperty.types.at( 0 );
-  tip += tr( "\n%1 as %2 in %3" ).arg( layerProperty.geometryColName, QgsPostgresConn::displayStringForWkbType( wkbType ) ).arg( layerProperty.srids.at( 0 ) );
+  tip += tr( "\n%1 as %2" ).arg( layerProperty.geometryColName, QgsPostgresConn::displayStringForWkbType( wkbType ) );
+  if ( layerProperty.srids.at( 0 ) != std::numeric_limits<int>::min() )
+    tip += tr( " (srid %1)" ).arg( layerProperty.srids.at( 0 ) );
+  else
+    tip += tr( " (unknown srid)" );
+
   if ( !layerProperty.tableComment.isEmpty() )
   {
     tip = layerProperty.tableComment + '\n' + tip;


### PR DESCRIPTION
When a PostGIS table does not have CRS specified (srid == 0) then it was not possible to correctly load it from browser (but it worked from DB manager). The problem was that browser item used negative srid in layer URI, messing up everything.

Also fixed the display of srid in tooltip (it says "unknown" rather than showing -2147483648)
