### PR TITLE
[server] Fix error message reported when QUERY_LAYERS is missing

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1028,7 +1028,7 @@ namespace QgsWms
     if ( queryLayers.isEmpty() )
     {
       QString msg = QObject::tr( "QUERY_LAYERS parameter is required for GetFeatureInfo" );
-      throw QgsBadRequestException( QStringLiteral( "LayerNotQueryable" ), msg );
+      throw QgsBadRequestException( QStringLiteral( "LayerNotDefined" ), msg );
     }
 
     // The I/J parameters are Mandatory if they are not replaced by X/Y or FILTER or FILTER_GEOM


### PR DESCRIPTION
According to WMS 1.3.0 specs:

7.4.3.4
QUERY_LAYERS
The mandatory QUERY_LAYERS parameter states the map layer(s) from which feature information is desired to
be retrieved. Its value is a comma-separated list of one or more map layers. This parameter shall contain at least
one layer name, but may contain fewer layers than the original GetMap request.
If any layer in the QUERY_LAYERS parameter is not defined in the service metadata of the WMS, the server
shall issue a service exception (code = LayerNotDefined).
