### PR TITLE
replace some PyQt5 to qgis.PyQt

### DIFF
--- a/python/plugins/MetaSearch/util.py
+++ b/python/plugins/MetaSearch/util.py
@@ -24,7 +24,7 @@
 #
 ###############################################################################
 
-# avoid PendingDeprecationWarning from PyQt.uic
+# avoid PendingDeprecationWarning from qgis.PyQt.uic
 import warnings
 warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/python/plugins/MetaSearch/util.py
+++ b/python/plugins/MetaSearch/util.py
@@ -24,7 +24,7 @@
 #
 ###############################################################################
 
-# avoid PendingDeprecationWarning from PyQt4.uic
+# avoid PendingDeprecationWarning from PyQt.uic
 import warnings
 warnings.filterwarnings("ignore", category=PendingDeprecationWarning)
 warnings.filterwarnings("ignore", category=DeprecationWarning)

--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -36,7 +36,7 @@ from qgis.core import (
     QgsProcessingParameterType,
     NULL)
 
-from PyQt5.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication
 
 from processing.algs.qgis.QgisAlgorithm import QgisFeatureBasedAlgorithm
 

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -62,7 +62,7 @@ from qgis.core import (QgsRasterLayer,
                        QgsProcessingParameterFeatureSource,
                        QgsProcessingParameterNumber)
 
-from PyQt5.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication
 
 PARAMETER_NUMBER = 'number'
 PARAMETER_DISTANCE = 'distance'

--- a/python/plugins/processing/script/ScriptTemplate.py
+++ b/python/plugins/processing/script/ScriptTemplate.py
@@ -11,7 +11,7 @@
 ***************************************************************************
 """
 
-from PyQt5.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (QgsProcessing,
                        QgsFeatureSink,
                        QgsProcessingException,


### PR DESCRIPTION
I was using the script template and I noticed the `PyQt5` statement.