### PR TITLE
Revert "drinking" mention on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,3 @@ Include a few sentences describing the overall goals for this PR (pull request).
 - [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
 - [ ] New unit tests have been added for core changes
 - [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
-- [ ] Did not drink while coding


### PR DESCRIPTION
A new mention "did not drink during coding" has been recently added to QGIS PR template.

I understand that this has to be considered as a joke. Events like codesprint sometimes include good beer, and I guess this new mention was a kind of private joke with regard to a specific situation. 

Offering beer or alcoholic beverage _alongside_ tea, coffee, juices and other alcohol-free beverages is no particular problem.

Meanwhile, I really think we should avoid this kind of reference. IT in general and OpenSource in particular, especially during events, often promote a drinking culture. This is wrong on many aspects. Some cultures ( mainly non-occidental) totally reject alcohol consumption, and we should be respectful for it.

Having a mention referring to alcohol in our PR template is really contradictory to our goal of inclusion and diversity. We should stay vigilant not to propagate a drinking culture which is opposite to our core values. We want to facilitate onboarding to the project, and a PR is one of the important steps converting users to contributors. We should keep it inclusive.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit

