### PR TITLE
Add /usr/lib64/libQTSignal.so to RPM tracked files

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -296,6 +296,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %{_libdir}/lib%{name}_gui.so.*
 %{_libdir}/lib%{name}_3d.so.*
 %{_libdir}/%{name}/
+%{_libdir}/libQTSignal.so
 %{?_qt5_plugindir}/sqldrivers/libqsqlspatialite.so
 %{_bindir}/%{name}
 %{_mandir}/man1/%{name}.1*


### PR DESCRIPTION
## Description
Update the RPM specfile following the introduction of `libQTSignal` in https://github.com/qgis/QGIS/pull/9311

Fixes https://copr.fedorainfracloud.org/coprs/dani/qgis-testing/build/865140/

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
