### PR TITLE
Change allowEmptyName 'since' version to 3.4.6

### DIFF
--- a/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
+++ b/python/gui/auto_generated/qgsfieldexpressionwidget.sip.in
@@ -63,7 +63,7 @@ Sets whether an optional empty field ("not set") option is shown in the combo bo
 
 .. seealso:: :py:func:`allowEmptyFieldName`
 
-.. versionadded:: 3.6
+.. versionadded:: 3.4.6
 %End
 
     bool allowEmptyFieldName() const;
@@ -72,7 +72,7 @@ Returns ``True`` if the combo box allows the empty field ("not set") choice.
 
 .. seealso:: :py:func:`setAllowEmptyFieldName`
 
-.. versionadded:: 3.6
+.. versionadded:: 3.4.6
 %End
 
     void setLeftHandButtonStyle( bool isLeft );

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -79,14 +79,14 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     /**
      * Sets whether an optional empty field ("not set") option is shown in the combo box.
      * \see allowEmptyFieldName()
-     * \since QGIS 3.6
+     * \since QGIS 3.4.6
      */
     void setAllowEmptyFieldName( bool allowEmpty );
 
     /**
      * Returns TRUE if the combo box allows the empty field ("not set") choice.
      * \see setAllowEmptyFieldName()
-     * \since QGIS 3.6
+     * \since QGIS 3.4.6
      */
     bool allowEmptyFieldName() const;
 


### PR DESCRIPTION
## Description

Related to this backport #9229 : Since version should be 3.4.6 and not 3.6

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
