### PR TITLE
Disable freaking annoying constantly failing unit tests

### DIFF
--- a/.ci/travis/linux/scripts/test_blacklist.txt
+++ b/.ci/travis/linux/scripts/test_blacklist.txt
@@ -18,6 +18,8 @@ qgis_openstreetmaptest
 qgis_wcsprovidertest
 PyQgsWFSProviderGUI
 qgis_ziplayertest
+qgis_fieldcalculatortest
+qgis_attributetabletest
 
 # Flaky, see https://dash.orfeo-toolbox.org/testDetails.php?test=63061783&build=297405
 PyQgsSpatialiteProvider


### PR DESCRIPTION
These two tests are randomly failing SO OFTEN THAT IT MAKES QGIS DEVELOPMENT A FREAKING PITA.

Disable them until they learn to be good citizens again.