### PR TITLE
Datum transformation UX and fixes, pt 2

### DIFF
--- a/python/gui/auto_generated/qgsmapcanvas.sip.in
+++ b/python/gui/auto_generated/qgsmapcanvas.sip.in
@@ -776,7 +776,6 @@ called to read map canvas settings from project
 called to write map canvas settings to project
 %End
 
-
     void setMagnificationFactor( double factor );
 %Docstring
 Sets the factor of magnification to apply to the map canvas. Indeed, we

--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -40,6 +40,11 @@ connections-xyz\OpenStreetMap\username=
 connections-xyz\OpenStreetMap\zmax=19
 connections-xyz\OpenStreetMap\zmin=0
 
+# Whether to prompt users for a selection when multiple possible transformation paths exist
+# when transforming coordinates. If false, a reasonable choice will be estimated by default
+# without asking users. If true, users are always required to make this choice themselves.
+projections\promptWhenMultipleTransformsExist=false
+
 # application stylesheet
 
 # Padding (in pixels) to add to toolbar icons, if blank then default padding will be used

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7855,8 +7855,7 @@ QString QgisApp::saveAsVectorFileGeneral( QgsVectorLayer *vlayer, bool symbology
       //ask user about datum transformation
       QgsSettings settings;
       QgsDatumTransformDialog dlg( vlayer->crs(), destCRS );
-      if ( dlg.availableTransformationCount() > 1 &&
-           settings.value( QStringLiteral( "Projections/showDatumTransformDialog" ), false ).toBool() )
+      if ( dlg.shouldAskUserForSelection() )
       {
         dlg.exec();
       }
@@ -9912,6 +9911,7 @@ void QgisApp::projectCrsChanged()
   }
   else if ( transformsToAskFor.count() > 1 )
   {
+    // TODO - this should actually loop through and ask for each in turn
     bool ask = QgsSettings().value( QStringLiteral( "/Projections/showDatumTransformDialog" ), false ).toBool();
     if ( ask )
     {
@@ -9921,8 +9921,6 @@ void QgisApp::projectCrsChanged()
                                         5 );
     }
   }
-
-
 }
 
 // toggle overview status
@@ -13736,14 +13734,9 @@ bool QgisApp::askUserForDatumTransform( const QgsCoordinateReferenceSystem &sour
   {
     //if several possibilities:  present dialog
     QgsDatumTransformDialog dlg( sourceCrs, destinationCrs );
-    if ( dlg.availableTransformationCount() > 1 )
+    if ( dlg.shouldAskUserForSelection() )
     {
-      bool ask = QgsSettings().value( QStringLiteral( "/Projections/showDatumTransformDialog" ), false ).toBool();
-      if ( !ask )
-      {
-        ok = false;
-      }
-      else if ( dlg.exec() )
+      if ( dlg.exec() )
       {
         QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > dt = dlg.selectedDatumTransforms();
         QgsCoordinateTransformContext context = QgsProject::instance()->transformContext();

--- a/src/app/qgsdatumtransformtablewidget.cpp
+++ b/src/app/qgsdatumtransformtablewidget.cpp
@@ -197,7 +197,7 @@ QgsDatumTransformTableWidget::QgsDatumTransformTableWidget( QWidget *parent )
 
 void QgsDatumTransformTableWidget::addDatumTransform()
 {
-  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem(), true, false );
+  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem(), true, false, false );
   if ( dlg.exec() )
   {
     QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > dt = dlg.selectedDatumTransforms();
@@ -250,7 +250,7 @@ void QgsDatumTransformTableWidget::editDatumTransform()
     if ( sourceCrs.isValid() && destinationCrs.isValid() &&
          ( sourceTransform != -1 || destinationTransform != -1 ) )
     {
-      QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, false, qMakePair( sourceTransform, destinationTransform ) );
+      QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, false, false, qMakePair( sourceTransform, destinationTransform ) );
       if ( dlg.exec() )
       {
         QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > dt = dlg.selectedDatumTransforms();

--- a/src/app/qgsdatumtransformtablewidget.cpp
+++ b/src/app/qgsdatumtransformtablewidget.cpp
@@ -197,7 +197,7 @@ QgsDatumTransformTableWidget::QgsDatumTransformTableWidget( QWidget *parent )
 
 void QgsDatumTransformTableWidget::addDatumTransform()
 {
-  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem(), true );
+  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem(), true, false );
   if ( dlg.exec() )
   {
     QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > dt = dlg.selectedDatumTransforms();
@@ -250,7 +250,7 @@ void QgsDatumTransformTableWidget::editDatumTransform()
     if ( sourceCrs.isValid() && destinationCrs.isValid() &&
          ( sourceTransform != -1 || destinationTransform != -1 ) )
     {
-      QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, qMakePair( sourceTransform, destinationTransform ) );
+      QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, false, qMakePair( sourceTransform, destinationTransform ) );
       if ( dlg.exec() )
       {
         QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > dt = dlg.selectedDatumTransforms();

--- a/src/app/qgsdatumtransformtablewidget.cpp
+++ b/src/app/qgsdatumtransformtablewidget.cpp
@@ -200,9 +200,9 @@ void QgsDatumTransformTableWidget::addDatumTransform()
   QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem(), QgsCoordinateReferenceSystem(), true, false, false );
   if ( dlg.exec() )
   {
-    QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > dt = dlg.selectedDatumTransforms();
+    const QgsDatumTransformDialog::TransformInfo dt = dlg.selectedDatumTransform();
     QgsCoordinateTransformContext context = mModel->transformContext();
-    context.addSourceDestinationDatumTransform( dt.first.first, dt.second.first, dt.first.second, dt.second.second );
+    context.addSourceDestinationDatumTransform( dt.sourceCrs, dt.destinationCrs, dt.sourceTransformId, dt.destinationTransformId );
     mModel->setTransformContext( context );
     selectionChanged();
   }
@@ -253,10 +253,10 @@ void QgsDatumTransformTableWidget::editDatumTransform()
       QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, true, false, false, qMakePair( sourceTransform, destinationTransform ) );
       if ( dlg.exec() )
       {
-        QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > dt = dlg.selectedDatumTransforms();
+        const QgsDatumTransformDialog::TransformInfo dt = dlg.selectedDatumTransform();
         QgsCoordinateTransformContext context = mModel->transformContext();
         // QMap::insert takes care of replacing existing value
-        context.addSourceDestinationDatumTransform( sourceCrs, destinationCrs, dt.first.second, dt.second.second );
+        context.addSourceDestinationDatumTransform( sourceCrs, destinationCrs, dt.sourceTransformId, dt.destinationTransformId );
         mModel->setTransformContext( context );
       }
     }

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -466,7 +466,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl, const QList<QgsOpti
   leProjectGlobalCrs->setCrs( mDefaultCrs );
   leProjectGlobalCrs->setOptionVisible( QgsProjectionSelectionWidget::DefaultCrs, false );
 
-  mShowDatumTransformDialogCheckBox->setChecked( mSettings->value( QStringLiteral( "/Projections/showDatumTransformDialog" ), false ).toBool() );
+  mShowDatumTransformDialogCheckBox->setChecked( mSettings->value( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), false, QgsSettings::App ).toBool() );
 
   // Datum transforms
   QgsCoordinateTransformContext context;
@@ -1540,7 +1540,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( QStringLiteral( "/Projections/layerDefaultCrs" ), mLayerDefaultCrs.authid() );
   mSettings->setValue( QStringLiteral( "/Projections/projectDefaultCrs" ), mDefaultCrs.authid() );
 
-  mSettings->setValue( QStringLiteral( "/Projections/showDatumTransformDialog" ), mShowDatumTransformDialogCheckBox->isChecked() );
+  mSettings->setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), mShowDatumTransformDialogCheckBox->isChecked(), QgsSettings::App );
 
   //measurement settings
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -943,6 +943,10 @@ void QgsProjectProperties::apply()
 {
   mMapCanvas->enableMapTileRendering( mMapTileRenderingCheckBox->isChecked() );
 
+  // important - set the transform context first, as changing the project CRS may otherwise change this and
+  // cause loss of user changes
+  QgsCoordinateTransformContext transformContext = mDatumTransformTableWidget->transformContext();
+  QgsProject::instance()->setTransformContext( transformContext );
   if ( projectionSelector->hasValidSelection() )
   {
     QgsCoordinateReferenceSystem srs = projectionSelector->crs();
@@ -961,9 +965,6 @@ void QgsProjectProperties::apply()
     // mark selected projection for push to front
     projectionSelector->pushProjectionToFront();
   }
-
-  QgsCoordinateTransformContext transformContext = mDatumTransformTableWidget->transformContext();
-  QgsProject::instance()->setTransformContext( transformContext );
 
   mMetadataWidget->acceptMetadata();
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -175,7 +175,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
   QgsCoordinateTransformContext context = QgsProject::instance()->transformContext();
   mDatumTransformTableWidget->setTransformContext( context );
 
-  bool show = settings.value( QStringLiteral( "/Projections/showDatumTransformDialog" ), false ).toBool();
+  bool show = settings.value( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), false, QgsSettings::App ).toBool();
   mShowDatumTransformDialogCheckBox->setChecked( show );
 
   QPolygonF mainCanvasPoly = mapCanvas->mapSettings().visiblePolygon();

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -195,6 +195,16 @@ int QgsDatumTransformDialog::availableTransformationCount()
   return mDatumTransforms.count();
 }
 
+bool QgsDatumTransformDialog::shouldAskUserForSelection()
+{
+  if ( availableTransformationCount() > 1 )
+  {
+    return QgsSettings().value( QStringLiteral( "/Projections/showDatumTransformDialog" ), false ).toBool();
+  }
+  // TODO: show if transform grids are required, but missing
+  return false;
+}
+
 QPair<QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int> > QgsDatumTransformDialog::selectedDatumTransforms()
 {
   int row = mDatumTransformTableWidget->currentRow();

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -38,7 +38,7 @@ bool QgsDatumTransformDialog::run( const QgsCoordinateReferenceSystem &sourceCrs
     return true;
   }
 
-  QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, false, true, qMakePair( -1, -1 ), parent );
+  QgsDatumTransformDialog dlg( sourceCrs, destinationCrs, false, true, true, qMakePair( -1, -1 ), parent );
   if ( dlg.shouldAskUserForSelection() )
   {
     if ( dlg.exec() )
@@ -62,7 +62,7 @@ bool QgsDatumTransformDialog::run( const QgsCoordinateReferenceSystem &sourceCrs
 }
 
 QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSystem &sourceCrs,
-    const QgsCoordinateReferenceSystem &destinationCrs, const bool allowCrsChanges, const bool showMakeDefault,
+    const QgsCoordinateReferenceSystem &destinationCrs, const bool allowCrsChanges, const bool showMakeDefault, const bool forceChoice,
     QPair<int, int> selectedDatumTransforms,
     QWidget *parent,
     Qt::WindowFlags f )
@@ -75,6 +75,13 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
 
   if ( !showMakeDefault )
     mMakeDefaultCheckBox->setVisible( false );
+
+  if ( forceChoice )
+  {
+    mButtonBox->removeButton( mButtonBox->button( QDialogButtonBox::Cancel ) );
+    setWindowFlags( windowFlags() | Qt::CustomizeWindowHint );
+    setWindowFlags( windowFlags() & ~Qt::WindowCloseButtonHint );
+  }
 
   mDatumTransformTableWidget->setColumnCount( 2 );
   QStringList headers;
@@ -251,6 +258,14 @@ void QgsDatumTransformDialog::accept()
     settings.setValue( srcAuthId + "//" + destAuthId + "_destTransform", destinationDatumProj );
   }
   QDialog::accept();
+}
+
+void QgsDatumTransformDialog::reject()
+{
+  if ( !mButtonBox->button( QDialogButtonBox::Cancel ) )
+    return; // users HAVE to make a choice, no click on the dialog "x" to avoid this!
+
+  QDialog::reject();
 }
 
 bool QgsDatumTransformDialog::shouldAskUserForSelection()

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -140,19 +140,15 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms )
     {
       std::unique_ptr< QTableWidgetItem > item = qgis::make_unique< QTableWidgetItem >();
       int nr = i == 0 ? transform.sourceTransformId : transform.destinationTransformId;
+      item->setData( Qt::UserRole, nr );
       item->setFlags( item->flags() & ~Qt::ItemIsEditable );
+
+      item->setText( QgsDatumTransform::datumTransformToProj( nr ) );
 
       //Describe datums in a tooltip
       QgsDatumTransform::TransformInfo info = i == 0 ? srcInfo : destInfo;
       if ( info.datumTransformId == -1 )
-      {
-        mDatumTransformTableWidget->setRowCount( row + 1 );
-        mDatumTransformTableWidget->setItem( row, i, item.release() );
         continue;
-      }
-
-      item->setData( Qt::UserRole, nr );
-      item->setText( QgsDatumTransform::datumTransformToProj( nr ) );
 
       if ( info.deprecated )
       {

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -134,6 +134,8 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms )
     if ( transform.sourceTransformId == -1 && transform.destinationTransformId == -1 )
       continue;
 
+    QgsDatumTransform::TransformInfo srcInfo = QgsDatumTransform::datumTransformInfo( transform.sourceTransformId );
+    QgsDatumTransform::TransformInfo destInfo = QgsDatumTransform::datumTransformInfo( transform.destinationTransformId );
     for ( int i = 0; i < 2; ++i )
     {
       std::unique_ptr< QTableWidgetItem > item = qgis::make_unique< QTableWidgetItem >();
@@ -144,7 +146,7 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms )
       item->setText( QgsDatumTransform::datumTransformToProj( nr ) );
 
       //Describe datums in a tooltip
-      QgsDatumTransform::TransformInfo info = QgsDatumTransform::datumTransformInfo( nr );
+      QgsDatumTransform::TransformInfo info = i == 0 ? srcInfo : destInfo;
       if ( info.datumTransformId == -1 )
         continue;
 
@@ -152,6 +154,14 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms )
       {
         itemHidden = mHideDeprecatedCheckBox->isChecked();
         item->setForeground( QBrush( QColor( 255, 0, 0 ) ) );
+      }
+
+      if ( ( srcInfo.preferred && !srcInfo.deprecated ) || ( destInfo.preferred && !destInfo.deprecated ) )
+      {
+        QFont f = item->font();
+        f.setBold( true );
+        item->setFont( f );
+        item->setForeground( QBrush( QColor( 0, 120, 0 ) ) );
       }
 
       if ( info.preferred && !info.deprecated && preferredInitialRow < 0 )

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -268,8 +268,8 @@ void QgsDatumTransformDialog::accept()
     if ( destinationDatumTransform >= 0 )
       destinationDatumProj = QgsDatumTransform::datumTransformToProj( destinationDatumTransform );
 
-    settings.setValue( srcAuthId + "//" + destAuthId + "_srcTransform", sourceDatumProj );
-    settings.setValue( srcAuthId + "//" + destAuthId + "_destTransform", destinationDatumProj );
+    settings.setValue( srcAuthId + QStringLiteral( "//" ) + destAuthId + QStringLiteral( "_srcTransform" ), sourceDatumProj );
+    settings.setValue( srcAuthId + QStringLiteral( "//" ) + destAuthId + QStringLiteral( "_destTransform" ), destinationDatumProj );
   }
   QDialog::accept();
 }
@@ -282,7 +282,7 @@ void QgsDatumTransformDialog::reject()
   QDialog::reject();
 }
 
-bool QgsDatumTransformDialog::shouldAskUserForSelection()
+bool QgsDatumTransformDialog::shouldAskUserForSelection() const
 {
   if ( mDatumTransforms.count() > 1 )
   {
@@ -292,7 +292,7 @@ bool QgsDatumTransformDialog::shouldAskUserForSelection()
   return false;
 }
 
-QPair<QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int> > QgsDatumTransformDialog::defaultDatumTransform()
+QPair<QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int> > QgsDatumTransformDialog::defaultDatumTransform() const
 {
   QPair<QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int> > preferredNonDeprecated;
   preferredNonDeprecated.first.first = mSourceCrs;

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -140,15 +140,19 @@ void QgsDatumTransformDialog::load( QPair<int, int> selectedDatumTransforms )
     {
       std::unique_ptr< QTableWidgetItem > item = qgis::make_unique< QTableWidgetItem >();
       int nr = i == 0 ? transform.sourceTransformId : transform.destinationTransformId;
-      item->setData( Qt::UserRole, nr );
       item->setFlags( item->flags() & ~Qt::ItemIsEditable );
-
-      item->setText( QgsDatumTransform::datumTransformToProj( nr ) );
 
       //Describe datums in a tooltip
       QgsDatumTransform::TransformInfo info = i == 0 ? srcInfo : destInfo;
       if ( info.datumTransformId == -1 )
+      {
+        mDatumTransformTableWidget->setRowCount( row + 1 );
+        mDatumTransformTableWidget->setItem( row, i, item.release() );
         continue;
+      }
+
+      item->setData( Qt::UserRole, nr );
+      item->setText( QgsDatumTransform::datumTransformToProj( nr ) );
 
       if ( info.deprecated )
       {

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -55,6 +55,9 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
     mDestCrsLabel->setText( QgsProjectionSelectionWidget::crsOptionText( destinationCrs ) );
   }
 
+  QgsSettings settings;
+  mHideDeprecatedCheckBox->setChecked( settings.value( QStringLiteral( "Windows/DatumTransformDialog/hideDeprecated" ), true ).toBool() );
+
   connect( mHideDeprecatedCheckBox, &QCheckBox::stateChanged, this, [ = ] { load(); } );
   connect( mDatumTransformTableWidget, &QTableWidget::currentItemChanged, this, &QgsDatumTransformDialog::tableCurrentItemChanged );
 
@@ -65,11 +68,6 @@ QgsDatumTransformDialog::QgsDatumTransformDialog( const QgsCoordinateReferenceSy
   mSourceCrs = sourceCrs;
   mDestinationCrs = destinationCrs;
   mDatumTransforms = QgsDatumTransform::datumTransformations( sourceCrs, destinationCrs );
-
-  setOKButtonEnabled();
-
-  QgsSettings settings;
-  mHideDeprecatedCheckBox->setChecked( settings.value( QStringLiteral( "Windows/DatumTransformDialog/hideDeprecated" ), true ).toBool() );
 
   mLabelSrcDescription->clear();
   mLabelDstDescription->clear();

--- a/src/gui/qgsdatumtransformdialog.cpp
+++ b/src/gui/qgsdatumtransformdialog.cpp
@@ -257,7 +257,7 @@ bool QgsDatumTransformDialog::shouldAskUserForSelection()
 {
   if ( mDatumTransforms.count() > 1 )
   {
-    return QgsSettings().value( QStringLiteral( "/Projections/showDatumTransformDialog" ), false ).toBool();
+    return QgsSettings().value( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), false, QgsSettings::App ).toBool();
   }
   // TODO: show if transform grids are required, but missing
   return false;

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -128,6 +128,8 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     QgsCoordinateReferenceSystem mSourceCrs;
     QgsCoordinateReferenceSystem mDestinationCrs;
     std::unique_ptr< QgsTemporaryCursorRestoreOverride > mPreviousCursorOverride;
+
+    friend class TestQgsDatumTransformDialog;
 };
 
 #endif // QGSDATUMTRANSFORMDIALOG_H

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -59,12 +59,14 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
                              const QgsCoordinateReferenceSystem &destinationCrs = QgsCoordinateReferenceSystem(),
                              bool allowCrsChanges = false,
                              bool showMakeDefault = true,
+                             bool forceChoice = true,
                              QPair<int, int> selectedDatumTransforms = qMakePair( -1, -1 ),
                              QWidget *parent = nullptr,
                              Qt::WindowFlags f = nullptr );
     ~QgsDatumTransformDialog() override;
 
     void accept() override;
+    void reject() override;
 
     /**
      * Returns the source and destination transforms, each being a pair of QgsCoordinateReferenceSystems and datum transform code

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -55,6 +55,13 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     int availableTransformationCount();
 
     /**
+     * Returns true if the dialog should be shown and the user prompted to make the transformation selection.
+     *
+     * \since QGIS 3.8
+     */
+    bool shouldAskUserForSelection();
+
+    /**
      * Returns the source and destination transforms, each being a pair of QgsCoordinateReferenceSystems and datum transform code
      * \since 3.0
      */

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -92,7 +92,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
      *
      * \see defaultDatumTransform()
      */
-    bool shouldAskUserForSelection();
+    bool shouldAskUserForSelection() const;
 
     /**
      * Returns the default transform (or only available transform). This represents the transform which
@@ -101,7 +101,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
      * \see shouldAskUserForSelection()
      * \see applyDefaultTransform()
      */
-    QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > defaultDatumTransform();
+    QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > defaultDatumTransform() const;
 
     /**
      * Applies the defaultDatumTransform(), adding it to the current QgsProject instance.

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -58,10 +58,13 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     QgsDatumTransformDialog( const QgsCoordinateReferenceSystem &sourceCrs = QgsCoordinateReferenceSystem(),
                              const QgsCoordinateReferenceSystem &destinationCrs = QgsCoordinateReferenceSystem(),
                              bool allowCrsChanges = false,
+                             bool showMakeDefault = true,
                              QPair<int, int> selectedDatumTransforms = qMakePair( -1, -1 ),
                              QWidget *parent = nullptr,
                              Qt::WindowFlags f = nullptr );
     ~QgsDatumTransformDialog() override;
+
+    void accept() override;
 
     /**
      * Returns the source and destination transforms, each being a pair of QgsCoordinateReferenceSystems and datum transform code

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -37,6 +37,22 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     Q_OBJECT
   public:
 
+    //! Dialog transformation entry info
+    struct TransformInfo
+    {
+      //! Source coordinate reference system
+      QgsCoordinateReferenceSystem sourceCrs;
+
+      //! Source transform ID
+      int sourceTransformId = -1;
+
+      //! Destination coordinate reference system
+      QgsCoordinateReferenceSystem destinationCrs;
+
+      //! Destination transform ID
+      int destinationTransformId = -1;
+    };
+
     /**
      * Runs the dialog (if required) prompting for the desired transform to use from \a sourceCrs to
      * \a destinationCrs, updating the current project transform context as required
@@ -72,7 +88,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
      * Returns the source and destination transforms, each being a pair of QgsCoordinateReferenceSystems and datum transform code
      * \since 3.0
      */
-    QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > selectedDatumTransforms();
+    TransformInfo selectedDatumTransform();
 
   private slots:
 
@@ -101,7 +117,7 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
      * \see shouldAskUserForSelection()
      * \see applyDefaultTransform()
      */
-    QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > defaultDatumTransform() const;
+    TransformInfo defaultDatumTransform() const;
 
     /**
      * Applies the defaultDatumTransform(), adding it to the current QgsProject instance.

--- a/src/gui/qgsdatumtransformdialog.h
+++ b/src/gui/qgsdatumtransformdialog.h
@@ -38,6 +38,21 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
   public:
 
     /**
+     * Runs the dialog (if required) prompting for the desired transform to use from \a sourceCrs to
+     * \a destinationCrs, updating the current project transform context as required
+     * based on the results of the run.
+     *
+     * This handles EVERYTHING, including only showing the dialog if multiple choices exist
+     * and the user has asked to be prompted, not re-adding transforms already in the current project
+     * context, etc.
+     *
+     * \since QGIS 3.8
+     */
+    static bool run( const QgsCoordinateReferenceSystem &sourceCrs = QgsCoordinateReferenceSystem(),
+                     const QgsCoordinateReferenceSystem &destinationCrs = QgsCoordinateReferenceSystem(),
+                     QWidget *parent = nullptr );
+
+    /**
      * Constructor for QgsDatumTransformDialog.
      */
     QgsDatumTransformDialog( const QgsCoordinateReferenceSystem &sourceCrs = QgsCoordinateReferenceSystem(),
@@ -47,19 +62,6 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
                              QWidget *parent = nullptr,
                              Qt::WindowFlags f = nullptr );
     ~QgsDatumTransformDialog() override;
-
-    /**
-     * Returns the number of possible datum transformation for currently selected source and destination CRS
-     * \since 3.0
-     */
-    int availableTransformationCount();
-
-    /**
-     * Returns true if the dialog should be shown and the user prompted to make the transformation selection.
-     *
-     * \since QGIS 3.8
-     */
-    bool shouldAskUserForSelection();
 
     /**
      * Returns the source and destination transforms, each being a pair of QgsCoordinateReferenceSystems and datum transform code
@@ -80,6 +82,26 @@ class GUI_EXPORT QgsDatumTransformDialog : public QDialog, private Ui::QgsDatumT
     void load( QPair<int, int> selectedDatumTransforms = qMakePair( -1, -1 ) );
     void setOKButtonEnabled();
 
+    /**
+     * Returns true if the dialog should be shown and the user prompted to make the transformation selection.
+     *
+     * \see defaultDatumTransform()
+     */
+    bool shouldAskUserForSelection();
+
+    /**
+     * Returns the default transform (or only available transform). This represents the transform which
+     * should be used if the user is not being prompted to make this selection for themselves.
+     *
+     * \see shouldAskUserForSelection()
+     * \see applyDefaultTransform()
+     */
+    QPair< QPair<QgsCoordinateReferenceSystem, int>, QPair<QgsCoordinateReferenceSystem, int > > defaultDatumTransform();
+
+    /**
+     * Applies the defaultDatumTransform(), adding it to the current QgsProject instance.
+     */
+    void applyDefaultTransform();
 
     QList< QgsDatumTransform::TransformPair > mDatumTransforms;
     QgsCoordinateReferenceSystem mSourceCrs;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -2132,40 +2132,6 @@ void QgsMapCanvas::writeProject( QDomDocument &doc )
   // TODO: store only units, extent, projections, dest CRS
 }
 
-#if 0
-void QgsMapCanvas::getDatumTransformInfo( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination )
-{
-  if ( !source.isValid() || !destination.isValid() )
-    return;
-
-  //check if default datum transformation available
-  QgsSettings s;
-  QString settingsString = "/Projections/" + source.authid() + "//" + destination.authid();
-  QVariant defaultSrcTransform = s.value( settingsString + "_srcTransform" );
-  QVariant defaultDestTransform = s.value( settingsString + "_destTransform" );
-  if ( defaultSrcTransform.isValid() && defaultDestTransform.isValid() )
-  {
-    int sourceDatumTransform = defaultSrcTransform.toInt();
-    int destinationDatumTransform = defaultDestTransform.toInt();
-
-    QgsCoordinateTransformContext context = QgsProject::instance()->transformContext();
-    context.addSourceDestinationDatumTransform( source, destination, sourceDatumTransform, destinationDatumTransform );
-    QgsProject::instance()->setTransformContext( context );
-    return;
-  }
-
-  if ( !s.value( QStringLiteral( "/Projections/showDatumTransformDialog" ), false ).toBool() )
-  {
-    return;
-  }
-
-  //if several possibilities:  present dialog
-  QgsDatumTransformDialog d( source, destination );
-  if ( d.availableTransformationCount() > 1 )
-    d.exec();
-}
-#endif
-
 void QgsMapCanvas::zoomByFactor( double scaleFactor, const QgsPointXY *center )
 {
   if ( mScaleLocked )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -678,11 +678,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! called to write map canvas settings to project
     void writeProject( QDomDocument & );
 
-#if 0
-    //! ask user about datum transformation
-    void getDatumTransformInfo( const QgsCoordinateReferenceSystem &source, const QgsCoordinateReferenceSystem &destination );
-#endif
-
     /**
      * Sets the factor of magnification to apply to the map canvas. Indeed, we
      * increase/decrease the DPI of the map settings according to this factor

--- a/src/ui/qgsdatumtransformdialogbase.ui
+++ b/src/ui/qgsdatumtransformdialogbase.ui
@@ -135,6 +135,16 @@
    <item row="3" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QCheckBox" name="mMakeDefaultCheckBox">
+       <property name="toolTip">
+        <string>If checked, the selected transformation will become the default choice in all new projects</string>
+       </property>
+       <property name="text">
+        <string>Make default</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -191,8 +201,8 @@
  </customwidgets>
  <tabstops>
   <tabstop>mDatumTransformTableWidget</tabstop>
+  <tabstop>mMakeDefaultCheckBox</tabstop>
   <tabstop>mHideDeprecatedCheckBox</tabstop>
-  <tabstop>mButtonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -121,6 +121,7 @@ ADD_QGIS_TEST(edittooltest testqgsmaptooledit.cpp)
 
 #ADD_QGIS_TEST(histogramtest testqgsrasterhistogram.cpp)
 ADD_QGIS_TEST(categorizedrendererwidget testqgscategorizedrendererwidget.cpp)
+ADD_QGIS_TEST(datumtransformdialog testqgsdatumtransformdialog.cpp)
 ADD_QGIS_TEST(doublespinbox testqgsdoublespinbox.cpp)
 ADD_QGIS_TEST(dualviewtest testqgsdualview.cpp)
 ADD_QGIS_TEST(attributeformtest testqgsattributeform.cpp)

--- a/tests/src/gui/testqgsdatumtransformdialog.cpp
+++ b/tests/src/gui/testqgsdatumtransformdialog.cpp
@@ -1,0 +1,144 @@
+/***************************************************************************
+    testqgsdatumtransformdialog.cpp
+     --------------------------------------
+    Date                 : March 2019
+    Copyright            : (C) 2019 Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "qgstest.h"
+
+#include "qgsdatumtransformdialog.h"
+#include "qgssettings.h"
+#include "qgsproject.h"
+
+class TestQgsDatumTransformDialog: public QObject
+{
+    Q_OBJECT
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void defaultTransform();
+    void shouldAskUser();
+    void applyDefaultTransform();
+    void runDialog();
+
+  private:
+
+};
+
+void TestQgsDatumTransformDialog::initTestCase()
+{
+  // initialize with test settings directory so we don't mess with user's stuff
+  QgsApplication::init( QDir::tempPath() + "/dot-qgis" );
+  QgsApplication::initQgis();
+  QgsApplication::createDatabase();
+  // output test environment
+  QgsApplication::showSettings();
+
+  // Set up the QgsSettings environment
+  QCoreApplication::setOrganizationName( QStringLiteral( "QGIS" ) );
+  QCoreApplication::setOrganizationDomain( QStringLiteral( "qgis.org" ) );
+  QCoreApplication::setApplicationName( QStringLiteral( "QGIS-TEST" ) );
+}
+
+void TestQgsDatumTransformDialog::cleanupTestCase()
+{
+}
+
+void TestQgsDatumTransformDialog::init()
+{
+}
+
+void TestQgsDatumTransformDialog::cleanup()
+{
+}
+
+void TestQgsDatumTransformDialog::defaultTransform()
+{
+  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+
+  QgsDatumTransformDialog::TransformInfo def = dlg.defaultDatumTransform();
+  QCOMPARE( def.sourceCrs.authid(), QStringLiteral( "EPSG:26742" ) );
+  QCOMPARE( def.destinationCrs.authid(), QStringLiteral( "EPSG:4326" ) );
+  QCOMPARE( QgsDatumTransform::datumTransformToProj( def.sourceTransformId ), QStringLiteral( "+towgs84=-10,158,187" ) );
+  QCOMPARE( QgsDatumTransform::datumTransformToProj( def.destinationTransformId ), QString() );
+
+  // default should be initially selected
+  def = dlg.selectedDatumTransform();
+  QCOMPARE( def.sourceCrs.authid(), QStringLiteral( "EPSG:26742" ) );
+  QCOMPARE( def.destinationCrs.authid(), QStringLiteral( "EPSG:4326" ) );
+  QCOMPARE( QgsDatumTransform::datumTransformToProj( def.sourceTransformId ), QStringLiteral( "+towgs84=-10,158,187" ) );
+  QCOMPARE( QgsDatumTransform::datumTransformToProj( def.destinationTransformId ), QString() );
+
+  QgsDatumTransformDialog dlg2( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ) );
+  def = dlg2.defaultDatumTransform();
+  QCOMPARE( def.sourceCrs.authid(), QStringLiteral( "EPSG:4326" ) );
+  QCOMPARE( def.destinationCrs.authid(), QStringLiteral( "EPSG:26742" ) );
+  QCOMPARE( QgsDatumTransform::datumTransformToProj( def.sourceTransformId ), QString() );
+  QCOMPARE( QgsDatumTransform::datumTransformToProj( def.destinationTransformId ), QStringLiteral( "+towgs84=-10,158,187" ) );
+
+}
+
+void TestQgsDatumTransformDialog::shouldAskUser()
+{
+  // no prompts!
+  QgsSettings().setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), false, QgsSettings::App );
+  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  QVERIFY( !dlg.shouldAskUserForSelection() );
+  QgsDatumTransformDialog dlg2( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:7406" ) ) );
+  QVERIFY( !dlg2.shouldAskUserForSelection() );
+
+//prompts
+  QgsSettings().setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), true, QgsSettings::App );
+  QgsDatumTransformDialog dlg3( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  QVERIFY( dlg3.shouldAskUserForSelection() );
+  QgsDatumTransformDialog dlg4( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:7406" ) ) );
+  QVERIFY( !dlg4.shouldAskUserForSelection() );
+}
+
+void TestQgsDatumTransformDialog::applyDefaultTransform()
+{
+  QgsSettings().setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), false, QgsSettings::App );
+
+  QgsDatumTransformDialog dlg( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:7406" ) ) );
+  dlg.applyDefaultTransform();
+  QVERIFY( QgsProject::instance()->transformContext().sourceDestinationDatumTransforms().isEmpty() );
+
+  QgsDatumTransformDialog dlg2( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) );
+  dlg2.applyDefaultTransform();
+
+  QVERIFY( !QgsProject::instance()->transformContext().sourceDestinationDatumTransforms().isEmpty() );
+  QCOMPARE( QgsDatumTransform::datumTransformToProj( QgsProject::instance()->transformContext().calculateDatumTransforms( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) ).sourceTransformId ), QStringLiteral( "+towgs84=-10,158,187" ) );
+  QgsProject::instance()->clear();
+}
+
+void TestQgsDatumTransformDialog::runDialog()
+{
+  QgsSettings().setValue( QStringLiteral( "/projections/promptWhenMultipleTransformsExist" ), false, QgsSettings::App );
+
+  QVERIFY( QgsDatumTransformDialog::run( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:7406" ) ) ) );
+  QVERIFY( QgsProject::instance()->transformContext().sourceDestinationDatumTransforms().isEmpty() );
+
+  QVERIFY( QgsDatumTransformDialog::run( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) ) );
+
+  QVERIFY( !QgsProject::instance()->transformContext().sourceDestinationDatumTransforms().isEmpty() );
+  QCOMPARE( QgsDatumTransform::datumTransformToProj( QgsProject::instance()->transformContext().calculateDatumTransforms( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) ).sourceTransformId ), QStringLiteral( "+towgs84=-10,158,187" ) );
+  QgsProject::instance()->clear();
+  QVERIFY( QgsDatumTransformDialog::run( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:26742" ) ), QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ) ) );
+}
+
+
+QGSTEST_MAIN( TestQgsDatumTransformDialog )
+#include "testqgsdatumtransformdialog.moc"


### PR DESCRIPTION
This one follows on from #9485, but unlike #9485 it contains more intrusive changes (9485 is straightforward UX tweaks).

The big improvement here is standardisation of the API for deciding whether the datum transform dialog should be shown and handling updating the project's transform context as a result of showing (or not showing) the dialog.

Most importantly fixes a bug where users are NEVER prompted for a transformation when only one
valid transformation exists AND this single transform is not added to the project context (in other words, QGIS could not handle transformations when only one possible path existed). Also fixes https://issues.qgis.org/issues/21275 in the process.

Some logic here is temporary (QgsDatumTransformDialog::defaultDatumTransform())
and will be replaced with proj db logic when we update to proj v6 API.

Requires tests.

Sponsored by ICSM.

(Note: I do **not** consider these changes suitable for backporting)