### PR TITLE
[expression] Negative index support to point_n(), angle_at_vertex(), distance_to_vertex() functions

### DIFF
--- a/resources/function_help/json/angle_at_vertex
+++ b/resources/function_help/json/angle_at_vertex
@@ -3,6 +3,6 @@
   "type": "function",
   "description": "Returns the bisector angle (average angle) to the geometry for a specified vertex on a linestring geometry. Angles are in degrees clockwise from north.",
   "arguments": [ {"arg":"geometry","description":"a linestring geometry"},
-                 {"arg":"vertex","description":"vertex index, starting from 0"}],
+                 {"arg":"vertex","description":"vertex index, starting from 0; if the value is negative, the selected vertex index will be its total count minus the absolute value"}],
   "examples": [ { "expression":"angle_at_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1)", "returns":"45.0"}]
 }

--- a/resources/function_help/json/distance_to_vertex
+++ b/resources/function_help/json/distance_to_vertex
@@ -3,6 +3,6 @@
   "type": "function",
   "description": "Returns the distance along the geometry to a specified vertex.",
   "arguments": [ {"arg":"geometry","description":"a linestring geometry"},
-                 {"arg":"vertex","description":"vertex index, starting from 0"}],
+                 {"arg":"vertex","description":"vertex index, starting from 0; if the value is negative, the selected vertex index will be its total count minus the absolute value"}],
   "examples": [ { "expression":"distance_to_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1)", "returns":"10.0"}]
 }

--- a/resources/function_help/json/point_n
+++ b/resources/function_help/json/point_n
@@ -3,6 +3,6 @@
   "type": "function",
   "description": "Returns a specific node from a geometry.",
   "arguments": [ {"arg":"geometry","description":"geometry object"},
-  {"arg":"index","description":"index of node to return, where 1 is the first node"} ],
+  {"arg":"index","description":"index of node to return, where 1 is the first node; if the value is negative, the selected vertex index will be its total count minus the absolute value"} ],
   "examples": [ { "expression":"geom_to_wkt(point_n(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'),2))", "returns":"'Point (4 0)'"}]
 }

--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -1979,8 +1979,19 @@ static QVariant fcnPointN( const QVariantList &values, const QgsExpressionContex
   if ( geom.isNull() )
     return QVariant();
 
-  //idx is 1 based
-  qlonglong idx = QgsExpressionUtils::getIntValue( values.at( 1 ), parent ) - 1;
+  qlonglong idx = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
+
+  if ( idx < 0 )
+  {
+    //negative idx
+    int count = geom.constGet()->nCoordinates();
+    idx = count + idx;
+  }
+  else
+  {
+    //positive idx is 1 based
+    idx -= 1;
+  }
 
   QgsVertexId vId;
   if ( idx < 0 || !geom.vertexIdFromVertexNr( idx, vId ) )
@@ -3586,6 +3597,12 @@ static QVariant fcnAngleAtVertex( const QVariantList &values, const QgsExpressio
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   qlonglong vertex = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
+  if ( vertex < 0 )
+  {
+    //negative idx
+    int count = geom.constGet()->nCoordinates();
+    vertex = count + vertex;
+  }
 
   return geom.angleAtVertex( vertex ) * 180.0 / M_PI;
 }
@@ -3594,6 +3611,12 @@ static QVariant fcnDistanceToVertex( const QVariantList &values, const QgsExpres
 {
   QgsGeometry geom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   qlonglong vertex = QgsExpressionUtils::getIntValue( values.at( 1 ), parent );
+  if ( vertex < 0 )
+  {
+    //negative idx
+    int count = geom.constGet()->nCoordinates();
+    vertex = count + vertex;
+  }
 
   return geom.distanceToVertex( vertex );
 }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -816,6 +816,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "point_n bad index" ) << "geom_to_wkt(point_n(geom_from_wkt('POINT(0 0)'),0))" << true << QVariant();
       QTest::newRow( "point_n bad index" ) << "geom_to_wkt(point_n(geom_from_wkt('POINT(0 0)'),2))" << true << QVariant();
       QTest::newRow( "point_n multipoint" ) << "geom_to_wkt(point_n(geom_from_wkt('MULTIPOINT((0 0), (1 1), (2 2))'),2))" << false << QVariant( "Point (1 1)" );
+      QTest::newRow( "point_n multipoint negative" ) << "geom_to_wkt(point_n(geom_from_wkt('MULTIPOINT((0 0), (1 1), (2 2))'),-1))" << false << QVariant( "Point (2 2)" );
       QTest::newRow( "point_n line" ) << "geom_to_wkt(point_n(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)'),3))" << false << QVariant( "Point (2 2)" );
       QTest::newRow( "point_n polygon" ) << "geom_to_wkt(point_n(geom_from_wkt('POLYGON((0 0, 4 0, 4 2, 0 2, 0 0))'),3))" << false << QVariant( "Point (4 2)" );
       QTest::newRow( "interior_ring_n not geom" ) << "interior_ring_n('g', 1)" << true << QVariant();
@@ -1040,10 +1041,12 @@ class TestQgsExpression: public QObject
       QTest::newRow( "angle_at_vertex null" ) << "angle_at_vertex(NULL, 0)" << false << QVariant();
       QTest::newRow( "angle_at_vertex point" ) << "angle_at_vertex(geom_from_wkt('POINT(1 2)'),0)" << false << QVariant( 0.0 );
       QTest::newRow( "angle_at_vertex line" ) << "angle_at_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1)" << false << QVariant( 45.0 );
+      QTest::newRow( "angle_at_vertex line negative" ) << "angle_at_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=-1)" << false << QVariant( 0.0 );
       QTest::newRow( "distance_to_vertex not geom" ) << "distance_to_vertex('g', 5)" << true << QVariant();
       QTest::newRow( "distance_to_vertex null" ) << "distance_to_vertex(NULL, 0)" << false << QVariant();
       QTest::newRow( "distance_to_vertex point" ) << "distance_to_vertex(geom_from_wkt('POINT(1 2)'),0)" << false << QVariant( 0.0 );
       QTest::newRow( "distance_to_vertex line" ) << "distance_to_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1)" << false << QVariant( 10.0 );
+      QTest::newRow( "distance_to_vertex line negative" ) << "distance_to_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=-1)" << false << QVariant( 20.0 );
       QTest::newRow( "line_substring not geom" ) << "line_substring('g', 5, 6)" << true << QVariant();
       QTest::newRow( "line_substring null" ) << "line_substring(NULL, 5, 6)" << false << QVariant();
       QTest::newRow( "line_substring point" ) << "line_substring(geom_from_wkt('POINT(1 2)'),5,6)" << true << QVariant();


### PR DESCRIPTION
## Description
Because we all love negative index support.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [x] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [x] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
