### PR TITLE
Allow the strength of provider constraints to be soft

### DIFF
--- a/python/core/auto_generated/qgsfieldconstraints.sip.in
+++ b/python/core/auto_generated/qgsfieldconstraints.sip.in
@@ -83,8 +83,7 @@ is not present on this field.
 
     void setConstraintStrength( Constraint constraint, ConstraintStrength strength );
 %Docstring
-Sets the strength of a constraint. Note that the strength of constraints which originate
-from a provider cannot be changed. Constraints default to ConstraintStrengthHard unless
+Sets the strength of a constraint. Constraints default to ConstraintStrengthHard unless
 explicitly changed.
 
 .. seealso:: :py:func:`constraintStrength`

--- a/src/app/qgsattributesformproperties.cpp
+++ b/src/app/qgsattributesformproperties.cpp
@@ -240,16 +240,17 @@ void QgsAttributesFormProperties::loadAttributeTypeDialog()
     delete mAttributeTypeDialog;
     mAttributeTypeDialog = new QgsAttributeTypeDialog( mLayer, index, mAttributeTypeFrame );
 
+    QgsFieldConstraints constraints = cfg.mFieldConstraints;
+
     mAttributeTypeDialog->setAlias( cfg.mAlias );
     mAttributeTypeDialog->setComment( cfg.mComment );
     mAttributeTypeDialog->setFieldEditable( cfg.mEditable );
     mAttributeTypeDialog->setLabelOnTop( cfg.mLabelOnTop );
-    mAttributeTypeDialog->setNotNull( cfg.mConstraints & QgsFieldConstraints::ConstraintNotNull );
-    mAttributeTypeDialog->setNotNullEnforced( cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard ) == QgsFieldConstraints::ConstraintStrengthHard );
-    mAttributeTypeDialog->setUnique( cfg.mConstraints & QgsFieldConstraints::ConstraintUnique );
-    mAttributeTypeDialog->setUniqueEnforced( cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintStrengthHard ) == QgsFieldConstraints::ConstraintStrengthHard );
+    mAttributeTypeDialog->setNotNull( constraints.constraints() & QgsFieldConstraints::ConstraintNotNull );
+    mAttributeTypeDialog->setNotNullEnforced( constraints.constraintStrength( QgsFieldConstraints::ConstraintNotNull ) == QgsFieldConstraints::ConstraintStrengthHard );
+    mAttributeTypeDialog->setUnique( constraints.constraints() & QgsFieldConstraints::ConstraintUnique );
+    mAttributeTypeDialog->setUniqueEnforced( constraints.constraintStrength( QgsFieldConstraints::ConstraintUnique ) == QgsFieldConstraints::ConstraintStrengthHard );
 
-    QgsFieldConstraints constraints = cfg.mFieldConstraints;
     QgsFieldConstraints::Constraints providerConstraints = nullptr;
     if ( constraints.constraintOrigin( QgsFieldConstraints::ConstraintNotNull ) == QgsFieldConstraints::ConstraintOriginProvider )
       providerConstraints |= QgsFieldConstraints::ConstraintNotNull;
@@ -259,9 +260,9 @@ void QgsAttributesFormProperties::loadAttributeTypeDialog()
       providerConstraints |= QgsFieldConstraints::ConstraintExpression;
     mAttributeTypeDialog->setProviderConstraints( providerConstraints );
 
-    mAttributeTypeDialog->setConstraintExpression( cfg.mConstraint );
-    mAttributeTypeDialog->setConstraintExpressionDescription( cfg.mConstraintDescription );
-    mAttributeTypeDialog->setConstraintExpressionEnforced( cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthHard ) == QgsFieldConstraints::ConstraintStrengthHard );
+    mAttributeTypeDialog->setConstraintExpression( constraints.constraintExpression() );
+    mAttributeTypeDialog->setConstraintExpressionDescription( constraints.constraintDescription() );
+    mAttributeTypeDialog->setConstraintExpressionEnforced( constraints.constraintStrength( QgsFieldConstraints::ConstraintExpression ) == QgsFieldConstraints::ConstraintStrengthHard );
     mAttributeTypeDialog->setDefaultValueExpression( mLayer->defaultValueDefinition( index ).expression() );
     mAttributeTypeDialog->setApplyDefaultValueOnUpdate( mLayer->defaultValueDefinition( index ).applyOnUpdate() );
 
@@ -287,54 +288,54 @@ void QgsAttributesFormProperties::storeAttributeTypeDialog()
   cfg.mLabelOnTop = mAttributeTypeDialog->labelOnTop();
   cfg.mAlias = mAttributeTypeDialog->alias();
 
-  //confustion (will be removed): wir laden teilweise sachen einfach beim store anstelle des applys auf die mLayer - eingie Sachen laden wir auch vom layer anstatt über das cfg. wieso
-  QgsFieldConstraints constraints = mLayer->fields().at( mAttributeTypeDialog->fieldIdx() ).constraints();
-  QgsFieldConstraints::Constraints providerConstraints = nullptr;
-  if ( constraints.constraintOrigin( QgsFieldConstraints::ConstraintNotNull ) == QgsFieldConstraints::ConstraintOriginProvider )
-    providerConstraints |= QgsFieldConstraints::ConstraintNotNull;
-  if ( constraints.constraintOrigin( QgsFieldConstraints::ConstraintUnique ) == QgsFieldConstraints::ConstraintOriginProvider )
-    providerConstraints |= QgsFieldConstraints::ConstraintUnique;
-  if ( constraints.constraintOrigin( QgsFieldConstraints::ConstraintExpression ) == QgsFieldConstraints::ConstraintOriginProvider )
-    providerConstraints |= QgsFieldConstraints::ConstraintExpression;
-  cfg.mConstraints = nullptr;
-  if ( mAttributeTypeDialog->notNull() && !( providerConstraints & QgsFieldConstraints::ConstraintNotNull ) )
+  QgsFieldConstraints constraints;
+  if ( mAttributeTypeDialog->notNull() )
   {
-    cfg.mConstraints |= QgsFieldConstraints::ConstraintNotNull;
+    constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull );
   }
-  if ( mAttributeTypeDialog->unique() && !( providerConstraints & QgsFieldConstraints::ConstraintUnique ) )
+  else if ( mAttributeTypeDialog->notNullFromProvider() )
   {
-    cfg.mConstraints |= QgsFieldConstraints::ConstraintUnique;
-  }
-  if ( !mAttributeTypeDialog->constraintExpression().isEmpty() && !( providerConstraints & QgsFieldConstraints::ConstraintExpression ) )
-  {
-    cfg.mConstraints |= QgsFieldConstraints::ConstraintExpression;
+    constraints.setConstraint( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintOriginProvider );
   }
 
-  cfg.mConstraintDescription = mAttributeTypeDialog->constraintExpressionDescription();
-  cfg.mConstraint = mAttributeTypeDialog->constraintExpression();
+  if ( mAttributeTypeDialog->unique() )
+  {
+    constraints.setConstraint( QgsFieldConstraints::ConstraintUnique );
+  }
+  else if ( mAttributeTypeDialog->uniqueFromProvider() )
+  {
+    constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
+  }
+
+  if ( !mAttributeTypeDialog->constraintExpression().isEmpty() )
+  {
+    constraints.setConstraint( QgsFieldConstraints::ConstraintExpression );
+  }
+
+  constraints.setConstraintExpression( mAttributeTypeDialog->constraintExpressionDescription(), mAttributeTypeDialog->constraintExpression() );
+
+  constraints.setConstraintStrength( QgsFieldConstraints::ConstraintNotNull, mAttributeTypeDialog->notNullEnforced() ?
+                                     QgsFieldConstraints::ConstraintStrengthHard : QgsFieldConstraints::ConstraintStrengthSoft );
+  constraints.setConstraintStrength( QgsFieldConstraints::ConstraintUnique, mAttributeTypeDialog->uniqueEnforced() ?
+                                     QgsFieldConstraints::ConstraintStrengthHard : QgsFieldConstraints::ConstraintStrengthSoft );
+  constraints.setConstraintStrength( QgsFieldConstraints::ConstraintExpression, mAttributeTypeDialog->constraintExpressionEnforced() ?
+                                     QgsFieldConstraints::ConstraintStrengthHard : QgsFieldConstraints::ConstraintStrengthSoft );
+
+  cfg.mFieldConstraints = constraints;
+
   mLayer->setDefaultValueDefinition( mAttributeTypeDialog->fieldIdx(), QgsDefaultValue( mAttributeTypeDialog->defaultValueExpression(), mAttributeTypeDialog->applyDefaultValueOnUpdate() ) );
 
   cfg.mEditorWidgetType = mAttributeTypeDialog->editorWidgetType();
   cfg.mEditorWidgetConfig = mAttributeTypeDialog->editorWidgetConfig();
 
-  cfg.mConstraintStrength.insert( QgsFieldConstraints::ConstraintNotNull, mAttributeTypeDialog->notNullEnforced() ?
-                                  QgsFieldConstraints::ConstraintStrengthHard : QgsFieldConstraints::ConstraintStrengthSoft );
-  cfg.mConstraintStrength.insert( QgsFieldConstraints::ConstraintUnique, mAttributeTypeDialog->uniqueEnforced() ?
-                                  QgsFieldConstraints::ConstraintStrengthHard : QgsFieldConstraints::ConstraintStrengthSoft );
-  cfg.mConstraintStrength.insert( QgsFieldConstraints::ConstraintExpression, mAttributeTypeDialog->constraintExpressionEnforced() ?
-                                  QgsFieldConstraints::ConstraintStrengthHard : QgsFieldConstraints::ConstraintStrengthSoft );
-
   QString fieldName = mLayer->fields().at( mAttributeTypeDialog->fieldIdx() ).name();
 
-  QTreeWidgetItemIterator itemIt( mAvailableWidgetsTree );
-  while ( *itemIt )
+  for ( auto itemIt = QTreeWidgetItemIterator( mAvailableWidgetsTree ); *itemIt; ++itemIt )
   {
     QTreeWidgetItem *item = *itemIt;
     if ( item->data( 0, FieldNameRole ).toString() == fieldName )
       item->setData( 0, FieldConfigRole, QVariant::fromValue<FieldConfig>( cfg ) );
-    ++itemIt;
   }
-
 }
 
 
@@ -696,28 +697,29 @@ void QgsAttributesFormProperties::apply()
 
     editFormConfig.setReadOnly( idx, !cfg.mEditable );
     editFormConfig.setLabelOnTop( idx, cfg.mLabelOnTop );
-    mLayer->setConstraintExpression( idx, cfg.mConstraint, cfg.mConstraintDescription );
     mLayer->setEditorWidgetSetup( idx, QgsEditorWidgetSetup( cfg.mEditorWidgetType, cfg.mEditorWidgetConfig ) );
 
-    if ( cfg.mConstraints & QgsFieldConstraints::ConstraintNotNull )
+    QgsFieldConstraints constraints = cfg.mFieldConstraints;
+    mLayer->setConstraintExpression( idx, constraints.constraintExpression(), constraints.constraintDescription() );
+    if ( constraints.constraints() & QgsFieldConstraints::ConstraintNotNull )
     {
-      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintNotNull, QgsFieldConstraints::ConstraintStrengthHard ) );
+      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull, constraints.constraintStrength( QgsFieldConstraints::ConstraintNotNull ) );
     }
     else
     {
       mLayer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintNotNull );
     }
-    if ( cfg.mConstraints & QgsFieldConstraints::ConstraintUnique )
+    if ( constraints.constraints() & QgsFieldConstraints::ConstraintUnique )
     {
-      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintStrengthHard ) );
+      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique, constraints.constraintStrength( QgsFieldConstraints::ConstraintUnique ) );
     }
     else
     {
       mLayer->removeFieldConstraint( idx, QgsFieldConstraints::ConstraintUnique );
     }
-    if ( cfg.mConstraints & QgsFieldConstraints::ConstraintExpression )
+    if ( constraints.constraints() & QgsFieldConstraints::ConstraintExpression )
     {
-      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintExpression, cfg.mConstraintStrength.value( QgsFieldConstraints::ConstraintExpression, QgsFieldConstraints::ConstraintStrengthHard ) );
+      mLayer->setFieldConstraint( idx, QgsFieldConstraints::ConstraintExpression, constraints.constraintStrength( QgsFieldConstraints::ConstraintExpression ) );
     }
     else
     {
@@ -780,12 +782,6 @@ QgsAttributesFormProperties::FieldConfig::FieldConfig( QgsVectorLayer *layer, in
                      && layer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression;
   mLabelOnTop = layer->editFormConfig().labelOnTop( idx );
   mFieldConstraints = layer->fields().at( idx ).constraints();
-  mConstraints = mFieldConstraints.constraints();
-  mConstraint = mFieldConstraints.constraintExpression();
-  mConstraintStrength.insert( QgsFieldConstraints::ConstraintNotNull, mFieldConstraints.constraintStrength( QgsFieldConstraints::ConstraintNotNull ) );
-  mConstraintStrength.insert( QgsFieldConstraints::ConstraintUnique, mFieldConstraints.constraintStrength( QgsFieldConstraints::ConstraintUnique ) );
-  mConstraintStrength.insert( QgsFieldConstraints::ConstraintExpression, mFieldConstraints.constraintStrength( QgsFieldConstraints::ConstraintExpression ) );
-  mConstraintDescription = mFieldConstraints.constraintDescription();
   const QgsEditorWidgetSetup setup = QgsGui::editorWidgetRegistry()->findBest( layer, layer->fields().field( idx ).name() );
   mEditorWidgetType = setup.type();
   mEditorWidgetConfig = setup.config();

--- a/src/app/qgsattributesformproperties.h
+++ b/src/app/qgsattributesformproperties.h
@@ -154,10 +154,6 @@ class APP_EXPORT QgsAttributesFormProperties : public QWidget, private Ui_QgsAtt
       bool mEditableEnabled =  true ;
       bool mLabelOnTop =  false ;
       QgsFieldConstraints mFieldConstraints;
-      QgsFieldConstraints::Constraints mConstraints = nullptr;
-      QHash< QgsFieldConstraints::Constraint, QgsFieldConstraints::ConstraintStrength > mConstraintStrength;
-      QString mConstraint;
-      QString mConstraintDescription;
       QPushButton *mButton = nullptr;
       QString mEditorWidgetType;
       QMap<QString, QVariant> mEditorWidgetConfig;

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -194,8 +194,6 @@ void QgsAttributeTypeDialog::setProviderConstraints( QgsFieldConstraints::Constr
     notNullCheckBox->setChecked( true );
     notNullCheckBox->setEnabled( false );
     notNullCheckBox->setToolTip( tr( "The provider for this layer has a NOT NULL constraint set on the field." ) );
-    mCheckBoxEnforceNotNull->setChecked( true );
-    mCheckBoxEnforceNotNull->setEnabled( false );
   }
 
   if ( constraints & QgsFieldConstraints::ConstraintUnique )
@@ -203,8 +201,6 @@ void QgsAttributeTypeDialog::setProviderConstraints( QgsFieldConstraints::Constr
     mUniqueCheckBox->setChecked( true );
     mUniqueCheckBox->setEnabled( false );
     mUniqueCheckBox->setToolTip( tr( "The provider for this layer has a UNIQUE constraint set on the field." ) );
-    mCheckBoxEnforceUnique->setChecked( true );
-    mCheckBoxEnforceUnique->setEnabled( false );
   }
 }
 
@@ -230,7 +226,12 @@ QString QgsAttributeTypeDialog::constraintExpressionDescription()
 
 bool QgsAttributeTypeDialog::notNull() const
 {
-  return notNullCheckBox->isChecked();
+  return notNullCheckBox->isEnabled() && notNullCheckBox->isChecked();
+}
+
+bool QgsAttributeTypeDialog::notNullFromProvider() const
+{
+  return ( !notNullCheckBox->isEnabled() ) && notNullCheckBox->isChecked();
 }
 
 void QgsAttributeTypeDialog::setNotNullEnforced( bool enforced )
@@ -250,7 +251,12 @@ void QgsAttributeTypeDialog::setUnique( bool unique )
 
 bool QgsAttributeTypeDialog::unique() const
 {
-  return mUniqueCheckBox->isChecked();
+  return mUniqueCheckBox->isEnabled() && mUniqueCheckBox->isChecked();
+}
+
+bool QgsAttributeTypeDialog::uniqueFromProvider() const
+{
+  return ( !mUniqueCheckBox->isEnabled() ) && mUniqueCheckBox->isChecked();
 }
 
 void QgsAttributeTypeDialog::setUniqueEnforced( bool enforced )

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -104,6 +104,16 @@ class APP_EXPORT QgsAttributeTypeDialog: public QWidget, private Ui::QgsAttribut
     bool notNull() const;
 
     /**
+     * Returns whether the not null constraint is set by the provider
+     */
+    bool notNullFromProvider() const;
+
+    /**
+     * Returns whether the unique constraint is set by the provider
+     */
+    bool uniqueFromProvider() const;
+
+    /**
      * Sets whether the not null constraint is enforced.
      */
     void setNotNullEnforced( bool enforced );

--- a/src/core/qgsfieldconstraints.cpp
+++ b/src/core/qgsfieldconstraints.cpp
@@ -35,12 +35,7 @@ QgsFieldConstraints::ConstraintStrength QgsFieldConstraints::constraintStrength(
 
 void QgsFieldConstraints::setConstraintStrength( QgsFieldConstraints::Constraint constraint, QgsFieldConstraints::ConstraintStrength strength )
 {
-  if ( constraintOrigin( constraint ) == ConstraintOriginProvider )
-  {
-    // cannot be overwritten
-    return;
-  }
-  else if ( strength == ConstraintStrengthNotSet )
+  if ( strength == ConstraintStrengthNotSet )
   {
     mConstraintStrengths.remove( constraint );
   }
@@ -62,7 +57,7 @@ void QgsFieldConstraints::setConstraint( QgsFieldConstraints::Constraint constra
   {
     mConstraints |= constraint;
     mConstraintOrigins.insert( constraint, origin );
-    if ( !mConstraintStrengths.contains( constraint ) || origin == ConstraintOriginProvider )
+    if ( !mConstraintStrengths.contains( constraint ) )
     {
       mConstraintStrengths.insert( constraint, ConstraintStrengthHard );
     }

--- a/src/core/qgsfieldconstraints.h
+++ b/src/core/qgsfieldconstraints.h
@@ -96,8 +96,7 @@ class CORE_EXPORT QgsFieldConstraints
     ConstraintStrength constraintStrength( Constraint constraint ) const;
 
     /**
-     * Sets the strength of a constraint. Note that the strength of constraints which originate
-     * from a provider cannot be changed. Constraints default to ConstraintStrengthHard unless
+     * Sets the strength of a constraint. Constraints default to ConstraintStrengthHard unless
      * explicitly changed.
      * \see constraintStrength()
      */

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -174,7 +174,7 @@ void TestQgsField::gettersSetters()
   constraints.setConstraint( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintOriginProvider );
   constraints.setConstraintStrength( QgsFieldConstraints::ConstraintUnique, QgsFieldConstraints::ConstraintStrengthSoft );
   field.setConstraints( constraints );
-  QCOMPARE( field.constraints().constraintStrength( QgsFieldConstraints::ConstraintUnique ), QgsFieldConstraints::ConstraintStrengthHard );
+  QCOMPARE( field.constraints().constraintStrength( QgsFieldConstraints::ConstraintUnique ), QgsFieldConstraints::ConstraintStrengthSoft );
 }
 
 void TestQgsField::isNumeric()


### PR DESCRIPTION
## Description

This is a new feature that should fix https://issues.qgis.org/issues/19671 and be a workaround for https://issues.qgis.org/issues/20073

Non null and unique constraints set by the provider can now by overridden by the user.

In terms of UX, this adds two checkboxes "Allow null" and "Allow non unique" when provider constraints are set.

![Capture d’écran de 2019-03-12 14-48-57](https://user-images.githubusercontent.com/1618556/54205134-03442b00-44d6-11e9-9df0-dbc36324aad2.png)


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
