### PR TITLE
Make default geometry checks configurable via settings [needs-docs]

### DIFF
--- a/resources/qgis_global_settings.ini
+++ b/resources/qgis_global_settings.ini
@@ -83,3 +83,7 @@ PostgreSQL\default_timeout=30
 # cause performance issues, as the records must all be loaded from the related table on display.
 maxEntriesRelationWidget=100
 
+[geometry_validation]
+# A comma separated list of geometry validations to enable by default for newly added layers
+# Available checks: QgsIsValidCheck,QgsGeometryGapCheck,QgsGeometryOverlapCheck,QgsGeometryMissingVertexCheck
+default_checks=

--- a/src/core/qgsgeometryoptions.cpp
+++ b/src/core/qgsgeometryoptions.cpp
@@ -19,6 +19,13 @@
 
 #include "qgsxmlutils.h"
 
+#include "qgssettings.h"
+
+QgsGeometryOptions::QgsGeometryOptions()
+{
+  mGeometryChecks = QgsSettings().value( QStringLiteral( "geometry_validation/default_checks" ) ).toString().split( ',' ) ;
+}
+
 bool QgsGeometryOptions::removeDuplicateNodes() const
 {
   return mRemoveDuplicateNodes;

--- a/src/core/qgsgeometryoptions.h
+++ b/src/core/qgsgeometryoptions.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsGeometryOptions : public QObject
     /**
      * Create a new QgsGeometryOptions object.
      */
-    QgsGeometryOptions() = default;
+    QgsGeometryOptions();
 
     /**
      * Automatically remove duplicate nodes on all geometries which are edited on this layer.


### PR DESCRIPTION
This makes it possible to enable geometry checks by default for newly added layers.

Configuration is done by setting

`geometry_validation/default_checks` to a comma separated list of the available checks.
- `QgsGeometryMissingVertexCheck`
- `QgsGeometryOverlapCheck`
- `QgsIsValidCheck`
- `QgsGeometryGapCheck`

e.g.

`geometry_validation/default_checks=QgsIsValidCheck`