### PR TITLE
Layer CRS validation is NOT thread safe, and can cause crashes in background threads

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -540,7 +540,18 @@ static QgsMessageOutput *messageOutputViewer_()
 
 static void customSrsValidation_( QgsCoordinateReferenceSystem &srs )
 {
-  QgisApp::instance()->emitCustomCrsValidation( srs );
+  if ( QThread::currentThread() != QApplication::instance()->thread() )
+  {
+    // Running in a background thread -- we can't queue this connection, because
+    // srs is a reference and may be deleted before the queued slot is called.
+    // We also can't do ANY gui related stuff here. Best we can do is log
+    // a warning and move on...
+    QgsMessageLog::logMessage( QObject::tr( "Layer has unknown CRS" ) );
+  }
+  else
+  {
+    QgisApp::instance()->emitCustomCrsValidation( srs );
+  }
 }
 
 void QgisApp::emitCustomCrsValidation( QgsCoordinateReferenceSystem &srs )


### PR DESCRIPTION
Tracked down a randomly crashing script to opening layers in a background thread where those layers have unknown CRS. Currently this tries to utilise the app unknown crs handling (asking users or showing a messagebar warning), which leads to crashes.

We can't queue the connection to prompt for CRS (or warn via messagebar), because the slot uses a modifiable reference which may be deleted before the queued slot is called.

We also can't do ANY gui related stuff when this occurs. Best we can do is log a warning and move on...
