### PR TITLE
Disable automatic zoom to problem when fixing errors on geometries

### DIFF
--- a/src/app/qgsgeometryvalidationdock.h
+++ b/src/app/qgsgeometryvalidationdock.h
@@ -80,6 +80,7 @@ class QgsGeometryValidationDock : public QgsDockWidget, public Ui_QgsGeometryVal
     QgsRubberBand *mErrorRubberband = nullptr;
     QgsRubberBand *mErrorLocationRubberband = nullptr;
     QgsVectorLayer *mCurrentLayer = nullptr;
+    bool mPreventZoomToError = false;
 };
 
 #endif // QGSGEOMETRYVALIDATIONPANEL_H

--- a/src/app/qgsgeometryvalidationmodel.cpp
+++ b/src/app/qgsgeometryvalidationmodel.cpp
@@ -257,6 +257,7 @@ void QgsGeometryValidationModel::onSingleGeometryCheckCleared( QgsVectorLayer *l
 
   if ( mCurrentLayer == layer && !layerErrors.empty() )
   {
+    emit aboutToRemoveSingleGeometryCheck();
     beginRemoveRows( QModelIndex(), 0, layerErrors.size() - 1 );
   }
 
@@ -279,7 +280,10 @@ void QgsGeometryValidationModel::onGeometryCheckCompleted( QgsVectorLayer *layer
   if ( featureIdx > -1 && errors.empty() ) // && !mGeometryValidationService->validationActive( layer, fid ) )
   {
     if ( mCurrentLayer == layer )
+    {
+      emit aboutToRemoveSingleGeometryCheck();
       beginRemoveRows( QModelIndex(), featureIdx, featureIdx );
+    }
 
     layerErrors.removeAt( featureIdx );
 

--- a/src/app/qgsgeometryvalidationmodel.h
+++ b/src/app/qgsgeometryvalidationmodel.h
@@ -49,6 +49,15 @@ class QgsGeometryValidationModel : public QAbstractItemModel
 
     QgsVectorLayer *currentLayer() const;
 
+  signals:
+
+    /**
+     * Emitted before single geometry check results are removed.
+     * This is guaranteed to be emitted before the models regular
+     * aboutToRemoveRows() signal.
+     */
+    void aboutToRemoveSingleGeometryCheck();
+
   public slots:
     void setCurrentLayer( QgsVectorLayer *currentLayer );
 


### PR DESCRIPTION
Single geomtry checks (is valid) are exuted on the fly, if the map canvas suddenly
changes the current extent while fixing a geometry this becomes very nervous for
a user.
