### PR TITLE
[Bugfix][Server] In WMS GetFeatureInfo CRS param not mandatory when FILTER param

### DIFF
--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1093,8 +1093,16 @@ namespace QgsWms
     QgsMapSettings mapSettings;
     std::unique_ptr<QImage> outputImage( createImage( imageWidth, imageHeight ) );
 
+    // The CRS parameter is considered as mandatory in configureMapSettings
+    // but in the case of filter parameter, CRS parameter has not to be mandatory
+    bool mandatoryCrsParam = true;
+    if ( filtersDefined && !ijDefined && !xyDefined && mWmsParameters.crs().isEmpty() )
+    {
+      mandatoryCrsParam = false;
+    }
+
     // configure map settings (background, DPI, ...)
-    configureMapSettings( outputImage.get(), mapSettings );
+    configureMapSettings( outputImage.get(), mapSettings, mandatoryCrsParam );
 
     QgsMessageLog::logMessage( "mapSettings.destinationCrs(): " +  mapSettings.destinationCrs().authid() );
     QgsMessageLog::logMessage( "mapSettings.extent(): " +  mapSettings.extent().toString() );
@@ -1231,7 +1239,7 @@ namespace QgsWms
     return image.release();
   }
 
-  void QgsRenderer::configureMapSettings( const QPaintDevice *paintDevice, QgsMapSettings &mapSettings ) const
+  void QgsRenderer::configureMapSettings( const QPaintDevice *paintDevice, QgsMapSettings &mapSettings, bool mandatoryCrsParam ) const
   {
     if ( !paintDevice )
     {
@@ -1253,6 +1261,10 @@ namespace QgsWms
     {
       crs = QString( "EPSG:4326" );
       mapExtent.invert();
+    }
+    else if ( crs.isEmpty() && !mandatoryCrsParam )
+    {
+      crs = QString( "EPSG:4326" );
     }
 
     QgsCoordinateReferenceSystem outputCRS;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -197,9 +197,10 @@ namespace QgsWms
        * Configures map settings according to WMS parameters.
        * \param paintDevice The device that is used for painting (for dpi)
        * \param mapSettings Map settings to use for rendering
+       * \param mandatoryCrsParam does the CRS parameter has to be considered mandatory
        * may throw an exception
        */
-      void configureMapSettings( const QPaintDevice *paintDevice, QgsMapSettings &mapSettings ) const;
+      void configureMapSettings( const QPaintDevice *paintDevice, QgsMapSettings &mapSettings, bool mandatoryCrsParam = true ) const;
 
       QDomDocument featureInfoDocument( QList<QgsMapLayer *> &layers, const QgsMapSettings &mapSettings,
                                         const QImage *outputImage, const QString &version ) const;

--- a/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
+++ b/tests/src/python/test_qgsserver_wms_getfeatureinfo.py
@@ -347,6 +347,16 @@ class TestQgsServerWMSGetFeatureInfo(TestQgsServerWMSTestBase):
                                  urllib.parse.quote(':"NAME" = \'two\''),
                                  'wms_getfeatureinfo_filter_no_width')
 
+        # Test a filter without CRS parameter
+        self.wms_request_compare('GetFeatureInfo',
+                                 '&layers=testlayer%20%C3%A8%C3%A9&' +
+                                 'INFO_FORMAT=text%2Fxml&' +
+                                 'width=600&height=400&' +
+                                 'query_layers=testlayer%20%C3%A8%C3%A9&' +
+                                 'FEATURE_COUNT=10&FILTER=testlayer%20%C3%A8%C3%A9' +
+                                 urllib.parse.quote(':"NAME" = \'two\''),
+                                 'wms_getfeatureinfo_filter_no_crs')
+
     def testGetFeatureInfoTolerance(self):
         self.wms_request_compare('GetFeatureInfo',
                                  '&layers=layer3&styles=&' +

--- a/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_crs.txt
+++ b/tests/testdata/qgis_server/wms_getfeatureinfo_filter_no_crs.txt
@@ -1,0 +1,14 @@
+Content-Length: 577
+Content-Type: text/xml; charset=utf-8
+
+<GetFeatureInfoResponse>
+ <BoundingBox maxy="44.90143568" maxx="8.20354699" miny="44.90143568" CRS="EPSG:4326" minx="8.20354699"/>
+ <Layer name="testlayer èé">
+  <Feature id="1">
+   <Attribute value="2" name="id"/>
+   <Attribute value="two" name="name"/>
+   <Attribute value="two àò" name="utf8nameè"/>
+   <BoundingBox maxy="44.9014" maxx="8.2035" miny="44.9014" CRS="EPSG:4326" minx="8.2035"/>
+  </Feature>
+ </Layer>
+</GetFeatureInfoResponse>


### PR DESCRIPTION
## Description
The CRS parameter is considered as mandatory in GetFeatureInfo even if the FILTER parameter is used without I and J parameters.

To fix it, set a fake CRS in the parameter when I/J and X/Y parameters are not defined and FILTER parameter is defined.

## Checklist

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
