### PR TITLE
Misc crash fixes

### DIFF
--- a/python/core/auto_generated/qgsfeaturerequest.sip.in
+++ b/python/core/auto_generated/qgsfeaturerequest.sip.in
@@ -243,6 +243,17 @@ Deserialize from XML
         QSet<QString> usedAttributes() const;
 %Docstring
 Returns a set of used attributes
+
+.. note::
+
+   The returned attributes names are NOT guaranteed to be valid.
+%End
+
+        QSet<int> usedAttributeIndices( const QgsFields &fields ) const;
+%Docstring
+Returns a set of used, validated attribute indices
+
+.. versionadded:: 3.8
 %End
 
         QString dump() const;

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -485,6 +485,24 @@ QSet<QString> QgsFeatureRequest::OrderBy::usedAttributes() const
   return usedAttributes;
 }
 
+QSet<int> QgsFeatureRequest::OrderBy::usedAttributeIndices( const QgsFields &fields ) const
+{
+  QSet<int> usedAttributeIdx;
+  for ( const OrderByClause &clause : *this )
+  {
+    const auto referencedColumns = clause.expression().referencedColumns();
+    for ( const QString &fieldName : referencedColumns )
+    {
+      int idx = fields.lookupField( fieldName );
+      if ( idx >= 0 )
+      {
+        usedAttributeIdx.insert( idx );
+      }
+    }
+  }
+  return usedAttributeIdx;
+}
+
 QString QgsFeatureRequest::OrderBy::dump() const
 {
   QStringList results;

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -257,8 +257,15 @@ class CORE_EXPORT QgsFeatureRequest
 
         /**
          * Returns a set of used attributes
+         * \note The returned attributes names are NOT guaranteed to be valid.
          */
         QSet<QString> CORE_EXPORT usedAttributes() const;
+
+        /**
+         * Returns a set of used, validated attribute indices
+         * \since QGIS 3.8
+         */
+        QSet<int> CORE_EXPORT usedAttributeIndices( const QgsFields &fields ) const;
 
         /**
          * Dumps the content to an SQL equivalent syntax

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1594,6 +1594,7 @@ bool QgsVectorLayer::setDataProvider( QString const &provider, const QgsDataProv
   if ( !mValid )
   {
     QgsDebugMsgLevel( QStringLiteral( "Invalid provider plugin %1" ).arg( QString( mDataSource.toUtf8() ) ), 2 );
+    return false;
   }
 
   if ( mDataProvider->capabilities() & QgsVectorDataProvider::ReadLayerMetadata )

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -189,9 +189,10 @@ QgsVectorLayerFeatureIterator::QgsVectorLayerFeatureIterator( QgsVectorLayerFeat
     // and only modify the subset if we cannot.
     if ( !mProviderRequest.orderBy().isEmpty() )
     {
-      Q_FOREACH ( const QString &attr, mProviderRequest.orderBy().usedAttributes() )
+      const auto usedAttributeIndices = mProviderRequest.orderBy().usedAttributeIndices( mSource->mFields );
+      for ( int attrIndex : usedAttributeIndices )
       {
-        providerSubset << mSource->mFields.lookupField( attr );
+        providerSubset << attrIndex;
       }
     }
 

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -161,9 +161,9 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && !mRequest.orderBy().isEmpty() )
   {
     QgsAttributeList attrs = request.subsetOfAttributes();
-    Q_FOREACH ( const QString &attr, mRequest.orderBy().usedAttributes() )
+    const auto usedAttributeIndices = mRequest.orderBy().usedAttributeIndices( mSource->mFields );
+    for ( int attrIndex : usedAttributeIndices )
     {
-      int attrIndex = mSource->mFields.lookupField( attr );
       if ( !attrs.contains( attrIndex ) )
         attrs << attrIndex;
     }

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -95,10 +95,9 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest &request )
     }
 
     // ensure that all attributes required for order by are fetched
-    const QSet< QString > orderByAttributes = mRequest.orderBy().usedAttributes();
-    for ( const QString &attr : orderByAttributes )
+    const auto usedAttributeIndices = mRequest.orderBy().usedAttributeIndices( mSource->mFields );
+    for ( int attrIndex : usedAttributeIndices )
     {
-      int attrIndex = mSource->mFields.lookupField( attr );
       if ( !attrs.contains( attrIndex ) )
         attrs << attrIndex;
     }

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -136,9 +136,10 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrFeatureSource *source, bool 
   if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && !mRequest.orderBy().isEmpty() )
   {
     QSet<int> attributeIndexes;
-    Q_FOREACH ( const QString &attr, mRequest.orderBy().usedAttributes() )
+    const auto usedAttributeIndices = mRequest.orderBy().usedAttributeIndices( mSource->mFields );
+    for ( int attrIdx : usedAttributeIndices )
     {
-      attributeIndexes << mSource->mFields.lookupField( attr );
+      attributeIndexes << attrIdx;
     }
     attributeIndexes += attrs.toSet();
     attrs = attributeIndexes.toList();

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -186,9 +186,9 @@ QgsPostgresFeatureIterator::QgsPostgresFeatureIterator( QgsPostgresFeatureSource
     if ( !mOrderByCompiled && mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes )
     {
       QgsAttributeList attrs = mRequest.subsetOfAttributes();
-      Q_FOREACH ( const QString &attr, mRequest.orderBy().usedAttributes() )
+      const auto usedAttributeIndices = mRequest.orderBy().usedAttributeIndices( mSource->mFields );
+      for ( int attrIndex : usedAttributeIndices )
       {
-        int attrIndex = mSource->mFields.lookupField( attr );
         if ( !attrs.contains( attrIndex ) )
           attrs << attrIndex;
       }

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -196,9 +196,10 @@ QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator( QgsSpatiaLiteFeature
     if ( !mOrderByCompiled && mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && !mRequest.orderBy().isEmpty() )
     {
       QSet<int> attributeIndexes;
-      Q_FOREACH ( const QString &attr, mRequest.orderBy().usedAttributes() )
+      const auto usedAttributeIndices = mRequest.orderBy().usedAttributeIndices( mSource->mFields );
+      for ( int attrIdx : usedAttributeIndices )
       {
-        attributeIndexes << mSource->mFields.lookupField( attr );
+        attributeIndexes << attrIdx;
       }
       attributeIndexes += mRequest.subsetOfAttributes().toSet();
       mRequest.setSubsetOfAttributes( attributeIndexes.toList() );

--- a/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
+++ b/src/providers/virtual/qgsvirtuallayerfeatureiterator.cpp
@@ -128,7 +128,8 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
     if ( request.flags() & QgsFeatureRequest::SubsetOfAttributes )
     {
       // copy only selected fields
-      Q_FOREACH ( int idx, request.subsetOfAttributes() )
+      const auto subsetOfAttributes = request.subsetOfAttributes();
+      for ( int idx : subsetOfAttributes )
       {
         mAttributes << idx;
       }
@@ -147,9 +148,9 @@ QgsVirtualLayerFeatureIterator::QgsVirtualLayerFeatureIterator( QgsVirtualLayerF
       // also need attributes required by order by
       if ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes && !mRequest.orderBy().isEmpty() )
       {
-        Q_FOREACH ( const QString &attr, mRequest.orderBy().usedAttributes() )
+        const auto usedAttributeIndices = mRequest.orderBy().usedAttributeIndices( mSource->mFields );
+        for ( int attrIdx : usedAttributeIndices )
         {
-          int attrIdx = mSource->mFields.lookupField( attr );
           if ( !mAttributes.contains( attrIdx ) )
             mAttributes << attrIdx;
         }


### PR DESCRIPTION
Following two issues were uncovered opening a project referencing invalid postgres datasources, as well as non-existing fields in existing data sources:

### Invalid fieldNames in the orderBy clauses cause QGIS to crash
Issue:
- The field names required by the orderBy clauses are returned by `QgsFeatureRequest::OrderBy::usedAttributes()`. The result may very well contain non-existing field names.
- Throughout the codebase, these field names are converted to indices via `QgsFields::lookupField`. This returns `-1` if the field does not exist. But, throughout the codebase, the invalid indices are pretty much never filtered out, and passed to `QgsFeatureRequest::setSubsetOfAttributes`
- The actual fields are then requested via `QgsFields::at`, which does not perform any range check, hence performing an out of bounds array access if the field index is invalid.

Proposed fix:
- Add a `QgsFeatureRequest::OrderBy::usedAttributeIndices` method which returns indices validated against the available fields, and use this method throughout.
- `QgsFeatureRequest::OrderBy::usedAttributes` should hence not be used / relied uppon...
- I wonder whether `QgsFields::at` (and others) should actually verify the validity of the index, and if invalid just return `QgsField()`? Downside might be that you can get very wierd behaviour, and the out-right crash might actually make debugging easier.

### Use of invalid providers 
Issue:
- `QgsVectorLayer::setDataProvider` does not return `false` if the provider reports it is not valid
- The invalid provider is hence used, which can lead to crashes, i.e.:

      QgsRectangle QgsVectorLayer::extent() -> QgsPostgresProvider::hasMetadata() ->  QgsPostgresProvider::relkind() -> QgsPostgresProvider::connectionRO()->PQexec()

  which segfaults due to `connectionRO()` returning `nullptr`.

Proposed fix:
- Return `false` from `QgsVectorLayer::setDataProvider` if the provider reports it is invalid.