### PR TITLE
[WIP] Add Logarithmic breaks to Vector Graduated Symbols

### DIFF
--- a/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.cpp
@@ -848,21 +848,20 @@ static QList<double> _calcJenksBreaks( QList<double> values, int classes,
   return breaks.toList();
 } //_calcJenksBreaks
 
-static QList<double> _calcLogarithmicBreaks( QList<double> values, int classes,
-                                       double minimum, double maximum)
+static QList<double> _calcLogarithmicBreaks( QList<double> values, int classes, double minimum, double maximum )
 {
-    QVector<double> breaks( 0 );
-    double value = minimum;
-    breaks.reserve( classes );
-    int lg10 = floor(log10(minimum));
-    //lg10--; // just to be 1 lower
-    for ( int i = 0; i < classes; i++ )
-    {
-      value = pow(10, lg10++);
-      breaks.append( value );
-    }
+  QVector<double> breaks( 0 );
+  double value = minimum;
+  breaks.reserve( classes );
+  int lg10 = floor( log10( minimum ) );
+  //lg10--; // just to be 1 lower
+  for ( int i = 0; i < classes; i++ )
+  {
+    value = pow( 10, lg10++ );
+    breaks.append( value );
+  }
 
-    return breaks.toList();
+  return breaks.toList();
 
 } //_calcLogarithmicBreaks
 
@@ -1026,8 +1025,9 @@ void QgsGraduatedSymbolRenderer::updateClasses( QgsVectorLayer *vlayer, Mode mod
         label = QString::number( labels[i - 1], 'f', 2 ) + " Std Dev" + " - " + QString::number( labels[i], 'f', 2 ) + " Std Dev";
       }
     }
-    else if ( mode == Logarithmic ) {
-        label = QString::number( lower, 'E', 0 ) + " - " + QString::number( upper, 'E', 1 );
+    else if ( mode == Logarithmic )
+    {
+      label = QString::number( lower, 'E', 0 ) + " - " + QString::number( upper, 'E', 0 );
     }
     else
     {

--- a/src/core/symbology/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology/qgsgraduatedsymbolrenderer.h
@@ -217,7 +217,8 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
       Jenks,
       StdDev,
       Pretty,
-      Custom
+      Custom,
+      Logarithmic
     };
 
     Mode mode() const { return mMode; }

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -457,6 +457,7 @@ QgsGraduatedSymbolRendererWidget::QgsGraduatedSymbolRendererWidget( QgsVectorLay
   cboGraduatedMode->addItem( tr( "Natural Breaks (Jenks)" ), QgsGraduatedSymbolRenderer::Jenks );
   cboGraduatedMode->addItem( tr( "Standard Deviation" ), QgsGraduatedSymbolRenderer::StdDev );
   cboGraduatedMode->addItem( tr( "Pretty Breaks" ), QgsGraduatedSymbolRenderer::Pretty );
+  cboGraduatedMode->addItem( tr( "Logarithmic Breaks" ), QgsGraduatedSymbolRenderer::Logarithmic );
 
   connect( methodComboBox, static_cast<void ( QComboBox::* )( int )>( &QComboBox::currentIndexChanged ), this, &QgsGraduatedSymbolRendererWidget::methodComboBox_currentIndexChanged );
   this->layout()->setContentsMargins( 0, 0, 0, 0 );
@@ -655,6 +656,7 @@ void QgsGraduatedSymbolRendererWidget::updateUiFromRenderer( bool updateCount )
     case QgsGraduatedSymbolRenderer::Quantile:
     case QgsGraduatedSymbolRenderer::Jenks:
     case QgsGraduatedSymbolRenderer::Custom:
+    case QgsGraduatedSymbolRenderer::Logarithmic:  // TODO: sure about this?
     {
       mGroupBoxSymmetric->setVisible( false );
       cbxAstride->setVisible( false );
@@ -914,6 +916,25 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
         symmetryPoint = spinSymmetryPointForOtherMethods->value();
         astride = cbxAstride->isChecked();
       }
+      break;
+    }
+
+    case QgsGraduatedSymbolRenderer::Logarithmic:
+    {
+       if (minimum <= 0){
+          int result = QMessageBox::warning(
+                         this,
+                         tr( "There is/are value(s) in your data <= zero. " ),
+                         tr( "Logarithmic mode cannot be used." ),
+                         QMessageBox::Ok );
+          if ( result != QMessageBox::Ok )
+          {
+            // set back too ???
+            //cboGraduatedMode->set
+            return;
+          }
+      }
+      mode = QgsGraduatedSymbolRenderer::Logarithmic;
       break;
     }
 

--- a/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
+++ b/src/gui/symbology/qgsgraduatedsymbolrendererwidget.cpp
@@ -656,7 +656,7 @@ void QgsGraduatedSymbolRendererWidget::updateUiFromRenderer( bool updateCount )
     case QgsGraduatedSymbolRenderer::Quantile:
     case QgsGraduatedSymbolRenderer::Jenks:
     case QgsGraduatedSymbolRenderer::Custom:
-    case QgsGraduatedSymbolRenderer::Logarithmic:  // TODO: sure about this?
+    case QgsGraduatedSymbolRenderer::Logarithmic:
     {
       mGroupBoxSymmetric->setVisible( false );
       cbxAstride->setVisible( false );
@@ -921,18 +921,19 @@ void QgsGraduatedSymbolRendererWidget::classifyGraduated()
 
     case QgsGraduatedSymbolRenderer::Logarithmic:
     {
-       if (minimum <= 0){
-          int result = QMessageBox::warning(
-                         this,
-                         tr( "There is/are value(s) in your data <= zero. " ),
-                         tr( "Logarithmic mode cannot be used." ),
-                         QMessageBox::Ok );
-          if ( result != QMessageBox::Ok )
-          {
-            // set back too ???
-            //cboGraduatedMode->set
-            return;
-          }
+      if ( minimum <= 0 )
+      {
+        int result = QMessageBox::warning(
+                       this,
+                       tr( "Logarithmic mode cannot be used." ),
+                       tr( "There is/are value(s) in your data <= zero.\nColumn: '%1' contains: %2 " ).arg( attrName, QString::number( minimum ) ),
+                       QMessageBox::Ok );
+        if ( result == QMessageBox::Ok )
+        {
+          // set back too ???
+          //cboGraduatedMode
+          return;
+        }
       }
       mode = QgsGraduatedSymbolRenderer::Logarithmic;
       break;


### PR DESCRIPTION
## Description

This PR is a WIP to add Logarithmic breaks in the Graduated Symbol Classification for Vector data.
In certain area's people prefer to have breaks on logarithmic values.

During the hackfest I heard that @3nids has maybe plans to work on this too, but thought to add this now as I had it around to maybe have a look or discuss about it. 

Creating 'breaks' in data is has now 3 different implementations, depending on the data type: vector, raster or mesh (@PeterPetrik). It would be awsom if this could be centralized to some shared code: 'break-providers' or so was @m-kuhn proposing.

Anyway, this is what it looks now:

![gnome-shell-screenshot-DYLQYZ](https://user-images.githubusercontent.com/731673/54492206-c8bb0380-48c4-11e9-80b2-4942e61d85c9.png)

I'm adding 
[random2.zip](https://github.com/qgis/QGIS/files/2975254/random2.zip)
a sample Geopackage with values besween 1E-5 till 1E+5 to test.

Some remarks/questions:

- in this code I set the Legend notation like '1E-5', that get's lost when you click the 'trim' button? Using classify it will be back. I think it works ok, but wonder if this is clear for a user'

- logarithmic values cannot be <= 0  so I added a check for it showing something like:

![gnome-shell-screenshot-G1ARYZ](https://user-images.githubusercontent.com/731673/54492254-336c3f00-48c5-11e9-879b-0f457db57bdd.png)

- In Graduated classification in vector, we do not have a way to add a minimum / maximum value. In raster you can, in future work this would be great.


## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
