### PR TITLE
[processing] Allow QgsGeometry values for point parameter values

### DIFF
--- a/src/core/processing/qgsprocessingparameters.cpp
+++ b/src/core/processing/qgsprocessingparameters.cpp
@@ -1126,6 +1126,12 @@ QgsPointXY QgsProcessingParameters::parameterAsPoint( const QgsProcessingParamet
   {
     return val.value<QgsPointXY>();
   }
+  if ( val.canConvert< QgsGeometry >() )
+  {
+    const QgsGeometry geom = val.value<QgsGeometry>();
+    if ( !geom.isNull() )
+      return geom.centroid().asPoint();
+  }
   if ( val.canConvert< QgsReferencedPointXY >() )
   {
     QgsReferencedPointXY rp = val.value<QgsReferencedPointXY>();
@@ -2129,6 +2135,10 @@ bool QgsProcessingParameterPoint::checkValueIsAcceptable( const QVariant &input,
   {
     return true;
   }
+  if ( input.canConvert< QgsGeometry >() )
+  {
+    return true;
+  }
 
   if ( input.type() == QVariant::String )
   {
@@ -2165,12 +2175,21 @@ QString QgsProcessingParameterPoint::valueAsPythonString( const QVariant &value,
     return QStringLiteral( "'%1,%2'" ).arg( qgsDoubleToString( r.x() ),
                                             qgsDoubleToString( r.y() ) );
   }
-  if ( value.canConvert< QgsReferencedPointXY >() )
+  else if ( value.canConvert< QgsReferencedPointXY >() )
   {
     QgsReferencedPointXY r = value.value<QgsReferencedPointXY>();
     return QStringLiteral( "'%1,%2 [%3]'" ).arg( qgsDoubleToString( r.x() ),
            qgsDoubleToString( r.y() ),
            r.crs().authid() );
+  }
+  else if ( value.canConvert< QgsGeometry >() )
+  {
+    const QgsGeometry g = value.value<QgsGeometry>();
+    if ( !g.isNull() )
+    {
+      const QString wkt = g.asWkt();
+      return QStringLiteral( "QgsGeometry.fromWkt('%1')" ).arg( wkt );
+    }
   }
 
   return QgsProcessingParameterDefinition::valueAsPythonString( value, context );

--- a/src/core/processing/qgsprocessingparametertypeimpl.h
+++ b/src/core/processing/qgsprocessingparametertypeimpl.h
@@ -508,7 +508,8 @@ class CORE_EXPORT QgsProcessingParameterTypePoint : public QgsProcessingParamete
       return QStringList() << QObject::tr( "str: as an 'x,y' string, e.g. '1.5,10.1'" )
              << QStringLiteral( "QgsPointXY" )
              << QStringLiteral( "QgsProperty" )
-             << QStringLiteral( "QgsReferencedPointXY" );
+             << QStringLiteral( "QgsReferencedPointXY" )
+             << QStringLiteral( "QgsGeometry: centroid of geometry is used" );
     }
 
     QStringList acceptedStringValues() const override

--- a/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
+++ b/src/gui/processing/qgsprocessingwidgetwrapperimpl.cpp
@@ -2373,7 +2373,7 @@ QList<int> QgsProcessingPointWidgetWrapper::compatibleDataTypes() const
 
 QString QgsProcessingPointWidgetWrapper::modelerExpressionFormatString() const
 {
-  return tr( "string of the format 'x,y'" );
+  return tr( "string of the format 'x,y' or a geometry value (centroid is used)" );
 }
 
 QString QgsProcessingPointWidgetWrapper::parameterType() const


### PR DESCRIPTION
(The centroid of the geometry is used for the point parameter value.)
This makes it easier to write expressions for the value of point parameters, since all the QGIS expression functions for working with geometry types return QgsGeometry value themselves (e.g.
make_point, centroid, ...). In this case it's much nicer to allow expression values like `make_point(3,4)` within a precalculated expression based value in a Processing model.

![image](https://user-images.githubusercontent.com/1829991/54510708-32591180-499a-11e9-8e0b-1a6d327eeb73.png)
