### PR TITLE
Raise a Python OwnershipException when trying to /Transfer/ owner objects

### DIFF
--- a/python/core/auto_generated/geometry/qgsmultipoint.sip.in
+++ b/python/core/auto_generated/geometry/qgsmultipoint.sip.in
@@ -40,8 +40,28 @@ Multi point geometry collection.
 
     virtual int nCoordinates() const;
 
-    virtual bool addGeometry( QgsAbstractGeometry *g /Transfer/ );
+    bool addGeometry( QgsAbstractGeometry *g ) /TypeHint="bool"/;
+%MethodCode
+    PyObject *obj = sipConvertFromType( a0, sipType_QgsAbstractGeometry, NULL );
+    if ( !sipIsPyOwned( ( sipSimpleWrapper * )obj ) )
+    {
+      PyErr_SetString( sipException_OwnershipException, "Geometry is already owned by another c++ object. Use .clone() to add a deep copy of the geometry to this multipoint." );
+      sipIsErr = 1;
+      Py_DECREF( obj );
+    }
+    else
+    {
+      bool res = sipCpp->addGeometry( a0 );
+      if ( res )
+      {
+        PyObject *owner = sipConvertFromType( sipCpp, sipType_QgsAbstractGeometry, NULL );
+        sipTransferTo( obj,  owner );
+      }
+      //Py_DECREF( obj );
+      return PyBool_FromLong( res );
+    }
 
+%End
     virtual bool insertGeometry( QgsAbstractGeometry *g /Transfer/, int index );
 
     virtual QgsAbstractGeometry *boundary() const /Factory/;

--- a/python/core/qgsexception.sip
+++ b/python/core/qgsexception.sip
@@ -33,3 +33,15 @@
   SIP_UNBLOCK_THREADS
 %End
 };
+
+%Exception OwnershipException(SIP_Exception) /PyName=OwnershipException/
+{
+%TypeHeaderCode
+#include <qgsexception.h>
+%End
+%RaiseCode
+  SIP_BLOCK_THREADS
+  PyErr_SetString(sipException_OwnershipException, sipExceptionRef.what().toUtf8().constData() );
+  SIP_UNBLOCK_THREADS
+%End
+};

--- a/src/core/geometry/qgsmultipoint.h
+++ b/src/core/geometry/qgsmultipoint.h
@@ -40,7 +40,32 @@ class CORE_EXPORT QgsMultiPoint: public QgsGeometryCollection
     QDomElement asGml3( QDomDocument &doc, int precision = 17, const QString &ns = "gml", QgsAbstractGeometry::AxisOrder axisOrder = QgsAbstractGeometry::AxisOrder::XY ) const override;
     QString asJson( int precision = 17 ) const override;
     int nCoordinates() const override;
+#ifndef SIP_RUN
     bool addGeometry( QgsAbstractGeometry *g SIP_TRANSFER ) override;
+#else
+    bool addGeometry( QgsAbstractGeometry *g ) SIP_TYPEHINT( bool );
+    % MethodCode
+    PyObject *obj = sipConvertFromType( a0, sipType_QgsAbstractGeometry, NULL );
+    if ( !sipIsPyOwned( ( sipSimpleWrapper * )obj ) )
+    {
+      PyErr_SetString( sipException_OwnershipException, "Geometry is already owned by another c++ object. Use .clone() to add a deep copy of the geometry to this multipoint." );
+      sipIsErr = 1;
+      Py_DECREF( obj );
+    }
+    else
+    {
+      bool res = sipCpp->addGeometry( a0 );
+      if ( res )
+      {
+        PyObject *owner = sipConvertFromType( sipCpp, sipType_QgsAbstractGeometry, NULL );
+        sipTransferTo( obj,  owner );
+      }
+      //Py_DECREF( obj );
+      return PyBool_FromLong( res );
+    }
+
+    % End
+#endif
     bool insertGeometry( QgsAbstractGeometry *g SIP_TRANSFER, int index ) override;
     QgsAbstractGeometry *boundary() const override SIP_FACTORY;
     int vertexNumberFromVertexId( QgsVertexId id ) const override;

--- a/src/core/qgsexception.h
+++ b/src/core/qgsexception.h
@@ -90,4 +90,21 @@ class CORE_EXPORT QgsProcessingException : public QgsException
 
 };
 
+/**
+ * \class OwnershipException
+ * \ingroup core
+ * Custom exception class for object ownership issues.
+ * \since QGIS 3.8
+ */
+class CORE_EXPORT OwnershipException : public QgsException
+{
+  public:
+
+    /**
+     * Constructor for OwnershipException, with the specified error \a message.
+     */
+    OwnershipException( const QString &message ) : QgsException( message ) {}
+
+};
+
 #endif

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -38,7 +38,8 @@ from qgis.core import (
     QgsWkbTypes,
     QgsRenderChecker,
     QgsCoordinateReferenceSystem,
-    QgsProject
+    QgsProject,
+    OwnershipException
 )
 from qgis.PyQt.QtCore import QDir
 from qgis.PyQt.QtGui import QImage, QPainter, QPen, QColor, QBrush, QPainterPath
@@ -545,6 +546,20 @@ class TestQgsGeometry(unittest.TestCase):
         self.assertEqual(g.asWkt(1), 'Polygon ((0 0, 1 0, 1 1, 0 0))')
         with self.assertRaises(IndexError):
             g.removeInteriorRing(0)
+
+    def testOwnership(self):
+        """
+        Test ownership related exceptions
+        """
+        mp = QgsGeometry.fromWkt('MultiPoint(1 1,2 2)')
+
+        mp2 = QgsGeometry.fromWkt('MultiPoint(3 3)')
+        with self.assertRaises(OwnershipException):
+            mp2.get().addGeometry(mp.constGet().geometryN(0))
+        self.assertEqual(mp2.asWkt(), 'MultiPoint ((3 3))')
+
+        self.assertTrue(mp2.get().addGeometry(QgsPoint(3, 4)))
+        self.assertEqual(mp2.asWkt(), 'MultiPoint ((3 3),(3 4))')
 
     def testPointXY(self):
         """


### PR DESCRIPTION
Proof of concept: Raise a Python OwnershipException when trying to /Transfer/ an object which is already owned by some other c++ object. This would be very nice to assist PyQGIS developers who aren't familiar with the c++ memory management model and concepts of ownership/etc. 

Just a proof of concept, because the sip ownership isn't quite right here and I sometimes get crashes :rofl: 