### PR TITLE
SRCHEIGHT/SRCWIDTH for GetLegendGraphic request

### DIFF
--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -716,21 +716,6 @@ namespace QgsWms
     return mWmsParameters[ QgsWmsParameter::SRCWIDTH ].toInt();
   }
 
-  int QgsWmsParameters::getHeightAsInt() const
-  {
-    if ( QStringList( { QStringLiteral( "GetLegendGraphic" ), QStringLiteral( "GetLegendGraphics" ) } ).contains( request() ) && srcHeightAsInt() > 0 )
-      return srcHeightAsInt();
-    return heightAsInt();
-  }
-
-  int QgsWmsParameters::getWidthAsInt() const
-  {
-
-    if ( QStringList( { QStringLiteral( "GetLegendGraphic" ), QStringLiteral( "GetLegendGraphics" ) } ).contains( request() ) && srcWidthAsInt() > 0 )
-      return srcWidthAsInt();
-    return widthAsInt();
-  }
-
   QString QgsWmsParameters::dpi() const
   {
     return mWmsParameters[ QgsWmsParameter::DPI ].toString();

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -718,18 +718,17 @@ namespace QgsWms
 
   int QgsWmsParameters::getHeightAsInt() const
   {
-    if ( request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) != 0 &&
-         request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) != 0 )
-      return heightAsInt();
-    return srcHeightAsInt();
+    if ( QStringList( { QStringLiteral( "GetLegendGraphic" ), QStringLiteral( "GetLegendGraphics" ) } ).contains( request() ) && srcHeightAsInt() > 0 )
+      return srcHeightAsInt();
+    return heightAsInt();
   }
 
   int QgsWmsParameters::getWidthAsInt() const
   {
-    if ( request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) != 0 &&
-         request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) != 0 )
-      return widthAsInt();
-    return srcWidthAsInt();
+
+    if ( QStringList( { QStringLiteral( "GetLegendGraphic" ), QStringLiteral( "GetLegendGraphics" ) } ).contains( request() ) && srcWidthAsInt() > 0 )
+      return srcWidthAsInt();
+    return widthAsInt();
   }
 
   QString QgsWmsParameters::dpi() const

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -363,6 +363,16 @@ namespace QgsWms
                                   QVariant( 0 ) );
     save( pWidth );
 
+    const QgsWmsParameter pSrcHeight( QgsWmsParameter::SRCHEIGHT,
+                                      QVariant::Int,
+                                      QVariant( 0 ) );
+    save( pSrcHeight );
+
+    const QgsWmsParameter pSrcWidth( QgsWmsParameter::SRCWIDTH,
+                                     QVariant::Int,
+                                     QVariant( 0 ) );
+    save( pSrcWidth );
+
     const QgsWmsParameter pBbox( QgsWmsParameter::BBOX );
     save( pBbox );
 
@@ -684,6 +694,42 @@ namespace QgsWms
   int QgsWmsParameters::widthAsInt() const
   {
     return mWmsParameters[ QgsWmsParameter::WIDTH ].toInt();
+  }
+
+  QString QgsWmsParameters::srcHeight() const
+  {
+    return mWmsParameters[ QgsWmsParameter::SRCHEIGHT ].toString();
+  }
+
+  QString QgsWmsParameters::srcWidth() const
+  {
+    return mWmsParameters[ QgsWmsParameter::SRCWIDTH ].toString();
+  }
+
+  int QgsWmsParameters::srcHeightAsInt() const
+  {
+    return mWmsParameters[ QgsWmsParameter::SRCHEIGHT ].toInt();
+  }
+
+  int QgsWmsParameters::srcWidthAsInt() const
+  {
+    return mWmsParameters[ QgsWmsParameter::SRCWIDTH ].toInt();
+  }
+
+  int QgsWmsParameters::getHeightAsInt() const
+  {
+    if ( request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) != 0 &&
+         request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) != 0 )
+      return heightAsInt();
+    return srcHeightAsInt();
+  }
+
+  int QgsWmsParameters::getWidthAsInt() const
+  {
+    if ( request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) != 0 &&
+         request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) != 0 )
+      return widthAsInt();
+    return srcWidthAsInt();
   }
 
   QString QgsWmsParameters::dpi() const

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -176,7 +176,9 @@ namespace QgsWms
         WITH_MAPTIP,
         WMTVER,
         ATLAS_PK,
-        FORMAT_OPTIONS
+        FORMAT_OPTIONS,
+        SRCWIDTH,
+        SRCHEIGHT
       };
       Q_ENUM( Name )
 
@@ -389,6 +391,50 @@ namespace QgsWms
        * \throws QgsBadRequestException
        */
       int heightAsInt() const;
+
+      /**
+       * Returns SRCWIDTH parameter or an empty string if not defined.
+       * \returns srcWidth parameter
+       */
+      QString srcWidth() const;
+
+      /**
+       * Returns SRCWIDTH parameter as an int or its default value if not
+       * defined. An exception is raised if SRCWIDTH is defined and cannot be
+       * converted.
+       * \returns srcWidth parameter
+       * \throws QgsBadRequestException
+       */
+      int srcWidthAsInt() const;
+
+      /**
+       * Returns SRCHEIGHT parameter or an empty string if not defined.
+       * \returns srcHeight parameter
+       */
+      QString srcHeight() const;
+
+      /**
+       * Returns SRCHEIGHT parameter as an int or its default value if not
+       * defined. An exception is raised if SRCHEIGHT is defined and cannot be
+       * converted.
+       * \returns srcHeight parameter
+       * \throws QgsBadRequestException
+       */
+      int srcHeightAsInt() const;
+
+      /**
+       * Returns SRCHEIGHT parameter if it's a GetLegendGraphics request and otherwise HEIGHT parameter
+       *
+       * \returns getHeightAsInt parameter
+       */
+      int getHeightAsInt() const;
+
+      /**
+       * Returns SRCWIDTH parameter if it's a GetLegendGraphics request and otherwise WIDTH parameter
+       *
+       * \returns getWidthAsInt parameter
+       */
+      int getWidthAsInt() const;
 
       /**
        * Returns VERSION parameter if defined or its default value.

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -395,6 +395,7 @@ namespace QgsWms
       /**
        * Returns SRCWIDTH parameter or an empty string if not defined.
        * \returns srcWidth parameter
+       * \since QGIS 3.8
        */
       QString srcWidth() const;
 
@@ -404,12 +405,14 @@ namespace QgsWms
        * converted.
        * \returns srcWidth parameter
        * \throws QgsBadRequestException
+       * \since QGIS 3.8
        */
       int srcWidthAsInt() const;
 
       /**
        * Returns SRCHEIGHT parameter or an empty string if not defined.
        * \returns srcHeight parameter
+       * \since QGIS 3.8
        */
       QString srcHeight() const;
 
@@ -419,6 +422,7 @@ namespace QgsWms
        * converted.
        * \returns srcHeight parameter
        * \throws QgsBadRequestException
+       * \since QGIS 3.8
        */
       int srcHeightAsInt() const;
 

--- a/src/server/services/wms/qgswmsparameters.h
+++ b/src/server/services/wms/qgswmsparameters.h
@@ -423,20 +423,6 @@ namespace QgsWms
       int srcHeightAsInt() const;
 
       /**
-       * Returns SRCHEIGHT parameter if it's a GetLegendGraphics request and otherwise HEIGHT parameter
-       *
-       * \returns getHeightAsInt parameter
-       */
-      int getHeightAsInt() const;
-
-      /**
-       * Returns SRCWIDTH parameter if it's a GetLegendGraphics request and otherwise WIDTH parameter
-       *
-       * \returns getWidthAsInt parameter
-       */
-      int getWidthAsInt() const;
-
-      /**
        * Returns VERSION parameter if defined or its default value.
        * \returns version
        */

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -187,7 +187,7 @@ namespace QgsWms
     if ( !mWmsParameters.bbox().isEmpty() )
     {
       QgsMapSettings mapSettings;
-      image.reset( createImage( getWidthAsInt(), getHeightAsInt(), false ) );
+      image.reset( createImage( width(), height(), false ) );
       configureMapSettings( image.get(), mapSettings );
       legendSettings.setMapScale( mapSettings.scale() );
       legendSettings.setMapUnitsPerPixel( mapSettings.mapUnitsPerPixel() );
@@ -1045,8 +1045,8 @@ namespace QgsWms
     }
 
     // create the mapSettings and the output image
-    int imageWidth = getWidthAsInt();
-    int imageHeight = getHeightAsInt();
+    int imageWidth = mWmsParameters.widthAsInt();
+    int imageHeight = mWmsParameters.heightAsInt();
 
     // Provide default image width/height values if format is not image
     if ( !( imageWidth && imageHeight ) &&  ! mWmsParameters.infoFormatIsImage() )
@@ -1123,10 +1123,10 @@ namespace QgsWms
   QImage *QgsRenderer::createImage( int width, int height, bool useBbox ) const
   {
     if ( width < 0 )
-      width = getWidthAsInt();
+      width = this->width();
 
     if ( height < 0 )
-      height = getHeightAsInt();
+      height = this->height();
 
     //Adapt width / height if the aspect ratio does not correspond with the BBOX.
     //Required by WMS spec. 1.3.
@@ -1315,8 +1315,8 @@ namespace QgsWms
       i = mWmsParameters.xAsInt();
       j = mWmsParameters.yAsInt();
     }
-    int width = getWidthAsInt();
-    int height = getHeightAsInt();
+    int width = mWmsParameters.widthAsInt();
+    int height = mWmsParameters.heightAsInt();
     if ( ( i != -1 && j != -1 && width != 0 && height != 0 ) && ( width != outputImage->width() || height != outputImage->height() ) )
     {
       i *= ( outputImage->width() / static_cast<double>( width ) );
@@ -1994,14 +1994,14 @@ namespace QgsWms
   {
     //test if maxWidth / maxHeight set and WIDTH / HEIGHT parameter is in the range
     int wmsMaxWidth = QgsServerProjectUtils::wmsMaxWidth( *mProject );
-    int width = getWidthAsInt();
+    int width = this->width();
     if ( wmsMaxWidth != -1 && width > wmsMaxWidth )
     {
       return false;
     }
 
     int wmsMaxHeight = QgsServerProjectUtils::wmsMaxHeight( *mProject );
-    int height = getHeightAsInt();
+    int height = this->height();
     if ( wmsMaxHeight != -1 && height > wmsMaxHeight )
     {
       return false;
@@ -3206,8 +3206,8 @@ namespace QgsWms
     // WIDTH / HEIGHT parameters. If not, the image has to be scaled (required
     // by WMS spec)
     QImage *scaledImage = nullptr;
-    int width = getWidthAsInt();
-    int height = getHeightAsInt();
+    int width = this->width();
+    int height = this->height();
     if ( width != image->width() || height != image->height() )
     {
       scaledImage = new QImage( image->scaled( width, height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation ) );
@@ -3418,20 +3418,22 @@ namespace QgsWms
     }
   }
 
-  int QgsRenderer::getHeightAsInt() const
+  int QgsRenderer::height() const
   {
-    if ( mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) == 0 ||
-         mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) )
+    if ( ( mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) == 0 ||
+           mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) == 0 ) &&
+         mWmsParameters.srcHeightAsInt() > 0 )
       return mWmsParameters.srcHeightAsInt();
     return mWmsParameters.heightAsInt();
   }
 
-  int QgsRenderer::getWidthAsInt() const
+  int QgsRenderer::width() const
   {
-    if ( mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) == 0 ||
-         mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) )
+    if ( ( mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) == 0 ||
+           mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) == 0 ) &&
+         mWmsParameters.srcWidthAsInt() > 0 )
       return mWmsParameters.srcWidthAsInt();
-    return mWmsParameters.heightAsInt();
+    return mWmsParameters.widthAsInt();
   }
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -187,7 +187,7 @@ namespace QgsWms
     if ( !mWmsParameters.bbox().isEmpty() )
     {
       QgsMapSettings mapSettings;
-      image.reset( createImage( mWmsParameters.getWidthAsInt(), mWmsParameters.getHeightAsInt(), false ) );
+      image.reset( createImage( getWidthAsInt(), getHeightAsInt(), false ) );
       configureMapSettings( image.get(), mapSettings );
       legendSettings.setMapScale( mapSettings.scale() );
       legendSettings.setMapUnitsPerPixel( mapSettings.mapUnitsPerPixel() );
@@ -1045,8 +1045,8 @@ namespace QgsWms
     }
 
     // create the mapSettings and the output image
-    int imageWidth = mWmsParameters.getWidthAsInt();
-    int imageHeight = mWmsParameters.getHeightAsInt();
+    int imageWidth = getWidthAsInt();
+    int imageHeight = getHeightAsInt();
 
     // Provide default image width/height values if format is not image
     if ( !( imageWidth && imageHeight ) &&  ! mWmsParameters.infoFormatIsImage() )
@@ -1123,10 +1123,10 @@ namespace QgsWms
   QImage *QgsRenderer::createImage( int width, int height, bool useBbox ) const
   {
     if ( width < 0 )
-      width = mWmsParameters.getWidthAsInt();
+      width = getWidthAsInt();
 
     if ( height < 0 )
-      height = mWmsParameters.getHeightAsInt();
+      height = getHeightAsInt();
 
     //Adapt width / height if the aspect ratio does not correspond with the BBOX.
     //Required by WMS spec. 1.3.
@@ -1315,8 +1315,8 @@ namespace QgsWms
       i = mWmsParameters.xAsInt();
       j = mWmsParameters.yAsInt();
     }
-    int width = mWmsParameters.getWidthAsInt();
-    int height = mWmsParameters.getHeightAsInt();
+    int width = getWidthAsInt();
+    int height = getHeightAsInt();
     if ( ( i != -1 && j != -1 && width != 0 && height != 0 ) && ( width != outputImage->width() || height != outputImage->height() ) )
     {
       i *= ( outputImage->width() / static_cast<double>( width ) );
@@ -1994,14 +1994,14 @@ namespace QgsWms
   {
     //test if maxWidth / maxHeight set and WIDTH / HEIGHT parameter is in the range
     int wmsMaxWidth = QgsServerProjectUtils::wmsMaxWidth( *mProject );
-    int width = mWmsParameters.getWidthAsInt();
+    int width = getWidthAsInt();
     if ( wmsMaxWidth != -1 && width > wmsMaxWidth )
     {
       return false;
     }
 
     int wmsMaxHeight = QgsServerProjectUtils::wmsMaxHeight( *mProject );
-    int height = mWmsParameters.getHeightAsInt();
+    int height = getHeightAsInt();
     if ( wmsMaxHeight != -1 && height > wmsMaxHeight )
     {
       return false;
@@ -3206,8 +3206,8 @@ namespace QgsWms
     // WIDTH / HEIGHT parameters. If not, the image has to be scaled (required
     // by WMS spec)
     QImage *scaledImage = nullptr;
-    int width = mWmsParameters.getWidthAsInt();
-    int height = mWmsParameters.getHeightAsInt();
+    int width = getWidthAsInt();
+    int height = getHeightAsInt();
     if ( width != image->width() || height != image->height() )
     {
       scaledImage = new QImage( image->scaled( width, height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation ) );
@@ -3416,6 +3416,22 @@ namespace QgsWms
         throw QgsServerException( QStringLiteral( "Print error" ) );
       }
     }
+  }
+
+  int QgsRenderer::getHeightAsInt() const
+  {
+    if ( mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) == 0 ||
+         mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) )
+      return mWmsParameters.srcHeightAsInt();
+    return mWmsParameters.heightAsInt();
+  }
+
+  int QgsRenderer::getWidthAsInt() const
+  {
+    if ( mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphic" ), Qt::CaseInsensitive ) == 0 ||
+         mWmsParameters.request().compare( QStringLiteral( "GetLegendGraphics" ), Qt::CaseInsensitive ) )
+      return mWmsParameters.srcWidthAsInt();
+    return mWmsParameters.heightAsInt();
   }
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -187,7 +187,7 @@ namespace QgsWms
     if ( !mWmsParameters.bbox().isEmpty() )
     {
       QgsMapSettings mapSettings;
-      image.reset( createImage( mWmsParameters.widthAsInt(), mWmsParameters.heightAsInt(), false ) );
+      image.reset( createImage( mWmsParameters.getWidthAsInt(), mWmsParameters.getHeightAsInt(), false ) );
       configureMapSettings( image.get(), mapSettings );
       legendSettings.setMapScale( mapSettings.scale() );
       legendSettings.setMapUnitsPerPixel( mapSettings.mapUnitsPerPixel() );
@@ -1045,8 +1045,8 @@ namespace QgsWms
     }
 
     // create the mapSettings and the output image
-    int imageWidth = mWmsParameters.widthAsInt();
-    int imageHeight = mWmsParameters.heightAsInt();
+    int imageWidth = mWmsParameters.getWidthAsInt();
+    int imageHeight = mWmsParameters.getHeightAsInt();
 
     // Provide default image width/height values if format is not image
     if ( !( imageWidth && imageHeight ) &&  ! mWmsParameters.infoFormatIsImage() )
@@ -1123,10 +1123,10 @@ namespace QgsWms
   QImage *QgsRenderer::createImage( int width, int height, bool useBbox ) const
   {
     if ( width < 0 )
-      width = mWmsParameters.widthAsInt();
+      width = mWmsParameters.getWidthAsInt();
 
     if ( height < 0 )
-      height = mWmsParameters.heightAsInt();
+      height = mWmsParameters.getHeightAsInt();
 
     //Adapt width / height if the aspect ratio does not correspond with the BBOX.
     //Required by WMS spec. 1.3.
@@ -1315,8 +1315,8 @@ namespace QgsWms
       i = mWmsParameters.xAsInt();
       j = mWmsParameters.yAsInt();
     }
-    int width = mWmsParameters.widthAsInt();
-    int height = mWmsParameters.heightAsInt();
+    int width = mWmsParameters.getWidthAsInt();
+    int height = mWmsParameters.getHeightAsInt();
     if ( ( i != -1 && j != -1 && width != 0 && height != 0 ) && ( width != outputImage->width() || height != outputImage->height() ) )
     {
       i *= ( outputImage->width() / static_cast<double>( width ) );
@@ -1994,14 +1994,14 @@ namespace QgsWms
   {
     //test if maxWidth / maxHeight set and WIDTH / HEIGHT parameter is in the range
     int wmsMaxWidth = QgsServerProjectUtils::wmsMaxWidth( *mProject );
-    int width = mWmsParameters.widthAsInt();
+    int width = mWmsParameters.getWidthAsInt();
     if ( wmsMaxWidth != -1 && width > wmsMaxWidth )
     {
       return false;
     }
 
     int wmsMaxHeight = QgsServerProjectUtils::wmsMaxHeight( *mProject );
-    int height = mWmsParameters.heightAsInt();
+    int height = mWmsParameters.getHeightAsInt();
     if ( wmsMaxHeight != -1 && height > wmsMaxHeight )
     {
       return false;
@@ -3206,8 +3206,8 @@ namespace QgsWms
     // WIDTH / HEIGHT parameters. If not, the image has to be scaled (required
     // by WMS spec)
     QImage *scaledImage = nullptr;
-    int width = mWmsParameters.widthAsInt();
-    int height = mWmsParameters.heightAsInt();
+    int width = mWmsParameters.getWidthAsInt();
+    int height = mWmsParameters.getHeightAsInt();
     if ( width != image->width() || height != image->height() )
     {
       scaledImage = new QImage( image->scaled( width, height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation ) );

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -299,15 +299,17 @@ namespace QgsWms
 
       /**
        * Returns QgsWmsParameter SRCWIDTH if it's a GetLegendGraphics request and otherwise HEIGHT parameter
-       * \returns getHeightAsInt parameter
+       * \returns height parameter
+       * \since QGIS 3.8
        */
-      int getHeightAsInt() const;
+      int height() const;
 
       /**
        * Returns QgsWmsParameter SRCWIDTH parameter if it's a GetLegendGraphics request and otherwise WIDTH parameter
-       * \returns getWidthAsInt parameter
+       * \returns width parameter
+       * \since QGIS 3.8
        */
-      int getWidthAsInt() const;
+      int width() const;
 
       const QgsWmsParameters &mWmsParameters;
 

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -297,6 +297,18 @@ namespace QgsWms
 
       void handlePrintErrors( const QgsLayout *layout ) const;
 
+      /**
+       * Returns QgsWmsParameter SRCWIDTH if it's a GetLegendGraphics request and otherwise HEIGHT parameter
+       * \returns getHeightAsInt parameter
+       */
+      int getHeightAsInt() const;
+
+      /**
+       * Returns QgsWmsParameter SRCWIDTH parameter if it's a GetLegendGraphics request and otherwise WIDTH parameter
+       * \returns getWidthAsInt parameter
+       */
+      int getWidthAsInt() const;
+
       const QgsWmsParameters &mWmsParameters;
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
@@ -495,6 +495,42 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
         r, h = self._result(self._execute_request(qs))
         self._img_diff_error(r, h, "WMS_GetLegendGraphic_BBox2")
 
+    def test_wms_GetLegendGraphic_BBox_Fallback(self):
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetLegendGraphic",
+            "LAYER": "Country,Hello,db_point",
+            "LAYERTITLE": "FALSE",
+            "FORMAT": "image/png",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "BBOX": "-151.7,-38.9,51.0,78.0",
+            "CRS": "EPSG:4326"
+        }.items())])
+
+        r, h = self._result(self._execute_request(qs))
+        self._img_diff_error(r, h, "WMS_GetLegendGraphic_BBox")
+
+    def test_wms_GetLegendGraphic_BBox2_Fallback(self):
+        qs = "?" + "&".join(["%s=%s" % i for i in list({
+            "MAP": urllib.parse.quote(self.projectPath),
+            "SERVICE": "WMS",
+            "VERSION": "1.1.1",
+            "REQUEST": "GetLegendGraphic",
+            "LAYER": "Country,Hello,db_point",
+            "LAYERTITLE": "FALSE",
+            "FORMAT": "image/png",
+            "HEIGHT": "500",
+            "WIDTH": "500",
+            "BBOX": "-76.08,-6.4,-19.38,38.04",
+            "SRS": "EPSG:4326"
+        }.items())])
+
+        r, h = self._result(self._execute_request(qs))
+        self._img_diff_error(r, h, "WMS_GetLegendGraphic_BBox2")
+
     def test_wms_GetLegendGraphic_EmptyLegend(self):
         qs = "?" + "&".join(["%s=%s" % i for i in list({
             "MAP": self.testdata_path + 'test_project_contextual_legend.qgs',

--- a/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
+++ b/tests/src/python/test_qgsserver_wms_getlegendgraphic.py
@@ -468,8 +468,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "LAYER": "Country,Hello,db_point",
             "LAYERTITLE": "FALSE",
             "FORMAT": "image/png",
-            "HEIGHT": "500",
-            "WIDTH": "500",
+            "SRCHEIGHT": "500",
+            "SRCWIDTH": "500",
             "BBOX": "-151.7,-38.9,51.0,78.0",
             "CRS": "EPSG:4326"
         }.items())])
@@ -486,8 +486,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "LAYER": "Country,Hello,db_point",
             "LAYERTITLE": "FALSE",
             "FORMAT": "image/png",
-            "HEIGHT": "500",
-            "WIDTH": "500",
+            "SRCHEIGHT": "500",
+            "SRCWIDTH": "500",
             "BBOX": "-76.08,-6.4,-19.38,38.04",
             "SRS": "EPSG:4326"
         }.items())])
@@ -503,8 +503,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "QGIS%20Server%20Hello%20World",
             "FORMAT": "image/png",
-            "HEIGHT": "840",
-            "WIDTH": "1226",
+            "SRCHEIGHT": "840",
+            "SRCWIDTH": "1226",
             "BBOX": "10.38450,-49.6370,73.8183,42.9461",
             "SRS": "EPSG:4326",
             "SCALE": "15466642"
@@ -525,8 +525,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "QGIS%20Server%20-%20Grouped%20Layer",
             "FORMAT": "image/png",
-            "HEIGHT": "840",
-            "WIDTH": "1226",
+            "SRCHEIGHT": "840",
+            "SRCWIDTH": "1226",
             "BBOX": "609152,5808188,625492,5814318",
             "SRS": "EPSG:25832",
             "SCALE": "38976"
@@ -544,8 +544,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "All_grouped_layers",
             "FORMAT": "image/png",
-            "HEIGHT": "840",
-            "WIDTH": "1226",
+            "SRCHEIGHT": "840",
+            "SRCWIDTH": "1226",
             "BBOX": "609152,5808188,625492,5814318",
             "SRS": "EPSG:25832",
             "SCALE": "38976"
@@ -563,8 +563,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "-608.4,-1002.6,698.2,1019.0",
             "CRS": "EPSG:4326"
         }.items())])
@@ -579,8 +579,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "-1261.7,-2013.5,1351.5,2029.9",
             "CRS": "EPSG:4326"
         }.items())])
@@ -596,8 +596,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "31.8,-12.0,58.0,28.4",
             "CRS": "EPSG:4326"
         }.items())])
@@ -613,8 +613,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "25.3,-22.1,64.5,38.5",
             "CRS": "EPSG:4326"
         }.items())])
@@ -630,8 +630,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "44.8,8.0,45.0,8.4",
             "CRS": "EPSG:4326"
         }.items())])
@@ -646,8 +646,8 @@ class TestQgsServerWMSGetLegendGraphic(QgsServerTestBase):
             "REQUEST": "GetLegendGraphic",
             "LAYER": "testlayer",
             "FORMAT": "image/png",
-            "HEIGHT": "550",
-            "WIDTH": "850",
+            "SRCHEIGHT": "550",
+            "SRCWIDTH": "850",
             "BBOX": "43.6,6.2,46.2,10.2",
             "CRS": "EPSG:4326"
         }.items())])


### PR DESCRIPTION
I my implementation here #9236 regarding `GetLegendGraphics` I used the `WIDTH` and `HEIGHT` (like already used for content dependent legends) as the width and height of the map that I can determine the size of the symbols with the bounding box. But on a `GetLegendGraphics` request these parameters are used for the size of the generated legend image. Usually. In QGIS Server they are only used for the legend image size, when there is a `RULE` passed. And if there is a `BBOX` it does not allow a combination `RULE`. If no `RULE` defined it takes the minimum size. So everything works fine still with that implementation. 

Still, it would make sense to have a non-standard parameter defining the with and the height used on the map on a `GetLegendGraphic` that is content depending. Since [Geoserver](https://docs.geoserver.org/latest/en/user/services/wms/get_legend_graphic/#content-dependent-legends) introduced `SRCHEIGHT` and `SRCWIDTH` I used the same keywords.

Since there are already tests that use `HEIGHT` and `WIDTH` on `GetLegendGraphic` requests wrongly I assume, that there are also users, that use it wrongly. So I added tha fallback, that if `SRCHEIGHT` is 0 it still tries to take `HEIGHT`.

