### PR TITLE
[3d] Add option to use terrain data from online service

### DIFF
--- a/src/3d/CMakeLists.txt
+++ b/src/3d/CMakeLists.txt
@@ -46,6 +46,8 @@ SET(QGIS_3D_SRCS
   terrain/qgsdemterraintilegeometry_p.cpp
   terrain/qgsdemterraintileloader_p.cpp
   terrain/qgsflatterraingenerator.cpp
+  terrain/qgsonlineterraingenerator.cpp
+  terrain/qgsterraindownloader.cpp
   terrain/qgsterrainentity_p.cpp
   terrain/qgsterraingenerator.cpp
   terrain/qgsterraintexturegenerator_p.cpp
@@ -130,6 +132,8 @@ SET(QGIS_3D_HDRS
   terrain/qgsdemterraingenerator.h
   terrain/qgsdemterraintilegeometry_p.h
   terrain/qgsdemterraintileloader_p.h
+  terrain/qgsonlineterraingenerator.h
+  terrain/qgsterraindownloader.h
   terrain/qgsterrainentity_p.h
   terrain/qgsterraingenerator.h
   terrain/qgsterraintexturegenerator_p.h

--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -18,7 +18,7 @@
 #include "qgs3dutils.h"
 #include "qgsflatterraingenerator.h"
 #include "qgsdemterraingenerator.h"
-//#include "quantizedmeshterraingenerator.h"
+#include "qgsonlineterraingenerator.h"
 #include "qgsvectorlayer3drenderer.h"
 #include "qgsmeshlayer3drenderer.h"
 
@@ -141,12 +141,11 @@ void Qgs3DMapSettings::readXml( const QDomElement &elem, const QgsReadWriteConte
     demTerrainGenerator->setCrs( mCrs, mTransformContext );
     mTerrainGenerator.reset( demTerrainGenerator );
   }
-  else if ( terrainGenType == QLatin1String( "quantized-mesh" ) )
+  else if ( terrainGenType == QLatin1String( "online" ) )
   {
-#if 0
-    terrainGenerator.reset( new QuantizedMeshTerrainGenerator );
-#endif
-    Q_ASSERT( false ); // currently disabled
+    QgsOnlineTerrainGenerator *onlineTerrainGenerator = new QgsOnlineTerrainGenerator;
+    onlineTerrainGenerator->setCrs( mCrs, mTransformContext );
+    mTerrainGenerator.reset( onlineTerrainGenerator );
   }
   else // "flat"
   {

--- a/src/3d/terrain/qgsdemterraintileloader_p.cpp
+++ b/src/3d/terrain/qgsdemterraintileloader_p.cpp
@@ -19,6 +19,7 @@
 #include "qgschunknode_p.h"
 #include "qgsdemterraingenerator.h"
 #include "qgsdemterraintilegeometry_p.h"
+#include "qgsonlineterraingenerator.h"
 #include "qgsterrainentity_p.h"
 #include "qgsterraintexturegenerator_p.h"
 #include "qgsterraintileentity_p.h"
@@ -56,13 +57,27 @@ QgsDemTerrainTileLoader::QgsDemTerrainTileLoader( QgsTerrainEntity *terrain, Qgs
 {
 
   const Qgs3DMapSettings &map = terrain->map3D();
-  QgsDemTerrainGenerator *generator = static_cast<QgsDemTerrainGenerator *>( map.terrainGenerator() );
+
+  QgsDemHeightMapGenerator *heightMapGenerator = nullptr;
+  if ( map.terrainGenerator()->type() == QgsTerrainGenerator::Dem )
+  {
+    QgsDemTerrainGenerator *generator = static_cast<QgsDemTerrainGenerator *>( map.terrainGenerator() );
+    heightMapGenerator = generator->heightMapGenerator();
+    mSkirtHeight = generator->skirtHeight();
+  }
+  else if ( map.terrainGenerator()->type() == QgsTerrainGenerator::Online )
+  {
+    QgsOnlineTerrainGenerator *generator = static_cast<QgsOnlineTerrainGenerator *>( map.terrainGenerator() );
+    heightMapGenerator = generator->heightMapGenerator();
+    mSkirtHeight = generator->skirtHeight();
+  }
+  else
+    Q_ASSERT( false );
 
   // get heightmap asynchronously
-  connect( generator->heightMapGenerator(), &QgsDemHeightMapGenerator::heightMapReady, this, &QgsDemTerrainTileLoader::onHeightMapReady );
-  mHeightMapJobId = generator->heightMapGenerator()->render( node->tileX(), node->tileY(), node->tileZ() );
-  mResolution = generator->heightMapGenerator()->resolution();
-  mSkirtHeight = generator->skirtHeight();
+  connect( heightMapGenerator, &QgsDemHeightMapGenerator::heightMapReady, this, &QgsDemTerrainTileLoader::onHeightMapReady );
+  mHeightMapJobId = heightMapGenerator->render( node->tileX(), node->tileY(), node->tileZ() );
+  mResolution = heightMapGenerator->resolution();
 }
 
 Qt3DCore::QEntity *QgsDemTerrainTileLoader::createEntity( Qt3DCore::QEntity *parent )
@@ -131,13 +146,15 @@ void QgsDemTerrainTileLoader::onHeightMapReady( int jobId, const QByteArray &hei
 #include <qgsrasterprojector.h>
 #include <QtConcurrent/QtConcurrentRun>
 #include <QFutureWatcher>
+#include "qgsterraindownloader.h"
 
 QgsDemHeightMapGenerator::QgsDemHeightMapGenerator( QgsRasterLayer *dtm, const QgsTilingScheme &tilingScheme, int resolution )
   : mDtm( dtm )
-  , mClonedProvider( ( QgsRasterDataProvider * )dtm->dataProvider()->clone() )
+  , mClonedProvider( dtm ? ( QgsRasterDataProvider * )dtm->dataProvider()->clone() : nullptr )
   , mTilingScheme( tilingScheme )
   , mResolution( resolution )
   , mLastJobId( 0 )
+  , mDownloader( dtm ? nullptr : new QgsTerrainDownloader )
 {
 }
 
@@ -188,6 +205,12 @@ static QByteArray _readDtmData( QgsRasterDataProvider *provider, const QgsRectan
   return data;
 }
 
+
+static QByteArray _readOnlineDtm( QgsTerrainDownloader *downloader, const QgsRectangle &extent, int res, const QgsCoordinateReferenceSystem &destCrs )
+{
+  return downloader->getHeightMap( extent, res, destCrs );
+}
+
 int QgsDemHeightMapGenerator::render( int x, int y, int z )
 {
   Q_ASSERT( mJobs.isEmpty() );  // should be always just one active job...
@@ -205,7 +228,10 @@ int QgsDemHeightMapGenerator::render( int x, int y, int z )
   jd.extent = extent;
   jd.timer.start();
   // make a clone of the data provider so it is safe to use in worker thread
-  jd.future = QtConcurrent::run( _readDtmData, mClonedProvider, extent, mResolution, mTilingScheme.crs() );
+  if ( mDtm )
+    jd.future = QtConcurrent::run( _readDtmData, mClonedProvider, extent, mResolution, mTilingScheme.crs() );
+  else
+    jd.future = QtConcurrent::run( _readOnlineDtm, mDownloader.get(), extent, mResolution, mTilingScheme.crs() );
 
   QFutureWatcher<QByteArray> *fw = new QFutureWatcher<QByteArray>( nullptr );
   fw->setFuture( jd.future );
@@ -241,6 +267,9 @@ QByteArray QgsDemHeightMapGenerator::renderSynchronously( int x, int y, int z )
 
 float QgsDemHeightMapGenerator::heightAt( double x, double y )
 {
+  if ( !mDtm )
+    return 0;  // TODO: calculate heights for online DTM
+
   // TODO: this is quite a primitive implementation: better to use heightmaps currently in use
   int res = 1024;
   QgsRectangle rect = mDtm->extent();

--- a/src/3d/terrain/qgsdemterraintileloader_p.h
+++ b/src/3d/terrain/qgsdemterraintileloader_p.h
@@ -64,6 +64,7 @@ class QgsDemTerrainTileLoader : public QgsTerrainTileLoader
 };
 
 
+class QgsTerrainDownloader;
 
 /**
  * \ingroup 3d
@@ -113,6 +114,8 @@ class QgsDemHeightMapGenerator : public QObject
     int mResolution;
 
     int mLastJobId;
+
+    std::unique_ptr<QgsTerrainDownloader> mDownloader;
 
     struct JobData
     {

--- a/src/3d/terrain/qgsonlineterraingenerator.cpp
+++ b/src/3d/terrain/qgsonlineterraingenerator.cpp
@@ -1,0 +1,104 @@
+#include "qgsonlineterraingenerator.h"
+
+#include "qgsdemterraintileloader_p.h"
+
+
+QgsOnlineTerrainGenerator::~QgsOnlineTerrainGenerator()
+{
+  delete mHeightMapGenerator;
+}
+
+QgsChunkLoader *QgsOnlineTerrainGenerator::createChunkLoader( QgsChunkNode *node ) const
+{
+  return new QgsDemTerrainTileLoader( mTerrain, node );
+}
+
+QgsTerrainGenerator *QgsOnlineTerrainGenerator::clone() const
+{
+  QgsOnlineTerrainGenerator *cloned = new QgsOnlineTerrainGenerator;
+  cloned->mCrs = mCrs;
+  cloned->mExtent = mExtent;
+  cloned->mResolution = mResolution;
+  cloned->mSkirtHeight = mSkirtHeight;
+  cloned->updateGenerator();
+  return cloned;
+}
+
+QgsTerrainGenerator::Type QgsOnlineTerrainGenerator::type() const
+{
+  return QgsTerrainGenerator::Online;
+}
+
+QgsRectangle QgsOnlineTerrainGenerator::extent() const
+{
+  return mTerrainTilingScheme.tileToExtent( 0, 0, 0 );
+}
+
+float QgsOnlineTerrainGenerator::heightAt( double x, double y, const Qgs3DMapSettings &map ) const
+{
+  Q_UNUSED( map );
+  if ( mHeightMapGenerator )
+    return mHeightMapGenerator->heightAt( x, y );
+  else
+    return 0;
+}
+
+void QgsOnlineTerrainGenerator::writeXml( QDomElement &elem ) const
+{
+  QgsRectangle r = mExtent;
+  QDomElement elemExtent = elem.ownerDocument().createElement( QStringLiteral( "extent" ) );
+  elemExtent.setAttribute( QStringLiteral( "xmin" ), QString::number( r.xMinimum() ) );
+  elemExtent.setAttribute( QStringLiteral( "xmax" ), QString::number( r.xMaximum() ) );
+  elemExtent.setAttribute( QStringLiteral( "ymin" ), QString::number( r.yMinimum() ) );
+  elemExtent.setAttribute( QStringLiteral( "ymax" ), QString::number( r.yMaximum() ) );
+
+  elem.setAttribute( QStringLiteral( "resolution" ), mResolution );
+  elem.setAttribute( QStringLiteral( "skirt-height" ), mSkirtHeight );
+
+  // crs is not read/written - it should be the same as destination crs of the map
+}
+
+void QgsOnlineTerrainGenerator::readXml( const QDomElement &elem )
+{
+  QDomElement elemExtent = elem.firstChildElement( QStringLiteral( "extent" ) );
+  double xmin = elemExtent.attribute( QStringLiteral( "xmin" ) ).toDouble();
+  double xmax = elemExtent.attribute( QStringLiteral( "xmax" ) ).toDouble();
+  double ymin = elemExtent.attribute( QStringLiteral( "ymin" ) ).toDouble();
+  double ymax = elemExtent.attribute( QStringLiteral( "ymax" ) ).toDouble();
+
+  setExtent( QgsRectangle( xmin, ymin, xmax, ymax ) );
+
+  mResolution = elem.attribute( QStringLiteral( "resolution" ) ).toInt();
+  mSkirtHeight = elem.attribute( QStringLiteral( "skirt-height" ) ).toFloat();
+
+  // crs is not read/written - it should be the same as destination crs of the map
+}
+
+void QgsOnlineTerrainGenerator::setCrs( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context )
+{
+  mCrs = crs;
+  mTransformContext = context;
+  updateGenerator();
+}
+
+void QgsOnlineTerrainGenerator::setExtent( const QgsRectangle &extent )
+{
+  mExtent = extent;
+  updateGenerator();
+}
+
+void QgsOnlineTerrainGenerator::updateGenerator()
+{
+  if ( mExtent.isNull() )
+  {
+    mTerrainTilingScheme = QgsTilingScheme();
+  }
+  else
+  {
+    // the real extent will be a square where the given extent fully fits
+    mTerrainTilingScheme = QgsTilingScheme( mExtent, mCrs );
+  }
+
+  delete mHeightMapGenerator;
+  mHeightMapGenerator = new QgsDemHeightMapGenerator( nullptr, mTerrainTilingScheme, mResolution );
+}

--- a/src/3d/terrain/qgsonlineterraingenerator.cpp
+++ b/src/3d/terrain/qgsonlineterraingenerator.cpp
@@ -1,3 +1,18 @@
+/***************************************************************************
+  qgsonlineterraingenerator.cpp
+  --------------------------------------
+  Date                 : March 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
 #include "qgsonlineterraingenerator.h"
 
 #include "qgsdemterraintileloader_p.h"

--- a/src/3d/terrain/qgsonlineterraingenerator.cpp
+++ b/src/3d/terrain/qgsonlineterraingenerator.cpp
@@ -18,10 +18,9 @@
 #include "qgsdemterraintileloader_p.h"
 
 
-QgsOnlineTerrainGenerator::~QgsOnlineTerrainGenerator()
-{
-  delete mHeightMapGenerator;
-}
+QgsOnlineTerrainGenerator::QgsOnlineTerrainGenerator() = default;
+
+QgsOnlineTerrainGenerator::~QgsOnlineTerrainGenerator() = default;
 
 QgsChunkLoader *QgsOnlineTerrainGenerator::createChunkLoader( QgsChunkNode *node ) const
 {
@@ -114,6 +113,5 @@ void QgsOnlineTerrainGenerator::updateGenerator()
     mTerrainTilingScheme = QgsTilingScheme( mExtent, mCrs );
   }
 
-  delete mHeightMapGenerator;
-  mHeightMapGenerator = new QgsDemHeightMapGenerator( nullptr, mTerrainTilingScheme, mResolution );
+  mHeightMapGenerator.reset( new QgsDemHeightMapGenerator( nullptr, mTerrainTilingScheme, mResolution ) );
 }

--- a/src/3d/terrain/qgsonlineterraingenerator.h
+++ b/src/3d/terrain/qgsonlineterraingenerator.h
@@ -1,0 +1,86 @@
+/***************************************************************************
+  qgsonlineterraingenerator.h
+  --------------------------------------
+  Date                 : March 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSONLINETERRAINGENERATOR_H
+#define QGSONLINETERRAINGENERATOR_H
+
+#include "qgis_3d.h"
+
+#include "qgsterraingenerator.h"
+
+#include "qgscoordinatetransformcontext.h"
+
+class QgsDemHeightMapGenerator;
+
+/**
+ * \ingroup 3d
+ * Implementation of terrain generator that uses online resources to download heightmaps.
+ * \since QGIS 3.8
+ */
+class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator
+{
+  public:
+    //! Constructor for QgsOnlineTerrainGenerator
+    QgsOnlineTerrainGenerator() = default;
+    ~QgsOnlineTerrainGenerator() override;
+
+    //! Sets extent of the terrain
+    void setExtent( const QgsRectangle &extent );
+
+    //! Sets CRS of the terrain
+    void setCrs( const QgsCoordinateReferenceSystem &crs, const QgsCoordinateTransformContext &context );
+    //! Returns CRS of the terrain
+    QgsCoordinateReferenceSystem crs() const { return mCrs; }
+
+    //! Sets resolution of the generator (how many elevation samples on one side of a terrain tile)
+    void setResolution( int resolution ) { mResolution = resolution; updateGenerator(); }
+    //! Returns resolution of the generator (how many elevation samples on one side of a terrain tile)
+    int resolution() const { return mResolution; }
+
+    //! Sets skirt height (in world units). Skirts at the edges of terrain tiles help hide cracks between adjacent tiles.
+    void setSkirtHeight( float skirtHeight ) { mSkirtHeight = skirtHeight; }
+    //! Returns skirt height (in world units). Skirts at the edges of terrain tiles help hide cracks between adjacent tiles.
+    float skirtHeight() const { return mSkirtHeight; }
+
+    //! Returns height map generator object - takes care of extraction of elevations from the layer)
+    QgsDemHeightMapGenerator *heightMapGenerator() { return mHeightMapGenerator; }
+
+    QgsTerrainGenerator *clone() const override SIP_FACTORY;
+    Type type() const override;
+    QgsRectangle extent() const override;
+    float heightAt( double x, double y, const Qgs3DMapSettings &map ) const override;
+    void writeXml( QDomElement &elem ) const override;
+    void readXml( const QDomElement &elem ) override;
+    //void resolveReferences( const QgsProject &project ) override;
+
+    QgsChunkLoader *createChunkLoader( QgsChunkNode *node ) const override SIP_FACTORY;
+
+  private:
+
+    void updateGenerator();
+
+    QgsRectangle mExtent;
+    QgsCoordinateReferenceSystem mCrs;
+    QgsCoordinateTransformContext mTransformContext;
+
+    //! how many vertices to place on one side of the tile
+    int mResolution = 16;
+    //! height of the "skirts" at the edges of tiles to hide cracks between adjacent cracks
+    float mSkirtHeight = 10.f;
+
+    QgsDemHeightMapGenerator *mHeightMapGenerator = nullptr;
+};
+
+#endif // QGSONLINETERRAINGENERATOR_H

--- a/src/3d/terrain/qgsonlineterraingenerator.h
+++ b/src/3d/terrain/qgsonlineterraingenerator.h
@@ -33,7 +33,7 @@ class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator
 {
   public:
     //! Constructor for QgsOnlineTerrainGenerator
-    QgsOnlineTerrainGenerator() = default;
+    QgsOnlineTerrainGenerator();
     ~QgsOnlineTerrainGenerator() override;
 
     //! Sets extent of the terrain
@@ -55,7 +55,7 @@ class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator
     float skirtHeight() const { return mSkirtHeight; }
 
     //! Returns height map generator object - takes care of extraction of elevations from the layer)
-    QgsDemHeightMapGenerator *heightMapGenerator() { return mHeightMapGenerator; }
+    QgsDemHeightMapGenerator *heightMapGenerator() { return mHeightMapGenerator.get(); }
 
     QgsTerrainGenerator *clone() const override SIP_FACTORY;
     Type type() const override;
@@ -80,7 +80,7 @@ class _3D_EXPORT QgsOnlineTerrainGenerator : public QgsTerrainGenerator
     //! height of the "skirts" at the edges of tiles to hide cracks between adjacent cracks
     float mSkirtHeight = 10.f;
 
-    QgsDemHeightMapGenerator *mHeightMapGenerator = nullptr;
+    std::unique_ptr<QgsDemHeightMapGenerator> mHeightMapGenerator;
 };
 
 #endif // QGSONLINETERRAINGENERATOR_H

--- a/src/3d/terrain/qgsterraindownloader.cpp
+++ b/src/3d/terrain/qgsterraindownloader.cpp
@@ -73,7 +73,7 @@ double QgsTerrainDownloader::findBestTileResolution( double requestedMupp )
 
 void QgsTerrainDownloader::tileImageToHeightMap( const QImage &img, QByteArray &heightMap )
 {
-  // assuming ARGB preformatted but with alpha 255
+  // assuming ARGB premultiplied but with alpha 255
   const QRgb *rgb = reinterpret_cast<const QRgb *>( img.constBits() );
   int count = img.width() * img.height();
   heightMap.resize( sizeof( float ) * count );

--- a/src/3d/terrain/qgsterraindownloader.cpp
+++ b/src/3d/terrain/qgsterraindownloader.cpp
@@ -1,0 +1,169 @@
+/***************************************************************************
+  qgsterraindownloader.cpp
+  --------------------------------------
+  Date                 : March 2019
+  Copyright            : (C) 2019 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsterraindownloader.h"
+
+#include "qgslogger.h"
+#include "qgsrasterlayer.h"
+
+#include "qgsgdalutils.h"
+
+
+QgsTerrainDownloader::QgsTerrainDownloader()
+{
+  QString uri = "type=xyz&url=http://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png&zmax=15&zmin=0";
+  onlineDtm.reset( new QgsRasterLayer( uri, "terrarium", "wms" ) );
+
+  // the whole world is projected to a square:
+  // X going from 180 W to 180 E
+  // Y going from ~85 N to ~85 S  (=atan(sinh(pi)) ... to get a square)
+  Q_NOWARN_DEPRECATED_PUSH
+  QgsCoordinateTransform ct( QgsCoordinateReferenceSystem( QStringLiteral( "EPSG:4326" ) ), QgsCoordinateReferenceSystem( "EPSG:3857" ) );
+  Q_NOWARN_DEPRECATED_POP
+  QgsPointXY topLeftLonLat( -180, 180.0 / M_PI * std::atan( std::sinh( M_PI ) ) );
+  QgsPointXY bottomRightLonLat( 180, 180.0 / M_PI * std::atan( std::sinh( -M_PI ) ) );
+  QgsPointXY topLeft = ct.transform( topLeftLonLat );
+  QgsPointXY bottomRight = ct.transform( bottomRightLonLat );
+  mXSpan = ( bottomRight.x() - topLeft.x() );
+}
+
+QgsTerrainDownloader::~QgsTerrainDownloader() = default;
+
+
+void QgsTerrainDownloader::adjustExtentAndResolution( double mupp, const QgsRectangle &extentOrig, QgsRectangle &extent, int &res )
+{
+  double xMin = floor( extentOrig.xMinimum() / mupp ) * mupp;
+  double xMax = ceil( extentOrig.xMaximum() / mupp ) * mupp;
+
+  double yMin = floor( extentOrig.yMinimum() / mupp ) * mupp;
+  double yMax = ceil( extentOrig.yMaximum() / mupp ) * mupp;
+
+  extent = QgsRectangle( xMin, yMin, xMax, yMax );
+  res = round( ( xMax - xMin ) / mupp );
+}
+
+
+double QgsTerrainDownloader::findBestTileResolution( double requestedMupp )
+{
+  int zoom = 0;
+  for ( ; zoom <= 15; ++zoom )
+  {
+    double tileMupp = mXSpan / ( 256 * ( 1 << zoom ) );
+    if ( tileMupp <= requestedMupp )
+      break;
+  }
+
+  if ( zoom > 15 ) zoom = 15;
+  double finalMupp = mXSpan / ( 256 * ( 1 << zoom ) );
+  return finalMupp;
+}
+
+
+void QgsTerrainDownloader::tileImageToHeightMap( const QImage &img, QByteArray &heightMap )
+{
+  // assuming ARGB preformatted but with alpha 255
+  const QRgb *rgb = reinterpret_cast<const QRgb *>( img.constBits() );
+  int count = img.width() * img.height();
+  heightMap.resize( sizeof( float ) * count );
+  float *hData = reinterpret_cast<float *>( heightMap.data() );
+  for ( int i = 0; i < count; ++i )
+  {
+    QRgb c = rgb[i];
+    if ( qAlpha( c ) == 255 )
+    {
+      float h = qRed( c ) * 256 + qGreen( c ) + qBlue( c ) / 256.f - 32768;
+      *hData++ = h;
+    }
+    else
+    {
+      *hData++ = std::numeric_limits<float>::quiet_NaN();
+    }
+  }
+}
+
+
+QByteArray QgsTerrainDownloader::getHeightMap( const QgsRectangle &extentOrig, int res, const QgsCoordinateReferenceSystem &destCrs, const QgsCoordinateTransformContext &context, QString tmpFilenameImg, QString tmpFilenameTif )
+{
+  QgsRectangle extentTr = extentOrig;
+  if ( destCrs != onlineDtm->crs() )
+  {
+    // if in different CRS - need to reproject extent and resolution
+    QgsCoordinateTransform ct( destCrs, onlineDtm->crs(), context );
+    extentTr = ct.transformBoundingBox( extentOrig );
+  }
+
+  double requestedMupp = extentTr.width() / res;
+  double finalMupp = findBestTileResolution( requestedMupp );
+
+  // adjust extent to match native resolution of terrain tiles
+
+  QgsRectangle extent;
+  int resOrig = res;
+  adjustExtentAndResolution( finalMupp, extentTr, extent, res );
+
+  // request tile
+
+  QgsRasterBlock *b = onlineDtm->dataProvider()->block( 1, extent, res, res );
+  QImage img = b->image();
+  delete b;
+  if ( !tmpFilenameImg.isEmpty() )
+    img.save( tmpFilenameImg );
+
+  // convert to height data
+
+  QByteArray heightMap;
+  tileImageToHeightMap( img, heightMap );
+
+  // prepare source/destination datasets for resampling
+
+  gdal::dataset_unique_ptr hSrcDS( QgsGdalUtils::createSingleBandMemoryDataset( GDT_Float32, extent, res, res, onlineDtm->crs() ) );
+  gdal::dataset_unique_ptr hDstDS;
+  if ( !tmpFilenameTif.isEmpty() )
+    hDstDS = QgsGdalUtils::createSingleBandTiffDataset( tmpFilenameTif, GDT_Float32, extentOrig, resOrig, resOrig, destCrs );
+  else
+    hDstDS = QgsGdalUtils::createSingleBandMemoryDataset( GDT_Float32, extentOrig, resOrig, resOrig, destCrs );
+
+  if ( !hSrcDS || !hDstDS )
+  {
+    QgsDebugMsg( "failed to create GDAL dataset for heightmap" );
+    return QByteArray();
+  }
+
+  CPLErr err = GDALRasterIO( GDALGetRasterBand( hSrcDS.get(), 1 ), GF_Write, 0, 0, res, res, heightMap.data(), res, res, GDT_Float32, 0, 0 );
+  if ( err != CE_None )
+  {
+    QgsDebugMsg( "failed to write heightmap data to GDAL dataset" );
+    return QByteArray();
+  }
+
+  // resample to the desired extent + resolution
+
+  QgsGdalUtils::resampleSingleBandRaster( hSrcDS.get(), hDstDS.get(), GRA_Bilinear );
+
+  QByteArray heightMapOut;
+  heightMapOut.resize( resOrig * resOrig * sizeof( float ) );
+  char *data = heightMapOut.data();
+
+  // read the data back
+
+  CPLErr err2 = GDALRasterIO( GDALGetRasterBand( hDstDS.get(), 1 ), GF_Read, 0, 0, resOrig, resOrig, data, resOrig, resOrig, GDT_Float32, 0, 0 );
+  if ( err2 != CE_None )
+  {
+    QgsDebugMsg( "failed to read heightmap data from GDAL dataset" );
+    return QByteArray();
+  }
+
+  return heightMapOut;
+}

--- a/src/3d/terrain/qgsterraindownloader.h
+++ b/src/3d/terrain/qgsterraindownloader.h
@@ -32,7 +32,10 @@ class QgsRasterLayer;
  * \ingroup 3d
  * Takes care of downloading terrain data from a publicly available data source.
  *
- * Currently using terrain tiles in GeoTIFF format hosted on AWS.
+ * Currently using terrain tiles in Terrarium format hosted on AWS. More info:
+ * - data format: https://github.com/tilezen/joerd/blob/master/docs/formats.md
+ * - data sources: https://github.com/tilezen/joerd/blob/master/docs/data-sources.md
+ * - hosting: https://registry.opendata.aws/terrain-tiles/
  *
  * \since QGIS 3.8
  */
@@ -42,6 +45,23 @@ class _3D_EXPORT QgsTerrainDownloader
   public:
     QgsTerrainDownloader();
     ~QgsTerrainDownloader();
+
+    //! Definition of data source for terrain tiles (assuming "terrarium" data encoding with usual XYZ tiling scheme)
+    typedef struct
+    {
+      QString uri;  //!< HTTP(S) template for XYZ tiles requests (e.g. http://example.com/{z}/{x}/{y}.png)
+      int zMin = 0;  //!< Minimum zoom level (Z) with valid data
+      int zMax = 0;  //!< Maximum zoom level (Z) with valid data
+    } DataSource;
+
+    //! Returns the data source used by default
+    static DataSource defaultDataSource();
+
+    //! Configures data source to be used for download of terrain tiles
+    void setDataSource( const DataSource &ds );
+
+    //! Returns currently configured data source
+    DataSource dataSource() const { return mDataSource; }
 
     /**
      * For given extent and resolution (number of pixels for width/height) in specified CRS, download necessary
@@ -69,7 +89,8 @@ class _3D_EXPORT QgsTerrainDownloader
     static void tileImageToHeightMap( const QImage &img, QByteArray &heightMap );
 
   private:
-    std::unique_ptr<QgsRasterLayer> onlineDtm;
+    DataSource mDataSource;
+    std::unique_ptr<QgsRasterLayer> mOnlineDtm;
     double mXSpan = 0;   //!< Width of the tile at zoom level 0 in map units
 };
 

--- a/src/3d/terrain/qgsterraingenerator.cpp
+++ b/src/3d/terrain/qgsterraingenerator.cpp
@@ -64,8 +64,8 @@ QString QgsTerrainGenerator::typeToString( QgsTerrainGenerator::Type type )
       return QStringLiteral( "flat" );
     case QgsTerrainGenerator::Dem:
       return QStringLiteral( "dem" );
-    case QgsTerrainGenerator::QuantizedMesh:
-      return QStringLiteral( "quantized-mesh" );
+    case QgsTerrainGenerator::Online:
+      return QStringLiteral( "online" );
   }
   return QString();
 }

--- a/src/3d/terrain/qgsterraingenerator.h
+++ b/src/3d/terrain/qgsterraingenerator.h
@@ -48,7 +48,7 @@ class _3D_EXPORT QgsTerrainGenerator : public QgsChunkLoaderFactory
     {
       Flat,           //!< The whole terrain is flat area
       Dem,            //!< Terrain is built from raster layer with digital elevation model
-      QuantizedMesh,  //!< Terrain is built from downloaded tiles in quantized mesh format
+      Online,         //!< Terrain is built from downloaded tiles with digital elevation model
     };
 
     //! Sets terrain entity for the generator (does not transfer ownership)

--- a/src/app/3d/qgs3dmapconfigwidget.h
+++ b/src/app/3d/qgs3dmapconfigwidget.h
@@ -37,6 +37,7 @@ class Qgs3DMapConfigWidget : public QWidget, private Ui::Map3DConfigWidget
   signals:
 
   private slots:
+    void onTerrainTypeChanged();
     void onTerrainLayerChanged();
     void updateMaxZoomLevel();
 

--- a/src/core/qgsgdalutils.cpp
+++ b/src/core/qgsgdalutils.cpp
@@ -33,3 +33,89 @@ bool QgsGdalUtils::supportsRasterCreate( GDALDriverH driver )
   return  CSLFetchBoolean( driverMetadata, GDAL_DCAP_CREATE, false ) &&
           CSLFetchBoolean( driverMetadata, GDAL_DCAP_RASTER, false );
 }
+
+gdal::dataset_unique_ptr QgsGdalUtils::createSingleBandMemoryDataset( GDALDataType dataType, QgsRectangle extent, int width, int height, const QgsCoordinateReferenceSystem &crs )
+{
+  GDALDriverH hDriverMem = GDALGetDriverByName( "MEM" );
+  if ( !hDriverMem )
+  {
+    return gdal::dataset_unique_ptr();
+  }
+
+  gdal::dataset_unique_ptr hSrcDS( GDALCreate( hDriverMem, "", width, height, 1, dataType, nullptr ) );
+
+  double cellSizeX = extent.width() / width;
+  double cellSizeY = extent.height() / height;
+  double geoTransform[6];
+  geoTransform[0] = extent.xMinimum();
+  geoTransform[1] = cellSizeX;
+  geoTransform[2] = 0;
+  geoTransform[3] = extent.yMinimum() + ( cellSizeY * height );
+  geoTransform[4] = 0;
+  geoTransform[5] = -cellSizeY;
+
+  GDALSetProjection( hSrcDS.get(), crs.toWkt().toLatin1().constData() );
+  GDALSetGeoTransform( hSrcDS.get(), geoTransform );
+  return hSrcDS;
+}
+
+gdal::dataset_unique_ptr QgsGdalUtils::createSingleBandTiffDataset( QString filename, GDALDataType dataType, QgsRectangle extent, int width, int height, const QgsCoordinateReferenceSystem &crs )
+{
+  double cellSizeX = extent.width() / width;
+  double cellSizeY = extent.height() / height;
+  double geoTransform[6];
+  geoTransform[0] = extent.xMinimum();
+  geoTransform[1] = cellSizeX;
+  geoTransform[2] = 0;
+  geoTransform[3] = extent.yMinimum() + ( cellSizeY * height );
+  geoTransform[4] = 0;
+  geoTransform[5] = -cellSizeY;
+
+  GDALDriverH hDriver = GDALGetDriverByName( "GTiff" );
+  if ( !hDriver )
+  {
+    return gdal::dataset_unique_ptr();
+  }
+
+  // Create the output file.
+  gdal::dataset_unique_ptr hDstDS( GDALCreate( hDriver, filename.toLocal8Bit().constData(), width, height, 1, dataType, nullptr ) );
+  if ( !hDstDS )
+  {
+    return gdal::dataset_unique_ptr();
+  }
+
+  // Write out the projection definition.
+  GDALSetProjection( hDstDS.get(), crs.toWkt().toLatin1().constData() );
+  GDALSetGeoTransform( hDstDS.get(), geoTransform );
+  return hDstDS;
+}
+
+void QgsGdalUtils::resampleSingleBandRaster( GDALDatasetH hSrcDS, GDALDatasetH hDstDS, GDALResampleAlg resampleAlg )
+{
+  gdal::warp_options_unique_ptr psWarpOptions( GDALCreateWarpOptions() );
+  psWarpOptions->hSrcDS = hSrcDS;
+  psWarpOptions->hDstDS = hDstDS;
+
+  psWarpOptions->nBandCount = 1;
+  psWarpOptions->panSrcBands = ( int * ) CPLMalloc( sizeof( int ) * 1 );
+  psWarpOptions->panDstBands = ( int * ) CPLMalloc( sizeof( int ) * 1 );
+  psWarpOptions->panSrcBands[0] = 1;
+  psWarpOptions->panDstBands[0] = 1;
+
+  psWarpOptions->eResampleAlg = resampleAlg;
+
+  // Establish reprojection transformer.
+  psWarpOptions->pTransformerArg =
+    GDALCreateGenImgProjTransformer( hSrcDS, GDALGetProjectionRef( hSrcDS ),
+                                     hDstDS, GDALGetProjectionRef( hDstDS ),
+                                     FALSE, 0.0, 1 );
+  psWarpOptions->pfnTransformer = GDALGenImgProjTransform;
+
+  // Initialize and execute the warp operation.
+  GDALWarpOperation oOperation;
+  oOperation.Initialize( psWarpOptions.get() );
+
+  oOperation.ChunkAndWarpImage( 0, 0, GDALGetRasterXSize( hDstDS ), GDALGetRasterYSize( hDstDS ) );
+
+  GDALDestroyGenImgProjTransformer( psWarpOptions->pTransformerArg );
+}

--- a/src/core/qgsgdalutils.h
+++ b/src/core/qgsgdalutils.h
@@ -21,6 +21,8 @@
 #include "qgis_core.h"
 #include <gdal.h>
 
+#include "qgsogrutils.h"
+
 /**
  * \ingroup core
  * \class QgsGdalUtils
@@ -39,6 +41,25 @@ class CORE_EXPORT QgsGdalUtils
      * \returns TRUE if a driver supports GDALCreate() for raster purposes.
      */
     static bool supportsRasterCreate( GDALDriverH driver );
+
+    /**
+     * Creates a new single band memory dataset with given parameters
+     * \since QGIS 3.8
+     */
+    static gdal::dataset_unique_ptr createSingleBandMemoryDataset( GDALDataType dataType, QgsRectangle extent, int width, int height, const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Creates a new single band TIFF dataset with given parameters
+     * \since QGIS 3.8
+     */
+    static gdal::dataset_unique_ptr createSingleBandTiffDataset( QString filename, GDALDataType dataType, QgsRectangle extent, int width, int height, const QgsCoordinateReferenceSystem &crs );
+
+    /**
+     * Resamples a single band raster to the destination dataset with different resolution (and possibly with different CRS).
+     * Ideally the source dataset should cover the whole area or the destination dataset.
+     * \since QGIS 3.8
+     */
+    static void resampleSingleBandRaster( GDALDatasetH hSrcDS, GDALDatasetH hDstDS, GDALResampleAlg resampleAlg );
 };
 
 #endif // QGSGDALUTILS_H

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -6,13 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>465</width>
-    <height>565</height>
+    <width>623</width>
+    <height>661</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Configure 3D Map Rendering</string>
-  </property>      
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QgsScrollArea" name="scrollArea">
@@ -23,9 +23,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-303</y>
+        <y>0</y>
         <width>557</width>
-        <height>1004</height>
+        <height>1298</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalInnerLayout">
@@ -48,9 +48,6 @@
              <string>°</string>
             </property>
             <property name="maximum">
-             <number>0</number>
-            </property>
-            <property name="maximum">
              <number>180</number>
             </property>
            </widget>
@@ -64,55 +61,24 @@
           <string>Terrain</string>
          </property>
          <layout class="QGridLayout" name="gridLayout1">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_10">
-            <property name="text">
-             <string>Tile resolution</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelTerrainLayer">
             <property name="text">
              <string>Elevation</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QgsMapLayerComboBox" name="cboTerrainLayer"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Vertical scale</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QgsDoubleSpinBox" name="spinTerrainScale">
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QgsSpinBox" name="spinTerrainResolution">
-            <property name="suffix">
-             <string> px</string>
-            </property>
-            <property name="maximum">
-             <number>4096</number>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_8">
+          <item row="4" column="0">
+           <widget class="QLabel" name="labelTerrainSkirtHeight">
             <property name="text">
              <string>Skirt height</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1" colspan="2">
+          <item row="1" column="1" colspan="2">
+           <widget class="QgsMapLayerComboBox" name="cboTerrainLayer"/>
+          </item>
+          <item row="4" column="1" colspan="2">
            <widget class="QgsDoubleSpinBox" name="spinTerrainSkirtHeight">
             <property name="suffix">
              <string> map units</string>
@@ -128,18 +94,75 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_9">
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelTerrainResolution">
+            <property name="text">
+             <string>Tile resolution</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QgsSpinBox" name="spinTerrainResolution">
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="maximum">
+             <number>4096</number>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="labelTerrainMapTheme">
             <property name="text">
              <string>Map theme</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1" colspan="2">
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelTerrainScale">
+            <property name="text">
+             <string>Vertical scale</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="QgsDoubleSpinBox" name="spinTerrainScale">
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1" colspan="2">
            <widget class="QComboBox" name="cboTerrainMapTheme">
             <property name="editable">
              <bool>false</bool>
             </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelTerrainType">
+            <property name="text">
+             <string>Type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="cboTerrainType">
+            <item>
+             <property name="text">
+              <string>Flat terrain</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>DEM (Raster layer)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Online</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>
@@ -339,6 +362,9 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>spinCameraFieldOfView</tabstop>
+  <tabstop>cboTerrainType</tabstop>
   <tabstop>cboTerrainLayer</tabstop>
   <tabstop>spinTerrainScale</tabstop>
   <tabstop>spinTerrainResolution</tabstop>

--- a/src/ui/3d/map3dconfigwidget.ui
+++ b/src/ui/3d/map3dconfigwidget.ui
@@ -147,23 +147,7 @@
            </widget>
           </item>
           <item row="0" column="1" colspan="2">
-           <widget class="QComboBox" name="cboTerrainType">
-            <item>
-             <property name="text">
-              <string>Flat terrain</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>DEM (Raster layer)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Online</string>
-             </property>
-            </item>
-           </widget>
+           <widget class="QComboBox" name="cboTerrainType"/>
           </item>
          </layout>
         </widget>

--- a/tests/src/core/testqgsgdalutils.cpp
+++ b/tests/src/core/testqgsgdalutils.cpp
@@ -22,6 +22,8 @@
 
 #include "qgsgdalutils.h"
 #include "qgsapplication.h"
+#include "qgsrasterlayer.h"
+
 
 class TestQgsGdalUtils: public QObject
 {
@@ -33,6 +35,9 @@ class TestQgsGdalUtils: public QObject
     void init();// will be called before each testfunction is executed.
     void cleanup();// will be called after every testfunction.
     void supportsRasterCreate();
+    void testCreateSingleBandMemoryDataset();
+    void testCreateSingleBandTiffDataset();
+    void testResampleSingleBandRaster();
 
   private:
 };
@@ -72,6 +77,89 @@ void TestQgsGdalUtils::supportsRasterCreate()
 
   // vector-only
   QVERIFY( !QgsGdalUtils::supportsRasterCreate( GDALGetDriverByName( "ESRI Shapefile" ) ) );
+}
+
+#define EPSG_4326_WKT \
+  "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]]," \
+  "AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433," \
+  "AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]"
+
+void TestQgsGdalUtils::testCreateSingleBandMemoryDataset()
+{
+  gdal::dataset_unique_ptr ds1 = QgsGdalUtils::createSingleBandMemoryDataset( GDT_Float32, QgsRectangle( 1, 1, 21, 11 ), 40, 20, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
+  QVERIFY( ds1 );
+
+  QCOMPARE( GDALGetRasterCount( ds1.get() ), 1 );
+  QCOMPARE( GDALGetRasterXSize( ds1.get() ), 40 );
+  QCOMPARE( GDALGetRasterYSize( ds1.get() ), 20 );
+
+  QCOMPARE( GDALGetProjectionRef( ds1.get() ), EPSG_4326_WKT );
+  double geoTransform[6];
+  double geoTransformExpected[] = { 1, 0.5, 0, 11, 0, -0.5 };
+  QCOMPARE( GDALGetGeoTransform( ds1.get(), geoTransform ), CE_None );
+  QVERIFY( memcmp( geoTransform, geoTransformExpected, sizeof( double ) * 6 ) == 0 );
+
+  QCOMPARE( GDALGetRasterDataType( GDALGetRasterBand( ds1.get(), 1 ) ), GDT_Float32 );
+}
+
+void TestQgsGdalUtils::testCreateSingleBandTiffDataset()
+{
+  QString filename = QDir::tempPath() + "/qgis_test_single_band_raster.tif";
+  QFile::remove( filename );
+  QVERIFY( !QFile::exists( filename ) );
+
+  gdal::dataset_unique_ptr ds1 = QgsGdalUtils::createSingleBandTiffDataset( filename, GDT_Float32, QgsRectangle( 1, 1, 21, 11 ), 40, 20, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
+  QVERIFY( ds1 );
+
+  QCOMPARE( GDALGetRasterCount( ds1.get() ), 1 );
+  QCOMPARE( GDALGetRasterXSize( ds1.get() ), 40 );
+  QCOMPARE( GDALGetRasterYSize( ds1.get() ), 20 );
+
+  QCOMPARE( GDALGetProjectionRef( ds1.get() ), EPSG_4326_WKT );
+  double geoTransform[6];
+  double geoTransformExpected[] = { 1, 0.5, 0, 11, 0, -0.5 };
+  QCOMPARE( GDALGetGeoTransform( ds1.get(), geoTransform ), CE_None );
+  QVERIFY( memcmp( geoTransform, geoTransformExpected, sizeof( double ) * 6 ) == 0 );
+
+  QCOMPARE( GDALGetRasterDataType( GDALGetRasterBand( ds1.get(), 1 ) ), GDT_Float32 );
+
+  ds1.reset();  // makes sure the file is fully written
+
+  QVERIFY( QFile::exists( filename ) );
+
+  std::unique_ptr<QgsRasterLayer> layer( new QgsRasterLayer( filename, "test", "gdal" ) );
+  QVERIFY( layer->isValid() );
+  QCOMPARE( layer->extent(), QgsRectangle( 1, 1, 21, 11 ) );
+  QCOMPARE( layer->width(), 40 );
+  QCOMPARE( layer->height(), 20 );
+
+  layer.reset();  // let's clean up before removing the file
+  QFile::remove( filename );
+}
+
+void TestQgsGdalUtils::testResampleSingleBandRaster()
+{
+  QString inputFilename = QString( TEST_DATA_DIR ) + "/float1-16.tif";
+  gdal::dataset_unique_ptr srcDS( GDALOpen( inputFilename.toUtf8().constData(), GA_ReadOnly ) );
+  QVERIFY( srcDS );
+
+  QString outputFilename = QDir::tempPath() + "/qgis_test_float1-16_resampled.tif";
+  QgsRectangle outputExtent( 106.25, -6.75, 106.55, -6.45 );
+  gdal::dataset_unique_ptr dstDS = QgsGdalUtils::createSingleBandTiffDataset( outputFilename, GDT_Float32, outputExtent, 2, 2, QgsCoordinateReferenceSystem( "EPSG:4326" ) );
+  QVERIFY( dstDS );
+
+  QgsGdalUtils::resampleSingleBandRaster( srcDS.get(), dstDS.get(), GRA_NearestNeighbour );
+  dstDS.reset();
+
+  std::unique_ptr<QgsRasterLayer> layer( new QgsRasterLayer( outputFilename, "test", "gdal" ) );
+  QVERIFY( layer );
+  std::unique_ptr<QgsRasterBlock> block( layer->dataProvider()->block( 1, outputExtent, 2, 2 ) );
+  QVERIFY( block );
+  QCOMPARE( block->value( 0, 0 ), 6. );
+  QCOMPARE( block->value( 1, 1 ), 11. );
+
+  layer.reset();
+  QFile::remove( outputFilename );
 }
 
 QGSTEST_MAIN( TestQgsGdalUtils )


### PR DESCRIPTION
This adds support for elevation tiles (using web mercator tiling) in "terrarium" format produced by Mapzen tools and publicly hosted by AWS.

Terrain tiles are downloaded just like ordinary XYZ tiles, then the elevations are decoded from RGB colors and finally resampled to whatever terrain tile resolution and CRS is used by the project.

Tiles are coming from this URL: http://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png
Zoom levels: 0 - 15

More details: https://registry.opendata.aws/terrain-tiles/

Users can pick now one of the three terrain generators:
![image](https://user-images.githubusercontent.com/193367/54535645-41869200-498f-11e9-9506-1154e9904a6c.png)

Online terrain generator has similar parameters like raster-based terrain generator:
![image](https://user-images.githubusercontent.com/193367/54535613-2b78d180-498f-11e9-89c7-06d0812a3ac6.png)
