### PR TITLE
Remove some use of deprecated QgsCoordinateTransform constructor

### DIFF
--- a/src/core/expression/qgsexpressionfunction.cpp
+++ b/src/core/expression/qgsexpressionfunction.cpp
@@ -4096,7 +4096,7 @@ static QVariant fcnGetGeometry( const QVariantList &values, const QgsExpressionC
   return QVariant();
 }
 
-static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent, const QgsExpressionNodeFunction * )
+static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent, const QgsExpressionNodeFunction * )
 {
   QgsGeometry fGeom = QgsExpressionUtils::getGeometry( values.at( 0 ), parent );
   QString sAuthId = QgsExpressionUtils::getStringValue( values.at( 1 ), parent );
@@ -4109,9 +4109,10 @@ static QVariant fcnTransformGeometry( const QVariantList &values, const QgsExpre
   if ( ! d.isValid() )
     return QVariant::fromValue( fGeom );
 
-  Q_NOWARN_DEPRECATED_PUSH
-  QgsCoordinateTransform t( s, d );
-  Q_NOWARN_DEPRECATED_POP
+  QgsCoordinateTransformContext tContext;
+  if ( context )
+    tContext = context->variable( QStringLiteral( "_project_transform_context" ) ).value<QgsCoordinateTransformContext>();
+  QgsCoordinateTransform t( s, d, tContext );
   try
   {
     if ( fGeom.transform( t ) == 0 )

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -148,14 +148,12 @@ bool QgsVectorLayerDiagramProvider::prepare( const QgsRenderContext &context, QS
   const QgsMapSettings &mapSettings = mEngine->mapSettings();
 
   if ( context.coordinateTransform().isValid() )
-    // this is context for layer rendering - use its CT as it includes correct datum transform
+    // this is context for layer rendering
     s2.setCoordinateTransform( context.coordinateTransform() );
   else
   {
-    // otherwise fall back to creating our own CT - this one may not have the correct datum transform!
-    Q_NOWARN_DEPRECATED_PUSH
-    s2.setCoordinateTransform( QgsCoordinateTransform( mLayerCrs, mapSettings.destinationCrs() ) );
-    Q_NOWARN_DEPRECATED_POP
+    // otherwise fall back to creating our own CT
+    s2.setCoordinateTransform( QgsCoordinateTransform( mLayerCrs, mapSettings.destinationCrs(), context.transformContext() ) );
   }
 
   s2.setRenderer( mDiagRenderer );


### PR DESCRIPTION
Removes some use of the deprecated transform constructor (which does not respect the project's coordinate transform settings).

Sponsored by ICSM

(Possibly backportable to 3.4)