### PR TITLE
Move ellipsoid handling to proj 6 api (where available)

### DIFF
--- a/python/core/auto_generated/qgsprojutils.sip.in
+++ b/python/core/auto_generated/qgsprojutils.sip.in
@@ -1,0 +1,37 @@
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsprojutils.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/
+
+
+
+
+class QgsProjUtils
+{
+%Docstring
+Utility functions for working with the proj library.
+
+.. versionadded:: 3.8
+%End
+
+%TypeHeaderCode
+#include "qgsprojutils.h"
+%End
+  public:
+
+    static int projVersionMajor();
+%Docstring
+Returns the proj library major version number.
+%End
+};
+
+/************************************************************************
+ * This file has been generated automatically from                      *
+ *                                                                      *
+ * src/core/qgsprojutils.h                                              *
+ *                                                                      *
+ * Do not edit manually ! Edit header and run scripts/sipify.pl again   *
+ ************************************************************************/

--- a/python/core/auto_generated/qgsprojutils.sip.in
+++ b/python/core/auto_generated/qgsprojutils.sip.in
@@ -9,6 +9,7 @@
 
 
 
+
 class QgsProjUtils
 {
 %Docstring

--- a/python/core/core_auto.sip
+++ b/python/core/core_auto.sip
@@ -99,6 +99,7 @@
 %Include auto_generated/qgsprojectstorageregistry.sip
 %Include auto_generated/qgsprojecttranslator.sip
 %Include auto_generated/qgsprojectversion.sip
+%Include auto_generated/qgsprojutils.sip
 %Include auto_generated/qgsproperty.sip
 %Include auto_generated/qgspropertycollection.sip
 %Include auto_generated/qgspropertytransformer.sip

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -295,6 +295,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas *mapCanvas, QWidget *pa
     int index = 0;
     for ( int i = 0; i < mEllipsoidList.length(); i++ )
     {
+      // TODO - use parameters instead of acronym
       if ( mEllipsoidList[ i ].acronym == QgsProject::instance()->crs().ellipsoidAcronym() )
       {
         index = i;
@@ -1651,6 +1652,7 @@ void QgsProjectProperties::srIdUpdated()
     int index = 0;
     for ( int i = 0; i < mEllipsoidList.length(); i++ )
     {
+      // TODO - use parameters instead of acronym
       if ( mEllipsoidList[ i ].acronym == mCrs.ellipsoidAcronym() )
       {
         index = i;

--- a/src/core/qgsellipsoidutils.cpp
+++ b/src/core/qgsellipsoidutils.cpp
@@ -147,7 +147,18 @@ const QMap< QString, QString > sProj6EllipsoidAcronymMap
   {"engelis", "EPSG:7054"},
   {"evrst56", "EPSG:7044"},
   {"SEasia", "ESRI:107004"},
-  {"SGS85", "EPSG:7054"}
+  {"SGS85", "EPSG:7054"},
+  {"andrae", "PROJ:ANDRAE"},
+  {"clrk80", "EPSG:7034"},
+  {"CPM", "PROJ:CPM"},
+  {"delmbr", "PROJ:DELMBR"},
+  {"Earth2000", "PROJ:EARTH2000"},
+  {"kaula", "PROJ:KAULA"},
+  {"lerch", "PROJ:LERCH"},
+  {"MERIT", "PROJ:MERIT"},
+  {"mprts", "PROJ:MPRTS"},
+  {"new_intl", "PROJ:NEW_INTL"},
+  {"WGS60", "PROJ:WGS60"}
 };
 
 QgsEllipsoidUtils::EllipsoidParameters QgsEllipsoidUtils::ellipsoidParameters( const QString &e )

--- a/src/core/qgsellipsoidutils.cpp
+++ b/src/core/qgsellipsoidutils.cpp
@@ -365,13 +365,13 @@ QList<QgsEllipsoidUtils::EllipsoidDefinition> QgsEllipsoidUtils::definitions()
         {
           def.parameters.semiMinor = semiMinor;
           def.parameters.inverseFlattening = def.parameters.semiMajor / ( def.parameters.semiMajor - def.parameters.semiMinor );
-          def.parameters.crs = QgsCoordinateReferenceSystem::fromProj4( QStringLiteral( "+proj=longlat +a=%1 +b=%2 +no_defs" ).arg( def.parameters.semiMajor ).arg( def.parameters.semiMinor ) );
+          def.parameters.crs = QgsCoordinateReferenceSystem::fromProj4( QStringLiteral( "+proj=longlat +a=%1 +b=%2 +no_defs" ).arg( def.parameters.semiMajor, 0, 'g', 17 ).arg( def.parameters.semiMinor, 0, 'g', 17 ) );
         }
         else
         {
           def.parameters.inverseFlattening = invFlattening;
           def.parameters.semiMinor = def.parameters.semiMajor  * ( 1 - def.parameters.inverseFlattening );
-          def.parameters.crs = QgsCoordinateReferenceSystem::fromProj4( QStringLiteral( "+proj=longlat +a=%1 +rf=%2 +no_defs" ).arg( def.parameters.semiMajor ).arg( def.parameters.inverseFlattening ) );
+          def.parameters.crs = QgsCoordinateReferenceSystem::fromProj4( QStringLiteral( "+proj=longlat +a=%1 +rf=%2 +no_defs" ).arg( def.parameters.semiMajor, 0, 'g', 17 ).arg( def.parameters.inverseFlattening, 0, 'g', 17 ) );
         }
       }
       else

--- a/src/core/qgsellipsoidutils.cpp
+++ b/src/core/qgsellipsoidutils.cpp
@@ -357,22 +357,18 @@ QList<QgsEllipsoidUtils::EllipsoidDefinition> QgsEllipsoidUtils::definitions()
       def.description = QStringLiteral( "%1 (%2:%3)" ).arg( name, authority, code );
 
       double semiMajor, semiMinor, invFlattening;
-      int semiMinorComputed;
+      int semiMinorComputed = 0;
       if ( proj_ellipsoid_get_parameters( context, ellipsoid, &semiMajor, &semiMinor, &semiMinorComputed, &invFlattening ) )
       {
         def.parameters.semiMajor = semiMajor;
-        if ( semiMinor > 0 )
-        {
-          def.parameters.semiMinor = semiMinor;
-          def.parameters.inverseFlattening = def.parameters.semiMajor / ( def.parameters.semiMajor - def.parameters.semiMinor );
+        def.parameters.semiMinor = semiMinor;
+        def.parameters.inverseFlattening = invFlattening;
+        if ( !semiMinorComputed )
           def.parameters.crs = QgsCoordinateReferenceSystem::fromProj4( QStringLiteral( "+proj=longlat +a=%1 +b=%2 +no_defs" ).arg( def.parameters.semiMajor, 0, 'g', 17 ).arg( def.parameters.semiMinor, 0, 'g', 17 ) );
-        }
-        else
-        {
-          def.parameters.inverseFlattening = invFlattening;
-          def.parameters.semiMinor = def.parameters.semiMajor  * ( 1 - def.parameters.inverseFlattening );
+        else if ( !qgsDoubleNear( def.parameters.inverseFlattening, 0.0 ) )
           def.parameters.crs = QgsCoordinateReferenceSystem::fromProj4( QStringLiteral( "+proj=longlat +a=%1 +rf=%2 +no_defs" ).arg( def.parameters.semiMajor, 0, 'g', 17 ).arg( def.parameters.inverseFlattening, 0, 'g', 17 ) );
-        }
+        else
+          def.parameters.crs = QgsCoordinateReferenceSystem::fromProj4( QStringLiteral( "+proj=longlat +a=%1 +no_defs" ).arg( def.parameters.semiMajor, 0, 'g', 17 ) );
       }
       else
       {

--- a/src/core/qgsellipsoidutils.cpp
+++ b/src/core/qgsellipsoidutils.cpp
@@ -263,6 +263,12 @@ QList<QgsEllipsoidUtils::EllipsoidDefinition> QgsEllipsoidUtils::definitions()
 
 #endif
 
+  QCollator collator;
+  collator.setCaseSensitivity( Qt::CaseInsensitive );
+  std::sort( defs.begin(), defs.end(), [&collator]( const EllipsoidDefinition & a, const EllipsoidDefinition & b )
+  {
+    return collator.compare( a.acronym, b.acronym ) < 0;
+  } );
   sDefinitionCache = defs;
   sDefinitionCacheLock.unlock();
 

--- a/src/core/qgsellipsoidutils.cpp
+++ b/src/core/qgsellipsoidutils.cpp
@@ -386,6 +386,8 @@ QList<QgsEllipsoidUtils::EllipsoidDefinition> QgsEllipsoidUtils::definitions()
               def.parameters.valid = false;
             }
 
+            proj_destroy( ellipsoid );
+
             defs << def;
             sEllipsoidCache.insert( def.acronym, def.parameters );
           }

--- a/src/core/qgsellipsoidutils.h
+++ b/src/core/qgsellipsoidutils.h
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsEllipsoidUtils
      */
     struct EllipsoidDefinition
     {
-      //! Acronym for ellipsoid
+      //! Acronym for ellipsoid, or authority:code for QGIS builds with proj version 6 or greater
       QString acronym;
       //! Description of ellipsoid
       QString description;

--- a/src/core/qgsellipsoidutils.h
+++ b/src/core/qgsellipsoidutils.h
@@ -62,7 +62,7 @@ class CORE_EXPORT QgsEllipsoidUtils
      */
     struct EllipsoidDefinition
     {
-      //! Acronym for ellipsoid, or authority:code for QGIS builds with proj version 6 or greater
+      //! authority:code for QGIS builds with proj version 6 or greater, or custom acronym for ellipsoid for earlier proj builds
       QString acronym;
       //! Description of ellipsoid
       QString description;

--- a/src/core/qgsprojutils.h
+++ b/src/core/qgsprojutils.h
@@ -26,7 +26,26 @@
 #include <QThreadStorage>
 #endif
 
-#define SIP_NO_FILE
+/**
+ * \class QgsProjUtils
+ * \ingroup core
+ * Utility functions for working with the proj library.
+ * \since QGIS 3.8
+ */
+class CORE_EXPORT QgsProjUtils
+{
+  public:
+
+    /**
+     * Returns the proj library major version number.
+     */
+    static int projVersionMajor()
+    {
+      return PROJ_VERSION_MAJOR;
+    }
+};
+
+#ifndef SIP_RUN
 
 #if PROJ_VERSION_MAJOR>=6
 struct projCtx_t;
@@ -68,5 +87,5 @@ class CORE_EXPORT QgsProjContext
 #endif
 };
 
-
+#endif
 #endif // QGSPROJUTILS_H

--- a/tests/src/python/test_qgsellipsoidutils.py
+++ b/tests/src/python/test_qgsellipsoidutils.py
@@ -68,7 +68,8 @@ class TestQgsEllipsoidUtils(unittest.TestCase):
                 self.assertEqual(params.semiMinor, 6356256.909237285)
                 self.assertEqual(params.inverseFlattening, 299.3249646)
                 self.assertFalse(params.useCustomParameters)
-                self.assertEqual(params.crs.toProj4(), '+proj=longlat +a=6377563.3959999997 +rf=299.32496459999999 +no_defs')
+                self.assertEqual(params.crs.toProj4(),
+                                 '+proj=longlat +a=6377563.3959999997 +rf=299.32496459999999 +no_defs')
 
                 params = QgsEllipsoidUtils.ellipsoidParameters("EPSG:7008")
                 self.assertTrue(params.valid)
@@ -76,7 +77,8 @@ class TestQgsEllipsoidUtils(unittest.TestCase):
                 self.assertEqual(params.semiMinor, 6356583.8)
                 self.assertEqual(params.inverseFlattening, 294.9786982138982)
                 self.assertFalse(params.useCustomParameters)
-                self.assertEqual(params.crs.toProj4(), '+proj=longlat +a=6378206.4000000004 +b=6356583.7999999998 +no_defs')
+                self.assertEqual(params.crs.toProj4(),
+                                 '+proj=longlat +a=6378206.4000000004 +b=6356583.7999999998 +no_defs')
 
         # using parameters
         for i in range(2):
@@ -95,7 +97,8 @@ class TestQgsEllipsoidUtils(unittest.TestCase):
 
     def testAcronyms(self):
         self.assertTrue('WGS84' if QgsProjUtils.projVersionMajor() < 6 else 'EPSG:7030' in QgsEllipsoidUtils.acronyms())
-        self.assertTrue('Ganymede2000' if QgsProjUtils.projVersionMajor() < 6 else 'ESRI:107916' in QgsEllipsoidUtils.acronyms())
+        self.assertTrue(
+            'Ganymede2000' if QgsProjUtils.projVersionMajor() < 6 else 'ESRI:107916' in QgsEllipsoidUtils.acronyms())
 
     def testDefinitions(self):
         defs = QgsEllipsoidUtils.definitions()
@@ -103,13 +106,88 @@ class TestQgsEllipsoidUtils(unittest.TestCase):
         gany_id = 'Ganymede2000' if QgsProjUtils.projVersionMajor() < 6 else 'ESRI:107916'
         gany_defs = [d for d in defs if d.acronym == gany_id][0]
         self.assertEqual(gany_defs.acronym, gany_id)
-        self.assertEqual(gany_defs.description, 'Ganymede2000' if QgsProjUtils.projVersionMajor() < 6 else 'Ganymede 2000 IAU IAG (ESRI:107916)')
+        self.assertEqual(gany_defs.description,
+                         'Ganymede2000' if QgsProjUtils.projVersionMajor() < 6 else 'Ganymede 2000 IAU IAG (ESRI:107916)')
         self.assertTrue(gany_defs.parameters.valid)
-        self.assertEqual(gany_defs.parameters.semiMajor, 2632400.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
-        self.assertEqual(gany_defs.parameters.semiMinor, 2632350.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
-        self.assertEqual(gany_defs.parameters.inverseFlattening, 52648.0 if QgsProjUtils.projVersionMajor() < 6 else 0.0)
+        self.assertEqual(gany_defs.parameters.semiMajor,
+                         2632400.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
+        self.assertEqual(gany_defs.parameters.semiMinor,
+                         2632350.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
+        self.assertEqual(gany_defs.parameters.inverseFlattening,
+                         52648.0 if QgsProjUtils.projVersionMajor() < 6 else 0.0)
         self.assertFalse(gany_defs.parameters.useCustomParameters)
         self.assertEqual(gany_defs.parameters.crs.authid(), '')
+
+    @unittest.skipIf(QgsProjUtils.projVersionMajor() < 6, 'Not a proj6 build')
+    def testMappingEllipsoidsToProj6(self):
+        old_qgis_ellipsoids = {'Adrastea2000': 'Adrastea2000', 'airy': 'Airy 1830', 'Amalthea2000': 'Amalthea2000',
+                               'Ananke2000': 'Ananke2000',
+                               'andrae': 'Andrae 1876 (Den., Iclnd.)',
+                               'Ariel2000': 'Ariel2000',
+                               'Atlas2000': 'Atlas2000', 'aust_SA': 'Australian Natl & S. Amer. 1969',
+                               'Belinda2000': 'Belinda2000',
+                               'bessel': 'Bessel 1841', 'bess_nam': 'Bessel 1841 (Namibia)', 'Bianca2000': 'Bianca2000',
+                               'Callisto2000': 'Callisto2000', 'Calypso2000': 'Calypso2000', 'Carme2000': 'Carme2000',
+                               'Charon2000': 'Charon2000', 'clrk66': 'Clarke 1866', 'IGNF:ELG004': 'Clarke 1866',
+                               'IGNF:ELG003': 'Clarke 1880 Anglais', 'IGNF:ELG010': 'Clarke 1880 IGN',
+                               'clrk80': 'Clarke 1880 mod.',
+                               'cape': 'Clarke 1880 mod.', 'CPM': 'Comm. des Poids et Mesures 1799',
+                               'Cordelia2000': 'Cordelia2000',
+                               'Cressida2000': 'Cressida2000', 'Deimos2000': 'Deimos2000',
+                               'delmbr': 'Delambre 1810 (Belgium)',
+                               'Desdemona2000': 'Desdemona2000', 'Despina2000': 'Despina2000', 'Dione2000': 'Dione2000',
+                               'Earth2000': 'Earth2000', 'Elara2000': 'Elara2000', 'Enceladus2000': 'Enceladus2000',
+                               'engelis': 'Engelis 1985',
+                               'Epimetheus2000': 'Epimetheus2000', 'Europa2000': 'Europa2000',
+                               'evrstSS': 'Everest (Sabah & Sarawak)',
+                               'evrst30': 'Everest 1830', 'evrst48': 'Everest 1948', 'evrst56': 'Everest 1956',
+                               'evrst69': 'Everest 1969',
+                               'fschr60': 'Fischer (Mercury Datum) 1960', 'fschr68': 'Fischer 1968',
+                               'GRS80': 'GRS 1980(IUGG, 1980)',
+                               'GRS67': 'GRS 67(IUGG 1967)', 'Galatea2000': 'Galatea2000',
+                               'Ganymede2000': 'Ganymede2000',
+                               'Helene2000': 'Helene2000', 'helmert': 'Helmert 1906', 'Himalia2000': 'Himalia2000',
+                               'hough': 'Hough',
+                               'Hyperion2000': 'Hyperion2000', 'IGNF:ELG108': 'IAG GRS 1967',
+                               'IGNF:ELG037': 'IAG GRS 1980',
+                               'IAU76': 'IAU 1976', 'Iapetus2000': 'Iapetus2000',
+                               'intl': 'International 1909 (Hayford)',
+                               'IGNF:ELG001': 'International-Hayford 1909', 'Io2000': 'Io2000',
+                               'Janus2000': 'Janus2000',
+                               'Juliet2000': 'Juliet2000', 'Jupiter2000': 'Jupiter2000', 'kaula': 'Kaula 1961',
+                               'krass': 'Krassovsky, 1942',
+                               'Larissa2000': 'Larissa2000', 'Leda2000': 'Leda2000', 'lerch': 'Lerch 1979',
+                               'Lysithea2000': 'Lysithea2000',
+                               'MERIT': 'MERIT 1983', 'Mars2000': 'Mars2000', 'mprts': 'Maupertius 1738',
+                               'Mercury2000': 'Mercury2000',
+                               'Metis2000': 'Metis2000', 'Mimas2000': 'Mimas2000', 'Miranda2000': 'Miranda2000',
+                               'mod_airy': 'Modified Airy',
+                               'fschr60m': 'Modified Fischer 1960', 'Moon2000': 'Moon2000', 'Naiad2000': 'Naiad2000',
+                               'NWL9D': 'Naval Weapons Lab., 1965', 'Neptune2000': 'Neptune2000',
+                               'Nereid2000': 'Nereid2000',
+                               'new_intl': 'New International 1967', 'sphere': 'Normal Sphere (r=6370997)',
+                               'Oberon2000': 'Oberon2000',
+                               'Ophelia2000': 'Ophelia2000', 'IGNF:ELG017': 'PLESSIS 1817', 'Pan2000': 'Pan2000',
+                               'Pandora2000': 'Pandora2000',
+                               'Pasiphae2000': 'Pasiphae2000', 'Phobos2000': 'Phobos2000', 'Phoebe2000': 'Phoebe2000',
+                               'plessis': 'Plessis 1817 (France)', 'Pluto2000': 'Pluto2000', 'Portia2000': 'Portia2000',
+                               'Prometheus2000': 'Prometheus2000', 'Proteus2000': 'Proteus2000', 'Puck2000': 'Puck2000',
+                               'Rhea2000': 'Rhea2000',
+                               'Rosalind2000': 'Rosalind2000', 'IGNF:ELG032': 'SPHERE PICARD',
+                               'Saturn2000': 'Saturn2000',
+                               'Sinope2000': 'Sinope2000', 'SEasia': 'Southeast Asia',
+                               'SGS85': 'Soviet Geodetic System 85',
+                               'Telesto2000': 'Telesto2000', 'Tethys2000': 'Tethys2000', 'Thalassa2000': 'Thalassa2000',
+                               'Thebe2000': 'Thebe2000', 'Titan2000': 'Titan2000', 'Titania2000': 'Titania2000',
+                               'Triton2000': 'Triton2000',
+                               'Umbriel2000': 'Umbriel2000', 'Uranus2000': 'Uranus2000', 'Venus2000': 'Venus2000',
+                               'WGS60': 'WGS 60',
+                               'WGS66': 'WGS 66', 'WGS72': 'WGS 72', 'WGS84': 'WGS 84', 'IGNF:ELG052': 'WGS72',
+                               'IGNF:ELG102': 'WGS72 (NWL-10F)', 'IGNF:ELG053': 'WGS84', 'walbeck': 'Walbeck'}
+
+        # ensure that all old QGIS custom ellipsoid definitions map across to new PROJ6 ones
+        for o in old_qgis_ellipsoids:
+            self.assertTrue(QgsEllipsoidUtils.ellipsoidParameters(o).valid, 'no defs for {}'.format(o))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsellipsoidutils.py
+++ b/tests/src/python/test_qgsellipsoidutils.py
@@ -13,7 +13,6 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
-import math
 from qgis.core import (QgsEllipsoidUtils,
                        QgsProjUtils)
 from qgis.testing import start_app, unittest
@@ -40,25 +39,44 @@ class TestQgsEllipsoidUtils(unittest.TestCase):
             if QgsProjUtils.projVersionMajor() < 6:
                 self.assertEqual(params.crs.authid(), 'EPSG:4030')
             else:
-                self.assertEqual(params.crs.toProj4(), '+proj=longlat +a=6378137 +b=6356752.3142451793 +no_defs')
+                self.assertEqual(params.crs.toProj4(), '+proj=longlat +a=6378137 +rf=298.25722356300003 +no_defs')
 
         for i in range(2):
             params = QgsEllipsoidUtils.ellipsoidParameters("Ganymede2000")
             self.assertTrue(params.valid)
             self.assertEqual(params.semiMajor, 2632400.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
             self.assertEqual(params.semiMinor, 2632350.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
-            self.assertEqual(params.inverseFlattening, 52648.0 if QgsProjUtils.projVersionMajor() < 6 else math.inf)
+            self.assertEqual(params.inverseFlattening, 52648.0 if QgsProjUtils.projVersionMajor() < 6 else 0)
             self.assertFalse(params.useCustomParameters)
-            self.assertEqual(params.crs.authid(), '')
+            if QgsProjUtils.projVersionMajor() < 6:
+                self.assertEqual(params.crs.authid(), '')
+            else:
+                self.assertEqual(params.crs.toProj4(), '+proj=longlat +a=2632345 +no_defs')
 
             if QgsProjUtils.projVersionMajor() >= 6:
                 params = QgsEllipsoidUtils.ellipsoidParameters("ESRI:107916")
                 self.assertTrue(params.valid)
-                self.assertEqual(params.semiMajor, 2632400.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
-                self.assertEqual(params.semiMinor, 2632350.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
-                self.assertEqual(params.inverseFlattening, 52648.0 if QgsProjUtils.projVersionMajor() < 6 else math.inf)
+                self.assertEqual(params.semiMajor, 2632345.0)
+                self.assertEqual(params.semiMinor, 2632345.0)
+                self.assertEqual(params.inverseFlattening, 0)
                 self.assertFalse(params.useCustomParameters)
-                self.assertEqual(params.crs.authid(), '')
+                self.assertEqual(params.crs.toProj4(), '+proj=longlat +a=2632345 +no_defs')
+
+                params = QgsEllipsoidUtils.ellipsoidParameters("EPSG:7001")
+                self.assertTrue(params.valid)
+                self.assertEqual(params.semiMajor, 6377563.396)
+                self.assertEqual(params.semiMinor, 6356256.909237285)
+                self.assertEqual(params.inverseFlattening, 299.3249646)
+                self.assertFalse(params.useCustomParameters)
+                self.assertEqual(params.crs.toProj4(), '+proj=longlat +a=6377563.3959999997 +rf=299.32496459999999 +no_defs')
+
+                params = QgsEllipsoidUtils.ellipsoidParameters("EPSG:7008")
+                self.assertTrue(params.valid)
+                self.assertEqual(params.semiMajor, 6378206.4)
+                self.assertEqual(params.semiMinor, 6356583.8)
+                self.assertEqual(params.inverseFlattening, 294.9786982138982)
+                self.assertFalse(params.useCustomParameters)
+                self.assertEqual(params.crs.toProj4(), '+proj=longlat +a=6378206.4000000004 +b=6356583.7999999998 +no_defs')
 
         # using parameters
         for i in range(2):
@@ -89,7 +107,7 @@ class TestQgsEllipsoidUtils(unittest.TestCase):
         self.assertTrue(gany_defs.parameters.valid)
         self.assertEqual(gany_defs.parameters.semiMajor, 2632400.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
         self.assertEqual(gany_defs.parameters.semiMinor, 2632350.0 if QgsProjUtils.projVersionMajor() < 6 else 2632345.0)
-        self.assertEqual(gany_defs.parameters.inverseFlattening, 52648.0 if QgsProjUtils.projVersionMajor() < 6 else math.inf)
+        self.assertEqual(gany_defs.parameters.inverseFlattening, 52648.0 if QgsProjUtils.projVersionMajor() < 6 else 0.0)
         self.assertFalse(gany_defs.parameters.useCustomParameters)
         self.assertEqual(gany_defs.parameters.crs.authid(), '')
 


### PR DESCRIPTION
This PR ports QGIS' ellipsoid handling to the newer proj 6 API (wherever available), and removes the use of the custom srs.db for ellipsoid lookups in favour of the standard proj database (accessed via proj c API).

One significant change here is that we no longer store ellipsoids by acronym, but instead use the unique authority:code identifier. Code is in place to transparently upgrade calls to the api using the older QGIS specific acronyms to their equivalent authority:code representation.

Sponsored by ICSM