### PR TITLE
[QgsQuick] 'Today' button for QgsQuickDateTime widget

### DIFF
--- a/src/quickgui/images/ic_today.svg
+++ b/src/quickgui/images/ic_today.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 3h-1V1h-2v2H8V1H6v2H5c-1.11 0-1.99.9-1.99 2L3 19c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V8h14v11zM7 10h5v5H7z"/></svg>

--- a/src/quickgui/images/images.qrc
+++ b/src/quickgui/images/images.qrc
@@ -11,5 +11,6 @@
         <file>ic_save_white.svg</file>
         <file>ic_camera.svg</file>
         <file>ic_gallery.svg</file>
+        <file>ic_today.svg</file>
     </qresource>
 </RCC>

--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -169,6 +169,14 @@ Item {
                 }
 
                 RowLayout {
+
+                    Button {
+                        text: qsTr( "Today" )
+                        Layout.fillWidth: true
+
+                        onClicked: main.currentValue = new Date()
+                    }
+
                     Button {
                         text: qsTr( "Ok" )
                         Layout.fillWidth: true

--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -17,6 +17,7 @@ import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 1.4 as Controls1
+import QtGraphicalEffects 1.0
 import QgsQuick 0.1 as QgsQuick
 
 /**
@@ -26,6 +27,7 @@ import QgsQuick 0.1 as QgsQuick
  */
 Item {
     signal valueChanged(var value, bool isNull)
+    property real iconSize:  fieldItem.height * 0.75
 
     id: fieldItem
     enabled: !readOnly
@@ -137,6 +139,31 @@ Item {
                     }
                 }
             }
+
+            Image {
+                id: todayBtn
+                height: fieldItem.iconSize
+                sourceSize.height: fieldItem.iconSize
+                autoTransform: true
+                fillMode: Image.PreserveAspectFit
+                source: QgsQuick.Utils.getThemeIcon("ic_today")
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                visible: fieldItem.enabled
+                anchors.rightMargin: fieldItem.anchors.rightMargin
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: main.currentValue = new Date()
+                }
+            }
+
+            ColorOverlay {
+                anchors.fill: todayBtn
+                source: todayBtn
+                color: customStyle.fontColor
+                visible: todayBtn.visible
+            }
         }
 
         Popup {
@@ -169,13 +196,6 @@ Item {
                 }
 
                 RowLayout {
-
-                    Button {
-                        text: qsTr( "Today" )
-                        Layout.fillWidth: true
-
-                        onClicked: main.currentValue = new Date()
-                    }
 
                     Button {
                         text: qsTr( "Ok" )

--- a/src/quickgui/plugin/editor/qgsquickdatetime.qml
+++ b/src/quickgui/plugin/editor/qgsquickdatetime.qml
@@ -196,7 +196,6 @@ Item {
                 }
 
                 RowLayout {
-
                     Button {
                         text: qsTr( "Ok" )
                         Layout.fillWidth: true


### PR DESCRIPTION
To enable quickly set current date.
Button is visible only if the widget is not in readOnly mode.

<img width="633" alt="Screenshot 2019-03-20 at 16 27 27" src="https://user-images.githubusercontent.com/6735606/54696995-1cc82100-4b2d-11e9-97d6-af983eb6a3b9.png">
