### PR TITLE
[processing] Add 'call' statements to SAGA batch file

### DIFF
--- a/python/plugins/processing/algs/saga/SagaUtils.py
+++ b/python/plugins/processing/algs/saga/SagaUtils.py
@@ -167,7 +167,7 @@ def executeSaga(feedback):
         command = ['cmd.exe', '/C ', sagaBatchJobFilename()]
     else:
         os.chmod(sagaBatchJobFilename(), stat.S_IEXEC 
-                | stat.S_IREAD | stat.S_IWRITE)
+                 | stat.S_IREAD | stat.S_IWRITE)
         command = ["'" + sagaBatchJobFilename() + "'"]
     loglines = []
     loglines.append(QCoreApplication.translate('SagaUtils', 'SAGA execution console output'))

--- a/python/plugins/processing/algs/saga/SagaUtils.py
+++ b/python/plugins/processing/algs/saga/SagaUtils.py
@@ -166,8 +166,8 @@ def executeSaga(feedback):
     if isWindows():
         command = ['cmd.exe', '/C ', sagaBatchJobFilename()]
     else:
-        os.chmod(sagaBatchJobFilename(), stat.S_IEXEC 
-                 | stat.S_IREAD | stat.S_IWRITE)
+        os.chmod(sagaBatchJobFilename(), stat.S_IEXEC |
+                 stat.S_IREAD | stat.S_IWRITE)
         command = ["'" + sagaBatchJobFilename() + "'"]
     loglines = []
     loglines.append(QCoreApplication.translate('SagaUtils', 'SAGA execution console output'))

--- a/python/plugins/processing/algs/saga/SagaUtils.py
+++ b/python/plugins/processing/algs/saga/SagaUtils.py
@@ -109,7 +109,10 @@ def createSagaBatchJobFileFromSagaCommands(commands):
         else:
             pass
         for command in commands:
-            fout.write('saga_cmd ' + command + '\n')
+            if isWindows():
+                fout.write('call saga_cmd ' + command + '\n')
+            else:
+                fout.write('saga_cmd ' + command + '\n')
 
         fout.write('exit')
 
@@ -163,8 +166,8 @@ def executeSaga(feedback):
     if isWindows():
         command = ['cmd.exe', '/C ', sagaBatchJobFilename()]
     else:
-        os.chmod(sagaBatchJobFilename(), stat.S_IEXEC |
-                 stat.S_IREAD | stat.S_IWRITE)
+        os.chmod(sagaBatchJobFilename(), stat.S_IEXEC 
+                | stat.S_IREAD | stat.S_IWRITE)
         command = ["'" + sagaBatchJobFilename() + "'"]
     loglines = []
     loglines.append(QCoreApplication.translate('SagaUtils', 'SAGA execution console output'))


### PR DESCRIPTION
## Description

This will have no effect in the current osgeo4w installation, but will prevent errors if a batch file is called from within another batch file, which might happen with a different installation.

see: https://stackoverflow.com/questions/7320074/batch-file-stops-running-after-the-first-command

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
