### PR TITLE
Only change map extent when manually changing the active error

### DIFF
--- a/src/app/qgsgeometryvalidationdock.cpp
+++ b/src/app/qgsgeometryvalidationdock.cpp
@@ -84,6 +84,7 @@ void QgsGeometryValidationDock::setGeometryValidationModel( QgsGeometryValidatio
   mErrorListView->setModel( mGeometryValidationModel );
 
   connect( mErrorListView->selectionModel(), &QItemSelectionModel::currentChanged, this, &QgsGeometryValidationDock::onCurrentErrorChanged );
+  connect( mErrorListView->selectionModel(), &QItemSelectionModel::currentChanged, this, [this]() { updateMapCanvasExtent(); } );
   connect( mGeometryValidationModel, &QgsGeometryValidationModel::dataChanged, this, &QgsGeometryValidationDock::onDataChanged );
   connect( mGeometryValidationModel, &QgsGeometryValidationModel::rowsRemoved, this, &QgsGeometryValidationDock::updateCurrentError );
   connect( mGeometryValidationModel, &QgsGeometryValidationModel::rowsInserted, this, &QgsGeometryValidationDock::onRowsInserted );
@@ -242,7 +243,10 @@ void QgsGeometryValidationDock::onCurrentErrorChanged( const QModelIndex &curren
 
   bool hasFeature = !FID_IS_NULL( current.data( QgsGeometryValidationModel::ErrorFeatureIdRole ) );
   mZoomToFeatureButton->setEnabled( hasFeature );
+}
 
+void QgsGeometryValidationDock::updateMapCanvasExtent()
+{
   if ( !mPreventZoomToError )
   {
     switch ( mLastZoomToAction )

--- a/src/app/qgsgeometryvalidationdock.h
+++ b/src/app/qgsgeometryvalidationdock.h
@@ -46,6 +46,7 @@ class QgsGeometryValidationDock : public QgsDockWidget, public Ui_QgsGeometryVal
   private slots:
     void updateCurrentError();
     void onCurrentErrorChanged( const QModelIndex &current, const QModelIndex &previous );
+    void updateMapCanvasExtent();
     void onCurrentLayerChanged( QgsMapLayer *layer );
     void onLayerDestroyed( QObject *layer );
     void gotoNextError();


### PR DESCRIPTION
This makes it much more comfortable to fix invalid geometries because while editing the geometry, the map canvas is not jumping around like crazy.

I'll give out free karma points to anyone giving me a :+1: to include this in this weeks patch release.