### PR TITLE
[mssql] More sensible srid when adding CRS to MS SQL database

### DIFF
--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1802,7 +1802,7 @@ QgsVectorLayerExporter::ExportError QgsMssqlProvider::createEmptyLayer( const QS
   long srid = 0;
   if ( srs.isValid() )
   {
-    srid = srs.srsid();
+    srid = srs.postgisSrid();
     QString auth_srid = QStringLiteral( "null" );
     QString auth_name = QStringLiteral( "null" );
     QStringList sl = srs.authid().split( ':' );
@@ -1812,7 +1812,7 @@ QgsVectorLayerExporter::ExportError QgsMssqlProvider::createEmptyLayer( const QS
       auth_srid = sl[1];
     }
     sql = QStringLiteral( "IF NOT EXISTS (SELECT * FROM spatial_ref_sys WHERE srid=%1) INSERT INTO spatial_ref_sys (srid, auth_name, auth_srid, srtext, proj4text) VALUES (%1, %2, %3, '%4', '%5')" )
-          .arg( srs.srsid() )
+          .arg( srid )
           .arg( auth_name,
                 auth_srid,
                 srs.toWkt(),


### PR DESCRIPTION
The spatial_ref_sys table has srid column with ID of CRS entries.
I believe the IDs can be arbitrary, however it has been a good habit
to use EPSG number for srid (at least in GDAL - and the same thing
happens in PostGIS - srid values are the same as EPSG numbers).

In QGIS import if we add a new row to spatial_ref_sys table, the code
was using srsid() as ID which is internal ID in QGIS srs.db and it has
nothing to do with other IDs. Some pieces of code (probably incorrectly)
expect that srid is actually the EPSG number, so let's use those
so that we are consistent with GDAL and fix these minor issues
(for example, tooltip of MS SQL layers in browser show srid - which
in case of layers loaded with QGIS were meaningless)
