### PR TITLE
[processing] New algorithm "Add X/Y fields to layer"

### DIFF
--- a/python/plugins/processing/gui/TestTools.py
+++ b/python/plugins/processing/gui/TestTools.py
@@ -135,7 +135,14 @@ def splitAlgIdAndParameters(command):
     """
     exp = re.compile(r"""['"](.*?)['"]\s*,\s*(.*)""")
     m = exp.search(command[len('processing.run('):-1])
-    return m.group(1), ast.literal_eval(m.group(2))
+    alg_id = m.group(1)
+    params = m.group(2)
+
+    # replace QgsCoordinateReferenceSystem('EPSG:4325') with just string value
+    exp = re.compile(r"""QgsCoordinateReferenceSystem\((['"].*?['"])\)""")
+    params = exp.sub('\\1', params)
+
+    return alg_id, ast.literal_eval(params)
 
 
 def createTest(text):

--- a/python/plugins/processing/tests/testdata/expected/add_xy_3857.gml
+++ b/python/plugins/processing/tests/testdata/expected/add_xy_3857.gml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ add_xy_3857.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:p_x>111319.4907932723</ogr:p_x>
+      <ogr:p_y>111325.1428663849</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:p_x>333958.4723798198</ogr:p_x>
+      <ogr:p_y>334111.1714019597</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:p_x>222638.9815865475</ogr:p_x>
+      <ogr:p_y>222684.2085055445</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:p_x>556597.4539663672</ogr:p_x>
+      <ogr:p_y>222684.2085055445</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:p_x>445277.9631730949</ogr:p_x>
+      <ogr:p_y>111325.1428663849</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:p_x>0.0000000000</ogr:p_x>
+      <ogr:p_y>-557305.2572745769</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:p_x>890555.9263461898</ogr:p_x>
+      <ogr:p_y>-111325.1428663860</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:p_x>779236.4355529146</ogr:p_x>
+      <ogr:p_y>-111325.1428663860</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_3857 fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:p_x>0.0000000000</ogr:p_x>
+      <ogr:p_y>-111325.1428663860</ogr:p_y>
+    </ogr:add_xy_3857>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/add_xy_3857.xsd
+++ b/python/plugins/processing/tests/testdata/expected/add_xy_3857.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="add_xy_3857" type="ogr:add_xy_3857_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="add_xy_3857_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="p_x" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="p_y" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/expected/add_xy_4326.gml
+++ b/python/plugins/processing/tests/testdata/expected/add_xy_4326.gml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://ogr.maptools.org/ add_xy_4326.xsd"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>1</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:x>1.0000000000</ogr:x>
+      <ogr:y>1.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>2</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:x>3.0000000000</ogr:x>
+      <ogr:y>3.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>3</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:x>2.0000000000</ogr:x>
+      <ogr:y>2.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>4</ogr:id>
+      <ogr:id2>2</ogr:id2>
+      <ogr:x>5.0000000000</ogr:x>
+      <ogr:y>2.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>5</ogr:id>
+      <ogr:id2>1</ogr:id2>
+      <ogr:x>4.0000000000</ogr:x>
+      <ogr:y>1.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>6</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:x>0.0000000000</ogr:x>
+      <ogr:y>-5.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>7</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:x>8.0000000000</ogr:x>
+      <ogr:y>-1.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>8</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:x>7.0000000000</ogr:x>
+      <ogr:y>-1.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:add_xy_4326 fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:id>9</ogr:id>
+      <ogr:id2>0</ogr:id2>
+      <ogr:x>0.0000000000</ogr:x>
+      <ogr:y>-1.0000000000</ogr:y>
+    </ogr:add_xy_4326>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/add_xy_4326.xsd
+++ b/python/plugins/processing/tests/testdata/expected/add_xy_4326.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://ogr.maptools.org/" xmlns:ogr="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml" elementFormDefault="qualified" version="1.0">
+<xs:import namespace="http://www.opengis.net/gml" schemaLocation="http://schemas.opengis.net/gml/2.1.2/feature.xsd"/>
+<xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:_FeatureCollection"/>
+<xs:complexType name="FeatureCollectionType">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureCollectionType">
+      <xs:attribute name="lockId" type="xs:string" use="optional"/>
+      <xs:attribute name="scope" type="xs:string" use="optional"/>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+<xs:element name="add_xy_4326" type="ogr:add_xy_4326_Type" substitutionGroup="gml:_Feature"/>
+<xs:complexType name="add_xy_4326_Type">
+  <xs:complexContent>
+    <xs:extension base="gml:AbstractFeatureType">
+      <xs:sequence>
+        <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="id" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="id2" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:integer">
+              <xs:totalDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="x" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+        <xs:element name="y" nillable="true" minOccurs="0" maxOccurs="1">
+          <xs:simpleType>
+            <xs:restriction base="xs:decimal">
+              <xs:totalDigits value="21"/>
+              <xs:fractionDigits value="10"/>
+            </xs:restriction>
+          </xs:simpleType>
+        </xs:element>
+      </xs:sequence>
+    </xs:extension>
+  </xs:complexContent>
+</xs:complexType>
+</xs:schema>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -7287,4 +7287,31 @@ tests:
         hash: 6c09e13126e16a267e36c79b0eeba7761422da7bd0387125f4c823e6
         type: rasterhash
 
+  - algorithm: native:addxyfields
+    name: Add XY 4326
+    params:
+      CRS: EPSG:4326
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      PREFIX: ''
+    results:
+      OUTPUT:
+        name: expected/add_xy_4326.gml
+        type: vector
+
+  - algorithm: native:addxyfields
+    name: Add XY 3785
+    params:
+      CRS: EPSG:3785
+      INPUT:
+        name: points.gml|layername=points
+        type: vector
+      PREFIX: p_
+    results:
+      OUTPUT:
+        name: expected/add_xy_3857.gml
+        type: vector
+
+
 # See ../README.md for a description of the file format

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(QGIS_ANALYSIS_SRCS
   interpolation/Vector3D.cpp
 
   processing/qgsalgorithmaddincrementalfield.cpp
+  processing/qgsalgorithmaddxyfields.cpp
   processing/qgsalgorithmarraytranslatedfeatures.cpp
   processing/qgsalgorithmassignprojection.cpp
   processing/qgsalgorithmboundary.cpp

--- a/src/analysis/processing/qgsalgorithmaddxyfields.cpp
+++ b/src/analysis/processing/qgsalgorithmaddxyfields.cpp
@@ -1,0 +1,148 @@
+/***************************************************************************
+                         qgsalgorithmaddixyfields.cpp
+                         -----------------------------------
+    begin                : March 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsalgorithmaddxyfields.h"
+#include "qgsfeaturerequest.h"
+
+///@cond PRIVATE
+
+QString QgsAddXYFieldsAlgorithm::name() const
+{
+  return QStringLiteral( "addxyfields" );
+}
+
+QString QgsAddXYFieldsAlgorithm::displayName() const
+{
+  return QObject::tr( "Add X/Y fields to layer" );
+}
+
+QString QgsAddXYFieldsAlgorithm::shortHelpString() const
+{
+  return QObject::tr( "Adds X and Y (or latitude/longitude) fields to a point layer. The X/Y fields can be calculated in a different CRS to the layer (e.g. creating latitude/longitude fields for a layer in a project CRS)." );
+}
+
+QString QgsAddXYFieldsAlgorithm::shortDescription() const
+{
+  return QObject::tr( "Adds X and Y (or latitude/longitude) fields to a point layer." );
+}
+
+QStringList QgsAddXYFieldsAlgorithm::tags() const
+{
+  return QObject::tr( "add,create,latitude,longitude,columns,attributes" ).split( ',' );
+}
+
+QString QgsAddXYFieldsAlgorithm::group() const
+{
+  return QObject::tr( "Vector table" );
+}
+
+QString QgsAddXYFieldsAlgorithm::groupId() const
+{
+  return QStringLiteral( "vectortable" );
+}
+
+QString QgsAddXYFieldsAlgorithm::outputName() const
+{
+  return QObject::tr( "Added fields" );
+}
+
+QList<int> QgsAddXYFieldsAlgorithm::inputLayerTypes() const
+{
+  return QList<int>() << QgsProcessing::TypeVectorPoint;
+}
+
+QgsAddXYFieldsAlgorithm *QgsAddXYFieldsAlgorithm::createInstance() const
+{
+  return new QgsAddXYFieldsAlgorithm();
+}
+
+QgsProcessingFeatureSource::Flag QgsAddXYFieldsAlgorithm::sourceFlags() const
+{
+  return QgsProcessingFeatureSource::FlagSkipGeometryValidityChecks;
+}
+
+void QgsAddXYFieldsAlgorithm::initParameters( const QVariantMap & )
+{
+  addParameter( new QgsProcessingParameterCrs( QStringLiteral( "CRS" ), QObject::tr( "Coordinate system" ), QStringLiteral( "EPSG:4326" ) ) );
+  addParameter( new QgsProcessingParameterString( QStringLiteral( "PREFIX" ), QObject::tr( "Field prefix" ), QVariant(), false, true ) );
+}
+
+QgsFields QgsAddXYFieldsAlgorithm::outputFields( const QgsFields &inputFields ) const
+{
+  const QString xFieldName = mPrefix + 'x';
+  const QString yFieldName = mPrefix + 'y';
+
+  QgsFields outFields = inputFields;
+  outFields.append( QgsField( xFieldName, QVariant::Double, QString(), 20, 10 ) );
+  outFields.append( QgsField( yFieldName, QVariant::Double, QString(), 20, 10 ) );
+  return outFields;
+}
+
+QgsCoordinateReferenceSystem QgsAddXYFieldsAlgorithm::outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const
+{
+  mSourceCrs = inputCrs;
+  return inputCrs;
+}
+
+bool QgsAddXYFieldsAlgorithm::prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback * )
+{
+  mPrefix = parameterAsString( parameters, QStringLiteral( "PREFIX" ), context );
+  mCrs = parameterAsCrs( parameters, QStringLiteral( "CRS" ), context );
+  return true;
+}
+
+QgsFeatureList QgsAddXYFieldsAlgorithm::processFeature( const QgsFeature &feature, QgsProcessingContext &context, QgsProcessingFeedback *feedback )
+{
+  if ( mTransformNeedsInitialization )
+  {
+    mTransform = QgsCoordinateTransform( mSourceCrs, mCrs, context.transformContext() );
+    mTransformNeedsInitialization = false;
+  }
+
+  QVariant x;
+  QVariant y;
+  if ( feature.hasGeometry() )
+  {
+    if ( feature.geometry().isMultipart() )
+      throw QgsProcessingException( QObject::tr( "Multipoint features are not supported - please convert to single point features first." ) );
+
+    const QgsPointXY point = feature.geometry().asPoint();
+    try
+    {
+      const QgsPointXY transformed = mTransform.transform( point );
+      x = transformed.x();
+      y = transformed.y();
+    }
+    catch ( QgsCsException & )
+    {
+      feedback->reportError( QObject::tr( "Could not transform point to destination CRS" ) );
+    }
+  }
+  QgsFeature f =  feature;
+  QgsAttributes attributes = f.attributes();
+  attributes << x << y;
+  f.setAttributes( attributes );
+  return QgsFeatureList() << f;
+}
+
+bool QgsAddXYFieldsAlgorithm::supportInPlaceEdit( const QgsMapLayer *layer ) const
+{
+  Q_UNUSED( layer );
+  return false;
+}
+
+///@endcond

--- a/src/analysis/processing/qgsalgorithmaddxyfields.h
+++ b/src/analysis/processing/qgsalgorithmaddxyfields.h
@@ -1,0 +1,73 @@
+/***************************************************************************
+                         qgsalgorithmaddixyfields.h
+                         ---------------------------------
+    begin                : March 2019
+    copyright            : (C) 2019 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSALGORITHMADDXYFIELDS_H
+#define QGSALGORITHMADDXYFIELDS_H
+
+#define SIP_NO_FILE
+
+#include "qgis_sip.h"
+#include "qgsprocessingalgorithm.h"
+
+///@cond PRIVATE
+
+/**
+ * Native add X/Y fields algorithm.
+ */
+class QgsAddXYFieldsAlgorithm : public QgsProcessingFeatureBasedAlgorithm
+{
+
+  public:
+
+    QgsAddXYFieldsAlgorithm() = default;
+    QString name() const override;
+    QString displayName() const override;
+    QStringList tags() const override;
+    QString group() const override;
+    QString groupId() const override;
+    QString shortHelpString() const override;
+    QString shortDescription() const override;
+    QList<int> inputLayerTypes() const override;
+    QgsAddXYFieldsAlgorithm *createInstance() const override SIP_FACTORY;
+
+  protected:
+
+    void initParameters( const QVariantMap &configuration = QVariantMap() ) override;
+    QString outputName() const override;
+    QgsFields outputFields( const QgsFields &inputFields ) const override;
+    QgsCoordinateReferenceSystem outputCrs( const QgsCoordinateReferenceSystem &inputCrs ) const override;
+    QgsProcessingFeatureSource::Flag sourceFlags() const override;
+
+    bool prepareAlgorithm( const QVariantMap &parameters, QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    QgsFeatureList processFeature( const QgsFeature &feature,  QgsProcessingContext &context, QgsProcessingFeedback *feedback ) override;
+    bool supportInPlaceEdit( const QgsMapLayer *layer ) const override;
+
+  private:
+
+    QString mPrefix;
+    mutable QgsCoordinateReferenceSystem mSourceCrs;
+    QgsCoordinateReferenceSystem mCrs;
+    QgsCoordinateTransform mTransform;
+    bool mTransformNeedsInitialization = true;
+
+};
+
+///@endcond PRIVATE
+
+#endif // QGSALGORITHMADDXYFIELDS_H
+
+

--- a/src/analysis/processing/qgsnativealgorithms.cpp
+++ b/src/analysis/processing/qgsnativealgorithms.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsnativealgorithms.h"
 #include "qgsalgorithmaddincrementalfield.h"
+#include "qgsalgorithmaddxyfields.h"
 #include "qgsalgorithmarraytranslatedfeatures.h"
 #include "qgsalgorithmassignprojection.h"
 #include "qgsalgorithmboundary.h"
@@ -150,6 +151,7 @@ bool QgsNativeAlgorithms::supportsNonFileBasedOutput() const
 void QgsNativeAlgorithms::loadAlgorithms()
 {
   addAlgorithm( new QgsAddIncrementalFieldAlgorithm() );
+  addAlgorithm( new QgsAddXYFieldsAlgorithm() );
   addAlgorithm( new QgsAddUniqueValueIndexAlgorithm() );
   addAlgorithm( new QgsArrayTranslatedFeaturesAlgorithm() );
   addAlgorithm( new QgsAssignProjectionAlgorithm() );


### PR DESCRIPTION
Adds X and Y (or latitude/longitude) fields to a point layer.
The X/Y fields can be calculated in a different CRS to the
layer (e.g. creating latitude/longitude fields for a layer in
a project CRS).

Sponsored by SMEC/SJ