### PR TITLE
fixes GRASS r.mapcalc tool

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.mapcalc.simple.txt
+++ b/python/plugins/processing/algs/grass7/description/r.mapcalc.simple.txt
@@ -1,11 +1,11 @@
 r.mapcalc.simple
 Calculate new raster map from a r.mapcalc expression.
 Raster (r.*)
-QgsProcessingParameterRasterLayer|a|Raster layer A|False
-QgsProcessingParameterRasterLayer|b|Raster layer B|True
-QgsProcessingParameterRasterLayer|c|Raster layer C|True
-QgsProcessingParameterRasterLayer|d|Raster layer D|True
-QgsProcessingParameterRasterLayer|e|Raster layer E|True
-QgsProcessingParameterRasterLayer|f|Raster layer F|True
-QgsProcessingParameterString|expression|Formula|A*2
+QgsProcessingParameterRasterLayer|a|Raster layer A|None|False
+QgsProcessingParameterRasterLayer|b|Raster layer B|None|True
+QgsProcessingParameterRasterLayer|c|Raster layer C|None|True
+QgsProcessingParameterRasterLayer|d|Raster layer D|None|True
+QgsProcessingParameterRasterLayer|e|Raster layer E|None|True
+QgsProcessingParameterRasterLayer|f|Raster layer F|None|True
+QgsProcessingParameterString|expression|Formula|A*2|False
 QgsProcessingParameterRasterDestination|output|Calculated


### PR DESCRIPTION
## Description
The description file was wrong, missing the "none" flag for input layers and the "false" (not optional) for the formula. Needs to be backported to 3.6 and 3.4

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
