### PR TITLE
Remove duplicate word

### DIFF
--- a/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
+++ b/python/core/auto_generated/processing/qgsprocessingparameters.sip.in
@@ -1949,7 +1949,7 @@ Creates a new parameter using the definition from a script code.
 class QgsProcessingParameterAuthConfig : QgsProcessingParameterDefinition
 {
 %Docstring
-A string parameter for authentication configuration configuration ID values.
+A string parameter for authentication configuration ID values.
 
 This parameter allows for users to select from available authentication configurations,
 or create new authentication configurations as required.

--- a/src/core/processing/qgsprocessingparameters.h
+++ b/src/core/processing/qgsprocessingparameters.h
@@ -1886,7 +1886,7 @@ class CORE_EXPORT QgsProcessingParameterString : public QgsProcessingParameterDe
 /**
  * \class QgsProcessingParameterAuthConfig
  * \ingroup core
- * A string parameter for authentication configuration configuration ID values.
+ * A string parameter for authentication configuration ID values.
  *
  * This parameter allows for users to select from available authentication configurations,
  * or create new authentication configurations as required.


### PR DESCRIPTION
Fix typo at https://qgis.org/pyqgis/master/core/QgsProcessingParameterAuthConfig.html#module-QgsProcessingParameterAuthConfig

To backport to 3.6