### PR TITLE
Fix marker line offset along line unit is ignored when in Interval mode

### DIFF
--- a/src/core/symbology/qgslinesymbollayer.cpp
+++ b/src/core/symbology/qgslinesymbollayer.cpp
@@ -1013,7 +1013,7 @@ void QgsMarkerLineSymbolLayer::renderPolylineInterval( const QPolygonF &points, 
   }
 
   double painterUnitInterval = rc.convertToPainterUnits( interval, mIntervalUnit, mIntervalMapUnitScale );
-  lengthLeft = painterUnitInterval - rc.convertToPainterUnits( offsetAlongLine, mIntervalUnit, mIntervalMapUnitScale );
+  lengthLeft = painterUnitInterval - rc.convertToPainterUnits( offsetAlongLine, mOffsetAlongLineUnit, mOffsetAlongLineMapUnitScale );
 
   int pointNum = 0;
   for ( int i = 1; i < points.count(); ++i )


### PR DESCRIPTION
(cherry picked from commit e7389db5c7cc81369a33c31e35c1cac42c90747b)
