### PR TITLE
WIP Correct array string display in table and form

### DIFF
--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -255,6 +255,28 @@ Sets the alias for the field (the friendly displayed name of the field ).
 .. versionadded:: 3.0
 %End
 
+    QString arrayFormatString() const;
+%Docstring
+Returns the format string used when displayString() is called on an array value.
+
+:return: format string where %1 will be replaced by array values separated with commas.
+
+.. seealso:: :py:func:`setArrayFormatString`
+
+.. versionadded:: 3.7
+%End
+
+    void setArrayFormatString( const QString &arrayFormatString );
+%Docstring
+Set the format string used when displayString() is called on an array value.
+
+:param format: string where %1 is replaced by array values separated with commas.
+
+.. seealso:: :py:func:`arrayFormatString`
+
+.. versionadded:: 3.7
+%End
+
     QString displayString( const QVariant &v ) const;
 %Docstring
 Formats string for display

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -270,7 +270,7 @@ Returns the format string used when displayString() is called on an array value.
 %Docstring
 Set the format string used when displayString() is called on an array value.
 
-:param format: string where %1 is replaced by array values separated with commas.
+:param arrayFormatString: format string where %1 is replaced by array values separated with commas.
 
 .. seealso:: :py:func:`arrayFormatString`
 

--- a/python/core/auto_generated/qgsfield.sip.in
+++ b/python/core/auto_generated/qgsfield.sip.in
@@ -32,6 +32,12 @@ length, and if applicable, precision.
 
   public:
 
+    enum ArrayFormatString
+    {
+      FormatJson,
+      FormatHstore,
+    };
+
     QgsField( const QString &name = QString(),
               QVariant::Type type = QVariant::Invalid,
               const QString &typeName = QString(),
@@ -255,26 +261,26 @@ Sets the alias for the field (the friendly displayed name of the field ).
 .. versionadded:: 3.0
 %End
 
-    QString arrayFormatString() const;
+    ArrayFormatString arrayFormatString() const;
 %Docstring
-Returns the format string used when displayString() is called on an array value.
+Returns the format used when displayString() is called on an array value.
 
-:return: format string where %1 will be replaced by array values separated with commas.
+:return: array format
 
 .. seealso:: :py:func:`setArrayFormatString`
 
-.. versionadded:: 3.7
+.. versionadded:: 3.10
 %End
 
-    void setArrayFormatString( const QString &arrayFormatString );
+    void setArrayFormatString( ArrayFormatString arrayFormatString );
 %Docstring
-Set the format string used when displayString() is called on an array value.
+Set the format used when displayString() is called on an array value.
 
-:param arrayFormatString: format string where %1 is replaced by array values separated with commas.
+:param arrayFormatString: array format
 
 .. seealso:: :py:func:`arrayFormatString`
 
-.. versionadded:: 3.7
+.. versionadded:: 3.10
 %End
 
     QString displayString( const QVariant &v ) const;

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -202,12 +202,12 @@ void QgsField::setAlias( const QString &alias )
   d->alias = alias;
 }
 
-QString QgsField::arrayFormatString() const
+QgsField::ArrayFormatString QgsField::arrayFormatString() const
 {
-  return d->arrayFormatString;
+  return QgsField::ArrayFormatString( d->arrayFormatString );
 }
 
-void QgsField::setArrayFormatString( const QString &arrayFormatString )
+void QgsField::setArrayFormatString( QgsField::ArrayFormatString arrayFormatString )
 {
   d->arrayFormatString = arrayFormatString;
 }
@@ -280,7 +280,8 @@ QString QgsField::displayString( const QVariant &v ) const
   }
   else if ( d->type == QVariant::StringList )
   {
-    return d->arrayFormatString.arg( v.toStringList().join( "," ) );
+    QString formatString = arrayFormatString() == QgsField::FormatHstore ? "{%1}" : "[%1]";
+    return formatString.arg( v.toStringList().join( "," ) );
   }
 
   // Fallback if special rules do not apply

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -280,7 +280,7 @@ QString QgsField::displayString( const QVariant &v ) const
   }
   else if ( d->type == QVariant::StringList )
   {
-    QString formatString = arrayFormatString() == QgsField::FormatHstore ? "{%1}" : "[%1]";
+    QString formatString = arrayFormatString() == QgsField::FormatHstore ? QStringLiteral("{%1}")  : QStringLiteral("[%1]");
     return formatString.arg( v.toStringList().join( "," ) );
   }
 

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -202,6 +202,16 @@ void QgsField::setAlias( const QString &alias )
   d->alias = alias;
 }
 
+QString QgsField::arrayFormatString() const
+{
+  return d->arrayFormatString;
+}
+
+void QgsField::setArrayFormatString( const QString &arrayFormatString )
+{
+  d->arrayFormatString = arrayFormatString;
+}
+
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests in testqgsfield.cpp.
@@ -270,7 +280,7 @@ QString QgsField::displayString( const QVariant &v ) const
   }
   else if ( d->type == QVariant::StringList )
   {
-    return "{" + v.toStringList().join( "," ) + "}";
+    return d->arrayFormatString.arg( v.toStringList().join( "," ) );
   }
 
   // Fallback if special rules do not apply

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -268,6 +268,11 @@ QString QgsField::displayString( const QVariant &v ) const
   {
     return QObject::tr( "BLOB" );
   }
+  else if ( d->type == QVariant::StringList )
+  {
+    return "{" + v.toStringList().join( "," ) + "}";
+  }
+
   // Fallback if special rules do not apply
   return v.toString();
 }

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -267,7 +267,7 @@ class CORE_EXPORT QgsField
 
     /**
      * Set the format string used when displayString() is called on an array value.
-     * \param format string where %1 is replaced by array values separated with commas.
+     * \param arrayFormatString format string where %1 is replaced by array values separated with commas.
      * \see arrayFormatString()
      * \since QGIS 3.7
      */

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -257,6 +257,22 @@ class CORE_EXPORT QgsField
      */
     void setAlias( const QString &alias );
 
+    /**
+     * Returns the format string used when displayString() is called on an array value.
+     * \returns format string where %1 will be replaced by array values separated with commas.
+     * \see setArrayFormatString()
+     * \since QGIS 3.7
+     */
+    QString arrayFormatString() const;
+
+    /**
+     * Set the format string used when displayString() is called on an array value.
+     * \param format string where %1 is replaced by array values separated with commas.
+     * \see arrayFormatString()
+     * \since QGIS 3.7
+     */
+    void setArrayFormatString( const QString &arrayFormatString );
+
     //! Formats string for display
     QString displayString( const QVariant &v ) const;
 

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -62,6 +62,13 @@ class CORE_EXPORT QgsField
 
   public:
 
+    //! Result of an edit operation
+    enum ArrayFormatString
+    {
+      FormatJson = 0, //!< Array JSON format {a,b,c}
+      FormatHstore = 1, //!< Array HStore format [a,b,c]
+    };
+
     /**
      * Constructor. Constructs a new QgsField object.
      * \param name Field name
@@ -258,20 +265,20 @@ class CORE_EXPORT QgsField
     void setAlias( const QString &alias );
 
     /**
-     * Returns the format string used when displayString() is called on an array value.
-     * \returns format string where %1 will be replaced by array values separated with commas.
+     * Returns the format used when displayString() is called on an array value.
+     * \returns array format
      * \see setArrayFormatString()
-     * \since QGIS 3.7
+     * \since QGIS 3.10
      */
-    QString arrayFormatString() const;
+    ArrayFormatString arrayFormatString() const;
 
     /**
-     * Set the format string used when displayString() is called on an array value.
-     * \param arrayFormatString format string where %1 is replaced by array values separated with commas.
+     * Set the format used when displayString() is called on an array value.
+     * \param arrayFormatString array format
      * \see arrayFormatString()
-     * \since QGIS 3.7
+     * \since QGIS 3.10
      */
-    void setArrayFormatString( const QString &arrayFormatString );
+    void setArrayFormatString( ArrayFormatString arrayFormatString );
 
     //! Formats string for display
     QString displayString( const QVariant &v ) const;

--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -60,6 +60,7 @@ class QgsFieldPrivate : public QSharedData
       , length( len )
       , precision( prec )
       , comment( comment )
+      , arrayFormatString( "[%1]" )
     {
     }
 
@@ -75,6 +76,7 @@ class QgsFieldPrivate : public QSharedData
       , alias( other.alias )
       , defaultValueDefinition( other.defaultValueDefinition )
       , constraints( other.constraints )
+      , arrayFormatString( other.arrayFormatString )
     {
     }
 
@@ -85,7 +87,8 @@ class QgsFieldPrivate : public QSharedData
       return ( ( name == other.name ) && ( type == other.type ) && ( subType == other.subType )
                && ( length == other.length ) && ( precision == other.precision )
                && ( alias == other.alias ) && ( defaultValueDefinition == other.defaultValueDefinition )
-               && ( constraints == other.constraints ) );
+               && ( constraints == other.constraints )
+               && ( arrayFormatString == other.arrayFormatString ) );
     }
 
     //! Name
@@ -119,6 +122,8 @@ class QgsFieldPrivate : public QSharedData
     QgsFieldConstraints constraints;
 
     QgsEditorWidgetSetup editorWidgetSetup;
+
+    QString arrayFormatString;
 };
 
 /// @endcond

--- a/src/core/qgsfield_p.h
+++ b/src/core/qgsfield_p.h
@@ -60,7 +60,7 @@ class QgsFieldPrivate : public QSharedData
       , length( len )
       , precision( prec )
       , comment( comment )
-      , arrayFormatString( "[%1]" )
+      , arrayFormatString( 0 )
     {
     }
 
@@ -123,7 +123,7 @@ class QgsFieldPrivate : public QSharedData
 
     QgsEditorWidgetSetup editorWidgetSetup;
 
-    QString arrayFormatString;
+    int arrayFormatString;
 };
 
 /// @endcond

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1084,7 +1084,7 @@ bool QgsPostgresProvider::loadFields()
     mDefaultValues.insert( mAttributeFields.size(), defValMap[tableoid][attnum] );
 
     QgsField newField = QgsField( fieldName, fieldType, fieldTypeName, fieldSize, fieldPrec, fieldComment, fieldSubType );
-    newField.setArrayFormatString( "{%1}" );
+    newField.setArrayFormatString( QgsField::FormatHstore );
 
     QgsFieldConstraints constraints;
     if ( notNullMap[tableoid][attnum] || ( mPrimaryKeyAttrs.size() == 1 && mPrimaryKeyAttrs[0] == i ) || identityMap[tableoid][attnum] != ' ' )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1084,6 +1084,7 @@ bool QgsPostgresProvider::loadFields()
     mDefaultValues.insert( mAttributeFields.size(), defValMap[tableoid][attnum] );
 
     QgsField newField = QgsField( fieldName, fieldType, fieldTypeName, fieldSize, fieldPrec, fieldComment, fieldSubType );
+    newField.setArrayFormatString( "{%1}" );
 
     QgsFieldConstraints constraints;
     if ( notNullMap[tableoid][attnum] || ( mPrimaryKeyAttrs.size() == 1 && mPrimaryKeyAttrs[0] == i ) || identityMap[tableoid][attnum] != ' ' )
@@ -5166,7 +5167,6 @@ void QgsPostgresSharedData::setFieldSupportsEnumValues( int index, bool isSuppor
   QMutexLocker locker( &mMutex );
   mFieldSupportsEnumValues[ index ] = isSupported;
 }
-
 
 QgsPostgresProviderMetadata::QgsPostgresProviderMetadata()
   : QgsProviderMetadata( QgsPostgresProvider::POSTGRES_KEY, QgsPostgresProvider::POSTGRES_DESCRIPTION )

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -421,7 +421,7 @@ void TestQgsField::displayString()
   // string list field
   QgsField stringListField( QStringLiteral( "stringlist" ), QVariant::StringList, QStringLiteral( "_text" ) );
   QCOMPARE( stringListField.displayString( QStringList() << "test1" << "test2" << "test3" ), QString( "[test1,test2,test3]" ) );
-  stringListField.setArrayFormatString( "{%1}" );
+  stringListField.setArrayFormatString( QgsField::FormatHstore );
   QCOMPARE( stringListField.displayString( QStringList() << "test1" << "test2" << "test3" ), QString( "{test1,test2,test3}" ) );
 }
 

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -417,6 +417,10 @@ void TestQgsField::displayString()
   QString testBAString( QStringLiteral( "test string" ) );
   QByteArray testBA( testBAString.toLocal8Bit() );
   QCOMPARE( binaryField.displayString( testBA ), QStringLiteral( "BLOB" ) );
+
+  // string list field
+  QgsField stringListField( QStringLiteral( "stringlist" ), QVariant::StringList, QStringLiteral( "_text" ) );
+  QCOMPARE( stringListField.displayString( QStringList() << "test1" << "test2" << "test3" ), QString( "{test1,test2,test3}" ) );
 }
 
 void TestQgsField::convertCompatible()

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -420,6 +420,8 @@ void TestQgsField::displayString()
 
   // string list field
   QgsField stringListField( QStringLiteral( "stringlist" ), QVariant::StringList, QStringLiteral( "_text" ) );
+  QCOMPARE( stringListField.displayString( QStringList() << "test1" << "test2" << "test3" ), QString( "[test1,test2,test3]" ) );
+  stringListField.setArrayFormatString( "{%1}" );
   QCOMPARE( stringListField.displayString( QStringList() << "test1" << "test2" << "test3" ), QString( "{test1,test2,test3}" ) );
 }
 


### PR DESCRIPTION
## Description

This is the following of PR #9048.
The previous PR fixes the read from postgres and it works with list widget but not with plain text widget.
This PR fixes the display with plain text widget for string array.

Be aware that there is still a problem to deal with integer and float array in plain text. 

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [x] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [x] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
