### PR TITLE
[server] log exceptions

### DIFF
--- a/python/server/auto_generated/qgsserverexception.sip.in
+++ b/python/server/auto_generated/qgsserverexception.sip.in
@@ -45,15 +45,6 @@ Formats the exception for sending to client
 The default implementation returns text/xml format.
 %End
 
-    QByteArray formatResponse() const;
-%Docstring
-Formats the exception for sending to client
-
-:return: QByteArray The formatted response.
-
-.. versionadded:: 3.8
-%End
-
 };
 
 class QgsOgcServiceException

--- a/python/server/auto_generated/qgsserverexception.sip.in
+++ b/python/server/auto_generated/qgsserverexception.sip.in
@@ -36,13 +36,22 @@ Constructor
 
     virtual QByteArray formatResponse( QString &responseFormat /Out/ ) const;
 %Docstring
-Format the exception for sending to client
+Formats the exception for sending to client
 
 
-:return: - QByteArray the fermatted response.
+:return: - QByteArray The formatted response.
          - responseFormat: QString to store the content type of the response format.
 
-The defaolt implementation return text/xml format.
+The default implementation returns text/xml format.
+%End
+
+    QByteArray formatResponse() const;
+%Docstring
+Formats the exception for sending to client
+
+:return: QByteArray The formatted response.
+
+.. versionadded:: 3.8
 %End
 
 };

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -352,7 +352,7 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
     catch ( QgsException &ex )
     {
       // Internal server error
-      response.sendError( 500, ex.what() );
+      response.sendError( 500, QStringLiteral( "Internal Server Error" ) );
       QgsMessageLog::logMessage( ex.what(), QStringLiteral( "Server" ), Qgis::Critical );
     }
   }

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -347,7 +347,8 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
     catch ( QgsServerException &ex )
     {
       responseDecorator.write( ex );
-      QgsMessageLog::logMessage( ex.formatResponse(), QStringLiteral( "Server" ), Qgis::Info );
+      QString format;
+      QgsMessageLog::logMessage( ex.formatResponse( format ), QStringLiteral( "Server" ), Qgis::Info );
     }
     catch ( QgsException &ex )
     {

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -347,11 +347,13 @@ void QgsServer::handleRequest( QgsServerRequest &request, QgsServerResponse &res
     catch ( QgsServerException &ex )
     {
       responseDecorator.write( ex );
+      QgsMessageLog::logMessage( ex.formatResponse(), QStringLiteral( "Server" ), Qgis::Info );
     }
     catch ( QgsException &ex )
     {
       // Internal server error
       response.sendError( 500, ex.what() );
+      QgsMessageLog::logMessage( ex.what(), QStringLiteral( "Server" ), Qgis::Critical );
     }
   }
   // Terminate the response

--- a/src/server/qgsserverexception.cpp
+++ b/src/server/qgsserverexception.cpp
@@ -27,6 +27,12 @@ QgsServerException::QgsServerException( const QString &message, int responseCode
 
 }
 
+QByteArray QgsServerException::formatResponse() const
+{
+  QString responseFormat;
+  return formatResponse( responseFormat );
+}
+
 QByteArray QgsServerException::formatResponse( QString &responseFormat ) const
 {
   QDomDocument doc;

--- a/src/server/qgsserverexception.cpp
+++ b/src/server/qgsserverexception.cpp
@@ -27,12 +27,6 @@ QgsServerException::QgsServerException( const QString &message, int responseCode
 
 }
 
-QByteArray QgsServerException::formatResponse() const
-{
-  QString responseFormat;
-  return formatResponse( responseFormat );
-}
-
 QByteArray QgsServerException::formatResponse( QString &responseFormat ) const
 {
   QDomDocument doc;

--- a/src/server/qgsserverexception.h
+++ b/src/server/qgsserverexception.h
@@ -49,15 +49,22 @@ class SERVER_EXPORT QgsServerException
     int responseCode() const { return mResponseCode; }
 
     /**
-     * Format the exception for sending to client
+     * Formats the exception for sending to client
      *
      * \param responseFormat QString to store the content type of the response format.
-     * \returns QByteArray the fermatted response.
+     * \returns QByteArray The formatted response.
      *
      * The default implementation returns text/xml format.
      */
     virtual QByteArray formatResponse( QString &responseFormat SIP_OUT ) const;
 
+    /**
+     * Formats the exception for sending to client
+     *
+     * \returns QByteArray The formatted response.
+     *
+     * \since QGIS 3.8
+     */
     QByteArray formatResponse() const;
 
   private:

--- a/src/server/qgsserverexception.h
+++ b/src/server/qgsserverexception.h
@@ -54,9 +54,11 @@ class SERVER_EXPORT QgsServerException
      * \param responseFormat QString to store the content type of the response format.
      * \returns QByteArray the fermatted response.
      *
-     * The defaolt implementation return text/xml format.
+     * The default implementation returns text/xml format.
      */
     virtual QByteArray formatResponse( QString &responseFormat SIP_OUT ) const;
+
+    QByteArray formatResponse() const;
 
   private:
     int mResponseCode;

--- a/src/server/qgsserverexception.h
+++ b/src/server/qgsserverexception.h
@@ -58,15 +58,6 @@ class SERVER_EXPORT QgsServerException
      */
     virtual QByteArray formatResponse( QString &responseFormat SIP_OUT ) const;
 
-    /**
-     * Formats the exception for sending to client
-     *
-     * \returns QByteArray The formatted response.
-     *
-     * \since QGIS 3.8
-     */
-    QByteArray formatResponse() const;
-
   private:
     int mResponseCode;
 };

--- a/src/server/qgsserverresponse.cpp
+++ b/src/server/qgsserverresponse.cpp
@@ -27,8 +27,6 @@ void QgsServerResponse::write( const QString &data )
   QIODevice *iodev = io();
   if ( iodev )
   {
-    //QTextStream stream( iodev );
-    //stream << data;
     iodev->write( data.toUtf8() );
   }
   else
@@ -36,7 +34,6 @@ void QgsServerResponse::write( const QString &data )
     QgsMessageLog::logMessage( "Error: No IODevice in QgsServerResponse !!!" );
   }
 }
-
 
 qint64 QgsServerResponse::write( const QByteArray &byteArray )
 {
@@ -47,7 +44,6 @@ qint64 QgsServerResponse::write( const QByteArray &byteArray )
   }
   return 0;
 }
-
 
 qint64 QgsServerResponse::write( const char *data, qint64 maxsize )
 {
@@ -88,4 +84,3 @@ void QgsServerResponse::write( const QgsServerException &ex )
   // log exception on server side too
   QgsMessageLog::logMessage( ba, QStringLiteral( "Server" ), Qgis::Critical );
 }
-

--- a/src/server/qgsserverresponse.cpp
+++ b/src/server/qgsserverresponse.cpp
@@ -84,5 +84,8 @@ void QgsServerResponse::write( const QgsServerException &ex )
   setStatusCode( ex.responseCode() );
   setHeader( "Content-Type", responseFormat );
   write( ba );
+
+  // log exception on server side too
+  QgsMessageLog::logMessage( ba, QStringLiteral( "Server" ), Qgis::Critical );
 }
 

--- a/src/server/qgsserverresponse.cpp
+++ b/src/server/qgsserverresponse.cpp
@@ -80,7 +80,4 @@ void QgsServerResponse::write( const QgsServerException &ex )
   setStatusCode( ex.responseCode() );
   setHeader( "Content-Type", responseFormat );
   write( ba );
-
-  // log exception on server side too
-  QgsMessageLog::logMessage( ba, QStringLiteral( "Server" ), Qgis::Critical );
 }


### PR DESCRIPTION
## Description

Log exceptions on server side.

## Checklist

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
