### PR TITLE
Add test for API Python snippets

### DIFF
--- a/python/gui/auto_generated/qgshighlight.sip.in
+++ b/python/gui/auto_generated/qgshighlight.sip.in
@@ -18,6 +18,9 @@ for highlighting features or geometries on a map canvas.
 
 .. code-block:: python
 
+       mapCanvas = iface.mapCanvas()
+       feature = QgsFeature()
+       layer = QgsVectorLayer("Point", "temporary_points", "memory")
        color = QColor(Qt.red)
        highlight = QgsHighlight(mapCanvas, feature, layer)
        highlight.setColor(color)

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -38,6 +38,9 @@ class QgsSymbol;
  * for highlighting features or geometries on a map canvas.
  *
  * \code{.py}
+ *   mapCanvas = iface.mapCanvas()
+ *   feature = QgsFeature()
+ *   layer = QgsVectorLayer("Point", "temporary_points", "memory")
  *   color = QColor(Qt.red)
  *   highlight = QgsHighlight(mapCanvas, feature, layer)
  *   highlight.setColor(color)

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -9,6 +9,7 @@ IF (WITH_SERVER)
 ENDIF (WITH_SERVER)
 
 ADD_PYTHON_TEST(PyCoreAdittions test_core_additions.py)
+ADD_PYTHON_TEST(PyDocstrings test_docstrings.py)
 ADD_PYTHON_TEST(PyPythonRepr test_python_repr.py)
 ADD_PYTHON_TEST(PyQgsActionManager test_qgsactionmanager.py)
 ADD_PYTHON_TEST(PyQgsAFSProvider test_provider_afs.py)

--- a/tests/src/python/test_docstrings.py
+++ b/tests/src/python/test_docstrings.py
@@ -1,0 +1,140 @@
+import doctest
+import inspect
+import unittest
+import qgis
+import glob
+import re
+from doctest import (
+    DocTestFinder,
+    DebugRunner,
+    DocTestRunner,
+    OutputChecker,
+    TestResults,
+)
+
+from qgis.testing import (
+    start_app,
+    unittest,
+)
+from qgis.testing.mocked import get_iface
+
+qgis_app = start_app()
+
+# Import required globals
+from qgis.core import *
+from qgis.gui import *
+from qgis.utils import *
+from qgis.PyQt.QtCore import *
+from qgis.PyQt.QtGui import *
+iface = get_iface()
+
+INCLUDES = ('QgsHighlight',)
+
+
+class CodeBlockParser(doctest.DocTestParser):
+    _EXAMPLE_RE = re.compile(r'''
+        ^\.\.[ ]code-block::[ ]python\n
+        \n?
+        (?P<source>
+            (?:(?![ ]*$)    # Not a blank line
+               (?P<indent>[ ]*).+$\n?       # But any other line stating with 3 spaces
+            )
+        *)
+        ''', re.MULTILINE | re.VERBOSE)
+
+    def _parse_example(self, m, name, lineno):
+        """
+        Given a regular expression match from `_EXAMPLE_RE` (`m`),
+        return a pair `(source, want)`, where `source` is the matched
+        example's source code (with prompts and indentation stripped);
+        and `want` is the example's expected output (with indentation
+        stripped).
+
+        `name` is the string's name, and `lineno` is the line number
+        where the example starts; both are used for error messages.
+        """
+        # Get the example's indentation level.
+        indent = len(m.group('indent'))
+
+        # Divide source into lines; check that they're properly
+        # indented; and then strip their indentation & prompts.
+        source_lines = m.group('source').split('\n')
+        # self._check_prompt_blank(source_lines, indent, name, lineno)
+        # self._check_prefix(source_lines[1:], ' '*indent + '.', name, lineno)
+        source = '\n'.join([sl[indent:] for sl in source_lines])
+
+        # For now we do not check output
+        want = ''
+
+        # If `want` contains a traceback message, then extract it.
+        exc_msg = None
+
+        # Extract options from the source.
+        options = self._find_options(source, name, lineno)
+
+        return source, options, want, exc_msg
+
+
+class CodeBlockOutputChecker(OutputChecker):
+
+    def check_output(self, want, got, optionflags):
+        return True
+
+
+class TestDocstrings(unittest.TestCase):
+
+    def setUp(self):
+        # HACK HACK HACK
+        # doctest compiles its snippets with type 'single'. That is nice
+        # for doctest examples but unusable for multi-statement code such
+        # as setup code -- to be able to use doctest error reporting with
+        # that code nevertheless, we monkey-patch the "compile" it uses.
+        doctest.compile = self.compile  # type: ignore
+
+    def tearDown(self):
+        """Run after each test."""
+        doctest.compile = compile
+
+    def compile(self, code, name, type, flags, dont_inherit):  # spellok
+        return compile(code, name, "exec", flags, dont_inherit)  # spellok
+
+    def _to_test(self, m, name):
+        to_test = {}
+        for valname, val in getattr(m, '__dict__', {}).items():
+            if (
+                    valname in INCLUDES
+                    and inspect.isclass(val)
+                    and val.__module__ == name):
+                to_test[valname] = val
+        return to_test
+
+    def _testmod(self, m=None, name=None, globs=None, verbose=None,
+                 report=True, optionflags=0, extraglobs=None,
+                 raise_on_error=False):
+
+        m.__test__ = self._to_test(m, name)
+
+        # Find, parse, and run all tests in the given module.
+        finder = DocTestFinder(parser=CodeBlockParser())
+        checker = CodeBlockOutputChecker()
+        if raise_on_error:
+            runner = DebugRunner(checker=checker, verbose=verbose, optionflags=optionflags)
+        else:
+            runner = DocTestRunner(checker=checker, verbose=verbose, optionflags=optionflags)
+
+        for test in finder.find(m, name, globs=globs, extraglobs=extraglobs):
+            runner.run(test)
+
+        if report:
+            runner.summarize()
+
+        self.assertEqual(runner.failures, 0,
+                         "{} tests fails out of {}".format(runner.failures, runner.tries))
+
+    def test_docstrings(self):
+        self._testmod(qgis.core, name='qgis._core', globs=globals(), verbose=True)
+        self._testmod(qgis.gui, name='qgis._gui', globs=globals(), verbose=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Add unittest.TestCase that use native python doctest module with custom parser to test API Python snippets.

In this PR, only QgsHighlight is tested, more classes might be tested later using INCLUDE variable.
 
## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
