### PR TITLE
Bugfix badlayers storage

### DIFF
--- a/python/core/auto_generated/qgsmaplayerstore.sip.in
+++ b/python/core/auto_generated/qgsmaplayerstore.sip.in
@@ -122,8 +122,8 @@ The layersAdded() and layerWasAdded() signals will always be emitted.
 
 .. note::
 
-   if layer with the same id is already in the store it is not added again,
-   but if the validity of the layer has changed from false to true, the
+   If a layer with the same id is already in the store it is not added again,
+   but if the validity of the layer has changed from ``False`` to ``True``, the
    layer data source is updated to the new one.
 
 

--- a/python/core/auto_generated/qgsmaplayerstore.sip.in
+++ b/python/core/auto_generated/qgsmaplayerstore.sip.in
@@ -120,6 +120,13 @@ The layersAdded() and layerWasAdded() signals will always be emitted.
 
 :param layers: A list of layer which should be added to the store.
 
+.. note::
+
+   if layer with the same id is already in the store it is not added again,
+   but if the validity of the layer has changed from false to true, the
+   layer data source is updated to the new one.
+
+
 :return: a list of the map layers that were added
          successfully. If a layer already exists in the store,
          it will not be part of the returned list.

--- a/src/app/qgshandlebadlayers.cpp
+++ b/src/app/qgshandlebadlayers.cpp
@@ -366,7 +366,6 @@ void QgsHandleBadLayers::apply()
   QHash<QString, QString> baseChange;
 
 
-
   for ( int i = 0; i < mLayerList->rowCount(); i++ )
   {
     int idx = mLayerList->item( i, 0 )->data( Qt::UserRole ).toInt();
@@ -405,7 +404,7 @@ void QgsHandleBadLayers::apply()
       datasource = datasource.replace( basepath, baseChange[basepath] );
 
 
-    bool dataSourceChanged { false };
+    bool dataSourceFixed { false };
     const QString layerId { node.namedItem( QStringLiteral( "id" ) ).toElement().text() };
     const QString provider { node.namedItem( QStringLiteral( "provider" ) ).toElement().text() };
 
@@ -413,19 +412,19 @@ void QgsHandleBadLayers::apply()
     // maintain the current status (checked/unchecked) and group
     if ( QgsProject::instance()->mapLayer( layerId ) )
     {
-      QgsDataProvider::ProviderOptions options;
       QgsMapLayer *mapLayer = QgsProject::instance()->mapLayer( layerId );
       if ( mapLayer )
       {
+        QgsDataProvider::ProviderOptions options;
         mapLayer->setDataSource( datasource, name, provider, options );
-        dataSourceChanged = mapLayer->isValid();
+        dataSourceFixed  = mapLayer->isValid();
       }
     }
 
     // If the data source was changed successfully, remove the bad layer from the dialog
     // otherwise, try to set the new datasource in the XML node and reload the layer,
     // finally marks with red all remaining bad layers.
-    if ( dataSourceChanged )
+    if ( dataSourceFixed )
     {
       mLayerList->removeRow( i-- );
     }
@@ -447,7 +446,8 @@ void QgsHandleBadLayers::apply()
     }
   }
 
-  // Final cleanup: remove any bad layer (it should not be any btw)
+  // Final cleanup: remove any remaining bad layer
+  // (there should not be any at this point)
   if ( mLayerList->rowCount() == 0 )
   {
     QList<QgsMapLayer *> toRemove;

--- a/src/core/qgsmaplayerstore.cpp
+++ b/src/core/qgsmaplayerstore.cpp
@@ -74,6 +74,11 @@ QList<QgsMapLayer *> QgsMapLayerStore::addMapLayers( const QList<QgsMapLayer *> 
       QgsDebugMsg( QStringLiteral( "Cannot add null layers" ) );
       continue;
     }
+    // If the layer is already in the store but its validity has changed reset data source
+    if ( mMapLayers.contains( myLayer->id() ) && ! mMapLayers[myLayer->id()]->isValid() && myLayer->isValid() &&  myLayer->dataProvider() )
+    {
+      mMapLayers[myLayer->id()]->setDataSource( myLayer->dataProvider()->dataSourceUri(), myLayer->name(), myLayer->providerType(), QgsDataProvider::ProviderOptions() );
+    }
     //check the layer is not already registered!
     if ( !mMapLayers.contains( myLayer->id() ) )
     {

--- a/src/core/qgsmaplayerstore.cpp
+++ b/src/core/qgsmaplayerstore.cpp
@@ -74,8 +74,8 @@ QList<QgsMapLayer *> QgsMapLayerStore::addMapLayers( const QList<QgsMapLayer *> 
       QgsDebugMsg( QStringLiteral( "Cannot add null layers" ) );
       continue;
     }
-    // If the layer is already in the store but its validity has changed reset data source
-    if ( mMapLayers.contains( myLayer->id() ) && ! mMapLayers[myLayer->id()]->isValid() && myLayer->isValid() &&  myLayer->dataProvider() )
+    // If the layer is already in the store but its validity has flipped to TRUE reset data source
+    if ( mMapLayers.contains( myLayer->id() ) && ! mMapLayers[myLayer->id()]->isValid() && myLayer->isValid() && myLayer->dataProvider() )
     {
       mMapLayers[myLayer->id()]->setDataSource( myLayer->dataProvider()->dataSourceUri(), myLayer->name(), myLayer->providerType(), QgsDataProvider::ProviderOptions() );
     }

--- a/src/core/qgsmaplayerstore.h
+++ b/src/core/qgsmaplayerstore.h
@@ -149,6 +149,11 @@ class CORE_EXPORT QgsMapLayerStore : public QObject
      *                      If you specify FALSE here you have take care of deleting
      *                      the layers yourself. Not available in Python.
      *
+     *
+     * \note if layer with the same id is already in the store it is not added again,
+     *       but if the validity of the layer has changed from false to true, the
+     *       layer data source is updated to the new one.
+     *
      * \returns a list of the map layers that were added
      *         successfully. If a layer already exists in the store,
      *         it will not be part of the returned list.

--- a/src/core/qgsmaplayerstore.h
+++ b/src/core/qgsmaplayerstore.h
@@ -150,7 +150,7 @@ class CORE_EXPORT QgsMapLayerStore : public QObject
      *                      the layers yourself. Not available in Python.
      *
      *
-     * \note if layer with the same id is already in the store it is not added again,
+     * \note If a layer with the same id is already in the store it is not added again,
      *       but if the validity of the layer has changed from false to true, the
      *       layer data source is updated to the new one.
      *

--- a/src/core/qgsmaplayerstore.h
+++ b/src/core/qgsmaplayerstore.h
@@ -151,7 +151,7 @@ class CORE_EXPORT QgsMapLayerStore : public QObject
      *
      *
      * \note If a layer with the same id is already in the store it is not added again,
-     *       but if the validity of the layer has changed from false to true, the
+     *       but if the validity of the layer has changed from FALSE to TRUE, the
      *       layer data source is updated to the new one.
      *
      * \returns a list of the map layers that were added

--- a/tests/src/python/test_qgsmaplayerstore.py
+++ b/tests/src/python/test_qgsmaplayerstore.py
@@ -12,14 +12,25 @@ __copyright__ = 'Copyright 2017, The QGIS Project'
 # This will get replaced with a git SHA1 when you do a git archive
 __revision__ = '$Format:%H$'
 
-from qgis.core import QgsMapLayerStore, QgsVectorLayer, QgsMapLayer
+import os
+from qgis.core import (
+    QgsMapLayerStore,
+    QgsVectorLayer,
+    QgsMapLayer,
+    QgsDataProvider,
+    QgsProject,
+    QgsReadWriteContext,
+)
 from qgis.testing import start_app, unittest
 from qgis.PyQt.QtCore import QT_VERSION_STR
 from qgis.PyQt import sip
 from qgis.PyQt.QtTest import QSignalSpy
+from qgis.PyQt.QtXml import QDomDocument, QDomNode
 from time import sleep
+from utilities import unitTestDataPath
 
 start_app()
+TEST_DATA_DIR = unitTestDataPath()
 
 
 def createLayer(name):
@@ -528,6 +539,38 @@ class TestQgsMapLayerStore(unittest.TestCase):
         self.assertFalse(store2.mapLayers()) # no layers left
         self.assertEqual(len(store1.mapLayers()), 3)
         self.assertEqual(store1.mapLayers(), {l1.id(): l1, l2.id(): l2, l3.id(): l3})
+
+    def testLayerDataSourceReset(self):
+        """When adding a layer with the same id to the store make sure
+        the data source is also updated in case the layer validity has
+        changed from False to True"""
+
+        p = QgsProject()
+        store = p.layerStore()
+        vl1 = createLayer('valid')
+        vl2 = QgsVectorLayer('/not_a_valid_path.shp', 'invalid', 'ogr')
+        self.assertTrue(vl1.isValid())
+        self.assertFalse(vl2.isValid())
+        store.addMapLayers([vl1, vl2])
+        self.assertEqual(store.validCount(), 1)
+        self.assertEqual(len(store.mapLayers()), 2)
+
+        # Re-add the bad layer
+        store.addMapLayers([vl2])
+        self.assertEqual(store.validCount(), 1)
+        self.assertEqual(len(store.mapLayers()), 2)
+
+        doc = QDomDocument()
+        doc.setContent('<maplayer><provider encoding="UTF-8">ogr</provider><layername>fixed</layername><id>%s</id></maplayer>' % vl2.id())
+        layer_node = QDomNode(doc.firstChild())
+        self.assertTrue(vl2.writeXml(layer_node, doc, QgsReadWriteContext()))
+        datasource_node = doc.createElement("datasource")
+        datasource_node.appendChild(doc.createTextNode(os.path.join(TEST_DATA_DIR, 'points.shp')))
+        layer_node.appendChild(datasource_node)
+        p.readLayer(layer_node)
+        self.assertEqual(store.validCount(), 2)
+        self.assertEqual(len(store.mapLayers()), 2)
+        self.assertEqual(store.mapLayers()[vl2.id()].name(), 'fixed')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a followup of recent changes to the bad layer dialog, the current
approach is to maintain the bad layers (and their position and status in the layer tree)
until the bad layer handling (which is an iterative process) has finished.

There was an issue with the layer store: the previous implementation was just skipping 
a new layer added if a layer with the same id was already in the store, we are
now checking if the layer validity has changed from invalid to valid, and in that case 
we reset the data source of the existing layer.

I believe this makes sense in general: if client code calls an API to add a layer to the store we need to check if the layer is already in the store but we also need to make sure the data source 
can be reset in case it has changed especially when the layer validity has changed from false to true.

The other option would have been to remove the layer before adding it back with the fixed 
data source, but this was leading to a complete loss of the layer configuration (checked/unchecked status , group etc.).

