### PR TITLE
[RPM] Fix a comment in %postun

### DIFF
--- a/rpm/qgis.spec.template
+++ b/rpm/qgis.spec.template
@@ -280,6 +280,7 @@ update-mime-database %{?fedora:-n} %{_datadir}/mime &> /dev/null || :
 %post -n python3-qgis -p /sbin/ldconfig
 
 %postun -n python3-qgis -p /sbin/ldconfig
+
 # END TODO #
 
 %files -f %{name}.lang


### PR DESCRIPTION
## Description

This PR fixes an error producing a non-critical failure during `python3-qgis` RPM upgrade/uninstall:

```bash
/sbin/ldconfig: relative path `1' used to build cache
warning: %postun(python3-qgis-3.6.0-1.fc29.x86_64) scriptlet failed, exit status 1

Error in POSTUN scriptlet in rpm package python3-qgis
```

This is due to a comment erroneously aggregated into `%postun`


```bash
$ rpm -q --scripts -p  python3-qgis-3.6.1-1.fc29.x86_64.rpm 
postinstall program: /sbin/ldconfig
postuninstall scriptlet (using /sbin/ldconfig):
# END TODO #
```

Needs backport to 3.6 and 3.4

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [x] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [x] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [x] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [x] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
