### PR TITLE
[server] Add a WMS render context 

### DIFF
--- a/src/server/services/wms/CMakeLists.txt
+++ b/src/server/services/wms/CMakeLists.txt
@@ -20,6 +20,7 @@ SET (wms_SRCS
   qgswmsrenderer.cpp
   qgswmsparameters.cpp
   qgslayerrestorer.cpp
+  qgswmsrendercontext.cpp
 )
 
 SET (wms_MOC_HDRS

--- a/src/server/services/wms/qgsdxfwriter.cpp
+++ b/src/server/services/wms/qgsdxfwriter.cpp
@@ -22,17 +22,24 @@ email                : david dot marteau at 3liz dot com
 namespace QgsWms
 {
   void writeAsDxf( QgsServerInterface *serverIface, const QgsProject *project,
-                   const QString &version,  const QgsServerRequest &request,
+                   const QString &,  const QgsServerRequest &request,
                    QgsServerResponse &response )
   {
-    Q_UNUSED( version );
+    // get wms parameters from query
+    QgsWmsParameters parameters( QUrlQuery( request.url() ) );
 
-    QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
-    QgsRenderer renderer( serverIface, project, wmsParameters );
+    // prepare render context
+    QgsWmsRenderContext context( project, serverIface );
+    context.setFlag( QgsWmsRenderContext::UseWfsLayersOnly );
+    context.setFlag( QgsWmsRenderContext::UseOpacity );
+    context.setFlag( QgsWmsRenderContext::UseFilter );
+    context.setFlag( QgsWmsRenderContext::SetAccessControl );
+    context.setParameters( parameters );
 
     // Write output
+    QgsRenderer renderer( context );
     QgsDxfExport dxf = renderer.getDxf();
     response.setHeader( "Content-Type", "application/dxf" );
-    dxf.writeToFile( response.io(), wmsParameters.dxfCodec() );
+    dxf.writeToFile( response.io(), parameters.dxfCodec() );
   }
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsgetfeatureinfo.cpp
+++ b/src/server/services/wms/qgswmsgetfeatureinfo.cpp
@@ -24,26 +24,25 @@
 
 namespace QgsWms
 {
-
   void writeGetFeatureInfo( QgsServerInterface *serverIface, const QgsProject *project,
                             const QString &version, const QgsServerRequest &request,
                             QgsServerResponse &response )
   {
-    Q_UNUSED( version );
-    QgsServerRequest::Parameters params = request.parameters();
+    // get wms parameters from query
+    QgsWmsParameters parameters( QUrlQuery( request.url() ) );
 
-    QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
-    QgsRenderer renderer( serverIface, project, wmsParameters );
+    // prepare render context
+    QgsWmsRenderContext context( project, serverIface );
+    context.setFlag( QgsWmsRenderContext::AddQueryLayers );
+    context.setFlag( QgsWmsRenderContext::UseFilter );
+    context.setFlag( QgsWmsRenderContext::UseScaleDenominator );
+    context.setFlag( QgsWmsRenderContext::SetAccessControl );
+    context.setParameters( parameters );
 
-    QString infoFormat = params.value( QStringLiteral( "INFO_FORMAT" ), QStringLiteral( "text/plain" ) );
-
+    const QString infoFormat = request.parameters().value( QStringLiteral( "INFO_FORMAT" ), QStringLiteral( "text/plain" ) );
     response.setHeader( QStringLiteral( "Content-Type" ), infoFormat + QStringLiteral( "; charset=utf-8" ) );
+
+    QgsRenderer renderer( context );
     response.write( renderer.getFeatureInfo( version ) );
   }
-
-
 } // namespace QgsWms
-
-
-
-

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -85,7 +85,7 @@ namespace QgsWms
 
     if ( result )
     {
-      writeImage( response, *result,  format, renderer.imageQuality() );
+      writeImage( response, *result,  format, context.imageQuality() );
       if ( cacheManager )
       {
         QByteArray content = response.data();

--- a/src/server/services/wms/qgswmsgetlegendgraphics.cpp
+++ b/src/server/services/wms/qgswmsgetlegendgraphics.cpp
@@ -26,19 +26,20 @@
 
 namespace QgsWms
 {
-
   void writeGetLegendGraphics( QgsServerInterface *serverIface, const QgsProject *project,
-                               const QString &version, const QgsServerRequest &request,
+                               const QString &, const QgsServerRequest &request,
                                QgsServerResponse &response )
   {
-    Q_UNUSED( version );
+    // get parameters from query
+    QgsWmsParameters parameters( QUrlQuery( request.url() ) );
 
-    QgsServerRequest::Parameters params = request.parameters();
-    QString format = params.value( QStringLiteral( "FORMAT" ), QStringLiteral( "PNG" ) );
-
-    QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
+    // init render context
+    QgsWmsRenderContext context( project, serverIface );
+    context.setFlag( QgsWmsRenderContext::UseScaleDenominator );
+    context.setParameters( parameters );
 
     // Get cached image
+    const QString format = request.parameters().value( QStringLiteral( "FORMAT" ), QStringLiteral( "PNG" ) );
     QgsAccessControl *accessControl = nullptr;
     QgsServerCacheManager *cacheManager = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
@@ -79,8 +80,7 @@ namespace QgsWms
       }
     }
 
-    QgsRenderer renderer( serverIface, project, wmsParameters );
-
+    QgsRenderer renderer( context );
     std::unique_ptr<QImage> result( renderer.getLegendGraphics() );
 
     if ( result )
@@ -99,10 +99,4 @@ namespace QgsWms
                                  QStringLiteral( "Failed to compute GetLegendGraphics image" ) );
     }
   }
-
-
 } // namespace QgsWms
-
-
-
-

--- a/src/server/services/wms/qgswmsgetmap.cpp
+++ b/src/server/services/wms/qgswmsgetmap.cpp
@@ -52,7 +52,7 @@ namespace QgsWms
     if ( result )
     {
       const QString format = request.parameters().value( QStringLiteral( "FORMAT" ), QStringLiteral( "PNG" ) );
-      writeImage( response, *result, format, renderer.imageQuality() );
+      writeImage( response, *result, format, context.imageQuality() );
     }
     else
     {
@@ -60,9 +60,4 @@ namespace QgsWms
                                  QStringLiteral( "Failed to compute GetMap image" ) );
     }
   }
-
 } // namespace QgsWms
-
-
-
-

--- a/src/server/services/wms/qgswmsgetprint.cpp
+++ b/src/server/services/wms/qgswmsgetprint.cpp
@@ -28,13 +28,12 @@ namespace QgsWms
                       const QString &, const QgsServerRequest &request,
                       QgsServerResponse &response )
   {
+    // get wms parameters from query
     const QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
-    QgsRenderer renderer( serverIface, project, wmsParameters );
-
-    const QgsWmsParameters::Format format = wmsParameters.format();
-    QString contentType;
 
     // GetPrint supports svg/png/pdf
+    const QgsWmsParameters::Format format = wmsParameters.format();
+    QString contentType;
     switch ( format )
     {
       case QgsWmsParameters::PNG:
@@ -55,8 +54,20 @@ namespace QgsWms
         break;
     }
 
+    // prepare render context
+    QgsWmsRenderContext context( project, serverIface );
+    context.setFlag( QgsWmsRenderContext::UpdateExtent );
+    context.setFlag( QgsWmsRenderContext::UseOpacity );
+    context.setFlag( QgsWmsRenderContext::UseFilter );
+    context.setFlag( QgsWmsRenderContext::UseSelection );
+    context.setFlag( QgsWmsRenderContext::SetAccessControl );
+    context.setFlag( QgsWmsRenderContext::AddHighlightLayers );
+    context.setFlag( QgsWmsRenderContext::AddExternalLayers );
+    context.setParameters( wmsParameters );
+
+    // rendering
+    QgsRenderer renderer( context );
     response.setHeader( QStringLiteral( "Content-Type" ), contentType );
     response.write( renderer.getPrint() );
   }
-
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsparameters.cpp
+++ b/src/server/services/wms/qgswmsparameters.cpp
@@ -1534,10 +1534,12 @@ namespace QgsWms
 
   QList<QgsWmsParametersExternalLayer> QgsWmsParameters::externalLayersParameters() const
   {
+    auto notExternalLayer = []( const QString & name ) { return ! QgsWmsParameters::isExternalLayer( name ); };
+
     QList<QgsWmsParametersExternalLayer> externalLayers;
 
     QStringList layers = allLayersNickname();
-    QStringList::const_iterator rit = std::remove_if( layers.begin(), layers.end(), QgsWmsParameters::isExternalLayer );
+    QStringList::const_iterator rit = std::remove_if( layers.begin(), layers.end(), notExternalLayer );
 
     for ( QStringList::const_iterator it = layers.begin(); it != rit; ++it )
     {

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -1,0 +1,454 @@
+/***************************************************************************
+                              qgswmsrendercontext.cpp
+                              ---------------------
+  begin                : March 22, 2019
+  copyright            : (C) 2019 by Paul Blottiere
+  email                : paul.blottiere@oslandia.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgslayertree.h"
+
+#include "qgswmsrendercontext.h"
+#include "qgsserverprojectutils.h"
+
+using namespace QgsWms;
+
+QgsWmsRenderContext::QgsWmsRenderContext( const QgsProject *project, QgsServerInterface *interface )
+  : mProject( project )
+  , mInterface( interface )
+  , mFlags()
+{
+}
+
+void QgsWmsRenderContext::setParameters( const QgsWmsParameters &parameters )
+{
+  mParameters = parameters;
+
+  initRestrictedLayers();
+  initNicknameLayers();
+
+  searchLayersToRender();
+  removeUnwantedLayers();
+  checkLayerReadPermissions();
+
+  std::reverse( mLayersToRender.begin(), mLayersToRender.end() );
+}
+
+void QgsWmsRenderContext::setFlag( const Flag flag, const bool on )
+{
+  if ( on )
+  {
+    mFlags |= flag;
+  }
+  else
+  {
+    mFlags &= ~flag;
+  }
+}
+
+bool QgsWmsRenderContext::testFlag( Flag flag ) const
+{
+  return mFlags.testFlag( flag );
+}
+
+QgsWmsParameters QgsWmsRenderContext::parameters() const
+{
+  return mParameters;
+}
+
+const QgsServerSettings &QgsWmsRenderContext::settings() const
+{
+  return *mInterface->serverSettings();
+}
+
+const QgsProject *QgsWmsRenderContext::project() const
+{
+  return mProject;
+}
+
+QDomElement QgsWmsRenderContext::sld( const QgsMapLayer &layer ) const
+{
+  QDomElement sld;
+
+  const QString nickname = layerNickname( layer );
+  if ( mSlds.contains( nickname ) )
+  {
+    sld = mSlds[ nickname ];
+  }
+
+  return sld;
+}
+
+QString QgsWmsRenderContext::style( const QgsMapLayer &layer ) const
+{
+  QString style;
+
+  const QString nickname = layerNickname( layer );
+  if ( mStyles.contains( nickname ) )
+  {
+    style = mStyles[ nickname ];
+  }
+
+  return style;
+}
+
+QgsWmsParametersLayer QgsWmsRenderContext::parameters( const QgsMapLayer &layer ) const
+{
+  QgsWmsParametersLayer parameters;
+
+  for ( const auto &params : mParameters.layersParameters() )
+  {
+    if ( params.mNickname == layerNickname( layer ) )
+    {
+      parameters = params;
+      break;
+    }
+  }
+
+  return parameters;
+}
+
+QList<QgsMapLayer *> QgsWmsRenderContext::layersToRender() const
+{
+  return mLayersToRender;
+}
+
+QList<QgsMapLayer *> QgsWmsRenderContext::layers() const
+{
+  return mNicknameLayers.values();
+}
+
+double QgsWmsRenderContext::scaleDenominator() const
+{
+  double denominator = -1;
+
+  if ( mScaleDenominator >= 0 )
+  {
+    denominator = mScaleDenominator;
+  }
+  else if ( mFlags & UseScaleDenominator && ! mParameters.scale().isEmpty() )
+  {
+    denominator = mParameters.scaleAsDouble();
+  }
+
+  return denominator;
+}
+
+void QgsWmsRenderContext::setScaleDenominator( double scaleDenominator )
+{
+  mScaleDenominator = scaleDenominator;
+  removeUnwantedLayers();
+}
+
+bool QgsWmsRenderContext::updateExtent() const
+{
+  bool update = false;
+
+  if ( mFlags & UpdateExtent && ! mParameters.bbox().isEmpty() )
+  {
+    update = true;
+  }
+
+  return update;
+}
+
+QString QgsWmsRenderContext::layerNickname( const QgsMapLayer &layer ) const
+{
+  QString name = layer.shortName();
+  if ( QgsServerProjectUtils::wmsUseLayerIds( *mProject ) )
+  {
+    name = layer.id();
+  }
+  else if ( name.isEmpty() )
+  {
+    name = layer.name();
+  }
+
+  return name;
+}
+
+void QgsWmsRenderContext::initNicknameLayers()
+{
+  for ( QgsMapLayer *ml : mProject->mapLayers() )
+  {
+    mNicknameLayers[ layerNickname( *ml ) ] = ml;
+  }
+
+  // init groups
+  const QString rootName { QgsServerProjectUtils::wmsRootName( *mProject ) };
+  const QgsLayerTreeGroup *root = mProject->layerTreeRoot();
+
+  initLayerGroupsRecursive( root, rootName.isEmpty() ? mProject->title() : rootName );
+}
+
+void QgsWmsRenderContext::initLayerGroupsRecursive( const QgsLayerTreeGroup *group, const QString &groupName )
+{
+  if ( !groupName.isEmpty() )
+  {
+    mLayerGroups[groupName] = QList<QgsMapLayer *>();
+    for ( QgsLayerTreeLayer *layer : group->findLayers() )
+    {
+      mLayerGroups[groupName].append( layer->layer() );
+    }
+  }
+
+  for ( const QgsLayerTreeNode *child : group->children() )
+  {
+    if ( child->nodeType() == QgsLayerTreeNode::NodeGroup )
+    {
+      QString name = child->customProperty( QStringLiteral( "wmsShortName" ) ).toString();
+
+      if ( name.isEmpty() )
+        name = child->name();
+
+      initLayerGroupsRecursive( static_cast<const QgsLayerTreeGroup *>( child ), name );
+
+    }
+  }
+}
+
+void QgsWmsRenderContext::initRestrictedLayers()
+{
+  mRestrictedLayers.clear();
+
+  // get name of restricted layers/groups in project
+  QStringList restricted = QgsServerProjectUtils::wmsRestrictedLayers( *mProject );
+
+  // extract restricted layers from excluded groups
+  QStringList restrictedLayersNames;
+  QgsLayerTreeGroup *root = mProject->layerTreeRoot();
+
+  for ( const QString &l : restricted )
+  {
+    QgsLayerTreeGroup *group = root->findGroup( l );
+    if ( group )
+    {
+      QList<QgsLayerTreeLayer *> groupLayers = group->findLayers();
+      for ( QgsLayerTreeLayer *treeLayer : groupLayers )
+      {
+        restrictedLayersNames.append( treeLayer->name() );
+      }
+    }
+    else
+    {
+      restrictedLayersNames.append( l );
+    }
+  }
+
+  // build output with names, ids or short name according to the configuration
+  QList<QgsLayerTreeLayer *> layers = root->findLayers();
+  for ( QgsLayerTreeLayer *layer : layers )
+  {
+    if ( restrictedLayersNames.contains( layer->name() ) )
+    {
+      mRestrictedLayers.append( layerNickname( *layer->layer() ) );
+    }
+  }
+}
+
+void QgsWmsRenderContext::searchLayersToRender()
+{
+  mLayersToRender.clear();
+  mStyles.clear();
+  mSlds.clear();
+
+  if ( ! mParameters.sldBody().isEmpty() )
+  {
+    searchLayersToRenderSld();
+  }
+  else
+  {
+    searchLayersToRenderStyle();
+  }
+
+  if ( mFlags & AddQueryLayers )
+  {
+    for ( const QString &layer : mParameters.queryLayersNickname() )
+    {
+      if ( mNicknameLayers.contains( layer )
+           && !mLayersToRender.contains( mNicknameLayers[layer] ) )
+      {
+        mLayersToRender.append( mNicknameLayers[layer] );
+      }
+    }
+  }
+}
+
+void QgsWmsRenderContext::searchLayersToRenderSld()
+{
+  const QString sld = mParameters.sldBody();
+
+  if ( sld.isEmpty() )
+  {
+    return;
+  }
+
+  QDomDocument doc;
+  ( void )doc.setContent( sld, true );
+  QDomElement docEl = doc.documentElement();
+
+  QDomElement root = doc.firstChildElement( "StyledLayerDescriptor" );
+  QDomElement namedElem = root.firstChildElement( "NamedLayer" );
+
+  if ( docEl.isNull() )
+  {
+    return;
+  }
+
+  QDomNodeList named = docEl.elementsByTagName( "NamedLayer" );
+  for ( int i = 0; i < named.size(); ++i )
+  {
+    QDomNodeList names = named.item( i ).toElement().elementsByTagName( "Name" );
+    if ( !names.isEmpty() )
+    {
+      QString lname = names.item( 0 ).toElement().text();
+      QString err;
+      if ( mNicknameLayers.contains( lname ) )
+      {
+        mSlds[lname] = namedElem;
+        mLayersToRender.append( mNicknameLayers[ lname ] );
+      }
+      else if ( mLayerGroups.contains( lname ) )
+      {
+        for ( QgsMapLayer *layer : mLayerGroups[lname] )
+        {
+          const QString name = layerNickname( *layer );
+          mSlds[name] = namedElem;
+          mLayersToRender.insert( 0, layer );
+        }
+      }
+      else
+      {
+        throw QgsBadRequestException( QStringLiteral( "LayerNotDefined" ),
+                                      QStringLiteral( "Layer \"%1\" does not exist" ).arg( lname ) );
+      }
+    }
+  }
+}
+
+void QgsWmsRenderContext::searchLayersToRenderStyle()
+{
+  for ( const QgsWmsParametersLayer &param : mParameters.layersParameters() )
+  {
+    const QString nickname = param.mNickname;
+    const QString style = param.mStyle;
+
+    if ( mNicknameLayers.contains( nickname ) )
+    {
+      if ( !style.isEmpty() )
+      {
+        mStyles[nickname] = style;
+      }
+
+      mLayersToRender.append( mNicknameLayers[ nickname ] );
+    }
+    else if ( mLayerGroups.contains( nickname ) )
+    {
+      // Reverse order of layers from a group
+      QList<QString> layersFromGroup;
+      for ( QgsMapLayer *layer : mLayerGroups[nickname] )
+      {
+        const QString nickname = layerNickname( *layer );
+        if ( !style.isEmpty() )
+        {
+          mStyles[ nickname ] = style;
+        }
+        layersFromGroup.push_front( nickname );
+      }
+
+      for ( const auto name : layersFromGroup )
+      {
+        mLayersToRender.append( mNicknameLayers[ name ] );
+      }
+    }
+    else
+    {
+      throw QgsBadRequestException( QStringLiteral( "LayerNotDefined" ),
+                                    QStringLiteral( "Layer \"%1\" does not exist" ).arg( nickname ) );
+    }
+  }
+}
+
+bool QgsWmsRenderContext::layerScaleVisibility( const QString &name ) const
+{
+  bool visible = false;
+
+  if ( ! mNicknameLayers.contains( name ) )
+  {
+    return visible;
+  }
+
+  const QgsMapLayer *layer = mNicknameLayers[ name ];
+  bool scaleBasedVisibility = layer->hasScaleBasedVisibility();
+  bool useScaleConstraint = ( scaleDenominator() > 0 && scaleBasedVisibility );
+
+  if ( !useScaleConstraint || layer->isInScaleRange( scaleDenominator() ) )
+  {
+    visible = true;
+  }
+
+  return visible;
+}
+
+void QgsWmsRenderContext::removeUnwantedLayers()
+{
+  QList<QgsMapLayer *> layers;
+
+  for ( QgsMapLayer *layer : mLayersToRender )
+  {
+    const QString nickname = layerNickname( *layer );
+
+    if ( !layerScaleVisibility( nickname ) )
+      continue;
+
+    if ( mRestrictedLayers.contains( nickname ) )
+      continue;
+
+    if ( mFlags & UseWfsLayersOnly )
+    {
+      if ( layer->type() != QgsMapLayer::VectorLayer )
+      {
+        continue;
+      }
+
+      const QStringList wfsLayers = QgsServerProjectUtils::wfsLayerIds( *mProject );
+      if ( ! wfsLayers.contains( layer->id() ) )
+      {
+        continue;
+      }
+    }
+
+    layers.append( layer );
+  }
+
+  mLayersToRender = layers;
+}
+
+void QgsWmsRenderContext::checkLayerReadPermissions()
+{
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+  for ( const auto layer : mLayersToRender )
+  {
+    if ( !accessControl()->layerReadPermission( layer ) )
+    {
+      throw QgsSecurityException( QStringLiteral( "You are not allowed to access to the layer: %1" ).arg( layer->name() ) );
+    }
+  }
+#endif
+}
+
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+QgsAccessControl *QgsWmsRenderContext::accessControl()
+{
+  return mInterface->accessControls();
+}
+#endif

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -511,7 +511,7 @@ void QgsWmsRenderContext::checkLayerReadPermissions()
 }
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-QgsAccessControl *QgsWmsRenderContext::accessControl()
+QgsAccessControl *QgsWmsRenderContext::accessControl() const
 {
   return mInterface->accessControls();
 }

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -214,6 +214,32 @@ QString QgsWmsRenderContext::layerNickname( const QgsMapLayer &layer ) const
   return name;
 }
 
+QgsMapLayer *QgsWmsRenderContext::layer( const QString &nickname ) const
+{
+  QgsMapLayer *mlayer = nullptr;
+
+  for ( auto layer : mLayersToRender )
+  {
+    if ( layerNickname( *layer ).compare( nickname ) == 0 )
+    {
+      mlayer = layer;
+      break;
+    }
+  }
+
+  return mlayer;
+}
+
+bool QgsWmsRenderContext::isValidLayer( const QString &nickname ) const
+{
+  return layer( nickname ) != nullptr;
+}
+
+bool QgsWmsRenderContext::isValidGroup( const QString &name ) const
+{
+  return mLayerGroups.contains( name );
+}
+
 void QgsWmsRenderContext::initNicknameLayers()
 {
   for ( QgsMapLayer *ml : mProject->mapLayers() )

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -482,7 +482,7 @@ void QgsWmsRenderContext::removeUnwantedLayers()
 
     if ( mFlags & UseWfsLayersOnly )
     {
-      if ( layer->type() != QgsMapLayer::VectorLayer )
+      if ( layer->type() != QgsMapLayerType::VectorLayer )
       {
         continue;
       }

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -117,6 +117,30 @@ QgsWmsParametersLayer QgsWmsRenderContext::parameters( const QgsMapLayer &layer 
   return parameters;
 }
 
+int QgsWmsRenderContext::imageQuality() const
+{
+  int imageQuality = QgsServerProjectUtils::wmsImageQuality( *mProject );
+
+  if ( !mParameters.imageQuality().isEmpty() )
+  {
+    imageQuality = mParameters.imageQualityAsInt();
+  }
+
+  return imageQuality;
+}
+
+int QgsWmsRenderContext::precision() const
+{
+  int precision = QgsServerProjectUtils::wmsFeatureInfoPrecision( *mProject );
+
+  if ( mParameters.wmsPrecisionAsInt() > -1 )
+  {
+    precision = mParameters.wmsPrecisionAsInt();
+  }
+
+  return precision;
+}
+
 QList<QgsMapLayer *> QgsWmsRenderContext::layersToRender() const
 {
   return mLayersToRender;

--- a/src/server/services/wms/qgswmsrendercontext.cpp
+++ b/src/server/services/wms/qgswmsrendercontext.cpp
@@ -141,6 +141,20 @@ int QgsWmsRenderContext::precision() const
   return precision;
 }
 
+qreal QgsWmsRenderContext::dotsPerMm() const
+{
+  // Apply DPI parameter if present. This is an extension of QGIS Server
+  // compared to WMS 1.3.
+  // Because of backwards compatibility, this parameter is optional
+  double OGC_PX_M = 0.00028; // OGC reference pixel size in meter
+  int dpm = 1 / OGC_PX_M;
+
+  if ( !mParameters.dpi().isEmpty() )
+    dpm = mParameters.dpiAsDouble() / 0.0254;
+
+  return dpm / 1000.0;
+}
+
 QList<QgsMapLayer *> QgsWmsRenderContext::layersToRender() const
 {
   return mLayersToRender;

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -184,7 +184,7 @@ namespace QgsWms
       /**
        * Returns the access control interface.
        */
-      QgsAccessControl *accessControl();
+      QgsAccessControl *accessControl() const;
 #endif
 
     private:

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -24,9 +24,17 @@
 
 namespace QgsWms
 {
+
+  /**
+   * \ingroup server
+   * \class QgsWmsRenderContext
+   * \brief Rendering context for the WMS renderer
+   * \since QGIS 3.8
+   */
   class QgsWmsRenderContext
   {
     public:
+      //! Available rendering options
       enum Flag
       {
         UseScaleDenominator    = 0x01,
@@ -42,39 +50,102 @@ namespace QgsWms
       };
       Q_DECLARE_FLAGS( Flags, Flag )
 
+      /**
+       * Default constructor for QgsWmsRenderContext.
+       */
       QgsWmsRenderContext() = default;
 
+      /**
+       * Constructor for QgsWmsRenderContext.
+       * \param project The project to use for the rendering
+       * \param interface The server interface
+       */
       QgsWmsRenderContext( const QgsProject *project, QgsServerInterface *interface );
 
+      /**
+       * Sets WMS parameters.
+       */
       void setParameters( const QgsWmsParameters &parameters );
 
+      /**
+       * Returns WMS parameters.
+       */
       QgsWmsParameters parameters() const;
 
+      /**
+       * Returns settings of the server.
+       */
       const QgsServerSettings &settings() const;
 
+      /**
+       * Returns the project.
+       */
       const QgsProject *project() const;
 
+      /**
+       * Sets or unsets a rendering flag according to the \a on value.
+       */
       void setFlag( Flag flag, bool on = true );
 
+      /**
+       * Returns the status of a rendering flag.
+       * \param flag The flag to test
+       * \returns true if the rendering option is activated, false otherwise
+       */
       bool testFlag( Flag flag ) const;
 
+      /**
+       * Returns a list of all layers read from the project.
+       */
       QList<QgsMapLayer *> layers() const;
 
+      /**
+       * Returns a list of all layers to actually render according to the
+       * current configuration.
+       */
       QList<QgsMapLayer *> layersToRender() const;
 
+      /**
+       * Returns a SLD document for a specific layer. An empty document is
+       * returned if not available.
+       */
       QDomElement sld( const QgsMapLayer &layer ) const;
 
+      /**
+       * Returns a style's name for a specific layer. An empty string is
+       * returned if not available.
+       */
       QString style( const QgsMapLayer &layer ) const;
 
+      /**
+       * Returns the scale denominator to use for rendering according to the
+       * current configuration.
+       */
       double scaleDenominator() const;
 
+      /**
+       * Sets a custom scale denominator. In this case, layers to render are
+       * updated according to their scale visibility.
+       */
       void setScaleDenominator( double scaleDenominator );
 
+      /**
+       * Returns true if the extent has to be updated before the rendering,
+       * false otherwise.
+       */
       bool updateExtent() const;
 
+      /**
+       * Returns WMS parameters for a specific layer. An empty instance is
+       * returned if not available.
+       */
       QgsWmsParametersLayer parameters( const QgsMapLayer &layer ) const;
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
+
+      /**
+       * Returns the access control interface.
+       */
       QgsAccessControl *accessControl();
 #endif
 

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -141,6 +141,17 @@ namespace QgsWms
        */
       QgsWmsParametersLayer parameters( const QgsMapLayer &layer ) const;
 
+      /**
+       * Returns the image quality to use for rendering according to the
+       * current configuration.
+       */
+      int imageQuality() const;
+
+      /**
+       * Returns the precision to use according to the current configuration.
+       */
+      int precision() const;
+
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 
       /**

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -152,6 +152,12 @@ namespace QgsWms
        */
       int precision() const;
 
+      /**
+       * Returns the nickname (short name, id or name) of the layer according
+       * to the current configuration.
+       */
+      QString layerNickname( const QgsMapLayer &layer ) const;
+
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 
       /**
@@ -161,8 +167,6 @@ namespace QgsWms
 #endif
 
     private:
-      QString layerNickname( const QgsMapLayer &layer ) const;
-
       void initNicknameLayers();
       void initRestrictedLayers();
       void initLayerGroupsRecursive( const QgsLayerTreeGroup *group, const QString &groupName );

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -1,0 +1,119 @@
+/***************************************************************************
+                              qgswmsrendercontext.h
+                              ---------------------
+  begin                : March 22, 2019
+  copyright            : (C) 2019 by Paul Blottiere
+  email                : paul.blottiere@oslandia.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSWMSRENDERCONTEXT_H
+#define QGSWMSRENDERCONTEXT_H
+
+#include "qgswmsparameters.h"
+#include "qgsproject.h"
+#include "qgsserverinterface.h"
+
+namespace QgsWms
+{
+  class QgsWmsRenderContext
+  {
+    public:
+      enum Flag
+      {
+        UseScaleDenominator    = 0x01,
+        UseOpacity             = 0x02,
+        UseFilter              = 0x04,
+        UseSelection           = 0x08,
+        AddHighlightLayers     = 0x10,
+        UpdateExtent           = 0x20,
+        SetAccessControl       = 0x40,
+        AddQueryLayers         = 0x80,
+        UseWfsLayersOnly       = 0x100,
+        AddExternalLayers      = 0x200
+      };
+      Q_DECLARE_FLAGS( Flags, Flag )
+
+      QgsWmsRenderContext() = default;
+
+      QgsWmsRenderContext( const QgsProject *project, QgsServerInterface *interface );
+
+      void setParameters( const QgsWmsParameters &parameters );
+
+      QgsWmsParameters parameters() const;
+
+      const QgsServerSettings &settings() const;
+
+      const QgsProject *project() const;
+
+      void setFlag( Flag flag, bool on = true );
+
+      bool testFlag( Flag flag ) const;
+
+      QList<QgsMapLayer *> layers() const;
+
+      QList<QgsMapLayer *> layersToRender() const;
+
+      QDomElement sld( const QgsMapLayer &layer ) const;
+
+      QString style( const QgsMapLayer &layer ) const;
+
+      double scaleDenominator() const;
+
+      void setScaleDenominator( double scaleDenominator );
+
+      bool updateExtent() const;
+
+      QgsWmsParametersLayer parameters( const QgsMapLayer &layer ) const;
+
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+      QgsAccessControl *accessControl();
+#endif
+
+    private:
+      QString layerNickname( const QgsMapLayer &layer ) const;
+
+      void initNicknameLayers();
+      void initRestrictedLayers();
+      void initLayerGroupsRecursive( const QgsLayerTreeGroup *group, const QString &groupName );
+
+      void searchLayersToRender();
+      void searchLayersToRenderSld();
+      void searchLayersToRenderStyle();
+      void removeUnwantedLayers();
+
+      void checkLayerReadPermissions();
+
+      bool layerScaleVisibility( const QString &name ) const;
+
+      const QgsProject *mProject = nullptr;
+      QgsServerInterface *mInterface = nullptr;
+      QgsWmsParameters mParameters;
+      Flags mFlags = nullptr;
+      double mScaleDenominator = -1.0;
+
+      // nickname of all layers defined within the project
+      QMap<QString, QgsMapLayer *> mNicknameLayers;
+
+      // map of layers to use for rendering
+      QList<QgsMapLayer *> mLayersToRender;
+
+      // list of layers which are not usable
+      QStringList mRestrictedLayers;
+
+      QMap<QString, QList<QgsMapLayer *> > mLayerGroups;
+
+      QMap<QString, QDomElement> mSlds;
+      QMap<QString, QString> mStyles;
+  };
+};
+
+#endif

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -159,6 +159,22 @@ namespace QgsWms
       QString layerNickname( const QgsMapLayer &layer ) const;
 
       /**
+       * Returns the layer corresponding to the nickname, or a nullptr if not
+       * found or if the layer do not need to be rendered.
+       */
+      QgsMapLayer *layer( const QString &nickname ) const;
+
+      /**
+       * Returns true if the layer has to be rendered, false otherwise.
+       */
+      bool isValidLayer( const QString &nickname ) const;
+
+      /**
+       * Returns true if \a name is a group.
+       */
+      bool isValidGroup( const QString &name ) const;
+
+      /**
        * Returns default dots per mm according to the current configuration.
        */
       qreal dotsPerMm() const;

--- a/src/server/services/wms/qgswmsrendercontext.h
+++ b/src/server/services/wms/qgswmsrendercontext.h
@@ -158,6 +158,11 @@ namespace QgsWms
        */
       QString layerNickname( const QgsMapLayer &layer ) const;
 
+      /**
+       * Returns default dots per mm according to the current configuration.
+       */
+      qreal dotsPerMm() const;
+
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 
       /**

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -163,36 +163,19 @@ namespace QgsWms
       throw QgsBadRequestException( QStringLiteral( "FormatNotSpecified" ),
                                     QStringLiteral( "FORMAT is mandatory for GetLegendGraphic operation" ) );
 
-    double scaleDenominator = -1;
-    if ( ! mWmsParameters.scale().isEmpty() )
-      scaleDenominator = mWmsParameters.scaleAsDouble();
-
-    QgsLegendSettings legendSettings = mWmsParameters.legendSettings();
-
     // get layers
     std::unique_ptr<QgsLayerRestorer> restorer;
-    restorer.reset( new QgsLayerRestorer( mNicknameLayers.values() ) );
+    restorer.reset( new QgsLayerRestorer( mContext.layers() ) );
 
-    QList<QgsMapLayer *> layers;
-    QList<QgsWmsParametersLayer> params = mWmsParameters.layersParameters();
-
-    QString sld = mWmsParameters.sldBody();
-    if ( !sld.isEmpty() )
-      layers = sldStylizedLayers( sld );
-    else
-      layers = stylizedLayers( params );
-
-    removeUnwantedLayers( layers, scaleDenominator );
-    std::reverse( layers.begin(), layers.end() );
-
-    // check permissions
-    for ( QgsMapLayer *ml : layers )
-      checkLayerReadPermissions( ml );
+    // configure layers
+    QList<QgsMapLayer *> layers = mContext.layersToRender();
+    configureLayers( layers );
 
     // build layer tree model for legend
     QgsLayerTree rootGroup;
+    QgsLegendSettings legendSettings = mContext.parameters().legendSettings();
     std::unique_ptr<QgsLayerTreeModel> legendModel;
-    legendModel.reset( buildLegendTreeModel( layers, scaleDenominator, rootGroup ) );
+    legendModel.reset( buildLegendTreeModel( layers, mContext.scaleDenominator(), rootGroup ) );
 
     // rendering step
     qreal dpmm = dotsPerMm();

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -161,7 +161,7 @@ namespace QgsWms
     legendModel.reset( buildLegendTreeModel( layers, mContext.scaleDenominator(), rootGroup ) );
 
     // rendering step
-    qreal dpmm = dotsPerMm();
+    const qreal dpmm = mContext.dotsPerMm();
     std::unique_ptr<QImage> image;
     std::unique_ptr<QPainter> painter;
 
@@ -1014,15 +1014,10 @@ namespace QgsWms
       throw QgsException( QStringLiteral( "createImage: image could not be created, check for out of memory conditions" ) );
     }
 
-    //apply DPI parameter if present. This is an extension of Qgis Mapserver compared to WMS 1.3.
-    //Because of backwards compatibility, this parameter is optional
-    double OGC_PX_M = 0.00028; // OGC reference pixel size in meter, also used by qgis
-    int dpm = 1 / OGC_PX_M;
-    if ( !mWmsParameters.dpi().isEmpty() )
-      dpm = mWmsParameters.dpiAsDouble() / 0.0254;
-
+    const qreal dpm = mContext.dotsPerMm() * 1000.0;
     image->setDotsPerMeterX( dpm );
     image->setDotsPerMeterY( dpm );
+
     return image.release();
   }
 
@@ -3018,12 +3013,6 @@ namespace QgsWms
     }
 
     return legendModel;
-  }
-
-  qreal QgsRenderer::dotsPerMm() const
-  {
-    std::unique_ptr<QImage> tmpImage( createImage( 1, 1, false ) );
-    return tmpImage->dotsPerMeterX() / 1000.0;
   }
 
   void QgsRenderer::handlePrintErrors( const QgsLayout *layout ) const

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -116,10 +116,6 @@ namespace QgsWms
   QgsRenderer::QgsRenderer( const QgsWmsRenderContext &context )
     : mContext( context )
   {
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
-    mAccessControl = mContext.accessControl();
-#endif
-
     mProject = mContext.project();
 
     mWmsParameters = mContext.parameters();
@@ -1415,14 +1411,14 @@ namespace QgsWms
     }
 
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    mAccessControl->filterFeatures( layer, fReq );
+    mContext.accessControl()->filterFeatures( layer, fReq );
 
     QStringList attributes;
     for ( const QgsField &field : fields )
     {
       attributes.append( field.name() );
     }
-    attributes = mAccessControl->layerAttributes( layer, attributes );
+    attributes = mContext.accessControl()->layerAttributes( layer, attributes );
     fReq.setSubsetOfAttributes( attributes, layer->fields() );
 #endif
 
@@ -2611,10 +2607,10 @@ namespace QgsWms
       QgsFeatureFilterProviderGroup filters;
       filters.addProvider( &mFeatureFilter );
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-      mAccessControl->resolveFilterFeatures( mapSettings.layers() );
-      filters.addProvider( mAccessControl );
+      mContext.accessControl()->resolveFilterFeatures( mapSettings.layers() );
+      filters.addProvider( mContext.accessControl() );
 #endif
-      QgsMapRendererJobProxy renderJob( mSettings.parallelRendering(), mSettings.maxThreads(), &filters );
+      QgsMapRendererJobProxy renderJob( mContext.settings().parallelRendering(), mContext.settings().maxThreads(), &filters );
       renderJob.render( mapSettings, &image );
       painter = renderJob.takePainter();
 
@@ -2740,7 +2736,7 @@ namespace QgsWms
   void QgsRenderer::setLayerAccessControlFilter( QgsMapLayer *layer ) const
   {
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    QgsOWSServerFilterRestorer::applyAccessControlLayerFilters( mAccessControl, layer );
+    QgsOWSServerFilterRestorer::applyAccessControlLayerFilters( mContext.accessControl(), layer );
 #else
     Q_UNUSED( layer );
 #endif

--- a/src/server/services/wms/qgswmsrenderer.cpp
+++ b/src/server/services/wms/qgswmsrenderer.cpp
@@ -1554,10 +1554,10 @@ namespace QgsWms
         {
           QDomElement bBoxElem = infoDocument.createElement( QStringLiteral( "BoundingBox" ) );
           bBoxElem.setAttribute( version == QLatin1String( "1.1.1" ) ? "SRS" : "CRS", outputCrs.authid() );
-          bBoxElem.setAttribute( QStringLiteral( "minx" ), qgsDoubleToString( box.xMinimum(), wmsPrecision() ) );
-          bBoxElem.setAttribute( QStringLiteral( "maxx" ), qgsDoubleToString( box.xMaximum(), wmsPrecision() ) );
-          bBoxElem.setAttribute( QStringLiteral( "miny" ), qgsDoubleToString( box.yMinimum(), wmsPrecision() ) );
-          bBoxElem.setAttribute( QStringLiteral( "maxy" ), qgsDoubleToString( box.yMaximum(), wmsPrecision() ) );
+          bBoxElem.setAttribute( QStringLiteral( "minx" ), qgsDoubleToString( box.xMinimum(), mContext.precision() ) );
+          bBoxElem.setAttribute( QStringLiteral( "maxx" ), qgsDoubleToString( box.xMaximum(), mContext.precision() ) );
+          bBoxElem.setAttribute( QStringLiteral( "miny" ), qgsDoubleToString( box.yMinimum(), mContext.precision() ) );
+          bBoxElem.setAttribute( QStringLiteral( "maxy" ), qgsDoubleToString( box.yMaximum(), mContext.precision() ) );
           featureElement.appendChild( bBoxElem );
         }
 
@@ -1588,7 +1588,7 @@ namespace QgsWms
             }
             QDomElement geometryElement = infoDocument.createElement( QStringLiteral( "Attribute" ) );
             geometryElement.setAttribute( QStringLiteral( "name" ), QStringLiteral( "geometry" ) );
-            geometryElement.setAttribute( QStringLiteral( "value" ), geom.asWkt( wmsPrecision() ) );
+            geometryElement.setAttribute( QStringLiteral( "value" ), geom.asWkt( mContext.precision() ) );
             geometryElement.setAttribute( QStringLiteral( "type" ), QStringLiteral( "derived" ) );
             featureElement.appendChild( geometryElement );
           }
@@ -2260,11 +2260,11 @@ namespace QgsWms
       QDomElement boxElem;
       if ( version < 3 )
       {
-        boxElem = QgsOgcUtils::rectangleToGMLBox( &box, doc, wmsPrecision() );
+        boxElem = QgsOgcUtils::rectangleToGMLBox( &box, doc, mContext.precision() );
       }
       else
       {
-        boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc, wmsPrecision() );
+        boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc, mContext.precision() );
       }
 
       if ( crs.isValid() )
@@ -2288,11 +2288,11 @@ namespace QgsWms
       QDomElement gmlElem;
       if ( version < 3 )
       {
-        gmlElem = QgsOgcUtils::geometryToGML( geom, doc, wmsPrecision() );
+        gmlElem = QgsOgcUtils::geometryToGML( geom, doc, mContext.precision() );
       }
       else
       {
-        gmlElem = QgsOgcUtils::geometryToGML( geom, doc, QStringLiteral( "GML3" ), wmsPrecision() );
+        gmlElem = QgsOgcUtils::geometryToGML( geom, doc, QStringLiteral( "GML3" ), mContext.precision() );
       }
 
       if ( !gmlElem.isNull() )
@@ -2363,34 +2363,6 @@ namespace QgsWms
       value = value.mid( 1, value.size() - 2 );
     }
     return value;
-  }
-
-  int QgsRenderer::imageQuality() const
-  {
-    // First taken from QGIS project
-    int imageQuality = QgsServerProjectUtils::wmsImageQuality( *mProject );
-
-    // Then checks if a parameter is given, if so use it instead
-    if ( !mWmsParameters.imageQuality().isEmpty() )
-    {
-      imageQuality = mWmsParameters.imageQualityAsInt();
-    }
-
-    return imageQuality;
-  }
-
-  int QgsRenderer::wmsPrecision() const
-  {
-    // First taken from QGIS project and the default value is 6
-    int WMSPrecision = QgsServerProjectUtils::wmsFeatureInfoPrecision( *mProject );
-
-    // Then checks if a parameter is given, if so use it instead
-    int WMSPrecisionParameter = mWmsParameters.wmsPrecisionAsInt();
-
-    if ( WMSPrecisionParameter > -1 )
-      return WMSPrecisionParameter;
-    else
-      return WMSPrecision;
   }
 
   QgsRectangle QgsRenderer::featureInfoSearchRect( QgsVectorLayer *ml, const QgsMapSettings &mapSettings, const QgsRenderContext &rct, const QgsPointXY &infoPoint ) const

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -63,13 +63,6 @@ namespace QgsWms
   {
     public:
 
-      /**
-       * Constructor. Does _NOT_ take ownership of
-          QgsConfigParser and QgsCapabilitiesCache*/
-      QgsRenderer( QgsServerInterface *serverIface,
-                   const QgsProject *project,
-                   const QgsWmsParameters &parameters );
-
       QgsRenderer( const QgsWmsRenderContext &context );
 
       ~QgsRenderer();
@@ -137,16 +130,6 @@ namespace QgsWms
       // the project configuration)
       QString layerNickname( const QgsMapLayer &layer ) const;
 
-      // Return true if the layer has to be displayed according to he current
-      // scale
-      bool layerScaleVisibility( const QgsMapLayer &layer, double scaleDenominator ) const;
-
-      // Remove unwanted layers (restricted, not visible, etc)
-      void removeUnwantedLayers( QList<QgsMapLayer *> &layers, double scaleDenominator = -1 ) const;
-
-      // Remove non identifiable layers (restricted, not visible, etc)
-      void removeNonIdentifiableLayers( QList<QgsMapLayer *> &layers ) const;
-
       // Rendering step for layers
       QPainter *layersRendering( const QgsMapSettings &mapSettings, QImage &image, HitTest *hitTest = nullptr ) const;
 
@@ -155,9 +138,6 @@ namespace QgsWms
 
       // Return a list of layers stylized with LAYERS/STYLES parameters
       QList<QgsMapLayer *> stylizedLayers( const QList<QgsWmsParametersLayer> &params );
-
-      // Return a list of layers stylized with SLD parameter
-      QList<QgsMapLayer *> sldStylizedLayers( const QString &sld ) const;
 
       // Set layer opacity
       void setLayerOpacity( QgsMapLayer *layer, int opacity ) const;
@@ -176,9 +156,6 @@ namespace QgsWms
 
       // Scale image with WIDTH/HEIGHT if necessary
       QImage *scaleImage( const QImage *image ) const;
-
-      // Check layer read permissions
-      void checkLayerReadPermissions( QgsMapLayer *layer ) const;
 
       // Build a layer tree model for legend
       QgsLayerTreeModel *buildLegendTreeModel( const QList<QgsMapLayer *> &layers, double scaleDenominator, QgsLayerTree &rootGroup );

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -22,6 +22,7 @@
 
 #include "qgsserversettings.h"
 #include "qgswmsparameters.h"
+#include "qgswmsrendercontext.h"
 #include "qgsfeaturefilter.h"
 #include <QDomDocument>
 #include <QMap>
@@ -68,6 +69,8 @@ namespace QgsWms
       QgsRenderer( QgsServerInterface *serverIface,
                    const QgsProject *project,
                    const QgsWmsParameters &parameters );
+
+      QgsRenderer( const QgsWmsRenderContext &context );
 
       ~QgsRenderer();
 
@@ -313,18 +316,27 @@ namespace QgsWms
 
       const QgsWmsParameters &mWmsParameters;
 
+      void configureLayers( QList<QgsMapLayer *> &layers, QgsMapSettings *settings = nullptr );
+
+      void setLayerStyle( QgsMapLayer *layer, const QString &style ) const;
+
+      void setLayerSld( QgsMapLayer *layer, const QDomElement &sld ) const;
+
+      QgsWmsParameters mWmsParameters;
+
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
       //! The access control helper
       QgsAccessControl *mAccessControl = nullptr;
 #endif
       QgsFeatureFilter mFeatureFilter;
 
-      const QgsServerSettings &mSettings;
+      QgsServerSettings mSettings;
       const QgsProject *mProject = nullptr;
       QStringList mRestrictedLayers;
       QMap<QString, QgsMapLayer *> mNicknameLayers;
       QMap<QString, QList<QgsMapLayer *> > mLayerGroups;
       QList<QgsMapLayer *> mTemporaryLayers;
+      QgsWmsRenderContext mContext;
   };
 
 } // namespace QgsWms

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -155,9 +155,6 @@ namespace QgsWms
       // Build a layer tree model for legend
       QgsLayerTreeModel *buildLegendTreeModel( const QList<QgsMapLayer *> &layers, double scaleDenominator, QgsLayerTree &rootGroup );
 
-      // Returns default dots per mm
-      qreal dotsPerMm() const;
-
       /**
        * Creates a QImage from the HEIGHT and WIDTH parameters
        * \param width image width (or -1 if width should be taken from WIDTH wms parameter)

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -285,13 +285,8 @@ namespace QgsWms
 
       QgsWmsParameters mWmsParameters;
 
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
-      //! The access control helper
-      QgsAccessControl *mAccessControl = nullptr;
-#endif
       QgsFeatureFilter mFeatureFilter;
 
-      QgsServerSettings mSettings;
       const QgsProject *mProject = nullptr;
       QList<QgsMapLayer *> mTemporaryLayers;
       QgsWmsRenderContext mContext;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -63,8 +63,16 @@ namespace QgsWms
   {
     public:
 
+      /**
+       * Constructor for QgsRenderer.
+       * \param context The rendering context.
+       * \since QGIS 3.8
+       */
       QgsRenderer( const QgsWmsRenderContext &context );
 
+      /**
+       * Destructor for QgsRenderer.
+       */
       ~QgsRenderer();
 
       /**

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -114,19 +114,11 @@ namespace QgsWms
 
     private:
 
-      // Init the restricted layers with nicknames
-      void initRestrictedLayers();
-
       // Build and returns highlight layers
       QList<QgsMapLayer *> highlightLayers( QList<QgsWmsParametersHighlightLayer> params );
 
       // Build and returns external layers
       QList<QgsMapLayer *> externalLayers( const QList<QgsWmsParametersExternalLayer> &params );
-
-      // Init a map with nickname for layers' project
-      void initNicknameLayers();
-
-      void initLayerGroupsRecursive( const QgsLayerTreeGroup *group, const QString &groupName );
 
       // Rendering step for layers
       QPainter *layersRendering( const QgsMapSettings &mapSettings, QImage &image, HitTest *hitTest = nullptr ) const;
@@ -301,9 +293,6 @@ namespace QgsWms
 
       QgsServerSettings mSettings;
       const QgsProject *mProject = nullptr;
-      QStringList mRestrictedLayers;
-      QMap<QString, QgsMapLayer *> mNicknameLayers;
-      QMap<QString, QList<QgsMapLayer *> > mLayerGroups;
       QList<QgsMapLayer *> mTemporaryLayers;
       QgsWmsRenderContext mContext;
   };

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -275,8 +275,6 @@ namespace QgsWms
        */
       int width() const;
 
-      const QgsWmsParameters &mWmsParameters;
-
       void configureLayers( QList<QgsMapLayer *> &layers, QgsMapSettings *settings = nullptr );
 
       void setLayerStyle( QgsMapLayer *layer, const QString &style ) const;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -128,18 +128,11 @@ namespace QgsWms
 
       void initLayerGroupsRecursive( const QgsLayerTreeGroup *group, const QString &groupName );
 
-      // Return the nickname of the layer (short name, id or name according to
-      // the project configuration)
-      QString layerNickname( const QgsMapLayer &layer ) const;
-
       // Rendering step for layers
       QPainter *layersRendering( const QgsMapSettings &mapSettings, QImage &image, HitTest *hitTest = nullptr ) const;
 
       // Rendering step for annotations
       void annotationsRendering( QPainter *painter ) const;
-
-      // Return a list of layers stylized with LAYERS/STYLES parameters
-      QList<QgsMapLayer *> stylizedLayers( const QList<QgsWmsParametersLayer> &params );
 
       // Set layer opacity
       void setLayerOpacity( QgsMapLayer *layer, int opacity ) const;

--- a/src/server/services/wms/qgswmsrenderer.h
+++ b/src/server/services/wms/qgswmsrenderer.h
@@ -112,12 +112,6 @@ namespace QgsWms
        */
       QByteArray getFeatureInfo( const QString &version = "1.3.0" );
 
-      //! Returns the image quality to use for getMap request
-      int imageQuality() const;
-
-      //! Returns the precision to use for GetFeatureInfo request
-      int wmsPrecision() const;
-
     private:
 
       // Init the restricted layers with nicknames

--- a/tests/src/python/test_qgsserver_wms_getmap.py
+++ b/tests/src/python/test_qgsserver_wms_getmap.py
@@ -622,7 +622,7 @@ class TestQgsServerWMSGetMap(QgsServerTestBase):
             "SERVICE": "WMS",
             "VERSION": "1.3.0",
             "REQUEST": "GetMap",
-            "LAYERS": "Hello",
+            "LAYERS": "",
             "STYLES": "",
             "FORMAT": "image/png",
             "HEIGHT": "5001",

--- a/tests/src/server/wms/CMakeLists.txt
+++ b/tests/src/server/wms/CMakeLists.txt
@@ -34,6 +34,7 @@ SET(MODULE_WMS_SRCS
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgslayerrestorer.cpp
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgsmaprendererjobproxy.cpp
   ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsparameters.cpp
+  ${CMAKE_SOURCE_DIR}/src/server/services/wms/qgswmsrendercontext.cpp
 )
 
 MACRO (ADD_QGIS_TEST TESTSRC)

--- a/tests/src/server/wms/test_qgsserver_wms_dxf.cpp
+++ b/tests/src/server/wms/test_qgsserver_wms_dxf.cpp
@@ -19,6 +19,7 @@
 #include "qgsserverinterfaceimpl.h"
 #include "qgswmsparameters.h"
 #include "qgswmsrenderer.h"
+#include "qgswmsrendercontext.h"
 
 /**
  * \ingroup UnitTests
@@ -76,9 +77,17 @@ void TestQgsServerWmsDxf::use_title_as_layername_true()
   QgsServiceRegistry registry;
   QgsServerSettings settings;
   QgsServerInterfaceImpl interface( &cache, &registry, &settings );
-  QgsWms::QgsRenderer renderer( &interface, &project, parameters );
 
+  QgsWms::QgsWmsRenderContext context( &project, &interface );
+  context.setFlag( QgsWms::QgsWmsRenderContext::UseWfsLayersOnly );
+  context.setFlag( QgsWms::QgsWmsRenderContext::UseOpacity );
+  context.setFlag( QgsWms::QgsWmsRenderContext::UseFilter );
+  context.setFlag( QgsWms::QgsWmsRenderContext::SetAccessControl );
+  context.setParameters( parameters );
+
+  QgsWms::QgsRenderer renderer( context );
   QgsDxfExport exporter = renderer.getDxf();
+
   const QString name = exporter.layerName( vl );
   QCOMPARE( exporter.layerName( vl ), QString( "testlayer \u00E8\u00E9" ) );
 
@@ -117,9 +126,17 @@ void TestQgsServerWmsDxf::use_title_as_layername_false()
   QgsServiceRegistry registry;
   QgsServerSettings settings;
   QgsServerInterfaceImpl interface( &cache, &registry, &settings );
-  QgsWms::QgsRenderer renderer( &interface, &project, parameters );
 
+  QgsWms::QgsWmsRenderContext context( &project, &interface );
+  context.setFlag( QgsWms::QgsWmsRenderContext::UseWfsLayersOnly );
+  context.setFlag( QgsWms::QgsWmsRenderContext::UseOpacity );
+  context.setFlag( QgsWms::QgsWmsRenderContext::UseFilter );
+  context.setFlag( QgsWms::QgsWmsRenderContext::SetAccessControl );
+  context.setParameters( parameters );
+
+  QgsWms::QgsRenderer renderer( context );
   QgsDxfExport exporter = renderer.getDxf();
+
   const QString name = exporter.layerName( vl );
   QCOMPARE( exporter.layerName( vl ), QString( "A test vector layer" ) );
 


### PR DESCRIPTION
## Description

Currently, the loop for configuring layers is mainly duplicated between `getMap()`, `getPrint()`, `getFeatureInfo()` and so on, within the WMS renderer.

In this PR, I added a new class `QgsWmsRenderContext` allowing to configure the renderer thanks to flags. This way, we may do this: 

```` c++
QgsWmsRenderContext context( project, serverIface );
context.setFlag( QgsWmsRenderContext::UseOpacity );
context.setFlag( QgsWmsRenderContext::UseFilter );
context.setFlag( QgsWmsRenderContext::UseSelection );

QgsWmsParameters wmsParameters( QUrlQuery( request.url() ) );
context.setParameters( parameters );

QgsRenderer renderer( context );
// do the rendering
````

Benefits are:
- capacities of the renderer are clearly stated through the `QgsWmsRenderContext` flags
- the renderer is not in charge of finding the configuration, it just does the rendering itself
- a single configuration loop for layers (`configureLayers()`) instead of one loop in each method

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and contain sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTING.md#contributing-to-qgis) before each commit
